### PR TITLE
[SPARK-34251][SQL] Fix table stats calculation by `TRUNCATE TABLE`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -565,11 +565,7 @@ case class TruncateTableCommand(
     // file relation in the metastore cache and cached table data in the cache manager.
     spark.catalog.refreshTable(tableIdentWithDB)
 
-    if (table.stats.nonEmpty) {
-      // empty table after truncation
-      val newStats = CatalogStatistics(sizeInBytes = 0, rowCount = Some(0))
-      catalog.alterTableStats(tableName, Some(newStats))
-    }
+    CommandUtils.updateTableStats(spark, table)
     Seq.empty[Row]
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -719,7 +719,6 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
         sql("CREATE TABLE tbl (c0 int, part int) USING parquet PARTITIONED BY (part)")
         sql("INSERT INTO tbl PARTITION (part=0) SELECT 0")
         sql("INSERT INTO tbl PARTITION (part=1) SELECT 1")
-        sql("ANALYZE TABLE tbl COMPUTE STATISTICS")
         val sizeOfTwoParts = getTableStats("tbl").sizeInBytes
         assert(sizeOfTwoParts > 0)
         sql("TRUNCATE TABLE tbl PARTITION (part=1)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -267,11 +267,12 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
       assert(fetched1.get.sizeInBytes > 0)
       assert(fetched1.get.colStats.size == 2)
 
-      // truncate table command
-      sql(s"TRUNCATE TABLE $table")
-      val fetched2 = checkTableStats(table, hasSizeInBytes = true, expectedRowCounts = Some(0))
-      assert(fetched2.get.sizeInBytes == 0)
-      assert(fetched2.get.colStats.isEmpty)
+      withSQLConf(SQLConf.AUTO_SIZE_UPDATE_ENABLED.key -> "true") {
+        sql(s"TRUNCATE TABLE $table")
+        val fetched2 = checkTableStats(table, hasSizeInBytes = true, expectedRowCounts = None)
+        assert(fetched2.get.sizeInBytes == 0)
+        assert(fetched2.get.colStats.isEmpty)
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Take into account the SQL config `spark.sql.statistics.size.autoUpdate.enabled` in the `TRUNCATE TABLE` command as other commands do.
2. Re-calculate actual table size in fs. Before the changes, `TRUNCATE TABLE` always sets table size to 0 in stats.

### Why are the changes needed?
This fixes the bug that is demonstrated by the example:
1. Create a partitioned table with 2 non-empty partitions:
```sql
spark-sql> CREATE TABLE tbl (c0 int, part int) PARTITIONED BY (part);
spark-sql> INSERT INTO tbl PARTITION (part=0) SELECT 0;
spark-sql> INSERT INTO tbl PARTITION (part=1) SELECT 1;
spark-sql> ANALYZE TABLE tbl COMPUTE STATISTICS;
spark-sql> DESCRIBE TABLE EXTENDED tbl;
...
Statistics	4 bytes, 2 rows
...
``` 
2. Truncate only one partition:
```sql
spark-sql> TRUNCATE TABLE tbl PARTITION (part=1);
spark-sql> SELECT * FROM tbl;
0	0
```
3. The table is still non-empty but `TRUNCATE TABLE` reseted stats:
```
spark-sql> DESCRIBE TABLE EXTENDED tbl;
...
Statistics	0 bytes, 0 rows
...
```

### Does this PR introduce _any_ user-facing change?
It could impact on performance of following queries.

### How was this patch tested?
Added new test to `StatisticsCollectionSuite`:
```
$ build/sbt -Phive -Phive-thriftserver "test:testOnly *StatisticsCollectionSuite"
$ build/sbt -Phive -Phive-thriftserver "test:testOnly *StatisticsSuite"
```