### PR TITLE
[SPARK-34256][ML] VectorSlicer refine numFeatures checking and toString method

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala
@@ -100,10 +100,10 @@ final class VectorSlicer @Since("1.5.0") (@Since("1.5.0") override val uid: Stri
     // Validity checks
     transformSchema(dataset.schema)
     val inputAttr = AttributeGroup.fromStructField(dataset.schema($(inputCol)))
-    inputAttr.numAttributes.foreach { numFeatures =>
+    if ($(indices).nonEmpty && inputAttr.size >= 0) {
       val maxIndex = $(indices).max
-      require(maxIndex < numFeatures,
-        s"Selected feature index $maxIndex invalid for only $numFeatures input features.")
+      require(maxIndex < inputAttr.size,
+        s"Selected feature index $maxIndex invalid for only ${inputAttr.size} input features.")
     }
 
     // Prepare output attributes
@@ -159,8 +159,13 @@ final class VectorSlicer @Since("1.5.0") (@Since("1.5.0") override val uid: Stri
 
   @Since("3.0.0")
   override def toString: String = {
-    s"VectorSlicer: uid=$uid" +
-      get(indices).map(i => s", numSelectedFeatures=${i.length}").getOrElse("")
+    val numSelectedFeatures =
+      get(indices).map(_.length).getOrElse(0) + get(names).map(_.length).getOrElse(0)
+    if (numSelectedFeatures > 0) {
+      s"VectorSlicer: uid=$uid, numSelectedFeatures=$numSelectedFeatures"
+    } else {
+      s"VectorSlicer: uid=$uid"
+    }
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala
@@ -19,7 +19,7 @@ package org.apache.spark.ml.feature
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.Transformer
-import org.apache.spark.ml.attribute.{Attribute, AttributeGroup}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param.{IntArrayParam, ParamMap, StringArrayParam}
 import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
@@ -100,15 +100,18 @@ final class VectorSlicer @Since("1.5.0") (@Since("1.5.0") override val uid: Stri
     // Validity checks
     transformSchema(dataset.schema)
     val inputAttr = AttributeGroup.fromStructField(dataset.schema($(inputCol)))
-    if ($(indices).nonEmpty && inputAttr.size >= 0) {
-      val maxIndex = $(indices).max
-      require(maxIndex < inputAttr.size,
-        s"Selected feature index $maxIndex invalid for only ${inputAttr.size} input features.")
+    if ($(indices).nonEmpty) {
+      val size = inputAttr.size
+      if (size >= 0) {
+        val maxIndex = $(indices).max
+        require(maxIndex < size,
+          s"Selected feature index $maxIndex invalid for only $size input features.")
+      }
     }
 
     // Prepare output attributes
     val inds = getSelectedFeatureIndices(dataset.schema)
-    val selectedAttrs: Option[Array[Attribute]] = inputAttr.attributes.map { attrs =>
+    val selectedAttrs = inputAttr.attributes.map { attrs =>
       inds.map(index => attrs(index))
     }
     val outputAttr = selectedAttrs match {


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, update checking of numFeatures;
2, update `toString` to take `names` into account;


### Why are the changes needed?
1, should use `inputAttr.size` instead of `inputAttr.numAttributes` to get numFeatures;
2, this checking is necessary only if `$(indices).nonEmpty`, otherwise, `$(indices).max` will throw exception java.lang.UnsupportedOperationException: empty.max
3, in toString, should add length of names;



### Does this PR introduce _any_ user-facing change?
Yes, toString now count `names`;


### How was this patch tested?
existing testsuites
