### PR TITLE
[SPARK-34257][SQL] Improve performance for last_value over unbounded window frame

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -573,6 +573,35 @@ class DataFrameWindowFunctionsSuite extends QueryTest
         Row("b", 2, null, null)))
   }
 
+  test("last without ignoreNulls") {
+    val nullStr: String = null
+    val df = Seq(
+      ("a", 0, nullStr),
+      ("a", 1, "x"),
+      ("a", 2, "y"),
+      ("a", 3, "z"),
+      ("a", 4, nullStr),
+      ("b", 1, nullStr),
+      ("b", 2, nullStr)).
+      toDF("key", "order", "value")
+    val window = Window.partitionBy($"key").orderBy($"order")
+      .rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
+    checkAnswer(
+      df.select(
+        $"key",
+        $"order",
+        $"value",
+        last($"value").over(window)),
+      Seq(
+        Row("a", 0, null, null),
+        Row("a", 1, "x", null),
+        Row("a", 2, "y", null),
+        Row("a", 3, "z", null),
+        Row("a", 4, null, null),
+        Row("b", 1, null, null),
+        Row("b", 2, null, null)))
+  }
+
   test("last/first with ignoreNulls") {
     val nullStr: String = null
     val df = Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current implement of `last_value` over unbounded window frame will execute `updateExpressions` multiple times.
In fact, `last_value` only execute `updateExpressions` once on the last row.


### Why are the changes needed?
Improve performance for last_value over unbounded window frame


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Jenkins test.
