### PR TITLE
[SPARK-34154][YARN] Extend LocalityPlacementStrategySuite's test with a timeout

### DIFF
--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/LocalityPlacementStrategySuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/LocalityPlacementStrategySuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.resource.ResourceProfile
 
 class LocalityPlacementStrategySuite extends SparkFunSuite {
 
-  (1 to 50).foreach(s => test(s"handle large number of containers and tasks (SPARK-18750) $s") {
+  (1 to 150).foreach(s => test(s"handle large number of containers and tasks (SPARK-18750) $s") {
     // Run the test in a thread with a small stack size, since the original issue
     // surfaced as a StackOverflowError.
     @volatile var error: Throwable = null

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/LocalityPlacementStrategySuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/LocalityPlacementStrategySuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.resource.ResourceProfile
 
 class LocalityPlacementStrategySuite extends SparkFunSuite {
 
-  (1 to 150).foreach(s => test(s"handle large number of containers and tasks (SPARK-18750) $s") {
+  test("handle large number of containers and tasks (SPARK-18750)") {
     // Run the test in a thread with a small stack size, since the original issue
     // surfaced as a StackOverflowError.
     @volatile var error: Throwable = null
@@ -46,7 +46,7 @@ class LocalityPlacementStrategySuite extends SparkFunSuite {
     val thread = new Thread(new ThreadGroup("test"), runnable, "test-thread", 256 * 1024)
     thread.setDaemon(true)
     thread.start()
-    val secondsToWait = 20
+    val secondsToWait = 30
     thread.join(secondsToWait * 1000)
     if (thread.isAlive()) {
       error = new RuntimeException(
@@ -60,7 +60,7 @@ class LocalityPlacementStrategySuite extends SparkFunSuite {
       error.printStackTrace(new PrintWriter(errors))
       fail(s"Failed with an exception or a timeout at thread join:\n\n$errors")
     }
-  })
+  }
 
   private def runTest(): Unit = {
     val yarnConf = new YarnConfiguration()

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/LocalityPlacementStrategySuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/LocalityPlacementStrategySuite.scala
@@ -30,10 +30,10 @@ import org.apache.spark.resource.ResourceProfile
 
 class LocalityPlacementStrategySuite extends SparkFunSuite {
 
-  test("handle large number of containers and tasks (SPARK-18750)") {
+  (1 to 50).foreach(s => test(s"handle large number of containers and tasks (SPARK-18750) $s") {
     // Run the test in a thread with a small stack size, since the original issue
     // surfaced as a StackOverflowError.
-    var error: Throwable = null
+    @volatile var error: Throwable = null
 
     val runnable = new Runnable() {
       override def run(): Unit = try {
@@ -44,15 +44,23 @@ class LocalityPlacementStrategySuite extends SparkFunSuite {
     }
 
     val thread = new Thread(new ThreadGroup("test"), runnable, "test-thread", 256 * 1024)
+    thread.setDaemon(true)
     thread.start()
-    thread.join()
+    val secondsToWait = 20
+    thread.join(secondsToWait * 1000)
+    if (thread.isAlive()) {
+      error = new RuntimeException(
+        "Timeout at waiting for thread to stop (its stack trace is added to the exception)")
+      error.setStackTrace(thread.getStackTrace)
+      thread.interrupt()
+    }
 
     if (error != null) {
       val errors = new StringWriter()
       error.printStackTrace(new PrintWriter(errors))
-      fail(s"StackOverflowError should not be thrown; however, got:\n\n$errors")
+      fail(s"Failed with an exception or a timeout at thread join:\n\n$errors")
     }
-  }
+  })
 
   private def runTest(): Unit = {
     val yarnConf = new YarnConfiguration()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends the `handle large number of containers and tasks (SPARK-18750)` test with a time limit and in case of timeout it saves the stack trace of the running thread to provide extra information about the reason why it got stuck.
 
### Why are the changes needed?

This is a flaky test which sometime runs for hours without stopping.  

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I checked it with a temporary code change: by adding a `Thread.sleep` to `LocalityPreferredContainerPlacementStrategy#expectedHostToContainerCount`. 

The stack trace showed the correct method:

```
[info] LocalityPlacementStrategySuite:
[info] - handle large number of containers and tasks (SPARK-18750) *** FAILED *** (30 seconds, 26 milliseconds)
[info]   Failed with an exception or a timeout at thread join:
[info]
[info]   java.lang.RuntimeException: Timeout at waiting for thread to stop (its stack trace is added to the exception)
[info]   	at java.lang.Thread.sleep(Native Method)
[info]   	at org.apache.spark.deploy.yarn.LocalityPreferredContainerPlacementStrategy.$anonfun$expectedHostToContainerCount$1(LocalityPreferredContainerPlacementStrategy.scala:198)
[info]   	at org.apache.spark.deploy.yarn.LocalityPreferredContainerPlacementStrategy$$Lambda$281/381161906.apply(Unknown Source)
[info]   	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238)
[info]   	at scala.collection.TraversableLike$$Lambda$16/322836221.apply(Unknown Source)
[info]   	at scala.collection.immutable.HashMap$HashMap1.foreach(HashMap.scala:234)
[info]   	at scala.collection.immutable.HashMap$HashTrieMap.foreach(HashMap.scala:468)
[info]   	at scala.collection.immutable.HashMap$HashTrieMap.foreach(HashMap.scala:468)
[info]   	at scala.collection.TraversableLike.map(TraversableLike.scala:238)
[info]   	at scala.collection.TraversableLike.map$(TraversableLike.scala:231)
[info]   	at scala.collection.AbstractTraversable.map(Traversable.scala:108)
[info]   	at org.apache.spark.deploy.yarn.LocalityPreferredContainerPlacementStrategy.expectedHostToContainerCount(LocalityPreferredContainerPlacementStrategy.scala:188)
[info]   	at org.apache.spark.deploy.yarn.LocalityPreferredContainerPlacementStrategy.localityOfRequestedContainers(LocalityPreferredContainerPlacementStrategy.scala:112)
[info]   	at org.apache.spark.deploy.yarn.LocalityPlacementStrategySuite.org$apache$spark$deploy$yarn$LocalityPlacementStrategySuite$$runTest(LocalityPlacementStrategySuite.scala:94)
[info]   	at org.apache.spark.deploy.yarn.LocalityPlacementStrategySuite$$anon$1.run(LocalityPlacementStrategySuite.scala:40)
[info]   	at java.lang.Thread.run(Thread.java:748) (LocalityPlacementStrategySuite.scala:61)
...
```
