### PR TITLE
[SPARK-34266][SQL][DOCS] Update comments for `SessionCatalog.refreshTable()` and `CatalogImpl.refreshTable()`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1000,7 +1000,7 @@ class SessionCatalog(
   /**
    * Refresh table entries in structures maintained by the session catalog such as:
    *   - The map of temporary or global temporary view names to their logical plans
-   *   - The relation cache which maps table/view identifiers to their logical plans
+   *   - The relation cache which maps table identifiers to their logical plans
    *
    * For temp views, it refreshes their logical plans, and as a consequence of that it can refresh
    * the file indexes of the base relations (`HadoopFsRelation` for instance) used in the views.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -998,7 +998,26 @@ class SessionCatalog(
   }
 
   /**
-   * Refresh the cache entry for a metastore table, if any.
+   * Refresh table entries in structures maintained by the session catalog such as:
+   *   - The map of temporary or global temporary view names to their logical plans
+   *   - The relation cache which maps table/view identifiers to their logical plans
+   *
+   * For temp views, it refreshes their logical plans, and as a consequence of that it can refresh
+   * the file indexes of the base relations (`HadoopFsRelation` for instance) used in the views.
+   * The method still keeps the views in the internal lists of session catalog.
+   *
+   * For tables/views, it removes their entries from the relation cache.
+   *
+   * The method is supposed to use in the following situations:
+   *   1. The logical plan of a table/view was changed, and cached table/view data is cleared
+   *      explicitly. For example, like in `AlterTableRenameCommand` which re-caches the table
+   *      itself. Otherwise if you need to re-fresh cached data, consider using of
+   *      `CatalogImpl.refreshTable()`.
+   *   2. A table/view doesn't exist, and need to only remove its entry in the relation cache since
+   *      the cached data is invalidated explicitly like in `DropTableCommand` which uncaches
+   *      table/view data itself.
+   *   3. Meta-data (such as file indexes) of any relation used in a temporary view should be
+   *      updated.
    */
   def refreshTable(name: TableIdentifier): Unit = synchronized {
     lookupTempView(name).map(_.refresh).getOrElse {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1011,7 +1011,7 @@ class SessionCatalog(
    * The method is supposed to use in the following situations:
    *   1. The logical plan of a table/view was changed, and cached table/view data is cleared
    *      explicitly. For example, like in `AlterTableRenameCommand` which re-caches the table
-   *      itself. Otherwise if you need to re-fresh cached data, consider using of
+   *      itself. Otherwise if you need to refresh cached data, consider using of
    *      `CatalogImpl.refreshTable()`.
    *   2. A table/view doesn't exist, and need to only remove its entry in the relation cache since
    *      the cached data is invalidated explicitly like in `DropTableCommand` which uncaches

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -524,7 +524,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *      Cached data is cleared while keeping the table/view and all its dependents are cached.
    *
    * The method does not do:
-   *   - schema inference for data source tables
+   *   - schema inference for file source tables
    *   - statistics update
    *
    * The method is supposed to use in all cases when need to refresh table/view data and meta-data.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -528,7 +528,8 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *   - schema inference for file source tables
    *   - statistics update
    *
-   * The method is supposed to use in all cases when need to refresh table/view data and meta-data.
+   * The method is supposed to be used in all cases when need to refresh table/view data
+   * and meta-data.
    *
    * @group cachemgmt
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -521,7 +521,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *   3. Table/View schema in the Hive Metastore if the SQL config
    *      `spark.sql.hive.caseSensitiveInferenceMode` is set to `INFER_AND_SAVE`.
    *   4. Cached data of the given table or view, and all its dependents that refer to it.
-   *      Cached data is cleared while keeping the table/view and all its dependents are cached.
+   *      Cached data is cleared while keeping the table/view and all its dependents as cached.
    *
    * The method does not do:
    *   - schema inference for file source tables

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -521,7 +521,8 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *   3. Table/View schema in the Hive Metastore if the SQL config
    *      `spark.sql.hive.caseSensitiveInferenceMode` is set to `INFER_AND_SAVE`.
    *   4. Cached data of the given table or view, and all its dependents that refer to it.
-   *      Cached data is cleared while keeping the table/view and all its dependents as cached.
+   *      Existing cached data will be cleared and the cache will be lazily filled when
+   *      the next time the table/view or the dependents are accessed.
    *
    * The method does not do:
    *   - schema inference for file source tables

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -515,14 +515,19 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
   }
 
   /**
-   * Invalidates and refreshes all the cached data and metadata of the given table or view.
-   * For Hive metastore table, the metadata is refreshed. For data source tables, the schema will
-   * not be inferred and refreshed.
+   * The method fully refreshes a table or view with the given name including:
+   *   1. The relation cache in the session catalog. The method remove table entry from the cache.
+   *   2. The file indexes of all relations used by the given view.
+   *   3. Table/View schema in the Hive Metastore if the SQL config
+   *      `spark.sql.hive.caseSensitiveInferenceMode` is set to `INFER_AND_SAVE`.
+   *   4. Cached data of the given table or view, and all its dependents that refer to it.
+   *      Cached data is cleared while keeping the table/view and all its dependents are cached.
    *
-   * If this table is cached as an InMemoryRelation, re-cache the table and its dependents lazily.
+   * The method does not do:
+   *   - schema inference for data source tables
+   *   - statistics update
    *
-   * In addition, refreshing a table also clear all caches that have reference to the table
-   * in a cascading manner. This is to prevent incorrect result from the otherwise staled caches.
+   * The method is supposed to use in all cases when need to refresh table/view data and meta-data.
    *
    * @group cachemgmt
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -516,7 +516,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
   /**
    * The method fully refreshes a table or view with the given name including:
-   *   1. The relation cache in the session catalog. The method remove table entry from the cache.
+   *   1. The relation cache in the session catalog. The method removes table entry from the cache.
    *   2. The file indexes of all relations used by the given view.
    *   3. Table/View schema in the Hive Metastore if the SQL config
    *      `spark.sql.hive.caseSensitiveInferenceMode` is set to `INFER_AND_SAVE`.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Describe `SessionCatalog.refreshTable()` and `CatalogImpl.refreshTable()`. what they do and when they are supposed to be used.

### Why are the changes needed?
To improve code maintenance.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running `./dev/scalastyle`