### PR TITLE
[SPARK-34260][SQL][2.4] Fix UnresolvedException when creating temp view twice

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -143,22 +143,22 @@ case class CreateViewCommand(
 
     val catalog = sparkSession.sessionState.catalog
     if (viewType == LocalTempView) {
+      val aliasedPlan = aliasPlan(sparkSession, analyzedPlan)
       if (replace && catalog.getTempView(name.table).isDefined &&
-          !catalog.getTempView(name.table).get.sameResult(child)) {
+          !catalog.getTempView(name.table).get.sameResult(aliasedPlan)) {
         logInfo(s"Try to uncache ${name.quotedString} before replacing.")
         CommandUtils.uncacheTableOrView(sparkSession, name.quotedString)
       }
-      val aliasedPlan = aliasPlan(sparkSession, analyzedPlan)
       catalog.createTempView(name.table, aliasedPlan, overrideIfExists = replace)
     } else if (viewType == GlobalTempView) {
+      val aliasedPlan = aliasPlan(sparkSession, analyzedPlan)
       if (replace && catalog.getGlobalTempView(name.table).isDefined &&
-          !catalog.getGlobalTempView(name.table).get.sameResult(child)) {
+          !catalog.getGlobalTempView(name.table).get.sameResult(aliasedPlan)) {
         val db = sparkSession.sessionState.conf.getConf(StaticSQLConf.GLOBAL_TEMP_DATABASE)
         val globalTempView = TableIdentifier(name.table, Option(db))
         logInfo(s"Try to uncache ${globalTempView.quotedString} before replacing.")
         CommandUtils.uncacheTableOrView(sparkSession, globalTempView.quotedString)
       }
-      val aliasedPlan = aliasPlan(sparkSession, analyzedPlan)
       catalog.createGlobalTempView(name.table, aliasedPlan, overrideIfExists = replace)
     } else if (catalog.tableExists(name)) {
       val tableMetadata = catalog.getTableMetadata(name)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -716,4 +716,21 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
       }
     }
   }
+
+  test("SPARK-34260: replace existing view using CREATE OR REPLACE") {
+    withTempView("testView") {
+      sql("CREATE TEMP VIEW testView AS SELECT * FROM (SELECT 1)")
+      checkAnswer(sql("SELECT * FROM testView"), Row(1))
+      sql("CREATE OR REPLACE TEMP VIEW testView AS SELECT * FROM (SELECT 2)")
+      checkAnswer(sql("SELECT * FROM testView"), Row(2))
+    }
+
+    val globalTempDB = spark.sharedState.globalTempViewManager.database
+    withTempView("testView") {
+      sql("CREATE GLOBAL TEMP VIEW testView AS SELECT * FROM (SELECT 1)")
+      checkAnswer(sql(s"SELECT * FROM $globalTempDB.testView"), Row(1))
+      sql("CREATE OR REPLACE GLOBAL TEMP VIEW testView AS SELECT * FROM (SELECT 2)")
+      checkAnswer(sql(s"SELECT * FROM $globalTempDB.testView"), Row(2))
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In PR #30140, it will compare new and old plans when replacing view and uncache data
if the view has changed. But the compared new plan is not analyzed which will cause
`UnresolvedException` when calling `sameResult`. So in this PR, we use the analyzed
plan to compare to fix this problem.


### Why are the changes needed?
bug fix


### Does this PR introduce _any_ user-facing change?
no 


### How was this patch tested?
newly added tests
