### PR TITLE
[SPARK-33212][FOLLOW-UP][BUILD] Fix test "built-in Hadoop version should support shaded client" for hadoop-2.7

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
@@ -81,7 +81,10 @@ class HadoopVersionInfoSuite extends SparkFunSuite {
     }
   }
 
-  test("SPARK-32212: built-in Hadoop version should support shaded client") {
-    assert(IsolatedClientLoader.supportsHadoopShadedClient(VersionInfo.getVersion))
+  test("SPARK-32212: built-in Hadoop version should support shaded client if it is not hadoop 2") {
+    val hadoopVersion = VersionInfo.getVersion
+    if (!hadoopVersion.startsWith("2")) {
+      assert(IsolatedClientLoader.supportsHadoopShadedClient(hadoopVersion))
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
We added test "built-in Hadoop version should support shaded client" in https://github.com/apache/spark/pull/31203, but it fails when profile hadoop-2.7 is activated. This change fixes the test by skipping the assertion when Hadoop version is 2.

### Why are the changes needed?
The test fails in master branch when profile hadoop-2.7 is activated.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Ran the test with hadoop-2.7 profile.