### PR TITLE
[SPARK-33599][SQL] Restore the assert-like in catalyst/analysis

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1022,8 +1022,8 @@ class Analyzer(override val catalogManager: CatalogManager)
           case u: UnresolvedRelation if !u.isStreaming =>
             lookupV2Relation(u.multipartIdentifier, u.options, false).map {
               case r: DataSourceV2Relation => write.withNewTable(r)
-              case other =>
-                throw QueryExecutionErrors.unexpectedPlanReturnError(other, "lookupV2Relation")
+              case other => throw new IllegalStateException(
+                "[BUG] unexpected plan returned by `lookupV2Relation`: " + other)
             }.getOrElse(write)
           case _ => write
         }
@@ -1134,8 +1134,8 @@ class Analyzer(override val catalogManager: CatalogManager)
                   throw QueryCompilationErrors.writeIntoV1TableNotAllowedError(
                     u.tableMeta.identifier, write)
                 case r: DataSourceV2Relation => write.withNewTable(r)
-                case other =>
-                  throw QueryExecutionErrors.unexpectedPlanReturnError(other, "lookupRelation")
+                case other => throw new IllegalStateException(
+                  "[BUG] unexpected plan returned by `lookupRelation`: " + other)
               }.getOrElse(write)
           case _ => write
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -96,7 +96,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
       case p if p.analyzed => // Skip already analyzed sub-plans
 
       case leaf: LeafNode if leaf.output.map(_.dataType).exists(CharVarcharUtils.hasCharVarchar) =>
-        throw QueryExecutionErrors.logicalPlanHaveOutputOfCharOrVarcharError(leaf)
+        throw new IllegalStateException(
+          "[BUG] logical plan should not have output of char/varchar type: " + leaf)
 
       case u: UnresolvedNamespace =>
         u.failAnalysis(s"Namespace not found: ${u.multipartIdentifier.quoted}")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -29,7 +29,6 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.UnresolvedGenerator
 import org.apache.spark.sql.catalyst.catalog.CatalogDatabase
 import org.apache.spark.sql.catalyst.expressions.{Expression, UnevaluableAggregate}
-import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
 import org.apache.spark.sql.types.{DataType, Decimal}
 import org.apache.spark.unsafe.array.ByteArrayMethods
 import org.apache.spark.unsafe.types.UTF8String

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -45,18 +45,9 @@ object QueryExecutionErrors {
     new UnsupportedOperationException("Please add an implementation for a column change here")
   }
 
-  def unexpectedPlanReturnError(plan: LogicalPlan, methodName: String): Throwable = {
-    new IllegalStateException(s"[BUG] unexpected plan returned by `$methodName`: $plan")
-  }
-
   def logicalHintOperatorNotRemovedDuringAnalysisError(): Throwable = {
     new IllegalStateException(
       "Internal error: logical hint operator should have been removed during analysis")
-  }
-
-  def logicalPlanHaveOutputOfCharOrVarcharError(leaf: LeafNode): Throwable = {
-    new IllegalStateException(
-      s"[BUG] logical plan should not have output of char/varchar type: $leaf")
   }
 
   def cannotEvaluateExpressionError(expression: Expression): Throwable = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
There exists some `Exception` for assert in fact. Such as:
`throw new IllegalStateException("[BUG] unexpected plan returned by `lookupV2Relation`: " + other)`

This kind `Exception` seems should not put in single dedicated files.


### Why are the changes needed?
Reduce the workload of auditing.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Jenkins test.
