### PR TITLE
[SPARK-34259][SQL] Don't attempt to parse file-based partitions as special timestamps

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -893,6 +893,16 @@ object DateTimeUtils {
   }
 
   /**
+   * Determines if the string is one of the notational shorthands for timestamps
+   *
+   * @param input A trimmed string
+   * @return true if the string matches one the of the notational shorthands
+   */
+  def isSpecialTimestamp(input: String): Boolean = {
+    convertSpecialTimestamp(input, ZoneId.systemDefault()).isDefined
+  }
+
+  /**
    * Converts notational shorthands that are converted to ordinary dates.
    *
    * @param input A trimmed string
@@ -907,6 +917,16 @@ object DateTimeUtils {
       case "yesterday" => Some(Math.subtractExact(currentDate(zoneId), 1))
       case _ => None
     }
+  }
+
+  /**
+   * Determines if the string is one of the notational shorthands for dates
+   *
+   * @param input A trimmed string
+   * @return true if the string matches one the of the notational shorthands
+   */
+  def isSpecialDate(input: String): Boolean = {
+    convertSpecialDate(input, ZoneId.systemDefault()).isDefined
   }
 
   private def convertSpecialDate(bytes: Array[Byte], zoneId: ZoneId): Option[Int] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -472,8 +472,8 @@ object PartitioningUtils {
       // the partition values with the right DataType (see
       // org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex.inferPartitioning)
       val dateValue = Cast(Literal(raw), DateType, Some(zoneId.getId)).eval()
-      // Disallow DateType if the cast returned null
-      require(dateValue != null)
+      // Disallow DateType if the cast returned null or if it's a special date
+      require(dateValue != null && !DateTimeUtils.isSpecialDate(raw.trim))
       Literal.create(dateValue, DateType)
     }
 
@@ -484,8 +484,8 @@ object PartitioningUtils {
       timestampFormatter.parse(unescapedRaw)
       // SPARK-23436: see comment for date
       val timestampValue = Cast(Literal(unescapedRaw), TimestampType, Some(zoneId.getId)).eval()
-      // Disallow TimestampType if the cast returned null
-      require(timestampValue != null)
+      // Disallow TimestampType if the cast returned null or if it's a special timestamp
+      require(timestampValue != null && DateTimeUtils.isSpecialTimestamp(raw.trim))
       Literal.create(timestampValue, TimestampType)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -485,7 +485,7 @@ object PartitioningUtils {
       // SPARK-23436: see comment for date
       val timestampValue = Cast(Literal(unescapedRaw), TimestampType, Some(zoneId.getId)).eval()
       // Disallow TimestampType if the cast returned null or if it's a special timestamp
-      require(timestampValue != null && DateTimeUtils.isSpecialTimestamp(raw.trim))
+      require(timestampValue != null && !DateTimeUtils.isSpecialTimestamp(raw.trim))
       Literal.create(timestampValue, TimestampType)
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -83,6 +83,8 @@ abstract class ParquetPartitionDiscoverySuite
       Literal.create(decimal, DecimalType(decimal.precision, decimal.scale)))
     check("1.5", Literal.create(1.5, DoubleType))
     check("hello", Literal.create("hello", StringType))
+    check("now", Literal.create("now", StringType))
+    check("TODAY", Literal.create("TODAY", StringType))
     check("1990-02-24", Literal.create(Date.valueOf("1990-02-24"), DateType))
     check("1990-02-24 12:00:30",
       Literal.create(Timestamp.valueOf("1990-02-24 12:00:30"), TimestampType))


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Added  `isSpecialTimestamp`  and `isSpecialDate` functions to `DatetimeUtils` so that we can determine if a string matches one of the shorthand date(time) notations (`now`, `today` etc). 
- Updated PartitioningUtils.inferPartitionColumnValue so that we don't infer date and time values if they match one of the shorthand notations.

### Why are the changes needed?
Previously, reading a partitioned dataset from file where one of the partition values matches a special date/timestamp (`NOW`, `TODAY` etc) caused the value to be interpreted as a date/timestamp rather than a string. This is incorrect for a number of reasons.  Specifically:

*  When a user writes a partition column of type string they do not expect to have it read back as type timestamp
*  The majority of these special values are dynamic.  This means that the same data yields different results depending on the time of day it is read etc.  Indeed in certain circumstances (specifically nested partitions) the same parition can end up with multiple distinct values in a given query as its value is evaluated at multiple points in time.
* Even if the the column as a whole is determined to be of type string, the special values are still parsed as timestamps .   This means you have a partitioning scheme where some partitions are being interpreted as strings while others are being interpreted as dates.

This change ensures that strings matching these shorthands are preserved as strings.    

### Does this PR introduce _any_ user-facing change?
Yes: any file-partitioned datasets possessing a string matching a special date/timestamp  as a partition key will have that value interpreted as a string rather than as a date/timestamp.

As an example, consider the following program:

```
import org.apache.spark.sql.SparkSession
import org.apache.spark.sql.functions._

object TestBug {

  def main(args: Array[String]): Unit = {
    val spark = SparkSession.builder().master("local[*]").getOrCreate()

    val df = spark.range(1, 2).withColumn("partition", lit("NOW"))
    df.write.mode("overwrite").partitionBy("partition").parquet("bug")
    
    spark.read.parquet("bug").show(truncate = false)
  }

}
```

Prior to this change, the output would be be of the form:

```
+---+--------------------------+
|id |partition |
+---+--------------------------+
|1 |2021-01-27 08:53:23.650039|
+---+--------------------------+
```

Following this change, the output is of the form:

```
+---+---------+
|id |partition|
+---+---------+
|1  |NOW      |
+---+---------+
```

### How was this patch tested?
* Extended  `column type inference` checks in ParquetPartitionDiscoverySuite to confirm that special date/timestamps where being correctly handled. 
* Ensured all existing tests pass