### PR TITLE
[SPARK-34300][PYSPARK][DOCS][MINOR] Fix some typos and syntax issues in docstrings and output of `dev/lint-python`

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -208,7 +208,7 @@ function sphinx_test {
     #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
     PYTHON_HAS_SPHINX_3_0=$("$PYTHON_EXECUTABLE" -c 'from distutils.version import LooseVersion; import sphinx; print(LooseVersion(sphinx.__version__) < LooseVersion("3.1.0"))')
     if [[ "$PYTHON_HAS_SPHINX_3_0" == "False" ]]; then
-        echo "$PYTHON_EXECUTABLE has Sphinx 3.1+ installed but it requires lower then 3.1. Skipping Sphinx build for now."
+        echo "$PYTHON_EXECUTABLE has Sphinx 3.1+ installed but it requires lower than 3.1. Skipping Sphinx build for now."
         echo
         return
     fi

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -37,7 +37,7 @@ def from_avro(data, jsonFormatSchema, options=None):
 
     Parameters
     ----------
-    data : :class:`pyspark.sql.Column` or str
+    data : :class:`~pyspark.sql.Column` or str
         the binary column.
     jsonFormatSchema : str
         the avro schema in JSON string format.
@@ -86,7 +86,7 @@ def to_avro(data, jsonFormatSchema=""):
 
     Parameters
     ----------
-    data : :class:`pyspark.sql.Column` or str
+    data : :class:`~pyspark.sql.Column` or str
         the data column.
     jsonFormatSchema : str, optional
         user-specified output avro schema in JSON string format.

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -37,7 +37,7 @@ def from_avro(data, jsonFormatSchema, options=None):
 
     Parameters
     ----------
-    data : :class:`Column` or str
+    data : :class:`pyspark.sql.Column` or str
         the binary column.
     jsonFormatSchema : str
         the avro schema in JSON string format.
@@ -86,7 +86,7 @@ def to_avro(data, jsonFormatSchema=""):
 
     Parameters
     ----------
-    data : :class:`Column` or str
+    data : :class:`pyspark.sql.Column` or str
         the data column.
     jsonFormatSchema : str, optional
         user-specified output avro schema in JSON string format.

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -52,7 +52,7 @@ def _get_get_jvm_function(name, sc):
 def _invoke_function(name, *args):
     """
     Invokes JVM function identified by name with args
-    and wraps the result with :class:`pyspark.sql.Column`.
+    and wraps the result with :class:`~pyspark.sql.Column`.
     """
     jf = _get_get_jvm_function(name, SparkContext._active_spark_context)
     return Column(jf(*args))
@@ -61,7 +61,7 @@ def _invoke_function(name, *args):
 def _invoke_function_over_column(name, col):
     """
     Invokes unary JVM function identified by name
-    and wraps the result with :class:`pyspark.sql.Column`.
+    and wraps the result with :class:`~pyspark.sql.Column`.
     """
     return _invoke_function(name, _to_java_column(col))
 
@@ -69,7 +69,7 @@ def _invoke_function_over_column(name, col):
 def _invoke_binary_math_function(name, col1, col2):
     """
     Invokes binary JVM math function identified by name
-    and wraps the result with :class:`pyspark.sql.Column`.
+    and wraps the result with :class:`~pyspark.sql.Column`.
     """
     return _invoke_function(
         name,
@@ -88,7 +88,7 @@ def _options_to_str(options=None):
 
 def lit(col):
     """
-    Creates a :class:`pyspark.sql.Column` of literal value.
+    Creates a :class:`~pyspark.sql.Column` of literal value.
 
     .. versionadded:: 1.3.0
 
@@ -103,7 +103,7 @@ def lit(col):
 @since(1.3)
 def col(col):
     """
-    Returns a :class:`pyspark.sql.Column` based on the given column name.'
+    Returns a :class:`~pyspark.sql.Column` based on the given column name.'
     """
     return _invoke_function("col", col)
 
@@ -111,7 +111,7 @@ def col(col):
 @since(1.3)
 def column(col):
     """
-    Returns a :class:`pyspark.sql.Column` based on the given column name.'
+    Returns a :class:`~pyspark.sql.Column` based on the given column name.'
     """
     return col(col)
 
@@ -216,7 +216,7 @@ def acos(col):
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         inverse cosine of `col`, as if computed by `java.lang.Math.acos()`
     """
     return _invoke_function_over_column("acos", col)
@@ -230,7 +230,7 @@ def acosh(col):
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
     """
     return _invoke_function_over_column("acosh", col)
 
@@ -242,7 +242,7 @@ def asin(col):
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         inverse sine of `col`, as if computed by `java.lang.Math.asin()`
     """
     return _invoke_function_over_column("asin", col)
@@ -256,7 +256,7 @@ def asinh(col):
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
     """
     return _invoke_function_over_column("asinh", col)
 
@@ -267,7 +267,7 @@ def atan(col):
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         inverse tangent of `col`, as if computed by `java.lang.Math.atan()`
     """
     return _invoke_function_over_column("atan", col)
@@ -281,7 +281,7 @@ def atanh(col):
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
     """
     return _invoke_function_over_column("atanh", col)
 
@@ -308,12 +308,12 @@ def cos(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         angle in radians
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         cosine of the angle, as if computed by `java.lang.Math.cos()`.
     """
     return _invoke_function_over_column("cos", col)
@@ -325,12 +325,12 @@ def cosh(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         hyperbolic angle
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         hyperbolic cosine of the angle, as if computed by `java.lang.Math.cosh()`
     """
     return _invoke_function_over_column("cosh", col)
@@ -407,11 +407,11 @@ def sin(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         sine of the angle, as if computed by `java.lang.Math.sin()`
     """
     return _invoke_function_over_column("sin", col)
@@ -423,12 +423,12 @@ def sinh(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         hyperbolic angle
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         hyperbolic sine of the given value,
         as if computed by `java.lang.Math.sinh()`
     """
@@ -441,12 +441,12 @@ def tan(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         angle in radians
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         tangent of the given value, as if computed by `java.lang.Math.tan()`
     """
     return _invoke_function_over_column("tan", col)
@@ -458,12 +458,12 @@ def tanh(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         hyperbolic angle
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         hyperbolic tangent of the given value
         as if computed by `java.lang.Math.tanh()`
     """
@@ -662,12 +662,12 @@ def degrees(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         angle in radians
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         angle in degrees, as if computed by `java.lang.Math.toDegrees()`
     """
     return _invoke_function_over_column("degrees", col)
@@ -682,12 +682,12 @@ def radians(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         angle in degrees
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         angle in radians, as if computed by `java.lang.Math.toRadians()`
     """
     return _invoke_function_over_column("radians", col)
@@ -699,14 +699,14 @@ def atan2(col1, col2):
 
     Parameters
     ----------
-    col1 : str, :class:`pyspark.sql.Column` or float
+    col1 : str, :class:`~pyspark.sql.Column` or float
         coordinate on y-axis
-    col2 : str, :class:`pyspark.sql.Column` or float
+    col2 : str, :class:`~pyspark.sql.Column` or float
         coordinate on x-axis
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
         the `theta` component of the point
         (`r`, `theta`)
         in polar coordinates that corresponds to the point
@@ -800,14 +800,14 @@ def approxCountDistinct(col, rsd=None):
 
 
 def approx_count_distinct(col, rsd=None):
-    """Aggregate function: returns a new :class:`pyspark.sql.Column` for approximate distinct count
+    """Aggregate function: returns a new :class:`~pyspark.sql.Column` for approximate distinct count
     of column `col`.
 
     .. versionadded:: 2.1.0
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
     rsd : float, optional
         maximum relative standard deviation allowed (default = 0.05).
         For rsd < 0.01, it is more efficient to use :func:`countDistinct`
@@ -874,7 +874,7 @@ def coalesce(*cols):
 
 
 def corr(col1, col2):
-    """Returns a new :class:`pyspark.sql.Column` for the Pearson Correlation Coefficient for
+    """Returns a new :class:`~pyspark.sql.Column` for the Pearson Correlation Coefficient for
     ``col1`` and ``col2``.
 
     .. versionadded:: 1.6.0
@@ -892,7 +892,7 @@ def corr(col1, col2):
 
 
 def covar_pop(col1, col2):
-    """Returns a new :class:`pyspark.sql.Column` for the population covariance of ``col1`` and
+    """Returns a new :class:`~pyspark.sql.Column` for the population covariance of ``col1`` and
     ``col2``.
 
     .. versionadded:: 2.0.0
@@ -910,7 +910,8 @@ def covar_pop(col1, col2):
 
 
 def covar_samp(col1, col2):
-    """Returns a new :class:`pyspark.sql.Column` for the sample covariance of ``col1`` and ``col2``.
+    """Returns a new :class:`~pyspark.sql.Column` for the sample covariance of ``col1`` and
+    ``col2``.
 
     .. versionadded:: 2.0.0
 
@@ -927,7 +928,7 @@ def covar_samp(col1, col2):
 
 
 def countDistinct(col, *cols):
-    """Returns a new :class:`pyspark.sql.Column` for distinct count of ``col`` or ``cols``.
+    """Returns a new :class:`~pyspark.sql.Column` for distinct count of ``col`` or ``cols``.
 
     .. versionadded:: 1.3.0
 
@@ -1335,8 +1336,8 @@ def struct(*cols):
 
     Parameters
     ----------
-    cols : list, set, str or :class:`pyspark.sql.Column`
-        column names or :class:`pyspark.sql.Column`\\s to contain in the output struct.
+    cols : list, set, str or :class:`~pyspark.sql.Column`
+        column names or :class:`~pyspark.sql.Column`\\s to contain in the output struct.
 
     Examples
     --------
@@ -1399,10 +1400,10 @@ def when(condition, value):
 
     Parameters
     ----------
-    condition : :class:`pyspark.sql.Column`
-        a boolean :class:`pyspark.sql.Column` expression.
+    condition : :class:`~pyspark.sql.Column`
+        a boolean :class:`~pyspark.sql.Column` expression.
     value :
-        a literal value, or a :class:`pyspark.sql.Column` expression.
+        a literal value, or a :class:`~pyspark.sql.Column` expression.
 
     >>> df.select(when(df['age'] == 2, 3).otherwise(4).alias("age")).collect()
     [Row(age=3), Row(age=4)]
@@ -1501,7 +1502,7 @@ def lag(col, offset=1, default=None):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     offset : int, optional
         number of row to extend
@@ -1524,7 +1525,7 @@ def lead(col, offset=1, default=None):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     offset : int, optional
         number of row to extend
@@ -1549,7 +1550,7 @@ def nth_value(col, offset, ignoreNulls=False):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     offset : int, optional
         number of row to use as the value
@@ -1876,7 +1877,7 @@ def months_between(date1, date2, roundOff=True):
 
 
 def to_date(col, format=None):
-    """Converts a :class:`pyspark.sql.Column` into :class:`pyspark.sql.types.DateType`
+    """Converts a :class:`~pyspark.sql.Column` into :class:`pyspark.sql.types.DateType`
     using the optionally specified format. Specify formats according to `datetime pattern`_.
     By default, it follows casting rules to :class:`pyspark.sql.types.DateType` if the format
     is omitted. Equivalent to ``col.cast("date")``.
@@ -1904,7 +1905,7 @@ def to_date(col, format=None):
 
 
 def to_timestamp(col, format=None):
-    """Converts a :class:`pyspark.sql.Column` into :class:`pyspark.sql.types.TimestampType`
+    """Converts a :class:`~pyspark.sql.Column` into :class:`pyspark.sql.types.TimestampType`
     using the optionally specified format. Specify formats according to `datetime pattern`_.
     By default, it follows casting rules to :class:`pyspark.sql.types.TimestampType` if the format
     is omitted. Equivalent to ``col.cast("timestamp")``.
@@ -1939,7 +1940,7 @@ def trunc(date, format):
 
     Parameters
     ----------
-    date : :class:`pyspark.sql.Column` or str
+    date : :class:`~pyspark.sql.Column` or str
     format : str
         'year', 'yyyy', 'yy' or 'month', 'mon', 'mm'
 
@@ -1966,7 +1967,7 @@ def date_trunc(format, timestamp):
     format : str
         'year', 'yyyy', 'yy', 'month', 'mon', 'mm',
         'day', 'dd', 'hour', 'minute', 'second', 'week', 'quarter'
-    timestamp : :class:`pyspark.sql.Column` or str
+    timestamp : :class:`~pyspark.sql.Column` or str
 
     Examples
     --------
@@ -2078,9 +2079,9 @@ def from_utc_timestamp(timestamp, tz):
 
     Parameters
     ----------
-    timestamp : :class:`pyspark.sql.Column` or str
+    timestamp : :class:`~pyspark.sql.Column` or str
         the column that contains timestamps
-    tz : :class:`pyspark.sql.Column` or str
+    tz : :class:`~pyspark.sql.Column` or str
         A string detailing the time zone ID that the input should be adjusted to. It should
         be in the format of either region-based zone IDs or zone offsets. Region IDs must
         have the form 'area/city', such as 'America/Los_Angeles'. Zone offsets must be in
@@ -2089,7 +2090,7 @@ def from_utc_timestamp(timestamp, tz):
         because they can be ambiguous.
 
         .. versionchanged:: 2.4
-           `tz` can take a :class:`pyspark.sql.Column` containing timezone ID strings.
+           `tz` can take a :class:`~pyspark.sql.Column` containing timezone ID strings.
 
     Examples
     --------
@@ -2124,9 +2125,9 @@ def to_utc_timestamp(timestamp, tz):
 
     Parameters
     ----------
-    timestamp : :class:`pyspark.sql.Column` or str
+    timestamp : :class:`~pyspark.sql.Column` or str
         the column that contains timestamps
-    tz : :class:`pyspark.sql.Column` or str
+    tz : :class:`~pyspark.sql.Column` or str
         A string detailing the time zone ID that the input should be adjusted to. It should
         be in the format of either region-based zone IDs or zone offsets. Region IDs must
         have the form 'area/city', such as 'America/Los_Angeles'. Zone offsets must be in
@@ -2135,7 +2136,7 @@ def to_utc_timestamp(timestamp, tz):
         because they can be ambiguous.
 
         .. versionchanged:: 2.4.0
-           `tz` can take a :class:`pyspark.sql.Column` containing timezone ID strings.
+           `tz` can take a :class:`~pyspark.sql.Column` containing timezone ID strings.
 
     Examples
     --------
@@ -2489,7 +2490,7 @@ def format_number(col, d):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         the column name of the numeric value to be formatted
     d : int
         the N decimal places
@@ -2511,8 +2512,8 @@ def format_string(format, *cols):
     ----------
     format : str
         string that can contain embedded format tags and used as result column's value
-    cols : :class:`pyspark.sql.Column` or str
-        column names or :class:`pyspark.sql.Column`\\s to be used in formatting
+    cols : :class:`~pyspark.sql.Column` or str
+        column names or :class:`~pyspark.sql.Column`\\s to be used in formatting
 
     Examples
     --------
@@ -2650,7 +2651,7 @@ def locate(substr, str, pos=1):
     ----------
     substr : str
         a string
-    str : :class:`pyspark.sql.Column` or str
+    str : :class:`~pyspark.sql.Column` or str
         a Column of :class:`pyspark.sql.types.StringType`
     pos : int, optional
         start position (zero based)
@@ -2726,7 +2727,7 @@ def split(str, pattern, limit=-1):
 
     Parameters
     ----------
-    str : :class:`pyspark.sql.Column` or str
+    str : :class:`~pyspark.sql.Column` or str
         a string expression to split
     pattern : str
         a string representing a regular expression. The regex string should be
@@ -2914,8 +2915,8 @@ def create_map(*cols):
 
     Parameters
     ----------
-    cols : :class:`pyspark.sql.Column` or str
-        column names or :class:`pyspark.sql.Column`\\s that are
+    cols : :class:`~pyspark.sql.Column` or str
+        column names or :class:`~pyspark.sql.Column`\\s that are
         grouped as key-value pairs, e.g. (key1, value1, key2, value2, ...).
 
     Examples
@@ -2939,9 +2940,9 @@ def map_from_arrays(col1, col2):
 
     Parameters
     ----------
-    col1 : :class:`pyspark.sql.Column` or str
+    col1 : :class:`~pyspark.sql.Column` or str
         name of column containing a set of keys. All elements should not be null
-    col2 : :class:`pyspark.sql.Column` or str
+    col2 : :class:`~pyspark.sql.Column` or str
         name of column containing a set of values
 
     Examples
@@ -2965,8 +2966,8 @@ def array(*cols):
 
     Parameters
     ----------
-    cols : :class:`pyspark.sql.Column` or str
-        column names or :class:`pyspark.sql.Column`\\s that have
+    cols : :class:`~pyspark.sql.Column` or str
+        column names or :class:`~pyspark.sql.Column`\\s that have
         the same data type.
 
     Examples
@@ -2992,7 +2993,7 @@ def array_contains(col, value):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column containing array
     value :
         value or column to check for in array
@@ -3037,11 +3038,11 @@ def slice(x, start, length):
 
     Parameters
     ----------
-    x : :class:`pyspark.sql.Column` or str
+    x : :class:`~pyspark.sql.Column` or str
         the array to be sliced
-    start : :class:`pyspark.sql.Column` or int
+    start : :class:`~pyspark.sql.Column` or int
         the starting index
-    length : :class:`pyspark.sql.Column` or int
+    length : :class:`~pyspark.sql.Column` or int
         the length of the slice
 
     Examples
@@ -3133,7 +3134,7 @@ def element_at(col, extraction):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column containing array or map
     extraction :
         index to check for in array or key to check for in map
@@ -3165,7 +3166,7 @@ def array_remove(col, element):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column containing array
     element :
         element to be removed from the array
@@ -3188,7 +3189,7 @@ def array_distinct(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3210,9 +3211,9 @@ def array_intersect(col1, col2):
 
     Parameters
     ----------
-    col1 : :class:`pyspark.sql.Column` or str
+    col1 : :class:`~pyspark.sql.Column` or str
         name of column containing array
-    col2 : :class:`pyspark.sql.Column` or str
+    col2 : :class:`~pyspark.sql.Column` or str
         name of column containing array
 
     Examples
@@ -3235,9 +3236,9 @@ def array_union(col1, col2):
 
     Parameters
     ----------
-    col1 : :class:`pyspark.sql.Column` or str
+    col1 : :class:`~pyspark.sql.Column` or str
         name of column containing array
-    col2 : :class:`pyspark.sql.Column` or str
+    col2 : :class:`~pyspark.sql.Column` or str
         name of column containing array
 
     Examples
@@ -3260,9 +3261,9 @@ def array_except(col1, col2):
 
     Parameters
     ----------
-    col1 : :class:`pyspark.sql.Column` or str
+    col1 : :class:`~pyspark.sql.Column` or str
         name of column containing array
-    col2 : :class:`pyspark.sql.Column` or str
+    col2 : :class:`~pyspark.sql.Column` or str
         name of column containing array
 
     Examples
@@ -3416,7 +3417,7 @@ def get_json_object(col, path):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         string column in json format
     path : str
         path to the json object to extract
@@ -3441,7 +3442,7 @@ def json_tuple(col, *fields):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         string column in json format
     fields : str
         fields to extract
@@ -3468,7 +3469,7 @@ def from_json(col, schema, options=None):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         string column in json format
     schema : :class:`DataType` or str
         a StructType or ArrayType of StructType to use when parsing the json column.
@@ -3523,7 +3524,7 @@ def to_json(col, options=None):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column containing a struct, an array or a map.
     options : dict, optional
         options to control converting. accepts the same options as the JSON datasource.
@@ -3569,7 +3570,7 @@ def schema_of_json(json, options=None):
 
     Parameters
     ----------
-    json : :class:`pyspark.sql.Column` or str
+    json : :class:`~pyspark.sql.Column` or str
         a JSON string or a foldable string column containing a JSON string.
     options : dict, optional
         options to control parsing. accepts the same options as the JSON datasource
@@ -3606,7 +3607,7 @@ def schema_of_csv(csv, options=None):
 
     Parameters
     ----------
-    csv : :class:`pyspark.sql.Column` or str
+    csv : :class:`~pyspark.sql.Column` or str
         a CSV string or a foldable string column containing a CSV string.
     options : dict, optional
         options to control parsing. accepts the same options as the CSV datasource
@@ -3640,7 +3641,7 @@ def to_csv(col, options=None):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column containing a struct.
     options: dict, optional
         options to control converting. accepts the same options as the CSV datasource.
@@ -3667,7 +3668,7 @@ def size(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3688,7 +3689,7 @@ def array_min(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3709,7 +3710,7 @@ def array_max(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3733,7 +3734,7 @@ def sort_array(col, asc=True):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     asc : bool, optional
 
@@ -3758,7 +3759,7 @@ def array_sort(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3779,7 +3780,7 @@ def shuffle(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Notes
@@ -3804,7 +3805,7 @@ def reverse(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3830,7 +3831,7 @@ def flatten(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3851,7 +3852,7 @@ def map_keys(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3877,7 +3878,7 @@ def map_values(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3903,7 +3904,7 @@ def map_entries(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3929,7 +3930,7 @@ def map_from_entries(col):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3975,7 +3976,7 @@ def arrays_zip(*cols):
 
     Parameters
     ----------
-    cols : :class:`pyspark.sql.Column` or str
+    cols : :class:`~pyspark.sql.Column` or str
         columns of arrays to be merged.
 
     Examples
@@ -3996,8 +3997,8 @@ def map_concat(*cols):
 
     Parameters
     ----------
-    cols : :class:`pyspark.sql.Column` or str
-        column names or :class:`pyspark.sql.Column`\\s
+    cols : :class:`~pyspark.sql.Column` or str
+        column names or :class:`~pyspark.sql.Column`\\s
 
     Examples
     --------
@@ -4051,9 +4052,9 @@ def from_csv(col, schema, options=None):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         string column in CSV format
-    schema :class:`pyspark.sql.Column` or str
+    schema :class:`~pyspark.sql.Column` or str
         a string with schema in DDL format to use when parsing the CSV column.
     options : dict, optional
         options to control parsing. accepts the same options as the CSV datasource
@@ -4198,7 +4199,7 @@ def transform(col, f):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     f : function
         a function that is applied to each element of the input array.
@@ -4208,14 +4209,14 @@ def transform(col, f):
         - Binary ``(x: Column, i: Column) -> Column...``, where the second argument is
             a 0-based index of the element.
 
-        and can use methods of :class:`pyspark.sql.Column`, functions defined in
+        and can use methods of :class:`~pyspark.sql.Column`, functions defined in
         :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
         Python ``UserDefinedFunctions`` are not supported
         (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
 
     Examples
     --------
@@ -4247,15 +4248,15 @@ def exists(col, f):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     f : function
         ``(x: Column) -> Column: ...``  returning the Boolean expression.
-        Can use methods of :class:`pyspark.sql.Column`, functions defined in
+        Can use methods of :class:`~pyspark.sql.Column`, functions defined in
         :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
         Python ``UserDefinedFunctions`` are not supported
         (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
-    :return: a :class:`pyspark.sql.Column`
+    :return: a :class:`~pyspark.sql.Column`
 
     Examples
     --------
@@ -4279,18 +4280,18 @@ def forall(col, f):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     f : function
         ``(x: Column) -> Column: ...``  returning the Boolean expression.
-        Can use methods of :class:`pyspark.sql.Column`, functions defined in
+        Can use methods of :class:`~pyspark.sql.Column`, functions defined in
         :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
         Python ``UserDefinedFunctions`` are not supported
         (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
 
     Examples
     --------
@@ -4318,7 +4319,7 @@ def filter(col, f):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     f : function
         A function that returns the Boolean expression.
@@ -4328,14 +4329,14 @@ def filter(col, f):
         - Binary ``(x: Column, i: Column) -> Column...``, where the second argument is
             a 0-based index of the element.
 
-        and can use methods of :class:`pyspark.sql.Column`, functions defined in
+        and can use methods of :class:`~pyspark.sql.Column`, functions defined in
         :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
         Python ``UserDefinedFunctions`` are not supported
         (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
 
     Examples
     --------
@@ -4363,7 +4364,7 @@ def aggregate(col, initialValue, merge, finish=None):
     and reduces this to a single state. The final state is converted into the final result
     by applying a finish function.
 
-    Both functions can use methods of :class:`pyspark.sql.Column`, functions defined in
+    Both functions can use methods of :class:`~pyspark.sql.Column`, functions defined in
     :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
     Python ``UserDefinedFunctions`` are not supported
     (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
@@ -4372,9 +4373,9 @@ def aggregate(col, initialValue, merge, finish=None):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
-    initialValue : :class:`pyspark.sql.Column` or str
+    initialValue : :class:`~pyspark.sql.Column` or str
         initial value. Name of column or expression
     merge : function
         a binary function ``(acc: Column, x: Column) -> Column...`` returning expression
@@ -4385,7 +4386,7 @@ def aggregate(col, initialValue, merge, finish=None):
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
 
     Examples
     --------
@@ -4440,20 +4441,20 @@ def zip_with(left, right, f):
 
     Parameters
     ----------
-    left : :class:`pyspark.sql.Column` or str
+    left : :class:`~pyspark.sql.Column` or str
         name of the first column or expression
-    right : :class:`pyspark.sql.Column` or str
+    right : :class:`~pyspark.sql.Column` or str
         name of the second column or expression
     f : function
         a binary function ``(x1: Column, x2: Column) -> Column...``
-        Can use methods of :class:`pyspark.sql.Column`, functions defined in
+        Can use methods of :class:`~pyspark.sql.Column`, functions defined in
         :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
         Python ``UserDefinedFunctions`` are not supported
         (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
 
     Examples
     --------
@@ -4485,18 +4486,18 @@ def transform_keys(col, f):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     f : function
         a binary function ``(k: Column, v: Column) -> Column...``
-        Can use methods of :class:`pyspark.sql.Column`, functions defined in
+        Can use methods of :class:`~pyspark.sql.Column`, functions defined in
         :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
         Python ``UserDefinedFunctions`` are not supported
         (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
 
     Examples
     --------
@@ -4522,18 +4523,18 @@ def transform_values(col, f):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     f : function
         a binary function ``(k: Column, v: Column) -> Column...``
-        Can use methods of :class:`pyspark.sql.Column`, functions defined in
+        Can use methods of :class:`~pyspark.sql.Column`, functions defined in
         :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
         Python ``UserDefinedFunctions`` are not supported
         (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
 
     Examples
     --------
@@ -4558,18 +4559,18 @@ def map_filter(col, f):
 
     Parameters
     ----------
-    col : :class:`pyspark.sql.Column` or str
+    col : :class:`~pyspark.sql.Column` or str
         name of column or expression
     f : function
         a binary function ``(k: Column, v: Column) -> Column...``
-        Can use methods of :class:`pyspark.sql.Column`, functions defined in
+        Can use methods of :class:`~pyspark.sql.Column`, functions defined in
         :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
         Python ``UserDefinedFunctions`` are not supported
         (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
 
     Examples
     --------
@@ -4594,20 +4595,20 @@ def map_zip_with(col1, col2, f):
 
     Parameters
     ----------
-    col1 : :class:`pyspark.sql.Column` or str
+    col1 : :class:`~pyspark.sql.Column` or str
         name of the first column or expression
-    col2 : :class:`pyspark.sql.Column` or str
+    col2 : :class:`~pyspark.sql.Column` or str
         name of the second column or expression
     f : function
         a ternary function ``(k: Column, v1: Column, v2: Column) -> Column...``
-        Can use methods of :class:`pyspark.sql.Column`, functions defined in
+        Can use methods of :class:`~pyspark.sql.Column`, functions defined in
         :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
         Python ``UserDefinedFunctions`` are not supported
         (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
 
     Returns
     -------
-    :class:`pyspark.sql.Column`
+    :class:`~pyspark.sql.Column`
 
     Examples
     --------

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -52,7 +52,7 @@ def _get_get_jvm_function(name, sc):
 def _invoke_function(name, *args):
     """
     Invokes JVM function identified by name with args
-    and wraps the result with :class:`Column`.
+    and wraps the result with :class:`pyspark.sql.Column`.
     """
     jf = _get_get_jvm_function(name, SparkContext._active_spark_context)
     return Column(jf(*args))
@@ -61,7 +61,7 @@ def _invoke_function(name, *args):
 def _invoke_function_over_column(name, col):
     """
     Invokes unary JVM function identified by name
-    and wraps the result with :class:`Column`.
+    and wraps the result with :class:`pyspark.sql.Column`.
     """
     return _invoke_function(name, _to_java_column(col))
 
@@ -69,7 +69,7 @@ def _invoke_function_over_column(name, col):
 def _invoke_binary_math_function(name, col1, col2):
     """
     Invokes binary JVM math function identified by name
-    and wraps the result with :class:`Column`.
+    and wraps the result with :class:`pyspark.sql.Column`.
     """
     return _invoke_function(
         name,
@@ -88,7 +88,7 @@ def _options_to_str(options=None):
 
 def lit(col):
     """
-    Creates a :class:`Column` of literal value.
+    Creates a :class:`pyspark.sql.Column` of literal value.
 
     .. versionadded:: 1.3.0
 
@@ -103,7 +103,7 @@ def lit(col):
 @since(1.3)
 def col(col):
     """
-    Returns a :class:`Column` based on the given column name.'
+    Returns a :class:`pyspark.sql.Column` based on the given column name.'
     """
     return _invoke_function("col", col)
 
@@ -111,7 +111,7 @@ def col(col):
 @since(1.3)
 def column(col):
     """
-    Returns a :class:`Column` based on the given column name.'
+    Returns a :class:`pyspark.sql.Column` based on the given column name.'
     """
     return col(col)
 
@@ -216,7 +216,7 @@ def acos(col):
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         inverse cosine of `col`, as if computed by `java.lang.Math.acos()`
     """
     return _invoke_function_over_column("acos", col)
@@ -230,7 +230,7 @@ def acosh(col):
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
     """
     return _invoke_function_over_column("acosh", col)
 
@@ -242,7 +242,7 @@ def asin(col):
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         inverse sine of `col`, as if computed by `java.lang.Math.asin()`
     """
     return _invoke_function_over_column("asin", col)
@@ -256,7 +256,7 @@ def asinh(col):
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
     """
     return _invoke_function_over_column("asinh", col)
 
@@ -267,7 +267,7 @@ def atan(col):
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         inverse tangent of `col`, as if computed by `java.lang.Math.atan()`
     """
     return _invoke_function_over_column("atan", col)
@@ -281,7 +281,7 @@ def atanh(col):
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
     """
     return _invoke_function_over_column("atanh", col)
 
@@ -308,12 +308,12 @@ def cos(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         angle in radians
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         cosine of the angle, as if computed by `java.lang.Math.cos()`.
     """
     return _invoke_function_over_column("cos", col)
@@ -325,12 +325,12 @@ def cosh(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         hyperbolic angle
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         hyperbolic cosine of the angle, as if computed by `java.lang.Math.cosh()`
     """
     return _invoke_function_over_column("cosh", col)
@@ -407,11 +407,11 @@ def sin(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         sine of the angle, as if computed by `java.lang.Math.sin()`
     """
     return _invoke_function_over_column("sin", col)
@@ -423,12 +423,12 @@ def sinh(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         hyperbolic angle
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         hyperbolic sine of the given value,
         as if computed by `java.lang.Math.sinh()`
     """
@@ -441,12 +441,12 @@ def tan(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         angle in radians
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         tangent of the given value, as if computed by `java.lang.Math.tan()`
     """
     return _invoke_function_over_column("tan", col)
@@ -458,12 +458,12 @@ def tanh(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         hyperbolic angle
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         hyperbolic tangent of the given value
         as if computed by `java.lang.Math.tanh()`
     """
@@ -662,12 +662,12 @@ def degrees(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         angle in radians
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         angle in degrees, as if computed by `java.lang.Math.toDegrees()`
     """
     return _invoke_function_over_column("degrees", col)
@@ -682,12 +682,12 @@ def radians(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         angle in degrees
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         angle in radians, as if computed by `java.lang.Math.toRadians()`
     """
     return _invoke_function_over_column("radians", col)
@@ -699,14 +699,14 @@ def atan2(col1, col2):
 
     Parameters
     ----------
-    col1 : str, :class:`Column` or float
+    col1 : str, :class:`pyspark.sql.Column` or float
         coordinate on y-axis
-    col2 : str, :class:`Column` or float
+    col2 : str, :class:`pyspark.sql.Column` or float
         coordinate on x-axis
 
     Returns
     -------
-    :class:`Column`
+    :class:`pyspark.sql.Column`
         the `theta` component of the point
         (`r`, `theta`)
         in polar coordinates that corresponds to the point
@@ -800,14 +800,14 @@ def approxCountDistinct(col, rsd=None):
 
 
 def approx_count_distinct(col, rsd=None):
-    """Aggregate function: returns a new :class:`Column` for approximate distinct count of
-    column `col`.
+    """Aggregate function: returns a new :class:`pyspark.sql.Column` for approximate distinct count
+    of column `col`.
 
     .. versionadded:: 2.1.0
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
     rsd : float, optional
         maximum relative standard deviation allowed (default = 0.05).
         For rsd < 0.01, it is more efficient to use :func:`countDistinct`
@@ -874,8 +874,8 @@ def coalesce(*cols):
 
 
 def corr(col1, col2):
-    """Returns a new :class:`Column` for the Pearson Correlation Coefficient for ``col1``
-    and ``col2``.
+    """Returns a new :class:`pyspark.sql.Column` for the Pearson Correlation Coefficient for
+    ``col1`` and ``col2``.
 
     .. versionadded:: 1.6.0
 
@@ -892,7 +892,8 @@ def corr(col1, col2):
 
 
 def covar_pop(col1, col2):
-    """Returns a new :class:`Column` for the population covariance of ``col1`` and ``col2``.
+    """Returns a new :class:`pyspark.sql.Column` for the population covariance of ``col1`` and
+    ``col2``.
 
     .. versionadded:: 2.0.0
 
@@ -909,7 +910,7 @@ def covar_pop(col1, col2):
 
 
 def covar_samp(col1, col2):
-    """Returns a new :class:`Column` for the sample covariance of ``col1`` and ``col2``.
+    """Returns a new :class:`pyspark.sql.Column` for the sample covariance of ``col1`` and ``col2``.
 
     .. versionadded:: 2.0.0
 
@@ -926,7 +927,7 @@ def covar_samp(col1, col2):
 
 
 def countDistinct(col, *cols):
-    """Returns a new :class:`Column` for distinct count of ``col`` or ``cols``.
+    """Returns a new :class:`pyspark.sql.Column` for distinct count of ``col`` or ``cols``.
 
     .. versionadded:: 1.3.0
 
@@ -1334,8 +1335,8 @@ def struct(*cols):
 
     Parameters
     ----------
-    cols : list, set, str or :class:`Column`
-        column names or :class:`Column`\\s to contain in the output struct.
+    cols : list, set, str or :class:`pyspark.sql.Column`
+        column names or :class:`pyspark.sql.Column`\\s to contain in the output struct.
 
     Examples
     --------
@@ -1391,16 +1392,17 @@ def least(*cols):
 
 def when(condition, value):
     """Evaluates a list of conditions and returns one of multiple possible result expressions.
-    If :func:`Column.otherwise` is not invoked, None is returned for unmatched conditions.
+    If :func:`pyspark.sql.Column.otherwise` is not invoked, None is returned for unmatched
+    conditions.
 
     .. versionadded:: 1.4.0
 
     Parameters
     ----------
-    condition : :class:`Column`
-        a boolean :class:`Column` expression.
+    condition : :class:`pyspark.sql.Column`
+        a boolean :class:`pyspark.sql.Column` expression.
     value :
-        a literal value, or a :class:`Column` expression.
+        a literal value, or a :class:`pyspark.sql.Column` expression.
 
     >>> df.select(when(df['age'] == 2, 3).otherwise(4).alias("age")).collect()
     [Row(age=3), Row(age=4)]
@@ -1499,7 +1501,7 @@ def lag(col, offset=1, default=None):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     offset : int, optional
         number of row to extend
@@ -1522,7 +1524,7 @@ def lead(col, offset=1, default=None):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     offset : int, optional
         number of row to extend
@@ -1547,7 +1549,7 @@ def nth_value(col, offset, ignoreNulls=False):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     offset : int, optional
         number of row to use as the value
@@ -1874,7 +1876,7 @@ def months_between(date1, date2, roundOff=True):
 
 
 def to_date(col, format=None):
-    """Converts a :class:`Column` into :class:`pyspark.sql.types.DateType`
+    """Converts a :class:`pyspark.sql.Column` into :class:`pyspark.sql.types.DateType`
     using the optionally specified format. Specify formats according to `datetime pattern`_.
     By default, it follows casting rules to :class:`pyspark.sql.types.DateType` if the format
     is omitted. Equivalent to ``col.cast("date")``.
@@ -1902,7 +1904,7 @@ def to_date(col, format=None):
 
 
 def to_timestamp(col, format=None):
-    """Converts a :class:`Column` into :class:`pyspark.sql.types.TimestampType`
+    """Converts a :class:`pyspark.sql.Column` into :class:`pyspark.sql.types.TimestampType`
     using the optionally specified format. Specify formats according to `datetime pattern`_.
     By default, it follows casting rules to :class:`pyspark.sql.types.TimestampType` if the format
     is omitted. Equivalent to ``col.cast("timestamp")``.
@@ -1937,7 +1939,7 @@ def trunc(date, format):
 
     Parameters
     ----------
-    date : :class:`Column` or str
+    date : :class:`pyspark.sql.Column` or str
     format : str
         'year', 'yyyy', 'yy' or 'month', 'mon', 'mm'
 
@@ -1964,7 +1966,7 @@ def date_trunc(format, timestamp):
     format : str
         'year', 'yyyy', 'yy', 'month', 'mon', 'mm',
         'day', 'dd', 'hour', 'minute', 'second', 'week', 'quarter'
-    timestamp : :class:`Column` or str
+    timestamp : :class:`pyspark.sql.Column` or str
 
     Examples
     --------
@@ -2076,9 +2078,9 @@ def from_utc_timestamp(timestamp, tz):
 
     Parameters
     ----------
-    timestamp : :class:`Column` or str
+    timestamp : :class:`pyspark.sql.Column` or str
         the column that contains timestamps
-    tz : :class:`Column` or str
+    tz : :class:`pyspark.sql.Column` or str
         A string detailing the time zone ID that the input should be adjusted to. It should
         be in the format of either region-based zone IDs or zone offsets. Region IDs must
         have the form 'area/city', such as 'America/Los_Angeles'. Zone offsets must be in
@@ -2087,7 +2089,7 @@ def from_utc_timestamp(timestamp, tz):
         because they can be ambiguous.
 
         .. versionchanged:: 2.4
-           `tz` can take a :class:`Column` containing timezone ID strings.
+           `tz` can take a :class:`pyspark.sql.Column` containing timezone ID strings.
 
     Examples
     --------
@@ -2122,9 +2124,9 @@ def to_utc_timestamp(timestamp, tz):
 
     Parameters
     ----------
-    timestamp : :class:`Column` or str
+    timestamp : :class:`pyspark.sql.Column` or str
         the column that contains timestamps
-    tz : :class:`Column` or str
+    tz : :class:`pyspark.sql.Column` or str
         A string detailing the time zone ID that the input should be adjusted to. It should
         be in the format of either region-based zone IDs or zone offsets. Region IDs must
         have the form 'area/city', such as 'America/Los_Angeles'. Zone offsets must be in
@@ -2133,7 +2135,7 @@ def to_utc_timestamp(timestamp, tz):
         because they can be ambiguous.
 
         .. versionchanged:: 2.4.0
-           `tz` can take a :class:`Column` containing timezone ID strings.
+           `tz` can take a :class:`pyspark.sql.Column` containing timezone ID strings.
 
     Examples
     --------
@@ -2487,7 +2489,7 @@ def format_number(col, d):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         the column name of the numeric value to be formatted
     d : int
         the N decimal places
@@ -2509,8 +2511,8 @@ def format_string(format, *cols):
     ----------
     format : str
         string that can contain embedded format tags and used as result column's value
-    cols : :class:`Column` or str
-        column names or :class:`Column`\\s to be used in formatting
+    cols : :class:`pyspark.sql.Column` or str
+        column names or :class:`pyspark.sql.Column`\\s to be used in formatting
 
     Examples
     --------
@@ -2648,7 +2650,7 @@ def locate(substr, str, pos=1):
     ----------
     substr : str
         a string
-    str : :class:`Column` or str
+    str : :class:`pyspark.sql.Column` or str
         a Column of :class:`pyspark.sql.types.StringType`
     pos : int, optional
         start position (zero based)
@@ -2724,7 +2726,7 @@ def split(str, pattern, limit=-1):
 
     Parameters
     ----------
-    str : :class:`Column` or str
+    str : :class:`pyspark.sql.Column` or str
         a string expression to split
     pattern : str
         a string representing a regular expression. The regex string should be
@@ -2912,8 +2914,8 @@ def create_map(*cols):
 
     Parameters
     ----------
-    cols : :class:`Column` or str
-        column names or :class:`Column`\\s that are
+    cols : :class:`pyspark.sql.Column` or str
+        column names or :class:`pyspark.sql.Column`\\s that are
         grouped as key-value pairs, e.g. (key1, value1, key2, value2, ...).
 
     Examples
@@ -2937,9 +2939,9 @@ def map_from_arrays(col1, col2):
 
     Parameters
     ----------
-    col1 : :class:`Column` or str
+    col1 : :class:`pyspark.sql.Column` or str
         name of column containing a set of keys. All elements should not be null
-    col2 : :class:`Column` or str
+    col2 : :class:`pyspark.sql.Column` or str
         name of column containing a set of values
 
     Examples
@@ -2963,8 +2965,8 @@ def array(*cols):
 
     Parameters
     ----------
-    cols : :class:`Column` or str
-        column names or :class:`Column`\\s that have
+    cols : :class:`pyspark.sql.Column` or str
+        column names or :class:`pyspark.sql.Column`\\s that have
         the same data type.
 
     Examples
@@ -2990,7 +2992,7 @@ def array_contains(col, value):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column containing array
     value :
         value or column to check for in array
@@ -3035,11 +3037,11 @@ def slice(x, start, length):
 
     Parameters
     ----------
-    x : :class:`Column` or str
+    x : :class:`pyspark.sql.Column` or str
         the array to be sliced
-    start : :class:`Column` or int
+    start : :class:`pyspark.sql.Column` or int
         the starting index
-    length : :class:`Column` or int
+    length : :class:`pyspark.sql.Column` or int
         the length of the slice
 
     Examples
@@ -3131,7 +3133,7 @@ def element_at(col, extraction):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column containing array or map
     extraction :
         index to check for in array or key to check for in map
@@ -3163,7 +3165,7 @@ def array_remove(col, element):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column containing array
     element :
         element to be removed from the array
@@ -3186,7 +3188,7 @@ def array_distinct(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3208,9 +3210,9 @@ def array_intersect(col1, col2):
 
     Parameters
     ----------
-    col1 : :class:`Column` or str
+    col1 : :class:`pyspark.sql.Column` or str
         name of column containing array
-    col2 : :class:`Column` or str
+    col2 : :class:`pyspark.sql.Column` or str
         name of column containing array
 
     Examples
@@ -3233,9 +3235,9 @@ def array_union(col1, col2):
 
     Parameters
     ----------
-    col1 : :class:`Column` or str
+    col1 : :class:`pyspark.sql.Column` or str
         name of column containing array
-    col2 : :class:`Column` or str
+    col2 : :class:`pyspark.sql.Column` or str
         name of column containing array
 
     Examples
@@ -3258,9 +3260,9 @@ def array_except(col1, col2):
 
     Parameters
     ----------
-    col1 : :class:`Column` or str
+    col1 : :class:`pyspark.sql.Column` or str
         name of column containing array
-    col2 : :class:`Column` or str
+    col2 : :class:`pyspark.sql.Column` or str
         name of column containing array
 
     Examples
@@ -3414,7 +3416,7 @@ def get_json_object(col, path):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         string column in json format
     path : str
         path to the json object to extract
@@ -3439,7 +3441,7 @@ def json_tuple(col, *fields):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         string column in json format
     fields : str
         fields to extract
@@ -3466,7 +3468,7 @@ def from_json(col, schema, options=None):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         string column in json format
     schema : :class:`DataType` or str
         a StructType or ArrayType of StructType to use when parsing the json column.
@@ -3521,7 +3523,7 @@ def to_json(col, options=None):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column containing a struct, an array or a map.
     options : dict, optional
         options to control converting. accepts the same options as the JSON datasource.
@@ -3567,7 +3569,7 @@ def schema_of_json(json, options=None):
 
     Parameters
     ----------
-    json : :class:`Column` or str
+    json : :class:`pyspark.sql.Column` or str
         a JSON string or a foldable string column containing a JSON string.
     options : dict, optional
         options to control parsing. accepts the same options as the JSON datasource
@@ -3604,7 +3606,7 @@ def schema_of_csv(csv, options=None):
 
     Parameters
     ----------
-    csv : :class:`Column` or str
+    csv : :class:`pyspark.sql.Column` or str
         a CSV string or a foldable string column containing a CSV string.
     options : dict, optional
         options to control parsing. accepts the same options as the CSV datasource
@@ -3638,7 +3640,7 @@ def to_csv(col, options=None):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column containing a struct.
     options: dict, optional
         options to control converting. accepts the same options as the CSV datasource.
@@ -3665,7 +3667,7 @@ def size(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3686,7 +3688,7 @@ def array_min(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3707,7 +3709,7 @@ def array_max(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3731,7 +3733,7 @@ def sort_array(col, asc=True):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     asc : bool, optional
 
@@ -3756,7 +3758,7 @@ def array_sort(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3777,7 +3779,7 @@ def shuffle(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Notes
@@ -3802,7 +3804,7 @@ def reverse(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3828,7 +3830,7 @@ def flatten(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3849,7 +3851,7 @@ def map_keys(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3875,7 +3877,7 @@ def map_values(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3901,7 +3903,7 @@ def map_entries(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3927,7 +3929,7 @@ def map_from_entries(col):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
 
     Examples
@@ -3973,7 +3975,7 @@ def arrays_zip(*cols):
 
     Parameters
     ----------
-    cols : :class:`Column` or str
+    cols : :class:`pyspark.sql.Column` or str
         columns of arrays to be merged.
 
     Examples
@@ -3994,8 +3996,8 @@ def map_concat(*cols):
 
     Parameters
     ----------
-    cols : :class:`Column` or str
-        column names or :class:`Column`\\s
+    cols : :class:`pyspark.sql.Column` or str
+        column names or :class:`pyspark.sql.Column`\\s
 
     Examples
     --------
@@ -4049,9 +4051,9 @@ def from_csv(col, schema, options=None):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         string column in CSV format
-    schema :class:`Column` or str
+    schema :class:`pyspark.sql.Column` or str
         a string with schema in DDL format to use when parsing the CSV column.
     options : dict, optional
         options to control parsing. accepts the same options as the CSV datasource
@@ -4196,7 +4198,7 @@ def transform(col, f):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     f : function
         a function that is applied to each element of the input array.
@@ -4245,7 +4247,7 @@ def exists(col, f):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     f : function
         ``(x: Column) -> Column: ...``  returning the Boolean expression.
@@ -4277,7 +4279,7 @@ def forall(col, f):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     f : function
         ``(x: Column) -> Column: ...``  returning the Boolean expression.
@@ -4316,7 +4318,7 @@ def filter(col, f):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     f : function
         A function that returns the Boolean expression.
@@ -4370,9 +4372,9 @@ def aggregate(col, initialValue, merge, finish=None):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
-    initialValue : :class:`Column` or str
+    initialValue : :class:`pyspark.sql.Column` or str
         initial value. Name of column or expression
     merge : function
         a binary function ``(acc: Column, x: Column) -> Column...`` returning expression
@@ -4438,9 +4440,9 @@ def zip_with(left, right, f):
 
     Parameters
     ----------
-    left : :class:`Column` or str
+    left : :class:`pyspark.sql.Column` or str
         name of the first column or expression
-    right : :class:`Column` or str
+    right : :class:`pyspark.sql.Column` or str
         name of the second column or expression
     f : function
         a binary function ``(x1: Column, x2: Column) -> Column...``
@@ -4483,7 +4485,7 @@ def transform_keys(col, f):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     f : function
         a binary function ``(k: Column, v: Column) -> Column...``
@@ -4520,7 +4522,7 @@ def transform_values(col, f):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     f : function
         a binary function ``(k: Column, v: Column) -> Column...``
@@ -4556,7 +4558,7 @@ def map_filter(col, f):
 
     Parameters
     ----------
-    col : :class:`Column` or str
+    col : :class:`pyspark.sql.Column` or str
         name of column or expression
     f : function
         a binary function ``(k: Column, v: Column) -> Column...``
@@ -4592,9 +4594,9 @@ def map_zip_with(col1, col2, f):
 
     Parameters
     ----------
-    col1 : :class:`Column` or str
+    col1 : :class:`pyspark.sql.Column` or str
         name of the first column or expression
-    col2 : :class:`Column` or str
+    col2 : :class:`pyspark.sql.Column` or str
         name of the second column or expression
     f : function
         a ternary function ``(k: Column, v1: Column, v2: Column) -> Column...``

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1490,7 +1490,7 @@ def factorial(col):
 def lag(col, offset=1, default=None):
     """
     Window function: returns the value that is `offset` rows before the current row, and
-    `defaultValue` if there is less than `offset` rows before the current row. For example,
+    `default` if there is less than `offset` rows before the current row. For example,
     an `offset` of one will return the previous row at any given point in the window partition.
 
     This is equivalent to the LAG function in SQL.
@@ -1513,7 +1513,7 @@ def lag(col, offset=1, default=None):
 def lead(col, offset=1, default=None):
     """
     Window function: returns the value that is `offset` rows after the current row, and
-    `defaultValue` if there is less than `offset` rows after the current row. For example,
+    `default` if there is less than `offset` rows after the current row. For example,
     an `offset` of one will return the next row at any given point in the window partition.
 
     This is equivalent to the LEAD function in SQL.


### PR DESCRIPTION
This changeset is published into the public domain.

### What changes were proposed in this pull request?

Some typos and syntax issues in docstrings and the output of `dev/lint-python` have been fixed.

### Why are the changes needed?
In some places, the documentation did not refer to parameters or classes by the full and correct name, potentially causing uncertainty in the reader or rendering issues in Sphinx. Also, a typo in the standard output of `dev/lint-python` was fixed.

### Does this PR introduce _any_ user-facing change?

Slight improvements in documentation, and in standard output of `dev/lint-python`.


### How was this patch tested?

Manual testing and `dev/lint-python` run. No new Sphinx warnings arise due to this change.
