### PR TITLE
[SPARK-34283][SQL] Combines all adjacent 'Union' operators into a single 'Union' when using 'Dataset.union.distinct.union.distinct'

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SetOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SetOperationSuite.scala
@@ -146,6 +146,94 @@ class SetOperationSuite extends PlanTest {
     comparePlans(distinctUnionCorrectAnswer2, optimized2)
   }
 
+  test("SPARK-34283: Remove unnecessary deduplicate in multiple unions") {
+    val query1 = OneRowRelation()
+      .select(Literal(1).as('a))
+    val query2 = OneRowRelation()
+      .select(Literal(2).as('b))
+    val query3 = OneRowRelation()
+      .select(Literal(3).as('c))
+
+    // D - U - D - U - query1
+    //     |       |
+    //     query3  query2
+    val unionQuery1 = Deduplicate(query1.output, Union(
+      Deduplicate(query1.output, Union(query1, query2)), query3)).analyze
+    val optimized1 = Optimize.execute(unionQuery1)
+    val deduplicateUnionCorrectAnswer1 = Deduplicate(query1.output,
+      Union(query1 :: query2 :: query3 :: Nil))
+    comparePlans(deduplicateUnionCorrectAnswer1, optimized1)
+
+    //         query1
+    //         |
+    // D - U - U - query2
+    //     |
+    //     D - U - query2
+    //         |
+    //         query3
+    val unionQuery2 = Deduplicate(query1.output, Union(Union(query1, query2),
+      Deduplicate(query2.output, Union(query2, query3)))).analyze
+    val optimized2 = Optimize.execute(unionQuery2)
+    val deduplicateUnionCorrectAnswer2 =
+      Deduplicate(query1.output, Union(query1 :: query2 :: query2 :: query3 :: Nil))
+    comparePlans(deduplicateUnionCorrectAnswer2, optimized2)
+
+    // D  -  U  -  D  -  U  -  testRelation
+    //       |           |
+    //  testRelation  testRelation
+    // Union with the same value of 'byName' and 'allowMissingCol'
+    val unionQuery3 = Deduplicate(testRelation.output,
+      Union(Deduplicate(testRelation.output,
+        Union(testRelation :: testRelation :: Nil, true, false)) :: testRelation :: Nil,
+        true, false))
+    val optimized3 = Optimize.execute(unionQuery3)
+    val deduplicateUnionCorrectAnswer3 =
+      Deduplicate(testRelation.output,
+        Union(testRelation :: testRelation :: testRelation :: Nil, true, false))
+    comparePlans(deduplicateUnionCorrectAnswer3, optimized3, false)
+  }
+
+  test("SPARK-34283: Keep necessary deduplicate in multiple unions") {
+    val query1 = OneRowRelation()
+      .select(Literal(1).as('a))
+    val query2 = OneRowRelation()
+      .select(Literal(2).as('b))
+    val query3 = OneRowRelation()
+      .select(Literal(3).as('c))
+    val query4 = OneRowRelation()
+      .select(Literal(4).as('d))
+
+    // U - D - U - query1
+    // |       |
+    // query3  query2
+    val unionQuery1 = Union(Deduplicate(query1.output, Union(query1, query2)), query3).analyze
+    val optimized1 = Optimize.execute(unionQuery1)
+    comparePlans(unionQuery1, optimized1)
+
+    //         query1
+    //         |
+    // U - D - U - query2
+    // |
+    // D - U - query3
+    //     |
+    //     query4
+    val unionQuery2 = Union(Deduplicate(query1.output, Union(query1, query2)),
+      Deduplicate(query3.output, Union(query3, query4))).analyze
+    val optimized2 = Optimize.execute(unionQuery2)
+    comparePlans(unionQuery2, optimized2)
+
+    // D  -  U  -  D  -  U  -  testRelation
+    //       |           |
+    //  testRelation  testRelation
+    // Union with different value of 'byName' and 'allowMissingCol'
+    val unionQuery3 = Deduplicate(testRelation.output,
+      Union(Deduplicate(testRelation.output,
+        Union(testRelation :: testRelation :: Nil, true, false)) :: testRelation :: Nil,
+        true, true))
+    val optimized3 = Optimize.execute(unionQuery3)
+    comparePlans(unionQuery3, optimized3, false)
+  }
+
   test("EXCEPT ALL rewrite") {
     val input = Except(testRelation, testRelation2, isAll = true)
     val rewrittenPlan = RewriteExceptAll(input)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Handled 'Deduplicate(Keys, Union)' operation in rule 'CombineUnions' to combine adjacent 'Union' operators  into a single 'Union' if necessary when using 'Dataset.union.distinct.union.distinct'.
Currently only handle distinct-like 'Deduplicate', where the keys == output, for example:
```
val df1 = Seq((1, 2, 3)).toDF("a", "b", "c")
val df2 = Seq((6, 2, 5)).toDF("a", "b", "c")
val df3 = Seq((2, 4, 3)).toDF("c", "a", "b")
val df4 = Seq((1, 4, 5)).toDF("b", "a", "c")
val unionDF1 = df1.unionByName(df2).dropDuplicates(Seq("b", "a", "c"))
      .unionByName(df3).dropDuplicates().unionByName(df4)
      .dropDuplicates("a")
```
In this case, **all Union operators will be combined**.
but, 
```
val df1 = Seq((1, 2, 3)).toDF("a", "b", "c")
val df2 = Seq((6, 2, 5)).toDF("a", "b", "c")
val df3 = Seq((2, 4, 3)).toDF("c", "a", "b")
val df4 = Seq((1, 4, 5)).toDF("b", "a", "c")
val unionDF = df1.unionByName(df2).dropDuplicates(Seq("a"))
      .unionByName(df3).dropDuplicates("c").unionByName(df4)
      .dropDuplicates("b")
```
In this case, **all unions will not be combined, because the Deduplicate.keys doesn't equal to Union.output**.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When using 'Dataset.union.distinct.union.distinct', the operator is  'Deduplicate(Keys, Union)', but AstBuilder transform sql-style 'Union' to operator 'Distinct(Union)', the rule 'CombineUnions' in Optimizer only handle 'Distinct(Union)' operator but not Deduplicate(Keys, Union).
Please see the detailed  description in [SPARK-34283](https://issues.apache.org/jira/browse/SPARK-34283).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.