### PR TITLE
[SPARK-33245][SQL][FOLLOW-UP] Remove bitwiseGet in Scala functions API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1414,16 +1414,6 @@ object functions {
   def bitwiseNOT(e: Column): Column = withExpr { BitwiseNot(e.expr) }
 
   /**
-   * Get the value of the bit (0 or 1) at the specified position.
-   * The positions are numbered from right to left, starting at zero.
-   * The position argument cannot be negative.
-   *
-   * @group bitwise_funcs
-   * @since 3.2.0
-   */
-  def bitwiseGet(e: Column, pos: Column): Column = withExpr { BitwiseGet(e.expr, pos.expr) }
-
-  /**
    * Parses the expression string into the column that it represents, similar to
    * [[Dataset#selectExpr]].
    * {{{

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -177,30 +177,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
       testData2.collect().toSeq.map(r => Row(~r.getInt(0))))
   }
 
-  test("bitwiseGet") {
-    val df = Seq(
-      (11L, 3),
-      (11L, 2),
-      (11L, 1),
-      (11L, 0),
-      (11L, 63)
-    ).toDF("a", "b")
-    checkAnswer(df.select(bitwiseGet($"a", $"b")),
-      Seq(Row(1.toByte), Row(0.toByte), Row(1.toByte), Row(1.toByte), Row(0.toByte)))
-
-    val df2 = Seq((11L, 64)).toDF("a", "b")
-    val msg = intercept[Exception] {
-      df2.select(bitwiseGet($"a", $"b")).collect
-    }.getMessage
-    assert(msg.contains("Invalid bit position: 64 exceeds the bit upper limit"))
-
-    val df3 = Seq((11L, -1)).toDF("a", "b")
-    val msg2 = intercept[Exception] {
-      df3.select(bitwiseGet($"a", $"b")).collect
-    }.getMessage
-    assert(msg2.contains("Invalid bit position: -1 is less than zero"))
-  }
-
   test("bin") {
     val df = Seq[(Integer, Integer)]((12, null)).toDF("a", "b")
     checkAnswer(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup that removes `bitwiseGet` in functions API. This is mainly for SQL compliance, and arguably not very much commonly used.

### Why are the changes needed?

See https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L41-L59

### Does this PR introduce _any_ user-facing change?

No, it's a change in unreleased branches.

### How was this patch tested?

Existing tests should cover.