### PR TITLE
[SPARK-34314][SQL] Create new file index after partition schema inferring w/ the schema

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -414,10 +414,10 @@ case class DataSource(
           val globbedPaths = checkAndGlobPathIfNecessary(
             checkEmptyGlobPath = true, checkFilesExist = checkFilesExist)
           val fileStatusCache = FileStatusCache.getOrCreate(sparkSession)
-          val indexInSchemaInferring = new InMemoryFileIndex(
+          val indexForSchemaInference = new InMemoryFileIndex(
             sparkSession, globbedPaths, options, userSpecifiedSchema, fileStatusCache)
           val (resultDataSchema, resultPartitionSchema) =
-            getOrInferFileFormatSchema(format, () => indexInSchemaInferring)
+            getOrInferFileFormatSchema(format, () => indexForSchemaInference)
           val index = new InMemoryFileIndex(
             sparkSession, globbedPaths, options, Some(resultPartitionSchema), fileStatusCache)
           (index, resultDataSchema, resultPartitionSchema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -413,9 +413,8 @@ case class DataSource(
         } else {
           val globbedPaths = checkAndGlobPathIfNecessary(
             checkEmptyGlobPath = true, checkFilesExist = checkFilesExist)
-          val indexInSchemaInferring = createInMemoryFileIndex(globbedPaths)
           val (resultDataSchema, resultPartitionSchema) =
-            getOrInferFileFormatSchema(format, () => indexInSchemaInferring)
+            getOrInferFileFormatSchema(format, () => createInMemoryFileIndex(globbedPaths))
           val index = createInMemoryFileIndex(globbedPaths, Some(resultPartitionSchema))
           (index, resultDataSchema, resultPartitionSchema)
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -31,7 +31,7 @@ import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.SparkException
 import org.apache.spark.metrics.source.HiveCatalogMetrics
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{QueryTest, Row, SparkSession}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
@@ -39,7 +39,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.util.KnownSizeEstimation
 
-class FileIndexSuite extends SharedSparkSession {
+class FileIndexSuite extends QueryTest with SharedSparkSession {
 
   private class TestInMemoryFileIndex(
       spark: SparkSession,
@@ -518,6 +518,21 @@ class FileIndexSuite extends SharedSparkSession {
       }
     } finally {
       SQLConf.get.setConf(StaticSQLConf.METADATA_CACHE_TTL_SECONDS, previousValue)
+    }
+  }
+
+  test("SPARK-XXXXX: use inferred partition schema in read") {
+    import testImplicits._
+    withTempPath { file =>
+      val path = file.getCanonicalPath
+      val df = Seq((0, "AA"), (1, "-0")).toDF("id", "part")
+      df.write
+        .partitionBy("part")
+        .format("parquet")
+        .save(path)
+      val readback = spark.read.parquet(path)
+      assert(readback.schema("part").dataType === StringType)
+      checkAnswer(readback, Row(0, "AA") :: Row(1, "-0") :: Nil)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -521,7 +521,7 @@ class FileIndexSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-XXXXX: rebuild file index after inferring of partition") {
+  test("SPARK-34314: rebuild file index after inferring of partition") {
     import testImplicits._
     withTempPath { file =>
       val path = file.getCanonicalPath

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -521,7 +521,7 @@ class FileIndexSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-34314: rebuild file index after inferring of partition") {
+  test("SPARK-34314: rebuild the file index after partition schema inferring") {
     import testImplicits._
     withTempPath { file =>
       val path = file.getCanonicalPath

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -521,7 +521,7 @@ class FileIndexSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-XXXXX: use inferred partition schema in read") {
+  test("SPARK-XXXXX: rebuild file index after inferring of partition") {
     import testImplicits._
     withTempPath { file =>
       val path = file.getCanonicalPath

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -1331,4 +1331,18 @@ class ParquetV2PartitionDiscoverySuite extends ParquetPartitionDiscoverySuite {
       }
     }
   }
+
+  test("SPARK-XXXXX: ") {
+    withTempPath { file =>
+      val path = file.getCanonicalPath
+      val df = Seq((0, "maybe"), (1, "now")).toDF("id", "part")
+      df.write
+        .partitionBy("part")
+        .format(dataSourceName)
+        .save(path)
+      val readback = spark.read.parquet(path)
+      assert(readback.schema("part").dataType === StringType)
+      checkAnswer(readback, Row(0, "maybe") :: Row(1, "now") :: Nil)
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -1331,18 +1331,4 @@ class ParquetV2PartitionDiscoverySuite extends ParquetPartitionDiscoverySuite {
       }
     }
   }
-
-  test("SPARK-XXXXX: ") {
-    withTempPath { file =>
-      val path = file.getCanonicalPath
-      val df = Seq((0, "maybe"), (1, "now")).toDF("id", "part")
-      df.write
-        .partitionBy("part")
-        .format(dataSourceName)
-        .save(path)
-      val readback = spark.read.parquet(path)
-      assert(readback.schema("part").dataType === StringType)
-      checkAnswer(readback, Row(0, "maybe") :: Row(1, "now") :: Nil)
-    }
-  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionedTablePerfStatsSuite.scala
@@ -370,7 +370,7 @@ class PartitionedTablePerfStatsSuite
           assert(HiveCatalogMetrics.METRIC_PARTITIONS_FETCHED.getCount() == 0)
 
           // reads and caches all the files initially
-          assert(HiveCatalogMetrics.METRIC_FILES_DISCOVERED.getCount() == 5)
+          assert(HiveCatalogMetrics.METRIC_FILES_DISCOVERED.getCount() == 10)
 
           HiveCatalogMetrics.reset()
           assert(spark.sql("select * from test where partCol1 < 2").count() == 2)
@@ -419,7 +419,7 @@ class PartitionedTablePerfStatsSuite
       HiveCatalogMetrics.reset()
       spark.read.load(dir.getAbsolutePath)
       assert(HiveCatalogMetrics.METRIC_FILES_DISCOVERED.getCount() == 1)
-      assert(HiveCatalogMetrics.METRIC_FILE_CACHE_HITS.getCount() == 0)
+      assert(HiveCatalogMetrics.METRIC_FILE_CACHE_HITS.getCount() == 1)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Create new file index after partition schema inferring, and use the inferred partition schema in it.

### Why are the changes needed?
The changes fix the bug demonstrated by the example:
1. There are partitioned parquet files (file format doesn't matter):
```
/private/var/folders/p3/dfs6mf655d7fnjrsjvldh0tc0000gn/T/spark-e09eae99-7ecf-4ab2-b99b-f63f8dea658d
├── _SUCCESS
├── part=-0
│   └── part-00001-02144398-2896-4d21-9628-a8743d098cb4.c000.snappy.parquet
└── part=AA
    └── part-00000-02144398-2896-4d21-9628-a8743d098cb4.c000.snappy.parquet
```
placed to two partitions "AA" and **"-0"**.

2. When reading them w/o specified schema:
```
val df = spark.read.parquet(path)
df.printSchema()
root
 |-- id: integer (nullable = true)
 |-- part: string (nullable = true)
```
the inferred type of the partition column `part` is the **string** type.
3. The expected values in the column `part` are "AA" and "-0" but we get:
```
df.show(false)
+---+----+
|id |part|
+---+----+
|0  |AA  |
|1  |0   |
+---+----+
```
So, Spark returns **"0"** instead of **"-0"**.

### Does this PR introduce _any_ user-facing change?
This PR can change query results.

### How was this patch tested?
By running new test and existing test suites:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *FileIndexSuite"
```