### PR TITLE
[SPARK-34330][SQL] Literal's constructor support UTF8String

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -62,6 +62,7 @@ object Literal {
     case b: Byte => Literal(b, ByteType)
     case s: Short => Literal(s, ShortType)
     case s: String => Literal(UTF8String.fromString(s), StringType)
+    case s: UTF8String => Literal(s, StringType)
     case c: Char => Literal(UTF8String.fromString(c.toString), StringType)
     case ac: Array[Char] => Literal(UTF8String.fromString(String.valueOf(ac)), StringType)
     case b: Boolean => Literal(b, BooleanType)
@@ -291,7 +292,7 @@ object DecimalLiteral {
 /**
  * In order to do type checking, use Literal.create() instead of constructor
  */
-case class Literal (value: Any, dataType: DataType) extends LeafExpression {
+case class Literal(value: Any, dataType: DataType) extends LeafExpression {
 
   Literal.validateLiteralValue(value, dataType)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Since when `UnsafeRow.getString` return UTF8String, but `Literal.apply()` don't support UF8String.

In this patch support it.

### Why are the changes needed?
Make Literal's constructor support UTF8String

### Does this PR introduce _any_ user-facing change?
When s is instance of `UTF8String`
user can use `Literal(s)`

### How was this patch tested?
Not need