### PR TITLE
[SPARK-34334][K8S] Correctly identify timed out pending pod requests as excess request

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -223,15 +223,15 @@ private[spark] class ExecutorPodsAllocator(
 
       if (knownPodCount > targetNum) {
         val excess = knownPodCount - targetNum
-        val timedOutNewlyCreated = newlyCreatedExecutorsForRpId
+        val newlyCreatedToDelete = newlyCreatedExecutorsForRpId
           .filter { case (_, (_, createTime)) =>
             currentTime - createTime > executorIdleTimeout
           }.keys.take(excess).toList
         val knownPendingToDelete = currentPendingExecutors
           .filter(x => isExecutorIdleTimedOut(x._2, currentTime))
+          .take(excess - newlyCreatedToDelete.size)
           .map { case (id, _) => id }
-          .take(excess - timedOutNewlyCreated.size)
-        val toDelete = timedOutNewlyCreated ++ knownPendingToDelete
+        val toDelete = newlyCreatedToDelete ++ knownPendingToDelete
 
         if (toDelete.nonEmpty) {
           logInfo(s"Deleting ${toDelete.size} excess pod requests (${toDelete.mkString(",")}).")


### PR DESCRIPTION

### What changes were proposed in this pull request?

Fixing identification of timed-out pending pod requests as excess requests to delete when the excess is higher than the newly created timed out requests and there is some non-timed out newly created requests too.

### Why are the changes needed?

After https://github.com/apache/spark/pull/29981 only timed out newly created requests and timed out pending requests are taken as excess request. 

But there is small bug when the excess is higher than the newly created timed out requests and there is some non-timed out newly created requests as well. Because all the newly created requests are counted as excess request when items are chosen from the timed out pod pending requests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
 
 There is new unit test added: `SPARK-34334: correctly identify timed out pending pod requests as excess`.