### PR TITLE
[SPARK-34336][SQL] Use GenericData as Avro serialization data model

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
@@ -40,6 +40,8 @@ private[sql] class AvroOutputWriterFactory(
       path: String,
       dataSchema: StructType,
       context: TaskAttemptContext): OutputWriter = {
+    context.getConfiguration.set("avro.serialization.data.model",
+      "org.apache.avro.generic.GenericData")
     new AvroOutputWriter(path, context, catalystSchema, avroSchema)
   }
 }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -1024,7 +1024,7 @@ abstract class AvroSuite
           .save(s"$tempDir/${UUID.randomUUID()}")
       }.getCause.getMessage
       assert(message.contains("Caused by: java.lang.NullPointerException: " +
-        "null of string in string in field Name of test_schema in test_schema"))
+        "null of string in field Name of test_schema"))
     }
   }
 


### PR DESCRIPTION
This optimization was originally put up by @msamirkhan in this PR https://github.com/apache/spark/pull/29354.

### What changes were proposed in this pull request?
Set "org.apache.avro.generic.GenericData" as Avro serialization data model in Avro output writer.

### Why are the changes needed?
We found that using "org.apache.avro.generic.GenericData" as Avro serialization data model in Avro writer can significantly improve Avro write benchmark performance and slightly improve Avro read benchmark performance. Full Benchmark results can be found on https://issues.apache.org/jira/browse/SPARK-34336.

Column chart comparison on avg time
![image](https://user-images.githubusercontent.com/26694233/106668248-a8a39480-656f-11eb-86a9-aa18d99f0942.png)
![image](https://user-images.githubusercontent.com/26694233/106668280-b48f5680-656f-11eb-882a-02028611c8f9.png)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually run benchmarks.
