### PR TITLE
[SPARK-34326][CORE][SQL] Fix UTs added in SPARK-31793 depending on the length of temp path

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1308,6 +1308,12 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     assert(Utils.buildLocationMetadata(paths, 10) == "[path0, path1]")
     assert(Utils.buildLocationMetadata(paths, 15) == "[path0, path1, path2]")
     assert(Utils.buildLocationMetadata(paths, 25) == "[path0, path1, path2, path3]")
+
+    // edge-case: we should consider the fact non-path chars including '[' and ", " are accounted
+    // 1. second path is not added due to the addition of '['
+    assert(Utils.buildLocationMetadata(paths, 6) == "[path0]")
+    // 2. third path is not added due to the addition of ", "
+    assert(Utils.buildLocationMetadata(paths, 13) == "[path0, path1]")
   }
 
   test("checkHost supports both IPV4 and IPV6") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
@@ -126,15 +126,9 @@ class DataSourceScanExecRedactionSuite extends DataSourceScanRedactionTest {
 
       // create a sub-directory with long name so that each root path will always exceed the limit
       // this is to ensure we always test the case for the path truncation
-      // 110 = limit 100 + margin 10 to clearly avoid edge case
-      val dataDir = if (dir.length >= 110) {
-        path
-      } else {
-        val dataDirName = Random.alphanumeric.take(110 - dir.length).toList.mkString
-        val f = new File(path, dataDirName)
-        f.mkdir()
-        f
-      }
+      val dataDirName = Random.alphanumeric.take(100).toList.mkString
+      val dataDir = new File(path, dataDirName)
+      dataDir.mkdir()
 
       val partitionCol = "partitionCol"
       spark.range(10)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the UTs being added in SPARK-31793, so that all things contributing the length limit are properly accounted.

### Why are the changes needed?

The test `DataSourceScanExecRedactionSuite.SPARK-31793: FileSourceScanExec metadata should contain limited file paths` is failing conditionally, depending on the length of the temp directory.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Modified UTs explain the missing points, which also do the test.