### PR TITLE
[SPARK-33763] Add metrics for better tracking of dynamic allocation

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.{ControlThrowable, NonFatal}
 
-import com.codahale.metrics.{Gauge, MetricRegistry}
+import com.codahale.metrics.{Counter, Gauge, MetricRegistry}
 
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.internal.config._
@@ -135,14 +135,14 @@ private[spark] class ExecutorAllocationManager(
   validateSettings()
 
   // Number of executors to add for each ResourceProfile in the next round
-  private val numExecutorsToAddPerResourceProfileId = new mutable.HashMap[Int, Int]
+  private[spark] val numExecutorsToAddPerResourceProfileId = new mutable.HashMap[Int, Int]
   numExecutorsToAddPerResourceProfileId(defaultProfileId) = 1
 
   // The desired number of executors at this moment in time. If all our executors were to die, this
   // is the number of executors we would immediately want from the cluster manager.
   // Note every profile will be allowed to have initial number,
   // we may want to make this configurable per Profile in the future
-  private val numExecutorsTargetPerResourceProfileId = new mutable.HashMap[Int, Int]
+  private[spark] val numExecutorsTargetPerResourceProfileId = new mutable.HashMap[Int, Int]
   numExecutorsTargetPerResourceProfileId(defaultProfileId) = initialNumExecutors
 
   // A timestamp of when an addition should be triggered, or NOT_SET if it is not set
@@ -155,14 +155,15 @@ private[spark] class ExecutorAllocationManager(
   // Listener for Spark events that impact the allocation policy
   val listener = new ExecutorAllocationListener
 
-  val executorMonitor = new ExecutorMonitor(conf, client, listenerBus, clock)
-
   // Executor that handles the scheduling task.
   private val executor =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("spark-dynamic-executor-allocation")
 
   // Metric source for ExecutorAllocationManager to expose internal status to MetricsSystem.
-  val executorAllocationManagerSource = new ExecutorAllocationManagerSource
+  val executorAllocationManagerSource = new ExecutorAllocationManagerSource(this)
+
+  val executorMonitor =
+    new ExecutorMonitor(conf, client, listenerBus, clock, executorAllocationManagerSource)
 
   // Whether we are still waiting for the initial set of executors to be allocated.
   // While this is true, we will not cancel outstanding executor requests. This is
@@ -288,7 +289,7 @@ private[spark] class ExecutorAllocationManager(
    * The maximum number of executors, for the ResourceProfile id passed in, that we would need
    * under the current load to satisfy all running and pending tasks, rounded up.
    */
-  private def maxNumExecutorsNeededPerResourceProfile(rpId: Int): Int = {
+  private[spark] def maxNumExecutorsNeededPerResourceProfile(rpId: Int): Int = {
     val pending = listener.totalPendingTasksPerResourceProfile(rpId)
     val pendingSpeculative = listener.pendingSpeculativeTasksPerResourceProfile(rpId)
     val unschedulableTaskSets = listener.pendingUnschedulableTaskSetsPerResourceProfile(rpId)
@@ -967,42 +968,47 @@ private[spark] class ExecutorAllocationManager(
         rplocalityToCount.map { case (k, v) => (k, v.toMap)}.toMap
     }
   }
+}
 
-  /**
-   * Metric source for ExecutorAllocationManager to expose its internal executor allocation
-   * status to MetricsSystem.
-   * Note: These metrics heavily rely on the internal implementation of
-   * ExecutorAllocationManager, metrics or value of metrics will be changed when internal
-   * implementation is changed, so these metrics are not stable across Spark version.
-   */
-  private[spark] class ExecutorAllocationManagerSource extends Source {
-    val sourceName = "ExecutorAllocationManager"
-    val metricRegistry = new MetricRegistry()
+/**
+ * Metric source for ExecutorAllocationManager to expose its internal executor allocation
+ * status to MetricsSystem.
+ * Note: These metrics heavily rely on the internal implementation of
+ * ExecutorAllocationManager, metrics or value of metrics will be changed when internal
+ * implementation is changed, so these metrics are not stable across Spark version.
+ */
+private[spark] class ExecutorAllocationManagerSource(
+    executorAllocationManager: ExecutorAllocationManager) extends Source {
+  val sourceName = "ExecutorAllocationManager"
+  val metricRegistry = new MetricRegistry()
 
-    private def registerGauge[T](name: String, value: => T, defaultValue: T): Unit = {
-      metricRegistry.register(MetricRegistry.name("executors", name), new Gauge[T] {
-        override def getValue: T = synchronized { Option(value).getOrElse(defaultValue) }
-      })
-    }
-
-    // The metrics are going to return the sum for all the different ResourceProfiles.
-    registerGauge("numberExecutorsToAdd",
-      numExecutorsToAddPerResourceProfileId.values.sum, 0)
-    registerGauge("numberExecutorsPendingToRemove", executorMonitor.pendingRemovalCount, 0)
-    registerGauge("numberExecutorsGracefullyDecommissioned",
-      executorMonitor.numExecutorsGracefullyDecommissioned, 0)
-    registerGauge("numberExecutorsDecommissionUnfinished",
-      executorMonitor.numExecutorsDecommissionUnfinished, 0)
-    registerGauge("numberExecutorsKilledByDriver",
-      executorMonitor.numExecutorsKilledByDriver, 0)
-    registerGauge("numberExecutorsExitedUnexpectedly",
-      executorMonitor.numExecutorsExitedUnexpectedly, 0)
-    registerGauge("numberAllExecutors", executorMonitor.executorCount, 0)
-    registerGauge("numberTargetExecutors",
-      numExecutorsTargetPerResourceProfileId.values.sum, 0)
-    registerGauge("numberMaxNeededExecutors", numExecutorsTargetPerResourceProfileId.keys
-        .map(maxNumExecutorsNeededPerResourceProfile(_)).sum, 0)
+  private def registerGauge[T](name: String, value: => T, defaultValue: T): Unit = {
+    metricRegistry.register(MetricRegistry.name("executors", name), new Gauge[T] {
+      override def getValue: T = synchronized { Option(value).getOrElse(defaultValue) }
+    })
   }
+
+  private def getCounter(name: String): Counter = {
+    metricRegistry.counter(MetricRegistry.name("executors", name))
+  }
+
+  val gracefullyDecommissioned: Counter = getCounter("numberExecutorsGracefullyDecommissioned")
+  val decommissionUnfinished: Counter = getCounter("numberExecutorsDecommissionUnfinished")
+  val driverKilled: Counter = getCounter("numberExecutorsKilledByDriver")
+  val exitedUnexpectedly: Counter = getCounter("numberExecutorsExitedUnexpectedly")
+
+  // The metrics are going to return the sum for all the different ResourceProfiles.
+  registerGauge("numberExecutorsToAdd",
+    executorAllocationManager.numExecutorsToAddPerResourceProfileId.values.sum, 0)
+  registerGauge("numberExecutorsPendingToRemove",
+    executorAllocationManager.executorMonitor.pendingRemovalCount, 0)
+  registerGauge("numberAllExecutors",
+    executorAllocationManager.executorMonitor.executorCount, 0)
+  registerGauge("numberTargetExecutors",
+    executorAllocationManager.numExecutorsTargetPerResourceProfileId.values.sum, 0)
+  registerGauge("numberMaxNeededExecutors",
+    executorAllocationManager.numExecutorsTargetPerResourceProfileId.keys
+      .map(executorAllocationManager.maxNumExecutorsNeededPerResourceProfile(_)).sum, 0)
 }
 
 private object ExecutorAllocationManager {

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -989,6 +989,14 @@ private[spark] class ExecutorAllocationManager(
     registerGauge("numberExecutorsToAdd",
       numExecutorsToAddPerResourceProfileId.values.sum, 0)
     registerGauge("numberExecutorsPendingToRemove", executorMonitor.pendingRemovalCount, 0)
+    registerGauge("numberExecutorsGracefullyDecommissioned",
+      executorMonitor.numExecutorsGracefullyDecommissioned, 0)
+    registerGauge("numberExecutorsDecommissionUnfinished",
+      executorMonitor.numExecutorsDecommissionUnfinished, 0)
+    registerGauge("numberExecutorsKilledByDriver",
+      executorMonitor.numExecutorsKilledByDriver, 0)
+    registerGauge("numberExecutorsExitedUnexpectedly",
+      executorMonitor.numExecutorsExitedUnexpectedly, 0)
     registerGauge("numberAllExecutors", executorMonitor.executorCount, 0)
     registerGauge("numberTargetExecutors",
       numExecutorsTargetPerResourceProfileId.values.sum, 0)

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -39,7 +39,7 @@ import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.resource.ResourceProfile._
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.rpc._
-import org.apache.spark.scheduler.{ExecutorLossReason, TaskDescription}
+import org.apache.spark.scheduler.{ExecutorLossMessage, ExecutorLossReason, TaskDescription}
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.util.{ChildFirstURLClassLoader, MutableURLClassLoader, SignalUtils, ThreadUtils, Utils}
@@ -322,13 +322,13 @@ private[spark] class CoarseGrainedExecutorBackend(
                 // since the start of computing it.
                 if (allBlocksMigrated && (migrationTime > lastTaskRunningTime)) {
                   logInfo("No running tasks, all blocks migrated, stopping.")
-                  exitExecutor(0, "Finished decommissioning", notifyDriver = true)
+                  exitExecutor(0, ExecutorLossMessage.decommissionFinished, notifyDriver = true)
                 } else {
                   logInfo("All blocks not yet migrated.")
                 }
               } else {
                 logInfo("No running tasks, no block migration configured, stopping.")
-                exitExecutor(0, "Finished decommissioning", notifyDriver = true)
+                exitExecutor(0, ExecutorLossMessage.decommissionFinished, notifyDriver = true)
               }
             } else {
               logInfo("Blocked from shutdown by running ${executor.numRunningtasks} tasks")

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutorLossReason.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutorLossReason.scala
@@ -40,6 +40,10 @@ private[spark] object ExecutorExited {
   }
 }
 
+private[spark] object ExecutorLossMessage {
+  val decommissionFinished = "Finished decommissioning"
+}
+
 private[spark] object ExecutorKilled extends ExecutorLossReason("Executor killed by driver.")
 
 /**

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -946,20 +946,20 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(executorsPendingToRemove(manager).contains("2"))
 
     onExecutorRemoved(manager, "1", "driver requested exit")
-    assert(manager.executorMonitor.numExecutorsKilledByDriver === 1)
-    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 0)
+    assert(manager.executorAllocationManagerSource.driverKilled.getCount() === 1)
+    assert(manager.executorAllocationManagerSource.exitedUnexpectedly.getCount() === 0)
 
     onExecutorRemoved(manager, "2", "another driver requested exit")
-    assert(manager.executorMonitor.numExecutorsKilledByDriver === 2)
-    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 0)
+    assert(manager.executorAllocationManagerSource.driverKilled.getCount() === 2)
+    assert(manager.executorAllocationManagerSource.exitedUnexpectedly.getCount() === 0)
 
     onExecutorRemoved(manager, "3", "this will be an unexpected exit")
-    assert(manager.executorMonitor.numExecutorsKilledByDriver === 2)
-    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 1)
+    assert(manager.executorAllocationManagerSource.driverKilled.getCount() === 2)
+    assert(manager.executorAllocationManagerSource.exitedUnexpectedly.getCount() === 1)
   }
 
-  test("SPARK-33763: metrics to track dynamic allocation (decommissionEnabled=true)") {
-    val manager = createManager(createConf(3, 5, 3, decommissioningEnabled=true))
+  test("SPARK-33763: metrics to track dynamic allocation (decommissionEnabled = true)") {
+    val manager = createManager(createConf(3, 5, 3, decommissioningEnabled = true))
     (1 to 5).map(_.toString).foreach { id => onExecutorAddedDefaultProfile(manager, id) }
 
     assert(executorsPendingToRemove(manager).isEmpty)
@@ -968,19 +968,19 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(executorsDecommissioning(manager).contains("2"))
 
     onExecutorRemoved(manager, "1", ExecutorLossMessage.decommissionFinished)
-    assert(manager.executorMonitor.numExecutorsGracefullyDecommissioned === 1)
-    assert(manager.executorMonitor.numExecutorsDecommissionUnfinished === 0)
-    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 0)
+    assert(manager.executorAllocationManagerSource.gracefullyDecommissioned.getCount() === 1)
+    assert(manager.executorAllocationManagerSource.decommissionUnfinished.getCount() === 0)
+    assert(manager.executorAllocationManagerSource.exitedUnexpectedly.getCount() === 0)
 
     onExecutorRemoved(manager, "2", "stopped before gracefully finished")
-    assert(manager.executorMonitor.numExecutorsGracefullyDecommissioned === 1)
-    assert(manager.executorMonitor.numExecutorsDecommissionUnfinished === 1)
-    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 0)
+    assert(manager.executorAllocationManagerSource.gracefullyDecommissioned.getCount() === 1)
+    assert(manager.executorAllocationManagerSource.decommissionUnfinished.getCount() === 1)
+    assert(manager.executorAllocationManagerSource.exitedUnexpectedly.getCount() === 0)
 
     onExecutorRemoved(manager, "3", "this will be an unexpected exit")
-    assert(manager.executorMonitor.numExecutorsGracefullyDecommissioned === 1)
-    assert(manager.executorMonitor.numExecutorsDecommissionUnfinished === 1)
-    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 1)
+    assert(manager.executorAllocationManagerSource.gracefullyDecommissioned.getCount() === 1)
+    assert(manager.executorAllocationManagerSource.decommissionUnfinished.getCount() === 1)
+    assert(manager.executorAllocationManagerSource.exitedUnexpectedly.getCount() === 1)
   }
 
   test("remove multiple executors") {

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -936,6 +936,53 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(executorsPendingToRemove(manager).isEmpty)
   }
 
+  test("SPARK-33763: metrics to track dynamic allocation (decommissionEnabled=false)") {
+    val manager = createManager(createConf(3, 5, 3))
+    (1 to 5).map(_.toString).foreach { id => onExecutorAddedDefaultProfile(manager, id) }
+
+    assert(executorsPendingToRemove(manager).isEmpty)
+    assert(removeExecutorsDefaultProfile(manager, Seq("1", "2")) === Seq("1", "2"))
+    assert(executorsPendingToRemove(manager).contains("1"))
+    assert(executorsPendingToRemove(manager).contains("2"))
+
+    onExecutorRemoved(manager, "1", "driver requested exit")
+    assert(manager.executorMonitor.numExecutorsKilledByDriver === 1)
+    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 0)
+
+    onExecutorRemoved(manager, "2", "another driver requested exit")
+    assert(manager.executorMonitor.numExecutorsKilledByDriver === 2)
+    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 0)
+
+    onExecutorRemoved(manager, "3", "this will be an unexpected exit")
+    assert(manager.executorMonitor.numExecutorsKilledByDriver === 2)
+    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 1)
+  }
+
+  test("SPARK-33763: metrics to track dynamic allocation (decommissionEnabled=true)") {
+    val manager = createManager(createConf(3, 5, 3, decommissioningEnabled=true))
+    (1 to 5).map(_.toString).foreach { id => onExecutorAddedDefaultProfile(manager, id) }
+
+    assert(executorsPendingToRemove(manager).isEmpty)
+    assert(removeExecutorsDefaultProfile(manager, Seq("1", "2")) === Seq("1", "2"))
+    assert(executorsDecommissioning(manager).contains("1"))
+    assert(executorsDecommissioning(manager).contains("2"))
+
+    onExecutorRemoved(manager, "1", ExecutorLossMessage.decommissionFinished)
+    assert(manager.executorMonitor.numExecutorsGracefullyDecommissioned === 1)
+    assert(manager.executorMonitor.numExecutorsDecommissionUnfinished === 0)
+    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 0)
+
+    onExecutorRemoved(manager, "2", "stopped before gracefully finished")
+    assert(manager.executorMonitor.numExecutorsGracefullyDecommissioned === 1)
+    assert(manager.executorMonitor.numExecutorsDecommissionUnfinished === 1)
+    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 0)
+
+    onExecutorRemoved(manager, "3", "this will be an unexpected exit")
+    assert(manager.executorMonitor.numExecutorsGracefullyDecommissioned === 1)
+    assert(manager.executorMonitor.numExecutorsDecommissionUnfinished === 1)
+    assert(manager.executorMonitor.numExecutorsExitedUnexpectedly === 1)
+  }
+
   test("remove multiple executors") {
     val manager = createManager(createConf(5, 10, 5))
     (1 to 10).map(_.toString).foreach { id => onExecutorAddedDefaultProfile(manager, id) }
@@ -1701,8 +1748,11 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     post(SparkListenerExecutorAdded(0L, id, execInfo))
   }
 
-  private def onExecutorRemoved(manager: ExecutorAllocationManager, id: String): Unit = {
-    post(SparkListenerExecutorRemoved(0L, id, null))
+  private def onExecutorRemoved(
+      manager: ExecutorAllocationManager,
+      id: String,
+      reason: String = null): Unit = {
+    post(SparkListenerExecutorRemoved(0L, id, reason))
   }
 
   private def onExecutorBusy(manager: ExecutorAllocationManager, id: String): Unit = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -16,6 +16,10 @@
  */
 package org.apache.spark.deploy.k8s.integrationtest
 
+import org.scalatest.concurrent.PatienceConfiguration
+import org.scalatest.time.Minutes
+import org.scalatest.time.Span
+
 import org.apache.spark.internal.config
 
 private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
@@ -107,7 +111,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
       expectedDriverLogOnCompletion = Seq(
         "Finished waiting, stopping Spark",
         "Decommission executors",
-        "Remove reason statistics: (gracefully decommissioned: 2, decommision unfinished: 0, " +
+        "Remove reason statistics: (gracefully decommissioned: 1, decommision unfinished: 0, " +
           "driver killed: 0, unexpectedly exited: 0)."),
       appArgs = Array.empty[String],
       driverPodChecker = doBasicDriverPyPodCheck,
@@ -115,7 +119,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
       appLocator = appLocator,
       isJVM = false,
       pyFiles = None,
-      executorPatience = None,
+      executorPatience = Some(None, Some(DECOMMISSIONING_FINISHED_TIMEOUT)),
       decommissioningTest = false)
   }
 }
@@ -125,4 +129,5 @@ private[spark] object DecommissionSuite {
   val PYSPARK_DECOMISSIONING: String = TEST_LOCAL_PYSPARK + "decommissioning.py"
   val PYSPARK_DECOMISSIONING_CLEANUP: String = TEST_LOCAL_PYSPARK + "decommissioning_cleanup.py"
   val PYSPARK_SCALE: String = TEST_LOCAL_PYSPARK + "autoscale.py"
+  val DECOMMISSIONING_FINISHED_TIMEOUT = PatienceConfiguration.Timeout(Span(4, Minutes))
 }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -106,7 +106,9 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
       mainClass = "",
       expectedDriverLogOnCompletion = Seq(
         "Finished waiting, stopping Spark",
-        "Decommission executors"),
+        "Decommission executors",
+        "Remove reason statistics: (gracefully decommissioned: 2, decommision unfinished: 0, " +
+          "driver killed: 0, unexpectedly exited: 0)."),
       appArgs = Array.empty[String],
       driverPodChecker = doBasicDriverPyPodCheck,
       executorPodChecker = doBasicExecutorPyPodCheck,

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -404,20 +404,22 @@ class KubernetesSuite extends SparkFunSuite
 
     Eventually.eventually(patienceTimeout, patienceInterval) {
       expectedDriverLogOnCompletion.foreach { e =>
-        assert(kubernetesTestComponents.kubernetesClient
+        val driverLog = kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(driverPod.getMetadata.getName)
           .getLog
-          .contains(e),
-          s"The application did not complete, driver log did not contain str ${e}")
+        assert(driverLog.contains(e),
+          s"The application did not complete, driver log did not contain str ${e}." +
+            s"Last driver log:\n$driverLog")
       }
       expectedExecutorLogOnCompletion.foreach { e =>
-        assert(kubernetesTestComponents.kubernetesClient
+        val execLog = kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(execPod.get.getMetadata.getName)
           .getLog
-          .contains(e),
-          s"The application did not complete, executor log did not contain str ${e}")
+        assert(execLog.contains(e),
+          s"The application did not complete, executor log did not contain str ${e}." +
+           s"Last executor log:\n$execLog")
       }
     }
     execWatcher.close()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -404,22 +404,20 @@ class KubernetesSuite extends SparkFunSuite
 
     Eventually.eventually(patienceTimeout, patienceInterval) {
       expectedDriverLogOnCompletion.foreach { e =>
-        val driverLog = kubernetesTestComponents.kubernetesClient
+        assert(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(driverPod.getMetadata.getName)
           .getLog
-        assert(driverLog.contains(e),
-          s"The application did not complete, driver log did not contain str ${e}." +
-            s"Last driver log:\n$driverLog")
+          .contains(e),
+          s"The application did not complete, driver log did not contain str ${e}")
       }
       expectedExecutorLogOnCompletion.foreach { e =>
-        val execLog = kubernetesTestComponents.kubernetesClient
+        assert(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(execPod.get.getMetadata.getName)
           .getLog
-        assert(execLog.contains(e),
-          s"The application did not complete, executor log did not contain str ${e}." +
-           s"Last executor log:\n$execLog")
+          .contains(e),
+          s"The application did not complete, executor log did not contain str ${e}")
       }
     }
     execWatcher.close()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the following metrics to track executor remove reasons during dynamic allocation:
-  `numberExecutorsGracefullyDecommissioned`: number of executors which reached the finished decommissioning state and shut itself down cleanly
- `numberExecutorsDecommissionUnfinished`: executors which requested to decommission but they stopped without reaching the finished decommissioning state 
- `numberExecutorsKilledByDriver`: executors killed by the driver (requested to stop)  
-  `numberExecutorsExitedUnexpectedly`: executors exited without driver request

### Why are the changes needed?

For supporting monitoring of dynamic allocation better with these metrics.  

### Does this PR introduce _any_ user-facing change?

Yes. The new metrics will be available for monitoring.

### How was this patch tested?

With unit and integration tests.

Finally manually checked the new metrics in jconsole:
<img width="1054" alt="jmx" src="https://user-images.githubusercontent.com/2017933/107458686-de8adf00-6b54-11eb-86f7-41faf2fb638f.png">
