### PR TITLE
[SPARK-34341][BUILD] Skip zinc related operations on aarch64

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -136,7 +136,9 @@ install_scala() {
 ZINC_PORT=${ZINC_PORT:-"3030"}
 
 # Install the proper version of Scala, Zinc and Maven for the build
-install_zinc
+if [ "$(uname -m)" != 'aarch64' ]; then
+  install_zinc
+fi
 install_scala
 install_mvn
 
@@ -145,7 +147,7 @@ cd "${_CALLING_DIR}"
 
 # Now that zinc is ensured to be installed, check its status and, if its
 # not running or just installed, start it
-if [ -n "${ZINC_INSTALL_FLAG}" -o -z "`"${ZINC_BIN}" -status -port ${ZINC_PORT}`" ]; then
+if [ "$(uname -m)" != 'aarch64' ] && [ -n "${ZINC_INSTALL_FLAG}" -o -z "`"${ZINC_BIN}" -status -port ${ZINC_PORT}`" ]; then
   export ZINC_OPTS=${ZINC_OPTS:-"$_COMPILE_JVM_OPTS"}
   "${ZINC_BIN}" -shutdown -port ${ZINC_PORT}
   "${ZINC_BIN}" -start -port ${ZINC_PORT} \
@@ -165,6 +167,8 @@ echo "Using \`mvn\` from path: $MVN_BIN" 1>&2
 MVN_RETCODE=$?
 
 # Try to shut down zinc explicitly if the server is still running.
-"${ZINC_BIN}" -shutdown -port ${ZINC_PORT}
+if [ "$(uname -m)" != 'aarch64' ]; then
+  "${ZINC_BIN}" -shutdown -port ${ZINC_PORT}
+fi
 
 exit $MVN_RETCODE


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip the zinc related  installation operations on aarch64 platform.


### Why are the changes needed?

The standalone zinc is not supported well on aarch64, so that the error ouput, `cannot execute binary file: Exec format error` dumped after build/mvn is called.

This patch try to skip the zinc installation and related operations on aarch64 to make sure the error output doesn't print again on aarch64.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

simple cmd: `build/mvn -v`, see no error ouput again in aarch64, and nothing changed on x86

- on AArch64 Ubuntu
```
root@yikun-arm:~/dev/spark# uname -a
Linux yikun-arm 4.15.0-70-generic #79-Ubuntu SMP Tue Nov 12 10:36:10 UTC 2019 aarch64 aarch64 aarch64 GNU/Linux
root@yikun-arm:~/dev/spark# uname -m
aarch64
root@yikun-arm:~/dev/spark# build/mvn -v
Using `mvn` from path: /root/dev/spark/build/apache-maven-3.6.3/bin/mvn
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /root/dev/spark/build/apache-maven-3.6.3
Java version: 1.8.0_222, vendor: Private Build, runtime: /usr/lib/jvm/java-8-openjdk-arm64/jre
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "4.15.0-70-generic", arch: "aarch64", family: "unix"
```
- on x86 Mac OS
```
# uname -a
Darwin MacBook.local 19.6.0 Darwin Kernel Version 19.6.0: Tue Nov 10 00:10:30 PST 2020; root:xnu-6153.141.10~1/RELEASE_X86_64 x86_64
# uname -m
x86_64
# build/mvn -v
Using `mvn` from path: /Users/jiangyikun/huawei/apache-maven-3.6.3/bin/mvn
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /Users/jiangyikun/huawei/apache-maven-3.6.3
Java version: 1.8.0_221, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/jdk1.8.0_221.jdk/Contents/Home/jre
Default locale: zh_CN, platform encoding: UTF-8
OS name: "mac os x", version: "10.15.7", arch: "x86_64", family: "mac"
```
- on x86 Ubuntu
```
root@yikun-x86:~/spark# uname -a
Linux yikun-x86 5.4.0-58-generic #64-Ubuntu SMP Wed Dec 9 08:16:25 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
root@yikun-x86:~/spark# uname -m
x86_64
root@yikun-x86:~/spark# ./build//mvn  -v
Using `mvn` from path: /root/spark/build/apache-maven-3.6.3/bin/mvn
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /root/spark/build/apache-maven-3.6.3
Java version: 1.8.0_275, vendor: Private Build, runtime: /usr/lib/jvm/java-8-openjdk-amd64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.4.0-58-generic", arch: "amd64", family: "unix"
```
