### PR TITLE
[SPARK-34352][SQL] Improve SQLQueryTestSuite so as could run on windows system

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -260,9 +260,6 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
       newLine.startsWith("--") && !newLine.startsWith("--QUERY-DELIMITER")
     }
 
-    // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
-    // here we need to check command available
-    assume(TestUtils.testCommandAvailable("/bin/bash"))
     val input = fileToString(new File(testCase.inputFile))
 
     val (comments, code) = splitCommentsAndCodes(input)
@@ -566,7 +563,14 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
     // Filter out test files with invalid extensions such as temp files created
     // by vi (.swp), Mac (.DS_Store) etc.
     val filteredFiles = files.filter(_.getName.endsWith(validFileExtensions))
-    filteredFiles ++ dirs.flatMap(listFilesRecursively)
+    val allFiles = filteredFiles ++ dirs.flatMap(listFilesRecursively)
+    // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
+    // here we need to check command available
+    if (TestUtils.testCommandAvailable("/bin/bash")) {
+      allFiles
+    } else {
+      allFiles.filterNot(_.getName == "transform.sql")
+    }
   }
 
   /** Load built-in test tables into the SparkSession. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -155,12 +155,12 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
     .set(SQLConf.SHUFFLE_PARTITIONS, 4)
 
   /** List of test cases to ignore, in lower cases. */
-  protected val ignoreList: Set[String] = if (TestUtils.testCommandAvailable("/bin/bash")) {
+  protected val ignoreList: Set[String] = Set(
+    "ignored.sql" // Do NOT remove this one. It is here to test the ignore functionality.
+  ) ++ {
     // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
     // here we need to ignore it.
-    Set("ignored.sql", "transform.sql")
-  } else {
-    Set("ignored.sql")   // Do NOT remove this one. It is here to test the ignore functionality.
+    if (TestUtils.testCommandAvailable("/bin/bash")) Nil else Set("transform.sql")
   }
 
   // Create all the test cases.

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -157,7 +157,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
   /** List of test cases to ignore, in lower cases. */
   protected def ignoreList: Set[String] = if (TestUtils.testCommandAvailable("/bin/bash")) {
     // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
-    // here we need to check command available
+    // here we need to ignore it.
     Set("ignored.sql", "transform.sql")
   } else {
     Set("ignored.sql")   // Do NOT remove this one. It is here to test the ignore functionality.

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -155,7 +155,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
     .set(SQLConf.SHUFFLE_PARTITIONS, 4)
 
   /** List of test cases to ignore, in lower cases. */
-  protected def ignoreList: Set[String] = if (TestUtils.testCommandAvailable("/bin/bash")) {
+  protected val ignoreList: Set[String] = if (TestUtils.testCommandAvailable("/bin/bash")) {
     // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
     // here we need to ignore it.
     Set("ignored.sql", "transform.sql")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -154,14 +154,14 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
     // Fewer shuffle partitions to speed up testing.
     .set(SQLConf.SHUFFLE_PARTITIONS, 4)
 
-  /** List of test cases to ignore, in lower cases. */
-  protected val ignoreList: Set[String] = Set(
-    "ignored.sql" // Do NOT remove this one. It is here to test the ignore functionality.
-  ) ++ {
-    // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
-    // here we need to ignore it.
+  // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
+  // here we need to ignore it.
+  private val otherIgnoreList =
     if (TestUtils.testCommandAvailable("/bin/bash")) Nil else Set("transform.sql")
-  }
+  /** List of test cases to ignore, in lower cases. */
+  protected def ignoreList: Set[String] = Set(
+    "ignored.sql" // Do NOT remove this one. It is here to test the ignore functionality.
+  ) ++ otherIgnoreList
 
   // Create all the test cases.
   listTestCases.foreach(createScalaTestCase)

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
@@ -61,7 +61,7 @@ class ThriftServerQueryTestSuite extends SQLQueryTestSuite with SharedThriftServ
   }
 
   /** List of test cases to ignore, in lower cases. */
-  override val ignoreList: Set[String] = super.ignoreList ++ Set(
+  override def ignoreList: Set[String] = super.ignoreList ++ Set(
     // Missing UDF
     "postgreSQL/boolean.sql",
     "postgreSQL/case.sql",

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerQueryTestSuite.scala
@@ -61,7 +61,7 @@ class ThriftServerQueryTestSuite extends SQLQueryTestSuite with SharedThriftServ
   }
 
   /** List of test cases to ignore, in lower cases. */
-  override def ignoreList: Set[String] = super.ignoreList ++ Set(
+  override val ignoreList: Set[String] = super.ignoreList ++ Set(
     // Missing UDF
     "postgreSQL/boolean.sql",
     "postgreSQL/case.sql",


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current implement of `SQLQueryTestSuite` cannot run on windows system.
Becasue the code below will fail on windows system:
`assume(TestUtils.testCommandAvailable("/bin/bash"))`

For operation system that cannot support `/bin/bash`, we just skip some tests.

### Why are the changes needed?
SQLQueryTestSuite has a bug on windows system.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Jenkins test
