### PR TITLE
[MINOR][ML] Param Validation should throw IllegalArgumentException 

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Selector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Selector.scala
@@ -247,7 +247,7 @@ private[ml] abstract class Selector[T <: SelectorModel[T]]
           .where(col("pValue") < $(fwe) / numFeatures)
           .as[Int].collect()
       case errorType =>
-        throw new IllegalStateException(s"Unknown Selector Type: $errorType")
+        throw new IllegalArgumentException(s"Unknown Selector Type: $errorType")
     }
 
     copyValues(createSelectorModel(uid, indices.sorted)

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/ChiSqSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/ChiSqSelector.scala
@@ -283,7 +283,7 @@ class ChiSqSelector @Since("2.1.0") () extends Serializable {
         chiSqTestResult
           .filter { case (res, _) => res.pValue < fwe / chiSqTestResult.length }
       case errorType =>
-        throw new IllegalStateException(s"Unknown ChiSqSelector Type: $errorType")
+        throw new IllegalArgumentException(s"Unknown ChiSqSelector Type: $errorType")
     }
     val indices = features.map { case (_, index) => index }
     new ChiSqSelectorModel(indices)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Param Validation throw `IllegalArgumentException`


### Why are the changes needed?
Param Validation should throw `IllegalArgumentException` instead of `IllegalStateException`


### Does this PR introduce _any_ user-facing change?
Yes, the type of exception changed


### How was this patch tested?
existing testsuites
