### PR TITLE
[SPARK-34356][ML] OVR transform fix potential column conflict

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -223,7 +223,7 @@ class OneVsRestSuite extends MLTest with DefaultReadWriteTest {
     assert(oldCols === newCols)
   }
 
-  test("SPARK-SPARK-34356: OneVsRestModel.transform should avoid potential column conflict") {
+  test("SPARK-34356: OneVsRestModel.transform should avoid potential column conflict") {
     val logReg = new LogisticRegression().setMaxIter(1)
     val ovr = new OneVsRest().setClassifier(logReg)
     val ovrm = ovr.fit(dataset)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -223,6 +223,13 @@ class OneVsRestSuite extends MLTest with DefaultReadWriteTest {
     assert(oldCols === newCols)
   }
 
+  test("SPARK-SPARK-34356: OneVsRestModel.transform should avoid potential column conflict") {
+    val logReg = new LogisticRegression().setMaxIter(1)
+    val ovr = new OneVsRest().setClassifier(logReg)
+    val ovrm = ovr.fit(dataset)
+    assert(ovrm.transform(dataset.withColumn("probability", lit(0.0))).count() === dataset.count())
+  }
+
   test("OneVsRest.copy and OneVsRestModel.copy") {
     val lr = new LogisticRegression()
       .setMaxIter(1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, clear predictionCol & probabilityCol, use tmp rawPred col, to avoid potential column conflict;
2, use array instead of map, to keep in line with the python side;
3, simplify transform

### Why are the changes needed?
if input dataset has a column whose name is `predictionCol`,`probabilityCol`,`RawPredictionCol`, transfrom will fail.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added testsuite