### PR TITLE
[SPARK-32384][CORE] repartitionAndSortWithinPartitions avoid shuffle with same partitioner

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
@@ -78,8 +78,8 @@ class OrderedRDDFunctions[K : Ordering : ClassTag,
       self.mapPartitions(iter => {
         val context = TaskContext.get()
         val sorter = new ExternalSorter[K, V, V](context, None, None, Some(ordering))
-        sorter.insertAll(iter)
-        new InterruptibleIterator(context, sorter.completionIterator.asInstanceOf[Iterator[(K, V)]])
+        new InterruptibleIterator(context,
+          sorter.insertAllAndUpdateMetrics(iter).asInstanceOf[Iterator[(K, V)]])
       }, preservesPartitioning = true)
     } else {
       new ShuffledRDD[K, V, V](self, partitioner).setKeyOrdering(ordering)

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -126,7 +126,7 @@ private[spark] class BlockStoreShuffleReader[K, C](
         val sorter =
           new ExternalSorter[K, C, C](context, ordering = Some(keyOrd), serializer = dep.serializer)
         sorter.insertAll(aggregatedIter)
-        sorter.interruptibleCompletionIterator
+        sorter.completionIterator
       case None =>
         aggregatedIter
     }

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -120,20 +120,13 @@ private[spark] class BlockStoreShuffleReader[K, C](
     }
 
     // Sort the output if there is a sort ordering defined.
-    val resultIter = dep.keyOrdering match {
+    val resultIter: Iterator[Product2[K, C]] = dep.keyOrdering match {
       case Some(keyOrd: Ordering[K]) =>
         // Create an ExternalSorter to sort the data.
         val sorter =
           new ExternalSorter[K, C, C](context, ordering = Some(keyOrd), serializer = dep.serializer)
         sorter.insertAll(aggregatedIter)
-        context.taskMetrics().incMemoryBytesSpilled(sorter.memoryBytesSpilled)
-        context.taskMetrics().incDiskBytesSpilled(sorter.diskBytesSpilled)
-        context.taskMetrics().incPeakExecutionMemory(sorter.peakMemoryUsedBytes)
-        // Use completion callback to stop sorter if task was finished/cancelled.
-        context.addTaskCompletionListener[Unit](_ => {
-          sorter.stop()
-        })
-        CompletionIterator[Product2[K, C], Iterator[Product2[K, C]]](sorter.iterator, sorter.stop())
+        sorter.interruptibleCompletionIterator
       case None =>
         aggregatedIter
     }

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -125,8 +125,7 @@ private[spark] class BlockStoreShuffleReader[K, C](
         // Create an ExternalSorter to sort the data.
         val sorter =
           new ExternalSorter[K, C, C](context, ordering = Some(keyOrd), serializer = dep.serializer)
-        sorter.insertAll(aggregatedIter)
-        sorter.completionIterator
+        sorter.insertAllAndUpdateMetrics(aggregatedIter)
       case None =>
         aggregatedIter
     }

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -32,7 +32,7 @@ import org.apache.spark.serializer._
 import org.apache.spark.shuffle.ShufflePartitionPairsWriter
 import org.apache.spark.shuffle.api.{ShuffleMapOutputWriter, ShufflePartitionWriter}
 import org.apache.spark.storage.{BlockId, DiskBlockObjectWriter, ShuffleBlockId}
-import org.apache.spark.util.{Utils => TryUtils}
+import org.apache.spark.util.{CompletionIterator, Utils => TryUtils}
 
 /**
  * Sorts and potentially merges a number of key-value pairs of type (K, V) to produce key-combiner
@@ -670,6 +670,24 @@ private[spark] class ExternalSorter[K, V, C](
   def iterator: Iterator[Product2[K, C]] = {
     isShuffleSort = false
     partitionedIterator.flatMap(pair => pair._2)
+  }
+
+  /**
+   * Return an iterator over all the data written to this object, aggregated by our aggregator.
+   * On task completion (success, failure, or cancellation), it updates related task metrics,
+   * and releases resources by calling `stop()`.
+   */
+  def interruptibleCompletionIterator: Iterator[Product2[K, C]] = {
+    // Use completion callback to stop sorter if task was finished/cancelled.
+    context.addTaskCompletionListener[Unit]{ _ =>
+      context.taskMetrics().incMemoryBytesSpilled(this.memoryBytesSpilled)
+      context.taskMetrics().incDiskBytesSpilled(this.diskBytesSpilled)
+      context.taskMetrics().incPeakExecutionMemory(this.peakMemoryUsedBytes)
+      this.stop()
+    }
+    val completionIterator = CompletionIterator[Product2[K, C], Iterator[Product2[K, C]]](
+      this.iterator, this.stop())
+    new InterruptibleIterator(context, completionIterator)
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -860,6 +860,32 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
     assert(partitions(1) === Seq((1, 3), (3, 8), (3, 8)))
   }
 
+  test("repartitionAndSortWithinPartitions without shuffle") {
+    val data = sc.parallelize(Seq((0, 5), (3, 8), (2, 6), (0, 8), (3, 8), (1, 3)), 2)
+
+    class ModePartitioner(val numPartitions: Int) extends Partitioner {
+      def getPartition(key: Any): Int = key.asInstanceOf[Int] % numPartitions
+
+      override def equals(other: Any): Boolean = other match {
+        case h: ModePartitioner => h.numPartitions == this.numPartitions
+        case _ => false
+      }
+
+      override def hashCode: Int = numPartitions
+    }
+
+    val partitioner = new ModePartitioner(2)
+    val agged = data.reduceByKey(partitioner, _ + _)
+    assert(agged.partitioner == Some(partitioner))
+
+    val sorted = agged.repartitionAndSortWithinPartitions(partitioner)
+    assert(sorted.partitioner == Some(partitioner))
+
+    val partitions = sorted.glom().collect()
+    assert(partitions(0) === Seq((0, 13), (2, 6)))
+    assert(partitions(1) === Seq((1, 3), (3, 16)))
+  }
+
   test("cartesian on empty RDD") {
     val a = sc.emptyRDD[Int]
     val b = sc.parallelize(1 to 3)

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -860,21 +860,21 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
     assert(partitions(1) === Seq((1, 3), (3, 8), (3, 8)))
   }
 
-  test("repartitionAndSortWithinPartitions without shuffle") {
+  test("SPARK-32384: repartitionAndSortWithinPartitions without shuffle") {
     val data = sc.parallelize(Seq((0, 5), (3, 8), (2, 6), (0, 8), (3, 8), (1, 3)), 2)
 
-    class ModePartitioner(val numPartitions: Int) extends Partitioner {
+    class ModPartitioner(val numPartitions: Int) extends Partitioner {
       def getPartition(key: Any): Int = key.asInstanceOf[Int] % numPartitions
 
       override def equals(other: Any): Boolean = other match {
-        case h: ModePartitioner => h.numPartitions == this.numPartitions
+        case h: ModPartitioner => h.numPartitions == this.numPartitions
         case _ => false
       }
 
       override def hashCode: Int = numPartitions
     }
 
-    val partitioner = new ModePartitioner(2)
+    val partitioner = new ModPartitioner(2)
     val agged = data.reduceByKey(partitioner, _ + _)
     assert(agged.partitioner == Some(partitioner))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
avoid unnecessary shuffle if possible


### Why are the changes needed?
avoid unnecessary shuffle.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added testsuites and existing testsuites
