### PR TITLE
[SQL][MINOR][TEST][3.1] Re-enable some DS v2 char/varchar test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -72,8 +72,6 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("char type values should be padded or trimmed: partitioned columns") {
-    // DSV2 doesn't support DROP PARTITION yet.
-    assume(format != "foo")
     // via dynamic partitioned columns
     withTable("t") {
       sql(s"CREATE TABLE t(i STRING, c CHAR(5)) USING $format PARTITIONED BY (c)")
@@ -102,8 +100,6 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("varchar type values length check and trim: partitioned columns") {
-    // DSV2 doesn't support DROP PARTITION yet.
-    assume(format != "foo")
     (0 to 5).foreach { n =>
       // SPARK-34192: we need to create a a new table for each round of test because of
       // trailing spaces in partition column will be treated differently.
@@ -131,7 +127,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("oversize char/varchar values for alter table partition operations") {
-    // DSV2 doesn't support DROP PARTITION yet.
+    // DSV2 doesn't support RENAME PARTITION yet.
     assume(format != "foo")
     Seq("CHAR(5)", "VARCHAR(5)").foreach { typ =>
       withTable("t") {
@@ -169,8 +165,6 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("char/varchar type values length check: partitioned columns of other types") {
-    // DSV2 doesn't support DROP PARTITION yet.
-    assume(format != "foo")
     Seq("CHAR(5)", "VARCHAR(5)").foreach { typ =>
       withTable("t") {
         sql(s"CREATE TABLE t(i STRING, c $typ) USING $format PARTITIONED BY (c)")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Some tests are skipped in branch 3.1 because some bug fixes were not backported. This PR re-enables some tests that are working fine now.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
enable test

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
N/A