### PR TITLE
[SPARK-34174][SQL] Add 'SHOW PARTITIONS' as table-valued function

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2587,8 +2587,6 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       sql("CREATE TABLE t(id INT) PARTITIONED BY (part STRING)")
       sql("INSERT OVERWRITE TABLE t PARTITION (part = '1') SELECT 1")
       sql("INSERT OVERWRITE TABLE t PARTITION (part = '2') SELECT 2")
-      sql("SELECT * FROM show_partitions('t')").explain()
-      sql("SELECT * FROM show_partitions('t')").show()
       checkAnswer(sql("SELECT * from show_partitions('t')"),
         Row("part=1") :: Row("part=2") :: Nil)
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2581,6 +2581,18 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       }
     }
   }
+
+  test("SPARK-34174: Support SHOW PARTITIONS as table valued function") {
+    withTable("t") {
+      sql("CREATE TABLE t(id INT) PARTITIONED BY (part STRING)")
+      sql("INSERT OVERWRITE TABLE t PARTITION (part = '1') SELECT 1")
+      sql("INSERT OVERWRITE TABLE t PARTITION (part = '2') SELECT 2")
+      sql("SELECT * FROM show_partitions('t')").explain()
+      sql("SELECT * FROM show_partitions('t')").show()
+      checkAnswer(sql("SELECT * from show_partitions('t')"),
+        Row("part=1") :: Row("part=2") :: Nil)
+    }
+  }
 }
 
 @SlowHiveTest


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `SHOW PARTITIONS` as  table-valued function 'show_partitions'
In origin, we can't directly analysis partition metadata information  in SQL, we need export it out and then analysis on it. 
Now, we can just use SQL to do this.

Analysis such as which partition is  lost? how many partitions in a partition value range etc

### Why are the changes needed?
Make it convenient for user to analysis metadata


### Does this PR introduce _any_ user-facing change?
User can use `show_partitions` table-valued function such as .

```
sql("CREATE TABLE t(id INT) PARTITIONED BY (part STRING)")
sql("INSERT OVERWRITE TABLE t PARTITION (part = '1') SELECT 1")
sql("INSERT OVERWRITE TABLE t PARTITION (part = '2') SELECT 2")
sql("SELECT * FROM show_partitions('t')").show()

+---------+
|partition|
+---------+
|   part=1|
|   part=2|
+---------+
```
### How was this patch tested?
added UT
