### PR TITLE
[SPARK-34171][SQL] Add 'SHOW COLUMNS' as table-valued function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableValuedFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableValuedFunctions.scala
@@ -21,9 +21,11 @@ import java.util.Locale
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Range}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Range, ShowColumns}
 import org.apache.spark.sql.catalyst.rules._
-import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
+import org.apache.spark.sql.types.{DataType, IntegerType, LongType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Rule that resolves table-valued function references.
@@ -103,6 +105,23 @@ object ResolveTableValuedFunctions extends Rule[LogicalPlan] {
           "numPartitions" -> IntegerType) {
         case Seq(start: Long, end: Long, step: Long, numPartitions: Int) =>
           Range(start, end, step, Some(numPartitions))
+      }),
+
+    "show_columns" -> Map(
+      /* show_columns(table) */
+      tvf("table" -> StringType) { case Seq(table: UTF8String) =>
+        ShowColumns(UnresolvedTable(
+          CatalystSqlParser.parseMultipartIdentifier(table.toString),
+          "SHOW COLUMNS", None), None)
+      },
+
+      /* show_columns(table, namespaces) */
+      tvf("table" -> StringType, "namespaces" -> StringType) {
+        case Seq(table: UTF8String, namespaces: UTF8String) =>
+          ShowColumns(UnresolvedTable(
+            CatalystSqlParser.parseMultipartIdentifier(table.toString),
+            "SHOW COLUMNS", None),
+            Some(CatalystSqlParser.parseMultipartIdentifier(namespaces.toString)))
       })
   )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `SHOW COLUMNS` as  table-valued function 'show_columns'
In origin, we can't directly analysis column metadata information  in SQL, we need export it out and then analysis on it. 
Now, we can just use SQL to do this.

Analysis columns count? check column name with regex like ecth

### Why are the changes needed?
Make it convenient for user to analysis metadata


### Does this PR introduce _any_ user-facing change?
User can use `show_columns` table-valued function such as .

```
sql("CREATE TABLE t(id INT) PARTITIONED BY (part STRING)")
sql("SELECT * from show_columns('t')")
+--------+
|col_name|
+--------+
|      id|
|    part|
+--------+
```
### How was this patch tested?
added UT
