### PR TITLE
custom formatters for partitioning

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -130,11 +130,9 @@ object PartitioningUtils {
       Map.empty[String, String]
     }
 
-    val dateFormatter = DateFormatter(zoneId)
-    val timestampFormatter = TimestampFormatter(
-      timestampPartitionPattern,
-      zoneId,
-      isParsing = true)
+    val dateFormatter = DateFormatter.getPartitioningFormatter(zoneId)
+    val timestampFormatter = TimestampFormatter.getPartitioningFormatter(zoneId)
+
     // First, we need to parse every partition's path and see if we can find partition values.
     val (partitionValues, optDiscoveredBasePaths) = paths.map { path =>
       parsePartition(path, typeInference, basePaths, userSpecifiedDataTypes,


### PR DESCRIPTION
WIP

Things I don't like:

1. We're still calling `convertSpecialDate/Timestamp` just as much as the previous solution as it's called twice in the `parse()` methods.
2. `DateFormatter.getPartitioningFormatter` and `TimestampFormatter.getPartitioningFormatter` are duplicating the legacy format stuff in `DateFormatter.apply` and `TimestampFormatter.apply``` respectively.

1) Could be solved by extracting the parse logic from e.g. Iso8601DateFormatter into some mthod with a `considerSpecial` flag.  This would come at the cost of the code more difficult to read. E.g. we might need an extra abstract base class.

2) Can only be solved if we decide we don't need to support legacy formats, but this would be a breaking change with the previous code.
