### PR TITLE
[SPARK-34400][CORE] Check spark.job.interruptOnCancel value is illegal before submit job

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -729,9 +729,9 @@ class SparkContext(config: SparkConf) extends Logging {
       try {
         value.toBoolean
       } catch {
-        case e: IllegalArgumentException =>
-          throw new SparkException(s"${SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL} " +
-            s"is invalid: $value. Please use 'true' or 'false'.", e)
+        case _: IllegalArgumentException =>
+          throw new IllegalArgumentException(s"${SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL} " +
+            s"value is invalid: $value. Please use 'true' or 'false'.")
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -719,7 +719,20 @@ class SparkContext(config: SparkConf) extends Logging {
     if (value == null) {
       localProperties.get.remove(key)
     } else {
+      checkLocalProperty(key, value)
       localProperties.get.setProperty(key, value)
+    }
+  }
+
+  private def checkLocalProperty(key: String, value: String): Unit = {
+    if (key == SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL) {
+      try {
+        value.toBoolean
+      } catch {
+        case e: IllegalArgumentException =>
+          throw new SparkException(s"${SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL} " +
+            s"is invalid: $value. Please use 'true' or 'false'.", e)
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1530,7 +1530,7 @@ private[spark] class DAGScheduler(
     if (job.properties == null) {
       false
     } else {
-        job.properties.getProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false").toBoolean
+      job.properties.getProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false").toBoolean
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1530,9 +1530,7 @@ private[spark] class DAGScheduler(
     if (job.properties == null) {
       false
     } else {
-      val shouldInterruptThread =
-        job.properties.getProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false")
-      shouldInterruptThread.toBoolean
+        job.properties.getProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false").toBoolean
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1532,14 +1532,7 @@ private[spark] class DAGScheduler(
     } else {
       val shouldInterruptThread =
         job.properties.getProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false")
-      try {
-        shouldInterruptThread.toBoolean
-      } catch {
-        case e: IllegalArgumentException =>
-          logWarning(s"${SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL} in Job ${job.jobId} " +
-            s"is invalid: $shouldInterruptThread. Using 'false' instead", e)
-          false
-      }
+      shouldInterruptThread.toBoolean
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1184,6 +1184,18 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     assert(sc.hadoopConfiguration.get(bufferKey).toInt === 65536,
       "spark configs have higher priority than spark.hadoop configs")
   }
+
+  test("SPARK-34400: Check spark.job.interruptOnCancel value is illegal before submit job") {
+    val conf = new SparkConf().setAppName("test").setMaster("local")
+    val sc = SparkContext.getOrCreate(conf)
+    val msg = intercept[IllegalArgumentException] {
+      sc.setLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false1")
+    }.getMessage
+    assert(msg.contains(s"${SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL} value is invalid: false1"))
+    sc.setLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false")
+    assert(!sc.getLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL).toBoolean)
+    sc.stop()
+  }
 }
 
 object SparkContextSuite {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add value check before setLcoalProperty if key is `spark.job.interruptOnCancel`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Checking config when setting is better than using.

Before this PR, `spark.job.interruptOnCancel` value will fallback to `false` if it's not a legal Boolean. E.g., a user has such code `sc.setLocalProperty("spark.job.interruptOnCancel", "ture")` and Spark will use `false` instead silently if need kill tasks.

This PR try to add a pre check when user set local property, and throw expcetion if the value is not a Boolean.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
add test