### PR TITLE
[SPARK-34157][BUILD][FOLLOW-UP] Fix Scala 2.13 compilation error via using Array.deep

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -109,19 +109,19 @@ trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase {
       withTable("tbl") {
         sql("CREATE TABLE tbl(col1 int, col2 string) USING parquet")
         checkAnswer(sql("show tables"), Row("ns", "tbl", false))
-        assert(sql("show tables").schema.fieldNames.deep ==
+        assert(sql("show tables").schema.fieldNames ===
           Seq("namespace", "tableName", "isTemporary"))
         assert(sql("show table extended like 'tbl'").collect()(0).length == 4)
-        assert(sql("show table extended like 'tbl'").schema.fieldNames.deep ==
+        assert(sql("show table extended like 'tbl'").schema.fieldNames ===
           Seq("namespace", "tableName", "isTemporary", "information"))
 
         // Keep the legacy output schema
         withSQLConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA.key -> "true") {
           checkAnswer(sql("show tables"), Row("ns", "tbl", false))
-          assert(sql("show tables").schema.fieldNames.deep ==
+          assert(sql("show tables").schema.fieldNames ===
             Seq("database", "tableName", "isTemporary"))
           assert(sql("show table extended like 'tbl'").collect()(0).length == 4)
-          assert(sql("show table extended like 'tbl'").schema.fieldNames.deep ==
+          assert(sql("show table extended like 'tbl'").schema.fieldNames ===
             Seq("database", "tableName", "isTemporary", "information"))
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -102,7 +102,7 @@ trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase {
     }
   }
 
-  test("SPARK-34157 Unify output of SHOW TABLES and pass output attributes properly") {
+  test("SPARK-34157: Unify output of SHOW TABLES and pass output attributes properly") {
     withNamespace(s"$catalog.ns") {
       sql(s"CREATE NAMESPACE $catalog.ns")
       sql(s"USE $catalog.ns")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/31245:

```
[error] /home/runner/work/spark/spark/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala:112:53: value deep is not a member of Array[String]
[error]         assert(sql("show tables").schema.fieldNames.deep ==
[error]                                                     ^
[error] /home/runner/work/spark/spark/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala:115:72: value deep is not a member of Array[String]
[error]         assert(sql("show table extended like 'tbl'").schema.fieldNames.deep ==
[error]                                                                        ^
[error] /home/runner/work/spark/spark/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala:121:55: value deep is not a member of Array[String]
[error]           assert(sql("show tables").schema.fieldNames.deep ==
[error]                                                       ^
[error] /home/runner/work/spark/spark/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala:124:74: value deep is not a member of Array[String]
[error]           assert(sql("show table extended like 'tbl'").schema.fieldNames.deep ==
[error]                                                                          ^
```

It broke Scala 2.13 build. This PR works around by using ScalaTests' `===` that can compare `Array`s safely.

### Why are the changes needed?

To fix the build.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this PR should test it out.