### PR TITLE
[MINOR] Add a note about pip installation test in RC for release vote template

### DIFF
--- a/dev/create-release/vote.tmpl
+++ b/dev/create-release/vote.tmpl
@@ -37,8 +37,9 @@ an existing Spark workload and running on this release candidate, then
 reporting any regressions.
 
 If you're working in PySpark you can set up a virtual env and install
-the current RC and see if anything important breaks, in the Java/Scala
-you can add the staging repository to your projects resolvers and test
+the current RC via "pip install https://dist.apache.org/repos/dist/dev/spark/{tag}-bin/pyspark-{version}.tar.gz"
+and see if anything important breaks.
+In the Java/Scala, you can add the staging repository to your projects resolvers and test
 with the RC (make sure to clean up the artifact cache before/after so
 you don't end up building with a out of date RC going forward).
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add a note about pip installation test in RC for release vote template.

### Why are the changes needed?

To promote PySpark users to test PyPi distribution and pip installation.

### Does this PR introduce _any_ user-facing change?

No. It will be used for release vote.

### How was this patch tested?

N/A
