### PR TITLE
[SPARK-34403][SQL]Remove dependency to commons-httpclient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <commons.httpclient.version>4.5.6</commons.httpclient.version>
     <commons.httpcore.version>4.4.12</commons.httpcore.version>
     <!--  commons-httpclient/commons-httpclient-->
-    <httpclient.classic.version>3.1</httpclient.classic.version>
+    <!-- SPARK-34403: contains vulnerabilities <httpclient.classic.version>3.1</httpclient.classic.version> -->
     <commons.math3.version>3.4.1</commons.math3.version>
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
@@ -580,11 +580,11 @@
         <artifactId>jsr305</artifactId>
         <version>${jsr305.version}</version>
       </dependency>
-      <dependency>
+      <!--SPARK-34403: contains vulnerabilities <dependency>
         <groupId>commons-httpclient</groupId>
         <artifactId>commons-httpclient</artifactId>
         <version>${httpclient.classic.version}</version>
-      </dependency>
+      </dependency> -->
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -129,10 +129,10 @@
       <artifactId>avro-mapred</artifactId>
       <classifier>${avro.mapred.classifier}</classifier>
     </dependency>
-    <dependency>
+    <!-- <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
-    </dependency>
+    </dependency> -->
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove below dependency:
```
<dependency>
  <groupId>commons-httpclient</groupId>
  <artifactId>commons-httpclient</artifactId>
</dependency>
```
Is unsafe due to CVE-2012-6153 and CVE-2012-6153. Also, there is no code calling these libs (`org.apache.commons.httpclient`). 


### Why are the changes needed?
Is unsafe due to CVE-2012-6153 and CVE-2012-6153. Also, there is no code calling these libs (`org.apache.commons.httpclient`). 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Run ```spark/sql/hive$mvn compile test``` result is SUCCESS
