### PR TITLE
[SPARK-34429] [ML] KMeansSummary class is omitted from PySpark documentation

### DIFF
--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -26,7 +26,7 @@ from pyspark.ml.common import inherit_doc
 from pyspark.sql import DataFrame
 
 __all__ = ['BisectingKMeans', 'BisectingKMeansModel', 'BisectingKMeansSummary',
-           'KMeans', 'KMeansModel',
+           'KMeans', 'KMeansModel', 'KMeansSummary',
            'GaussianMixture', 'GaussianMixtureModel', 'GaussianMixtureSummary',
            'LDA', 'LDAModel', 'LocalLDAModel', 'DistributedLDAModel', 'PowerIterationClustering']
 


### PR DESCRIPTION
#### What changes were proposed in this pull request?

KMeansSummary was added to __all__ in the file clustering.py.
#### Why are the changes needed?

KMeansSummary class is undocumented, invisible to modules which import clustering.py.
#### Does this PR introduce any user-facing change?

Yes. The documentation for KMeansSummary is now emitted by Sphinx.
#### How was this patch tested?

Existing tests.