### PR TITLE
[SPARK-34412][SQL] RemoveNoopOperators should only remove trivial projects

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -494,11 +494,14 @@ object RemoveRedundantAliases extends Rule[LogicalPlan] {
 object RemoveNoopOperators extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
     // Eliminate no-op Projects
-    case p @ Project(_, child) if child.sameOutput(p) => child
+    case p @ Project(projectList, child)
+      if projectList.forall(isAttribute) && child.sameOutput(p) => child
 
     // Eliminate no-op Window
     case w: Window if w.windowExpressions.isEmpty => w.child
   }
+
+  private def isAttribute(ne: NamedExpression): Boolean = ne.isInstanceOf[Attribute]
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2737,7 +2737,7 @@ class DataFrameSuite extends QueryTest
     checkAnswer(df.select(col2), Row(1) :: Row(2) :: Row(3) :: Nil)
   }
 
-  test("SC-13495: Self union in PropagateEmptyRelation") {
+  test("SPARK-34412: Self union in PropagateEmptyRelation & RemoveNoopOperators") {
     val rowRDD1 = sparkContext.parallelize(Seq(Row(100, "OK"), Row(200, "OK")))
     val schema1 = StructType(Array(StructField("id", IntegerType, false),
       StructField("status", StringType, false)))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR makes the RemoveNoopOperators only remove attribute only projects.

### Why are the changes needed?
RemoveNoopOperators can remove non-trivial projections that contain actual expressions instead of just attributes, when that expression reuses the expression id of its input. This is a problem with self unions.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test + regression test.