### PR TITLE
[SPARK-34416][SQL] Adding support for user provided schema url in Avro

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -55,9 +55,7 @@ private[avro] case class AvroDataToCatalyst(
 
   @transient private lazy val actualSchema = new Schema.Parser().parse(jsonFormatSchema)
 
-  @transient private lazy val expectedSchema = avroOptions.schema
-    .map(expectedSchema => new Schema.Parser().parse(expectedSchema))
-    .getOrElse(actualSchema)
+  @transient private lazy val expectedSchema = avroOptions.schema.getOrElse(actualSchema)
 
   @transient private lazy val reader = new GenericDatumReader[Any](actualSchema, expectedSchema)
 

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
@@ -22,7 +22,6 @@ import java.net.URI
 
 import scala.util.control.NonFatal
 
-import org.apache.avro.Schema
 import org.apache.avro.file.DataFileReader
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.mapred.FsInput
@@ -91,7 +90,7 @@ private[sql] class AvroFileFormat extends FileFormat
 
     (file: PartitionedFile) => {
       val conf = broadcastedConf.value.value
-      val userProvidedSchema = parsedOptions.schema.map(new Schema.Parser().parse)
+      val userProvidedSchema = parsedOptions.schema
 
       // TODO Removes this check once `FileFormat` gets a general file filtering interface method.
       // Doing input file filtering is improper because we may generate empty tasks that process no

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -53,18 +53,22 @@ private[sql] class AvroOptions(
    */
   val schema: Option[Schema] = {
 
-    val avroUrlSchema = parameters.get("avroSchemaUrl").map(schemaFSUrl => {
-      log.info("loading avro schema from url: " + schemaFSUrl)
-      val fs = FileSystem.get(new URI(schemaFSUrl), conf)
-      val in = fs.open(new Path(schemaFSUrl))
-      try {
-        new Schema.Parser().parse(in)
-      } finally {
-        in.close()
-      }
+    parameters.get("avroSchema").map(new Schema.Parser().parse).orElse({
+
+      val avroUrlSchema = parameters.get("avroSchemaUrl").map(schemaFSUrl => {
+        log.info("loading avro schema from url: " + schemaFSUrl)
+        val fs = FileSystem.get(new URI(schemaFSUrl), conf)
+        val in = fs.open(new Path(schemaFSUrl))
+        try {
+          new Schema.Parser().parse(in)
+        } finally {
+          in.close()
+        }
+      })
+
+      avroUrlSchema
     })
 
-    avroUrlSchema.orElse(parameters.get("avroSchema").map(new Schema.Parser().parse))
   }
 
   /**

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -17,7 +17,11 @@
 
 package org.apache.spark.sql.avro
 
+import java.net.URI
+
+import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
@@ -36,7 +40,7 @@ private[sql] class AvroOptions(
   }
 
   /**
-   * Optional schema provided by a user in JSON format.
+   * Optional schema provided by a user in schema file or in JSON format.
    *
    * When reading Avro, this option can be set to an evolved schema, which is compatible but
    * different with the actual Avro schema. The deserialization schema will be consistent with
@@ -47,7 +51,21 @@ private[sql] class AvroOptions(
    * schema converted by Spark. For example, the expected schema of one column is of "enum" type,
    * instead of "string" type in the default converted schema.
    */
-  val schema: Option[String] = parameters.get("avroSchema")
+  val schema: Option[Schema] = {
+
+    val avroUrlSchema = parameters.get("avroSchemaUrl").map(schemaFSUrl => {
+      log.info("loading avro schema from url: " + schemaFSUrl)
+      val fs = FileSystem.get(new URI(schemaFSUrl), conf)
+      val in = fs.open(new Path(schemaFSUrl))
+      try {
+        new Schema.Parser().parse(in)
+      } finally {
+        in.close()
+      }
+    })
+
+    avroUrlSchema.orElse(parameters.get("avroSchema").map(new Schema.Parser().parse))
+  }
 
   /**
    * Top level record name in write result, which is required in Avro spec.

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -52,23 +52,19 @@ private[sql] class AvroOptions(
    * instead of "string" type in the default converted schema.
    */
   val schema: Option[Schema] = {
-
     parameters.get("avroSchema").map(new Schema.Parser().parse).orElse({
-
-      val avroUrlSchema = parameters.get("avroSchemaUrl").map(schemaFSUrl => {
-        log.info("loading avro schema from url: " + schemaFSUrl)
-        val fs = FileSystem.get(new URI(schemaFSUrl), conf)
-        val in = fs.open(new Path(schemaFSUrl))
+      val avroUrlSchema = parameters.get("avroSchemaUrl").map(url => {
+        log.debug("loading avro schema from url: " + url)
+        val fs = FileSystem.get(new URI(url), conf)
+        val in = fs.open(new Path(url))
         try {
           new Schema.Parser().parse(in)
         } finally {
           in.close()
         }
       })
-
       avroUrlSchema
     })
-
   }
 
   /**

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -54,7 +54,6 @@ private[sql] object AvroUtils extends Logging {
     }
     // User can specify an optional avro json schema.
     val avroSchema = parsedOptions.schema
-      .map(new Schema.Parser().parse)
       .getOrElse {
         inferAvroSchemaFromFiles(files, conf, parsedOptions.ignoreExtension,
           spark.sessionState.conf.ignoreCorruptFiles)
@@ -94,7 +93,6 @@ private[sql] object AvroUtils extends Logging {
       dataSchema: StructType): OutputWriterFactory = {
     val parsedOptions = new AvroOptions(options, job.getConfiguration)
     val outputAvroSchema: Schema = parsedOptions.schema
-      .map(new Schema.Parser().parse)
       .getOrElse(SchemaConverters.toAvroType(dataSchema, nullable = false,
         parsedOptions.recordName, parsedOptions.recordNamespace))
 

--- a/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroPartitionReaderFactory.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroPartitionReaderFactory.scala
@@ -20,7 +20,6 @@ import java.net.URI
 
 import scala.util.control.NonFatal
 
-import org.apache.avro.Schema
 import org.apache.avro.file.DataFileReader
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.mapred.FsInput
@@ -61,7 +60,7 @@ case class AvroPartitionReaderFactory(
 
   override def buildReader(partitionedFile: PartitionedFile): PartitionReader[InternalRow] = {
     val conf = broadcastedConf.value.value
-    val userProvidedSchema = parsedOptions.schema.map(new Schema.Parser().parse)
+    val userProvidedSchema = parsedOptions.schema
 
     if (parsedOptions.ignoreExtension || partitionedFile.filePath.endsWith(".avro")) {
       val reader = {

--- a/external/avro/src/test/resources/test_sub.avsc
+++ b/external/avro/src/test/resources/test_sub.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "test_schema",
+  "fields" : [{
+    "name" : "string",
+    "type" : "string",
+    "doc"  : "Meaningless string of characters"
+  }]
+}

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -702,7 +702,7 @@ abstract class AvroSuite
     }
   }
 
-  test("support user provided avro schema") {
+  test("support user provided avro schema string") {
     val avroSchema =
       """
         |{
@@ -718,6 +718,16 @@ abstract class AvroSuite
     val result = spark
       .read
       .option("avroSchema", avroSchema)
+      .format("avro")
+      .load(testAvro)
+      .collect()
+    val expected = spark.read.format("avro").load(testAvro).select("string").collect()
+    assert(result.sameElements(expected))
+  }
+
+  test("support user provided avro schema url") {
+    val avroSchemaUrl = "src/test/resources/test_sub.avsc"
+    val result = spark.read.option("avroSchemaUrl", avroSchemaUrl)
       .format("avro")
       .load(testAvro)
       .collect()

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -702,7 +702,7 @@ abstract class AvroSuite
     }
   }
 
-  test("support user provided avro schema string") {
+  test("support user provided avro schema") {
     val avroSchema =
       """
         |{
@@ -725,7 +725,7 @@ abstract class AvroSuite
     assert(result.sameElements(expected))
   }
 
-  test("support user provided avro schema url") {
+  test("SPARK-34416: support user provided avro schema url") {
     val avroSchemaUrl = testFile("test_sub.avsc")
     val result = spark.read.option("avroSchemaUrl", avroSchemaUrl)
       .format("avro")
@@ -733,6 +733,42 @@ abstract class AvroSuite
       .collect()
     val expected = spark.read.format("avro").load(testAvro).select("string").collect()
     assert(result.sameElements(expected))
+  }
+
+  test("SPARK-34416: support user provided both avro schema and avro schema url") {
+    val avroSchemaUrl = testFile("test_sub.avsc")
+    val avroSchema =
+      """
+        |{
+        |  "type" : "record",
+        |  "name" : "test_schema",
+        |  "fields" : [{
+        |    "name" : "union_int_long_null",
+        |    "type" : ["int", "long", "null"]
+        |  }]
+        |}
+      """.stripMargin
+
+    val result = spark.read
+      .option("avroSchema", avroSchema)
+      .option("avroSchemaUrl", avroSchemaUrl)
+      .format("avro")
+      .load(testAvro)
+      .collect()
+    val expected = spark.read.format("avro").load(testAvro).select("union_int_long_null").collect()
+    assert(result.sameElements(expected))
+  }
+
+  test("SPARK-34416: support user provided wrong avro schema url") {
+    val e = intercept[FileNotFoundException] {
+      spark.read
+        .option("avroSchemaUrl", "not_exists.avsc")
+        .format("avro")
+        .load(testAvro)
+        .collect()
+    }
+
+    assertExceptionMsg[FileNotFoundException](e, "File not_exists.avsc does not exist")
   }
 
   test("support user provided avro schema with defaults for missing fields") {

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -726,7 +726,7 @@ abstract class AvroSuite
   }
 
   test("support user provided avro schema url") {
-    val avroSchemaUrl = "src/test/resources/test_sub.avsc"
+    val avroSchemaUrl = testFile("test_sub.avsc")
     val result = spark.read.option("avroSchemaUrl", avroSchemaUrl)
       .format("avro")
       .load(testAvro)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added option to provide Avro schema by URL.

### Why are the changes needed?
(copied from Jira ticket)

We have a use case in which we read a huge table in Avro format. About 30k columns.

using the default Hive reader - `AvroGenericRecordReader` it is just hangs forever. after 4 hours not even one task has finished.

We tried instead to use `spark.read.format("com.databricks.spark.avro").load(..)` but we failed on:

```

org.apache.spark.sql.AnalysisException: Found duplicate column(s) in the data schema

..

at org.apache.spark.sql.util.SchemaUtils$.checkColumnNameDuplication(SchemaUtils.scala:85)
at org.apache.spark.sql.util.SchemaUtils$.checkColumnNameDuplication(SchemaUtils.scala:67)
at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:421)
at org.apache.spark.sql.DataFrameReader.loadV1Source(DataFrameReader.scala:239)
at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:227)
at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:174)
... 53 elided

```

 

because files schema contain duplicate column names (when considering case-insensitive).

So we wanted to provide a user schema with non-duplicated fields, but the schema is huge. a few MBs. it is not practical to provide it in json format.

 

So we patched spark-avro to be able to get also `avroSchemaUrl` in addition to `avroSchema` and it worked perfectly.


### How was this patch tested?
added a unitest to AvroSuite and tested locally with patched version
