### PR TITLE
[SPARK-34417] [SQL] org.apache.spark.sql.DataFrameNaFunctions.fillMap fails for column name having a dot

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -396,7 +396,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
   private def fillMap(values: Seq[(String, Any)]): DataFrame = {
     // Error handling
     val attrToValue = AttributeMap(values.map { case (colName, replaceValue) =>
-	  // Check column name exists
+	    // Check column name exists
       val attr = df.resolve(colName) match {
         case a: Attribute => a
         case _ => throw new IllegalArgumentException("Nested field is not supported.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -399,7 +399,8 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
       // Check column name exists
       val attr = df.resolve(colName) match {
         case a: Attribute => a
-        case _ => throw new IllegalArgumentException("Nested field is not supported.")
+        case _ => throw new UnsupportedOperationException(
+          s"Nested field ${colName} is not supported.")
       }
       // Check data type
       replaceValue match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -21,6 +21,7 @@ import java.{lang => jl}
 import java.util.Locale
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.expressions._
@@ -394,7 +395,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
   }
 
   private def fillMap(values: Seq[(String, Any)]): DataFrame = {
-    var resolved: Map[String, Any] = Map()
+    val resolved = mutable.Map[String, Any]()
     // Error handling
     values.foreach { case (colName, replaceValue) =>
       // Check column name exists

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -395,10 +395,11 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
 
   private def fillMap(values: Seq[(String, Any)]): DataFrame = {
     // Error handling
-    val resolved = values.map { case (colName, replaceValue) =>
-      // Check column name exists
-      val resolvedColumn = df.resolve(colName)
-
+    val attrToValue = AttributeMap(values.map { case (colName, replaceValue) =>
+      val attr = df.resolve(colName) match {
+        case a: Attribute => a
+        case _ => throw new IllegalArgumentException("Nested field is not supported.")
+      }
       // Check data type
       replaceValue match {
         case _: jl.Double | _: jl.Float | _: jl.Integer | _: jl.Long | _: jl.Boolean | _: String =>
@@ -406,38 +407,29 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
         case _ => throw new IllegalArgumentException(
           s"Unsupported value type ${replaceValue.getClass.getName} ($replaceValue).")
       }
-      // Use resolved column name onwards for filling the null values.
-      // It is needed for the column names having a dot and quoted with back-tick.
-      // Eg: "`ColWith.Dot`" will be resolved to the column with name "ColWith.Dot"
-      // in a dataframe having columns ("ColWith.Dot", "Col").
-      // If resolved name is not used, while filling null values "`ColWith.Dot`" will
-      // not match "ColWith.Dot".
-      (resolvedColumn.name -> replaceValue)
-    }
+      attr -> replaceValue
+    })
 
-    val columnEquals = df.sparkSession.sessionState.analyzer.resolver
-    val projections = df.schema.fields.map { f =>
-      resolved.find { case (k, _) => columnEquals(k, f.name) }.map { case (_, v) =>
-        v match {
-          case v: jl.Float => fillCol[Float](f, v)
-          case v: jl.Double => fillCol[Double](f, v)
-          case v: jl.Long => fillCol[Long](f, v)
-          case v: jl.Integer => fillCol[Integer](f, v)
-          case v: jl.Boolean => fillCol[Boolean](f, v.booleanValue())
-          case v: String => fillCol[String](f, v)
-        }
-      }.getOrElse(df.col(s"`${f.name}`"))
+    val output = df.queryExecution.analyzed.output
+    val projections = output.map {
+      attr => attrToValue.get(attr).map {
+        case v: jl.Float => fillCol[Float](attr, v)
+        case v: jl.Double => fillCol[Double](attr, v)
+        case v: jl.Long => fillCol[Long](attr, v)
+        case v: jl.Integer => fillCol[Integer](attr, v)
+        case v: jl.Boolean => fillCol[Boolean](attr, v.booleanValue())
+        case v: String => fillCol[String](attr, v)
+      }.getOrElse(Column(attr))
     }
     df.select(projections : _*)
   }
 
   /**
-   * Returns a [[Column]] expression that replaces null value in `col` with `replacement`.
-   * It selects a column based on its name.
+   * Returns a [[Column]] expression that replaces null value in column defined by `attr`
+   * with `replacement`.
    */
-  private def fillCol[T](col: StructField, replacement: T): Column = {
-    val quotedColName = "`" + col.name + "`"
-    fillCol(col.dataType, col.name, df.col(quotedColName), replacement)
+  private def fillCol[T](attr: Attribute, replacement: T): Column = {
+    fillCol(attr.dataType, attr.name, Column(attr), replacement)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -396,6 +396,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
   private def fillMap(values: Seq[(String, Any)]): DataFrame = {
     // Error handling
     val attrToValue = AttributeMap(values.map { case (colName, replaceValue) =>
+	  // Check column name exists
       val attr = df.resolve(colName) match {
         case a: Attribute => a
         case _ => throw new IllegalArgumentException("Nested field is not supported.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -413,8 +413,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
       // Eg: "`ColWith.Dot`" will be resolved to the column with name "ColWith.Dot"
       // in a dataframe having columns ("ColWith.Dot", "Col").
       // If resolved name is not used, while filling null values "`ColWith.Dot`" will
-      // neither match "ColWith.Dot" nor "ColWith.Dot" will be found in the dataframe,
-      // it leads to the failure.
+      // not match "ColWith.Dot".
     }
 
     val columnEquals = df.sparkSession.sessionState.analyzer.resolver
@@ -428,9 +427,9 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
           case v: jl.Boolean => fillCol[Boolean](f, v.booleanValue())
           case v: String => fillCol[String](f, v)
         }
-      }.getOrElse(df.col(f.name))
+      }.getOrElse(df.col(if (f.name.contains('.')) s"`${f.name}`" else f.name))
     }
-    df.select(projections: _*)
+    df.select(projections : _*)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -395,9 +395,8 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
   }
 
   private def fillMap(values: Seq[(String, Any)]): DataFrame = {
-    val resolved = mutable.Map[String, Any]()
     // Error handling
-    values.foreach { case (colName, replaceValue) =>
+    val resolved = values.map { case (colName, replaceValue) =>
       // Check column name exists
       val resolvedColumn = df.resolve(colName)
 
@@ -414,7 +413,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
       // in a dataframe having columns ("ColWith.Dot", "Col").
       // If resolved name is not used, while filling null values "`ColWith.Dot`" will
       // not match "ColWith.Dot".
-      resolved += (resolvedColumn.name -> replaceValue)
+      (resolvedColumn.name -> replaceValue)
     }
 
     val columnEquals = df.sparkSession.sessionState.analyzer.resolver

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -21,7 +21,6 @@ import java.{lang => jl}
 import java.util.Locale
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.expressions._

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -408,13 +408,13 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
         case _ => throw new IllegalArgumentException(
           s"Unsupported value type ${replaceValue.getClass.getName} ($replaceValue).")
       }
-      resolved += (resolvedColumn.name -> replaceValue)
       // Use resolved column name onwards for filling the null values.
       // It is needed for the column names having a dot and quoted with back-tick.
       // Eg: "`ColWith.Dot`" will be resolved to the column with name "ColWith.Dot"
       // in a dataframe having columns ("ColWith.Dot", "Col").
       // If resolved name is not used, while filling null values "`ColWith.Dot`" will
       // not match "ColWith.Dot".
+      resolved += (resolvedColumn.name -> replaceValue)
     }
 
     val columnEquals = df.sparkSession.sessionState.analyzer.resolver
@@ -428,7 +428,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
           case v: jl.Boolean => fillCol[Boolean](f, v.booleanValue())
           case v: String => fillCol[String](f, v)
         }
-      }.getOrElse(df.col(if (f.name.contains('.')) s"`${f.name}`" else f.name))
+      }.getOrElse(df.col(s"`${f.name}`"))
     }
     df.select(projections : _*)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameNaFunctions.scala
@@ -396,7 +396,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame) {
   private def fillMap(values: Seq[(String, Any)]): DataFrame = {
     // Error handling
     val attrToValue = AttributeMap(values.map { case (colName, replaceValue) =>
-	    // Check column name exists
+      // Check column name exists
       val attr = df.resolve(colName) match {
         case a: Attribute => a
         case _ => throw new IllegalArgumentException("Nested field is not supported.")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -466,6 +466,15 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       Seq(("abc", 23L), ("def", 44L), (null, 0L)).toDF("ColWith.Dot", "Col")
         .na.fill(Map("`ColWith.Dot`" -> na)),
-        Row("abc", 23) :: Row("def", 44L) :: Row(na, 0L) :: Nil)
+      Row("abc", 23) :: Row("def", 44L) :: Row(na, 0L) :: Nil)
+  }
+
+  test("SPARK-34417 - test fillMap() for column without a dot in the name" +
+    " and dataframe with another column having a dot in the name") {
+    val na = "n/a"
+    checkAnswer(
+      Seq(("abc", 23L), ("def", 44L), (null, 0L)).toDF("Col", "ColWith.Dot")
+        .na.fill(Map("Col" -> na)),
+      Row("abc", 23) :: Row("def", 44L) :: Row(na, 0L) :: Nil)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -476,7 +476,7 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
         .na.fill(Map("testDF.`ColWith.Dot`" -> na)),
       Row("abc", 23) :: Row("def", 44L) :: Row(na, 0L) :: Nil)
   }
-  
+
   test("SPARK-34417 - test fillMap() for column without a dot in the name" +
     " and dataframe with another column having a dot in the name") {
     val na = "n/a"

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -460,4 +460,12 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
       Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) ::
       Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) :: Nil)
   }
+
+  test("test column name with a dot") {
+    val na = "n/a"
+    checkAnswer(
+      Seq(("abc", 23L), ("def", 44L), (null, 0L)).toDF("ColWith.Dot", "Col")
+        .na.fill(Map("`ColWith.Dot`" -> na)),
+        Row("abc", 23) :: Row("def", 44L) :: Row(na, 0L) :: Nil)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -469,6 +469,14 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
       Row("abc", 23) :: Row("def", 44L) :: Row(na, 0L) :: Nil)
   }
 
+  test("SPARK-34417 - test fillMap() for qualified-column with a dot in the name") {
+    val na = "n/a"
+    checkAnswer(
+      Seq(("abc", 23L), ("def", 44L), (null, 0L)).toDF("ColWith.Dot", "Col").as("testDF")
+        .na.fill(Map("testDF.`ColWith.Dot`" -> na)),
+      Row("abc", 23) :: Row("def", 44L) :: Row(na, 0L) :: Nil)
+  }
+  
   test("SPARK-34417 - test fillMap() for column without a dot in the name" +
     " and dataframe with another column having a dot in the name") {
     val na = "n/a"

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -461,7 +461,7 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
       Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) :: Nil)
   }
 
-  test("test column name with a dot") {
+  test("SPARK-34417 - test fillMap() for column with a dot in the name") {
     val na = "n/a"
     checkAnswer(
       Seq(("abc", 23L), ("def", 44L), (null, 0L)).toDF("ColWith.Dot", "Col")


### PR DESCRIPTION
**What changes were proposed in this pull request?**

This PR fixes dataframe.na.fillMap() for column having a dot in the name as mentioned in [SPARK-34417](https://issues.apache.org/jira/browse/SPARK-34417).

Use resolved attributes of a column for replacing null values.

**Why are the changes needed?**
dataframe.na.fillMap() does not work for column having a dot in the name

**Does this PR introduce any user-facing change?**
None

**How was this patch tested?**
Added unit test for the same