### PR TITLE
[SPARK-34430][Doc] Update index.md with a pyspark hint to avoid java.nio.DirectByteBuffer.(long, int) not available

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,11 @@ uses Scala {{site.SCALA_BINARY_VERSION}}. You will need to use a compatible Scal
 For Python 3.9, Arrow optimization and pandas UDFs might not work due to the supported Python versions in Apache Arrow. Please refer to the latest [Python Compatibility](https://arrow.apache.org/docs/python/install.html#python-compatibility) page.
 For Java 11, `-Dio.netty.tryReflectionSetAccessible=true` is required additionally for Apache Arrow library. This prevents `java.lang.UnsupportedOperationException: sun.misc.Unsafe or java.nio.DirectByteBuffer.(long, int) not available` when Apache Arrow uses Netty internally.
 
+```python
+# PySpark
+SparkSession.builder.config('spark.driver.extraJavaOptions', '-Dio.netty.tryReflectionSetAccessible=true').getOrCreate()
+```
+
 # Running the Examples and Shell
 
 Spark comes with several sample programs.  Scala, Java, Python and R examples are in the


### PR DESCRIPTION
Took us a while to figure out how to fix this with pyspark this might save a few people a few hours...

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
doc update, see title


### Why are the changes needed?
save people time figuring out how to resolve it


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
no code changes
