### PR TITLE
[SPARK-34424][SQL][TESTS] Fix failures of HiveOrcHadoopFsRelationSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -200,11 +200,12 @@ object RandomDataGenerator {
           randomNumeric[LocalDate](
             rand,
             (rand: Random) => {
-              if (validJulianDatetime) {
-                getRandomDate(rand).toLocalDate
+              val days = if (validJulianDatetime) {
+                DateTimeUtils.fromJavaDate(getRandomDate(rand))
               } else {
-                LocalDate.ofEpochDay(uniformDaysRand(rand))
+                uniformDaysRand(rand)
               }
+              LocalDate.ofEpochDay(days)
             },
             specialDates.map(LocalDate.parse))
         } else {
@@ -248,11 +249,12 @@ object RandomDataGenerator {
           randomNumeric[Instant](
             rand,
             (rand: Random) => {
-              if (validJulianDatetime) {
-                getRandomTimestamp(rand).toInstant
+              val micros = if (validJulianDatetime) {
+                DateTimeUtils.fromJavaTimestamp(getRandomTimestamp(rand))
               } else {
-                DateTimeUtils.microsToInstant(uniformMicrosRand(rand))
+                uniformMicrosRand(rand)
               }
+              DateTimeUtils.microsToInstant(micros)
             },
             specialTs.map { s =>
               val ldt = LocalDateTime.parse(s.replace(" ", "T"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Modify `RandomDataGenerator.forType()` to allow generation of dates/timestamps that are valid in both Julian and Proleptic Gregorian calendars. Currently, the function can produce a date (for example `1582-10-06`) which is valid in the Proleptic Gregorian calendar. Though it cannot be saved to ORC files AS IS since ORC format (ORC libs in fact) assumes Julian calendar. So, Spark shifts `1582-10-06` to the next valid date `1582-10-15` while saving it to ORC files. And as a consequence of that, the test fails because it compares original date `1582-10-06` and the date `1582-10-15` loaded back from the ORC files.

In this PR, I propose to generate valid dates/timestamps in both calendars for ORC datasource till SPARK-34440 is resolved.

### Why are the changes needed?
The changes fix failures of `HiveOrcHadoopFsRelationSuite`. For instance, the test "test all data types" fails with the seed **610710213676**:
```
== Results ==
!== Correct Answer - 20 ==    == Spark Answer - 20 ==
 struct<index:int,col:date>   struct<index:int,col:date>
...
![9,1582-10-06]               [9,1582-10-15]
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
By running the modified test suite:
```
$ build/sbt -Phive -Phive-thriftserver "test:testOnly *HiveOrcHadoopFsRelationSuite"
```