### PR TITLE
[WIP][SPARK-34425][SQL] Clarify error message

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/LookupCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/LookupCatalog.scala
@@ -170,7 +170,8 @@ private[sql] trait LookupCatalog extends Logging {
           ident.namespace match {
             case Array(db) => FunctionIdentifier(ident.name, Some(db))
             case _ =>
-              throw new AnalysisException(s"Unsupported function name '$ident'")
+              throw new AnalysisException(s"Unsupported function name '$ident', " +
+              "namespace in default Spark session catalog must have exactly one name.")
           }
         }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2085,7 +2085,8 @@ class DataSourceV2SQLSuite
     val e1 = intercept[AnalysisException] {
       sql("DESCRIBE FUNCTION default.ns1.ns2.fun")
     }
-    assert(e1.message.contains("Unsupported function name 'default.ns1.ns2.fun'"))
+    assert(e1.message.contains("Unsupported function name 'default.ns1.ns2.fun', " +
+      "namespace in default Spark session catalog must have exactly one name."))
   }
 
   test("SHOW FUNCTIONS not valid v1 namespace") {
@@ -2106,7 +2107,8 @@ class DataSourceV2SQLSuite
     val e1 = intercept[AnalysisException] {
       sql("DROP FUNCTION default.ns1.ns2.fun")
     }
-    assert(e1.message.contains("Unsupported function name 'default.ns1.ns2.fun'"))
+    assert(e1.message.contains("Unsupported function name 'default.ns1.ns2.fun', " +
+      "namespace in default Spark session catalog must have exactly one name."))
   }
 
   test("CREATE FUNCTION: only support session catalog") {
@@ -2118,7 +2120,8 @@ class DataSourceV2SQLSuite
     val e1 = intercept[AnalysisException] {
       sql("CREATE FUNCTION default.ns1.ns2.fun as 'f'")
     }
-    assert(e1.message.contains("Unsupported function name 'default.ns1.ns2.fun'"))
+    assert(e1.message.contains("Unsupported function name 'default.ns1.ns2.fun', " +
+      "namespace in default Spark session catalog must have exactly one name."))
   }
 
   test("REFRESH FUNCTION: only support session catalog") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clarify the error messages for functions in Spark session.

### Why are the changes needed?

Delegating the validation to the catalog decreased the clarify of the message.

### Does this PR introduce _any_ user-facing change?

Error message

### How was this patch tested?

Updated tests.