### PR TITLE
[SPARK-33210][SQL][DOCS][FOLLOWUP] Fix descriptions of the SQL configs for the parquet INT96 rebase modes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2867,11 +2867,11 @@ object SQLConf {
   val LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE =
     buildConf("spark.sql.legacy.parquet.int96RebaseModeInWrite")
       .internal()
-      .doc("When LEGACY, which is the default, Spark will rebase INT96 timestamps from " +
-        "Proleptic Gregorian calendar to the legacy hybrid (Julian + Gregorian) calendar when " +
-        "writing Parquet files. When CORRECTED, Spark will not do rebase and write the timestamps" +
-        " as it is. When EXCEPTION, Spark will fail the writing if it sees ancient timestamps " +
-        "that are ambiguous between the two calendars.")
+      .doc("When LEGACY, Spark will rebase INT96 timestamps from Proleptic Gregorian calendar to " +
+        "the legacy hybrid (Julian + Gregorian) calendar when writing Parquet files. " +
+        "When CORRECTED, Spark will not do rebase and write the timestamps as it is. " +
+        "When EXCEPTION, which is the default, Spark will fail the writing if it sees ancient " +
+        "timestamps that are ambiguous between the two calendars.")
       .version("3.1.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
@@ -2898,12 +2898,12 @@ object SQLConf {
   val LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ =
     buildConf("spark.sql.legacy.parquet.int96RebaseModeInRead")
       .internal()
-      .doc("When LEGACY, which is the default, Spark will rebase INT96 timestamps from " +
-        "the legacy hybrid (Julian + Gregorian) calendar to Proleptic Gregorian calendar when " +
-        "reading Parquet files. When CORRECTED, Spark will not do rebase and read the timestamps " +
-        "as it is. When EXCEPTION, Spark will fail the reading if it sees ancient timestamps " +
-        "that are ambiguous between the two calendars. This config is only effective if the " +
-        "writer info (like Spark, Hive) of the Parquet files is unknown.")
+      .doc("When LEGACY, Spark will rebase INT96 timestamps from the legacy hybrid (Julian + " +
+        "Gregorian) calendar to Proleptic Gregorian calendar when reading Parquet files. " +
+        "When CORRECTED, Spark will not do rebase and read the timestamps as it is. " +
+        "When EXCEPTION, which is the default, Spark will fail the reading if it sees ancient " +
+        "timestamps that are ambiguous between the two calendars. This config is only effective " +
+        "if the writer info (like Spark, Hive) of the Parquet files is unknown.")
       .version("3.1.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix descriptions of the SQL configs `spark.sql.legacy.parquet.int96RebaseModeInRead` and `spark.sql.legacy.parquet.int96RebaseModeInWrite`, and mention `EXCEPTION` as the default value.

### Why are the changes needed?
This fixes incorrect descriptions that can mislead users.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running `./dev/scalastyle`.