### PR TITLE
[SPARK-34438][SPARK SUBMIT] Check path component in isPython/isR, not full URI

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -25,10 +25,12 @@ import java.text.ParseException
 import java.util.{ServiceLoader, UUID}
 import java.util.jar.JarInputStream
 import javax.ws.rs.core.UriBuilder
+
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.util.{Properties, Try}
+
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.conf.{Configuration => HadoopConfiguration}
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -45,6 +47,7 @@ import org.apache.ivy.core.settings.IvySettings
 import org.apache.ivy.plugins.matcher.GlobPatternMatcher
 import org.apache.ivy.plugins.repository.file.FileRepository
 import org.apache.ivy.plugins.resolver.{ChainResolver, FileSystemResolver, IBiblioResolver}
+
 import org.apache.spark._
 import org.apache.spark.api.r.RUtils
 import org.apache.spark.deploy.rest._

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1072,14 +1072,29 @@ object SparkSubmit extends CommandLineUtils with Logging {
    * Return whether the given primary resource requires running python.
    */
   private[deploy] def isPython(res: String): Boolean = {
-    res != null && res.endsWith(".py") || res == PYSPARK_SHELL
+    if (res == null) {
+      return false
+    }
+    if (res == PYSPARK_SHELL) {
+      return true
+    }
+    val uri = new java.net.URI(res)
+    return uri.getPath.endsWith(".py")
   }
 
   /**
    * Return whether the given primary resource requires running R.
    */
   private[deploy] def isR(res: String): Boolean = {
-    res != null && (res.endsWith(".R") || res.endsWith(".r")) || res == SPARKR_SHELL
+    if (res == null) {
+      return false
+    }
+    if (res == SPARKR_SHELL) {
+      return true
+    }
+    val uri = new java.net.URI(res)
+    val path = uri.getPath
+    return path.endsWith(".R") || path.endsWith(".r")
   }
 
   private[deploy] def isInternal(res: String): Boolean = {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -833,6 +833,24 @@ class SparkSubmitSuite
         PythonRunner.formatPaths(Utils.resolveURIs(pyFiles)))
       conf3.get(PYSPARK_DRIVER_PYTHON.key) should be("python3.4")
       conf3.get(PYSPARK_PYTHON.key) should be("python3.5")
+
+      // Test remote python driver with query part
+      val clArgs4 = Seq(
+        "https://bucket-name.s3.us-east-1.amazonaws.com/driver.py" +
+          "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+          "&X-Amz-Credential=AKIATBNPKWPCNUMWMLUR%2F20210214%2Fus-east-1%2Fs3%2Faws4_request" +
+          "&X-Amz-Date=20210214T062047Z&X-Amz-Expires=172800&X-Amz-SignedHeaders=host" +
+          "&X-Amz-Signature=49ef39b6bb7090001af9312692788892551916a6ac0ff6c961ce52efb9acc235"
+      )
+      val appArgs4 = new SparkSubmitArguments(clArgs3)
+      val (args4, _, conf4, mainClass4) = submit.prepareSubmitEnvironment(appArgs3)
+
+      appArgs4.isPython should be(true)
+      print("+++ HERE WE GO +++")
+      print(appArgs4.mainClass)
+      print(args4)
+      print(conf4)
+      print(mainClass4)
     }
   }
 


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/SPARK-34438

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?

This changes `spark-submit` to accept URIs which have their path component ending in `.py` as py-spark drivers. This is important to work for example with pre-signed URIs from AWS S3.

### Why are the changes needed?

It is surprising to see that a regular URI does not work as expected, i.e. `http://my-web-server/driver.py` works as expected, but `http://my-web-server/driver.py?some-query` does not (spark will try to download the latter as a JAR).

### Does this PR introduce _any_ user-facing change?

Yes, as it makes `spark-submit` accept a wider range of inputs as Python or R drivers (the correct range).

### How was this patch tested?

We're building our own spark distribution and are using it in production.
