### PR TITLE
[SPARK-34439][SQL] Recognize `spark_catalog` in new identifier while view/table renaming

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -196,8 +196,11 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         s
       }
 
-    case RenameTable(ResolvedV1TableOrViewIdentifier(oldName), newName, isView) =>
-      AlterTableRenameCommand(oldName.asTableIdentifier, newName.asTableIdentifier, isView)
+    case RenameTable(
+        ResolvedV1TableOrViewIdentifier(oldName),
+        AsTableIdentifier(newName),
+        isView) =>
+      AlterTableRenameCommand(oldName.asTableIdentifier, newName, isView)
 
     // Use v1 command to describe (temp) view, as v2 catalog doesn't support view yet.
     case DescribeRelation(ResolvedV1TableOrViewIdentifier(ident), partitionSpec, isExtended) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1009,13 +1009,14 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
     }
   }
 
-  test("SPARK-XXXXX: recognize spark_catalog in rename table") {
+  test("SPARK-34439: recognize spark_catalog in new identifier while view/table renaming") {
     withDatabase("spark_catalog.db") {
       sql("CREATE DATABASE spark_catalog.db")
-      sql(s"CREATE TABLE spark_catalog.db.src_tbl (c0 INT) USING $dataSource")
-      sql(s"INSERT INTO spark_catalog.db.src_tbl SELECT 0")
-      sql("ALTER TABLE spark_catalog.db.src_tbl RENAME TO spark_catalog.db.dst_tbl")
+      val src = "spark_catalog.db.src_tbl"
+      sql(s"CREATE TABLE $src (c0 INT) USING $dataSource")
+      sql(s"INSERT INTO $src SELECT 0")
       val dst = "spark_catalog.db.dst_tbl"
+      sql(s"ALTER TABLE spark_catalog.db.src_tbl RENAME TO $dst")
       checkAnswer(sql(s"SELECT * FROM $dst"), Row(0))
 
       withView("v0_dst") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `LookupCatalog.AsTableIdentifier` in `ResolveSessionCatalog` to recognize `spark_catalog` and cut it off from new table/view identifier before passing it to `AlterTableRenameCommand`.

### Why are the changes needed?
1. Other v1 commands recognize `spark_catalog` in table names. The table renaming command should recognize it for consistency.
2. To be able to write unified tests for the v1 and v2 table renaming command.

### Does this PR introduce _any_ user-facing change?
Yes.

Before:
```sql
spark-sql> CREATE TABLE spark_catalog.db.tbl (c0 INT) USING parquet;
spark-sql> INSERT INTO spark_catalog.db.tbl SELECT 0;
spark-sql> SELECT * FROM spark_catalog.db.tbl;
0
spark-sql> ALTER TABLE spark_catalog.db.tbl RENAME TO spark_catalog.db.tbl2;
Error in query: spark_catalog.db.tbl2 is not a valid TableIdentifier as it has more than 2 name parts.
```

After:
```sql
spark-sql> ALTER TABLE spark_catalog.db.tbl RENAME TO spark_catalog.db.tbl2;
spark-sql> SELECT * FROM spark_catalog.db.tbl2;
0
```

### How was this patch tested?
By running new test:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *CatalogedDDLSuite"
```