### PR TITLE
[SPARK-34442][INFRA][DOCS][3.0] Pin Sphinx version to `sphinx<3.5.0`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -322,7 +322,7 @@ jobs:
     - name: Install dependencies for documentation generation
       run: |
         apt-get install -y libcurl4-openssl-dev pandoc
-        python3.6 -m pip install sphinx mkdocs numpy
+        python3.6 -m pip install "sphinx<3.5.0" mkdocs numpy
         apt-get update -y
         apt-get install -y ruby ruby-dev
         gem install jekyll jekyll-redirect-from rouge

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@ Note: Other versions of roxygen2 might work in SparkR documentation generation b
 To generate API docs for any language, you'll need to install these libraries:
 
 ```sh
-$ sudo pip install sphinx mkdocs numpy
+$ sudo pip install 'sphinx<3.5.0' mkdocs numpy
 ```
 
 ## Generating the Documentation HTML


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin the Sphinx version to avoid 3.5.0 changes. Note that Spark 3.1.0+ switches the document structure and it has a stronger restriction than this. This PR is irrelevant to SPARK-32407.
```
SPARK-32407: Sphinx 3.1+ does not correctly index nested classes.
```

### Why are the changes needed?

[Sphinx 3.5.0](https://pypi.org/project/Sphinx/3.5.0/) was released Feb. 13rd, 2021 and broke GitHub Action Python Linter job.
- https://github.com/apache/spark/runs/1906315781
- https://github.com/apache/spark/runs/1906310012
```
Extension error (sphinx.ext.viewcode):
Handler <function env_purge_doc at 0x7f1d9a6420d0> for event 'env-purge-doc' threw an exception (exception: 'bool' object is not iterable)
make: *** [Makefile:55: html] Error 2
```

**THIS PR**
- https://github.com/apache/spark/pull/31568/checks?check_run_id=1906638805
```
starting python compilation test...
python compilation succeeded.

starting pycodestyle test...
pycodestyle checks passed.

starting flake8 test...
flake8 checks passed.

starting sphinx-build tests...
sphinx-build checks passed.

all lint-python tests passed!
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action CI.