### PR TITLE
[SPARK-34445][SQL][DOCS] Make `spark.sql.legacy.replaceDatabricksSparkAvro.enabled` as non-internal

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2505,7 +2505,6 @@ object SQLConf {
 
   val LEGACY_REPLACE_DATABRICKS_SPARK_AVRO_ENABLED =
     buildConf("spark.sql.legacy.replaceDatabricksSparkAvro.enabled")
-      .internal()
       .doc("If it is set to true, the data source provider com.databricks.spark.avro is mapped " +
         "to the built-in but external Avro data source module for backward compatibility.")
       .version("2.4.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove `.internal()` from the SQL legacy config `spark.sql.legacy.replaceDatabricksSparkAvro.enabled`.

### Why are the changes needed?
In fact, the SQL config `spark.sql.legacy.replaceDatabricksSparkAvro.enabled` has been already documented publicly, see http://spark.apache.org/docs/latest/sql-data-sources-avro.html. So, it cannot be considered as an internal config.

### Does this PR introduce _any_ user-facing change?
This updates the list of auto generated SQL configs.

### How was this patch tested?
By generating docs:
```
$ ./sql/create-docs.sh
$ cd docs
$ SKIP_API=1 SKIP_SCALADOC=1 SKIP_PYTHONDOC=1 SKIP_RDOC=1 jekyll serve --watch
```