### PR TITLE
[SPARK-34449][BUILD] Upgrade Jetty to fix CVE-2020-27218

### DIFF
--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -384,7 +384,7 @@ class UISuite extends SparkFunSuite {
     }
   }
 
-  test("SPARK-34449: Jetty 9.4.35.v20201120 and later no longer returns status code 302 " +
+  test("SPARK-34449: Jetty 9.4.35.v20201120 and later no longer return status code 302 " +
        " and handle internally when request URL ends with a context path without trailing '/'") {
     val proxyRoot = "https://proxy.example.com:443/prefix"
     val (conf, securityMgr, sslOptions) = sslDisabledConf()

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -356,19 +356,8 @@ class UISuite extends SparkFunSuite {
     try {
       val serverAddr = s"http://localhost:${serverInfo.boundPort}"
 
-      val (_, ctx) = newContext("/ctx1")
-      serverInfo.addHandler(ctx, securityMgr)
-
       val redirect = JettyUtils.createRedirectHandler("/src", "/dst")
       serverInfo.addHandler(redirect, securityMgr)
-
-      // Test Jetty's built-in redirect to add the trailing slash to the context path.
-      TestUtils.withHttpConnection(new URL(s"$serverAddr/ctx1")) { conn =>
-        assert(conn.getResponseCode() === HttpServletResponse.SC_FOUND)
-        val location = Option(conn.getHeaderFields().get("Location"))
-          .map(_.get(0)).orNull
-        assert(location === s"$proxyRoot/ctx1/")
-      }
 
       // Test with a URL handled by the added redirect handler, and also including a path prefix.
       val headers = Seq("X-Forwarded-Context" -> "/prefix")
@@ -395,6 +384,28 @@ class UISuite extends SparkFunSuite {
     }
   }
 
+  test("SPARK-34449: Jetty 9.4.35.v20201120 and later no longer returns status code 302 " +
+       " and handle internally when request URL ends with a context path without trailing '/'") {
+    val proxyRoot = "https://proxy.example.com:443/prefix"
+    val (conf, securityMgr, sslOptions) = sslDisabledConf()
+    conf.set(UI.PROXY_REDIRECT_URI, proxyRoot)
+    val serverInfo = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)
+
+    try {
+      val (_, ctx) = newContext("/ctx")
+      serverInfo.addHandler(ctx, securityMgr)
+      val urlStr = s"http://localhost:${serverInfo.boundPort}/ctx"
+
+      assert(TestUtils.httpResponseCode(new URL(urlStr + "/")) === HttpServletResponse.SC_OK)
+
+      // If the following assertion fails when we upgrade Jetty, it seems to change the behavior of
+      // handling context path which doesn't have the trailing slash.
+      assert(TestUtils.httpResponseCode(new URL(urlStr)) === HttpServletResponse.SC_OK)
+    } finally {
+      stopServer(serverInfo)
+    }
+  }
+
   /**
    * Create a new context handler for the given path, with a single servlet that responds to
    * requests in `$path/root`.
@@ -403,7 +414,9 @@ class UISuite extends SparkFunSuite {
     val servlet = new CapturingServlet()
     val ctx = new ServletContextHandler()
     ctx.setContextPath(path)
-    ctx.addServlet(new ServletHolder(servlet), "/root")
+    val servletHolder = new ServletHolder(servlet)
+    ctx.addServlet(servletHolder, "/root")
+    ctx.addServlet(servletHolder, "/")
     (servlet, ctx)
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.11.1</parquet.version>
     <orc.version>1.6.7</orc.version>
-    <jetty.version>9.4.34.v20201102</jetty.version>
+    <jetty.version>9.4.36.v20210114</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.9.5</chill.version>
     <ivy.version>2.4.0</ivy.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR upgrades Jetty from `9.4.34` to `9.4.36`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
CVE-2020-27218 affects currently used Jetty 9.4.34.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27218

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Modified existing test and new test which comply with the new version of Jetty.