### PR TITLE
[SPARK-34467][BUILD] Upgrade Zstd-jni to 1.4.8-4

### DIFF
--- a/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.9.1+1-Ubuntu-0ubuntu1.18.04 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 11.0.10+9-Ubuntu-0ubuntu1.18.04 on Linux 4.15.0-1044-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           1175           1307         187          0.0      117459.2       1.0X
-Compression 10000 times at level 2 without buffer pool            979           1020          58          0.0       97889.6       1.2X
-Compression 10000 times at level 3 without buffer pool           1241           1282          58          0.0      124101.1       0.9X
-Compression 10000 times at level 1 with buffer pool               466            476           6          0.0       46593.2       2.5X
-Compression 10000 times at level 2 with buffer pool               544            554           6          0.0       54421.3       2.2X
-Compression 10000 times at level 3 with buffer pool               795            804           8          0.0       79453.9       1.5X
+Compression 10000 times at level 1 without buffer pool           1165           1255         128          0.0      116483.1       1.0X
+Compression 10000 times at level 2 without buffer pool            932            981          42          0.0       93225.9       1.2X
+Compression 10000 times at level 3 without buffer pool           1176           1216          55          0.0      117634.8       1.0X
+Compression 10000 times at level 1 with buffer pool               415            424           5          0.0       41470.4       2.8X
+Compression 10000 times at level 2 with buffer pool               493            503           7          0.0       49295.1       2.4X
+Compression 10000 times at level 3 with buffer pool               754            759           6          0.0       75403.9       1.5X
 
-OpenJDK 64-Bit Server VM 11.0.9.1+1-Ubuntu-0ubuntu1.18.04 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 11.0.10+9-Ubuntu-0ubuntu1.18.04 on Linux 4.15.0-1044-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           1033           1069          52          0.0      103254.9       1.0X
-Decompression 10000 times from level 2 without buffer pool           1033           1070          53          0.0      103262.6       1.0X
-Decompression 10000 times from level 3 without buffer pool           1031           1076          64          0.0      103104.7       1.0X
-Decompression 10000 times from level 1 with buffer pool               603            609           5          0.0       60285.0       1.7X
-Decompression 10000 times from level 2 with buffer pool               602            607           4          0.0       60156.6       1.7X
-Decompression 10000 times from level 3 with buffer pool               608            613           4          0.0       60767.3       1.7X
+Decompression 10000 times from level 1 without buffer pool           1102           1103           2          0.0      110154.5       1.0X
+Decompression 10000 times from level 2 without buffer pool           1019           1057          54          0.0      101865.8       1.1X
+Decompression 10000 times from level 3 without buffer pool           1020           1067          65          0.0      102046.4       1.1X
+Decompression 10000 times from level 1 with buffer pool               590            596           4          0.0       58957.2       1.9X
+Decompression 10000 times from level 2 with buffer pool               590            594           4          0.0       58979.5       1.9X
+Decompression 10000 times from level 3 with buffer pool               592            598           5          0.0       59164.3       1.9X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_275-8u275-b01-0ubuntu1~18.04-b01 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_282-8u282-b08-0ubuntu1~18.04-b08 on Linux 4.15.0-1044-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           1414           1435          30          0.0      141387.0       1.0X
-Compression 10000 times at level 2 without buffer pool            978           1017          55          0.0       97829.9       1.4X
-Compression 10000 times at level 3 without buffer pool           1229           1272          61          0.0      122918.0       1.2X
-Compression 10000 times at level 1 with buffer pool               443            453           6          0.0       44315.4       3.2X
-Compression 10000 times at level 2 with buffer pool               532            543           7          0.0       53229.1       2.7X
-Compression 10000 times at level 3 with buffer pool               783            790           7          0.0       78263.5       1.8X
+Compression 10000 times at level 1 without buffer pool           1382           1418          50          0.0      138213.9       1.0X
+Compression 10000 times at level 2 without buffer pool            968           1012          63          0.0       96784.1       1.4X
+Compression 10000 times at level 3 without buffer pool           1203           1247          63          0.0      120266.3       1.1X
+Compression 10000 times at level 1 with buffer pool               431            439           5          0.0       43117.4       3.2X
+Compression 10000 times at level 2 with buffer pool               515            522           5          0.0       51484.4       2.7X
+Compression 10000 times at level 3 with buffer pool               753            759           6          0.0       75321.5       1.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_275-8u275-b01-0ubuntu1~18.04-b01 on Linux 4.15.0-1044-aws
+OpenJDK 64-Bit Server VM 1.8.0_282-8u282-b08-0ubuntu1~18.04-b08 on Linux 4.15.0-1044-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           1047           1084          53          0.0      104669.3       1.0X
-Decompression 10000 times from level 2 without buffer pool           1050           1089          55          0.0      105023.0       1.0X
-Decompression 10000 times from level 3 without buffer pool           1054           1101          66          0.0      105398.5       1.0X
-Decompression 10000 times from level 1 with buffer pool               608            613           4          0.0       60752.1       1.7X
-Decompression 10000 times from level 2 with buffer pool               607            612           4          0.0       60660.4       1.7X
-Decompression 10000 times from level 3 with buffer pool               607            612           3          0.0       60746.5       1.7X
+Decompression 10000 times from level 1 without buffer pool           1037           1074          52          0.0      103699.4       1.0X
+Decompression 10000 times from level 2 without buffer pool           1040           1077          52          0.0      104009.1       1.0X
+Decompression 10000 times from level 3 without buffer pool           1041           1083          60          0.0      104099.2       1.0X
+Decompression 10000 times from level 1 with buffer pool               597            605           5          0.0       59720.1       1.7X
+Decompression 10000 times from level 2 with buffer pool               603            607           3          0.0       60275.4       1.7X
+Decompression 10000 times from level 3 with buffer pool               596            603           5          0.0       59602.2       1.7X
 
 

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -242,4 +242,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.4.8-3//zstd-jni-1.4.8-3.jar
+zstd-jni/1.4.8-4//zstd-jni-1.4.8-4.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -209,4 +209,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.4.8-3//zstd-jni-1.4.8-3.jar
+zstd-jni/1.4.8-4//zstd-jni-1.4.8-4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.4.8-3</version>
+        <version>1.4.8-4</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Zstd-JNI library to 1.4.8-4 to bring JNI side optimization.
`ZStandardBenchmark` shows that there is no regression in terms of performance and show some improvements.

### Why are the changes needed?

https://github.com/luben/zstd-jni/commits/v1.4.8-4
- https://github.com/luben/zstd-jni/commit/be9be47fae23b5510344b67f9c0f7b258c2f5890
- https://github.com/luben/zstd-jni/commit/be51ebade15cbd4939a46581070836cc56e23ae6
- https://github.com/luben/zstd-jni/commit/44ff8b6f958bfcd75e187c6a51acf324a481cbe1


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.
