### PR TITLE
[SPARK-34466][SQL][DOCS] Improve docs for `ALTER TABLE .. RENAME TO`

### DIFF
--- a/docs/sql-ref-syntax-ddl-alter-table.md
+++ b/docs/sql-ref-syntax-ddl-alter-table.md
@@ -25,7 +25,7 @@ license: |
 
 ### RENAME 
 
-`ALTER TABLE RENAME TO` statement changes the table name of an existing table in the database.
+`ALTER TABLE RENAME TO` statement changes the table name of an existing table in the database. The table rename command cannot be used to move a table between databases, only to rename a table within the same database.
 
 #### Syntax
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Explicitly highlight that the table rename command cannot move a table between databases.

### Why are the changes needed?
To inform users about actual behavior of the table rename command.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```sql
spark-sql> CREATE DATABASE db1;
spark-sql> CREATE DATABASE db2;
spark-sql> CREATE TABLE db1.tbl1 (c0 INT);
spark-sql> ALTER TABLE db1.tbl1 RENAME TO db2.tbl1;
Error in query: RENAME TABLE source and destination databases do not match: 'db1' != 'db2';
spark-sql> ALTER TABLE db1.tbl1 RENAME TO db1.tbl2;
spark-sql> SHOW TABLES IN db1 LIKE '*';
db1	tbl2	false
```