### PR TITLE
[SPARK-34470][ML] VectorSlicer utilize ordering if possible

### DIFF
--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
@@ -383,6 +383,13 @@ class VectorsSuite extends SparkMLFunSuite {
     assert(v.slice(Array(2, 0, 3, 4)) === new SparseVector(4, Array(0, 3), Array(2.2, 4.4)))
   }
 
+  test("SparseVector.sliceSorted") {
+    val v = new SparseVector(5, Array(1, 2, 4), Array(1.1, 2.2, 4.4))
+    assert(v.slice(Array(0, 2)) === v.sliceSorted(Array(0, 2)))
+    assert(v.slice(Array(0, 2, 4)) === v.sliceSorted(Array(0, 2, 4)))
+    assert(v.slice(Array(1, 3)) === v.sliceSorted(Array(1, 3)))
+  }
+
   test("sparse vector only support non-negative length") {
     val v1 = Vectors.sparse(0, Array.emptyIntArray, Array.emptyDoubleArray)
     val v2 = Vectors.sparse(0, Array.empty[(Int, Double)])

--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/VectorsSuite.scala
@@ -383,11 +383,11 @@ class VectorsSuite extends SparkMLFunSuite {
     assert(v.slice(Array(2, 0, 3, 4)) === new SparseVector(4, Array(0, 3), Array(2.2, 4.4)))
   }
 
-  test("SparseVector.sliceSorted") {
+  test("SparseVector.slice with sorted indices") {
     val v = new SparseVector(5, Array(1, 2, 4), Array(1.1, 2.2, 4.4))
-    assert(v.slice(Array(0, 2)) === v.sliceSorted(Array(0, 2)))
-    assert(v.slice(Array(0, 2, 4)) === v.sliceSorted(Array(0, 2, 4)))
-    assert(v.slice(Array(1, 3)) === v.sliceSorted(Array(1, 3)))
+    assert(v.slice(Array(0, 2), true) === v.slice(Array(0, 2), false))
+    assert(v.slice(Array(0, 2, 4), true) === v.slice(Array(0, 2, 4), false))
+    assert(v.slice(Array(1, 3), true) === v.slice(Array(1, 3), false))
   }
 
   test("sparse vector only support non-negative length") {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala
@@ -110,22 +110,27 @@ final class VectorSlicer @Since("1.5.0") (@Since("1.5.0") override val uid: Stri
     }
 
     // Prepare output attributes
-    val inds = getSelectedFeatureIndices(dataset.schema)
-    val selectedAttrs = inputAttr.attributes.map { attrs =>
-      inds.map(index => attrs(index))
-    }
+    val selectedIndices = getSelectedFeatureIndices(dataset.schema)
+    val selectedAttrs = inputAttr.attributes.map { attrs => selectedIndices.map(attrs.apply) }
     val outputAttr = selectedAttrs match {
       case Some(attrs) => new AttributeGroup($(outputCol), attrs)
-      case None => new AttributeGroup($(outputCol), inds.length)
+      case None => new AttributeGroup($(outputCol), selectedIndices.length)
     }
 
-    // Select features
+    val isSorted = selectedIndices.length > 1 &&
+      selectedIndices.sliding(2).forall(t => t(1) > t(0))
+    val sparseSliceFunc = if (isSorted) {
+      (features: SparseVector) => features.sliceSorted(selectedIndices)
+    } else {
+      (features: SparseVector) => features.slice(selectedIndices)
+    }
     val slicer = udf { vec: Vector =>
       vec match {
-        case features: DenseVector => Vectors.dense(inds.map(features.apply))
-        case features: SparseVector => features.slice(inds)
+        case features: DenseVector => Vectors.dense(selectedIndices.map(features.apply))
+        case features: SparseVector => sparseSliceFunc(features)
       }
     }
+
     dataset.withColumn($(outputCol), slicer(dataset($(inputCol))), outputAttr.toMetadata())
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorSlicer.scala
@@ -117,17 +117,11 @@ final class VectorSlicer @Since("1.5.0") (@Since("1.5.0") override val uid: Stri
       case None => new AttributeGroup($(outputCol), selectedIndices.length)
     }
 
-    val isSorted = selectedIndices.length > 1 &&
-      selectedIndices.sliding(2).forall(t => t(1) > t(0))
-    val sparseSliceFunc = if (isSorted) {
-      (features: SparseVector) => features.sliceSorted(selectedIndices)
-    } else {
-      (features: SparseVector) => features.slice(selectedIndices)
-    }
+    val sorted = selectedIndices.length > 1 && selectedIndices.sliding(2).forall(t => t(1) > t(0))
     val slicer = udf { vec: Vector =>
       vec match {
-        case features: DenseVector => Vectors.dense(selectedIndices.map(features.apply))
-        case features: SparseVector => sparseSliceFunc(features)
+        case dv: DenseVector => Vectors.dense(selectedIndices.map(dv.apply))
+        case sv: SparseVector => sv.slice(selectedIndices, sorted)
       }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, add a new param `sorted` in `slice`;
2, in `VectorSlicer`, set `sorted = true` if input indices are ordered.


### Why are the changes needed?
The input indices of VectorSlicer are probably ordered.
VectorSlicer should use this attribute if possible.

I did a simple test and `sorted = true` maybe about 70% faster than existing `slice`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added testsuite
