### PR TITLE
[SPARK-34472][YARN] Ship ivySettings file to driver in cluster mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1279,7 +1279,7 @@ private[spark] object SparkSubmitUtils {
       ivyPath: Option[String]): IvySettings = {
     val uri = new URI(settingsFile)
     val file = Option(uri.getScheme).getOrElse("file") match {
-      case "file" => new File(settingsFile)
+      case "file" => new File(uri.getPath)
       case scheme => throw new IllegalArgumentException(s"Scheme $scheme not supported in " +
         "spark.jars.ivySettings")
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1277,10 +1277,11 @@ private[spark] object SparkSubmitUtils {
       settingsFile: String,
       remoteRepos: Option[String],
       ivyPath: Option[String]): IvySettings = {
-    val file = if (Utils.isLocalUri(settingsFile)) {
-      new File(new URI(settingsFile).getPath)
-    } else {
-      new File(settingsFile)
+    val uri = new URI(settingsFile)
+    val file = Option(uri.getScheme).getOrElse("file") match {
+      case "file" => new File(settingsFile)
+      case scheme => throw new IllegalArgumentException(s"Scheme $scheme not supported in " +
+        "spark.jars.ivySettings")
     }
     require(file.exists(), s"Ivy settings file $file does not exist")
     require(file.isFile(), s"Ivy settings file $file is not a normal file")

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1277,7 +1277,11 @@ private[spark] object SparkSubmitUtils {
       settingsFile: String,
       remoteRepos: Option[String],
       ivyPath: Option[String]): IvySettings = {
-    val file = new File(settingsFile)
+    val file = if (Utils.isLocalUri(settingsFile)) {
+      new File(new URI(settingsFile).getPath)
+    } else {
+      new File(settingsFile)
+    }
     require(file.exists(), s"Ivy settings file $file does not exist")
     require(file.isFile(), s"Ivy settings file $file is not a normal file")
     val ivySettings: IvySettings = new IvySettings

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -300,15 +300,6 @@ private[spark] class SparkSubmit extends Logging {
     val isKubernetesClusterModeDriver = isKubernetesClient &&
       sparkConf.getBoolean("spark.kubernetes.submitInDriver", false)
 
-    // When running in cluster mode, add ivySettings file to files so that the driver can use
-    // it to resolve ivy packages
-    if (deployMode == CLUSTER && args.ivySettingsPath.isDefined) {
-      val ivySettingsFile = new File(args.ivySettingsPath.get)
-      require(ivySettingsFile.exists(), s"Ivy settings file $ivySettingsFile not found")
-      require(ivySettingsFile.isFile(), s"Ivy settings file $ivySettingsFile is not a normal file")
-      args.files = mergeFileLists(args.files, ivySettingsFile.getAbsolutePath)
-    }
-
     if (!isMesosCluster && !isStandAloneCluster) {
       // Resolve maven dependencies if there are any and add classpath to jars. Add them to py-files
       // too for packages that include Python code
@@ -1098,7 +1089,7 @@ object SparkSubmit extends CommandLineUtils with Logging {
 }
 
 /** Provides utility functions to be used inside SparkSubmit. */
-private[spark] object SparkSubmitUtils extends Logging {
+private[spark] object SparkSubmitUtils {
 
   // Exposed for testing
   var printStream = SparkSubmit.printStream
@@ -1287,22 +1278,11 @@ private[spark] object SparkSubmitUtils extends Logging {
       remoteRepos: Option[String],
       ivyPath: Option[String]): IvySettings = {
     val file = new File(settingsFile)
-    // When running driver in cluster mode, the settingsFile is localized and so needs to be
-    // accessed using just the file name and not the full file path
-    val localizedFile = new File(file.getName)
-    val resolvedFile = if (file.exists()) {
-      Some(file)
-    } else if (localizedFile.exists()) {
-      Some(localizedFile)
-    } else {
-      None
-    }
-    require(resolvedFile.isDefined, s"Ivy settings file $file does not exist")
-    require(resolvedFile.get.isFile, s"Ivy settings file $file is not a normal file")
-
+    require(file.exists(), s"Ivy settings file $file does not exist")
+    require(file.isFile(), s"Ivy settings file $file is not a normal file")
     val ivySettings: IvySettings = new IvySettings
     try {
-      ivySettings.load(resolvedFile.get)
+      ivySettings.load(file)
     } catch {
       case e @ (_: IOException | _: ParseException) =>
         throw new SparkException(s"Failed when loading Ivy settings from $settingsFile", e)

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1525,6 +1525,21 @@ class SparkSubmitSuite
       conf.get(k) should be (v)
     }
   }
+
+  test("SPARK-34472: ship ivySettings file to the driver in cluster mode") {
+    val args = Seq(
+      "--class", "Foo",
+      "--master", "yarn",
+      "--deploy-mode", "cluster",
+      "--conf", s"spark.jars.ivySettings=${emptyIvySettings.getAbsolutePath}",
+      "app.jar"
+    )
+
+    val appArgs = new SparkSubmitArguments(args)
+    val (_, _, conf, _) = submit.prepareSubmitEnvironment(appArgs)
+
+    conf.get("spark.yarn.dist.files") should be(s"file://${emptyIvySettings.getAbsolutePath}")
+  }
 }
 
 object SparkSubmitSuite extends SparkFunSuite with TimeLimits {

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1525,21 +1525,6 @@ class SparkSubmitSuite
       conf.get(k) should be (v)
     }
   }
-
-  test("SPARK-34472: ship ivySettings file to the driver in cluster mode") {
-    val args = Seq(
-      "--class", "Foo",
-      "--master", "yarn",
-      "--deploy-mode", "cluster",
-      "--conf", s"spark.jars.ivySettings=${emptyIvySettings.getAbsolutePath}",
-      "app.jar"
-    )
-
-    val appArgs = new SparkSubmitArguments(args)
-    val (_, _, conf, _) = submit.prepareSubmitEnvironment(appArgs)
-
-    conf.get("spark.yarn.dist.files") should be(s"file://${emptyIvySettings.getAbsolutePath}")
-  }
 }
 
 object SparkSubmitSuite extends SparkFunSuite with TimeLimits {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -771,7 +771,9 @@ Apart from these, the following properties are also available, and may be useful
     option <code>--repositories</code> or <code>spark.jars.repositories</code> will also be included.
     Useful for allowing Spark to resolve artifacts from behind a firewall e.g. via an in-house
     artifact server like Artifactory. Details on the settings file format can be
-    found at <a href="http://ant.apache.org/ivy/history/latest-milestone/settings.html">Settings Files</a>
+    found at <a href="http://ant.apache.org/ivy/history/latest-milestone/settings.html">Settings Files</a>.
+    Only paths with <code>file://</code> scheme are supported. Paths without a scheme are assumed to have
+    a <code>file://</code> scheme.
     <p/>
     When running in YARN cluster mode, this file will also be localized to the remote driver for dependency
     resolution within <code>SparkContext#addJar</code>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -772,6 +772,9 @@ Apart from these, the following properties are also available, and may be useful
     Useful for allowing Spark to resolve artifacts from behind a firewall e.g. via an in-house
     artifact server like Artifactory. Details on the settings file format can be
     found at <a href="http://ant.apache.org/ivy/history/latest-milestone/settings.html">Settings Files</a>
+    <p/>
+    When running in YARN cluster mode, this file will also be localized to the remote driver for dependency
+    resolution within <code>SparkContext#addJar</code>
   </td>
   <td>2.2.0</td>
 </tr>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -526,7 +526,7 @@ private[spark] class Client(
         val uri = new URI(ivySettingsPath)
         Option(uri.getScheme).getOrElse("file") match {
           case "file" =>
-            val ivySettingsFile = new File(ivySettingsPath)
+            val ivySettingsFile = new File(uri.getPath)
             require(ivySettingsFile.exists(), s"Ivy settings file $ivySettingsFile not found")
             require(ivySettingsFile.isFile(), s"Ivy settings file $ivySettingsFile is not a" +
               "normal file")
@@ -534,11 +534,11 @@ private[spark] class Client(
             // conflict with any user file.
             val localizedFileName = Some(ivySettingsFile.getName() + "-" +
               UUID.randomUUID().toString)
-            val (_, localizedPath) = distribute(ivySettings.get, destName = localizedFileName)
+            val (_, localizedPath) = distribute(ivySettingsPath, destName = localizedFileName)
             require(localizedPath != null, "IvySettings file already distributed.")
             Some(localizedPath)
           case scheme =>
-            throw new IllegalArgumentException(s"Scheme $scheme not supported in" +
+            throw new IllegalArgumentException(s"Scheme $scheme not supported in " +
               "spark.jars.ivySettings")
         }
       case _ => None

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -818,7 +818,6 @@ private[spark] class Client(
         props.setProperty("spark.jars.ivySettings", ivy)
       }
 
-
       writePropertiesToArchive(props, SPARK_CONF_FILE, confStream)
 
       // Write the distributed cache config to the archive.

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -29,6 +29,7 @@ import com.google.common.io.{ByteStreams, Files}
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.util.ConverterUtils
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
@@ -375,17 +376,56 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     emptyIvySettings
   }
 
-  test("SPARK-34472: non-local ivySettings file should be localized on driver in cluster mode") {
+  test("SPARK-34472: ivySettings file with no scheme or file:// scheme should be " +
+    "localized on driver in cluster mode") {
     val emptyIvySettings = createEmptyIvySettingsFile
+    // For file:// URIs or URIs without scheme, make sure that ivySettings conf was changed
+    // to the localized file. So the expected ivySettings path on the driver will start with
+    // the file name and then some random UUID suffix
+    testIvySettingsDistribution(clientMode = false, emptyIvySettings.getAbsolutePath,
+      emptyIvySettings.getName, prefixMatch = true)
+    testIvySettingsDistribution(clientMode = false, s"file://${emptyIvySettings.getAbsolutePath}",
+      emptyIvySettings.getName, prefixMatch = true)
+  }
+
+  test("SPARK-34472: ivySettings file with no scheme or file:// scheme should retain " +
+    "user provided path in client mode") {
+    val emptyIvySettings = createEmptyIvySettingsFile
+    // In client mode, the file is present locally on the driver and so does not need to be
+    // distributed. So the user provided path should be kept as is.
+    testIvySettingsDistribution(clientMode = true, emptyIvySettings.getAbsolutePath,
+      emptyIvySettings.getAbsolutePath)
+    testIvySettingsDistribution(clientMode = true, s"file://${emptyIvySettings.getAbsolutePath}",
+      s"file://${emptyIvySettings.getAbsolutePath}")
+  }
+
+  test("SPARK-34472: ivySettings file with non-file:// schemes should throw an error") {
+    val emptyIvySettings = createEmptyIvySettingsFile
+    val e1 = intercept[TestFailedException] {
+      testIvySettingsDistribution(clientMode = false,
+        s"local://${emptyIvySettings.getAbsolutePath}", "")
+    }
+    assert(e1.getMessage.contains("IllegalArgumentException: " +
+      "Scheme local not supported in spark.jars.ivySettings"))
+    val e2 = intercept[TestFailedException] {
+      testIvySettingsDistribution(clientMode = false,
+        s"hdfs://${emptyIvySettings.getAbsolutePath}", "")
+    }
+    assert(e2.getMessage.contains("IllegalArgumentException: " +
+      "Scheme hdfs not supported in spark.jars.ivySettings"))
+  }
+
+  def testIvySettingsDistribution(clientMode: Boolean, ivySettingsPath: String,
+    expectedIvySettingsPrefixOnDriver: String, prefixMatch: Boolean = false): Unit = {
     val result = File.createTempFile("result", null, tempDir)
-    val finalState = runSpark(clientMode = false,
+    val outFile = File.createTempFile("out", null, tempDir)
+    val finalState = runSpark(clientMode = clientMode,
       mainClassName(YarnAddJarTest.getClass),
-      // For non-local URIs, make sure that ivySettings conf was changed to the localized file
-      // So the expected ivySettings path on the driver will start with the file name and then
-      // some random UUID suffix
-      appArgs = Seq(result.getAbsolutePath, emptyIvySettings.getName),
-      extraConf = Map("spark.jars.ivySettings" -> emptyIvySettings.getAbsolutePath))
-    checkResult(finalState, result)
+      appArgs = Seq(result.getAbsolutePath, expectedIvySettingsPrefixOnDriver,
+        prefixMatch.toString),
+      extraConf = Map("spark.jars.ivySettings" -> ivySettingsPath),
+      outFile = Option(outFile))
+    checkResult(finalState, result, outFile = Option(outFile))
   }
 }
 
@@ -604,26 +644,32 @@ private object YarnClasspathTest extends Logging {
 
 private object YarnAddJarTest extends Logging {
   def main(args: Array[String]): Unit = {
-    if (args.length != 2) {
+    if (args.length != 3) {
       // scalastyle:off println
       System.err.println(
         s"""
            |Invalid command line: ${args.mkString(" ")}
            |
-           |Usage: YarnAddJarTest [result file] [expected ivy settings prefix]
+           |Usage: YarnAddJarTest [result file] [expected ivy settings path] [prefix match]
         """.stripMargin)
       // scalastyle:on println
       System.exit(1)
     }
 
     val resultPath = args(0)
-    val expectedIvySettingsPrefix = args(1)
+    val expectedIvySettingsPath = args(1)
+    val prefixMatch = args(2).toBoolean
     val sc = new SparkContext(new SparkConf())
 
     var result = "failure"
     try {
       val settingsFile = sc.getConf.get("spark.jars.ivySettings")
-      assert(settingsFile.startsWith(expectedIvySettingsPrefix))
+      if (prefixMatch) {
+        assert(settingsFile !== expectedIvySettingsPath)
+        assert(settingsFile.startsWith(expectedIvySettingsPath))
+      } else {
+        assert(settingsFile === expectedIvySettingsPath)
+      }
 
       val caught = intercept[RuntimeException] {
         sc.addJar("ivy://org.fake-project.test:test:1.0.0")

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -375,20 +375,6 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     emptyIvySettings
   }
 
-
-  test("SPARK-34472: local:// ivySettings file should not be localized on driver in cluster mode") {
-    val emptyIvySettings = createEmptyIvySettingsFile
-    val localIvySettingsPath = s"${Utils.LOCAL_SCHEME}://${emptyIvySettings.getAbsolutePath}"
-    val result = File.createTempFile("result", null, tempDir)
-    val finalState = runSpark(clientMode = false,
-      mainClassName(YarnAddJarTest.getClass),
-      // If original ivySettings was a local URI, it should not be localized through YarnClient
-      // so the expected ivySettings path on the driver is exactly the same as the user path
-      appArgs = Seq(result.getAbsolutePath, localIvySettingsPath),
-      extraConf = Map("spark.jars.ivySettings" -> localIvySettingsPath))
-    checkResult(finalState, result)
-  }
-
   test("SPARK-34472: non-local ivySettings file should be localized on driver in cluster mode") {
     val emptyIvySettings = createEmptyIvySettingsFile
     val result = File.createTempFile("result", null, tempDir)
@@ -396,7 +382,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
       mainClassName(YarnAddJarTest.getClass),
       // For non-local URIs, make sure that ivySettings conf was changed to the localized file
       // So the expected ivySettings path on the driver will start with the file name and then
-      // so random UUID suffix
+      // some random UUID suffix
       appArgs = Seq(result.getAbsolutePath, emptyIvySettings.getName),
       extraConf = Map("spark.jars.ivySettings" -> emptyIvySettings.getAbsolutePath))
     checkResult(finalState, result)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -377,7 +377,6 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
 
 
   test("SPARK-34472: local:// ivySettings file should not be localized on driver in cluster mode") {
-
     val emptyIvySettings = createEmptyIvySettingsFile
     val localIvySettingsPath = s"${Utils.LOCAL_SCHEME}://${emptyIvySettings.getAbsolutePath}"
     val result = File.createTempFile("result", null, tempDir)
@@ -391,7 +390,6 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
   }
 
   test("SPARK-34472: non-local ivySettings file should be localized on driver in cluster mode") {
-
     val emptyIvySettings = createEmptyIvySettingsFile
     val result = File.createTempFile("result", null, tempDir)
     val finalState = runSpark(clientMode = false,

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -26,7 +26,6 @@ import scala.concurrent.duration._
 import scala.io.Source
 
 import com.google.common.io.{ByteStreams, Files}
-import org.apache.commons.io.FileUtils
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.util.ConverterUtils
 import org.scalatest.concurrent.Eventually._
@@ -373,7 +372,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
   test("SPARK-34472: ivySettings file should be localized on driver in cluster mode") {
 
     val emptyIvySettings = File.createTempFile("ivy", ".xml")
-    FileUtils.write(emptyIvySettings, "<ivysettings />", StandardCharsets.UTF_8)
+    Files.write("<ivysettings />", emptyIvySettings, StandardCharsets.UTF_8)
 
     val result = File.createTempFile("result", null, tempDir)
     val finalState = runSpark(clientMode = false,
@@ -625,7 +624,7 @@ private object YarnAddJarTest extends Logging {
       }
       if (caught.getMessage.contains("unresolved dependency: org.fake-project.test#test")) {
         // "unresolved dependency" is expected as the dependency does not exist
-        // but exception like "Ivy settings file <file> does not exist should result in failure"
+        // but exception like "Ivy settings file <file> does not exist" should result in failure
         result = "success"
       }
     } finally {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -26,6 +26,7 @@ import scala.concurrent.duration._
 import scala.io.Source
 
 import com.google.common.io.{ByteStreams, Files}
+import org.apache.commons.io.FileUtils
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.util.ConverterUtils
 import org.scalatest.concurrent.Eventually._
@@ -368,6 +369,19 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     )
     checkResult(finalState, result, "true")
   }
+
+  test("SPARK-34472: ivySettings file should be localized on driver in cluster mode") {
+
+    val emptyIvySettings = File.createTempFile("ivy", ".xml")
+    FileUtils.write(emptyIvySettings, "<ivysettings />", StandardCharsets.UTF_8)
+
+    val result = File.createTempFile("result", null, tempDir)
+    val finalState = runSpark(clientMode = false,
+      mainClassName(YarnAddJarTest.getClass),
+      appArgs = Seq(result.getAbsolutePath),
+      extraConf = Map("spark.jars.ivySettings" -> emptyIvySettings.getAbsolutePath))
+    checkResult(finalState, result)
+  }
 }
 
 private[spark] class SaveExecutorInfo extends SparkListener {
@@ -581,6 +595,47 @@ private object YarnClasspathTest extends Logging {
     }
   }
 
+}
+
+private object YarnAddJarTest extends Logging {
+  def main(args: Array[String]): Unit = {
+    if (args.length != 1) {
+      // scalastyle:off println
+      System.err.println(
+        s"""
+           |Invalid command line: ${args.mkString(" ")}
+           |
+           |Usage: YarnAddJarTest [result file]
+        """.stripMargin)
+      // scalastyle:on println
+      System.exit(1)
+    }
+
+    val resultPath = args(0)
+    val sc = new SparkContext(new SparkConf())
+
+    var result = "failure"
+    try {
+      val settingsFile = sc.getConf.get("spark.jars.ivySettings")
+      // Delete the original ivySettings file, so we ensure that the YARN localized file
+      // is used by the addJar call
+      // In a real cluster mode, the original settings file at the absolute path won't be present
+      // on the driver
+      new File(settingsFile).delete()
+
+      val caught = intercept[Exception] {
+        sc.addJar("ivy://org.fake-project.test:test:1.0.0")
+      }
+      if (caught.getMessage.contains("unresolved dependency: org.fake-project.test#test")) {
+        // "unresolved dependency" is expected as the dependency does not exist
+        // but exception like "Ivy settings file <file> does not exist should result in failure
+        result = "success"
+      }
+    } finally {
+      Files.write(result, new File(resultPath), StandardCharsets.UTF_8)
+      sc.stop()
+    }
+  }
 }
 
 private object YarnLauncherTestApp {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -26,6 +26,7 @@ import scala.concurrent.duration._
 import scala.io.Source
 
 import com.google.common.io.{ByteStreams, Files}
+import org.apache.commons.io.FileUtils
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.util.ConverterUtils
 import org.scalatest.concurrent.Eventually._
@@ -368,6 +369,19 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     )
     checkResult(finalState, result, "true")
   }
+
+  test("SPARK-34472: ivySettings file should be localized on driver in cluster mode") {
+
+    val emptyIvySettings = File.createTempFile("ivy", ".xml")
+    FileUtils.write(emptyIvySettings, "<ivysettings />", StandardCharsets.UTF_8)
+
+    val result = File.createTempFile("result", null, tempDir)
+    val finalState = runSpark(clientMode = false,
+      mainClassName(YarnAddJarTest.getClass),
+      appArgs = Seq(result.getAbsolutePath),
+      extraConf = Map("spark.jars.ivySettings" -> emptyIvySettings.getAbsolutePath))
+    checkResult(finalState, result)
+  }
 }
 
 private[spark] class SaveExecutorInfo extends SparkListener {
@@ -581,6 +595,44 @@ private object YarnClasspathTest extends Logging {
     }
   }
 
+}
+
+private object YarnAddJarTest extends Logging {
+  def main(args: Array[String]): Unit = {
+    if (args.length != 1) {
+      // scalastyle:off println
+      System.err.println(
+        s"""
+           |Invalid command line: ${args.mkString(" ")}
+           |
+           |Usage: YarnAddJarTest [result file]
+        """.stripMargin)
+      // scalastyle:on println
+      System.exit(1)
+    }
+
+    val resultPath = args(0)
+    val sc = new SparkContext(new SparkConf())
+
+    var result = "failure"
+    try {
+      val settingsFile = sc.getConf.get("spark.jars.ivySettings")
+      // Make sure that ivySettings conf was set to the localized file
+      assert(settingsFile.startsWith(Client.LOCALIZED_CONF_DIR))
+
+      val caught = intercept[RuntimeException] {
+        sc.addJar("ivy://org.fake-project.test:test:1.0.0")
+      }
+      if (caught.getMessage.contains("unresolved dependency: org.fake-project.test#test")) {
+        // "unresolved dependency" is expected as the dependency does not exist
+        // but exception like "Ivy settings file <file> does not exist should result in failure"
+        result = "success"
+      }
+    } finally {
+      Files.write(result, new File(resultPath), StandardCharsets.UTF_8)
+      sc.stop()
+    }
+  }
 }
 
 private object YarnLauncherTestApp {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In YARN, ship the `spark.jars.ivySettings` file to the driver when using `cluster` deploy mode so that `addJar` is able to find it in order to resolve ivy paths.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
SPARK-33084 introduced support for Ivy paths in `sc.addJar` or Spark SQL `ADD JAR`. If we use a custom ivySettings file using `spark.jars.ivySettings`, it is loaded at https://github.com/apache/spark/blob/b26e7b510bbaee63c4095ab47e75ff2a70e377d7/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala#L1280. However, this file is only accessible on the client machine. In YARN cluster mode, this file is not available on the driver and so `addJar` fails to find it.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests to verify that the `ivySettings` file is localized by the YARN client and that a YARN cluster mode application is able to find to load the `ivySettings` file.