### PR TITLE
[SPARK-34478][SQL] When build SparkSession, we should check config keys

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2690,7 +2690,10 @@ object SparkContext extends Logging {
         setActiveContext(new SparkContext(config))
       } else {
         if (config.getAll.nonEmpty) {
-          logWarning("Using an existing SparkContext; some configuration may not take effect.")
+          logWarning("Using an existing SparkContext; some configuration may not take effect." +
+            " For how to set these configuration correctly, you can refer to" +
+            " https://spark.apache.org/docs/latest/configuration.html" +
+            "#dynamically-loading-spark-properties.")
         }
       }
       activeContext.get()

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2690,10 +2690,10 @@ object SparkContext extends Logging {
         setActiveContext(new SparkContext(config))
       } else {
         if (config.getAll.nonEmpty) {
-          logWarning("Using an existing SparkContext; some configuration may not take effect." +
-            " For how to set these configuration correctly, you can refer to" +
-            s" https://spark.apache.org/docs/$SPARK_VERSION/configuration.html" +
-            "#dynamically-loading-spark-properties.")
+          logWarning("Using an existing SparkContext; some configuration may not take effect. " +
+            "For how to set these configuration correctly, you can refer to " +
+            s"https://spark.apache.org/docs/${SPARK_VERSION.replace("-SNAPSHOT", "")}" +
+            s"/configuration.html#dynamically-loading-spark-properties.")
         }
       }
       activeContext.get()

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2692,7 +2692,7 @@ object SparkContext extends Logging {
         if (config.getAll.nonEmpty) {
           logWarning("Using an existing SparkContext; some configuration may not take effect." +
             " For how to set these configuration correctly, you can refer to" +
-            " https://spark.apache.org/docs/latest/configuration.html" +
+            s" https://spark.apache.org/docs/$SPARK_VERSION/configuration.html" +
             "#dynamically-loading-spark-properties.")
         }
       }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,21 +115,58 @@ versions of Spark; in such cases, the older key names are still accepted, but ta
 precedence than any instance of the newer key.
 
 Spark properties mainly can be divided into three kinds: 
-
-    1. configuration used to submit application, such as "spark.driver.memory", "spark.driver.extraclassPath",
-       these kind of properties only effect before driver's JVM is started, so it would be suggested to set through
-       configuration file or `spark-submit` command line options. For these kind of configuration, they are 
-       "spark.driver.memory", "spark.driver.memoryOverhead", "spark.driver.cores", "spark.driver.userClassPathFirst",
-       "spark.driver.extraClassPath", "spark.driver.defaultJavaOptions", "spark.driver.extraJavaOptions",
-       "spark.driver.extraLibraryPath", "spark.driver.resource.*", "spark.pyspark.driver.python", "spark.pyspark.python", "spark.r.shell.command",
-       "spark.launcher.childProcLoggerName", "spark.launcher.childConectionTimeout", "spark.yarn.driver.*".
-    2. one is related to deploy, like "spark.master", "spark.executor.instances", this kind of properties may not
-       be affected when setting programmatically through `SparkConf` in runtime after SparkContext has been started,
-       or the behavior is depending on which cluster manager and deploy mode you choose, so it would be suggested to
-       set through configuration file, `spark-submit` command line options, or setting programmatically through `SparkConf`
-       in runtime before start SparkContext.
-    3. another is mainly related to Spark runtime control,
-       like "spark.task.maxFailures", this kind of properties can be set in either way.
+<table class="table">
+<tr><th>Configuration Type</th><th>Effect Scope</th><th>Usage</th><th>Remark</th></tr>
+<tr>
+  <td><code>Driver Launch Related Configuration</code></td>
+  <td>Effect before start driver process.</td>
+  <td>
+    Configuration used to submit application, such as `spark.driver.memory`, `spark.driver.extraclassPath`,
+    these kind of properties only effect before driver's JVM is started, so it would be suggested to set through
+    configuration file or `spark-submit` command line options.  
+  </td>
+  <td>
+    `spark.driver.memory`
+    `spark.driver.memoryOverhead`
+    `spark.driver.cores`
+    `spark.driver.userClassPathFirst`
+    `spark.driver.extraClassPath`
+    `spark.driver.defaultJavaOptions`
+    `spark.driver.extraJavaOptions`
+    `spark.driver.extraLibraryPath`
+    `spark.driver.resource.*`
+    `spark.pyspark.driver.python`
+    `spark.pyspark.python`
+    `spark.r.shell.command'
+    `spark.launcher.childProcLoggerName`
+    `spark.launcher.childConectionTimeout`
+    `spark.yarn.driver.*`
+  </td>
+</tr>
+<tr>
+  <td><code>Application Deploy Related Configuration</code></td>
+  <td>Effect before start SparkContext.</td>
+  <td>
+    Like "spark.master", "spark.executor.instances", this kind of properties may not
+    be affected when setting programmatically through `SparkConf` in runtime after SparkContext has been started,
+    or the behavior is depending on which cluster manager and deploy mode you choose, so it would be suggested to
+    set through configuration file, `spark-submit` command line options, or setting programmatically through `SparkConf`
+    in runtime before start SparkContext.  
+  </td>
+  <td>
+    
+  </td>
+</tr>
+<tr>
+  <td><code>Spark Runtime Control Related Configuration</code></td>
+  <td>Effect when runtime.</td>
+  <td>
+    Like "spark.task.maxFailures", this kind of properties can be set in either way. 
+  </td>
+  <td>
+    
+  </td>
+</tr>
 
 ## Viewing Spark Properties
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,7 +114,7 @@ in the `spark-defaults.conf` file. A few configuration keys have been renamed si
 versions of Spark; in such cases, the older key names are still accepted, but take lower
 precedence than any instance of the newer key.
 
-Note that Spark properties have different effective timing and they can be divided into two kinds:
+Note that Spark properties have different effective timing and they can be divided into three kinds:
 <table class="table">
 <tr><th>Effect Timing</th><th>Meaning</th><th>Examples</th></tr>
 <tr>
@@ -157,6 +157,19 @@ Note that Spark properties have different effective timing and they can be divid
        <li><code>spark.submit.deployMode</code></li>
        <li><code>spark.eventLog.enabled</code></li>
      </ul>
+  </td>
+</tr>
+<tr>
+  <td><code>Spark Runtime</code></td>
+  <td>
+    Like <code>spark.task.maxFailures</code>, all other properties can be set either way when runtime.
+  </td>
+  <td>
+     The following is examples of such configurations:
+     <ul>
+       <li><code>spark.task.maxFailures</code></li>
+       <li><code>etc...</code></li>
+      </ul>
   </td>
 </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,29 +118,30 @@ Spark properties mainly can be divided into three kinds:
 <table class="table">
 <tr><th>Configuration Type</th><th>Effect Scope</th><th>Usage</th><th>Remark</th></tr>
 <tr>
-  <td><code>Driver Launch Related Configuration</code></td>
-  <td>Effect before start driver process.</td>
+  <td><code>Lauch Driver Related Configuration</code></td>
+  <td>Effect before start driver JVM.</td>
   <td>
-    Configuration used to submit application, such as `spark.driver.memory`, `spark.driver.extraclassPath`,
+    Configuration used to submit application, such as `spark.driver.memory`, `spark.driver.extraClassPath`,
     these kind of properties only effect before driver's JVM is started, so it would be suggested to set through
     configuration file or `spark-submit` command line options.  
   </td>
   <td>
-    `spark.driver.memory`
-    `spark.driver.memoryOverhead`
-    `spark.driver.cores`
-    `spark.driver.userClassPathFirst`
-    `spark.driver.extraClassPath`
-    `spark.driver.defaultJavaOptions`
-    `spark.driver.extraJavaOptions`
-    `spark.driver.extraLibraryPath`
-    `spark.driver.resource.*`
-    `spark.pyspark.driver.python`
-    `spark.pyspark.python`
-    `spark.r.shell.command'
-    `spark.launcher.childProcLoggerName`
-    `spark.launcher.childConectionTimeout`
-    `spark.yarn.driver.*`
+    The following is a list of such configurations:<br/>
+     `spark.driver.memory`<br/>
+     `spark.driver.memoryOverhead`<br/>
+     `spark.driver.cores`<br/>
+     `spark.driver.userClassPathFirst`<br/>
+     `spark.driver.extraClassPath`<br/>
+     `spark.driver.defaultJavaOptions`<br/>
+     `spark.driver.extraJavaOptions`<br/>
+     `spark.driver.extraLibraryPath`<br/>
+     `spark.driver.resource.*`<br/>
+     `spark.pyspark.driver.python`<br/>
+     `spark.pyspark.python`<br/>
+     `spark.r.shell.command`<br/>
+     `spark.launcher.childProcLoggerName`<br/>
+     `spark.launcher.childConnectionTimeout`<br/>
+     `spark.yarn.driver.*`
   </td>
 </tr>
 <tr>
@@ -167,6 +168,7 @@ Spark properties mainly can be divided into three kinds:
     
   </td>
 </tr>
+</table>
 
 ## Viewing Spark Properties
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,21 +126,21 @@ Note that Spark properties have different effective timing and they can be divid
   <td>
     The following is a list of such configurations:
     <ul>
-      <li><code>spark.driver.memory</code>
-      <li><code>spark.driver.memoryOverhead</code>
-      <li><code>spark.driver.cores</code>
-      <li><code>spark.driver.userClassPathFirst</code>
-      <li><code>spark.driver.extraClassPath</code>
-      <li><code>spark.driver.defaultJavaOptions</code>
-      <li><code>spark.driver.extraJavaOptions</code>
-      <li><code>spark.driver.extraLibraryPath</code>
-      <li><code>spark.driver.resource.*</code>
-      <li><code>spark.pyspark.driver.python</code>
-      <li><code>spark.pyspark.python</code>
-      <li><code>spark.r.shell.command</code>
-      <li><code>spark.launcher.childProcLoggerName</code>
-      <li><code>spark.launcher.childConnectionTimeout</code>
-      <li><code>spark.yarn.driver.*</code>
+      <li><code>spark.driver.memory</code></li>
+      <li><code>spark.driver.memoryOverhead</code></li>
+      <li><code>spark.driver.cores</code></li>
+      <li><code>spark.driver.userClassPathFirst</code></li>
+      <li><code>spark.driver.extraClassPath</code></li>
+      <li><code>spark.driver.defaultJavaOptions</code></li>
+      <li><code>spark.driver.extraJavaOptions</code></li>
+      <li><code>spark.driver.extraLibraryPath</code></li>
+      <li><code>spark.driver.resource.*</code></li>
+      <li><code>spark.pyspark.driver.python</code></li>
+      <li><code>spark.pyspark.python</code></li>
+      <li><code>spark.r.shell.command</code></li>
+      <li><code>spark.launcher.childProcLoggerName</code></li>
+      <li><code>spark.launcher.childConnectionTimeout</code></li>
+      <li><code>spark.yarn.driver.*</code></li>
      </ul>
   </td>
 </tr>
@@ -152,14 +152,14 @@ Note that Spark properties have different effective timing and they can be divid
   </td>
   <td>
      The following is a example such configurations:
-      <ul>
-        <li><code>spark.master</code>
-        <li><code>spark.app.name</code>
-        <li><code>spark.executor.memory</code>
-        <li><code>spark.submit.deployMode</code>
-        <li><code>spark.eventLog.enabled</code>
-        <li><code>etc...</code>
-       </ul>
+     <ul>
+       <li><code>spark.master</code></li>
+       <li><code>spark.app.name</code></li>
+       <li><code>spark.executor.memory</code></li>
+       <li><code>spark.submit.deployMode</code></li>
+       <li><code>spark.eventLog.enabled</code></li>
+       <li><code>etc...</code></li>
+     </ul>
   </td>
 </tr>
 <tr>
@@ -170,11 +170,11 @@ Note that Spark properties have different effective timing and they can be divid
   </td>
   <td>
      The following is examples of such configurations:
-      <ul>
-        <li><code>spark.task.maxFailures</code>
-        <li><code>spark.sql.shuffle.partitions</code>
-        <li><code>etc...</code>
-       </ul>
+     <ul>
+       <li><code>spark.task.maxFailures</code></li>
+       <li><code>spark.sql.shuffle.partitions</code></li>
+       <li><code>etc...</code></li>
+      </ul>
   </td>
 </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,13 +116,12 @@ precedence than any instance of the newer key.
 
 Note that Spark properties have different effective timing and they can be divided into three kinds:
 <table class="table">
-<tr><th>Configuration Type</th><th>Effective Timing</th><th>Meaning</th><th>Examples</th></tr>
+<tr><th>Configuration Type</th><th>Meaning</th><th>Examples</th></tr>
 <tr>
   <td><code>Configurations needed at driver launch</code></td>
   <td>
     Configuration used to submit an application, such as <code>spark.driver.memory</code>, <code>spark.driver.extraClassPath</code>, these kind of properties only effect before driver's JVM is started, so it would be suggested to set through configuration file or <code>spark-submit</code> command line options.  
   </td>
-  <td>Effect before start driver JVM.</td>
   <td>
     The following is a list of such configurations:
     <ul>
@@ -146,7 +145,6 @@ Note that Spark properties have different effective timing and they can be divid
 </tr>
 <tr>
   <td><code>Application Deploy Related Configuration</code></td>
-  <td>Effect before start SparkContext.</td>
   <td>
     Like <code>spark.master</code>, <code>spark.executor.instances</code>, this kind of properties may not be affected when setting programmatically through <code>SparkConf</code> in runtime after SparkContext has been started, or the behavior is depending on which cluster manager and deploy mode you choose, so it would be suggested to set through configuration file, <code>spark-submit</code> command line options, or setting programmatically through <code>SparkConf</code> in runtime before start SparkContext.  
   </td>
@@ -164,9 +162,8 @@ Note that Spark properties have different effective timing and they can be divid
 </tr>
 <tr>
   <td><code>Spark Runtime Control Related Configuration</code></td>
-  <td>Effect when runtime.</td>
   <td>
-    Like <code>spark.task.maxFailures</code>, all other properties can be set either way. 
+    Like <code>spark.task.maxFailures</code>, all other properties can be set either way when run time. 
   </td>
   <td>
      The following is examples of such configurations:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,11 +116,11 @@ precedence than any instance of the newer key.
 
 Note that Spark properties have different effective timing and they can be divided into two kinds:
 <table class="table">
-<tr><th>Configuration Type</th><th>Meaning</th><th>Examples</th></tr>
+<tr><th>Effect Timing</th><th>Meaning</th><th>Examples</th></tr>
 <tr>
   <td><code>Launching Driver</code></td>
   <td>
-    Configuration used to submit an application, such as <code>spark.driver.memory</code>, <code>spark.driver.extraClassPath</code>, these kind of properties only effect before driver's JVM is started, so it would be suggested to set through configuration file or <code>spark-submit</code> command line options.  
+    Configurations used to submit an application, such as <code>spark.driver.memory</code>, <code>spark.driver.extraClassPath</code>, these kinds of properties only effect before a driver JVM is started, so it would be suggested to set through a configuration file or <code>spark-submit</code> command line options.  
   </td>
   <td>
     The following is a list of such configurations:
@@ -144,9 +144,9 @@ Note that Spark properties have different effective timing and they can be divid
   </td>
 </tr>
 <tr>
-  <td><code>Application Deployment</code></td>
+  <td><code>Deploying Application</code> according to <code>Launching Driver</code></td>
   <td>
-    Like <code>spark.master</code>, <code>spark.executor.instances</code>, this kind of properties may not be affected when setting programmatically through <code>SparkConf</code> in runtime after SparkContext has been started, or the behavior is depending on which cluster manager and deploy mode you choose, so it would be suggested to set through configuration file, <code>spark-submit</code> command line options, or setting programmatically through <code>SparkConf</code> in runtime before start SparkContext.  
+    Like <code>spark.master</code>, <code>spark.executor.instances</code>, these kinds of properties may not be affected when setting programmatically through <code>SparkConf</code> in runtime after SparkContext has been started, or the behavior depends on which cluster manager and the deploy mode you choose, so it would be suggested to set through a configuration file, <code>spark-submit</code> command line options, or setting programmatically through <code>SparkConf</code> in runtime before starting <code>SparkContext</code>.  
   </td>
   <td>
      The following is some examples of such configurations:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,12 +114,22 @@ in the `spark-defaults.conf` file. A few configuration keys have been renamed si
 versions of Spark; in such cases, the older key names are still accepted, but take lower
 precedence than any instance of the newer key.
 
-Spark properties mainly can be divided into two kinds: one is related to deploy, like
-"spark.driver.memory", "spark.executor.instances", this kind of properties may not be affected when
-setting programmatically through `SparkConf` in runtime, or the behavior is depending on which
-cluster manager and deploy mode you choose, so it would be suggested to set through configuration
-file or `spark-submit` command line options; another is mainly related to Spark runtime control,
-like "spark.task.maxFailures", this kind of properties can be set in either way.
+Spark properties mainly can be divided into three kinds: 
+
+    1. configuration used to submit application, such as "spark.driver.memory", "spark.driver.extraclassPath",
+       these kind of properties only effect before driver's JVM is started, so it would be suggested to set through
+       configuration file or `spark-submit` command line options. For these kind of configuration, they are 
+       "spark.driver.memory", "spark.driver.memoryOverhead", "spark.driver.cores", "spark.driver.userClassPathFirst",
+       "spark.driver.extraClassPath", "spark.driver.defaultJavaOptions", "spark.driver.extraJavaOptions",
+       "spark.driver.extraLibraryPath", "spark.driver.resource.*", "spark.pyspark.driver.python", "spark.pyspark.python", "spark.r.shell.command",
+       "spark.launcher.childProcLoggerName", "spark.launcher.childConectionTimeout", "spark.yarn.driver.*".
+    2. one is related to deploy, like "spark.master", "spark.executor.instances", this kind of properties may not
+       be affected when setting programmatically through `SparkConf` in runtime after SparkContext has been started,
+       or the behavior is depending on which cluster manager and deploy mode you choose, so it would be suggested to
+       set through configuration file, `spark-submit` command line options, or setting programmatically through `SparkConf`
+       in runtime before start SparkContext.
+    3. another is mainly related to Spark runtime control,
+       like "spark.task.maxFailures", this kind of properties can be set in either way.
 
 ## Viewing Spark Properties
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,58 +114,67 @@ in the `spark-defaults.conf` file. A few configuration keys have been renamed si
 versions of Spark; in such cases, the older key names are still accepted, but take lower
 precedence than any instance of the newer key.
 
-Spark properties mainly can be divided into three kinds: 
+Note that Spark properties have different effective timing and they can be divided into three kinds:
 <table class="table">
-<tr><th>Configuration Type</th><th>Effect Scope</th><th>Usage</th><th>Remark</th></tr>
+<tr><th>Configuration Type</th><th>Effective Timing</th><th>Meaning</th><th>Examples</th></tr>
 <tr>
-  <td><code>Lauch Driver Related Configuration</code></td>
+  <td><code>Configurations needed at driver launch</code></td>
+  <td>
+    Configuration used to submit an application, such as <code>spark.driver.memory</code>, <code>spark.driver.extraClassPath</code>, these kind of properties only effect before driver's JVM is started, so it would be suggested to set through configuration file or <code>spark-submit</code> command line options.  
+  </td>
   <td>Effect before start driver JVM.</td>
   <td>
-    Configuration used to submit application, such as `spark.driver.memory`, `spark.driver.extraClassPath`,
-    these kind of properties only effect before driver's JVM is started, so it would be suggested to set through
-    configuration file or `spark-submit` command line options.  
-  </td>
-  <td>
-    The following is a list of such configurations:<br/>
-     `spark.driver.memory`<br/>
-     `spark.driver.memoryOverhead`<br/>
-     `spark.driver.cores`<br/>
-     `spark.driver.userClassPathFirst`<br/>
-     `spark.driver.extraClassPath`<br/>
-     `spark.driver.defaultJavaOptions`<br/>
-     `spark.driver.extraJavaOptions`<br/>
-     `spark.driver.extraLibraryPath`<br/>
-     `spark.driver.resource.*`<br/>
-     `spark.pyspark.driver.python`<br/>
-     `spark.pyspark.python`<br/>
-     `spark.r.shell.command`<br/>
-     `spark.launcher.childProcLoggerName`<br/>
-     `spark.launcher.childConnectionTimeout`<br/>
-     `spark.yarn.driver.*`
+    The following is a list of such configurations:
+    <ul>
+      <li><code>spark.driver.memory</code>
+      <li><code>spark.driver.memoryOverhead</code>
+      <li><code>spark.driver.cores</code>
+      <li><code>spark.driver.userClassPathFirst</code>
+      <li><code>spark.driver.extraClassPath</code>
+      <li><code>spark.driver.defaultJavaOptions</code>
+      <li><code>spark.driver.extraJavaOptions</code>
+      <li><code>spark.driver.extraLibraryPath</code>
+      <li><code>spark.driver.resource.*</code>
+      <li><code>spark.pyspark.driver.python</code>
+      <li><code>spark.pyspark.python</code>
+      <li><code>spark.r.shell.command</code>
+      <li><code>spark.launcher.childProcLoggerName</code>
+      <li><code>spark.launcher.childConnectionTimeout</code>
+      <li><code>spark.yarn.driver.*</code>
+     </ul>
   </td>
 </tr>
 <tr>
   <td><code>Application Deploy Related Configuration</code></td>
   <td>Effect before start SparkContext.</td>
   <td>
-    Like "spark.master", "spark.executor.instances", this kind of properties may not
-    be affected when setting programmatically through `SparkConf` in runtime after SparkContext has been started,
-    or the behavior is depending on which cluster manager and deploy mode you choose, so it would be suggested to
-    set through configuration file, `spark-submit` command line options, or setting programmatically through `SparkConf`
-    in runtime before start SparkContext.  
+    Like <code>spark.master</code>, <code>spark.executor.instances</code>, this kind of properties may not be affected when setting programmatically through <code>SparkConf</code> in runtime after SparkContext has been started, or the behavior is depending on which cluster manager and deploy mode you choose, so it would be suggested to set through configuration file, <code>spark-submit</code> command line options, or setting programmatically through <code>SparkConf</code> in runtime before start SparkContext.  
   </td>
   <td>
-    
+     The following is a example such configurations:
+      <ul>
+        <li><code>spark.master</code>
+        <li><code>spark.app.name</code>
+        <li><code>spark.executor.memory</code>
+        <li><code>spark.submit.deployMode</code>
+        <li><code>spark.eventLog.enabled</code>
+        <li><code>etc...</code>
+       </ul>
   </td>
 </tr>
 <tr>
   <td><code>Spark Runtime Control Related Configuration</code></td>
   <td>Effect when runtime.</td>
   <td>
-    Like "spark.task.maxFailures", this kind of properties can be set in either way. 
+    Like <code>spark.task.maxFailures</code>, all other properties can be set either way. 
   </td>
   <td>
-    
+     The following is examples of such configurations:
+      <ul>
+        <li><code>spark.task.maxFailures</code>
+        <li><code>spark.sql.shuffle.partitions</code>
+        <li><code>etc...</code>
+       </ul>
   </td>
 </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,7 @@ Note that Spark properties have different effective timing and they can be divid
 <table class="table">
 <tr><th>Configuration Type</th><th>Meaning</th><th>Examples</th></tr>
 <tr>
-  <td><code>Configuration: Launching Driver</code></td>
+  <td><code>Launching Driver</code></td>
   <td>
     Configuration used to submit an application, such as <code>spark.driver.memory</code>, <code>spark.driver.extraClassPath</code>, these kind of properties only effect before driver's JVM is started, so it would be suggested to set through configuration file or <code>spark-submit</code> command line options.  
   </td>
@@ -144,7 +144,7 @@ Note that Spark properties have different effective timing and they can be divid
   </td>
 </tr>
 <tr>
-  <td><code>Configuration: Application Deployment</code></td>
+  <td><code>Application Deployment</code></td>
   <td>
     Like <code>spark.master</code>, <code>spark.executor.instances</code>, this kind of properties may not be affected when setting programmatically through <code>SparkConf</code> in runtime after SparkContext has been started, or the behavior is depending on which cluster manager and deploy mode you choose, so it would be suggested to set through configuration file, <code>spark-submit</code> command line options, or setting programmatically through <code>SparkConf</code> in runtime before start SparkContext.  
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,11 +114,11 @@ in the `spark-defaults.conf` file. A few configuration keys have been renamed si
 versions of Spark; in such cases, the older key names are still accepted, but take lower
 precedence than any instance of the newer key.
 
-Note that Spark properties have different effective timing and they can be divided into three kinds:
+Note that Spark properties have different effective timing and they can be divided into two kinds:
 <table class="table">
 <tr><th>Configuration Type</th><th>Meaning</th><th>Examples</th></tr>
 <tr>
-  <td><code>Configurations needed at driver launch</code></td>
+  <td><code>Configuration: Launching Driver</code></td>
   <td>
     Configuration used to submit an application, such as <code>spark.driver.memory</code>, <code>spark.driver.extraClassPath</code>, these kind of properties only effect before driver's JVM is started, so it would be suggested to set through configuration file or <code>spark-submit</code> command line options.  
   </td>
@@ -144,34 +144,19 @@ Note that Spark properties have different effective timing and they can be divid
   </td>
 </tr>
 <tr>
-  <td><code>Application Deploy Related Configuration</code></td>
+  <td><code>Configuration: Application Deployment</code></td>
   <td>
     Like <code>spark.master</code>, <code>spark.executor.instances</code>, this kind of properties may not be affected when setting programmatically through <code>SparkConf</code> in runtime after SparkContext has been started, or the behavior is depending on which cluster manager and deploy mode you choose, so it would be suggested to set through configuration file, <code>spark-submit</code> command line options, or setting programmatically through <code>SparkConf</code> in runtime before start SparkContext.  
   </td>
   <td>
-     The following is a example such configurations:
+     The following is some examples of such configurations:
      <ul>
        <li><code>spark.master</code></li>
        <li><code>spark.app.name</code></li>
        <li><code>spark.executor.memory</code></li>
        <li><code>spark.submit.deployMode</code></li>
        <li><code>spark.eventLog.enabled</code></li>
-       <li><code>etc...</code></li>
      </ul>
-  </td>
-</tr>
-<tr>
-  <td><code>Spark Runtime Control Related Configuration</code></td>
-  <td>
-    Like <code>spark.task.maxFailures</code>, all other properties can be set either way when runtime. 
-  </td>
-  <td>
-     The following is examples of such configurations:
-     <ul>
-       <li><code>spark.task.maxFailures</code></li>
-       <li><code>spark.sql.shuffle.partitions</code></li>
-       <li><code>etc...</code></li>
-      </ul>
   </td>
 </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,7 +163,7 @@ Note that Spark properties have different effective timing and they can be divid
 <tr>
   <td><code>Spark Runtime Control Related Configuration</code></td>
   <td>
-    Like <code>spark.task.maxFailures</code>, all other properties can be set either way when run time. 
+    Like <code>spark.task.maxFailures</code>, all other properties can be set either way when runtime. 
   </td>
   <td>
      The following is examples of such configurations:

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -73,11 +73,11 @@ public class SparkLauncher extends AbstractLauncher<SparkLauncher> {
   /** Configuration key for the number of executor CPU cores. */
   public static final String EXECUTOR_CORES = "spark.executor.cores";
 
-  static final String PYSPARK_DRIVER_PYTHON = "spark.pyspark.driver.python";
+  public static final String PYSPARK_DRIVER_PYTHON = "spark.pyspark.driver.python";
 
-  static final String PYSPARK_PYTHON = "spark.pyspark.python";
+  public static final String PYSPARK_PYTHON = "spark.pyspark.python";
 
-  static final String SPARKR_R_SHELL = "spark.r.shell.command";
+  public static final String SPARKR_R_SHELL = "spark.r.shell.command";
 
   /** Logger name to use when launching a child process. */
   public static final String CHILD_PROCESS_LOGGER_NAME = "spark.launcher.childProcLoggerName";

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -934,11 +934,11 @@ object SparkSession extends Logging {
 
       if (nonEffectConfigurations.nonEmpty) {
         logWarning(
-          s"Since spark has been submitted, such configurations" +
+          "Since spark has been submitted, such configurations" +
             s" `${nonEffectConfigurations.mkString(", ")}` may not take effect." +
-            s" For how to set these configuration correctly, you can refer to" +
-            s" https://spark.apache.org/docs/latest/configuration.html" +
-            s"#dynamically-loading-spark-properties.")
+            " For how to set these configuration correctly, you can refer to" +
+            s" https://spark.apache.org/docs/$SPARK_VERSION/configuration.html" +
+            "#dynamically-loading-spark-properties.")
       }
 
       mayEffectConfigurations.foreach { case (k, v) => sparkConf.set(k, v) }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -951,10 +951,10 @@ object SparkSession extends Logging {
 
       if (SparkContext.getActive.isDefined) {
         logWarning(
-          s"""Since spark has been started and SparkContext has been initialized, such
-             | configuration `${scAlreadySetConfigurations.mkString(", ")}` may not be affected when
-             | setting programmatically through SparkConf in runtime, or the behavior is
-             | depending on which cluster manager and deploy mode you choose, so it would
+          s"""Since spark has been started and SparkContext has been initialized, SparkSession
+             | will use an existing SparkContext, such configuration
+             | `${scAlreadySetConfigurations.mkString(", ")}` may not be affected when
+             | setting programmatically through SparkConf in runtime, so it would
              | be suggested to set through configuration file or spark-submit command line options.
              |""".stripMargin)
         normalConfigs.foreach { case (k, v) => sparkConf.set(k, v) }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -934,11 +934,11 @@ object SparkSession extends Logging {
 
       if (nonEffectConfigurations.nonEmpty) {
         logWarning(
-          "Since spark has been submitted, such configurations" +
-            s" `${nonEffectConfigurations.mkString(", ")}` may not take effect." +
-            " For how to set these configuration correctly, you can refer to" +
-            s" https://spark.apache.org/docs/$SPARK_VERSION/configuration.html" +
-            "#dynamically-loading-spark-properties.")
+          "Since spark has been submitted, such configurations " +
+            s"`${nonEffectConfigurations.mkString(", ")}` may not take effect. " +
+            "For how to set these configuration correctly, you can refer to " +
+            s"https://spark.apache.org/docs/${SPARK_VERSION.replace("-SNAPSHOT", "")}" +
+            s"/configuration.html#dynamically-loading-spark-properties.")
       }
 
       mayEffectConfigurations.foreach { case (k, v) => sparkConf.set(k, v) }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -910,14 +910,6 @@ object SparkSession extends Logging {
       CHILD_PROCESS_LOGGER_NAME, CHILD_CONNECTION_TIMEOUT, DRIVER_USER_CLASS_PATH_FIRST.key,
       "spark.yarn.*")
 
-    // These configurations related to executor when deploy like `spark.executor.memory`,
-    // `spark.executor.cores`, this kind of properties may not be affected when setting
-    // programmatically after SparkContext is started, so it would
-    // be suggested to set through configuration file or spark-submit command line options.
-    private val EXECUTOR_LAUNCHER_CONFIG = Seq(SPARK_MASTER, DEPLOY_MODE, EXECUTOR_MEMORY,
-      EXECUTOR_EXTRA_CLASSPATH, EXECUTOR_DEFAULT_JAVA_OPTIONS, EXECUTOR_EXTRA_JAVA_OPTIONS,
-      EXECUTOR_EXTRA_LIBRARY_PATH, EXECUTOR_CORES)
-
     /**
      * Gets an existing [[SparkSession]] or, if there is no existing one, creates a new
      * one based on the options set in this builder.

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -898,8 +898,8 @@ object SparkSession extends Logging {
       this
     }
 
-    // These configurations related to driver when deploy like “spark.master”,
-    // “spark.driver.memory”, this kind of properties may not be affected when
+    // These configurations related to driver when deploy like `spark.master`,
+    // `spark.driver.memory`, this kind of properties may not be affected when
     // setting programmatically through SparkConf in runtime, or the behavior is
     // depending on which cluster manager and deploy mode you choose, so it would
     // be suggested to set through configuration file or spark-submit command line options.
@@ -908,8 +908,8 @@ object SparkSession extends Logging {
       PYSPARK_DRIVER_PYTHON, PYSPARK_PYTHON, SPARKR_R_SHELL, CHILD_PROCESS_LOGGER_NAME,
       CHILD_CONNECTION_TIMEOUT)
 
-    // These configurations related to executor when deploy like “spark.executor.memory”,
-    // “spark.executor.cores”, this kind of properties may not be affected when setting
+    // These configurations related to executor when deploy like `spark.executor.memory`,
+    // `spark.executor.cores`, this kind of properties may not be affected when setting
     // programmatically after SparkContext is started, so it would
     // be suggested to set through configuration file or spark-submit command line options.
     private val EXECUTOR_LAUNCHER_CONFIG = Seq(SPARK_MASTER, DEPLOY_MODE, EXECUTOR_MEMORY,

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -934,11 +934,11 @@ object SparkSession extends Logging {
 
       if (nonEffectConfigurations.nonEmpty) {
         logWarning(
-          s"""Since spark has been submitted, such configurations
-             | `${nonEffectConfigurations.mkString(", ")}` may not take effect.
-             | For how to set these configuration correctly, you can refer to
-             | https://spark.apache.org/docs/latest/configuration.html#dynamically-loading-spark-properties.
-             |""".stripMargin)
+          s"Since spark has been submitted, such configurations" +
+            s" `${nonEffectConfigurations.mkString(", ")}` may not take effect." +
+            s" For how to set these configuration correctly, you can refer to" +
+            s" https://spark.apache.org/docs/latest/configuration.html" +
+            s"#dynamically-loading-spark-properties.")
       }
 
       mayEffectConfigurations.foreach { case (k, v) => sparkConf.set(k, v) }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Some user who not so clear about spark when build SparkSession
```
SparkSession.builder().config()
```
In this method user may config `spark.driver.memory` then he will think when submit job, spark driver's memory is change. But when we run this code, JVM has been  started,  so this configuration won't work at all.  And in Spark UI, it will show `spark.driver.memory` as this configuration set by `SparkSession.builder().config()`. This makes user and administer confuse.
So we should ignore such as wrong way and logWarn.

After this PR:
https://spark.apache.org/docs/latest/configuration.html#dynamically-loading-spark-properties 's note part will be 

![image](https://user-images.githubusercontent.com/46485123/109502393-e0045300-7ad3-11eb-84da-82768cffded8.png)


### Why are the changes needed?
Make usage more clear


### Does this PR introduce _any_ user-facing change?
No, this pr only handle wrong use case.

### How was this patch tested?
WIP
