### PR TITLE
[SPARK-34495][TESTS] Add `DedicatedJVMTest` test tag

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -65,7 +65,7 @@ jobs:
             java: 8
             hadoop: hadoop3.2
             hive: hive2.3
-            included-tags: org.apache.spark.tags.SecurityTest
+            included-tags: org.apache.spark.tags.DedicatedJVMTest
             comment: "- security tests"
           - modules: sql
             java: 8
@@ -77,7 +77,7 @@ jobs:
             java: 8
             hadoop: hadoop3.2
             hive: hive2.3
-            excluded-tags: org.apache.spark.tags.SecurityTest,org.apache.spark.tags.ExtendedSQLTest
+            excluded-tags: org.apache.spark.tags.DedicatedJVMTest,org.apache.spark.tags.ExtendedSQLTest
             comment: "- other tests"
     env:
       MODULES_TO_TEST: ${{ matrix.modules }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
             hadoop: hadoop3.2
             hive: hive2.3
             included-tags: org.apache.spark.tags.DedicatedJVMTest
-            comment: "- security tests"
+            comment: "- dedicated JVM tests"
           - modules: sql
             java: 8
             hadoop: hadoop3.2

--- a/common/tags/src/test/java/org/apache/spark/tags/DedicatedJVMTest.java
+++ b/common/tags/src/test/java/org/apache/spark/tags/DedicatedJVMTest.java
@@ -27,4 +27,4 @@ import java.lang.annotation.Target;
 @TagAnnotation
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
-public @interface SecurityTest { }
+public @interface DedicatedJVMTest { }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcEncryptionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcEncryptionSuite.scala
@@ -19,9 +19,9 @@ package org.apache.spark.sql.execution.datasources.orc
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.tags.SecurityTest
+import org.apache.spark.tags.DedicatedJVMTest
 
-@SecurityTest
+@DedicatedJVMTest
 class OrcEncryptionSuite extends OrcTest with SharedSparkSession {
   import testImplicits._
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a test tag, `DedicatedJVMTest`, and replace `SecurityTest` with this.

### Why are the changes needed?

To have a reusable general test tag.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.