### PR TITLE
[SPARK-34496][BUILD] Upgrade ZSTD-JNI to 1.4.8-5 for better API compatibility

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -243,4 +243,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.4.8-4//zstd-jni-1.4.8-4.jar
+zstd-jni/1.4.8-5//zstd-jni-1.4.8-5.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -210,4 +210,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.4.8-4//zstd-jni-1.4.8-4.jar
+zstd-jni/1.4.8-5//zstd-jni-1.4.8-5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.4.8-4</version>
+        <version>1.4.8-5</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ZSTD-JNI to 1.4.8-5 for better API compatibility.

### Why are the changes needed?

Previously, we upgrade for ZSTD-JNI performance improvement.
And, `Apache Spark`/`Apache Parquet`/`Apache Avro` master branches are using JZSTD-JNI 1.4.8-x.

This PR aims to upgrade a minor version for a better API compatibility.
- https://github.com/luben/zstd-jni/commit/def1860c6f454ca50bf360bb0da133545daeed31
- https://github.com/luben/zstd-jni/commit/188c803044249409ee234f7e987cfdd712a567fd

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs
