### PR TITLE
[MINOR][SQL] Fix the comment for CalendarIntervalType about comparability.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/CalendarIntervalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/CalendarIntervalType.scala
@@ -28,7 +28,7 @@ import org.apache.spark.annotation.Stable
  *
  * Please use the singleton `DataTypes.CalendarIntervalType` to refer the type.
  *
- * @note Calendar intervals support comparison and ordering since 3.0.0.
+ * @note Calendar intervals are not comparable.
  *
  * @since 1.5.0
  */


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to revert https://github.com/apache/spark/pull/26659 partially regarding to comparability of interval values. The comment became incorrect after https://github.com/apache/spark/pull/27262.

### Why are the changes needed?
The comment is incorrect, and it might confuse Spark's devs/users.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By checking scala coding style `./dev/scalastyle`.