### PR TITLE
[SPARK-34476][SQL] Duplicate referenceNames are given for ambiguousReferences

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -359,7 +359,18 @@ package object expressions  {
 
         case ambiguousReferences =>
           // More than one match.
-          val referenceNames = ambiguousReferences.map(_.qualifiedName).mkString(", ")
+          var referenceNames = ""
+          if (ambiguousReferences.map(_.qualifiedName).toSet.size == 1) {
+            val sz = ambiguousReferences.size
+            var i = 0
+            for (ref <- ambiguousReferences) {
+              i = i + 1
+              referenceNames += ref.qualifiedName + "#" + ref.exprId.id
+              if (i < sz) referenceNames += ", "
+            }
+          } else {
+            referenceNames = ambiguousReferences.map(_.qualifiedName).mkString(", ")
+          }
           throw new AnalysisException(s"Reference '$name' is ambiguous, could be: $referenceNames.")
       }
     }

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/join.sql.out
@@ -3225,7 +3225,7 @@ select * from
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Reference 'f1' is ambiguous, could be: j.f1, j.f1.; line 2 pos 63
+Reference 'f1' is ambiguous, could be: j.f1#x, j.f1#x.; line 2 pos 63
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-join.sql.out
@@ -3253,7 +3253,7 @@ select * from
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Reference 'f1' is ambiguous, could be: j.f1, j.f1.; line 2 pos 72
+Reference 'f1' is ambiguous, could be: j.f1#x, j.f1#x.; line 2 pos 72
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?
exprId is appended to each reference for ambiguousReferences.

### Why are the changes needed?
In the current AnalysisException for ambiguousReferences, the strings of references may look the same.
The following example loosely corresponds to https://github.com/yugabyte/yugabyte-db/blob/master/java/yb-cql-4x/src/test/java/org/yb/loadtest/TestSpark3Jsonb.java#L90
```
org.apache.spark.sql.AnalysisException: Reference 'phone->'key'->1->'m'->2->>'b'' is ambiguous, could be: mycatalog.test.person.phone->'key'->1->'m'->2->>'b', mycatalog.test.person.phone->'key'->1->'m'->2->>'b'.; line 1 pos 8
```

### Does this PR introduce _any_ user-facing change?
In case the ambiguous references have the same qualifiedNames, the id portion of ExprId would be shown in the exception message as well:
```
Reference is ambiguous, could be: x.b#196786, x.b#196909.; line 3 pos 14"
```
### How was this patch tested?
Verified via local build where exprId is observed.