### PR TITLE
[MINOR][DOCS] Replace http to https when possible in PySpark documentation

### DIFF
--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -21,14 +21,14 @@ Contributing to PySpark
 
 There are many types of contribution, for example, helping other users, testing releases, reviewing changes,
 documentation contribution, bug reporting, JIRA maintenance, code changes, etc.
-These are documented at `the general guidelines <http://spark.apache.org/contributing.html>`_.
+These are documented at `the general guidelines <https://spark.apache.org/contributing.html>`_.
 This page focuses on PySpark and includes additional details specifically for PySpark.
 
 
 Contributing by Testing Releases
 --------------------------------
 
-Before the official release, PySpark release candidates are shared in the `dev@spark.apache.org <http://apache-spark-developers-list.1001551.n3.nabble.com/>`_ mailing list to vote on.
+Before the official release, PySpark release candidates are shared in the `dev@spark.apache.org <https://mail-archives.apache.org/mod_mbox/spark-dev/>`_ mailing list to vote on.
 This release candidates can be easily installed via pip. For example, in case of Spark 3.0.0 RC1, you can install as below:
 
 .. code-block:: bash
@@ -71,7 +71,7 @@ under ``python/docs/source/reference``. Otherwise, they would not be documented 
 Preparing to Contribute Code Changes
 ------------------------------------
 
-Before starting to work on codes in PySpark, it is recommended to read `the general guidelines <http://spark.apache.org/contributing.html>`_.
+Before starting to work on codes in PySpark, it is recommended to read `the general guidelines <https://spark.apache.org/contributing.html>`_.
 There are a couple of additional notes to keep in mind when contributing to codes in PySpark:
 
 * Be Pythonic.

--- a/python/docs/source/getting_started/index.rst
+++ b/python/docs/source/getting_started/index.rst
@@ -22,8 +22,8 @@ Getting Started
 
 This page summarizes the basic steps required to setup and get started with PySpark.
 There are more guides shared with other languages such as
-`Quick Start <http://spark.apache.org/docs/latest/quick-start.html>`_ in Programming Guides
-at `the Spark documentation <http://spark.apache.org/docs/latest/index.html#where-to-go-from-here>`_.
+`Quick Start <https://spark.apache.org/docs/latest/quick-start.html>`_ in Programming Guides
+at `the Spark documentation <https://spark.apache.org/docs/latest/index.html#where-to-go-from-here>`_.
 
 .. toctree::
     :maxdepth: 2

--- a/python/docs/source/migration_guide/index.rst
+++ b/python/docs/source/migration_guide/index.rst
@@ -36,8 +36,8 @@ This page describes the migration guide specific to PySpark.
 Many items of other migration guides can also be applied when migrating PySpark to higher versions because PySpark internally shares other components.
 Please also refer other migration guides:
 
-- `Migration Guide: Spark Core <http://spark.apache.org/docs/latest/core-migration-guide.html>`_
-- `Migration Guide: SQL, Datasets and DataFrame <http://spark.apache.org/docs/latest/sql-migration-guide.html>`_
-- `Migration Guide: Structured Streaming <http://spark.apache.org/docs/latest/ss-migration-guide.html>`_
-- `Migration Guide: MLlib (Machine Learning) <http://spark.apache.org/docs/latest/ml-migration-guide.html>`_
+- `Migration Guide: Spark Core <https://spark.apache.org/docs/latest/core-migration-guide.html>`_
+- `Migration Guide: SQL, Datasets and DataFrame <https://spark.apache.org/docs/latest/sql-migration-guide.html>`_
+- `Migration Guide: Structured Streaming <https://spark.apache.org/docs/latest/ss-migration-guide.html>`_
+- `Migration Guide: MLlib (Machine Learning) <https://spark.apache.org/docs/latest/ml-migration-guide.html>`_
 

--- a/python/docs/source/user_guide/arrow_pandas.rst
+++ b/python/docs/source/user_guide/arrow_pandas.rst
@@ -408,5 +408,5 @@ This will instruct PyArrow >= 0.15.0 to use the legacy IPC format with the older
 is in Spark 2.3.x and 2.4.x. Not setting this environment variable will lead to a similar error as
 described in `SPARK-29367 <https://issues.apache.org/jira/browse/SPARK-29367>`_ when running
 ``pandas_udf``\s or :meth:`DataFrame.toPandas` with Arrow enabled. More information about the Arrow IPC change can
-be read on the Arrow 0.15.0 release `blog <http://arrow.apache.org/blog/2019/10/06/0.15.0-release/#columnar-streaming-protocol-change-since-0140>`_.
+be read on the Arrow 0.15.0 release `blog <https://arrow.apache.org/blog/2019/10/06/0.15.0-release/#columnar-streaming-protocol-change-since-0140>`_.
 

--- a/python/docs/source/user_guide/index.rst
+++ b/python/docs/source/user_guide/index.rst
@@ -30,11 +30,11 @@ This page is the guide for PySpark users which contains PySpark specific topics.
 
 
 There are more guides shared with other languages in Programming Guides
-at `the Spark documentation <http://spark.apache.org/docs/latest/index.html#where-to-go-from-here>`_.
+at `the Spark documentation <https://spark.apache.org/docs/latest/index.html#where-to-go-from-here>`_.
 
-- `RDD Programming Guide <http://spark.apache.org/docs/latest/rdd-programming-guide.html>`_
-- `Spark SQL, DataFrames and Datasets Guide <http://spark.apache.org/docs/latest/sql-programming-guide.html>`_
-- `Structured Streaming Programming Guide <http://spark.apache.org/docs/latest/structured-streaming-programming-guide.html>`_
-- `Spark Streaming Programming Guide <http://spark.apache.org/docs/latest/streaming-programming-guide.html>`_
-- `Machine Learning Library (MLlib) Guide <http://spark.apache.org/docs/latest/ml-guide.html>`_
+- `RDD Programming Guide <https://spark.apache.org/docs/latest/rdd-programming-guide.html>`_
+- `Spark SQL, DataFrames and Datasets Guide <https://spark.apache.org/docs/latest/sql-programming-guide.html>`_
+- `Structured Streaming Programming Guide <https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html>`_
+- `Spark Streaming Programming Guide <https://spark.apache.org/docs/latest/streaming-programming-guide.html>`_
+- `Machine Learning Library (MLlib) Guide <https://spark.apache.org/docs/latest/ml-guide.html>`_
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes:
- Change http to https for better security
- Change http://apache-spark-developers-list.1001551.n3.nabble.com/ to official mailing list link (https://mail-archives.apache.org/mod_mbox/spark-dev/)

### Why are the changes needed?

For better security, and to use official link.

### Does this PR introduce _any_ user-facing change?

Yes, It exposes more secure and correct links to the PySpark end users in PySpark documentation.

### How was this patch tested?

I manually checked if each link works
