### PR TITLE
[SPARK-34505][BUILD] Upgrade Scala to 2.13.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3278,7 +3278,7 @@
     <profile>
       <id>scala-2.13</id>
       <properties>
-        <scala.version>2.13.4</scala.version>
+        <scala.version>2.13.5</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
       </properties>
       <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update from Scala 2.13.4 to Scala 2.13.5 for Apache Spark 3.2.

### Why are the changes needed?

Scala 2.13.5 is a maintenance release for 2.13 line and improves Java 13, 14, 15, 16, and 17 support.
- https://github.com/scala/scala/releases/tag/v2.13.5

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass the GitHub Action `Scala 2.13` job and manual test.

I verified the following locally and all passed.
```
$ dev/change-scala-version.sh 2.13
$ build/sbt test -Pscala-2.13
```