### PR TITLE
[SPARK-34498][SQL][TESTS]  fix the remaining problems in  #31560

### DIFF
--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaSimpleWritableDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaSimpleWritableDataSource.java
@@ -33,7 +33,6 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.SimpleCounter;
 import org.apache.spark.sql.connector.TestingV2Source;
-import org.apache.spark.sql.connector.catalog.SessionConfigSupport;
 import org.apache.spark.sql.connector.catalog.SupportsWrite;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCapability;
@@ -50,12 +49,7 @@ import org.apache.spark.util.SerializableConfiguration;
  * Each task writes data to `target/_temporary/uniqueId/$jobId-$partitionId-$attemptNumber`.
  * Each job moves files from `target/_temporary/uniqueId/` to `target`.
  */
-public class JavaSimpleWritableDataSource implements TestingV2Source, SessionConfigSupport {
-
-  @Override
-  public String keyPrefix() {
-    return "javaSimpleWritableDataSource";
-  }
+public class JavaSimpleWritableDataSource implements TestingV2Source {
 
   static class MyScanBuilder extends JavaSimpleScanBuilder {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/SimpleWritableDataSource.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/SimpleWritableDataSource.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table, TableCapabi
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory, ScanBuilder}
 import org.apache.spark.sql.connector.write._
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.SerializableConfiguration
 
@@ -62,8 +61,6 @@ class SimpleWritableDataSource extends TestingV2Source {
       val serializableConf = new SerializableConfiguration(conf)
       new CSVReaderFactory(serializableConf)
     }
-
-    override def readSchema(): StructType = TestingV2Source.schema
   }
 
   class MyWriteBuilder(path: String, info: LogicalWriteInfo)
@@ -128,8 +125,6 @@ class SimpleWritableDataSource extends TestingV2Source {
 
     private val path = options.get("path")
     private val conf = SparkContext.getActive.get.hadoopConfiguration
-
-    override def schema(): StructType = TestingV2Source.schema
 
     override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
       new MyScanBuilder(new Path(path).toUri.toString, conf)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/SimpleWritableDataSource.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/SimpleWritableDataSource.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.connector.catalog.{SessionConfigSupport, SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory, ScanBuilder}
 import org.apache.spark.sql.connector.write._
@@ -41,11 +41,9 @@ import org.apache.spark.util.SerializableConfiguration
  * Each task writes data to `target/_temporary/uniqueId/$jobId-$partitionId-$attemptNumber`.
  * Each job moves files from `target/_temporary/uniqueId/` to `target`.
  */
-class SimpleWritableDataSource extends SimpleTableProvider with SessionConfigSupport {
+class SimpleWritableDataSource extends SimpleTableProvider {
 
-  private val tableSchema = new StructType().add("i", "long").add("j", "long")
-
-  override def keyPrefix: String = "simpleWritableDataSource"
+  private val tableSchema = new StructType().add("i", "int").add("j", "int")
 
   class MyScanBuilder(path: String, conf: Configuration) extends SimpleScanBuilder {
     override def planInputPartitions(): Array[InputPartition] = {
@@ -179,7 +177,7 @@ class CSVReaderFactory(conf: SerializableConfiguration)
         }
       }
 
-      override def get(): InternalRow = InternalRow(currentLine.split(",").map(_.trim.toLong): _*)
+      override def get(): InternalRow = InternalRow(currentLine.split(",").map(_.trim.toInt): _*)
 
       override def close(): Unit = {
         inputStream.close()
@@ -222,7 +220,7 @@ class CSVDataWriter(fs: FileSystem, file: Path) extends DataWriter[InternalRow] 
   private val out = fs.create(file)
 
   override def write(record: InternalRow): Unit = {
-    out.writeBytes(s"${record.getLong(0)},${record.getLong(1)}\n")
+    out.writeBytes(s"${record.getInt(0)},${record.getInt(1)}\n")
   }
 
   override def commit(): WriterCommitMessage = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/SimpleWritableDataSource.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/SimpleWritableDataSource.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table, TableCapabi
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory, ScanBuilder}
 import org.apache.spark.sql.connector.write._
-import org.apache.spark.sql.internal.connector.SimpleTableProvider
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.SerializableConfiguration
@@ -41,9 +40,7 @@ import org.apache.spark.util.SerializableConfiguration
  * Each task writes data to `target/_temporary/uniqueId/$jobId-$partitionId-$attemptNumber`.
  * Each job moves files from `target/_temporary/uniqueId/` to `target`.
  */
-class SimpleWritableDataSource extends SimpleTableProvider {
-
-  private val tableSchema = new StructType().add("i", "int").add("j", "int")
+class SimpleWritableDataSource extends TestingV2Source {
 
   class MyScanBuilder(path: String, conf: Configuration) extends SimpleScanBuilder {
     override def planInputPartitions(): Array[InputPartition] = {
@@ -66,7 +63,7 @@ class SimpleWritableDataSource extends SimpleTableProvider {
       new CSVReaderFactory(serializableConf)
     }
 
-    override def readSchema(): StructType = tableSchema
+    override def readSchema(): StructType = TestingV2Source.schema
   }
 
   class MyWriteBuilder(path: String, info: LogicalWriteInfo)
@@ -132,7 +129,7 @@ class SimpleWritableDataSource extends SimpleTableProvider {
     private val path = options.get("path")
     private val conf = SparkContext.getActive.get.hadoopConfiguration
 
-    override def schema(): StructType = tableSchema
+    override def schema(): StructType = TestingV2Source.schema
 
     override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
       new MyScanBuilder(new Path(path).toUri.toString, conf)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of #31560,  
In  #31560,  we added `JavaSimpleWritableDataSource ` and left some little problems like unused interface `SessionConfigSupport` 、 inconsistent schema between `JavaSimpleWritableDataSource ` and `SimpleWritableDataSource`.
This PR fixes the remaining problems in #31560.

### Why are the changes needed?

1. `SessionConfigSupport` in `JavaSimpleWritableDataSource ` and `SimpleWritableDataSource` is never used, so we don't need to implement it.
2. change the schema of `SimpleWritableDataSource`, to match `TestingV2Source`

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

existing testsuites
