### PR TITLE
[SPARK-34497][SQL] Fix built-in JDBC connection providers to restore JVM security context changes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution.datasources.jdbc.connection
 import java.security.PrivilegedExceptionAction
 import java.sql.{Connection, Driver}
 import java.util.Properties
-import javax.security.auth.login.Configuration
 
 import org.apache.hadoop.security.UserGroupInformation
 
@@ -35,22 +34,15 @@ private[sql] class DB2ConnectionProvider extends SecureConnectionProvider {
 
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = {
     val jdbcOptions = new JDBCOptions(options)
-    val parent = Configuration.getConfiguration
-    try {
-      setAuthenticationConfig(parent, driver, jdbcOptions)
-      UserGroupInformation.loginUserFromKeytabAndReturnUGI(jdbcOptions.principal,
-        jdbcOptions.keytab)
-        .doAs(
-          new PrivilegedExceptionAction[Connection]() {
-            override def run(): Connection = {
-              DB2ConnectionProvider.super.getConnection(driver, options)
-            }
+    setAuthenticationConfig(driver, jdbcOptions)
+    UserGroupInformation.loginUserFromKeytabAndReturnUGI(jdbcOptions.principal, jdbcOptions.keytab)
+      .doAs(
+        new PrivilegedExceptionAction[Connection]() {
+          override def run(): Connection = {
+            DB2ConnectionProvider.super.getConnection(driver, options)
           }
-        )
-    } finally {
-      logDebug("Restoring original security configuration")
-      Configuration.setConfiguration(parent)
-    }
+        }
+      )
   }
 
   override def getAdditionalProperties(options: JDBCOptions): Properties = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProvider.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.jdbc.connection
 import java.security.PrivilegedExceptionAction
 import java.sql.{Connection, Driver}
 import java.util.Properties
+import javax.security.auth.login.Configuration
 
 import org.apache.hadoop.security.UserGroupInformation
 
@@ -34,15 +35,22 @@ private[sql] class DB2ConnectionProvider extends SecureConnectionProvider {
 
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = {
     val jdbcOptions = new JDBCOptions(options)
-    setAuthenticationConfigIfNeeded(driver, jdbcOptions)
-    UserGroupInformation.loginUserFromKeytabAndReturnUGI(jdbcOptions.principal, jdbcOptions.keytab)
-      .doAs(
-        new PrivilegedExceptionAction[Connection]() {
-          override def run(): Connection = {
-            DB2ConnectionProvider.super.getConnection(driver, options)
+    val parent = Configuration.getConfiguration
+    try {
+      setAuthenticationConfig(parent, driver, jdbcOptions)
+      UserGroupInformation.loginUserFromKeytabAndReturnUGI(jdbcOptions.principal,
+        jdbcOptions.keytab)
+        .doAs(
+          new PrivilegedExceptionAction[Connection]() {
+            override def run(): Connection = {
+              DB2ConnectionProvider.super.getConnection(driver, options)
+            }
           }
-        }
-      )
+        )
+    } finally {
+      logDebug("Restoring original security configuration")
+      Configuration.setConfiguration(parent)
+    }
   }
 
   override def getAdditionalProperties(options: JDBCOptions): Properties = {
@@ -51,12 +59,5 @@ private[sql] class DB2ConnectionProvider extends SecureConnectionProvider {
     result.put("securityMechanism", new String("11"))
     result.put("KerberosServerPrincipal", options.principal)
     result
-  }
-
-  override def setAuthenticationConfigIfNeeded(driver: Driver, options: JDBCOptions): Unit = {
-    val (parent, configEntry) = getConfigWithAppEntry(driver, options)
-    if (configEntry == null || configEntry.isEmpty) {
-      setAuthenticationConfig(parent, driver, options)
-    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProvider.scala
@@ -26,20 +26,5 @@ private[jdbc] class MariaDBConnectionProvider extends SecureConnectionProvider {
 
   override val name: String = "mariadb"
 
-  override def appEntry(driver: Driver, options: JDBCOptions): String =
-    "Krb5ConnectorContext"
-
-  override def setAuthenticationConfigIfNeeded(driver: Driver, options: JDBCOptions): Unit = {
-    val (parent, configEntry) = getConfigWithAppEntry(driver, options)
-    /**
-     * Couple of things to mention here (v2.5.4 client):
-     * 1. MariaDB doesn't support JAAS application name configuration
-     * 2. MariaDB sets a default JAAS config if "java.security.auth.login.config" is not set
-     */
-    val entryUsesKeytab = configEntry != null &&
-      configEntry.exists(_.getOptions().get("useKeyTab") == "true")
-    if (configEntry == null || configEntry.isEmpty || !entryUsesKeytab) {
-      setAuthenticationConfig(parent, driver, options)
-    }
-  }
+  override def appEntry(driver: Driver, options: JDBCOptions): String = "Krb5ConnectorContext"
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/OracleConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/OracleConnectionProvider.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution.datasources.jdbc.connection
 import java.security.PrivilegedExceptionAction
 import java.sql.{Connection, Driver}
 import java.util.Properties
-import javax.security.auth.login.Configuration
 
 import org.apache.hadoop.security.UserGroupInformation
 
@@ -35,22 +34,15 @@ private[sql] class OracleConnectionProvider extends SecureConnectionProvider {
 
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = {
     val jdbcOptions = new JDBCOptions(options)
-    val parent = Configuration.getConfiguration
-    try {
-      setAuthenticationConfig(parent, driver, jdbcOptions)
-      UserGroupInformation.loginUserFromKeytabAndReturnUGI(jdbcOptions.principal,
-        jdbcOptions.keytab)
-        .doAs(
-          new PrivilegedExceptionAction[Connection]() {
-            override def run(): Connection = {
-              OracleConnectionProvider.super.getConnection(driver, options)
-            }
+    setAuthenticationConfig(driver, jdbcOptions)
+    UserGroupInformation.loginUserFromKeytabAndReturnUGI(jdbcOptions.principal, jdbcOptions.keytab)
+      .doAs(
+        new PrivilegedExceptionAction[Connection]() {
+          override def run(): Connection = {
+            OracleConnectionProvider.super.getConnection(driver, options)
           }
-        )
-    } finally {
-      logDebug("Restoring original security configuration")
-      Configuration.setConfiguration(parent)
-    }
+        }
+      )
   }
 
   override def getAdditionalProperties(options: JDBCOptions): Properties = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -32,11 +32,4 @@ private[jdbc] class PostgresConnectionProvider extends SecureConnectionProvider 
     val properties = parseURL.invoke(driver, options.url, null).asInstanceOf[Properties]
     properties.getProperty("jaasApplicationName", "pgjdbc")
   }
-
-  override def setAuthenticationConfigIfNeeded(driver: Driver, options: JDBCOptions): Unit = {
-    val (parent, configEntry) = getConfigWithAppEntry(driver, options)
-    if (configEntry == null || configEntry.isEmpty) {
-      setAuthenticationConfig(parent, driver, options)
-    }
-  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/SecureConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/SecureConnectionProvider.scala
@@ -40,8 +40,14 @@ private[jdbc] abstract class SecureConnectionProvider extends BasicConnectionPro
 
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = {
     val jdbcOptions = new JDBCOptions(options)
-    setAuthenticationConfigIfNeeded(driver, jdbcOptions)
-    super.getConnection(driver: Driver, options: Map[String, String])
+    val parent = Configuration.getConfiguration
+    try {
+      setAuthenticationConfig(parent, driver, jdbcOptions)
+      super.getConnection(driver: Driver, options: Map[String, String])
+    } finally {
+      logDebug("Restoring original security configuration")
+      Configuration.setConfiguration(parent)
+    }
   }
 
   /**
@@ -49,21 +55,7 @@ private[jdbc] abstract class SecureConnectionProvider extends BasicConnectionPro
    */
   def appEntry(driver: Driver, options: JDBCOptions): String
 
-  /**
-   * Sets database specific authentication configuration when needed. If configuration already set
-   * then later calls must be no op. When the global JVM security configuration changed then the
-   * related code parts must be synchronized properly.
-   */
-  def setAuthenticationConfigIfNeeded(driver: Driver, options: JDBCOptions): Unit
-
-  protected def getConfigWithAppEntry(
-      driver: Driver,
-      options: JDBCOptions): (Configuration, Array[AppConfigurationEntry]) = {
-    val parent = Configuration.getConfiguration
-    (parent, parent.getAppConfigurationEntry(appEntry(driver, options)))
-  }
-
-  protected def setAuthenticationConfig(
+  private[connection] def setAuthenticationConfig(
       parent: Configuration,
       driver: Driver,
       options: JDBCOptions) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/SecureConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/SecureConnectionProvider.scala
@@ -40,14 +40,8 @@ private[jdbc] abstract class SecureConnectionProvider extends BasicConnectionPro
 
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = {
     val jdbcOptions = new JDBCOptions(options)
-    val parent = Configuration.getConfiguration
-    try {
-      setAuthenticationConfig(parent, driver, jdbcOptions)
-      super.getConnection(driver: Driver, options: Map[String, String])
-    } finally {
-      logDebug("Restoring original security configuration")
-      Configuration.setConfiguration(parent)
-    }
+    setAuthenticationConfig(driver, jdbcOptions)
+    super.getConnection(driver: Driver, options: Map[String, String])
   }
 
   /**
@@ -55,10 +49,8 @@ private[jdbc] abstract class SecureConnectionProvider extends BasicConnectionPro
    */
   def appEntry(driver: Driver, options: JDBCOptions): String
 
-  private[connection] def setAuthenticationConfig(
-      parent: Configuration,
-      driver: Driver,
-      options: JDBCOptions) = {
+  private[connection] def setAuthenticationConfig(driver: Driver, options: JDBCOptions) = {
+    val parent = Configuration.getConfiguration
     val config = new SecureConnectionProvider.JDBCConfiguration(
       parent, appEntry(driver, options), options.keytab, options.principal)
     logDebug("Adding database specific security configuration")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
@@ -61,10 +61,10 @@ class ConnectionProviderSuite extends ConnectionProviderSuiteBase with SharedSpa
     assert(rootConfig.getAppConfigurationEntry(postgresAppEntry) == null)
     assert(rootConfig.getAppConfigurationEntry(db2AppEntry) == null)
 
-    postgresProvider.setAuthenticationConfig(rootConfig, postgresDriver, postgresOptions)
+    postgresProvider.setAuthenticationConfig(postgresDriver, postgresOptions)
     val postgresConfig = Configuration.getConfiguration
 
-    db2Provider.setAuthenticationConfig(postgresConfig, db2Driver, db2Options)
+    db2Provider.setAuthenticationConfig(db2Driver, db2Options)
     val db2Config = Configuration.getConfiguration
 
     // Make sure authentication for the databases are set

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
@@ -57,17 +57,23 @@ class ConnectionProviderSuite extends ConnectionProviderSuiteBase with SharedSpa
     val db2AppEntry = db2Provider.appEntry(db2Driver, db2Options)
 
     // Make sure no authentication for the databases are set
-    val oldConfig = Configuration.getConfiguration
-    assert(oldConfig.getAppConfigurationEntry(postgresAppEntry) == null)
-    assert(oldConfig.getAppConfigurationEntry(db2AppEntry) == null)
+    val rootConfig = Configuration.getConfiguration
+    assert(rootConfig.getAppConfigurationEntry(postgresAppEntry) == null)
+    assert(rootConfig.getAppConfigurationEntry(db2AppEntry) == null)
 
-    postgresProvider.setAuthenticationConfigIfNeeded(postgresDriver, postgresOptions)
-    db2Provider.setAuthenticationConfigIfNeeded(db2Driver, db2Options)
+    postgresProvider.setAuthenticationConfig(rootConfig, postgresDriver, postgresOptions)
+    val postgresConfig = Configuration.getConfiguration
+
+    db2Provider.setAuthenticationConfig(postgresConfig, db2Driver, db2Options)
+    val db2Config = Configuration.getConfiguration
 
     // Make sure authentication for the databases are set
-    val newConfig = Configuration.getConfiguration
-    assert(oldConfig != newConfig)
-    assert(newConfig.getAppConfigurationEntry(postgresAppEntry) != null)
-    assert(newConfig.getAppConfigurationEntry(db2AppEntry) != null)
+    assert(rootConfig != postgresConfig)
+    assert(rootConfig != db2Config)
+    // The topmost config in the chain is linked with all the subsequent entries
+    assert(db2Config.getAppConfigurationEntry(postgresAppEntry) != null)
+    assert(db2Config.getAppConfigurationEntry(db2AppEntry) != null)
+
+    Configuration.setConfiguration(null)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuiteBase.scala
@@ -61,7 +61,7 @@ abstract class ConnectionProviderSuiteBase extends SparkFunSuite with BeforeAndA
 
     // Make sure setAuthenticationConfig call sets authentication properly
     val savedConfig = Configuration.getConfiguration
-    provider.setAuthenticationConfig(savedConfig, driver, options)
+    provider.setAuthenticationConfig(driver, options)
     val config = Configuration.getConfiguration
     assert(savedConfig != config)
     val appEntry = config.getAppConfigurationEntry(providerAppEntry)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuiteBase.scala
@@ -59,16 +59,12 @@ abstract class ConnectionProviderSuiteBase extends SparkFunSuite with BeforeAndA
     // Make sure no authentication for the database is set
     assert(Configuration.getConfiguration.getAppConfigurationEntry(providerAppEntry) == null)
 
-    // Make sure the first call sets authentication properly
+    // Make sure setAuthenticationConfig call sets authentication properly
     val savedConfig = Configuration.getConfiguration
-    provider.setAuthenticationConfigIfNeeded(driver, options)
+    provider.setAuthenticationConfig(savedConfig, driver, options)
     val config = Configuration.getConfiguration
     assert(savedConfig != config)
     val appEntry = config.getAppConfigurationEntry(providerAppEntry)
     assert(appEntry != null)
-
-    // Make sure a second call is not modifying the existing authentication
-    provider.setAuthenticationConfigIfNeeded(driver, options)
-    assert(config.getAppConfigurationEntry(providerAppEntry) === appEntry)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProviderSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
 class DB2ConnectionProviderSuite extends ConnectionProviderSuiteBase {
-  test("setAuthenticationConfigIfNeeded must set authentication if not set") {
+  test("setAuthenticationConfig must set authentication all the time") {
     val provider = new DB2ConnectionProvider()
     val driver = registerDriver(provider.driverClass)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MSSQLConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MSSQLConnectionProviderSuite.scala
@@ -22,7 +22,7 @@ import java.sql.Driver
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
 class MSSQLConnectionProviderSuite extends ConnectionProviderSuiteBase {
-  test("setAuthenticationConfigIfNeeded default parser must set authentication if not set") {
+  test("setAuthenticationConfig default parser must set authentication all the time") {
     val provider = new MSSQLConnectionProvider()
     val driver = registerDriver(provider.driverClass)
 
@@ -30,7 +30,7 @@ class MSSQLConnectionProviderSuite extends ConnectionProviderSuiteBase {
       options("jdbc:sqlserver://localhost/mssql;jaasConfigurationName=custommssql"))
   }
 
-  test("setAuthenticationConfigIfNeeded custom parser must set authentication if not set") {
+  test("setAuthenticationConfig custom parser must set authentication all the time") {
     val provider = new MSSQLConnectionProvider() {
       override val parserMethod: String = "IntentionallyNotExistingMethod"
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MariaDBConnectionProviderSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
 class MariaDBConnectionProviderSuite extends ConnectionProviderSuiteBase {
-  test("setAuthenticationConfigIfNeeded must set authentication if not set") {
+  test("setAuthenticationConfig must set authentication all the time") {
     val provider = new MariaDBConnectionProvider()
     val driver = registerDriver(provider.driverClass)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/OracleConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/OracleConnectionProviderSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
 class OracleConnectionProviderSuite extends ConnectionProviderSuiteBase {
-  test("setAuthenticationConfigIfNeeded must set authentication if not set") {
+  test("setAuthenticationConfig must set authentication all the time") {
     val provider = new OracleConnectionProvider()
     val driver = registerDriver(provider.driverClass)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProviderSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
 class PostgresConnectionProviderSuite extends ConnectionProviderSuiteBase {
-  test("setAuthenticationConfigIfNeeded must set authentication if not set") {
+  test("setAuthenticationConfig must set authentication all the time") {
     val provider = new PostgresConnectionProvider()
     val defaultOptions = options("jdbc:postgresql://localhost/postgres")
     val customOptions =


### PR DESCRIPTION
### What changes were proposed in this pull request?
Some of the built-in JDBC connection providers are changing the JVM security context to do the authentication which is fine. The problematic part is that executors can be reused by another query. The following situation leads to incorrect behaviour:
* Query1 opens JDBC connection and changes JVM security context in Executor1
* Query2 tries to open JDBC connection but it realizes there is already an entry for that DB type in Executor1
* Query2 is not changing JVM security context and uses Query1 keytab and principal
* Query2 fails with authentication error

In this PR I've changed to code such a way that JVM security context is changed all the time but only temporarily until the connection built-up and then rolled back. Since `getConnection` is synchronised with `SecurityConfigurationLock` it ends-up in correct behaviour without any race.

### Why are the changes needed?
Incorrect JVM security context handling.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing unit + integration tests.
