### PR TITLE
[MINOR][DOCS][K8S] Use hadoop-aws 3.2.2 in K8s example

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -212,7 +212,7 @@ A typical example of this using S3 is via passing the following options:
 
 ```
 ...
---packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.6
+--packages org.apache.hadoop:hadoop-aws:3.2.2
 --conf spark.kubernetes.file.upload.path=s3a://<s3-bucket>/path
 --conf spark.hadoop.fs.s3a.access.key=...
 --conf spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `Hadoop` dependency in K8S doc example.

### Why are the changes needed?

Apache Spark 3.2.0 is using Apache Hadoop 3.2.2 by default.

### Does this PR introduce _any_ user-facing change?

No. This is a doc-only change.

### How was this patch tested?

N/A