### PR TITLE
[SPARK-31891][SQL][DOCS][FOLLOWUP] Fix typo in the description of `MSCK REPAIR TABLE`

### DIFF
--- a/docs/sql-ref-syntax-ddl-repair-table.md
+++ b/docs/sql-ref-syntax-ddl-repair-table.md
@@ -41,6 +41,8 @@ MSCK REPAIR TABLE table_identifier [{ADD|DROP|SYNC} PARTITIONS]
 
 * **`{ADD|DROP|SYNC} PARTITIONS`**
 
+    Specifies how to recover partitions. If not specified, **ADD** is the default.
+
     * **ADD**, the command adds new partitions to the session catalog for all sub-folder in the base table folder that don't belong to any table partitions.
     * **DROP**, the command drops all partitions from the session catalog that have non-existing locations in the file system.
     * **SYNC** is the combination of **DROP** and **ADD**. 

--- a/docs/sql-ref-syntax-ddl-repair-table.md
+++ b/docs/sql-ref-syntax-ddl-repair-table.md
@@ -46,7 +46,6 @@ MSCK REPAIR TABLE table_identifier [{ADD|DROP|SYNC} PARTITIONS]
     * **ADD**, the command adds new partitions to the session catalog for all sub-folder in the base table folder that don't belong to any table partitions.
     * **DROP**, the command drops all partitions from the session catalog that have non-existing locations in the file system.
     * **SYNC** is the combination of **DROP** and **ADD**. 
-    * If not specified, **ADD** is the default.
 
 ### Examples
 

--- a/docs/sql-ref-syntax-ddl-repair-table.md
+++ b/docs/sql-ref-syntax-ddl-repair-table.md
@@ -41,10 +41,10 @@ MSCK REPAIR TABLE table_identifier [{ADD|DROP|SYNC} PARTITIONS]
 
 * **`{ADD|DROP|SYNC} PARTITIONS`**
 
-    * If specified, `MSCK REPAIR TABLE` only adds partitions to the session catalog.
     * **ADD**, the command adds new partitions to the session catalog for all sub-folder in the base table folder that don't belong to any table partitions.
     * **DROP**, the command drops all partitions from the session catalog that have non-existing locations in the file system.
     * **SYNC** is the combination of **DROP** and **ADD**. 
+    * If not specified, **ADD** is the default.
 
 ### Examples
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix typo and highlight that `ADD PARTITIONS` is the default.

### Why are the changes needed?
Fix a typo which can mislead users.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
n/a