### PR TITLE
[SPARK-34524][SQL] Simplify v2 partition commands resolution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.optimizer.BooleanSimplification
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, TypeUtils}
-import org.apache.spark.sql.connector.catalog.{LookupCatalog, SupportsAtomicPartitionManagement, SupportsPartitionManagement, Table, TruncatableTable}
+import org.apache.spark.sql.connector.catalog.{LookupCatalog, SupportsAtomicPartitionManagement, SupportsPartitionManagement, Table}
 import org.apache.spark.sql.connector.catalog.TableChange.{AddColumn, After, ColumnPosition, DeleteColumn, RenameColumn, UpdateColumnComment, UpdateColumnNullability, UpdateColumnPosition, UpdateColumnType}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
@@ -149,6 +149,15 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
 
       case AlterTable(_, _, u: UnresolvedV2Relation, _) =>
         failAnalysis(s"Table not found: ${u.originalNameParts.quoted}")
+
+      case command: V2PartitionCommand =>
+        command.table match {
+          case r @ ResolvedTable(_, _, table, _) =>
+            if (!table.isInstanceOf[SupportsPartitionManagement]) {
+              failAnalysis(s"Table ${r.name} does not support partition management.")
+            }
+          case _ =>
+        }
 
       case operator: LogicalPlan =>
         // Check argument data types of higher-order functions downwards first.
@@ -564,19 +573,6 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
               case _ =>
               // no validation needed for set and remove property
             }
-
-          case AddPartitions(r: ResolvedTable, parts, _) =>
-            checkAlterTablePartition(r.table, parts)
-
-          case DropPartitions(r: ResolvedTable, parts, _, _) =>
-            checkAlterTablePartition(r.table, parts)
-
-          case RenamePartitions(r: ResolvedTable, from, _) =>
-            checkAlterTablePartition(r.table, Seq(from))
-
-          case showPartitions: ShowPartitions => checkShowPartitions(showPartitions)
-
-          case truncateTable: TruncateTable => checkTruncateTable(truncateTable)
 
           case _ => // Falls back to the following checks
         }
@@ -1008,36 +1004,5 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
 
       case _ =>
     }
-  }
-
-  // Make sure that the `SHOW PARTITIONS` command is allowed for the table
-  private def checkShowPartitions(showPartitions: ShowPartitions): Unit = showPartitions match {
-    case ShowPartitions(rt: ResolvedTable, _, _)
-        if !rt.table.isInstanceOf[SupportsPartitionManagement] =>
-      failAnalysis("SHOW PARTITIONS cannot run for a table which does not support partitioning")
-    case ShowPartitions(ResolvedTable(_, _, partTable: SupportsPartitionManagement, _), _, _)
-        if partTable.partitionSchema().isEmpty =>
-      failAnalysis(
-        s"SHOW PARTITIONS is not allowed on a table that is not partitioned: ${partTable.name()}")
-    case _ =>
-  }
-
-  private def checkTruncateTable(truncateTable: TruncateTable): Unit = truncateTable match {
-    case TruncateTable(rt: ResolvedTable, None) if !rt.table.isInstanceOf[TruncatableTable] =>
-      failAnalysis(s"The table ${rt.table.name()} does not support truncation")
-    case TruncateTable(rt: ResolvedTable, Some(_))
-        if !rt.table.isInstanceOf[SupportsPartitionManagement] =>
-      failAnalysis("TRUNCATE TABLE cannot run for a table which does not support partitioning")
-    case TruncateTable(
-        ResolvedTable(_, _, _: SupportsPartitionManagement, _),
-        Some(_: UnresolvedPartitionSpec)) =>
-      failAnalysis("Partition spec is not resolved")
-    case TruncateTable(
-        ResolvedTable(_, _, table: SupportsPartitionManagement, _),
-        Some(spec: ResolvedPartitionSpec))
-      if spec.names.length < table.partitionSchema.length &&
-        !table.isInstanceOf[SupportsAtomicPartitionManagement] =>
-      failAnalysis(s"The table ${table.name()} does not support truncation of multiple partitions")
-    case _ =>
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolvePartitionSpec.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolvePartitionSpec.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Cast, Literal}
-import org.apache.spark.sql.catalyst.plans.logical.{AddPartitions, DropPartitions, LogicalPlan, RenamePartitions, ShowPartitions, TruncateTable}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, V2PartitionCommand}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.SupportsPartitionManagement
@@ -33,70 +33,42 @@ import org.apache.spark.sql.util.PartitioningUtils.{normalizePartitionSpec, requ
 object ResolvePartitionSpec extends Rule[LogicalPlan] {
 
   def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-    case r @ AddPartitions(
-        ResolvedTable(_, _, table: SupportsPartitionManagement, _), partSpecs, _) =>
-      val partitionSchema = table.partitionSchema()
-      r.copy(parts = resolvePartitionSpecs(
-        table.name,
-        partSpecs,
-        partitionSchema,
-        requireExactMatchedPartitionSpec(table.name, _, partitionSchema.fieldNames)))
-
-    case r @ DropPartitions(
-        ResolvedTable(_, _, table: SupportsPartitionManagement, _), partSpecs, _, _) =>
-      val partitionSchema = table.partitionSchema()
-      r.copy(parts = resolvePartitionSpecs(
-        table.name,
-        partSpecs,
-        partitionSchema,
-        requireExactMatchedPartitionSpec(table.name, _, partitionSchema.fieldNames)))
-
-    case r @ RenamePartitions(
-        ResolvedTable(_, _, table: SupportsPartitionManagement, _), from, to) =>
-      val partitionSchema = table.partitionSchema()
-      val Seq(resolvedFrom, resolvedTo) = resolvePartitionSpecs(
-        table.name,
-        Seq(from, to),
-        partitionSchema,
-        requireExactMatchedPartitionSpec(table.name, _, partitionSchema.fieldNames))
-      r.copy(from = resolvedFrom, to = resolvedTo)
-
-    case r @ ShowPartitions(
-        ResolvedTable(_, _, table: SupportsPartitionManagement, _), partSpecs, _) =>
-      r.copy(pattern = resolvePartitionSpecs(
-        table.name,
-        partSpecs.toSeq,
-        table.partitionSchema()).headOption)
-
-    case r @ TruncateTable(ResolvedTable(_, _, table: SupportsPartitionManagement, _), partSpecs) =>
-      r.copy(partitionSpec = resolvePartitionSpecs(
-        table.name,
-        partSpecs.toSeq,
-        table.partitionSchema()).headOption)
+    case command: V2PartitionCommand if command.childrenResolved && !command.resolved =>
+      command.table match {
+        case r @ ResolvedTable(_, _, table: SupportsPartitionManagement, _) =>
+          command.transformExpressions {
+            case partSpecs: UnresolvedPartitionSpec =>
+              val partitionSchema = table.partitionSchema()
+              resolvePartitionSpec(
+                r.name,
+                partSpecs,
+                partitionSchema,
+                command.allowPartialPartitionSpec)
+          }
+        case _ => command
+      }
   }
 
-  private def resolvePartitionSpecs(
+  private def resolvePartitionSpec(
       tableName: String,
-      partSpecs: Seq[PartitionSpec],
+      partSpec: UnresolvedPartitionSpec,
       partSchema: StructType,
-      checkSpec: TablePartitionSpec => Unit = _ => ()): Seq[ResolvedPartitionSpec] =
-    partSpecs.map {
-      case unresolvedPartSpec: UnresolvedPartitionSpec =>
-        val normalizedSpec = normalizePartitionSpec(
-          unresolvedPartSpec.spec,
-          partSchema,
-          tableName,
-          conf.resolver)
-        checkSpec(normalizedSpec)
-        val partitionNames = normalizedSpec.keySet
-        val requestedFields = partSchema.filter(field => partitionNames.contains(field.name))
-        ResolvedPartitionSpec(
-          requestedFields.map(_.name),
-          convertToPartIdent(normalizedSpec, requestedFields),
-          unresolvedPartSpec.location)
-      case resolvedPartitionSpec: ResolvedPartitionSpec =>
-        resolvedPartitionSpec
+      allowPartitionSpec: Boolean): ResolvedPartitionSpec = {
+    val normalizedSpec = normalizePartitionSpec(
+      partSpec.spec,
+      partSchema,
+      tableName,
+      conf.resolver)
+    if (!allowPartitionSpec) {
+      requireExactMatchedPartitionSpec(tableName, _, partSchema.fieldNames)
     }
+    val partitionNames = normalizedSpec.keySet
+    val requestedFields = partSchema.filter(field => partitionNames.contains(field.name))
+    ResolvedPartitionSpec(
+      requestedFields.map(_.name),
+      convertToPartIdent(normalizedSpec, requestedFields),
+      partSpec.location)
+  }
 
   private[sql] def convertToPartIdent(
       partitionSpec: TablePartitionSpec,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolvePartitionSpec.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolvePartitionSpec.scala
@@ -60,7 +60,7 @@ object ResolvePartitionSpec extends Rule[LogicalPlan] {
       tableName,
       conf.resolver)
     if (!allowPartitionSpec) {
-      requireExactMatchedPartitionSpec(tableName, _, partSchema.fieldNames)
+      requireExactMatchedPartitionSpec(tableName, normalizedSpec, partSchema.fieldNames)
     }
     val partitionNames = normalizedSpec.keySet
     val requestedFields = partSchema.filter(field => partitionNames.contains(field.name))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
@@ -19,10 +19,12 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, LeafExpression, Unevaluable}
 import org.apache.spark.sql.catalyst.plans.logical.LeafNode
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, Table, TableCatalog}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+import org.apache.spark.sql.types.DataType
 
 /**
  * Holds the name of a namespace that has yet to be looked up in a catalog. It will be resolved to
@@ -73,11 +75,18 @@ case class UnresolvedTableOrView(
   override def output: Seq[Attribute] = Nil
 }
 
-sealed trait PartitionSpec
+sealed trait PartitionSpec extends LeafExpression with Unevaluable {
+  override def dataType: DataType = throw new IllegalStateException(
+    "PartitionSpec.dataType should not be called.")
+  override def nullable: Boolean = throw new IllegalStateException(
+    "PartitionSpec.nullable should not be called.")
+}
 
 case class UnresolvedPartitionSpec(
     spec: TablePartitionSpec,
-    location: Option[String] = None) extends PartitionSpec
+    location: Option[String] = None) extends PartitionSpec {
+  override lazy val resolved = false
+}
 
 /**
  * Holds the name of a function that has yet to be looked up in a catalog. It will be resolved to
@@ -109,6 +118,7 @@ case class ResolvedTable(
     val qualifier = catalog.name +: identifier.namespace :+ identifier.name
     outputAttributes.map(_.withQualifier(qualifier))
   }
+  def name: String = (catalog.name +: identifier.namespace() :+ identifier.name()).quoted
 }
 
 object ResolvedTable {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3757,11 +3757,10 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
    * }}}
    */
   override def visitTruncateTable(ctx: TruncateTableContext): LogicalPlan = withOrigin(ctx) {
-    TruncateTable(
-      createUnresolvedTable(ctx.multipartIdentifier, "TRUNCATE TABLE"),
-      Option(ctx.partitionSpec).map { spec =>
-        UnresolvedPartitionSpec(visitNonOptionalPartitionSpec(spec))
-      })
+    val table = createUnresolvedTable(ctx.multipartIdentifier, "TRUNCATE TABLE")
+    Option(ctx.partitionSpec).map { spec =>
+      TruncatePartition(table, UnresolvedPartitionSpec(visitNonOptionalPartitionSpec(spec)))
+    }.getOrElse(TruncateTable(table))
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Implicits.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{PartitionSpec, ResolvedPartitionSpec, UnresolvedPartitionSpec}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
-import org.apache.spark.sql.connector.catalog.{MetadataColumn, SupportsAtomicPartitionManagement, SupportsDelete, SupportsPartitionManagement, SupportsRead, SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.connector.catalog.{MetadataColumn, SupportsAtomicPartitionManagement, SupportsDelete, SupportsPartitionManagement, SupportsRead, SupportsWrite, Table, TableCapability, TruncatableTable}
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -54,6 +54,14 @@ object DataSourceV2Implicits {
           support
         case _ =>
           throw new AnalysisException(s"Table does not support deletes: ${table.name}")
+      }
+    }
+
+    def asTruncatable: TruncatableTable = {
+      table match {
+        case t: TruncatableTable => t
+        case _ =>
+          throw new AnalysisException(s"Table does not support truncates: ${table.name}")
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -394,10 +394,13 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         ShowCreateTableCommand(ident.asTableIdentifier)
       }
 
-    case TruncateTable(ResolvedV1TableIdentifier(ident), partitionSpec) =>
+    case TruncateTable(ResolvedV1TableIdentifier(ident)) =>
+      TruncateTableCommand(ident.asTableIdentifier, None)
+
+    case TruncatePartition(ResolvedV1TableIdentifier(ident), partitionSpec) =>
       TruncateTableCommand(
         ident.asTableIdentifier,
-        partitionSpec.toSeq.asUnresolvedPartitionSpecs.map(_.spec).headOption)
+        Seq(partitionSpec).asUnresolvedPartitionSpecs.map(_.spec).headOption)
 
     case s @ ShowPartitions(
         ResolvedV1TableOrViewIdentifier(ident),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -337,9 +337,6 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
     case ShowTables(ResolvedNamespace(catalog, ns), pattern, output) =>
       ShowTablesExec(output, catalog.asTableCatalog, ns, pattern) :: Nil
 
-    case _: ShowTableExtended =>
-      throw new AnalysisException("SHOW TABLE EXTENDED is not supported for v2 tables.")
-
     case SetCatalogAndNamespace(catalogManager, catalogName, ns) =>
       SetCatalogAndNamespaceExec(catalogManager, catalogName, ns) :: Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -394,10 +394,15 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
     case ShowCreateTable(_: ResolvedTable, _) =>
       throw new AnalysisException("SHOW CREATE TABLE is not supported for v2 tables.")
 
-    case TruncateTable(r: ResolvedTable, parts) =>
+    case TruncateTable(r: ResolvedTable) =>
       TruncateTableExec(
-        r.table,
-        parts.toSeq.asResolvedPartitionSpecs.headOption,
+        r.table.asTruncatable,
+        recacheTable(r)) :: Nil
+
+    case TruncatePartition(r: ResolvedTable, part) =>
+      TruncatePartitionExec(
+        r.table.asPartitionable,
+        Seq(part).asResolvedPartitionSpecs.head,
         recacheTable(r)) :: Nil
 
     case ShowColumns(_: ResolvedTable, _, _) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TruncatePartitionExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/TruncatePartitionExec.scala
@@ -18,20 +18,35 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.ResolvedPartitionSpec
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.connector.catalog.TruncatableTable
+import org.apache.spark.sql.connector.catalog.{SupportsAtomicPartitionManagement, SupportsPartitionManagement}
 
 /**
- * Physical plan node for table truncation.
+ * Physical plan node for table partition truncation.
  */
-case class TruncateTableExec(
-    table: TruncatableTable,
+case class TruncatePartitionExec(
+    table: SupportsPartitionManagement,
+    partSpec: ResolvedPartitionSpec,
     refreshCache: () => Unit) extends V2CommandExec {
 
   override def output: Seq[Attribute] = Seq.empty
 
   override protected def run(): Seq[InternalRow] = {
-    if (table.truncateTable()) refreshCache()
+    val isTableAltered = if (table.partitionSchema.length != partSpec.names.length) {
+      table match {
+        case atomicPartTable: SupportsAtomicPartitionManagement =>
+          val partitionIdentifiers = atomicPartTable.listPartitionIdentifiers(
+            partSpec.names.toArray, partSpec.ident)
+          atomicPartTable.truncatePartitions(partitionIdentifiers)
+        case _ =>
+          throw new UnsupportedOperationException(
+            s"The table ${table.name()} does not support truncation of multiple partition.")
+      }
+    } else {
+      table.truncatePartition(partSpec.ident)
+    }
+    if (isTableAltered) refreshCache()
     Seq.empty
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsSuiteBase.scala
@@ -69,7 +69,9 @@ trait ShowPartitionsSuiteBase extends QueryTest with DDLCommandTestUtils {
       val errMsg = intercept[AnalysisException] {
         sql(s"SHOW PARTITIONS $t")
       }.getMessage
-      assert(errMsg.contains("not allowed on a table that is not partitioned"))
+      assert(errMsg.contains("not allowed on a table that is not partitioned") ||
+        // V2 error message.
+        errMsg.contains(s"Table $t is not partitioned"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
@@ -20,30 +20,30 @@ package org.apache.spark.sql.execution.command
 import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedPartitionSpec, UnresolvedTable}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.logical.TruncateTable
+import org.apache.spark.sql.catalyst.plans.logical.{TruncatePartition, TruncateTable}
 import org.apache.spark.sql.test.SharedSparkSession
 
 class TruncateTableParserSuite extends AnalysisTest with SharedSparkSession {
   test("truncate table") {
     comparePlans(
       parsePlan("TRUNCATE TABLE a.b.c"),
-      TruncateTable(UnresolvedTable(Seq("a", "b", "c"), "TRUNCATE TABLE", None), None))
+      TruncateTable(UnresolvedTable(Seq("a", "b", "c"), "TRUNCATE TABLE", None)))
   }
 
   test("truncate a single part partition") {
     comparePlans(
       parsePlan("TRUNCATE TABLE a.b.c PARTITION(ds='2017-06-10')"),
-      TruncateTable(
+      TruncatePartition(
         UnresolvedTable(Seq("a", "b", "c"), "TRUNCATE TABLE", None),
-        Some(UnresolvedPartitionSpec(Map("ds" -> "2017-06-10"), None))))
+        UnresolvedPartitionSpec(Map("ds" -> "2017-06-10"), None)))
   }
 
   test("truncate a multi parts partition") {
     comparePlans(
       parsePlan("TRUNCATE TABLE ns.tbl PARTITION(a = 1, B = 'ABC')"),
-      TruncateTable(
+      TruncatePartition(
         UnresolvedTable(Seq("ns", "tbl"), "TRUNCATE TABLE", None),
-        Some(UnresolvedPartitionSpec(Map("a" -> "1", "B" -> "ABC"), None))))
+        UnresolvedPartitionSpec(Map("a" -> "1", "B" -> "ABC"), None)))
   }
 
   test("empty values in non-optional partition specs") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
@@ -33,7 +33,7 @@ class AlterTableAddPartitionSuite
       val errMsg = intercept[AnalysisException] {
         sql(s"ALTER TABLE $t ADD PARTITION (id=1)")
       }.getMessage
-      assert(errMsg.contains(s"Table $t can not alter partitions"))
+      assert(errMsg.contains(s"Table $t does not support partition management"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableDropPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableDropPartitionSuite.scala
@@ -36,7 +36,7 @@ class AlterTableDropPartitionSuite
       val errMsg = intercept[AnalysisException] {
         sql(s"ALTER TABLE $t DROP PARTITION (id=1)")
       }.getMessage
-      assert(errMsg.contains("can not alter partitions"))
+      assert(errMsg.contains(s"Table $t does not support partition management"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowPartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowPartitionsSuite.scala
@@ -33,8 +33,7 @@ class ShowPartitionsSuite extends command.ShowPartitionsSuiteBase with CommandSu
       val errMsg = intercept[AnalysisException] {
         sql(s"SHOW PARTITIONS $table")
       }.getMessage
-      assert(errMsg.contains(
-        "SHOW PARTITIONS cannot run for a table which does not support partitioning"))
+      assert(errMsg.contains(s"Table $table does not support partition management"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/TruncateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/TruncateTableSuite.scala
@@ -36,7 +36,7 @@ class TruncateTableSuite extends command.TruncateTableSuiteBase with CommandSuit
         sql(s"TRUNCATE TABLE $t PARTITION (c0=1)")
       }.getMessage
       assert(errMsg.contains(
-        "TRUNCATE TABLE cannot run for a table which does not support partitioning"))
+        "Table non_part_test_catalog.ns.tbl does not support partition management"))
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR simplifies the resolution of v2 partition commands:
1. Add a common trait for v2 partition commands, so that we don't need to match them one by one in the rules.
2. Make partition spec an expression, so that it's easier to resolve them via tree node transformation.
3. Add `TruncatePartition` so that `TruncateTable` doesn't need to be a v2 partition command.
4. Simplify `CheckAnalysis` to only check if the table is partitioned. For partitioned tables, partition spec is always resolved, so we don't need to check it. The `SupportsAtomicPartitionManagement` check is also done in the runtime. Since Spark eagerly executes commands, exception in runtime will also be thrown at analysis time.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
code cleanup

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
existing tests