### PR TITLE
[SPARK-34528][SQL] Named explicitly field in struct of a catalog view

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -205,7 +205,7 @@ class HiveCatalogedDDLSuite extends DDLSuite with TestHiveSingleton with BeforeA
       spark.sql("CREATE VIEW v AS SELECT STRUCT('a' AS `a`, 1 AS b) q")
       checkAnswer(spark.table("v"), Row(Row("a", 1)) :: Nil)
 
-      spark.sql("ALTER VIEW v AS SELECT STRUCT('a' AS `b`, 1 AS b) q1")
+      spark.sql("ALTER VIEW v AS SELECT STRUCT('a' AS `c`, 1 AS b) q1")
       val df = spark.table("v")
       assert("q1".equals(df.schema.fields(0).name))
       checkAnswer(df, Row(Row("a", 1)) :: Nil)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In a shared environnement where Hive Tez and Spark shared the same metastore and data and where Spark is connecting to the metastore of Hive Tez. I found a bug because Hive Tez allow you to change the order inside a struct that spark do not allow you.

In Hive Tez : 
1) You create a table with a struct:
 CREATE table test_struct (id int, sub STRUCT <a :INT, b:STRING>);
2) You insert data into it :
INSERT INTO TABLE test_struct select 1, named_struct("a",1,"b","v1");
3) Create a view on top of it :
CREATE view test_view_struct as select id, sub from test_view_struct

You try to access it in spark, you can access both.

In Hive Tez : 
4) Change the table struct reodoring the struct
ALTER TABLE test_struct CHANGE COLUMN sub sub STRUCT < b:STRING,a :INT>;
Hive Tez can query the table and the view.

Spark can query the table but when spark query the view spark have a cast issue because spark will try to cast a STRUCT < b:STRING,a :INT> in a struct<a :INT, b:STRING>
And if the modification it's castable you can even have a silent failed the data of column a are in column b and vice versa.

So I proposed to instead of resolving the struct directly during the resolution of the view, i use explicit named during the select.

### Why are the changes needed?
It safer to resolve by name the view and it's affected the ability to spark to be used in a shared environnement and to be integrated in a eco system where Hive it's predominant.
The silent failed it's also really dangerous because the dev can miss it so you will have at the end the wrong information in the column.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New UT added.
I also have to change a test because duplicate named in a struct are not allowed in hive.
Test on a shared Hive Tez and Spark environnement with an external metastore for spark

