### PR TITLE
[SPARK-34534][CORE] Fix blockIds order when use FetchShuffleBlocks to fetch blocks

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -176,7 +176,7 @@ public class OneForOneBlockFetcher {
     final ArrayList<Integer> reduceIds;
     final ArrayList<String> blockIds;
 
-    public BlocksInfo() {
+    BlocksInfo() {
       this.reduceIds = new ArrayList<>();
       this.blockIds = new ArrayList<>();
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -132,14 +132,15 @@ public class OneForOneBlockFetcher {
       }
       ArrayList<Integer> reduceIdsByMapId = mapIdToReduceIds.get(mapId);
       int reduceId = Integer.parseInt(blockIdParts[3]);
-      assert(reduceIdsByMapId.isEmpty() || reduceId > reduceIdsByMapId.get(reduceIdsByMapId.size() - 1));
+      assert(reduceIdsByMapId.isEmpty()
+              || reduceId > reduceIdsByMapId.get(reduceIdsByMapId.size() - 1));
       reduceIdsByMapId.add(reduceId);
       if (batchFetchEnabled) {
         // When we read continuous shuffle blocks in batch, we will reuse reduceIds in
         // FetchShuffleBlocks to store the start and end reduce id for range
         // [startReduceId, endReduceId).
         assert(blockIdParts.length == 5);
-        mapIdToReduceIds.get(mapId).add(Integer.parseInt(blockIdParts[4]));
+        reduceIdsByMapId.add(Integer.parseInt(blockIdParts[4]));
       }
     }
     long[] mapIds = Longs.toArray(orderedMapId);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -117,6 +117,8 @@ public class OneForOneBlockFetcher {
     boolean batchFetchEnabled = firstBlock.length == 5;
 
     HashMap<Long, ArrayList<Integer>> mapIdToReduceIds = new HashMap<>();
+    // The mapIds and reducesId must be same order with blockIds because the shuffle data's
+    // return order will match the `blockIds` order to ensure blockId and data match.
     ArrayList<Long> orderedMapId = new ArrayList<>();
     for (String blockId : blockIds) {
       String[] blockIdParts = splitBlockId(blockId);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
@@ -116,7 +116,7 @@ public class OneForOneBlockFetcher {
     int shuffleId = Integer.parseInt(firstBlock[1]);
     boolean batchFetchEnabled = firstBlock.length == 5;
 
-    HashMap<Long, BlocksInfo> mapIdToBlocksInfo = new HashMap<>();
+    LinkedHashMap<Long, BlocksInfo> mapIdToBlocksInfo = new LinkedHashMap<>();
     for (String blockId : blockIds) {
       String[] blockIdParts = splitBlockId(blockId);
       if (Integer.parseInt(blockIdParts[1]) != shuffleId) {
@@ -125,7 +125,7 @@ public class OneForOneBlockFetcher {
       }
       long mapId = Long.parseLong(blockIdParts[2]);
       if (!mapIdToBlocksInfo.containsKey(mapId)) {
-        mapIdToBlocksInfo.put(mapId, new BlocksInfo(new ArrayList<>(), new ArrayList<>()));
+        mapIdToBlocksInfo.put(mapId, new BlocksInfo());
       }
       BlocksInfo blocksInfoByMapId = mapIdToBlocksInfo.get(mapId);
       blocksInfoByMapId.blockIds.add(blockId);
@@ -173,12 +173,12 @@ public class OneForOneBlockFetcher {
   /** The reduceIds and blocks in a single mapId */
   private class BlocksInfo {
 
-    ArrayList<Integer> reduceIds;
-    ArrayList<String> blockIds;
+    final ArrayList<Integer> reduceIds;
+    final ArrayList<String> blockIds;
 
-    public BlocksInfo(ArrayList<Integer> reduceIds, ArrayList<String> blockIds) {
-      this.reduceIds = reduceIds;
-      this.blockIds = blockIds;
+    public BlocksInfo() {
+      this.reduceIds = new ArrayList<>();
+      this.blockIds = new ArrayList<>();
     }
   }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -117,8 +117,8 @@ public class OneForOneBlockFetcher {
     boolean batchFetchEnabled = firstBlock.length == 5;
 
     HashMap<Long, ArrayList<Integer>> mapIdToReduceIds = new HashMap<>();
-    // The mapIds and reducesId must be same order with blockIds because the shuffle data's
-    // return order will match the `blockIds` order to ensure blockId and data match.
+    // The mapIds and reducesIds must be same order with blockIds because the shuffle data's
+    // return order should match the `blockIds` order to ensure blockId and data match.
     ArrayList<Long> orderedMapId = new ArrayList<>();
     for (String blockId : blockIds) {
       String[] blockIdParts = splitBlockId(blockId);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -135,7 +135,7 @@ public class OneForOneBlockFetcher {
       ArrayList<Integer> reduceIdsByMapId = mapIdToReduceIds.get(mapId);
       int reduceId = Integer.parseInt(blockIdParts[3]);
       assert(reduceIdsByMapId.isEmpty()
-              || reduceId > reduceIdsByMapId.get(reduceIdsByMapId.size() - 1));
+        || reduceId > reduceIdsByMapId.get(reduceIdsByMapId.size() - 1));
       reduceIdsByMapId.add(reduceId);
       if (batchFetchEnabled) {
         // When we read continuous shuffle blocks in batch, we will reuse reduceIds in

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -81,7 +81,6 @@ public class OneForOneBlockFetcher {
       TransportConf transportConf,
       DownloadFileManager downloadFileManager) {
     this.client = client;
-    this.blockIds = blockIds;
     this.listener = listener;
     this.chunkCallback = new ChunkCallback();
     this.transportConf = transportConf;
@@ -90,8 +89,10 @@ public class OneForOneBlockFetcher {
       throw new IllegalArgumentException("Zero-sized blockIds array");
     }
     if (!transportConf.useOldFetchProtocol() && isShuffleBlocks(blockIds)) {
-      this.message = createFetchShuffleBlocksMsg(appId, execId, blockIds);
+      this.blockIds = new String[blockIds.length];
+      this.message = createFetchShuffleBlocksMsgAndRebuildBlockIds(appId, execId, blockIds);
     } else {
+      this.blockIds = blockIds;
       this.message = new OpenBlocks(appId, execId, blockIds);
     }
   }
@@ -106,20 +107,16 @@ public class OneForOneBlockFetcher {
   }
 
   /**
-   * Analyze the pass in blockIds and create FetchShuffleBlocks message.
-   * The blockIds has been sorted by mapId and reduceId. It's produced in
-   * org.apache.spark.MapOutputTracker.convertMapStatuses.
+   * Create FetchShuffleBlocks message and rebuild internal blockIds by
+   * analyzing the pass in blockIds.
    */
-  private FetchShuffleBlocks createFetchShuffleBlocksMsg(
+  private FetchShuffleBlocks createFetchShuffleBlocksMsgAndRebuildBlockIds(
       String appId, String execId, String[] blockIds) {
     String[] firstBlock = splitBlockId(blockIds[0]);
     int shuffleId = Integer.parseInt(firstBlock[1]);
     boolean batchFetchEnabled = firstBlock.length == 5;
 
     HashMap<Long, ArrayList<Integer>> mapIdToReduceIds = new HashMap<>();
-    // The mapIds and reducesIds must be same order with blockIds because the shuffle data's
-    // return order should match the `blockIds` order to ensure blockId and data match.
-    ArrayList<Long> orderedMapId = new ArrayList<>();
     for (String blockId : blockIds) {
       String[] blockIdParts = splitBlockId(blockId);
       if (Integer.parseInt(blockIdParts[1]) != shuffleId) {
@@ -127,30 +124,38 @@ public class OneForOneBlockFetcher {
           ", got:" + blockId);
       }
       long mapId = Long.parseLong(blockIdParts[2]);
-      assert(orderedMapId.isEmpty() || mapId >= orderedMapId.get(orderedMapId.size() - 1));
       if (!mapIdToReduceIds.containsKey(mapId)) {
         mapIdToReduceIds.put(mapId, new ArrayList<>());
-        orderedMapId.add(mapId);
       }
-      ArrayList<Integer> reduceIdsByMapId = mapIdToReduceIds.get(mapId);
-      int reduceId = Integer.parseInt(blockIdParts[3]);
-      assert(reduceIdsByMapId.isEmpty()
-        || reduceId > reduceIdsByMapId.get(reduceIdsByMapId.size() - 1));
-      reduceIdsByMapId.add(reduceId);
+      mapIdToReduceIds.get(mapId).add(Integer.parseInt(blockIdParts[3]));
       if (batchFetchEnabled) {
         // When we read continuous shuffle blocks in batch, we will reuse reduceIds in
         // FetchShuffleBlocks to store the start and end reduce id for range
         // [startReduceId, endReduceId).
         assert(blockIdParts.length == 5);
-        reduceIdsByMapId.add(Integer.parseInt(blockIdParts[4]));
+        mapIdToReduceIds.get(mapId).add(Integer.parseInt(blockIdParts[4]));
       }
     }
-    long[] mapIds = Longs.toArray(orderedMapId);
+    long[] mapIds = Longs.toArray(mapIdToReduceIds.keySet());
     int[][] reduceIdArr = new int[mapIds.length][];
+    int blockIdIndex = 0;
     for (int i = 0; i < mapIds.length; i++) {
       reduceIdArr[i] = Ints.toArray(mapIdToReduceIds.get(mapIds[i]));
+      // The `blockIds`'s order must be same with the read order specified in in FetchShuffleBlocks
+      // because the shuffle data's return order should match the `blockIds`'s order to ensure
+      // blockId and data match.
+      if (!batchFetchEnabled) {
+        for (int j = 0; j < reduceIdArr[i].length; j++) {
+          this.blockIds[blockIdIndex++] = "shuffle_" + shuffleId + "_" + mapIds[i] + "_"
+                  + reduceIdArr[i][j];
+        }
+      } else {
+        assert (reduceIdArr[i].length == 2);
+        this.blockIds[blockIdIndex++] = "shuffle_" + shuffleId + "_" + mapIds[i] + "_"
+                + reduceIdArr[i][0] + "_" + reduceIdArr[i][1];
+      }
     }
-
+    assert(blockIdIndex == this.blockIds.length);
     return new FetchShuffleBlocks(
       appId, execId, shuffleId, mapIds, reduceIdArr, batchFetchEnabled);
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
@@ -212,7 +212,7 @@ public class OneForOneBlockFetcherSuite {
     BlockFetchingListener listener = fetchBlocks(
       blocks,
       blockIds,
-      new FetchShuffleBlocks("app-id", "exec-id", 0, new long[]{0}, new int[][]{{0, 3}}, false),
+      new FetchShuffleBlocks("app-id", "exec-id", 0, new long[]{0, 2, 10}, new int[][]{{0}, {1}, {2}}, false),
       conf);
 
     for (int chunkIndex = 0; chunkIndex < blockIds.length; chunkIndex++) {
@@ -232,12 +232,8 @@ public class OneForOneBlockFetcherSuite {
     BlockFetchingListener listener = fetchBlocks(
       blocks,
       blockIds,
-      new OpenBlocks("app-id", "exec-id", blockIds),
-      new TransportConf("shuffle", new MapConfigProvider(
-              new HashMap<String, String>() {{
-                put("spark.shuffle.useOldFetchProtocol", "true");
-              }}
-      )));
+      new FetchShuffleBlocks("app-id", "exec-id", 0, new long[]{0, 2, 10}, new int[][]{{1, 2}, {2, 3}, {3, 4}}, true),
+      conf);
 
     for (int chunkIndex = 0; chunkIndex < blockIds.length; chunkIndex++) {
       String blockId = blockIds[chunkIndex];

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
@@ -212,7 +212,8 @@ public class OneForOneBlockFetcherSuite {
     BlockFetchingListener listener = fetchBlocks(
       blocks,
       blockIds,
-      new FetchShuffleBlocks("app-id", "exec-id", 0, new long[]{0, 2, 10}, new int[][]{{0}, {1}, {2}}, false),
+      new FetchShuffleBlocks("app-id", "exec-id", 0,
+              new long[]{0, 2, 10}, new int[][]{{0}, {1}, {2}}, false),
       conf);
 
     for (int chunkIndex = 0; chunkIndex < blockIds.length; chunkIndex++) {
@@ -232,7 +233,8 @@ public class OneForOneBlockFetcherSuite {
     BlockFetchingListener listener = fetchBlocks(
       blocks,
       blockIds,
-      new FetchShuffleBlocks("app-id", "exec-id", 0, new long[]{0, 2, 10}, new int[][]{{1, 2}, {2, 3}, {3, 4}}, true),
+      new FetchShuffleBlocks("app-id", "exec-id", 0,
+              new long[]{0, 2, 10}, new int[][]{{1, 2}, {2, 3}, {3, 4}}, true),
       conf);
 
     for (int chunkIndex = 0; chunkIndex < blockIds.length; chunkIndex++) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix a problems which can lead to data correctness after part blocks retry in `OneForOneBlockFetcher` when use `FetchShuffleBlocks` .


### Why are the changes needed?
This is a data correctness bug, It's is no problems when use old protocol to send `OpenBlocks` before fetch chunks in `OneForOneBlockFetcher`; 
In latest branch, `OpenBlocks`  has been replaced to `FetchShuffleBlocks`. Howerver, `FetchShuffleBlocks` read shuffle blocks order is not the same as `blockIds` in `OneForOneBlockFetcher`; the `blockIds` is used to match blockId with shuffle data with index, now it is out of order;
It will lead to read wrong block chunk when some blocks fetch failed in `OneForOneBlockFetcher`, it will retry the rest of the blocks in `blockIds`  based on the `blockIds`'s order.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
