### PR TITLE
[SPARK-34538][SQL] Hive Metastore support filter by not-in

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -864,8 +864,8 @@ object SQLConf {
         "Metastore. When the set size exceeds the threshold, we rewrite the InSet predicate " +
         "to be greater than or equal to the minimum value in set and less than or equal to the " +
         "maximum value in set. Larger values may cause Hive Metastore stack overflow. But for " +
-        "the predicate of Not InSet which values exceeds the threshold, we won't to push it " +
-        "to Hive Metastore.")
+        "the predicate of Not InSet which values exceeds the threshold, we won't push it to " +
+        "Hive Metastore.")
       .version("3.1.0")
       .internal()
       .intConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -863,7 +863,7 @@ object SQLConf {
       .doc("The threshold of set size for InSet predicate when pruning partitions through Hive " +
         "Metastore. When the set size exceeds the threshold, we rewrite the InSet predicate " +
         "to be greater than or equal to the minimum value in set and less than or equal to the " +
-        "maximum value in set. Larger values may cause Hive Metastore stack overflow. But if " +
+        "maximum value in set. Larger values may cause Hive Metastore stack overflow. But for " +
         "the predicate of Not InSet which values exceeds the threshold, we won't to push it " +
         "to Hive Metastore.")
       .version("3.1.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -864,8 +864,8 @@ object SQLConf {
         "Metastore. When the set size exceeds the threshold, we rewrite the InSet predicate " +
         "to be greater than or equal to the minimum value in set and less than or equal to the " +
         "maximum value in set. Larger values may cause Hive Metastore stack overflow. But for " +
-        "the predicate of Not InSet which values exceeds the threshold, we won't push it to " +
-        "Hive Metastore.")
+        "InSet inside Not with values exceeding the threshold, we won't push it to Hive Metastore."
+      )
       .version("3.1.0")
       .internal()
       .intConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -863,7 +863,9 @@ object SQLConf {
       .doc("The threshold of set size for InSet predicate when pruning partitions through Hive " +
         "Metastore. When the set size exceeds the threshold, we rewrite the InSet predicate " +
         "to be greater than or equal to the minimum value in set and less than or equal to the " +
-        "maximum value in set. Larger values may cause Hive Metastore stack overflow.")
+        "maximum value in set. Larger values may cause Hive Metastore stack overflow. But if " +
+        "the predicate of Not InSet which values exceeds the threshold, we won't to push it " +
+        "to Hive Metastore.")
       .version("3.1.0")
       .internal()
       .intConf

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -783,6 +783,9 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
         convert(And(GreaterThanOrEqual(child, Literal(sortedValues.head, dataType)),
           LessThanOrEqual(child, Literal(sortedValues.last, dataType))))
 
+      case Not(InSet(_, values)) if values.size > inSetThreshold =>
+        None
+
       case InSet(child @ ExtractAttribute(SupportedAttribute(name)), ExtractableDateValues(values))
           if useAdvanced && child.dataType == DateType =>
         Some(convertInToOr(name, values))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -772,6 +772,9 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
     }
 
     def convert(expr: Expression): Option[String] = expr match {
+      case Not(InSet(_, values)) if values.size > inSetThreshold =>
+        None
+
       case Not(In(_, list)) if hasNullLiteral(list) => None
       case Not(InSet(_, list)) if list.contains(null) => None
 
@@ -790,9 +793,6 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
           .sorted(TypeUtils.getInterpretedOrdering(dataType))
         convert(And(GreaterThanOrEqual(child, Literal(sortedValues.head, dataType)),
           LessThanOrEqual(child, Literal(sortedValues.last, dataType))))
-
-      case Not(InSet(_, values)) if values.size > inSetThreshold =>
-        None
 
       case InSet(child @ ExtractAttribute(SupportedAttribute(name)), ExtractableDateValues(values))
           if useAdvanced && child.dataType == DateType =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -752,6 +752,16 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       values.map(value => s"$name != $value").mkString("(", " and ", ")")
     }
 
+    def hasNullLiteral(list: Seq[Expression]): Boolean = list.contains {
+      case Literal(null, _) => true
+      case _ => false
+    }
+
+    def hasNullValue(list: Set[Any]): Boolean = list.contains {
+      case null => true
+      case _ => false
+    }
+
     val useAdvanced = SQLConf.get.advancedPartitionPredicatePushdownEnabled
     val inSetThreshold = SQLConf.get.metastorePartitionPruningInSetThreshold
 
@@ -767,6 +777,9 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
     }
 
     def convert(expr: Expression): Option[String] = expr match {
+      case Not(In(_, list)) if hasNullLiteral(list) => None
+      case Not(InSet(_, list)) if hasNullValue(list) => None
+
       case In(ExtractAttribute(SupportedAttribute(name)), ExtractableLiterals(values))
           if useAdvanced =>
         Some(convertInToOr(name, values))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -752,13 +752,8 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       values.map(value => s"$name != $value").mkString("(", " and ", ")")
     }
 
-    def hasNullLiteral(list: Seq[Expression]): Boolean = list.contains {
+    def hasNullLiteral(list: Seq[Expression]): Boolean = list.exists {
       case Literal(null, _) => true
-      case _ => false
-    }
-
-    def hasNullValue(list: Set[Any]): Boolean = list.contains {
-      case null => true
       case _ => false
     }
 
@@ -778,7 +773,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
 
     def convert(expr: Expression): Option[String] = expr match {
       case Not(In(_, list)) if hasNullLiteral(list) => None
-      case Not(InSet(_, list)) if hasNullValue(list) => None
+      case Not(InSet(_, list)) if list.contains(null) => None
 
       case In(ExtractAttribute(SupportedAttribute(name)), ExtractableLiterals(values))
           if useAdvanced =>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -211,5 +211,13 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     }
   }
 
+  test("Don't push not inset if it's values exceeds the threshold") {
+    withSQLConf(SQLConf.HIVE_METASTORE_PARTITION_PRUNING_INSET_THRESHOLD.key -> "2") {
+      val filter = Not(InSet(a("p", IntegerType), Set(1, 2, 3)))
+      val converted = shim.convertFilters(testTable, Seq(filter), conf.sessionLocalTimeZone)
+      assert(converted.isEmpty)
+    }
+  }
+
   private def a(name: String, dataType: DataType) = AttributeReference(name, dataType)()
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -109,25 +109,27 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     "datecol != 2019-01-01")
 
   filterTest("not-in int filter",
-    (Not(In(a("intcol", IntegerType), Seq(Literal(1), Literal(2))))) :: Nil,
+    (Not(In(a("intcol", IntegerType), Seq(Literal(1), Literal(2), Literal(null))))) :: Nil,
     "(intcol != 1 and intcol != 2)")
 
   filterTest("not-in string filter",
-    (Not(In(a("strcol", StringType), Seq(Literal("a"), Literal("b"))))) :: Nil,
+    (Not(In(a("strcol", StringType), Seq(Literal("a"), Literal("b"), Literal(null))))) :: Nil,
     """(strcol != "a" and strcol != "b")""")
 
   filterTest("not-inset, int filter",
-    (Not(InSet(a("intcol", IntegerType), Set(1, 2)))) :: Nil,
+    (Not(InSet(a("intcol", IntegerType), Set(1, 2, null)))) :: Nil,
     "(intcol != 1 and intcol != 2)")
 
   filterTest("not-inset, string filter",
-    (Not(InSet(a("strcol", StringType), Set(Literal("a").eval(), Literal("b").eval())))) :: Nil,
+    (Not(InSet(a("strcol", StringType),
+      Set(Literal("a").eval(), Literal("b").eval(), Literal(null).eval())))) :: Nil,
     """(strcol != "a" and strcol != "b")""")
 
   filterTest("not-inset, date filter",
     (Not(InSet(a("datecol", DateType),
       Set(Literal(Date.valueOf("2020-01-01")).eval(),
-        Literal(Date.valueOf("2020-01-02")).eval())))) :: Nil,
+        Literal(Date.valueOf("2020-01-02")).eval(),
+        Literal(null).eval())))) :: Nil,
     """(datecol != 2020-01-01 and datecol != 2020-01-02)""")
 
   // Applying the predicate `x IN (NULL)` should return an empty set, but since this optimization

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -108,20 +108,31 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     (a("datecol", DateType) =!= Literal(Date.valueOf("2019-01-01"))) :: Nil,
     "datecol != 2019-01-01")
 
-  filterTest("not-in int filter",
+  filterTest("not-in, int filter",
     (Not(In(a("intcol", IntegerType), Seq(Literal(1), Literal(2))))) :: Nil,
     "(intcol != 1 and intcol != 2)")
 
-  filterTest("not-in int filter with null",
+  filterTest("not-in, int filter with null",
     (Not(In(a("intcol", IntegerType), Seq(Literal(1), Literal(2), Literal(null))))) :: Nil,
     "")
 
-  filterTest("not-in string filter",
+  filterTest("not-in, string filter",
     (Not(In(a("strcol", StringType), Seq(Literal("a"), Literal("b"))))) :: Nil,
     """(strcol != "a" and strcol != "b")""")
 
-  filterTest("not-in string filter with null",
+  filterTest("not-in, string filter with null",
     (Not(In(a("strcol", StringType), Seq(Literal("a"), Literal("b"), Literal(null))))) :: Nil,
+    "")
+
+  filterTest("not-in, date filter",
+    (Not(In(a("datecol", DateType),
+      Seq(Literal(Date.valueOf("2021-01-01")), Literal(Date.valueOf("2021-01-02")))))) :: Nil,
+    """(datecol != 2021-01-01 and datecol != 2021-01-02)""")
+
+  filterTest("not-in, date filter with null",
+    (Not(In(a("datecol", DateType),
+      Seq(Literal(Date.valueOf("2021-01-01")), Literal(Date.valueOf("2021-01-02")),
+        Literal(null))))) :: Nil,
     "")
 
   filterTest("not-inset, int filter",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -128,7 +128,7 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     (Not(InSet(a("datecol", DateType),
       Set(Literal(Date.valueOf("2020-01-01")).eval(),
         Literal(Date.valueOf("2020-01-02")).eval())))) :: Nil,
-    """(datecol != "2020-01-01" and datecol != "2020-01-02")""")
+    """(datecol != 2020-01-01 and datecol != 2020-01-02)""")
 
   // Applying the predicate `x IN (NULL)` should return an empty set, but since this optimization
   // will be applied by Catalyst, this filter converter does not need to account for this.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -108,14 +108,6 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     (a("datecol", DateType) =!= Literal(Date.valueOf("2019-01-01"))) :: Nil,
     "datecol != 2019-01-01")
 
-  filterTest("not-in, int filter",
-    (Not(In(a("intcol", IntegerType), Seq(Literal(1), Literal(2))))) :: Nil,
-    "(intcol != 1 and intcol != 2)")
-
-  filterTest("not-in, int filter with null",
-    (Not(In(a("intcol", IntegerType), Seq(Literal(1), Literal(2), Literal(null))))) :: Nil,
-    "")
-
   filterTest("not-in, string filter",
     (Not(In(a("strcol", StringType), Seq(Literal("a"), Literal("b"))))) :: Nil,
     """(strcol != "a" and strcol != "b")""")
@@ -133,14 +125,6 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     (Not(In(a("datecol", DateType),
       Seq(Literal(Date.valueOf("2021-01-01")), Literal(Date.valueOf("2021-01-02")),
         Literal(null))))) :: Nil,
-    "")
-
-  filterTest("not-inset, int filter",
-    (Not(InSet(a("intcol", IntegerType), Set(1, 2)))) :: Nil,
-    "(intcol != 1 and intcol != 2)")
-
-  filterTest("not-inset, int filter with null",
-    (Not(InSet(a("intcol", IntegerType), Set(1, 2, null)))) :: Nil,
     "")
 
   filterTest("not-inset, string filter",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -108,6 +108,28 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     (a("datecol", DateType) =!= Literal(Date.valueOf("2019-01-01"))) :: Nil,
     "datecol != 2019-01-01")
 
+  filterTest("not-in int filter",
+    (Not(In(a("intcol", IntegerType), Seq(Literal(1), Literal(2))))) :: Nil,
+    "(intcol != 1 and intcol != 2)")
+
+  filterTest("not-in string filter",
+    (Not(In(a("strcol", StringType), Seq(Literal("a"), Literal("b"))))) :: Nil,
+    """(strcol != "a" and strcol != "b")""")
+
+  filterTest("not-inset, int filter",
+    (Not(InSet(a("intcol", IntegerType), Set(1, 2)))) :: Nil,
+    "(intcol != 1 and intcol != 2)")
+
+  filterTest("not-inset, string filter",
+    (Not(InSet(a("strcol", StringType), Set(Literal("a").eval(), Literal("b").eval())))) :: Nil,
+    """(strcol != "a" and strcol != "b")""")
+
+  filterTest("not-inset, date filter",
+    (Not(InSet(a("datecol", DateType),
+      Set(Literal(Date.valueOf("2020-01-01")).eval(),
+        Literal(Date.valueOf("2020-01-02")).eval())))) :: Nil,
+    """(datecol != "2020-01-01" and datecol != "2020-01-02")""")
+
   // Applying the predicate `x IN (NULL)` should return an empty set, but since this optimization
   // will be applied by Catalyst, this filter converter does not need to account for this.
   filterTest("SPARK-24879 IN predicates with only NULLs will not cause a NPE",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -109,28 +109,50 @@ class FiltersSuite extends SparkFunSuite with Logging with PlanTest {
     "datecol != 2019-01-01")
 
   filterTest("not-in int filter",
-    (Not(In(a("intcol", IntegerType), Seq(Literal(1), Literal(2), Literal(null))))) :: Nil,
+    (Not(In(a("intcol", IntegerType), Seq(Literal(1), Literal(2))))) :: Nil,
     "(intcol != 1 and intcol != 2)")
+
+  filterTest("not-in int filter with null",
+    (Not(In(a("intcol", IntegerType), Seq(Literal(1), Literal(2), Literal(null))))) :: Nil,
+    "")
 
   filterTest("not-in string filter",
-    (Not(In(a("strcol", StringType), Seq(Literal("a"), Literal("b"), Literal(null))))) :: Nil,
+    (Not(In(a("strcol", StringType), Seq(Literal("a"), Literal("b"))))) :: Nil,
     """(strcol != "a" and strcol != "b")""")
+
+  filterTest("not-in string filter with null",
+    (Not(In(a("strcol", StringType), Seq(Literal("a"), Literal("b"), Literal(null))))) :: Nil,
+    "")
 
   filterTest("not-inset, int filter",
-    (Not(InSet(a("intcol", IntegerType), Set(1, 2, null)))) :: Nil,
+    (Not(InSet(a("intcol", IntegerType), Set(1, 2)))) :: Nil,
     "(intcol != 1 and intcol != 2)")
 
+  filterTest("not-inset, int filter with null",
+    (Not(InSet(a("intcol", IntegerType), Set(1, 2, null)))) :: Nil,
+    "")
+
   filterTest("not-inset, string filter",
+    (Not(InSet(a("strcol", StringType), Set(Literal("a").eval(), Literal("b").eval())))) :: Nil,
+    """(strcol != "a" and strcol != "b")""")
+
+  filterTest("not-inset, string filter with null",
     (Not(InSet(a("strcol", StringType),
       Set(Literal("a").eval(), Literal("b").eval(), Literal(null).eval())))) :: Nil,
-    """(strcol != "a" and strcol != "b")""")
+    "")
 
   filterTest("not-inset, date filter",
     (Not(InSet(a("datecol", DateType),
       Set(Literal(Date.valueOf("2020-01-01")).eval(),
+        Literal(Date.valueOf("2020-01-02")).eval())))) :: Nil,
+    """(datecol != 2020-01-01 and datecol != 2020-01-02)""")
+
+  filterTest("not-inset, date filter with null",
+    (Not(InSet(a("datecol", DateType),
+      Set(Literal(Date.valueOf("2020-01-01")).eval(),
         Literal(Date.valueOf("2020-01-02")).eval(),
         Literal(null).eval())))) :: Nil,
-    """(datecol != 2020-01-01 and datecol != 2020-01-02)""")
+    "")
 
   // Applying the predicate `x IN (NULL)` should return an empty set, but since this optimization
   // will be applied by Catalyst, this filter converter does not need to account for this.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -418,6 +418,52 @@ class HivePartitionFilteringSuite(version: String)
       dateStrValue)
   }
 
+  test("getPartitionsByFilter: not in chunk") {
+    testMetastorePartitionFiltering(
+      Not(In(attr("chunk"), Seq(Literal("aa"), Literal("ab")))),
+      dsValue,
+      hValue,
+      Seq("ba", "bb"),
+      dateValue,
+      dateStrValue
+    )
+  }
+
+  test("getPartitionsByFilter: not in ds") {
+    testMetastorePartitionFiltering(
+      Not(In(attr("ds"), Seq(Literal(20170102)))),
+      Seq(20170101, 20170103),
+      hValue,
+      chunkValue,
+      dateValue,
+      dateStrValue
+    )
+  }
+
+  test("getPartitionsByFilter: not inset date") {
+    testMetastorePartitionFiltering(
+      Not(InSet(attr("d"),
+        Set(Literal(Date.valueOf("2019-01-01")).eval(),
+          Literal(Date.valueOf("2019-01-02")).eval()))),
+      dsValue,
+      hValue,
+      chunkValue,
+      Seq("2019-01-03") ++ defaultPartition,
+      dateStrValue
+    )
+  }
+
+  test("getPartitionsByFilter: not inset h") {
+    testMetastorePartitionFiltering(
+      Not(InSet(attr("h"), Set(1, 2))),
+      dsValue,
+      Seq(0, 3, 4),
+      chunkValue,
+      dateValue,
+      dateStrValue
+    )
+  }
+
   test("getPartitionsByFilter: cast(datestr as date)= 2020-01-01") {
     testMetastorePartitionFiltering(
       attr("datestr").cast(DateType) === Date.valueOf("2020-01-01"),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -418,49 +418,104 @@ class HivePartitionFilteringSuite(version: String)
       dateStrValue)
   }
 
-  test("getPartitionsByFilter: not in chunk") {
-    testMetastorePartitionFiltering(
+  test("getPartitionsByFilter: not in/inset string type") {
+    def check(condition: Expression, result: Seq[String]): Unit = {
+      testMetastorePartitionFiltering(
+        condition,
+        dsValue,
+        hValue,
+        result,
+        dateValue,
+        dateStrValue
+      )
+    }
+
+    check(
       Not(In(attr("chunk"), Seq(Literal("aa"), Literal("ab")))),
-      dsValue,
-      hValue,
-      Seq("ba", "bb"),
-      dateValue,
-      dateStrValue
+      Seq("ba", "bb")
+    )
+    check(
+      Not(In(attr("chunk"), Seq(Literal("aa"), Literal("ab"), Literal(null)))),
+      chunkValue
+    )
+
+    check(
+      Not(InSet(attr("chunk"), Set(Literal("aa").eval(), Literal("ab").eval()))),
+      Seq("ba", "bb")
+    )
+    check(
+      Not(InSet(attr("chunk"), Set("aa", "ab", null))),
+      chunkValue
     )
   }
 
-  test("getPartitionsByFilter: not in ds") {
-    testMetastorePartitionFiltering(
+  test("getPartitionsByFilter: not in/inset int type") {
+    def check(condition: Expression, result: Seq[Int]): Unit = {
+      testMetastorePartitionFiltering(
+        condition,
+        result,
+        hValue,
+        chunkValue,
+        dateValue,
+        dateStrValue
+      )
+    }
+
+    check(
       Not(In(attr("ds"), Seq(Literal(20170102)))),
-      Seq(20170101, 20170103),
-      hValue,
-      chunkValue,
-      dateValue,
-      dateStrValue
+      Seq(20170101, 20170103)
+    )
+    check(
+      Not(In(attr("ds"), Seq(Literal(20170102), Literal(null)))),
+      dsValue
+    )
+
+    check(
+      Not(InSet(attr("ds"), Set(Literal(20170102).eval()))),
+      Seq(20170101, 20170103)
+    )
+    check(
+      Not(InSet(attr("ds"), Set(Literal(20170102).eval(), null))),
+      dsValue
     )
   }
 
-  test("getPartitionsByFilter: not inset date") {
-    testMetastorePartitionFiltering(
+  test("getPartitionsByFilter: not in/inset date type") {
+    def check(condition: Expression, result: Seq[String]): Unit = {
+      testMetastorePartitionFiltering(
+        condition,
+        dsValue,
+        hValue,
+        chunkValue,
+        result,
+        dateStrValue
+      )
+    }
+
+    check(
+      Not(In(attr("d"),
+        Seq(Literal(Date.valueOf("2019-01-01")),
+          Literal(Date.valueOf("2019-01-02"))))),
+      Seq("2019-01-03")
+    )
+    check(
+      Not(In(attr("d"),
+        Seq(Literal(Date.valueOf("2019-01-01")),
+          Literal(Date.valueOf("2019-01-02")), Literal(null)))),
+      dateValue
+    )
+
+    check(
       Not(InSet(attr("d"),
         Set(Literal(Date.valueOf("2019-01-01")).eval(),
           Literal(Date.valueOf("2019-01-02")).eval()))),
-      dsValue,
-      hValue,
-      chunkValue,
-      Seq("2019-01-03"),
-      dateStrValue
+      Seq("2019-01-03")
     )
-  }
-
-  test("getPartitionsByFilter: not inset h") {
-    testMetastorePartitionFiltering(
-      Not(InSet(attr("h"), Set(1, 2))),
-      dsValue,
-      Seq(0, 3, 4),
-      chunkValue,
-      dateValue,
-      dateStrValue
+    check(
+      Not(InSet(attr("d"),
+        Set(Literal(Date.valueOf("2019-01-01")).eval(),
+          Literal(Date.valueOf("2019-01-02")).eval(), null))),
+      dateValue
     )
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -448,7 +448,7 @@ class HivePartitionFilteringSuite(version: String)
       dsValue,
       hValue,
       chunkValue,
-      Seq("2019-01-03") ++ defaultPartition,
+      Seq("2019-01-03"),
       dateStrValue
     )
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -449,37 +449,6 @@ class HivePartitionFilteringSuite(version: String)
     )
   }
 
-  test("getPartitionsByFilter: not in/inset int type") {
-    def check(condition: Expression, result: Seq[Int]): Unit = {
-      testMetastorePartitionFiltering(
-        condition,
-        result,
-        hValue,
-        chunkValue,
-        dateValue,
-        dateStrValue
-      )
-    }
-
-    check(
-      Not(In(attr("ds"), Seq(Literal(20170102)))),
-      Seq(20170101, 20170103)
-    )
-    check(
-      Not(In(attr("ds"), Seq(Literal(20170102), Literal(null)))),
-      dsValue
-    )
-
-    check(
-      Not(InSet(attr("ds"), Set(Literal(20170102).eval()))),
-      Seq(20170101, 20170103)
-    )
-    check(
-      Not(InSet(attr("ds"), Set(Literal(20170102).eval(), null))),
-      dsValue
-    )
-  }
-
   test("getPartitionsByFilter: not in/inset date type") {
     def check(condition: Expression, result: Seq[String]): Unit = {
       testMetastorePartitionFiltering(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add `Not(In)` and `Not(InSet)` pattern when convert filter to metastore. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`NOT IN` is a useful condition to prune partition, it would be better to support it.

Technically, we can convert `c not in(x,y)` to `c != x and c != y`, then push it to metastore.

Avoid metastore overflow and respect the config `spark.sql.hive.metastorePartitionPruningInSetThreshold`, `Not(InSet)` won't push to metastore if it's value exceeds the threshold.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add test.