### PR TITLE
[SPARK-33832][SQL] v2. move OptimzieSkewedJoin to query stage preparation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -423,6 +423,12 @@ object SQLConf {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("64MB")
 
+  val ADAPTIVE_FORCE_IF_SHUFFLE = buildConf("spark.sql.adaptive.force.if.shuffle")
+    .doc("Make OptimizeSkewJoin choose skew mitigation even if it causes an extra shuffle")
+    .version("3.2.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val ADAPTIVE_EXECUTION_ENABLED = buildConf("spark.sql.adaptive.enabled")
     .doc("When true, enable adaptive query execution, which re-optimizes the query plan in the " +
       "middle of query execution, based on accurate runtime statistics.")
@@ -3259,6 +3265,8 @@ class SQLConf extends Serializable with Logging {
   def adaptiveExecutionEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_ENABLED)
 
   def adaptiveExecutionLogLevel: String = getConf(ADAPTIVE_EXECUTION_LOG_LEVEL)
+
+  def adaptiveForceIfShuffle: Boolean = getConf(ADAPTIVE_FORCE_IF_SHUFFLE)
 
   def fetchShuffleBlocksInBatch: Boolean = getConf(FETCH_SHUFFLE_BLOCKS_IN_BATCH)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala
@@ -263,8 +263,10 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
     val v = "(ShuffleId,QueryStageId,shuffle origin:): " +
       shuffleStages.map(s => {
         // RDD with no partitions (e.g. SparkContext.emptyRDD) has not mapStats even
-        // after stage materialization
-        val shuffleId = if (s.mapStats.isDefined) s.mapStats.get.shuffleId else -1
+        // after stage materialization.  Also Option(null) eq None ....
+        // see ShuffleExchangeExec.mapOutputStatisticsFuture
+        val shuffleId =
+          if (s.isMaterialized && s.mapStats.isDefined) s.mapStats.get.shuffleId else -1
         s"($shuffleId,${s.id},${s.shuffle.shuffleOrigin})"
       }).mkString(",")
     v

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -89,7 +89,7 @@ case class AdaptiveSparkPlanExec(
     EnsureRequirements,
     RemoveRedundantSorts,
     DisableUnnecessaryBucketedScan
-  ) ++ context.session.sessionState.queryStagePrepRules
+  ) ++ context.session.sessionState.queryStagePrepRules // can be set when creating SparkSession
 
   // A list of physical optimizer rules to be applied to a new stage before its execution. These
   // optimizations should be stage-independent.
@@ -248,7 +248,20 @@ case class AdaptiveSparkPlanExec(
           stagesToReplace = Seq.empty[QueryStageExec]
         }
         // Now that some stages have finished, we can try creating new stages.
-        result = createQueryStages(currentPhysicalPlan)
+        var continue = true
+        while (continue) {
+          try {
+            continue = false
+            result = createQueryStages(currentPhysicalPlan)
+          } catch {
+            case e: ShuffleAddedException =>
+              continue = true
+              val z = insertShuffle(e.sp, currentPhysicalPlan)
+              logOnLevel(s"Plan (new shuffle) changed from $currentPhysicalPlan to $z")
+              currentPhysicalPlan = z
+          }
+        }
+        result = handleFinalStageShuffle(result)
       }
 
       // Run the final plan when there's no more unfinished stages.
@@ -262,6 +275,100 @@ case class AdaptiveSparkPlanExec(
     }
   }
 
+  /**
+   * Check if [[queryStageOptimizerRules]] will introduce a new shuffle.
+   * @param result
+   * @return
+   */
+  private def handleFinalStageShuffle(result: CreateStageResult): CreateStageResult = {
+    if (!result.allChildStagesMaterialized) {
+      // this method is called right after createQueryStages() so allChildStagesMaterialized = true
+      // means no new QueryStageExec have been created so the remainder of the query is
+      // the "final" stage unless this method adds a new ShuffleExchangeExec
+      return result
+    }
+    // Run queryStageOptimizerRules to see if a new shuffle will be added.
+    // use queryStageOptimizerRules rather than finalStageOptimizerRules since if we do insert a
+    // new shuffle, we don't need to restrict the rules - whatever is above the shuffle will
+    // have to match the expected output
+    // but don't run createQueryStages() since there are no more Exchange nodes in the
+    // result.newPlan (yet)
+    val optimizedPlan = applyPhysicalRules(result.newPlan,
+      queryStageOptimizerRules,
+      Some((planChangeLogger, "AQE Query Stage Optimization (new shuffle)")))
+    val osp = findNewShuffleLocation(optimizedPlan, result.newPlan)
+    if (osp.isEmpty) {
+      return result
+    }
+    currentPhysicalPlan = insertShuffle(osp.get, result.newPlan)
+    logOnLevel(s"Plan changed from ${result.newPlan} to $currentPhysicalPlan")
+    // now that there is a new shuffle in the plan, create a QueryStage for it
+    // createQueryStages should never throw ShuffleAddedException since we just
+    // ran queryStageOptimizerRules and added the new shuffle in the plan so the
+    // QueryStage wraps that shuffle.
+    createQueryStages(currentPhysicalPlan)
+  }
+
+  private def insertShuffle(sp: NewShuffleLocation, plan: SparkPlan): SparkPlan = {
+    plan.transformUp {
+      case v: SparkPlan if v eq sp.origPlanParent =>
+        val se = createShuffle(v, sp.idx)
+        if (sp.origPlanParent.isInstanceOf[BinaryExecNode]) {
+          // todo: add test where this will be a BinaryExecNode
+          if (sp.idx == 0) {
+            v.withNewChildren(Seq(se, sp.origPlanParent.children(1)))
+          } else {
+            v.withNewChildren(Seq(sp.origPlanParent.children(0), se))
+          }
+        } else {
+          v.withNewChildren(Seq(se))
+        }
+      case o: SparkPlan => o
+    }
+  }
+
+  /**
+   * You cannot run OptimizeSkewedJoin twice - it barfs if it finds something
+   * other than CoalesceShufflePartitions so to maintain the overall flow, insert the equivalent
+   * of newShuffle in result.newPlan and let the main loop of getFinalPhysicalPlan() handle it
+   * @param optimizedPlan after [[queryStageOptimizerRules]]
+   * @param originalPlan
+   * @return [[None]] - means no new shuffle is needed (allowed)
+   */
+  private def findNewShuffleLocation(optimizedPlan: SparkPlan, originalPlan: SparkPlan):
+  Option[NewShuffleLocation] = {
+    val newShuffles = optimizedPlan.collect {
+      // can this ever create > 1 new shuffle?  Logically no since a new shuffle
+      // is only allowed by OptimizeSkewedJoin (above the join)
+      case e: ShuffleExchangeExec => e
+    }
+    assert(newShuffles.length < 2, s"Expected < 2 shuffles $newShuffles")
+    if (newShuffles.isEmpty) {
+      return None
+    }
+    val newShuffle = newShuffles.head
+    val parentOfNewShuffle = optimizedPlan.find(_.containsChild(newShuffle)).get
+    val t = parentOfNewShuffle.getTagValue(SparkPlan.LOGICAL_PLAN_TAG)
+    // find corresponding node in the original plan
+    val origPlanParent = originalPlan
+      .find(_.getTagValue(SparkPlan.LOGICAL_PLAN_TAG).get eq t.get).get
+    val idx = origPlanParent match {
+      case _: UnaryExecNode => 0
+      case _: BinaryExecNode =>
+        // figure out if the new shuffle was added on left or right in "optimizedPlan"
+        val p = parentOfNewShuffle.asInstanceOf[BinaryExecNode]
+        if (p.left eq newShuffle) 0 else 1
+    }
+    Option(NewShuffleLocation(origPlanParent, idx))
+  }
+  // todo: factor out this bit from EnsureRequirements.ensureDistributionAndOrdering()
+  //  and call here to make it clear that this is the same logic .. maybe
+  private def createShuffle(v: SparkPlan, idx: Int): ShuffleExchangeExec = {
+    val distribution = v.requiredChildDistribution(idx)
+    val numPartitions = distribution.requiredNumPartitions
+      .getOrElse(conf.numShufflePartitions)
+    ShuffleExchangeExec(distribution.createPartitioning(numPartitions), v.children(idx))
+  }
   // Use a lazy val to avoid this being called more than once.
   @transient private lazy val finalPlanUpdate: Unit = {
     // Subqueries that don't belong to any query stage of the main query will execute after the
@@ -453,6 +560,11 @@ case class AdaptiveSparkPlanExec(
   private def newQueryStage(e: Exchange): QueryStageExec = {
     val optimizedPlan = applyPhysicalRules(
       e.child, queryStageOptimizerRules, Some((planChangeLogger, "AQE Query Stage Optimization")))
+    val osp = findNewShuffleLocation(optimizedPlan, e.child)
+    if(osp.isDefined) {
+      // will retry createQueryStages() with new shuffle added
+      throw ShuffleAddedException(osp.get)
+    }
     val queryStage = e match {
       case s: ShuffleExchangeLike =>
         val newShuffle = applyPhysicalRules(
@@ -727,3 +839,9 @@ case class StageSuccess(stage: QueryStageExec, result: Any) extends StageMateria
  * The materialization of a query stage hit an error and failed.
  */
 case class StageFailure(stage: QueryStageExec, error: Throwable) extends StageMaterializationEvent
+
+case class ShuffleAddedException(sp: NewShuffleLocation) extends Exception
+/**
+ * New shuffle should be wrap a child of [[origPlanParent]] at [[idx]]
+ */
+case class NewShuffleLocation(origPlanParent: SparkPlan, idx: Int)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -184,7 +184,7 @@ case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffl
         }
       }
     })
-    newPartSpecs
+    newPartSpecs.toSeq
   }
   private def supportCoalesce(s: ShuffleExchangeLike): Boolean = {
     s.outputPartitioning != SinglePartition && supportedShuffleOrigins.contains(s.shuffleOrigin)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -37,6 +37,13 @@ case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffl
     }
     if (!plan.collectLeaves().forall(_.isInstanceOf[QueryStageExec])
         || plan.find(_.isInstanceOf[CustomShuffleReaderExec]).isDefined) {
+      /* Todo:
+        * does this need changes to run after Join Skew mitigation?
+        * at a minimum the check for CustomShuffleReaderExec is not right as
+        * skew join will add them
+        * This needs to know not to coalesce anything that was skew mitigated
+        * How does it know?  Skew mitigation creates PartialReducerPartitionSpec
+       */
       // If not all leaf nodes are query stages, it's not safe to reduce the number of
       // shuffle partitions, because we may break the assumption that all children of a spark plan
       // have same number of output partitions.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
@@ -110,6 +110,7 @@ case class CustomShuffleReaderExec private(
   def hasCoalescedPartition: Boolean = {
     // shouldn't this check that at least some index ranges are > 1?
     // otherwise it's just reading original shuffle results
+    // that is how OptimizeSkewedJoin.optimizeSkewJoin defines it
     partitionSpecs.exists(_.isInstanceOf[CoalescedPartitionSpec])
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
@@ -19,10 +19,11 @@ package org.apache.spark.sql.execution.adaptive
 
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.spark.MapOutputStatistics
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
-import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning, SinglePartition, UnknownPartitioning}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeLike}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -66,6 +67,25 @@ case class CustomShuffleReaderExec private(
           }
         case _ =>
           throw new IllegalStateException("operating on canonicalization plan")
+      }
+    } else if (partitionSpecs.length == 1) {
+      SinglePartition
+    } else if (partitionSpecs.nonEmpty &&
+      partitionSpecs.forall(_.isInstanceOf[CoalescedPartitionSpec]) &&
+      partitionSpecs.map(_.asInstanceOf[CoalescedPartitionSpec].startReducerIndex).toSet.size
+        == partitionSpecs.size) {
+      // if here, some partitions were coalesced and nothing was split/replicated
+      // as in skew mitigation
+      child match {
+        case a: ShuffleQueryStageExec =>
+          a.outputPartitioning match {
+            case hp: HashPartitioning => hp.copy(numPartitions = partitionSpecs.length)
+            // relies on the fact that coalesce only combines contiguous pre shuffle
+            //  partition indexes then
+            case rp: RangePartitioning => rp.copy(numPartitions = partitionSpecs.length)
+            case _ => UnknownPartitioning(partitionSpecs.length)
+          }
+        case _ => UnknownPartitioning(partitionSpecs.length)
       }
     } else {
       UnknownPartitioning(partitionSpecs.length)
@@ -189,9 +209,38 @@ case class CustomShuffleReaderExec private(
   }
 
   override protected def doExecute(): RDD[InternalRow] = {
+    logPartitionSpecs(shuffleStage.flatMap(_.mapStats))
     shuffleRDD.asInstanceOf[RDD[InternalRow]]
+
   }
 
+  /**
+   * Log map side metrics and new partition specs so that we know what got coalesced
+   * what got split/replicated due to skew
+   */
+  private def logPartitionSpecs(mos: Option[MapOutputStatistics]): Unit = {
+    val shuffleId = if (mos.isDefined) mos.get.shuffleId else -1
+    // include shuffleId to correlate to other logs
+    val n = s"(id=${id})"
+    logInfo(s"CustomShuffleReaderExec: shuffle(${shuffleId}) $n " +
+      metrics.map(kv => (s"${kv._1}=${kv._2.value}")).mkString(","))
+    if(shuffleId < 0) {
+      return // we don't MapOutputStatistics - probably due to 0-partition RDD
+    }
+    /* if AQE did nothing, then reduce side tasks would provide info about partition sizes but
+    if it rebalanced partitions there is no place what they were before rebalancing
+    todo: could we have 100K partitions? */
+    logInfo(s"CustomShuffleReaderExec (map): ${mos.get.bytesByPartitionId.mkString(",")}")
+    val specs = partitionSpecs.map {
+      case a : CoalescedPartitionSpec => s"CP(${a.startReducerIndex},${a.endReducerIndex})"
+      case a : PartialReducerPartitionSpec =>
+        s"PRP(${a.reducerIndex},${a.startMapIndex},${a.endMapIndex})"
+      case a : PartialMapperPartitionSpec =>
+        s"PMP(${a.mapIndex},${a.startReducerIndex},${a.endReducerIndex})"
+      case a => s"$a"
+    }.mkString("[", ",", "]")
+    logInfo(s"CustomShuffleReaderExec (reduce): $specs")
+  }
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
     shuffleRDD.asInstanceOf[RDD[ColumnarBatch]]
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
@@ -107,8 +107,11 @@ case class CustomShuffleReaderExec private(
     Iterator(desc)
   }
 
-  def hasCoalescedPartition: Boolean =
+  def hasCoalescedPartition: Boolean = {
+    // shouldn't this check that at least some index ranges are > 1?
+    // otherwise it's just reading original shuffle results
     partitionSpecs.exists(_.isInstanceOf[CoalescedPartitionSpec])
+  }
 
   def hasSkewedPartition: Boolean =
     partitionSpecs.exists(_.isInstanceOf[PartialReducerPartitionSpec])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DemoteBroadcastHashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DemoteBroadcastHashJoin.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 object DemoteBroadcastHashJoin extends Rule[LogicalPlan] {
 
   private def shouldDemote(plan: LogicalPlan): Boolean = plan match {
-    case LogicalQueryStage(_, stage: ShuffleQueryStageExec) if stage.resultOption.get().isDefined
+    case LogicalQueryStage(_, stage: ShuffleQueryStageExec) if stage.isMaterialized
       && stage.mapStats.isDefined =>
       val mapStats = stage.mapStats.get
       val partitionCnt = mapStats.bytesByPartitionId.length

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/EliminateJoinToEmptyRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/EliminateJoinToEmptyRelation.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.joins.{EmptyHashedRelation, HashedRelation
 object EliminateJoinToEmptyRelation extends Rule[LogicalPlan] {
 
   private def canEliminate(plan: LogicalPlan, relation: HashedRelation): Boolean = plan match {
-    case LogicalQueryStage(_, stage: BroadcastQueryStageExec) if stage.resultOption.get().isDefined
+    case LogicalQueryStage(_, stage: BroadcastQueryStageExec) if stage.isMaterialized
       && stage.broadcast.relationFuture.get().value == relation => true
     case _ => false
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -50,8 +50,11 @@ object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
         val localReader = createLocalReader(shuffleStage)
         join.asInstanceOf[BroadcastHashJoinExec].copy(right = localReader)
     }
-
-    val numShuffles = ensureRequirements.apply(optimizedPlan).collect {
+    if(optimizedPlan eq plan) {
+      return plan
+    }
+    val executedPlan = ensureRequirements.apply(optimizedPlan)
+    val numShuffles = executedPlan.collect {
       case e: ShuffleExchangeExec => e
     }.length
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -142,6 +142,7 @@ abstract class QueryStageExec extends LeafExecNode {
     plan.generateTreeString(
       depth + 1, lastChildren :+ true, append, verbose, "", false, maxFields, printNodeId, indent)
   }
+  private[execution] def isMaterialized = resultOption.get().isDefined
 }
 
 /**
@@ -184,9 +185,9 @@ case class ShuffleQueryStageExec(
    * this method returns None, as there is no map statistics.
    */
   def mapStats: Option[MapOutputStatistics] = {
-    assert(resultOption.get().isDefined, s"${getClass.getSimpleName} should already be ready")
+    assert(isMaterialized, s"${getClass.getSimpleName} should already be ready")
     val stats = resultOption.get().get.asInstanceOf[MapOutputStatistics]
-    Option(stats)
+    Option(stats) // Note: Option(null) eq None
   }
 
   override def getRuntimeStatistics: Statistics = shuffle.runtimeStatistics

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -120,7 +120,7 @@ case class ShuffleExchangeExec(
   // 'mapOutputStatisticsFuture' is only needed when enable AQE.
   @transient override lazy val mapOutputStatisticsFuture: Future[MapOutputStatistics] = {
     if (inputRDD.getNumPartitions == 0) {
-      Future.successful(null)
+      Future.successful(null) // Option(null) eq None
     } else {
       sparkContext.submitMapStage(shuffleDependency)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptivePreferShuffleSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptivePreferShuffleSuite.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * This tests SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE = true
+ * By default SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE = false.
+ * New tests should be added in AdaptiveQueryExecSuite so that they get
+ * tested with the option both on and off.
+ */
+class AdaptivePreferShuffleSuite extends AdaptiveQueryExecSuite {
+  var initVal = false
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    initVal = SQLConf.get.getConf(SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE)
+    SQLConf.get.setConf(SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE, true)
+  }
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    SQLConf.get.setConf(SQLConf.ADAPTIVE_FORCE_IF_SHUFFLE, initVal)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1385,7 +1385,13 @@ class AdaptiveQueryExecSuite
       checkNumLocalShuffleReaders(df.queryExecution.executedPlan, numShufflesWithoutLocalReader = 1)
     }
   }
-
+ /**
+  * todo:
+  * Note: my original solution didn't properly handle a case where top level shuffle was
+  * optimized away - or did it????
+  * Id did not.  handleFinalStageShuffle() didn't look at initialPlan, and just ran
+  * OptimizeSkewedJoin, which would've done mitigation...  why doesn't this test fail then!?
+  */
   test("SPARK-33551: Do not use custom shuffle reader for repartition") {
     def hasRepartitionShuffle(plan: SparkPlan): Boolean = {
       find(plan) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -88,7 +88,8 @@ class AdaptiveQueryExecSuite
     val exchanges = adaptivePlan.collect {
       case e: Exchange => e
     }
-    assert(exchanges.isEmpty, "The final plan should not contain any Exchange node.")
+    assert(exchanges.isEmpty, "The final plan should not contain any Exchange node." +
+        "\n" + adaptivePlan)
     (dfAdaptive.queryExecution.sparkPlan, adaptivePlan)
   }
 
@@ -114,6 +115,11 @@ class AdaptiveQueryExecSuite
     collectWithSubqueries(plan) {
       case ShuffleQueryStageExec(_, e: ReusedExchangeExec) => e
       case BroadcastQueryStageExec(_, e: ReusedExchangeExec) => e
+    }
+  }
+  private def findCustomShuffleReaders(plan: SparkPlan): Seq[CustomShuffleReaderExec] = {
+    collect(plan) {
+      case r: CustomShuffleReaderExec => r
     }
   }
 
@@ -665,20 +671,82 @@ class AdaptiveQueryExecSuite
           .selectExpr("id % 1 as key2", "id as value2")
           .createOrReplaceTempView("skewData2")
 
-        def checkSkewJoin(query: String, optimizeSkewJoin: Boolean): Unit = {
+        def checkSkewJoin(query: String, optimizeSkewJoin: Boolean): SparkPlan = {
           val (_, innerAdaptivePlan) = runAdaptiveAndVerifyResult(query)
           val innerSmj = findTopLevelSortMergeJoin(innerAdaptivePlan)
           assert(innerSmj.size == 1 && innerSmj.head.isSkewJoin == optimizeSkewJoin)
+          innerAdaptivePlan
         }
 
         checkSkewJoin(
           "SELECT key1 FROM skewData1 JOIN skewData2 ON key1 = key2", true)
         // Additional shuffle introduced, so disable the "OptimizeSkewedJoin" optimization
-        checkSkewJoin(
-          "SELECT key1 FROM skewData1 JOIN skewData2 ON key1 = key2 GROUP BY key1", false)
+        val adaptivePlan = checkSkewJoin(
+          "SELECT key1 FROM skewData1 JOIN skewData2 ON key1 = key2 GROUP BY key1",
+          conf.adaptiveForceIfShuffle)
+        val readers = findCustomShuffleReaders(adaptivePlan)
+        if(conf.adaptiveForceIfShuffle) {
+          // new shuffle in the Agg gets coalesced
+          assert(readers.length == 3, s"$adaptivePlan")
+        } else {
+          assert(readers.length == 2, s"$adaptivePlan")
+        }
       }
     }
   }
+  test("skew in deeply nested join - test ShuffleAddedException") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD.key -> "100",
+      SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "100"
+    ) {
+      withTempView("skewData1", "skewData2", "skewData3") {
+        spark
+          .range(0, 1000, 1, 10)
+          .selectExpr("id % 3 as key1", "id as value1")
+          .createOrReplaceTempView("skewData1")
+        spark
+          .range(0, 1000, 1, 10)
+          .selectExpr("id % 1 as key2", "id as value2")
+          .createOrReplaceTempView("skewData2")
+        spark
+          .range(0, 10, 1, 10)
+          .selectExpr("id as key3", "id as value3")
+          .createOrReplaceTempView("skewData3")
+
+        /*
+        SMJ1
+        :-Sort
+          :-Agg
+            :-SMJ2
+              :-Sort
+              :-Sort
+        :-Sort
+        Agg is on SMJ2 key, so no skew mitigation unless adaptiveForceIfShuffle is ON
+        in which case SMJ2.isSkewJoin = true & a new shuffle is added for Agg
+        */
+        val (_, innerAdaptivePlan) = runAdaptiveAndVerifyResult(
+          "select * from (SELECT key1, count(*) as c FROM skewData1 JOIN " +
+            "skewData2 ON key1 = key2 group by key1 ) A " +
+            "INNER JOIN skewData3 on c = value3")
+        val innerSmj = findTopLevelSortMergeJoin(innerAdaptivePlan)
+        val csre = findCustomShuffleReaders(innerAdaptivePlan)
+        if(!conf.adaptiveForceIfShuffle) {
+          assert(innerSmj.size == 2 && !innerSmj.head.isSkewJoin,
+            s"actual plan=$innerAdaptivePlan")
+          assert(!innerSmj.last.isSkewJoin, s"actual plan=$innerAdaptivePlan")
+          assert(csre.length == 4, s"actual plan=$innerAdaptivePlan")
+        } else {
+          assert(innerSmj.size == 2 && !innerSmj.head.isSkewJoin,
+            s"actual plan=$innerAdaptivePlan")
+          assert(innerSmj.last.isSkewJoin, s"actual plan=$innerAdaptivePlan")
+          assert(csre.length == 5, s"actual plan=$innerAdaptivePlan")
+        }
+      }
+    }
+  }
+
 
   test("SPARK-29544: adaptive skew join with different join types") {
     withSQLConf(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.execution.adaptive
 
 import java.io.File
 import java.net.URI
+
 import org.apache.log4j.Level
+
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds `spark.sql.adaptive.force.if.shuffle` config option which, if set to true, causes `OptimizeSkewedJoin` to perform skew mitigation even if it requires a new shuffle to be performed.
For example, current behavior is not perform skew mitigation in the following query
```
Project
|-Group By key1
  |-SMJ on key1 = key2
```
With `spark.sql.adaptive.force.if.shuffle=true`, the SMJ will become `skew=true` and a new shuffle will be added for the Aggregate.  New shuffle itself will be processed by AQE and coalesced, etc if needed.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It enables AQE to apply in cases where the cost of extra shuffle is less than the cost of unmitigated skew.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, with `spark.sql.adaptive.force.if.shuffle=false`, which is the default


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New UTs + enhancements of existing ones