### PR TITLE
[SPARK-32617][K8S][TESTS][FOLLOWUP] Use `--minify` to fix failures in case of multi configs

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/Minikube.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/Minikube.scala
@@ -111,7 +111,7 @@ private[spark] object Minikube extends Logging {
   }
 
   private def kubectlBasedKubernetesClientConf: Config = {
-    val outputs = executeMinikube("kubectl config view")
+    val outputs = executeMinikube("kubectl config view --minify")
     val apiVersionString = outputs.find(_.contains(APIVERSION_PREFIX))
     val serverString = outputs.find(_.contains(SERVER_PREFIX))
     val caString = outputs.find(_.contains(CA_PREFIX))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/30751.
This PR fixes an integration test failure by using `--minify` option.

### Why are the changes needed?

To fix the K8s integration failures.
`kubectl config view` shows all merged configs.
To get a config of the current context, `--minify` is required.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the K8s IT.