### PR TITLE
[SPARK-34553][INFRA] Rename GITHUB_API_TOKEN to GITHUB_OAUTH_KEY in translate-contributors.py

### DIFF
--- a/dev/create-release/translate-contributors.py
+++ b/dev/create-release/translate-contributors.py
@@ -45,11 +45,11 @@ except ImportError:
 JIRA_API_BASE = os.environ.get("JIRA_API_BASE", "https://issues.apache.org/jira")
 JIRA_USERNAME = os.environ.get("JIRA_USERNAME", None)
 JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", None)
-GITHUB_API_TOKEN = os.environ.get("GITHUB_API_TOKEN", None)
+GITHUB_OAUTH_KEY = os.environ.get("GITHUB_OAUTH_KEY", os.environ.get("GITHUB_API_TOKEN", None))
 if not JIRA_USERNAME or not JIRA_PASSWORD:
     sys.exit("Both JIRA_USERNAME and JIRA_PASSWORD must be set")
-if not GITHUB_API_TOKEN:
-    sys.exit("GITHUB_API_TOKEN must be set")
+if not GITHUB_OAUTH_KEY:
+    sys.exit("GITHUB_OAUTH_KEY must be set")
 
 # Write new contributors list to <old_file_name>.final
 if not os.path.isfile(contributors_file_name):
@@ -71,7 +71,7 @@ if INTERACTIVE_MODE:
 # Setup GitHub and JIRA clients
 jira_options = {"server": JIRA_API_BASE}
 jira_client = JIRA(options=jira_options, basic_auth=(JIRA_USERNAME, JIRA_PASSWORD))
-github_client = Github(GITHUB_API_TOKEN)
+github_client = Github(GITHUB_OAUTH_KEY)
 
 # Load known author translations that are cached locally
 known_translations = {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add an alias environment variable `GITHUB_OAUTH_KEY` for `GITHUB_API_TOKEN` in `translate-contributors.py` script.

### Why are the changes needed?

```
dev/github_jira_sync.py:GITHUB_OAUTH_KEY = os.environ.get("GITHUB_OAUTH_KEY")
dev/github_jira_sync.py:        request.add_header('Authorization', 'token %s' % GITHUB_OAUTH_KEY)
dev/github_jira_sync.py:        request.add_header('Authorization', 'token %s' % GITHUB_OAUTH_KEY)
dev/merge_spark_pr.py:GITHUB_OAUTH_KEY = os.environ.get("GITHUB_OAUTH_KEY")
dev/merge_spark_pr.py:        if GITHUB_OAUTH_KEY:
dev/merge_spark_pr.py:            request.add_header('Authorization', 'token %s' % GITHUB_OAUTH_KEY)
dev/run-tests-jenkins.py:    github_oauth_key = os.environ["GITHUB_OAUTH_KEY"]
```

Spark uses `GITHUB_OAUTH_KEY` for GitHub token, but `translate-contributors.py` script alone uses `GITHUB_API_TOKEN`. We should better match to make it easier to run the script

### Does this PR introduce _any_ user-facing change?

No, it's dev-only.

### How was this patch tested?

I manually tested by running this script.
