### PR TITLE
[SPARK-34557][BUILD] Exclude Avro's transitive zstd-jni dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1235,6 +1235,10 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to exclude `Apache Avro`'s transitive zstd-jni dependency.

### Why are the changes needed?

While SPARK-27733 upgrades Apache Avro from 1.8 to 1.10,
`zstd-jni` transitive dependency is created.

This PR explicitly prevents dependency conflicts.

**BEFORE**
```
$ build/sbt "core/evicted" | grep zstd
[info] 	* com.github.luben:zstd-jni:1.4.8-5 is selected over 1.4.5-12
```

**AFTER**
```
$ build/sbt "core/evicted" | grep zstd
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.