### PR TITLE
[SPARK-34558][SQL] warehouse path should be qualified ahead of populating and use

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit
 import org.apache.spark.util.Utils
 
 
-
 /**
  * Static SQL configuration is a cross-session, immutable Spark configuration. External users can
  * see the static sql configs via `SparkSession.conf`, but can NOT set/unset them.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -20,6 +20,10 @@ package org.apache.spark.sql.internal
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
+import org.apache.spark.util.Utils
+
+
+
 /**
  * Static SQL configuration is a cross-session, immutable Spark configuration. External users can
  * see the static sql configs via `SparkSession.conf`, but can NOT set/unset them.
@@ -32,7 +36,7 @@ object StaticSQLConf {
     .doc("The default location for managed databases and tables.")
     .version("2.0.0")
     .stringConf
-    .createWithDefault("spark-warehouse")
+    .createWithDefault(Utils.resolveURI("spark-warehouse").toString)
 
   val CATALOG_IMPLEMENTATION = buildStaticConf("spark.sql.catalogImplementation")
     .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -20,9 +20,6 @@ package org.apache.spark.sql.internal
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-import org.apache.spark.util.Utils
-
-
 /**
  * Static SQL configuration is a cross-session, immutable Spark configuration. External users can
  * see the static sql configs via `SparkSession.conf`, but can NOT set/unset them.
@@ -35,7 +32,7 @@ object StaticSQLConf {
     .doc("The default location for managed databases and tables.")
     .version("2.0.0")
     .stringConf
-    .createWithDefault(Utils.resolveURI("spark-warehouse").toString)
+    .createWithDefault("spark-warehouse")
 
   val CATALOG_IMPLEMENTATION = buildStaticConf("spark.sql.catalogImplementation")
     .internal()

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.{SparkConf, SparkContext, SparkException, SparkFunSuite}
@@ -31,13 +32,15 @@ import org.apache.spark.util.ThreadUtils
  */
 class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
 
-  override def afterEach(): Unit = {
+  def reset(): Unit = {
     // This suite should not interfere with the other test suites.
     SparkSession.getActiveSession.foreach(_.stop())
     SparkSession.clearActiveSession()
     SparkSession.getDefaultSession.foreach(_.stop())
     SparkSession.clearDefaultSession()
   }
+
+  override def afterEach(): Unit = reset()
 
   test("create with config options and propagate them to SparkContext and SparkSession") {
     val session = SparkSession.builder()
@@ -240,7 +243,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
       .getOrCreate()
     assert(session.conf.get("spark.app.name") === "test-app-SPARK-31532-2")
     assert(session.conf.get(GLOBAL_TEMP_DATABASE) === "globaltempdb-spark-31532-2")
-    assert(session.conf.get(WAREHOUSE_PATH) === "SPARK-31532-db-2")
+    assert(session.conf.get(WAREHOUSE_PATH) contains "SPARK-31532-db-2")
   }
 
   test("SPARK-32062: reset listenerRegistered in SparkSession") {
@@ -306,14 +309,14 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     // newly specified values
     val sharedWH = spark.sharedState.conf.get(wh)
     val sharedTD = spark.sharedState.conf.get(td)
-    assert(sharedWH === "./data2",
+    assert(sharedWH contains "data2",
       "The warehouse dir in shared state should be determined by the 1st created spark session")
     assert(sharedTD === "alice",
       "Static sql configs in shared state should be determined by the 1st created spark session")
     assert(spark.sharedState.conf.getOption(custom).isEmpty,
       "Dynamic sql configs is session specific")
 
-    assert(spark.conf.get(wh) === sharedWH,
+    assert(spark.conf.get(wh) contains sharedWH,
       "The warehouse dir in session conf and shared state conf should be consistent")
     assert(spark.conf.get(td) === sharedTD,
       "Static sql configs in session conf and shared state conf should be consistent")
@@ -321,7 +324,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
 
     spark.sql("RESET")
 
-    assert(spark.conf.get(wh) === sharedWH,
+    assert(spark.conf.get(wh) contains sharedWH,
       "The warehouse dir in shared state should be respect after RESET")
     assert(spark.conf.get(td) === sharedTD,
       "Static sql configs in shared state should be respect after RESET")
@@ -331,7 +334,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     val spark2 = SparkSession.builder()
       .config(wh, "./data3")
       .config(custom, "kyaoo").getOrCreate()
-    assert(spark2.conf.get(wh) === sharedWH)
+    assert(spark2.conf.get(wh) contains sharedWH)
     assert(spark2.conf.get(td) === sharedTD)
     assert(spark2.conf.get(custom) === "kyaoo")
   }
@@ -352,7 +355,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     spark.sql(s"SET $custom=c1")
     assert(spark.conf.get(custom) === "c1")
     spark.sql("RESET")
-    assert(spark.conf.get(wh) === "./data0",
+    assert(spark.conf.get(wh) contains "data0",
       "The warehouse dir in shared state should be respect after RESET")
     assert(spark.conf.get(td) === "bob",
       "Static sql configs in shared state should be respect after RESET")
@@ -381,7 +384,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     spark2.sql(s"SET $custom=c1")
     assert(spark2.conf.get(custom) === "c1")
     spark2.sql("RESET")
-    assert(spark2.conf.get(wh) === "./data1")
+    assert(spark2.conf.get(wh) contains "data1")
     assert(spark2.conf.get(td) === "alice")
     assert(spark2.conf.get(custom) === "c2")
 
@@ -411,5 +414,32 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
         .sharedState
     }
     assert(!logAppender.loggingEvents.exists(_.getRenderedMessage.contains(msg)))
+  }
+
+  test(" SPARK-34558: warehouse path should be qualified and populate to spark and hadoop conf") {
+    Seq(".", "..", "dir0", "dir0/dir1", "/dir0/dir1", "./dir0").foreach { pathStr =>
+      val path = new Path(pathStr)
+      val conf = new SparkConf().set(WAREHOUSE_PATH, pathStr)
+      val session = SparkSession.builder()
+        .master("local")
+        .config(conf)
+        .getOrCreate()
+      val hadoopConf = session.sessionState.newHadoopConf()
+      val expected = path.getFileSystem(hadoopConf).makeQualified(path).toString
+      // session related configs
+      assert(hadoopConf.get("hive.metastore.warehouse.dir") === expected)
+      assert(session.conf.get(WAREHOUSE_PATH) === expected)
+
+      // shared configs
+      assert(session.sharedState.conf.get(WAREHOUSE_PATH) === expected)
+      assert(session.sharedState.hadoopConf.get("hive.metastore.warehouse.dir") === expected)
+
+      // spark context configs
+      assert(session.sparkContext.conf.get(WAREHOUSE_PATH) === expected)
+      assert(session.sparkContext.hadoopConfiguration.get("hive.metastore.warehouse.dir") ===
+        expected)
+
+      reset()
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -416,7 +416,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     assert(!logAppender.loggingEvents.exists(_.getRenderedMessage.contains(msg)))
   }
 
-  test(" SPARK-34558: warehouse path should be qualified and populate to spark and hadoop conf") {
+  test("SPARK-34558: warehouse path should be qualified and populate to spark and hadoop conf") {
     Seq(".", "..", "dir0", "dir0/dir1", "/dir0/dir1", "./dir0").foreach { pathStr =>
       val path = new Path(pathStr)
       val conf = new SparkConf().set(WAREHOUSE_PATH, pathStr)
@@ -429,6 +429,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
       // session related configs
       assert(hadoopConf.get("hive.metastore.warehouse.dir") === expected)
       assert(session.conf.get(WAREHOUSE_PATH) === expected)
+      assert(session.sessionState.conf.warehousePath === expected)
 
       // shared configs
       assert(session.sharedState.conf.get(WAREHOUSE_PATH) === expected)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -415,7 +415,7 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
   }
 
   Seq(".", "..", "dir0", "dir0/dir1", "/dir0/dir1", "./dir0").foreach { pathStr =>
-    test(s"SPARK-34558: warehouse should be qualified for spark/hadoop conf - $pathStr") {
+    test(s"SPARK-34558: warehouse path ($pathStr) should be qualified for spark/hadoop conf") {
       val path = new Path(pathStr)
       val conf = new SparkConf().set(WAREHOUSE_PATH, pathStr)
       val session = SparkSession.builder()

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -32,15 +32,13 @@ import org.apache.spark.util.ThreadUtils
  */
 class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
 
-  def reset(): Unit = {
+  override def afterEach(): Unit = {
     // This suite should not interfere with the other test suites.
     SparkSession.getActiveSession.foreach(_.stop())
     SparkSession.clearActiveSession()
     SparkSession.getDefaultSession.foreach(_.stop())
     SparkSession.clearDefaultSession()
   }
-
-  override def afterEach(): Unit = reset()
 
   test("create with config options and propagate them to SparkContext and SparkSession") {
     val session = SparkSession.builder()
@@ -416,8 +414,8 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
     assert(!logAppender.loggingEvents.exists(_.getRenderedMessage.contains(msg)))
   }
 
-  test("SPARK-34558: warehouse path should be qualified and populate to spark and hadoop conf") {
-    Seq(".", "..", "dir0", "dir0/dir1", "/dir0/dir1", "./dir0").foreach { pathStr =>
+  Seq(".", "..", "dir0", "dir0/dir1", "/dir0/dir1", "./dir0").foreach { pathStr =>
+    test(s"SPARK-34558: warehouse should be qualified for spark/hadoop conf - $pathStr") {
       val path = new Path(pathStr)
       val conf = new SparkConf().set(WAREHOUSE_PATH, pathStr)
       val session = SparkSession.builder()
@@ -439,8 +437,8 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
       assert(session.sparkContext.conf.get(WAREHOUSE_PATH) === expected)
       assert(session.sparkContext.hadoopConfiguration.get("hive.metastore.warehouse.dir") ===
         expected)
-
-      reset()
     }
   }
+
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -439,6 +439,4 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach {
         expected)
     }
   }
-
-
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.hive
 
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hive.common.FileUtils
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
@@ -35,7 +37,7 @@ class HiveSharedStateSuite extends SparkFunSuite {
   test("initial configs should be passed to SharedState but not SparkContext") {
     val conf = new SparkConf().setMaster("local").setAppName("SharedState Test")
     val sc = SparkContext.getOrCreate(conf)
-    val wareHouseDir = Utils.createTempDir().toString
+    val warehousePath = Utils.createTempDir().toString
     val invalidPath = "invalid/path"
     val metastorePath = Utils.createTempDir()
     val tmpDb = "tmp_db"
@@ -45,8 +47,8 @@ class HiveSharedStateSuite extends SparkFunSuite {
     // Especially, all these configs are passed to the cloned confs inside SharedState for sharing
     // cross sessions.
     val initialConfigs = Map("spark.foo" -> "bar",
-      WAREHOUSE_PATH.key -> wareHouseDir,
-      ConfVars.METASTOREWAREHOUSE.varname -> wareHouseDir,
+      WAREHOUSE_PATH.key -> warehousePath,
+      ConfVars.METASTOREWAREHOUSE.varname -> warehousePath,
       CATALOG_IMPLEMENTATION.key -> "hive",
       ConfVars.METASTORECONNECTURLKEY.varname ->
         s"jdbc:derby:;databaseName=$metastorePath/metastore_db;create=true",
@@ -56,9 +58,11 @@ class HiveSharedStateSuite extends SparkFunSuite {
     initialConfigs.foreach { case (k, v) => builder.config(k, v) }
     val ss = builder.getOrCreate()
     val state = ss.sharedState
-    assert(sc.conf.get(WAREHOUSE_PATH.key) === wareHouseDir,
+    val qualifiedWH =
+      FileUtils.makeQualified(new Path(warehousePath), sc.hadoopConfiguration).toString
+    assert(sc.conf.get(WAREHOUSE_PATH.key) === qualifiedWH,
       "initial warehouse conf in session options can affect application wide spark conf")
-    assert(sc.hadoopConfiguration.get(ConfVars.METASTOREWAREHOUSE.varname) === wareHouseDir,
+    assert(sc.hadoopConfiguration.get(ConfVars.METASTOREWAREHOUSE.varname) === qualifiedWH,
       "initial warehouse conf in session options can affect application wide hadoop conf")
 
     assert(!state.sparkContext.conf.contains("spark.foo"),
@@ -68,7 +72,7 @@ class HiveSharedStateSuite extends SparkFunSuite {
     val client = state.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
     assert(client.getConf("spark.foo", "") === "bar",
       "session level conf should be passed to catalog")
-    assert(client.getConf(ConfVars.METASTOREWAREHOUSE.varname, "") === wareHouseDir,
+    assert(client.getConf(ConfVars.METASTOREWAREHOUSE.varname, "") === qualifiedWH,
       "session level conf should be passed to catalog")
 
     assert(state.globalTempViewManager.database === tmpDb)
@@ -76,12 +80,12 @@ class HiveSharedStateSuite extends SparkFunSuite {
    val ss2 =
      builder.config("spark.foo", "bar2222").config(WAREHOUSE_PATH.key, invalidPath).getOrCreate()
 
-    assert(ss2.sparkContext.conf.get(WAREHOUSE_PATH.key) !== invalidPath,
+    assert(!ss2.sparkContext.conf.get(WAREHOUSE_PATH.key).contains(invalidPath),
       "warehouse conf in session options can't affect application wide spark conf")
     assert(ss2.sparkContext.hadoopConfiguration.get(ConfVars.METASTOREWAREHOUSE.varname) !==
       invalidPath, "warehouse conf in session options can't affect application wide hadoop conf")
     assert(ss.conf.get("spark.foo") === "bar2222", "session level conf should be passed to catalog")
-    assert(ss.conf.get(WAREHOUSE_PATH) !== invalidPath,
+    assert(!ss.conf.get(WAREHOUSE_PATH).contains(invalidPath),
       "session level conf should be passed to catalog")
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -58,11 +58,11 @@ class HiveSharedStateSuite extends SparkFunSuite {
     initialConfigs.foreach { case (k, v) => builder.config(k, v) }
     val ss = builder.getOrCreate()
     val state = ss.sharedState
-    val qualifiedWH =
+    val qualifiedWHPath =
       FileUtils.makeQualified(new Path(warehousePath), sc.hadoopConfiguration).toString
-    assert(sc.conf.get(WAREHOUSE_PATH.key) === qualifiedWH,
+    assert(sc.conf.get(WAREHOUSE_PATH.key) === qualifiedWHPath,
       "initial warehouse conf in session options can affect application wide spark conf")
-    assert(sc.hadoopConfiguration.get(ConfVars.METASTOREWAREHOUSE.varname) === qualifiedWH,
+    assert(sc.hadoopConfiguration.get(ConfVars.METASTOREWAREHOUSE.varname) === qualifiedWHPath,
       "initial warehouse conf in session options can affect application wide hadoop conf")
 
     assert(!state.sparkContext.conf.contains("spark.foo"),
@@ -72,7 +72,7 @@ class HiveSharedStateSuite extends SparkFunSuite {
     val client = state.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
     assert(client.getConf("spark.foo", "") === "bar",
       "session level conf should be passed to catalog")
-    assert(client.getConf(ConfVars.METASTOREWAREHOUSE.varname, "") === qualifiedWH,
+    assert(client.getConf(ConfVars.METASTOREWAREHOUSE.varname, "") === qualifiedWHPath,
       "session level conf should be passed to catalog")
 
     assert(state.globalTempViewManager.database === tmpDb)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
@@ -409,11 +409,11 @@ object SetWarehouseLocationTest extends Logging {
 
     }
 
-    val qualifiedWH = FileUtils.makeQualified(
+    val qualifiedWHPath = FileUtils.makeQualified(
       new Path(expectedWarehouseLocation), sparkSession.sparkContext.hadoopConfiguration).toString
-    if (sparkSession.conf.get(WAREHOUSE_PATH.key) != qualifiedWH) {
+    if (sparkSession.conf.get(WAREHOUSE_PATH.key) != qualifiedWHPath) {
       throw new Exception(
-        s"${WAREHOUSE_PATH.key} is not set to the expected warehouse location $qualifiedWH.")
+        s"${WAREHOUSE_PATH.key} is not set to the expected warehouse location $qualifiedWHPath.")
     }
 
     val catalog = sparkSession.sessionState.catalog
@@ -426,7 +426,7 @@ object SetWarehouseLocationTest extends Logging {
       val tableMetadata =
         catalog.getTableMetadata(TableIdentifier("testLocation", Some("default")))
       val expectedLocation =
-        CatalogUtils.stringToURI(s"$qualifiedWH/testlocation")
+        CatalogUtils.stringToURI(s"$qualifiedWHPath/testlocation")
       val actualLocation = tableMetadata.location
       if (actualLocation != expectedLocation) {
         throw new Exception(
@@ -442,7 +442,7 @@ object SetWarehouseLocationTest extends Logging {
       val tableMetadata =
         catalog.getTableMetadata(TableIdentifier("testLocation", Some("testLocationDB")))
       val expectedLocation = CatalogUtils.stringToURI(
-        s"$qualifiedWH/testlocationdb.db/testlocation")
+        s"$qualifiedWHPath/testlocationdb.db/testlocation")
       val actualLocation = tableMetadata.location
       if (actualLocation != expectedLocation) {
         throw new Exception(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
@@ -27,8 +27,8 @@ import org.apache.hadoop.hive.common.FileUtils
 import org.scalatest.Assertions._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.must.Matchers
-import org.apache.spark._
 
+import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.sql.{QueryTest, Row, SparkSession}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, the warehouse path gets fully qualified in the caller side for creating a database, table, partition, etc. An unqualified path is populated into Spark and Hadoop confs, which leads to inconsistent API behaviors.  We should make it qualified ahead.


When the value is a relative path `spark.sql.warehouse.dir=lakehouse`, some behaviors become inconsistent, for example.

If the default database is absent at runtime, the app fails with

```java
Caused by: java.lang.IllegalArgumentException: java.net.URISyntaxException: Relative path in absolute URI: file:./lakehouse
	at org.apache.hadoop.fs.Path.initialize(Path.java:263)
	at org.apache.hadoop.fs.Path.<init>(Path.java:254)
	at org.apache.hadoop.hive.metastore.Warehouse.getDnsPath(Warehouse.java:133)
	at org.apache.hadoop.hive.metastore.Warehouse.getDnsPath(Warehouse.java:137)
	at org.apache.hadoop.hive.metastore.Warehouse.getWhRoot(Warehouse.java:150)
	at org.apache.hadoop.hive.metastore.Warehouse.getDefaultDatabasePath(Warehouse.java:163)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.createDefaultDB_core(HiveMetaStore.java:636)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.createDefaultDB(HiveMetaStore.java:655)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.init(HiveMetaStore.java:431)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invokeInternal(RetryingHMSHandler.java:148)
	at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invoke(RetryingHMSHandler.java:107)
	at org.apache.hadoop.hive.metastore.RetryingHMSHandler.<init>(RetryingHMSHandler.java:79)
	... 73 more
```

If the default database is present at runtime, the app can work with it, and if we create a database, it gets fully qualified, for example


```sql
spark-sql> create database test;
Time taken: 0.052 seconds
spark-sql> desc database test;
Database Name	test
Comment
Location	file:/Users/kentyao/Downloads/spark/spark-3.2.0-SNAPSHOT-bin-20210226/lakehouse/test.db
Owner	kentyao
Time taken: 0.023 seconds, Fetched 4 row(s)
```

Another thing is that the log becomes nubilous, for example.

```logtalk
21/02/27 13:54:17 INFO SharedState: Setting hive.metastore.warehouse.dir ('null') to the value of spark.sql.warehouse.dir ('datalake').
21/02/27 13:54:17 INFO SharedState: Warehouse path is 'lakehouse'.
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix bug and ambiguity
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, the path now resolved with proper order - `warehouse->database->table->partition` 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
w/ ut added