### PR TITLE
[SPARK-34566][LAUNCHER] Fix configuration typo of spark. launcher.childConnectionTimeout

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -93,7 +93,7 @@ public class SparkLauncher extends AbstractLauncher<SparkLauncher> {
    * Maximum time (in ms) to wait for a child process to connect back to the launcher server
    * when using @link{#start()}.
    */
-  public static final String CHILD_CONNECTION_TIMEOUT = "spark.launcher.childConectionTimeout";
+  public static final String CHILD_CONNECTION_TIMEOUT = "spark.launcher.childConnectionTimeout";
 
   /** Used internally to create unique logger names. */
   private static final AtomicInteger COUNTER = new AtomicInteger();


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix typo if `spark. launcher .childConnectionTimeout`


### Why are the changes needed?
Fix configuration type

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Not need
