### PR TITLE
[SPARK-34571][SQL][CORE] Provide a more convenient way to deprecate/remove/alternate configs

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -627,7 +627,7 @@ private[spark] object SparkConf extends Logging {
       DeprecatedConfig("spark.yarn.credentials.file.retention.days", "2.4.0", "Not used anymore."),
       DeprecatedConfig("spark.yarn.services", "3.0.0", "Feature no longer available."),
       DeprecatedConfig("spark.executor.plugins", "3.0.0",
-        "Feature replaced with new plugin API. See Monitoring documentation."),
+        "Feature replaced with new plugin API. See Monitoring documentation.")
     ) ++ LegacyConfigsRegister.deprecateConfigs
 
     Map(configs.map { cfg => (cfg.key -> cfg) } : _*)

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -28,7 +28,6 @@ import org.apache.avro.{Schema, SchemaNormalization}
 import org.apache.spark.SparkConf.{AlternativeConfig, DeprecatedConfig}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
-import org.apache.spark.internal.config.History._
 import org.apache.spark.internal.config.Kryo._
 import org.apache.spark.internal.config.Network._
 import org.apache.spark.serializer.KryoSerializer

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -593,11 +593,11 @@ private[spark] object LegacyConfigsRegister {
   }
 
   def registerAlternated(
-      key: String,
+      activeKey: String,
       alternativeConfigs: Seq[(String, String, String => String)]): Unit = {
-    val configs = alternatedConfigs.getOrElseUpdate(key, new ArrayBuffer[AlternateConfig]())
-    configs ++= alternativeConfigs.map { case (key, version, translation) =>
-      AlternateConfig(key, version, translation)
+    val configs = alternatedConfigs.getOrElseUpdate(activeKey, new ArrayBuffer[AlternateConfig]())
+    configs ++= alternativeConfigs.map { case (alternativeKey, version, translation) =>
+      AlternateConfig(alternativeKey, version, translation)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
@@ -209,9 +209,9 @@ private[spark] case class ConfigBuilder(key: String) {
   /**
    * Deprecated the current config
    *
-   * @param version Version of Spark where the config was deprecated.
-   * @param deprecationMessage Message to include in the deprecation warning.
-   * @return
+   * @param version version of Spark where the config was deprecated.
+   * @param deprecationMessage message to include in the deprecation warning.
+   * @return this.type
    */
   def deprecated(version: String, deprecationMessage: String): ConfigBuilder = {
     LegacyConfigsRegister.registerDeprecated(key, version, deprecationMessage)
@@ -219,16 +219,16 @@ private[spark] case class ConfigBuilder(key: String) {
   }
 
   /**
+   * Add alternative configs for the current config
    *
-   * @param alternativeConfig
-   * @param others
-   * @return
+   * @param alternativeConfig (alternative key, deprecated version)
+   * @param others a variable sequence of alternativeConfig
+   * @return this.type
    */
   def alternative(
       alternativeConfig: (String, String),
       others: (String, String)*): ConfigBuilder = {
     val alternativeWithNullTranslation = (alternativeConfig +: others).map { alternative =>
-      _alternatives = _alternatives :+ alternative._1
       (alternative._1, alternative._2, null: String => String)
     }
     alternativeWithTranslation(
@@ -237,10 +237,19 @@ private[spark] case class ConfigBuilder(key: String) {
     this
   }
 
+  /**
+   * Add alternative configs with translation for the current config
+   *
+   * @param alternativeConfig (alternative key, deprecated version, translation)
+   * @param others a variable sequence of alternativeConfig
+   * @return this.type
+   */
   def alternativeWithTranslation(
       alternativeConfig: (String, String, String => String),
       others: (String, String, String => String)*): ConfigBuilder = {
-    LegacyConfigsRegister.registerAlternative(key, alternativeConfig +: others)
+    val alternatives = alternativeConfig +: others
+    alternatives.foreach(c => _alternatives :+= c._1)
+    LegacyConfigsRegister.registerAlternative(key, alternatives)
     this
   }
 

--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
@@ -22,6 +22,7 @@ import java.util.regex.PatternSyntaxException
 
 import scala.util.matching.Regex
 
+import org.apache.spark.LegacyConfigsRegister
 import org.apache.spark.network.util.{ByteUnit, JavaUtils}
 import org.apache.spark.util.Utils
 
@@ -202,6 +203,23 @@ private[spark] case class ConfigBuilder(key: String) {
 
   def version(v: String): ConfigBuilder = {
     _version = v
+    this
+  }
+
+  def deprecated(version: String, deprecationMessage: String): ConfigBuilder = {
+    LegacyConfigsRegister.registerDeprecated(key, version, deprecationMessage)
+    this
+  }
+
+  def alternated(
+      alternativeConfig: (String, String, String => String),
+      others: (String, String, String => String)*): ConfigBuilder = {
+    LegacyConfigsRegister.registerAlternated(key, alternativeConfig +: others )
+    this
+  }
+
+  def removed(version: String, defaultValue: String, comment: String): ConfigBuilder = {
+    LegacyConfigsRegister.registerRemoved(key, version, defaultValue, comment)
     this
   }
 

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -37,6 +37,10 @@ private[spark] object History {
 
   val UPDATE_INTERVAL_S = ConfigBuilder("spark.history.fs.update.interval")
     .version("1.4.0")
+    .alternative(
+      ("spark.history.fs.update.interval.seconds", "1.4"),
+      ("spark.history.fs.updateInterval", "1.3"),
+      ("spark.history.updateInterval", "1.3"))
     .timeConf(TimeUnit.SECONDS)
     .createWithDefaultString("10s")
 
@@ -47,11 +51,13 @@ private[spark] object History {
 
   val CLEANER_INTERVAL_S = ConfigBuilder("spark.history.fs.cleaner.interval")
     .version("1.4.0")
+    .alternative(("spark.history.fs.cleaner.interval.seconds", "1.4"))
     .timeConf(TimeUnit.SECONDS)
     .createWithDefaultString("1d")
 
   val MAX_LOG_AGE_S = ConfigBuilder("spark.history.fs.cleaner.maxAge")
     .version("1.4.0")
+    .alternative(("spark.history.fs.cleaner.maxAge.seconds", "1.4"))
     .timeConf(TimeUnit.SECONDS)
     .createWithDefaultString("7d")
 

--- a/core/src/main/scala/org/apache/spark/internal/config/Kryo.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Kryo.scala
@@ -55,11 +55,14 @@ private[spark] object Kryo {
 
   val KRYO_SERIALIZER_BUFFER_SIZE = ConfigBuilder("spark.kryoserializer.buffer")
     .version("1.4.0")
+    .alternativeWithTranslation(("spark.kryoserializer.buffer.mb", "1.4",
+      s => s"${(s.toDouble * 1000).toInt}k"))
     .bytesConf(ByteUnit.KiB)
     .createWithDefaultString("64k")
 
   val KRYO_SERIALIZER_MAX_BUFFER_SIZE = ConfigBuilder("spark.kryoserializer.buffer.max")
     .version("1.4.0")
+    .alternative(("spark.kryoserializer.buffer.max.mb", "1.4"))
     .bytesConf(ByteUnit.MiB)
     .createWithDefaultString("64m")
 

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -54,6 +54,7 @@ private[spark] object Network {
   private[spark] val RPC_ASK_TIMEOUT =
     ConfigBuilder("spark.rpc.askTimeout")
       .version("1.4.0")
+      .alternative(("spark.akka.askTimeout", "1.4"))
       .stringConf
       .createOptional
 
@@ -78,12 +79,14 @@ private[spark] object Network {
   private[spark] val RPC_LOOKUP_TIMEOUT =
     ConfigBuilder("spark.rpc.lookupTimeout")
       .version("1.4.0")
+      .alternative(("spark.akka.lookupTimeout", "1.4"))
       .stringConf
       .createOptional
 
   private[spark] val RPC_MESSAGE_MAX_SIZE =
     ConfigBuilder("spark.rpc.message.maxSize")
       .version("2.0.0")
+      .alternative(("spark.akka.frameSize", "1.6"))
       .intConf
       .createWithDefault(128)
 
@@ -96,12 +99,14 @@ private[spark] object Network {
   private[spark] val RPC_NUM_RETRIES =
     ConfigBuilder("spark.rpc.numRetries")
       .version("1.4.0")
+      .alternative(("spark.akka.num.retries", "1.4"))
       .intConf
       .createWithDefault(3)
 
   private[spark] val RPC_RETRY_WAIT =
     ConfigBuilder("spark.rpc.retry.wait")
       .version("1.4.0")
+      .alternative(("spark.akka.retry.wait", "1.4"))
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("3s")
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -83,6 +83,7 @@ package object config {
   private[spark] val DRIVER_USER_CLASS_PATH_FIRST =
     ConfigBuilder("spark.driver.userClassPathFirst")
       .version("1.3.0")
+      .alternative(("spark.yarn.user.classpath.first", "1.3"))
       .booleanConf
       .createWithDefault(false)
 
@@ -102,6 +103,7 @@ package object config {
     .doc("The amount of non-heap memory to be allocated per driver in cluster mode, " +
       "in MiB unless otherwise specified.")
     .version("2.3.0")
+    .alternative(("spark.yarn.driver.memoryOverhead", "2.3"))
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
@@ -294,6 +296,9 @@ package object config {
   private[spark] val EXECUTOR_USER_CLASS_PATH_FIRST =
     ConfigBuilder("spark.executor.userClassPathFirst")
       .version("1.3.0")
+      .alternative(
+        ("spark.yarn.user.classpath.first", "1.3"),
+        ("spark.files.userClassPathFirst", "1.3"))
       .booleanConf
       .createWithDefault(false)
 
@@ -312,6 +317,7 @@ package object config {
     .doc("The amount of non-heap memory to be allocated per executor, in MiB unless otherwise" +
       " specified.")
     .version("2.3.0")
+    .alternative(("spark.yarn.executor.memoryOverhead", "2.3"))
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
@@ -329,7 +335,7 @@ package object config {
     .doc("If true, Spark will attempt to use off-heap memory for certain operations. " +
       "If off-heap memory use is enabled, then spark.memory.offHeap.size must be positive.")
     .version("1.6.0")
-    .withAlternative("spark.unsafe.offHeap")
+    .alternative(("spark.unsafe.offHeap", "1.6"))
     .booleanConf
     .createWithDefault(false)
 
@@ -526,8 +532,8 @@ package object config {
 
   private[spark] val STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT =
     ConfigBuilder("spark.storage.blockManagerHeartbeatTimeoutMs")
-      .version("0.7.0")
-      .withAlternative("spark.storage.blockManagerSlaveTimeoutMs")
+      .version("3.1.0")
+      .alternative(("spark.storage.blockManagerSlaveTimeoutMs", "3.1.0"))
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
@@ -683,16 +689,19 @@ package object config {
   private[spark] val KEYTAB = ConfigBuilder("spark.kerberos.keytab")
     .doc("Location of user's keytab.")
     .version("3.0.0")
+    .alternative(("spark.yarn.keytab", "3.0"))
     .stringConf.createOptional
 
   private[spark] val PRINCIPAL = ConfigBuilder("spark.kerberos.principal")
     .doc("Name of the Kerberos principal.")
     .version("3.0.0")
+    .alternative(("spark.yarn.principal", "3.0"))
     .stringConf
     .createOptional
 
   private[spark] val KERBEROS_RELOGIN_PERIOD = ConfigBuilder("spark.kerberos.relogin.period")
     .version("3.0.0")
+    .alternative(("spark.yarn.kerberos.relogin.period", "3.0"))
     .timeConf(TimeUnit.SECONDS)
     .createWithDefaultString("1m")
 
@@ -712,6 +721,9 @@ package object config {
     .doc("Extra Hadoop filesystem URLs for which to request delegation tokens. The filesystem " +
       "that hosts fs.defaultFS does not need to be listed here.")
     .version("3.0.0")
+    .alternative(
+      ("spark.yarn.access.namenodes", "2.2"),
+      ("spark.yarn.access.hadoopFileSystems", "3.0"))
     .stringConf
     .toSequence
     .createWithDefault(Nil)
@@ -767,63 +779,63 @@ package object config {
   private[spark] val EXCLUDE_ON_FAILURE_ENABLED =
     ConfigBuilder("spark.excludeOnFailure.enabled")
       .version("3.1.0")
-      .withAlternative("spark.blacklist.enabled")
+      .alternative(("spark.blacklist.enabled", "3.1.0"))
       .booleanConf
       .createOptional
 
   private[spark] val MAX_TASK_ATTEMPTS_PER_EXECUTOR =
     ConfigBuilder("spark.excludeOnFailure.task.maxTaskAttemptsPerExecutor")
       .version("3.1.0")
-      .withAlternative("spark.blacklist.task.maxTaskAttemptsPerExecutor")
+      .alternative(("spark.blacklist.task.maxTaskAttemptsPerExecutor", "3.1.0"))
       .intConf
       .createWithDefault(1)
 
   private[spark] val MAX_TASK_ATTEMPTS_PER_NODE =
     ConfigBuilder("spark.excludeOnFailure.task.maxTaskAttemptsPerNode")
       .version("3.1.0")
-      .withAlternative("spark.blacklist.task.maxTaskAttemptsPerNode")
+      .alternative(("spark.blacklist.task.maxTaskAttemptsPerNode", "3.1.0"))
       .intConf
       .createWithDefault(2)
 
   private[spark] val MAX_FAILURES_PER_EXEC =
     ConfigBuilder("spark.excludeOnFailure.application.maxFailedTasksPerExecutor")
       .version("3.1.0")
-      .withAlternative("spark.blacklist.application.maxFailedTasksPerExecutor")
+      .alternative(("spark.blacklist.application.maxFailedTasksPerExecutor", "3.1.0"))
       .intConf
       .createWithDefault(2)
 
   private[spark] val MAX_FAILURES_PER_EXEC_STAGE =
     ConfigBuilder("spark.excludeOnFailure.stage.maxFailedTasksPerExecutor")
       .version("3.1.0")
-      .withAlternative("spark.blacklist.stage.maxFailedTasksPerExecutor")
+      .alternative(("spark.blacklist.stage.maxFailedTasksPerExecutor", "3.1.0"))
       .intConf
       .createWithDefault(2)
 
   private[spark] val MAX_FAILED_EXEC_PER_NODE =
     ConfigBuilder("spark.excludeOnFailure.application.maxFailedExecutorsPerNode")
       .version("3.1.0")
-      .withAlternative("spark.blacklist.application.maxFailedExecutorsPerNode")
+      .alternative(("spark.blacklist.application.maxFailedExecutorsPerNode", "3.1.0"))
       .intConf
       .createWithDefault(2)
 
   private[spark] val MAX_FAILED_EXEC_PER_NODE_STAGE =
     ConfigBuilder("spark.excludeOnFailure.stage.maxFailedExecutorsPerNode")
       .version("3.1.0")
-      .withAlternative("spark.blacklist.stage.maxFailedExecutorsPerNode")
+      .alternative(("spark.blacklist.stage.maxFailedExecutorsPerNode", "3.1.0"))
       .intConf
       .createWithDefault(2)
 
   private[spark] val EXCLUDE_ON_FAILURE_TIMEOUT_CONF =
     ConfigBuilder("spark.excludeOnFailure.timeout")
       .version("3.1.0")
-      .withAlternative("spark.blacklist.timeout")
+      .alternative(("spark.blacklist.timeout", "3.1.0"))
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
   private[spark] val EXCLUDE_ON_FAILURE_KILL_ENABLED =
     ConfigBuilder("spark.excludeOnFailure.killExcludedExecutors")
       .version("3.1.0")
-      .withAlternative("spark.blacklist.killBlacklistedExecutors")
+      .alternative(("spark.blacklist.killBlacklistedExecutors", "3.1.0"))
       .booleanConf
       .createWithDefault(false)
 
@@ -838,14 +850,14 @@ package object config {
     ConfigBuilder("spark.scheduler.executorTaskExcludeOnFailureTime")
       .internal()
       .version("3.1.0")
-      .withAlternative("spark.scheduler.executorTaskBlacklistTime")
+      .alternative(("spark.scheduler.executorTaskBlacklistTime", "2.1.0"))
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
   private[spark] val EXCLUDE_ON_FAILURE_FETCH_FAILURE_ENABLED =
     ConfigBuilder("spark.excludeOnFailure.application.fetchFailure.enabled")
       .version("3.1.0")
-      .withAlternative("spark.blacklist.application.fetchFailure.enabled")
+      .alternative(("spark.blacklist.application.fetchFailure.enabled", "3.1.0"))
       .booleanConf
       .createWithDefault(false)
 
@@ -865,6 +877,7 @@ package object config {
         ".eventqueue.queueName.capacity` first. If it's not configured, Spark will " +
         "use the default capacity specified by this config.")
       .version("2.3.0")
+      .alternative(("spark.scheduler.listenerbus.eventqueue.size", "2.3"))
       .intConf
       .checkValue(_ > 0, "The capacity of listener bus event queue must be positive")
       .createWithDefault(10000)
@@ -1191,6 +1204,9 @@ package object config {
         "For users who enabled external shuffle service, this feature can only work when " +
         "external shuffle service is at least 2.3.0.")
       .version("3.0.0")
+      .alternative(
+        ("spark.reducer.maxReqSizeShuffleToMem", "2.3"),
+        ("spark.maxRemoteBlockSizeFetchToMem", "3.0"))
       .bytesConf(ByteUnit.BYTE)
       // fetch-to-mem is guaranteed to fail if the message is bigger than 2 GB, so we might
       // as well use fetch-to-disk in that case.  The message includes some metadata in addition
@@ -1223,6 +1239,7 @@ package object config {
         "otherwise specified. These buffers reduce the number of disk seeks and system calls " +
         "made in creating intermediate shuffle files.")
       .version("1.4.0")
+      .alternative(("spark.shuffle.file.buffer.kb", "1.4"))
       .bytesConf(ByteUnit.KiB)
       .checkValue(v => v > 0 && v <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH / 1024,
         s"The file buffer size must be positive and less than or equal to" +
@@ -1516,7 +1533,7 @@ package object config {
         "before aborting a TaskSet which is unschedulable because all executors are " +
         "excluded due to failures.")
       .version("3.1.0")
-      .withAlternative("spark.scheduler.blacklist.unschedulableTaskSetTimeout")
+      .alternative(("spark.scheduler.blacklist.unschedulableTaskSetTimeout", "3.1.0"))
       .timeConf(TimeUnit.SECONDS)
       .checkValue(v => v >= 0, "The value should be a non negative time value.")
       .createWithDefault(120)
@@ -1630,6 +1647,7 @@ package object config {
   private[spark] val EXECUTOR_LOGS_ROLLING_MAX_SIZE =
     ConfigBuilder("spark.executor.logs.rolling.maxSize")
       .version("1.4.0")
+      .alternative(("spark.executor.logs.rolling.size.maxBytes", "1.4"))
       .stringConf
       .createWithDefault((1024 * 1024).toString)
 
@@ -1666,6 +1684,7 @@ package object config {
         "Snappy compression codec is used. Lowering this block size " +
         "will also lower shuffle memory usage when Snappy is used")
       .version("1.4.0")
+      .alternative(("spark.io.compression.snappy.block.size", "1.4"))
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("32k")
 
@@ -1675,6 +1694,7 @@ package object config {
         "codec is used. Lowering this block size will also lower shuffle memory " +
         "usage when LZ4 is used.")
       .version("1.4.0")
+      .alternative(("spark.io.compression.lz4.block.size", "1.4"))
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("32k")
 
@@ -1756,6 +1776,7 @@ package object config {
       "buffer to receive it, this represents a fixed memory overhead per reduce task, " +
       "so keep it small unless you have a large amount of memory")
     .version("1.4.0")
+    .alternative(("spark.reducer.maxMbInFlight", "1.4"))
     .bytesConf(ByteUnit.MiB)
     .createWithDefaultString("48m")
 

--- a/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
@@ -265,8 +265,8 @@ class ConfigEntrySuite extends SparkFunSuite {
   test("conf entry: alternative keys") {
     val conf = new SparkConf()
     val iConf = ConfigBuilder(testKey("a"))
-      .withAlternative(testKey("b"))
-      .withAlternative(testKey("c"))
+      .alternative((testKey("b"), "version"))
+      .alternative((testKey("c"), "version"))
       .intConf.createWithDefault(0)
 
     // no key is set, return default value.

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/package.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/package.scala
@@ -46,6 +46,7 @@ package object kafka010 {   // scalastyle:ignore
       .doc("The maximum number of consumers cached. Please note it's a soft limit" +
         " (check Structured Streaming Kafka integration guide for further details).")
       .version("3.0.0")
+      .alternative(("spark.sql.kafkaConsumerCache.capacity", "3.0"))
       .intConf
       .createWithDefault(64)
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -133,6 +133,7 @@ package object config extends Logging {
   private[spark] val SPARK_JARS = ConfigBuilder("spark.yarn.jars")
     .doc("Location of jars containing Spark classes.")
     .version("2.0.0")
+    .alternative(("spark.yarn.jar", "2.0"))
     .stringConf
     .toSequence
     .createOptional
@@ -202,6 +203,9 @@ package object config extends Logging {
 
   private[spark] val AM_MAX_WAIT_TIME = ConfigBuilder("spark.yarn.am.waitTime")
     .version("1.3.0")
+    .alternativeWithTranslation(("spark.yarn.applicationMaster.waitTries", "1.3",
+      // Translate old value to a duration, with 10s wait time per try.
+      s => s"${s.toLong * 10}s"))
     .timeConf(TimeUnit.MILLISECONDS)
     .createWithDefaultString("100s")
 
@@ -225,6 +229,7 @@ package object config extends Logging {
 
   private[spark] val MAX_EXECUTOR_FAILURES = ConfigBuilder("spark.yarn.max.executor.failures")
     .version("1.0.0")
+    .alternative(("spark.yarn.max.worker.failures", "1.5"))
     .intConf
     .createOptional
 
@@ -392,7 +397,7 @@ package object config extends Logging {
   private[spark] val YARN_EXECUTOR_LAUNCH_EXCLUDE_ON_FAILURE_ENABLED =
     ConfigBuilder("spark.yarn.executor.launch.excludeOnFailure.enabled")
       .version("3.1.0")
-      .withAlternative("spark.yarn.blacklist.executor.launch.blacklisting.enabled")
+      .alternative(("spark.yarn.blacklist.executor.launch.blacklisting.enabled", "3.1.0"))
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -31,7 +31,7 @@ import scala.util.matching.Regex
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{LegacyConfigsRegister, SparkConf, SparkContext, TaskContext}
-import org.apache.spark.SparkConf.{DeprecatedConfig, RemovedConfig}
+import org.apache.spark.SparkConf.DeprecatedConfig
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.{IGNORE_MISSING_FILES => SPARK_IGNORE_MISSING_FILES}
@@ -423,6 +423,7 @@ object SQLConf {
       .internal()
       .doc("(Deprecated since Spark 3.0)")
       .version("1.6.0")
+      .deprecated("3.0", s"Use '${ADVISORY_PARTITION_SIZE_IN_BYTES.key}' instead of it.")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("64MB")
 
@@ -846,6 +847,7 @@ object SQLConf {
          "when reading data stored in HDFS. This configuration will be deprecated in the future " +
          s"releases and replaced by ${SPARK_IGNORE_MISSING_FILES.key}.")
     .version("1.4.0")
+    .deprecated("3.0", s"This config is replaced by '${SPARK_IGNORE_MISSING_FILES.key}'.")
     .booleanConf
     .createWithDefault(false)
 
@@ -928,6 +930,9 @@ object SQLConf {
       "It will be removed in the future releases. If you must use, use 'SparkSessionExtensions' " +
       "instead to inject it as a custom rule.")
     .version("2.1.1")
+    .deprecated("3.0", "Avoid to depend on this optimization to " +
+      "prevent a potential correctness issue. If you must use, use 'SparkSessionExtensions' " +
+      "instead to inject it as a custom rule.")
     .booleanConf
     .createWithDefault(false)
 
@@ -1006,6 +1011,7 @@ object SQLConf {
       "without specifying any storage property will be converted to a data source table, " +
       s"using the data source set by ${DEFAULT_DATA_SOURCE_NAME.key}.")
     .version("2.0.0")
+    .deprecated("3.1", s"Set '${LEGACY_CREATE_HIVE_TABLE_BY_DEFAULT.key}' to false instead.")
     .booleanConf
     .createWithDefault(false)
 
@@ -2020,6 +2026,7 @@ object SQLConf {
     buildConf("spark.sql.execution.arrow.enabled")
       .doc("(Deprecated since Spark 3.0, please set 'spark.sql.execution.arrow.pyspark.enabled'.)")
       .version("2.3.0")
+      .deprecated("3.0", s"Use '${ARROW_PYSPARK_EXECUTION_ENABLED.key}' instead of it.")
       .booleanConf
       .createWithDefault(false)
 
@@ -2073,6 +2080,7 @@ object SQLConf {
       .doc("(Deprecated since Spark 3.0, please set " +
         "'spark.sql.execution.arrow.pyspark.fallback.enabled'.)")
       .version("2.4.0")
+      .deprecated("3.0", s"Use '${ARROW_PYSPARK_FALLBACK_ENABLED.key}' instead of it.")
       .booleanConf
       .createWithDefault(true)
 
@@ -2119,6 +2127,8 @@ object SQLConf {
         "the returned Pandas DataFrame based on position, regardless of column label type. " +
         "This configuration will be deprecated in future releases.")
       .version("2.4.1")
+      .deprecated("2.4", "The config allows to switch to the behaviour " +
+        "before Spark 2.4 and will be removed in the future releases.")
       .booleanConf
       .createWithDefault(true)
 
@@ -2510,6 +2520,8 @@ object SQLConf {
       .doc("If it is set to true, the data source provider com.databricks.spark.avro is mapped " +
         "to the built-in but external Avro data source module for backward compatibility.")
       .version("2.4.0")
+      .deprecated("3.2",
+       """Use `.format("avro")` in `DataFrameWriter` or `DataFrameReader` instead.""")
       .booleanConf
       .createWithDefault(true)
 
@@ -2875,7 +2887,7 @@ object SQLConf {
         "When EXCEPTION, which is the default, Spark will fail the writing if it sees ancient " +
         "timestamps that are ambiguous between the two calendars.")
       .version("3.1.0")
-      .withAlternative("spark.sql.legacy.parquet.int96RebaseModeInWrite")
+      .alternative(("spark.sql.legacy.parquet.int96RebaseModeInWrite", "3.2"))
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(LegacyBehaviorPolicy.values.map(_.toString))
@@ -2893,7 +2905,7 @@ object SQLConf {
         "TIMESTAMP_MILLIS, TIMESTAMP_MICROS. The INT96 type has the separate config: " +
         s"${PARQUET_INT96_REBASE_MODE_IN_WRITE.key}.")
       .version("3.0.0")
-      .withAlternative("spark.sql.legacy.parquet.datetimeRebaseModeInWrite")
+      .alternative(("spark.sql.legacy.parquet.datetimeRebaseModeInWrite", "3.2"))
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(LegacyBehaviorPolicy.values.map(_.toString))
@@ -2909,7 +2921,7 @@ object SQLConf {
         "timestamps that are ambiguous between the two calendars. This config is only effective " +
         "if the writer info (like Spark, Hive) of the Parquet files is unknown.")
       .version("3.1.0")
-      .withAlternative("spark.sql.legacy.parquet.int96RebaseModeInRead")
+      .alternative(("spark.sql.legacy.parquet.int96RebaseModeInRead", "3.2"))
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(LegacyBehaviorPolicy.values.map(_.toString))
@@ -2928,7 +2940,7 @@ object SQLConf {
         "TIMESTAMP_MILLIS, TIMESTAMP_MICROS. The INT96 type has the separate config: " +
         s"${PARQUET_INT96_REBASE_MODE_IN_READ.key}.")
       .version("3.0.0")
-      .withAlternative("spark.sql.legacy.parquet.datetimeRebaseModeInRead")
+      .alternative(("spark.sql.legacy.parquet.datetimeRebaseModeInRead", "3.2"))
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(LegacyBehaviorPolicy.values.map(_.toString))
@@ -2943,7 +2955,7 @@ object SQLConf {
         "When EXCEPTION, which is the default, Spark will fail the writing if it sees " +
         "ancient dates/timestamps that are ambiguous between the two calendars.")
       .version("3.0.0")
-      .withAlternative("spark.sql.legacy.avro.datetimeRebaseModeInWrite")
+      .alternative(("spark.sql.legacy.avro.datetimeRebaseModeInWrite", "3.2"))
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(LegacyBehaviorPolicy.values.map(_.toString))
@@ -2959,7 +2971,7 @@ object SQLConf {
         "ancient dates/timestamps that are ambiguous between the two calendars. This config is " +
         "only effective if the writer info (like Spark, Hive) of the Avro files is unknown.")
       .version("3.0.0")
-      .withAlternative("spark.sql.legacy.avro.datetimeRebaseModeInRead")
+      .alternative(("spark.sql.legacy.avro.datetimeRebaseModeInRead", "3.2"))
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
       .checkValues(LegacyBehaviorPolicy.values.map(_.toString))
@@ -3106,44 +3118,19 @@ object SQLConf {
    * in the user's configuration.
    */
   val deprecatedSQLConfigs: Map[String, DeprecatedConfig] = {
-    val configs = Seq(
-      DeprecatedConfig(
-        PANDAS_GROUPED_MAP_ASSIGN_COLUMNS_BY_NAME.key, "2.4",
-        "The config allows to switch to the behaviour before Spark 2.4 " +
-          "and will be removed in the future releases."),
-      DeprecatedConfig(HIVE_VERIFY_PARTITION_PATH.key, "3.0",
-        s"This config is replaced by '${SPARK_IGNORE_MISSING_FILES.key}'."),
-      DeprecatedConfig(ARROW_EXECUTION_ENABLED.key, "3.0",
-        s"Use '${ARROW_PYSPARK_EXECUTION_ENABLED.key}' instead of it."),
-      DeprecatedConfig(ARROW_FALLBACK_ENABLED.key, "3.0",
-        s"Use '${ARROW_PYSPARK_FALLBACK_ENABLED.key}' instead of it."),
-      DeprecatedConfig(SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE.key, "3.0",
-        s"Use '${ADVISORY_PARTITION_SIZE_IN_BYTES.key}' instead of it."),
-      DeprecatedConfig(OPTIMIZER_METADATA_ONLY.key, "3.0",
-        "Avoid to depend on this optimization to prevent a potential correctness issue. " +
-          "If you must use, use 'SparkSessionExtensions' instead to inject it as a custom rule."),
-      DeprecatedConfig(CONVERT_CTAS.key, "3.1",
-        s"Set '${LEGACY_CREATE_HIVE_TABLE_BY_DEFAULT.key}' to false instead."),
-      DeprecatedConfig("spark.sql.sources.schemaStringLengthThreshold", "3.2",
-        s"Use '${HIVE_TABLE_PROPERTY_LENGTH_THRESHOLD.key}' instead."),
-      DeprecatedConfig(PARQUET_INT96_REBASE_MODE_IN_WRITE.alternatives.head, "3.2",
-        s"Use '${PARQUET_INT96_REBASE_MODE_IN_WRITE.key}' instead."),
-      DeprecatedConfig(PARQUET_INT96_REBASE_MODE_IN_READ.alternatives.head, "3.2",
-        s"Use '${PARQUET_INT96_REBASE_MODE_IN_READ.key}' instead."),
-      DeprecatedConfig(PARQUET_REBASE_MODE_IN_WRITE.alternatives.head, "3.2",
-        s"Use '${PARQUET_REBASE_MODE_IN_WRITE.key}' instead."),
-      DeprecatedConfig(PARQUET_REBASE_MODE_IN_READ.alternatives.head, "3.2",
-        s"Use '${PARQUET_REBASE_MODE_IN_READ.key}' instead."),
-      DeprecatedConfig(AVRO_REBASE_MODE_IN_WRITE.alternatives.head, "3.2",
-        s"Use '${AVRO_REBASE_MODE_IN_WRITE.key}' instead."),
-      DeprecatedConfig(AVRO_REBASE_MODE_IN_READ.alternatives.head, "3.2",
-        s"Use '${AVRO_REBASE_MODE_IN_READ.key}' instead."),
-      DeprecatedConfig(LEGACY_REPLACE_DATABRICKS_SPARK_AVRO_ENABLED.key, "3.2",
-        """Use `.format("avro")` in `DataFrameWriter` or `DataFrameReader` instead.""")
-    ) ++ LegacyConfigsRegister.deprecateConfigs
-
-    Map(configs.map { cfg => cfg.key -> cfg } : _*)
+    Map(LegacyConfigsRegister.deprecateConfigs.map { cfg => cfg.key -> cfg } : _*)
   }
+
+  /**
+   * Holds information about keys that have been removed.
+   *
+   * @param key The removed config key.
+   * @param version Version of Spark where key was removed.
+   * @param defaultValue The default config value. It can be used to notice
+   *                     users that they set non-default value to an already removed config.
+   * @param comment Additional info regarding to the removed config.
+   */
+  case class RemovedConfig(key: String, version: String, defaultValue: String, comment: String)
 
   /**
    * The map contains info about removed SQL configs. Keys are SQL config names,
@@ -3175,7 +3162,7 @@ object SQLConf {
         s"Please use `${PLAN_CHANGE_LOG_RULES.key}` instead."),
       RemovedConfig("spark.sql.optimizer.planChangeLog.batches", "3.1.0", "",
         s"Please use `${PLAN_CHANGE_LOG_BATCHES.key}` instead.")
-    ) ++ LegacyConfigsRegister.removedConfigs
+    )
 
     Map(configs.map { cfg => cfg.key -> cfg } : _*)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -66,6 +66,7 @@ object StaticSQLConf {
       .doc("The maximum length allowed in a single cell when " +
         "storing additional schema information in Hive's metastore.")
       .version("1.3.1")
+      .deprecated("3.2", s"Use '${SQLConf.HIVE_TABLE_PROPERTY_LENGTH_THRESHOLD.key}' instead.")
       .intConf
       .createWithDefault(4000)
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingConf.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingConf.scala
@@ -185,4 +185,10 @@ object StreamingConf {
       .longConf
       .createWithDefault(0)
 
+  private[streaming] val FILE_STREAM_MIN_REMEMBER_DURATION =
+    ConfigBuilder("spark.streaming.fileStream.minRememberDuration")
+      .version("1.5.0")
+      .alternative(("spark.streaming.minRememberDuration", "1.5"))
+      .timeConf(TimeUnit.SECONDS)
+      .createWithDefaultString("60s")
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -89,10 +89,7 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
    * Files with mod times older than this "window" of remembering will be ignored. So if new
    * files are visible within this window, then the file will get selected in the next batch.
    */
-  private val minRememberDurationS = {
-    Seconds(ssc.conf.getTimeAsSeconds("spark.streaming.fileStream.minRememberDuration",
-      ssc.conf.get("spark.streaming.minRememberDuration", "60s")))
-  }
+  private val minRememberDurationS = ssc.conf.get(StreamingConf.FILE_STREAM_MIN_REMEMBER_DURATION)
 
   // This is a def so that it works during checkpoint recovery:
   private def clock = ssc.scheduler.clock


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This pr proposes to add `deprecated()`/ `removed()` / `alternated()` functions to `ConfigBuilder` in order to provide more convenient ways to do these stuff.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, Spark maintains the active configs and deprecated/alternated/removed configs separately,
which is not convenient when developers want to deprecate configs and not good to maintain for the long term.

After this PR, developers can deprecate/alternate/remove a config like this:

```scala
val SOME_CONFIG =
  buildConf("spark.xxx.yyy.zzz")
    .doc(".....")")
    .version("2.3.0")
    .deprecated("3.0", "because...")
    // .removed("3.0", "because...")
    // .alternated(("3.0", "spark.aaa.bbb.ccc"))
    .booleanConf
    .createWithDefault(false)
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Manually tested.
