### PR TITLE
[SPARK-34572][DOCS][BUILD] Remove invalid reference to make the checks run successfully

### DIFF
--- a/docs/ml-tuning.md
+++ b/docs/ml-tuning.md
@@ -97,16 +97,6 @@ Refer to the [`ParamRandomBuilder` Java docs](api/java/org/apache/spark/ml/tunin
 {% include_example java/org/apache/spark/examples/ml/JavaModelSelectionViaRandomHyperparametersExample.java %}
 </div>
 
-<div data-lang="python" markdown="1">
-
-Python users are recommended to look at Python libraries that are specifically for hyperparameter tuning such as Hyperopt.  
-
-Refer to the [`ParamRandomBuilder` Java docs](api/python/reference/api/pyspark.ml.tuning.ParamRandomBuilder.html) for details on the API.
-
-{% include_example python/ml/model_selection_random_hyperparameters_example.py %}
-
-</div>
-
 </div>
 
 # Cross-Validation


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
An Invalid reference to the model_selection_random_hyperparameters_example.py was added in  [commit](https://github.com/apache/spark/commit/397b843890db974a0534394b1907d33d62c2b888#diff-02f10976f2f83e219445cd4860a2999f45dc254b173f1ffefb323d8fe1d1c817R100-R108) which is causing the (Linters, licenses, dependencies and documentation generation) checks to fail. I am proposing to remove this reference so that builds can run successfully. 


### Why are the changes needed?
Because the (Linters, licenses, dependencies and documentation generation) check has been failing because of the invalid reference.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
I tested this manually using the following.
```bash
cd docs
SKIP_API=1 jekyll build
open _site/index.html
```
