### PR TITLE
[SPARK-34503][DOCS][FOLLOWUP] Document available codecs for event log compression

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1042,7 +1042,13 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.eventLog.compression.codec</code></td>
   <td>zstd</td>
   <td>
-    The codec to compress logged events.
+    The codec to compress logged events. By default, Spark provides four codecs:
+    <code>lz4</code>, <code>lzf</code>, <code>snappy</code>, and <code>zstd</code>.
+    You can also use fully qualified class names to specify the codec, e.g.
+    <code>org.apache.spark.io.LZ4CompressionCodec</code>,
+    <code>org.apache.spark.io.LZFCompressionCodec</code>,
+    <code>org.apache.spark.io.SnappyCompressionCodec</code>,
+    and <code>org.apache.spark.io.ZStdCompressionCodec</code>.
   </td>
   <td>3.0.0</td>
 </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of https://github.com/apache/spark/pull/31618 to document the available codecs for event log compression.

### Why are the changes needed?

Documentation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.