### PR TITLE
[SPARK-34587][CORE][SQL][DSTREAM][SS][3.0] Replaces map and getOrElse(false/true) with exists/forall

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManager.scala
@@ -298,9 +298,7 @@ private[spark] object HadoopDelegationTokenManager extends Logging {
 
     val isEnabledDeprecated = deprecatedProviderEnabledConfigs.forall { pattern =>
       sparkConf
-        .getOption(pattern.format(serviceName))
-        .map(_.toBoolean)
-        .getOrElse(true)
+        .getOption(pattern.format(serviceName)).forall(_.toBoolean)
     }
 
     sparkConf

--- a/core/src/main/scala/org/apache/spark/storage/RDDInfo.scala
+++ b/core/src/main/scala/org/apache/spark/storage/RDDInfo.scala
@@ -60,8 +60,7 @@ private[spark] object RDDInfo {
     val rddName = Option(rdd.name).getOrElse(Utils.getFormattedClassName(rdd))
     val parentIds = rdd.dependencies.map(_.rdd.id)
     val callsiteLongForm = Option(SparkEnv.get)
-      .map(_.conf.get(EVENT_LOG_CALLSITE_LONG_FORM))
-      .getOrElse(false)
+      .exists(_.conf.get(EVENT_LOG_CALLSITE_LONG_FORM))
 
     val callSite = if (callsiteLongForm) {
       rdd.creationSite.longForm

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -48,7 +48,7 @@ private[spark] class SparkUI private (
   with Logging
   with UIRoot {
 
-  val killEnabled = sc.map(_.conf.get(UI_KILL_ENABLED)).getOrElse(false)
+  val killEnabled = sc.exists(_.conf.get(UI_KILL_ENABLED))
 
   var appId: String = _
 
@@ -66,7 +66,7 @@ private[spark] class SparkUI private (
     addStaticHandler(SparkUI.STATIC_RESOURCE_DIR)
     attachHandler(createRedirectHandler("/", "/jobs/", basePath = basePath))
     attachHandler(ApiRootResource.getServletHandler(this))
-    if (sc.map(_.conf.get(UI_PROMETHEUS_ENABLED)).getOrElse(false)) {
+    if (sc.exists(_.conf.get(UI_PROMETHEUS_ENABLED))) {
       attachHandler(PrometheusResource.getServletHandler(this))
     }
 

--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -155,7 +155,7 @@ private[spark] abstract class WebUI(
   }
 
   /** @return Whether SSL enabled. Only valid after [[bind]]. */
-  def isSecure: Boolean = serverInfo.map(_.securePort.isDefined).getOrElse(false)
+  def isSecure: Boolean = serverInfo.exists(_.securePort.isDefined)
 
   /** @return The scheme of web interface. Only valid after [[bind]]. */
   def scheme: String = if (isSecure) "https://" else "http://"

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -101,7 +101,7 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
     val taskSortColumn = Option(parameterTaskSortColumn).map { sortColumn =>
       UIUtils.decodeURLParameter(sortColumn)
     }.getOrElse("Index")
-    val taskSortDesc = Option(parameterTaskSortDesc).map(_.toBoolean).getOrElse(false)
+    val taskSortDesc = Option(parameterTaskSortDesc).exists(_.toBoolean)
     val taskPageSize = Option(parameterTaskPageSize).map(_.toInt).getOrElse(100)
     val stageId = parameterId.toInt
     val stageAttemptId = parameterAttempt.toInt

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -1084,7 +1084,7 @@ private[spark] object JsonProtocol {
       .map { l => l.extract[List[JValue]].map(_.extract[Int]) }
       .getOrElse(Seq.empty)
     val storageLevel = storageLevelFromJson(json \ "Storage Level")
-    val isBarrier = jsonOption(json \ "Barrier").map(_.extract[Boolean]).getOrElse(false)
+    val isBarrier = jsonOption(json \ "Barrier").exists(_.extract[Boolean])
     val numPartitions = (json \ "Number of Partitions").extract[Int]
     val numCachedPartitions = (json \ "Number of Cached Partitions").extract[Int]
     val memSize = (json \ "Memory Size").extract[Long]

--- a/repl/src/main/scala/org/apache/spark/repl/Signaling.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/Signaling.scala
@@ -29,7 +29,7 @@ private[repl] object Signaling extends Logging {
    * This makes it possible to interrupt a running shell job by pressing Ctrl+C.
    */
   def cancelOnInterrupt(): Unit = SignalUtils.register("INT") {
-    SparkContext.getActive.map { ctx =>
+    SparkContext.getActive.exists { ctx =>
       if (!ctx.statusTracker.getActiveJobIds().isEmpty) {
         logWarning("Cancelling all active jobs, this can take a while. " +
           "Press Ctrl+C again to exit now.")
@@ -38,7 +38,7 @@ private[repl] object Signaling extends Logging {
       } else {
         false
       }
-    }.getOrElse(false)
+    }
   }
 
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -156,7 +156,7 @@ class CSVOptions(
       s"${DateFormatter.defaultPattern}'T'HH:mm:ss[.SSS][XXX]"
     })
 
-  val multiLine = parameters.get("multiLine").map(_.toBoolean).getOrElse(false)
+  val multiLine = parameters.get("multiLine").exists(_.toBoolean)
 
   val maxColumns = getInt("maxColumns", 20480)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -133,7 +133,7 @@ case class CaseWhen(
 
   override def nullable: Boolean = {
     // Result is nullable if any of the branch is nullable, or if the else value is nullable
-    branches.exists(_._2.nullable) || elseValue.map(_.nullable).getOrElse(true)
+    branches.exists(_._2.nullable) || elseValue.forall(_.nullable)
   }
 
   override def checkInputDataTypes(): TypeCheckResult = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -53,23 +53,23 @@ private[sql] class JSONOptions(
   val samplingRatio =
     parameters.get("samplingRatio").map(_.toDouble).getOrElse(1.0)
   val primitivesAsString =
-    parameters.get("primitivesAsString").map(_.toBoolean).getOrElse(false)
+    parameters.get("primitivesAsString").exists(_.toBoolean)
   val prefersDecimal =
-    parameters.get("prefersDecimal").map(_.toBoolean).getOrElse(false)
+    parameters.get("prefersDecimal").exists(_.toBoolean)
   val allowComments =
-    parameters.get("allowComments").map(_.toBoolean).getOrElse(false)
+    parameters.get("allowComments").exists(_.toBoolean)
   val allowUnquotedFieldNames =
-    parameters.get("allowUnquotedFieldNames").map(_.toBoolean).getOrElse(false)
+    parameters.get("allowUnquotedFieldNames").exists(_.toBoolean)
   val allowSingleQuotes =
-    parameters.get("allowSingleQuotes").map(_.toBoolean).getOrElse(true)
+    parameters.get("allowSingleQuotes").forall(_.toBoolean)
   val allowNumericLeadingZeros =
-    parameters.get("allowNumericLeadingZeros").map(_.toBoolean).getOrElse(false)
+    parameters.get("allowNumericLeadingZeros").exists(_.toBoolean)
   val allowNonNumericNumbers =
-    parameters.get("allowNonNumericNumbers").map(_.toBoolean).getOrElse(true)
+    parameters.get("allowNonNumericNumbers").forall(_.toBoolean)
   val allowBackslashEscapingAnyCharacter =
-    parameters.get("allowBackslashEscapingAnyCharacter").map(_.toBoolean).getOrElse(false)
+    parameters.get("allowBackslashEscapingAnyCharacter").exists(_.toBoolean)
   private val allowUnquotedControlChars =
-    parameters.get("allowUnquotedControlChars").map(_.toBoolean).getOrElse(false)
+    parameters.get("allowUnquotedControlChars").exists(_.toBoolean)
   val compressionCodec = parameters.get("compression").map(CompressionCodecs.getCodecClassName)
   val parseMode: ParseMode =
     parameters.get("mode").map(ParseMode.fromString).getOrElse(PermissiveMode)
@@ -77,7 +77,7 @@ private[sql] class JSONOptions(
     parameters.getOrElse("columnNameOfCorruptRecord", defaultColumnNameOfCorruptRecord)
 
   // Whether to ignore column of all null values or empty array/struct during schema inference
-  val dropFieldIfAllNull = parameters.get("dropFieldIfAllNull").map(_.toBoolean).getOrElse(false)
+  val dropFieldIfAllNull = parameters.get("dropFieldIfAllNull").exists(_.toBoolean)
 
   // Whether to ignore null fields during json generating
   val ignoreNullFields = parameters.get("ignoreNullFields").map(_.toBoolean)
@@ -98,7 +98,7 @@ private[sql] class JSONOptions(
       s"${DateFormatter.defaultPattern}'T'HH:mm:ss[.SSS][XXX]"
     })
 
-  val multiLine = parameters.get("multiLine").map(_.toBoolean).getOrElse(false)
+  val multiLine = parameters.get("multiLine").exists(_.toBoolean)
 
   /**
    * A string between two consecutive JSON records.
@@ -127,13 +127,13 @@ private[sql] class JSONOptions(
   /**
    * Generating JSON strings in pretty representation if the parameter is enabled.
    */
-  val pretty: Boolean = parameters.get("pretty").map(_.toBoolean).getOrElse(false)
+  val pretty: Boolean = parameters.get("pretty").exists(_.toBoolean)
 
   /**
    * Enables inferring of TimestampType from strings matched to the timestamp pattern
    * defined by the timestampFormat option.
    */
-  val inferTimestamp: Boolean = parameters.get("inferTimestamp").map(_.toBoolean).getOrElse(false)
+  val inferTimestamp: Boolean = parameters.get("inferTimestamp").exists(_.toBoolean)
 
   /** Build a Jackson [[JsonFactory]] using JSON options. */
   def buildJsonFactory(): JsonFactory = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -41,7 +41,7 @@ object EstimationUtils {
    *  in the corresponding statistic. */
   def columnStatsWithCountsExist(statsAndAttr: (Statistics, Attribute)*): Boolean = {
     statsAndAttr.forall { case (stats, attr) =>
-      stats.attributeStats.get(attr).map(_.hasCountStats).getOrElse(false)
+      stats.attributeStats.get(attr).exists(_.hasCountStats)
     }
   }
 
@@ -89,7 +89,7 @@ object EstimationUtils {
     // We assign a generic overhead for a Row object, the actual overhead is different for different
     // Row format.
     8 + attributes.map { attr =>
-      if (attrStats.get(attr).map(_.avgLen.isDefined).getOrElse(false)) {
+      if (attrStats.get(attr).exists(_.avgLen.isDefined)) {
         attr.dataType match {
           case StringType =>
             // UTF8String: base + offset + numBytes

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/JoinEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/JoinEstimation.scala
@@ -86,7 +86,7 @@ case class JoinEstimation(join: Join) extends Logging {
       val inputAttrStats = AttributeMap(
         leftStats.attributeStats.toSeq ++ rightStats.attributeStats.toSeq)
       val attributesWithStat = join.output.filter(a =>
-        inputAttrStats.get(a).map(_.hasCountStats).getOrElse(false))
+        inputAttrStats.get(a).exists(_.hasCountStats))
       val (fromLeft, fromRight) = attributesWithStat.partition(join.left.outputSet.contains(_))
 
       val outputStats: Seq[(Attribute, ColumnStat)] = if (outputRows == 0) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -121,9 +121,7 @@ case class DataSource(
    * Whether or not paths should be globbed before being used to access files.
    */
   def globPaths: Boolean = {
-    options.get(DataSource.GLOB_PATHS_KEY)
-      .map(_ == "true")
-      .getOrElse(true)
+    options.get(DataSource.GLOB_PATHS_KEY).forall(_ == "true")
   }
 
   bucketSpec.map { bucket =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
@@ -145,7 +145,7 @@ abstract class FileTable(
    */
   private def globPaths: Boolean = {
     val entry = options.get(DataSource.GLOB_PATHS_KEY)
-    Option(entry).map(_ == "true").getOrElse(true)
+    Option(entry).forall(_ == "true")
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowNamespacesExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowNamespacesExec.scala
@@ -47,7 +47,7 @@ case class ShowNamespacesExec(
     val toRow = RowEncoder(schema).resolveAndBind().createSerializer()
 
     namespaces.map(_.quoted).map { ns =>
-      if (pattern.map(StringUtils.filterPattern(Seq(ns), _).nonEmpty).getOrElse(true)) {
+      if (pattern.forall(StringUtils.filterPattern(Seq(ns), _).nonEmpty)) {
         rows += toRow(new GenericRowWithSchema(Array(ns), schema)).copy()
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExec.scala
@@ -41,7 +41,7 @@ case class ShowTablesExec(
 
     val tables = catalog.listTables(namespace.toArray)
     tables.map { table =>
-      if (pattern.map(StringUtils.filterPattern(Seq(table.name()), _).nonEmpty).getOrElse(true)) {
+      if (pattern.forall(StringUtils.filterPattern(Seq(table.name()), _).nonEmpty)) {
         val result = new GenericRowWithSchema(
           Array(table.namespace().quoted, table.name()),
           schema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -351,8 +351,8 @@ class MicroBatchExecution(
   private def isNewDataAvailable: Boolean = {
     availableOffsets.exists {
       case (source, available) =>
-        committedOffsets
-          .get(source).forall(committed => committed != available)
+        !committedOffsets
+          .get(source).contains(available)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -351,8 +351,8 @@ class MicroBatchExecution(
   private def isNewDataAvailable: Boolean = {
     availableOffsets.exists {
       case (source, available) =>
-        !committedOffsets
-          .get(source).contains(available)
+        committedOffsets
+          .get(source).forall(committed => committed != available)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/console.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/console.scala
@@ -53,7 +53,7 @@ class ConsoleSinkProvider extends SimpleTableProvider
     val numRowsToShow = parameters.get("numRows").map(_.toInt).getOrElse(20)
 
     // Truncate the displayed data if it is too long, by default it is true
-    val isTruncated = parameters.get("truncate").map(_.toBoolean).getOrElse(true)
+    val isTruncated = parameters.get("truncate").forall(_.toBoolean)
     data.show(numRowsToShow, isTruncated)
 
     ConsoleRelation(sqlContext, data)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -458,7 +458,7 @@ object StateStore extends Logging {
     if (SparkEnv.get != null) {
       val executorId = SparkEnv.get.blockManager.blockManagerId.executorId
       val verified =
-        coordinatorRef.map(_.verifyIfInstanceActive(storeProviderId, executorId)).getOrElse(false)
+        coordinatorRef.exists(_.verifyIfInstanceActive(storeProviderId, executorId))
       logDebug(s"Verified whether the loaded instance $storeProviderId is active: $verified")
       verified
     } else {

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -956,8 +956,8 @@ class CheckpointSuite extends TestSuiteBase with LocalStreamingContext with DStr
         }
 
         shouldCheckpointAllMarkedRDDs =
-          Option(rdd.sparkContext.getLocalProperty(RDD.CHECKPOINT_ALL_MARKED_ANCESTORS)).
-            map(_.toBoolean).getOrElse(false)
+          Option(rdd.sparkContext.getLocalProperty(RDD.CHECKPOINT_ALL_MARKED_ANCESTORS))
+            .exists(_.toBoolean)
 
         val stateRDDs = findAllMarkedRDDs(rdd)
         rdd.count()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replaces `map and getOrElse(false/true)` with `exists/forall`, it's semantically consistent, but looks simpler.

**Before**

```
option.map(booleanFunc).getOrElse(false)
option.map(booleanFunc).getOrElse(true)
```

**After**

```
option.exists(booleanFunc)
option.forall(booleanFunc)
```

### Why are the changes needed?
Code Simpilefications.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the Jenkins or GitHub Action