### PR TITLE
[SPARK-34589][CORE] Make BypassMergeSortShuffleWriter close partitionWriters in case of success

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -267,6 +267,12 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
         if (mapStatus == null) {
           throw new IllegalStateException("Cannot call stop(true) without having called write()");
         }
+        if (partitionWriters != null) {
+          // Safely close files because it's stopped.
+          for (DiskBlockObjectWriter writer : partitionWriters) {
+            writer.close();
+          }
+        }
         return Option.apply(mapStatus);
       } else {
         // The map task failed, so delete our output data.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to close `partitionWriters` when `BypassMergeSortShuffleWriter.stop` with success.

### Why are the changes needed?

In case of failure, we call `writer.revertPartialWritesAndClose` and delete the files.
Likewise, we had better close the resources at this level.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the existing UTs.