### PR TITLE
[SPARK-34592][WebUI] Mark indeterminate RDD in Web UI

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.css
@@ -96,6 +96,12 @@
   stroke-width: 2px;
 }
 
+#dag-viz-graph svg.job g.node.indeterminate circle {
+  fill: #f6b187;
+  stroke: #D97536;
+  stroke-width: 2px;
+}
+
 /* Stage page specific styles */
 
 #dag-viz-graph svg.stage g.cluster rect {
@@ -133,6 +139,12 @@
 #dag-viz-graph svg.stage g.cluster.barrier rect {
   fill: #84E9E2;
   stroke: #32DBC6;
+  stroke-width: 2px;
+}
+
+#dag-viz-graph svg.stage g.node.indeterminate rect {
+  fill: #F09c67;
+  stroke: #D97536;
   stroke-width: 2px;
 }
 

--- a/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
@@ -180,6 +180,12 @@ function renderDagViz(forJob) {
     svg.selectAll("g[id=" + stageClusterId + "] g." + opClusterId).classed("barrier", true)
   });
 
+  metadataContainer().selectAll(".indeterminate-rdd").each(function(v) {
+    var rddId = d3.select(this).text().trim();
+    var nodeId = VizConstants.nodePrefix + rddId;
+    svg.selectAll("g." + nodeId).classed("indeterminate", true);
+  });
+
   resizeSvg(svg);
   interpretLineBreak(svg);
 }

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -2016,13 +2016,13 @@ abstract class RDD[T: ClassTag](
    * Returns the deterministic level of this RDD's output. Please refer to [[DeterministicLevel]]
    * for the definition.
    *
-   *l By default, an reliably checkpointed RDD, or RDD without parents(root RDD) is DETERMINATE. For
+   * By default, an reliably checkpointed RDD, or RDD without parents(root RDD) is DETERMINATE. For
    * RDDs with parents, we will generate a deterministic level candidate per parent according to
    * the dependency. The deterministic level of the current RDD is the deterministic level
    * candidate that is deterministic least. Please override [[getOutputDeterministicLevel]] to
    * provide custom logic of calculating output deterministic level.
    */
-  // TODO: make it public so users can set deterministic level to their custom RDDs.
+  // TODO(SPARK-34612): make it public so users can set deterministic level to their custom RDDs.
   // TODO: this can be per-partition. e.g. UnionRDD can have different deterministic level for
   // different partitions.
   private[spark] final def outputDeterministicLevel: DeterministicLevel.Value = {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -2022,7 +2022,7 @@ abstract class RDD[T: ClassTag](
   // TODO: make it public so users can set deterministic level to their custom RDDs.
   // TODO: this can be per-partition. e.g. UnionRDD can have different deterministic level for
   // different partitions.
-  private[spark] final lazy val outputDeterministicLevel: DeterministicLevel.Value = {
+  private[spark] final def outputDeterministicLevel: DeterministicLevel.Value = {
     if (isReliablyCheckpointed) {
       DeterministicLevel.DETERMINATE
     } else {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -2009,6 +2009,9 @@ abstract class RDD[T: ClassTag](
   @transient protected lazy val isBarrier_ : Boolean =
     dependencies.filter(!_.isInstanceOf[ShuffleDependency[_, _, _]]).exists(_.rdd.isBarrier())
 
+  private final lazy val _outputDeterministicLevel: DeterministicLevel.Value =
+    getOutputDeterministicLevel
+
   /**
    * Returns the deterministic level of this RDD's output. Please refer to [[DeterministicLevel]]
    * for the definition.
@@ -2026,7 +2029,7 @@ abstract class RDD[T: ClassTag](
     if (isReliablyCheckpointed) {
       DeterministicLevel.DETERMINATE
     } else {
-      getOutputDeterministicLevel
+      _outputDeterministicLevel
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -2013,7 +2013,7 @@ abstract class RDD[T: ClassTag](
    * Returns the deterministic level of this RDD's output. Please refer to [[DeterministicLevel]]
    * for the definition.
    *
-   * By default, an reliably checkpointed RDD, or RDD without parents(root RDD) is DETERMINATE. For
+   *l By default, an reliably checkpointed RDD, or RDD without parents(root RDD) is DETERMINATE. For
    * RDDs with parents, we will generate a deterministic level candidate per parent according to
    * the dependency. The deterministic level of the current RDD is the deterministic level
    * candidate that is deterministic least. Please override [[getOutputDeterministicLevel]] to

--- a/core/src/main/scala/org/apache/spark/storage/RDDInfo.scala
+++ b/core/src/main/scala/org/apache/spark/storage/RDDInfo.scala
@@ -20,7 +20,7 @@ package org.apache.spark.storage
 import org.apache.spark.SparkEnv
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.config._
-import org.apache.spark.rdd.{RDD, RDDOperationScope}
+import org.apache.spark.rdd.{DeterministicLevel, RDD, RDDOperationScope}
 import org.apache.spark.util.Utils
 
 @DeveloperApi
@@ -32,7 +32,8 @@ class RDDInfo(
     val isBarrier: Boolean,
     val parentIds: Seq[Int],
     val callSite: String = "",
-    val scope: Option[RDDOperationScope] = None)
+    val scope: Option[RDDOperationScope] = None,
+    val outputDeterministicLevel: DeterministicLevel.Value = DeterministicLevel.DETERMINATE)
   extends Ordered[RDDInfo] {
 
   var numCachedPartitions = 0
@@ -68,6 +69,7 @@ private[spark] object RDDInfo {
       rdd.creationSite.shortForm
     }
     new RDDInfo(rdd.id, rddName, rdd.partitions.length,
-      rdd.getStorageLevel, rdd.isBarrier(), parentIds, callSite, rdd.scope)
+      rdd.getStorageLevel, rdd.isBarrier(), parentIds, callSite, rdd.scope,
+      rdd.outputDeterministicLevel)
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -506,7 +506,6 @@ private[spark] object UIUtils extends Logging {
         <a data-toggle="tooltip" title={if (forJob) ToolTips.JOB_DAG else ToolTips.STAGE_DAG}
            data-placement="top">
           DAG Visualization
-
         </a>
       </span>
       <div id="dag-viz-graph"></div>

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -506,6 +506,7 @@ private[spark] object UIUtils extends Logging {
         <a data-toggle="tooltip" title={if (forJob) ToolTips.JOB_DAG else ToolTips.STAGE_DAG}
            data-placement="top">
           DAG Visualization
+
         </a>
       </span>
       <div id="dag-viz-graph"></div>
@@ -524,6 +525,9 @@ private[spark] object UIUtils extends Logging {
                 } ++
                 g.rootCluster.getBarrierClusters.map { c =>
                   <div class="barrier-rdd">{c.id}</div>
+                } ++
+                g.rootCluster.getIndeterminateNodes.map { n =>
+                  <div class="indeterminate-rdd">{n.id}</div>
                 }
               }
             </div>

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -26,6 +26,7 @@ import scala.xml.Utility
 import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.DeterministicLevel
 import org.apache.spark.scheduler.StageInfo
 import org.apache.spark.storage.StorageLevel
 
@@ -48,7 +49,8 @@ private[spark] case class RDDOperationNode(
     name: String,
     cached: Boolean,
     barrier: Boolean,
-    callsite: String)
+    callsite: String,
+    outputDeterministicLevel: DeterministicLevel.Value)
 
 /**
  * A directed edge connecting two nodes in an RDDOperationGraph.
@@ -86,6 +88,11 @@ private[spark] class RDDOperationCluster(
 
   def getBarrierClusters: Seq[RDDOperationCluster] = {
     (_childClusters.filter(_.barrier) ++ _childClusters.flatMap(_.getBarrierClusters)).toSeq
+  }
+
+  def getIndeterminateNodes: Seq[RDDOperationNode] = {
+    (_childNodes.filter(_.outputDeterministicLevel == DeterministicLevel.INDETERMINATE) ++
+      _childClusters.flatMap(_.getIndeterminateNodes)).toSeq
   }
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[RDDOperationCluster]
@@ -156,7 +163,8 @@ private[spark] object RDDOperationGraph extends Logging {
 
       // TODO: differentiate between the intention to cache an RDD and whether it's actually cached
       val node = nodes.getOrElseUpdate(rdd.id, RDDOperationNode(
-        rdd.id, rdd.name, rdd.storageLevel != StorageLevel.NONE, rdd.isBarrier, rdd.callSite))
+        rdd.id, rdd.name, rdd.storageLevel != StorageLevel.NONE, rdd.isBarrier, rdd.callSite,
+        rdd.outputDeterministicLevel))
       if (rdd.scope.isEmpty) {
         // This RDD has no encompassing scope, so we put it directly in the root cluster
         // This should happen only if an RDD is instantiated outside of a public RDD API
@@ -246,8 +254,14 @@ private[spark] object RDDOperationGraph extends Logging {
     } else {
       ""
     }
+    val outputDeterministicLevel = node.outputDeterministicLevel match {
+      case DeterministicLevel.DETERMINATE => ""
+      case DeterministicLevel.INDETERMINATE => " [indeterminate]"
+      case DeterministicLevel.UNORDERED => " [unordered]"
+    }
     val escapedCallsite = Utility.escape(node.callsite)
-    val label = s"${node.name} [${node.id}]$isCached$isBarrier<br>${escapedCallsite}"
+    val label = s"${node.name} [${node.id}]$isCached$isBarrier$outputDeterministicLevel" +
+      s"<br>${escapedCallsite}"
     s"""${node.id} [labelType="html" label="${StringEscapeUtils.escapeJava(label)}"]"""
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -256,8 +256,8 @@ private[spark] object RDDOperationGraph extends Logging {
     }
     val outputDeterministicLevel = node.outputDeterministicLevel match {
       case DeterministicLevel.DETERMINATE => ""
-      case DeterministicLevel.INDETERMINATE => " [indeterminate]"
-      case DeterministicLevel.UNORDERED => " [unordered]"
+      case DeterministicLevel.INDETERMINATE => " [Indeterminate]"
+      case DeterministicLevel.UNORDERED => " [Unordered]"
     }
     val escapedCallsite = Utility.escape(node.callsite)
     val label = s"${node.name} [${node.id}]$isCached$isBarrier$outputDeterministicLevel" +

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -32,7 +32,7 @@ import org.json4s.jackson.JsonMethods._
 import org.apache.spark._
 import org.apache.spark.executor._
 import org.apache.spark.metrics.ExecutorMetricType
-import org.apache.spark.rdd.RDDOperationScope
+import org.apache.spark.rdd.{DeterministicLevel, RDDOperationScope}
 import org.apache.spark.resource.{ExecutorResourceRequest, ResourceInformation, ResourceProfile, TaskResourceRequest}
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.ExecutorInfo
@@ -498,6 +498,7 @@ private[spark] object JsonProtocol {
     ("Parent IDs" -> parentIds) ~
     ("Storage Level" -> storageLevel) ~
     ("Barrier" -> rddInfo.isBarrier) ~
+    ("DeterministicLevel" -> rddInfo.outputDeterministicLevel.toString) ~
     ("Number of Partitions" -> rddInfo.numPartitions) ~
     ("Number of Cached Partitions" -> rddInfo.numCachedPartitions) ~
     ("Memory Size" -> rddInfo.memSize) ~
@@ -1175,8 +1176,12 @@ private[spark] object JsonProtocol {
     val memSize = (json \ "Memory Size").extract[Long]
     val diskSize = (json \ "Disk Size").extract[Long]
 
+    val outputDeterministicLevel = DeterministicLevel
+      .withName((json \ "DeterministicLevel").extract[String])
+
     val rddInfo =
-      new RDDInfo(rddId, name, numPartitions, storageLevel, isBarrier, parentIds, callsite, scope)
+      new RDDInfo(rddId, name, numPartitions, storageLevel, isBarrier, parentIds, callsite, scope,
+        outputDeterministicLevel)
     rddInfo.numCachedPartitions = numCachedPartitions
     rddInfo.memSize = memSize
     rddInfo.diskSize = diskSize

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -1176,8 +1176,8 @@ private[spark] object JsonProtocol {
     val memSize = (json \ "Memory Size").extract[Long]
     val diskSize = (json \ "Disk Size").extract[Long]
 
-    val outputDeterministicLevel = DeterministicLevel
-      .withName((json \ "DeterministicLevel").extract[String])
+    val outputDeterministicLevel = DeterministicLevel.withName(
+      jsonOption(json \ "DeterministicLevel").map(_.extract[String]).getOrElse("DETERMINATE"))
 
     val rddInfo =
       new RDDInfo(rddId, name, numPartitions, storageLevel, isBarrier, parentIds, callsite, scope,

--- a/core/src/test/scala/org/apache/spark/ui/scope/RDDOperationGraphSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/scope/RDDOperationGraphSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ui.scope
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.rdd.DeterministicLevel
 
 class RDDOperationGraphSuite extends SparkFunSuite {
   test("Test simple cluster equals") {
@@ -25,7 +26,8 @@ class RDDOperationGraphSuite extends SparkFunSuite {
     val c1 = new RDDOperationCluster("1", false, "Bender")
     val c2 = new RDDOperationCluster("2", false, "Hal")
     c1.attachChildCluster(c2)
-    c1.attachChildNode(new RDDOperationNode(3, "Marvin", false, false, "collect!"))
+    c1.attachChildNode(new RDDOperationNode(3, "Marvin", false, false, "collect!",
+      DeterministicLevel.DETERMINATE))
 
     // create an equal cluster, but without the child node
     val c1copy = new RDDOperationCluster("1", false, "Bender")

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -1171,6 +1171,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |          "Replication": 1
       |        },
       |        "Barrier" : false,
+      |        "DeterministicLevel" : "DETERMINATE",
       |        "Number of Partitions": 201,
       |        "Number of Cached Partitions": 301,
       |        "Memory Size": 401,
@@ -1695,6 +1696,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
+      |          "DeterministicLevel" : "DETERMINATE",
       |          "Number of Partitions": 200,
       |          "Number of Cached Partitions": 300,
       |          "Memory Size": 400,
@@ -1741,6 +1743,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
+      |          "DeterministicLevel" : "DETERMINATE",
       |          "Number of Partitions": 400,
       |          "Number of Cached Partitions": 600,
       |          "Memory Size": 800,
@@ -1758,6 +1761,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
+      |          "DeterministicLevel" : "DETERMINATE",
       |          "Number of Partitions": 401,
       |          "Number of Cached Partitions": 601,
       |          "Memory Size": 801,
@@ -1804,6 +1808,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
+      |          "DeterministicLevel" : "DETERMINATE",
       |          "Number of Partitions": 600,
       |          "Number of Cached Partitions": 900,
       |          "Memory Size": 1200,
@@ -1821,6 +1826,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
+      |          "DeterministicLevel" : "DETERMINATE",
       |          "Number of Partitions": 601,
       |          "Number of Cached Partitions": 901,
       |          "Memory Size": 1201,
@@ -1838,6 +1844,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
+      |          "DeterministicLevel" : "DETERMINATE",
       |          "Number of Partitions": 602,
       |          "Number of Cached Partitions": 902,
       |          "Memory Size": 1202,
@@ -1884,6 +1891,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
+      |          "DeterministicLevel" : "DETERMINATE",
       |          "Number of Partitions": 800,
       |          "Number of Cached Partitions": 1200,
       |          "Memory Size": 1600,
@@ -1901,6 +1909,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
+      |          "DeterministicLevel" : "DETERMINATE",
       |          "Number of Partitions": 801,
       |          "Number of Cached Partitions": 1201,
       |          "Memory Size": 1601,
@@ -1918,6 +1927,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
+      |          "DeterministicLevel" : "DETERMINATE",
       |          "Number of Partitions": 802,
       |          "Number of Cached Partitions": 1202,
       |          "Memory Size": 1602,
@@ -1935,6 +1945,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
+      |          "DeterministicLevel" : "DETERMINATE",
       |          "Number of Partitions": 803,
       |          "Number of Cached Partitions": 1203,
       |          "Memory Size": 1603,

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -31,7 +31,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.apache.spark._
 import org.apache.spark.executor._
 import org.apache.spark.metrics.ExecutorMetricType
-import org.apache.spark.rdd.RDDOperationScope
+import org.apache.spark.rdd.{DeterministicLevel, RDDOperationScope}
 import org.apache.spark.resource._
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.ExecutorInfo
@@ -168,7 +168,7 @@ class JsonProtocolSuite extends SparkFunSuite {
   test("Dependent Classes") {
     val logUrlMap = Map("stderr" -> "mystderr", "stdout" -> "mystdout").toMap
     val attributes = Map("ContainerId" -> "ct1", "User" -> "spark").toMap
-    testRDDInfo(makeRddInfo(2, 3, 4, 5L, 6L))
+    testRDDInfo(makeRddInfo(2, 3, 4, 5L, 6L, DeterministicLevel.DETERMINATE))
     testStageInfo(makeStageInfo(10, 20, 30, 40L, 50L))
     testTaskInfo(makeTaskInfo(999L, 888, 55, 777L, false))
     testTaskMetrics(makeTaskMetrics(
@@ -983,9 +983,11 @@ private[spark] object JsonProtocolSuite extends Assertions {
     )
   }
 
-  private def makeRddInfo(a: Int, b: Int, c: Int, d: Long, e: Long) = {
+  private def makeRddInfo(a: Int, b: Int, c: Int, d: Long, e: Long,
+      deterministic: DeterministicLevel.Value) = {
     val r =
-      new RDDInfo(a, "mayor", b, StorageLevel.MEMORY_AND_DISK, false, Seq(1, 4, 7), a.toString)
+      new RDDInfo(a, "mayor", b, StorageLevel.MEMORY_AND_DISK, false, Seq(1, 4, 7), a.toString,
+        outputDeterministicLevel = deterministic)
     r.numCachedPartitions = c
     r.memSize = d
     r.diskSize = e
@@ -999,7 +1001,13 @@ private[spark] object JsonProtocolSuite extends Assertions {
       d: Long,
       e: Long,
       rpId: Int = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID) = {
-    val rddInfos = (0 until a % 5).map { i => makeRddInfo(a + i, b + i, c + i, d + i, e + i) }
+    val rddInfos = (0 until a % 5).map { i =>
+      if (i == (a % 5) - 1) {
+        makeRddInfo(a + i, b + i, c + i, d + i, e + i, DeterministicLevel.INDETERMINATE)
+      } else {
+        makeRddInfo(a + i, b + i, c + i, d + i, e + i, DeterministicLevel.DETERMINATE)
+      }
+    }
     val stageInfo = new StageInfo(a, 0, "greetings", b, rddInfos, Seq(100, 200, 300), "details",
       resourceProfileId = rpId)
     val (acc1, acc2) = (makeAccumulableInfo(1), makeAccumulableInfo(2))
@@ -1171,7 +1179,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |          "Replication": 1
       |        },
       |        "Barrier" : false,
-      |        "DeterministicLevel" : "DETERMINATE",
+      |        "DeterministicLevel" : "INDETERMINATE",
       |        "Number of Partitions": 201,
       |        "Number of Cached Partitions": 301,
       |        "Memory Size": 401,
@@ -1696,7 +1704,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
-      |          "DeterministicLevel" : "DETERMINATE",
+      |          "DeterministicLevel" : "INDETERMINATE",
       |          "Number of Partitions": 200,
       |          "Number of Cached Partitions": 300,
       |          "Memory Size": 400,
@@ -1761,7 +1769,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
-      |          "DeterministicLevel" : "DETERMINATE",
+      |          "DeterministicLevel" : "INDETERMINATE",
       |          "Number of Partitions": 401,
       |          "Number of Cached Partitions": 601,
       |          "Memory Size": 801,
@@ -1844,7 +1852,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
-      |          "DeterministicLevel" : "DETERMINATE",
+      |          "DeterministicLevel" : "INDETERMINATE",
       |          "Number of Partitions": 602,
       |          "Number of Cached Partitions": 902,
       |          "Memory Size": 1202,
@@ -1945,7 +1953,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |            "Replication": 1
       |          },
       |          "Barrier" : false,
-      |          "DeterministicLevel" : "DETERMINATE",
+      |          "DeterministicLevel" : "INDETERMINATE",
       |          "Number of Partitions": 803,
       |          "Number of Cached Partitions": 1203,
       |          "Memory Size": 1603,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposes to mark indeterminate RDD in Web UI. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

It is somehow hard to track which part is indeterminate in a graph of RDDs. In some cases we may need to track indeterminate RDDs. For example, indeterminate map stage fails and Spark is unable to fallback some parent stages. The developers are usually unable to easily identify indeterminate part from the complicated RDD computation. If Web UI can show up indeterminate RDD like cached RDD, it could be useful to track it.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, there is a UI change for users.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Manual check with Web UI locally. Updated existing unit tests.

<img width="544" alt="Screen Shot 2021-03-02 at 12 38 02 AM" src="https://user-images.githubusercontent.com/68855/109621580-020bce80-7af0-11eb-834f-46b0f89d47c0.png">
<img width="390" alt="Screen Shot 2021-03-05 at 9 27 14 AM" src="https://user-images.githubusercontent.com/68855/110151181-04db1d80-7d95-11eb-8b3a-7235f7fe9eac.png">

