### PR TITLE
[SPARK-34598][SQL] RewritePredicateSubquery Rule must not update Filters without subqueries

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -98,55 +98,59 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
         splitConjunctivePredicates(condition)
           .partition(SubqueryExpression.hasInOrCorrelatedExistsSubquery)
 
-      // Construct the pruned filter condition.
-      val newFilter: LogicalPlan = withoutSubquery match {
-        case Nil => child
-        case conditions => Filter(conditions.reduce(And), child)
-      }
+      withSubquery match {
+        case withSubquery =>
+          // Construct the pruned filter condition.
+          val newFilter: LogicalPlan = withoutSubquery match {
+            case Nil => child
+            case conditions => Filter(conditions.reduce(And), child)
+          }
 
-      // Filter the plan by applying left semi and left anti joins.
-      withSubquery.foldLeft(newFilter) {
-        case (p, Exists(sub, conditions, _)) =>
-          val (joinCond, outerPlan) = rewriteExistentialExpr(conditions, p)
-          buildJoin(outerPlan, sub, LeftSemi, joinCond)
-        case (p, Not(Exists(sub, conditions, _))) =>
-          val (joinCond, outerPlan) = rewriteExistentialExpr(conditions, p)
-          buildJoin(outerPlan, sub, LeftAnti, joinCond)
-        case (p, InSubquery(values, ListQuery(sub, conditions, _, _))) =>
-          // Deduplicate conflicting attributes if any.
-          val newSub = dedupSubqueryOnSelfJoin(p, sub, Some(values))
-          val inConditions = values.zip(newSub.output).map(EqualTo.tupled)
-          val (joinCond, outerPlan) = rewriteExistentialExpr(inConditions ++ conditions, p)
-          Join(outerPlan, newSub, LeftSemi, joinCond, JoinHint.NONE)
-        case (p, Not(InSubquery(values, ListQuery(sub, conditions, _, _)))) =>
-          // This is a NULL-aware (left) anti join (NAAJ) e.g. col NOT IN expr
-          // Construct the condition. A NULL in one of the conditions is regarded as a positive
-          // result; such a row will be filtered out by the Anti-Join operator.
+          // Filter the plan by applying left semi and left anti joins.
+          withSubquery.foldLeft(newFilter) {
+            case (p, Exists(sub, conditions, _)) =>
+              val (joinCond, outerPlan) = rewriteExistentialExpr(conditions, p)
+              buildJoin(outerPlan, sub, LeftSemi, joinCond)
+            case (p, Not(Exists(sub, conditions, _))) =>
+              val (joinCond, outerPlan) = rewriteExistentialExpr(conditions, p)
+              buildJoin(outerPlan, sub, LeftAnti, joinCond)
+            case (p, InSubquery(values, ListQuery(sub, conditions, _, _))) =>
+              // Deduplicate conflicting attributes if any.
+              val newSub = dedupSubqueryOnSelfJoin(p, sub, Some(values))
+              val inConditions = values.zip(newSub.output).map(EqualTo.tupled)
+              val (joinCond, outerPlan) = rewriteExistentialExpr(inConditions ++ conditions, p)
+              Join(outerPlan, newSub, LeftSemi, joinCond, JoinHint.NONE)
+            case (p, Not(InSubquery(values, ListQuery(sub, conditions, _, _)))) =>
+              // This is a NULL-aware (left) anti join (NAAJ) e.g. col NOT IN expr
+              // Construct the condition. A NULL in one of the conditions is regarded as a positive
+              // result; such a row will be filtered out by the Anti-Join operator.
 
-          // Note that will almost certainly be planned as a Broadcast Nested Loop join.
-          // Use EXISTS if performance matters to you.
+              // Note that will almost certainly be planned as a Broadcast Nested Loop join.
+              // Use EXISTS if performance matters to you.
 
-          // Deduplicate conflicting attributes if any.
-          val newSub = dedupSubqueryOnSelfJoin(p, sub, Some(values))
-          val inConditions = values.zip(newSub.output).map(EqualTo.tupled)
-          val (joinCond, outerPlan) = rewriteExistentialExpr(inConditions, p)
-          // Expand the NOT IN expression with the NULL-aware semantic
-          // to its full form. That is from:
-          //   (a1,a2,...) = (b1,b2,...)
-          // to
-          //   (a1=b1 OR isnull(a1=b1)) AND (a2=b2 OR isnull(a2=b2)) AND ...
-          val baseJoinConds = splitConjunctivePredicates(joinCond.get)
-          val nullAwareJoinConds = baseJoinConds.map(c => Or(c, IsNull(c)))
-          // After that, add back the correlated join predicate(s) in the subquery
-          // Example:
-          // SELECT ... FROM A WHERE A.A1 NOT IN (SELECT B.B1 FROM B WHERE B.B2 = A.A2 AND B.B3 > 1)
-          // will have the final conditions in the LEFT ANTI as
-          // (A.A1 = B.B1 OR ISNULL(A.A1 = B.B1)) AND (B.B2 = A.A2) AND B.B3 > 1
-          val finalJoinCond = (nullAwareJoinConds ++ conditions).reduceLeft(And)
-          Join(outerPlan, newSub, LeftAnti, Option(finalJoinCond), JoinHint.NONE)
-        case (p, predicate) =>
-          val (newCond, inputPlan) = rewriteExistentialExpr(Seq(predicate), p)
-          Project(p.output, Filter(newCond.get, inputPlan))
+              // Deduplicate conflicting attributes if any.
+              val newSub = dedupSubqueryOnSelfJoin(p, sub, Some(values))
+              val inConditions = values.zip(newSub.output).map(EqualTo.tupled)
+              val (joinCond, outerPlan) = rewriteExistentialExpr(inConditions, p)
+              // Expand the NOT IN expression with the NULL-aware semantic
+              // to its full form. That is from:
+              //   (a1,a2,...) = (b1,b2,...)
+              // to
+              //   (a1=b1 OR isnull(a1=b1)) AND (a2=b2 OR isnull(a2=b2)) AND ...
+              val baseJoinConds = splitConjunctivePredicates(joinCond.get)
+              val nullAwareJoinConds = baseJoinConds.map(c => Or(c, IsNull(c)))
+              // After that, add back the correlated join predicate(s) in the subquery
+              // Example:
+              // SELECT ... FROM A
+              // WHERE A.A1 NOT IN (SELECT B.B1 FROM B WHERE B.B2 = A.A2 AND B.B3 > 1)
+              // will have the final conditions in the LEFT ANTI as
+              // (A.A1 = B.B1 OR ISNULL(A.A1 = B.B1)) AND (B.B2 = A.A2) AND B.B3 > 1
+              val finalJoinCond = (nullAwareJoinConds ++ conditions).reduceLeft(And)
+              Join(outerPlan, newSub, LeftAnti, Option(finalJoinCond), JoinHint.NONE)
+            case (p, predicate) =>
+              val (newCond, inputPlan) = rewriteExistentialExpr(Seq(predicate), p)
+              Project(p.output, Filter(newCond.get, inputPlan))
+          }
       }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -74,6 +74,6 @@ class RewriteSubquerySuite extends PlanTest {
     val query = relation.where(('a === 1 || 'b === 2) && ('c === 3 && 'd === 4)).select('a)
     val tracker = new QueryPlanningTracker
     Optimize.executeAndTrack(query.analyze, tracker)
-    assert(tracker.rules.get(RewritePredicateSubquery.ruleName).get.numEffectiveInvocations == 0)
+    assert(tracker.rules(RewritePredicateSubquery.ruleName).numEffectiveInvocations == 0)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.{IsNull, ListQuery, Not}
@@ -66,5 +67,13 @@ class RewriteSubquerySuite extends PlanTest {
     val optimized = Optimize.execute(query.analyze)
 
     comparePlans(optimized, correctAnswer)
+  }
+
+  test("SPARK-34598: Filters without subquery must not be modified by RewritePredicateSubquery") {
+    val relation = LocalRelation('a.int, 'b.int, 'c.int, 'd.int)
+    val query = relation.where(('a === 1 || 'b === 2) && ('c === 3 && 'd === 4)).select('a)
+    val tracker = new QueryPlanningTracker
+    Optimize.executeAndTrack(query.analyze, tracker)
+    assert(tracker.rules.get(RewritePredicateSubquery.ruleName).get.numEffectiveInvocations == 0)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
RewritePredicateSubquery Optimizer Rule must not update Filters without subqueries.

Following is one such example.

```
=== Applying Rule org.apache.spark.sql.catalyst.optimizer.RewritePredicateSubquery ===
 Project [a#0]                                                        Project [a#0]
!+- Filter (((a#0 > 1) OR (b#1 > 2)) AND ((c#2 > 1) AND (d#3 > 2)))   +- Filter ((((a#0 > 1) OR (b#1 > 2)) AND (c#2 > 1)) AND (d#3 > 2))
    +- LocalRelation <empty>, [a#0, b#1, c#2, d#3]                       +- LocalRelation <empty>, [a#0, b#1, c#2, d#3]
```


### Why are the changes needed?
minor change.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing UTs pass.
