### PR TITLE
[SPARK-34556][SQL][3.0] Checking duplicate static partition columns should respect case sensitive conf

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -500,7 +500,11 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
     // Before calling `toMap`, we check duplicated keys to avoid silently ignore partition values
     // in partition spec like PARTITION(a='1', b='2', a='3'). The real semantical check for
     // partition columns will be done in analyzer.
-    checkDuplicateKeys(parts, ctx)
+    if (conf.caseSensitiveAnalysis) {
+      checkDuplicateKeys(parts, ctx)
+    } else {
+      checkDuplicateKeys(parts.map(kv => kv._1.toLowerCase(Locale.ROOT) -> kv._2), ctx)
+    }
     parts.toMap
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -353,6 +353,17 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
     assert(e.contains("Found duplicate keys 'key1'"))
   }
 
+  test("SPARK-34556: duplicate keys in partition spec") {
+    val e = intercept[ParseException] {
+      parser.parsePlan("INSERT OVERWRITE t PARTITION (c='2', C='3') VALUES (1)")
+    }.getMessage
+    assert(e.contains("Found duplicate keys 'c'"))
+    val conf = new SQLConf()
+    conf.setConf(SQLConf.CASE_SENSITIVE, true)
+    val caseSensitiveParser = new SparkSqlParser(conf)
+    caseSensitiveParser.parsePlan("INSERT OVERWRITE t PARTITION (c='2', C='3') VALUES (1)")
+  }
+
   test("duplicate columns in partition specs") {
     val e = intercept[ParseException] {
       parser.parsePlan(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backport #31669 to branch-3.0. Add a new test in DDLParserSuite.scala since SQLInsertTestSuite.scala doesn't exist in branch-3.0.