### PR TITLE
[SPARK-34225][CORE] Don't encode further when a URI form string is passed to addFile or addJar

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1583,11 +1583,7 @@ class SparkContext(config: SparkConf) extends Logging {
   private def addFile(
       path: String, recursive: Boolean, addedOnSubmit: Boolean, isArchive: Boolean = false
     ): Unit = {
-    val uri = if (!isArchive) {
-      new Path(path).toUri
-    } else {
-      Utils.resolveURI(path)
-    }
+    val uri = Utils.resolveURI(path)
     val schemeCorrectedURI = uri.getScheme match {
       case null => new File(path).getCanonicalFile.toURI
       case "local" =>
@@ -1619,10 +1615,8 @@ class SparkContext(config: SparkConf) extends Logging {
       env.rpcEnv.fileServer.addFile(new File(uri.getPath))
     } else if (uri.getScheme == null) {
       schemeCorrectedURI.toString
-    } else if (isArchive) {
-      uri.toString
     } else {
-      path
+      uri.toString
     }
 
     val timestamp = if (addedOnSubmit) startTime else System.currentTimeMillis
@@ -1975,9 +1969,9 @@ class SparkContext(config: SparkConf) extends Logging {
     } else {
       val (keys, scheme) = if (path.contains("\\") && Utils.isWindows) {
         // For local paths with backslashes on Windows, URI throws an exception
-        (addLocalJarFile(new File(path)), "local")
+        (addLocalJarFile(new File(Utils.resolveURI(path))), "local")
       } else {
-        val uri = new Path(path).toUri
+        val uri = Utils.resolveURI(path)
         // SPARK-17650: Make sure this is a valid URL before adding it to the list of dependencies
         Utils.validateURL(uri)
         val uriScheme = uri.getScheme

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1922,13 +1922,6 @@ class SparkContext(config: SparkConf) extends Logging {
     addJar(path, false)
   }
 
-  // Visible for testing
-  private[spark] def convertPathToFileForWin(path: String): File = {
-    // Make URI from path to ensure using Utils.resolveURI to ensure encoded characters like %20
-    // are not encoded further regardless of `path` is URI form or not.
-    new File(Utils.resolveURI(path))
-  }
-
   private def addJar(path: String, addedOnSubmit: Boolean): Unit = {
     def addLocalJarFile(file: File): Seq[String] = {
       try {
@@ -1976,7 +1969,7 @@ class SparkContext(config: SparkConf) extends Logging {
     } else {
       val (keys, scheme) = if (path.contains("\\") && Utils.isWindows) {
         // For local paths with backslashes on Windows, URI throws an exception
-        (addLocalJarFile(convertPathToFileForWin(path)), "local")
+        (addLocalJarFile(new File(path)), "local")
       } else {
         val uri = Utils.resolveURI(path)
         // SPARK-17650: Make sure this is a valid URL before adding it to the list of dependencies

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1922,6 +1922,13 @@ class SparkContext(config: SparkConf) extends Logging {
     addJar(path, false)
   }
 
+  // Visible for testing
+  private[spark] def convertPathToFileForWin(path: String): File = {
+    // Make URI from path to ensure using Utils.resolveURI to ensure encoded characters like %20
+    // are not encoded further regardless of `path` is URI form or not.
+    new File(Utils.resolveURI(path))
+  }
+
   private def addJar(path: String, addedOnSubmit: Boolean): Unit = {
     def addLocalJarFile(file: File): Seq[String] = {
       try {
@@ -1969,7 +1976,7 @@ class SparkContext(config: SparkConf) extends Logging {
     } else {
       val (keys, scheme) = if (path.contains("\\") && Utils.isWindows) {
         // For local paths with backslashes on Windows, URI throws an exception
-        (addLocalJarFile(new File(Utils.resolveURI(path))), "local")
+        (addLocalJarFile(convertPathToFileForWin(path)), "local")
       } else {
         val uri = Utils.resolveURI(path)
         // SPARK-17650: Make sure this is a valid URL before adding it to the list of dependencies

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2063,6 +2063,17 @@ private[spark] object Utils extends Logging {
     }
   }
 
+  /** Check whether a path is an absolute URI. */
+  def isAbsoluteURI(path: String): Boolean = {
+    try {
+      val uri = new URI(path: String)
+      uri.isAbsolute
+    } catch {
+      case _: URISyntaxException =>
+        false
+    }
+  }
+
   /** Return all non-local paths from a comma-separated list of paths. */
   def nonLocalPaths(paths: String, testWindows: Boolean = false): Array[String] = {
     val windows = isWindows || testWindows

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1224,15 +1224,6 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
         sc.stop()
       }
     }
-
-    val sep = File.separator
-    val winJar = s"C:${sep}foo${sep}test jar.jar"
-    val winJarUrl = "file:/C:/foo/test%20jar.jar"
-    val resolvedWinJar = sc.convertPathToFileForWin(winJar).toString
-    val resolvedWinJarUrl = sc.convertPathToFileForWin(winJarUrl).toString
-
-    assert(resolvedWinJar.substring(resolvedWinJar.lastIndexOf("/C:") + 1) === winJar)
-    assert(resolvedWinJarUrl.substring(resolvedWinJarUrl.lastIndexOf("/C:") + 1) === winJar)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1197,11 +1197,12 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     assert(sc.hadoopConfiguration.get(bufferKey).toInt === 65536,
       "spark configs have higher priority than spark.hadoop configs")
   }
+
   test("SPARK-34225: addFile/addJar shouldn't further encode URI if a URI form string is passed") {
     withTempDir { dir =>
-      val jar = File.createTempFile("testprefix", "test jar1.jar", dir)
+      val jar = File.createTempFile("testprefix", "test jar.jar", dir)
       val jarUrl = jar.toURI.toString
-      val file = File.createTempFile("testprefix", "test file1.txt", dir)
+      val file = File.createTempFile("testprefix", "test file.txt", dir)
       val fileUrl = file.toURI.toString
 
       try {
@@ -1223,6 +1224,15 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
         sc.stop()
       }
     }
+
+    val sep = File.separator
+    val winJar = s"C:${sep}foo${sep}test jar.jar"
+    val winJarUrl = "file:/C:/foo/test%20jar.jar"
+    val resolvedWinJar = sc.convertPathToFileForWin(winJar).toString
+    val resolvedWinJarUrl = sc.convertPathToFileForWin(winJarUrl).toString
+
+    assert(resolvedWinJar.substring(resolvedWinJar.lastIndexOf("/C:") + 1) === winJar)
+    assert(resolvedWinJarUrl.substring(resolvedWinJarUrl.lastIndexOf("/C:") + 1) === winJar)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1200,23 +1200,35 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
 
   test("SPARK-34225: addFile/addJar shouldn't further encode URI if a URI form string is passed") {
     withTempDir { dir =>
-      val jar = File.createTempFile("testprefix", "test jar.jar", dir)
-      val jarUrl = jar.toURI.toString
-      val file = File.createTempFile("testprefix", "test file.txt", dir)
-      val fileUrl = file.toURI.toString
+      val jar1 = File.createTempFile("testprefix", "test jar.jar", dir)
+      val jarUrl1 = jar1.toURI.toString
+      val file1 = File.createTempFile("testprefix", "test file.txt", dir)
+      val fileUrl1 = file1.toURI.toString
+      val jar2 = File.createTempFile("testprefix", "test %20jar.jar", dir)
+      val file2 = File.createTempFile("testprefix", "test %20file.txt", dir)
 
       try {
         sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
-        sc.addJar(jarUrl)
-        sc.addFile(fileUrl)
+        sc.addJar(jarUrl1)
+        sc.addFile(fileUrl1)
+        sc.addJar(jar2.toString)
+        sc.addFile(file2.toString)
         sc.parallelize(Array(1), 1).map { x =>
-          val gottenJar = new File(SparkFiles.get(jar.getName))
-          if (!gottenJar.exists()) {
-            throw new SparkException("file doesn't exist : " + jar)
+          val gottenJar1 = new File(SparkFiles.get(jar1.getName))
+          if (!gottenJar1.exists()) {
+            throw new SparkException("file doesn't exist : " + jar1)
           }
-          val gottenFile = new File(SparkFiles.get(file.getName))
-          if (!gottenFile.exists()) {
-            throw new SparkException("file doesn't exist : " + file)
+          val gottenFile1 = new File(SparkFiles.get(file1.getName))
+          if (!gottenFile1.exists()) {
+            throw new SparkException("file doesn't exist : " + file1)
+          }
+          val gottenJar2 = new File(SparkFiles.get(jar2.getName))
+          if (!gottenJar2.exists()) {
+            throw new SparkException("file doesn't exist : " + jar2)
+          }
+          val gottenFile2 = new File(SparkFiles.get(file2.getName))
+          if (!gottenFile2.exists()) {
+            throw new SparkException("file doesn't exist : " + file2)
           }
           x
         }.collect()


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes an issue that `addFile` and `addJar` further encode even though a URI form string is passed.
For example, the following operation will throw exception even though the file exists.
```
sc.addFile("file:/foo/test%20file.txt")
```

Another case is `--files` and `--jars` option when we submit an application.
```
bin/spark-shell --files "/foo/test file.txt"
```
The path above is transformed to URI form [here](https://github.com/apache/spark/blob/ecf4811764f1ef91954c865a864e0bf6691f99a6/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala#L400) and passed to `addFile` so the same issue happens.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is a bug.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New test.