### PR TITLE
[SPARK-34361][K8S][FOLLOWUP] Fix potentially flaky unit test with multiple resource profiles in ExecutorPodsAllocatorSuite

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -198,8 +198,8 @@ private[spark] class ExecutorPodsAllocator(
     }
 
     var totalPendingCount = 0
-    // The order we request executors for each ResourceProfile is not guaranteed.
-    totalExpectedExecutorsPerResourceProfileId.asScala.foreach { case (rpId, targetNum) =>
+    totalExpectedExecutorsPerResourceProfileId.asScala.toSeq.sortBy(_._1)
+      .foreach { case (rpId, targetNum) =>
       val podsForRpId = rpIdToExecsAndPodState.getOrElse(rpId, mutable.HashMap.empty)
 
       val currentRunningCount = podsForRpId.values.count {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -439,11 +439,15 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     verify(podOperations, times(7)).create(any())
 
     // 5) requesting 1 more executor for each resource
+    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3, rp -> 2))
+    snapshotsStore.notifySubscribers()
+    verify(podOperations).create(podWithAttachedContainerForId(8, defaultProfile.id))
+    assert(podsAllocatorUnderTest.numOutstandingPods.get() == 1)
+
     podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3, rp -> 3))
     snapshotsStore.notifySubscribers()
     assert(podsAllocatorUnderTest.numOutstandingPods.get() == 2)
     verify(podOperations, times(9)).create(any())
-    verify(podOperations).create(podWithAttachedContainerForId(8, defaultProfile.id))
     verify(podOperations).create(podWithAttachedContainerForId(9, rp.id))
   }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -389,15 +389,17 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     val rp = rpb.build()
 
     // 0) request 3 PODs for the default and 4 PODs for the other resource profile
-    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3, rp -> 4))
-    assert(podsAllocatorUnderTest.numOutstandingPods.get() == 7)
+    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3))
     verify(podOperations).create(podWithAttachedContainerForId(1, defaultProfile.id))
     verify(podOperations).create(podWithAttachedContainerForId(2, defaultProfile.id))
     verify(podOperations).create(podWithAttachedContainerForId(3, defaultProfile.id))
+    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3, rp -> 4))
+    snapshotsStore.notifySubscribers()
     verify(podOperations).create(podWithAttachedContainerForId(4, rp.id))
     verify(podOperations).create(podWithAttachedContainerForId(5, rp.id))
     verify(podOperations).create(podWithAttachedContainerForId(6, rp.id))
     verify(podOperations).create(podWithAttachedContainerForId(7, rp.id))
+    assert(podsAllocatorUnderTest.numOutstandingPods.get() == 7)
 
     // 1) make 1 POD known by the scheduler backend for each resource profile
     when(schedulerBackend.getExecutorIds).thenReturn(Seq("1", "4"))

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -389,17 +389,15 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     val rp = rpb.build()
 
     // 0) request 3 PODs for the default and 4 PODs for the other resource profile
-    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3))
+    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3, rp -> 4))
+    assert(podsAllocatorUnderTest.numOutstandingPods.get() == 7)
     verify(podOperations).create(podWithAttachedContainerForId(1, defaultProfile.id))
     verify(podOperations).create(podWithAttachedContainerForId(2, defaultProfile.id))
     verify(podOperations).create(podWithAttachedContainerForId(3, defaultProfile.id))
-    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3, rp -> 4))
-    snapshotsStore.notifySubscribers()
     verify(podOperations).create(podWithAttachedContainerForId(4, rp.id))
     verify(podOperations).create(podWithAttachedContainerForId(5, rp.id))
     verify(podOperations).create(podWithAttachedContainerForId(6, rp.id))
     verify(podOperations).create(podWithAttachedContainerForId(7, rp.id))
-    assert(podsAllocatorUnderTest.numOutstandingPods.get() == 7)
 
     // 1) make 1 POD known by the scheduler backend for each resource profile
     when(schedulerBackend.getExecutorIds).thenReturn(Seq("1", "4"))
@@ -439,15 +437,11 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     verify(podOperations, times(7)).create(any())
 
     // 5) requesting 1 more executor for each resource
-    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3, rp -> 2))
-    snapshotsStore.notifySubscribers()
-    verify(podOperations).create(podWithAttachedContainerForId(8, defaultProfile.id))
-    assert(podsAllocatorUnderTest.numOutstandingPods.get() == 1)
-
     podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3, rp -> 3))
     snapshotsStore.notifySubscribers()
     assert(podsAllocatorUnderTest.numOutstandingPods.get() == 2)
     verify(podOperations, times(9)).create(any())
+    verify(podOperations).create(podWithAttachedContainerForId(8, defaultProfile.id))
     verify(podOperations).create(podWithAttachedContainerForId(9, rp.id))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixing the potentially flaky test in `ExecutorPodsAllocatorSuite` where multiple resource profiles are used:
- `SPARK-34361: scheduler backend known pods with multiple resource profiles at downscaling`
- `SPARK-33288: multiple resource profiles` 

### Why are the changes needed?

Resource profiles in executor PODs allocator are processed in a nondeterministic order.

Even as the tests are using Maps created by a constructor with two entries and the implementation behind is [Map2 where the iterator keeps the ordering](https://github.com/scala/scala/blob/2.13.x/src/library/scala/collection/immutable/Map.scala#L291-L332) in the `setTotalExpectedExecutors()` method the entries are added to a `ConcurrentHashMap` `totalExpectedExecutorsPerResourceProfileId`. 

So the resource allocation order might change from run to run.
 
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit test.