### PR TITLE
[SPARK-34595][sql] DPP support RLIKE

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
@@ -160,7 +160,7 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper {
     case Not(expr) => isLikelySelective(expr)
     case And(l, r) => isLikelySelective(l) || isLikelySelective(r)
     case Or(l, r) => isLikelySelective(l) && isLikelySelective(r)
-    case Like(_, _, _) => true
+    case _: StringRegexExpression => true
     case _: BinaryComparison => true
     case _: In | _: InSet => true
     case _: StringPredicate => true

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1403,6 +1403,49 @@ abstract class DynamicPartitionPruningSuiteBase
       )
     }
   }
+
+  test("SPARK-34436: DPP support Like/RLike expression") {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true") {
+      val df = sql(
+        """
+          |SELECT date_id, product_id FROM fact_sk f
+          |JOIN dim_store s
+          |ON f.store_id = s.store_id WHERE s.country LIKE  '%D%'
+        """.stripMargin)
+
+      checkPartitionPruningPredicate(df, false, true)
+
+      checkAnswer(df,
+        Row(1030, 2) ::
+          Row(1040, 2) ::
+          Row(1050, 2) ::
+          Row(1060, 2) :: Nil
+      )
+    }
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true") {
+      val df = sql(
+        """
+          |SELECT date_id, product_id FROM fact_sk f
+          |JOIN dim_store s
+          |ON f.store_id = s.store_id WHERE s.country RLIKE  '[DE|US]'
+        """.stripMargin)
+
+      checkPartitionPruningPredicate(df, false, true)
+
+      checkAnswer(df,
+        Row(1030, 2) ::
+          Row(1040, 2) ::
+          Row(1050, 2) ::
+          Row(1060, 2) ::
+          Row(1070, 2) ::
+          Row(1080, 3) ::
+          Row(1090, 3) ::
+          Row(1100, 3) ::
+          Row(1110, 3) ::
+          Row(1120, 4) :: Nil
+      )
+    }
+  }
 }
 
 class DynamicPartitionPruningSuiteAEOff extends DynamicPartitionPruningSuiteBase


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr make DPP support RLIKE expression:

```sql
SELECT date_id, product_id FROM fact_sk f
JOIN dim_store s
ON f.store_id = s.store_id WHERE s.country RLIKE  '[DE|US]'
``` 
 ### Why are the changes needed?
Improve query performance.
 
 ### Does this PR introduce _any_ user-facing change?
 No.
 
 ### How was this patch tested?
 Unit test.

