### PR TITLE
[SPARK-34613][SQL] Fix view does not capture disable hint config

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -363,6 +363,11 @@ object ViewHelper {
     SQLConf.DISABLE_HINTS.key
   )
 
+  /**
+   * Capture view config either of:
+   * 1. exists in allowList
+   * 2. do not exists in denyList
+   */
   private def shouldCaptureConfig(key: String): Boolean = {
     configAllowList.exists(prefix => key.equals(prefix)) ||
       !configPrefixDenyList.exists(prefix => key.startsWith(prefix))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -359,8 +359,13 @@ object ViewHelper {
     "spark.sql.shuffle.",
     "spark.sql.adaptive.")
 
+  private val configPrefixAllowList = Seq(
+    SQLConf.DISABLE_HINTS.key
+  )
+
   private def shouldCaptureConfig(key: String): Boolean = {
-    !configPrefixDenyList.exists(prefix => key.startsWith(prefix))
+    configPrefixAllowList.exists(prefix => key.startsWith(prefix)) ||
+      !configPrefixDenyList.exists(prefix => key.startsWith(prefix))
   }
 
   import CatalogTable._

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -359,12 +359,12 @@ object ViewHelper {
     "spark.sql.shuffle.",
     "spark.sql.adaptive.")
 
-  private val configPrefixAllowList = Seq(
+  private val configAllowList = Seq(
     SQLConf.DISABLE_HINTS.key
   )
 
   private def shouldCaptureConfig(key: String): Boolean = {
-    configPrefixAllowList.exists(prefix => key.startsWith(prefix)) ||
+    configAllowList.exists(prefix => key.equals(prefix)) ||
       !configPrefixDenyList.exists(prefix => key.startsWith(prefix))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -910,17 +910,4 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
       }
     }
   }
-
-  test("SPARK-34613: Fix view does not capture disable hint config") {
-    withSQLConf(DISABLE_HINTS.key -> "true") {
-      withView("v1") {
-        sql("CREATE VIEW v1 AS SELECT /*+ repartition(1) */ 1")
-        assert(
-          sql("SELECT * FROM v1").queryExecution.analyzed.collect {
-            case e: Repartition => e
-          }.isEmpty
-        )
-      }
-    }
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.logical.Repartition
 import org.apache.spark.sql.internal.SQLConf._
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -282,8 +282,8 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
 
   test("SPARK-34613: Fix view does not capture disable hint config") {
     withSQLConf(DISABLE_HINTS.key -> "true") {
-      withView("v1") {
-        val viewName = createView("v1", "SELECT /*+ repartition(1) */ 1")
+      val viewName = createView("v1", "SELECT /*+ repartition(1) */ 1")
+      withView(viewName) {
         assert(
           sql(s"SELECT * FROM $viewName").queryExecution.analyzed.collect {
             case e: Repartition => e

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -283,12 +283,13 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
   test("SPARK-34613: Fix view does not capture disable hint config") {
     withSQLConf(DISABLE_HINTS.key -> "true") {
       withView("v1") {
-        createView("v1", "SELECT /*+ repartition(1) */ 1")
+        val viewName = createView("v1", "SELECT /*+ repartition(1) */ 1")
         assert(
           sql("SELECT * FROM v1").queryExecution.analyzed.collect {
             case e: Repartition => e
           }.isEmpty
         )
+        checkViewOutput(viewName, Seq(Row(1)))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -283,7 +283,7 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
   test("SPARK-34613: Fix view does not capture disable hint config") {
     withSQLConf(DISABLE_HINTS.key -> "true") {
       withView("v1") {
-        sql("CREATE VIEW v1 AS SELECT /*+ repartition(1) */ 1")
+        createView("v1", "SELECT /*+ repartition(1) */ 1")
         assert(
           sql("SELECT * FROM v1").queryExecution.analyzed.collect {
             case e: Repartition => e

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -285,7 +285,7 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
       withView("v1") {
         val viewName = createView("v1", "SELECT /*+ repartition(1) */ 1")
         assert(
-          sql("SELECT * FROM v1").queryExecution.analyzed.collect {
+          sql(s"SELECT * FROM $viewName").queryExecution.analyzed.collect {
             case e: Repartition => e
           }.isEmpty
         )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add allow list to capture sql config for view.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Spark use origin text sql to store view then capture and store sql config into view metadata.

Capture config will skip some config with some prefix, e.g. `spark.sql.optimizer.` but unfortunately `spark.sql.optimizer.disableHints` is start with `spark.sql.optimizer.`.

We need a allow list to help capture the config.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes bug fix.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add test.