### PR TITLE
[SPARK-34623][SQL] Remove duplicate window expressions from the Window node

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -90,7 +90,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         // Constant folding and strength reduction
         OptimizeRepartition,
         TransposeWindow,
-        DeduplicateWindowExpressions,
+        RemoveDuplicateWindowExprs,
         NullPropagation,
         ConstantPropagation,
         FoldablePropagation,
@@ -950,7 +950,7 @@ object TransposeWindow extends Rule[LogicalPlan] {
 /**
  * Replaces duplicate window expressions with an alias in a Project above the Window node.
  */
-object DeduplicateWindowExpressions extends Rule[LogicalPlan] {
+object RemoveDuplicateWindowExprs extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case w @ Window(wes, _, _, _) if wes.length > 1 =>
       val equivalenceMap = mutable.HashMap.empty[Expression, Attribute]

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DeduplicateWindowExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DeduplicateWindowExpressionsSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.rules.RuleExecutor
 class DeduplicateWindowExpressionsSuite extends PlanTest {
   object Optimize extends RuleExecutor[LogicalPlan] {
     val batches =
-      Batch("DeduplicateWindowExpressions", FixedPoint(10), DeduplicateWindowExpressions) :: Nil
+      Batch("DeduplicateWindowExpressions", Once, DeduplicateWindowExpressions) :: Nil
   }
 
   val testRelation = LocalRelation($"a".int, $"b".int)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DeduplicateWindowExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DeduplicateWindowExpressionsSuite.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class DeduplicateWindowExpressionsSuite extends PlanTest {
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("DeduplicateWindowExpressions", FixedPoint(10), DeduplicateWindowExpressions) :: Nil
+  }
+
+  val testRelation = LocalRelation($"a".int, $"b".int)
+
+  val a = testRelation.output(0)
+  val b = testRelation.output(1)
+
+  test("Deduplicate equal expressions") {
+    val query = testRelation
+      .window(Seq(sum(a).as("a_sum1"), sum(a).as("a_sum2")), Seq.empty, Seq.empty)
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = testRelation
+      .window(Seq(sum(a).as("a_sum1")), Seq.empty, Seq.empty)
+      .select($"a", $"b", $"a_sum1", $"a_sum1" as "a_sum2")
+      .analyze
+
+    comparePlans(optimized, expected)
+  }
+
+  test("Deduplicate equivalent expressions") {
+    val query = testRelation
+      .window(
+        Seq(sum(Literal(2) * a).as("a_sum1"), sum(a * Literal(2)).as("a_sum2")),
+        Seq.empty, Seq.empty)
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = testRelation
+      .window(Seq(sum(Literal(2) * a).as("a_sum1")), Seq.empty, Seq.empty)
+      .select($"a", $"b", $"a_sum1", $"a_sum1" as "a_sum2")
+      .analyze
+
+    comparePlans(optimized, expected)
+  }
+
+  test("Do not deduplicate distinct expressions") {
+    val query = testRelation
+      .window(Seq(sum(a).as("a_sum"), sum(b).as("b_sum")), Seq.empty, Seq.empty)
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    comparePlans(optimized, query)
+  }
+
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveDuplicateWindowExprsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveDuplicateWindowExprsSuite.scala
@@ -24,10 +24,10 @@ import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 
-class DeduplicateWindowExpressionsSuite extends PlanTest {
+class RemoveDuplicateWindowExprsSuite extends PlanTest {
   object Optimize extends RuleExecutor[LogicalPlan] {
     val batches =
-      Batch("DeduplicateWindowExpressions", Once, DeduplicateWindowExpressions) :: Nil
+      Batch("RemoveDuplicateWindowExprs", Once, RemoveDuplicateWindowExprs) :: Nil
   }
 
   val testRelation = LocalRelation($"a".int, $"b".int)
@@ -76,5 +76,4 @@ class DeduplicateWindowExpressionsSuite extends PlanTest {
 
     comparePlans(optimized, query)
   }
-
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added an optimizer rule `RemoveDuplicateWindowExprs`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Duplicate window expressions can be introduced to the same `Window` node by the analyzer rule `ExtractWindowExpressions`, by the optimizer rule `CollapseWindow` or by the user. Currently these duplicate expressions are executed twice.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UTs