### PR TITLE
[SPARK-33000] Cleanup checkpoint data on shutdown

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/ReliableRDDCheckpointData.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ReliableRDDCheckpointData.scala
@@ -58,7 +58,7 @@ private[spark] class ReliableRDDCheckpointData[T: ClassTag](@transient private v
   protected override def doCheckpoint(): CheckpointRDD[T] = {
     val newRDD = ReliableCheckpointRDD.writeRDDToCheckpointDirectory(rdd, cpDir)
 
-    // Optionally clean our checkpoint files if the reference is out of scope
+    // Optionally register our checkpoint files for cleanup when the reference goes out of scope
     if (rdd.conf.get(CLEANER_REFERENCE_TRACKING_CLEAN_CHECKPOINTS)) {
       rdd.context.cleaner.foreach { cleaner =>
         cleaner.registerRDDCheckpointDataForCleanup(newRDD, rdd.id)

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -355,8 +355,6 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
   test("SPARK-33000: shutdown cleans up checkpointed data when configured to do so") {
     // TODO: How do I write a test for this?
   }
-
-
 }
 
 

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -351,6 +351,12 @@ class ContextCleanerSuite extends ContextCleanerSuiteBase {
       case _ => false
     }, askStorageEndpoints = true).isEmpty)
   }
+
+  test("SPARK-33000: shutdown cleans up checkpointed data when configured to do so") {
+    // TODO: How do I write a test for this?
+  }
+
+
 }
 
 

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -755,6 +755,16 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     assert(output.toList === List(Int.MaxValue, Int.MaxValue, 4, 3, 2, Int.MinValue, Int.MinValue))
   }
 
+  test("shutdown hook priorities") {
+    import org.apache.spark.util.ShutdownHookManager.{
+      DEFAULT_SHUTDOWN_PRIORITY,
+      SPARK_CONTEXT_SHUTDOWN_PRIORITY,
+      TEMP_DIR_SHUTDOWN_PRIORITY
+    }
+    assert(SPARK_CONTEXT_SHUTDOWN_PRIORITY < DEFAULT_SHUTDOWN_PRIORITY)
+    assert(TEMP_DIR_SHUTDOWN_PRIORITY < SPARK_CONTEXT_SHUTDOWN_PRIORITY)
+  }
+
   test("isInDirectory") {
     val tmpDir = new File(sys.props("java.io.tmpdir"))
     val parentDir = new File(tmpDir, "parent-dir")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes Spark's behavior when `spark.cleaner.referenceTracking.cleanCheckpoints` is set to `true`. Previously, checkpoint data would be left around when Spark is shut down. With this PR, Spark now cleans up checkpoint data as expected.

This PR also add a test to check that the `ShutdownHookManager.*_SHUTDOWN_PRIORITY` constants are in the relative order that their comments [say they should be in](https://github.com/apache/spark/blob/d7c3e9e53e01011f809b6cb145349ee8a9c5e5f0/core/src/main/scala/org/apache/spark/util/ShutdownHookManager.scala#L33-L46).

### Why are the changes needed?

Spark's behavior does not match the description of the `spark.cleaner.referenceTracking.cleanCheckpoints` configuration. 

> Controls whether to clean checkpoint files if the reference is out of scope.

When Spark is shut down, all references go out of scope. These changes bring Spark's behavior in line with the intended (and documented) behavior.

### Does this PR introduce _any_ user-facing change?

Yes. Previously, if you set `cleanCheckpoints` to `true`, checkpoint some data, and then shut down Spark, that checkpoint data will be left intact. With this PR, that checkpoint data will now be cleaned up.

### How was this patch tested?

I tested this PR manually as follows:

```sh
# Cleanup checkpoint directory and start Spark.
trash ./checkpoint/
./bin/pyspark --conf 'spark.cleaner.referenceTracking.cleanCheckpoints=true'
```

```python
# Checkpoint some data and exit.
spark.sparkContext.setCheckpointDir('./checkpoint/')
spark.range(3).checkpoint()
import sys; sys.exit()
```

```sh
# Check that there is no checkpoint data in the checkpoint directory.
ll ./checkpoint/*
```
