### PR TITLE
[SPARK-34627][SQL] Use FunctionIdentifier in UnresolvedTableValuedFunction

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -695,7 +695,7 @@ inlineTable
     ;
 
 functionTable
-    : funcName=errorCapturingIdentifier '(' (expression (',' expression)*)? ')' tableAlias
+    : funcName=functionName '(' (expression (',' expression)*)? ')' tableAlias
     ;
 
 tableAlias

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableValuedFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableValuedFunctions.scala
@@ -111,13 +111,13 @@ object ResolveTableValuedFunctions extends Rule[LogicalPlan] {
       // The whole resolution is somewhat difficult to understand here due to too much abstractions.
       // We should probably rewrite the following at some point. Reynold was just here to improve
       // error messages and didn't have time to do a proper rewrite.
-      val resolvedFunc = builtinFunctions.get(u.functionName.toLowerCase(Locale.ROOT)) match {
+      val resolvedFunc = builtinFunctions.get(u.name.funcName.toLowerCase(Locale.ROOT)) match {
         case Some(tvf) =>
 
           def failAnalysis(): Nothing = {
             val argTypes = u.functionArgs.map(_.dataType.typeName).mkString(", ")
             u.failAnalysis(
-              s"""error: table-valued function ${u.functionName} with alternatives:
+              s"""error: table-valued function ${u.name} with alternatives:
                  |${tvf.keys.map(_.toString).toSeq.sorted.map(x => s" ($x)").mkString("\n")}
                  |cannot be applied to: ($argTypes)""".stripMargin)
           }
@@ -139,7 +139,7 @@ object ResolveTableValuedFunctions extends Rule[LogicalPlan] {
             failAnalysis()
           }
         case _ =>
-          u.failAnalysis(s"could not resolve `${u.functionName}` to a table-valued function")
+          u.failAnalysis(s"could not resolve `${u.name}` to a table-valued function")
       }
 
       // If alias names assigned, add `Project` with the aliases
@@ -148,7 +148,7 @@ object ResolveTableValuedFunctions extends Rule[LogicalPlan] {
         // Checks if the number of the aliases is equal to expected one
         if (u.outputNames.size != outputAttrs.size) {
           u.failAnalysis(s"Number of given aliases does not match number of output columns. " +
-            s"Function name: ${u.functionName}; number of aliases: " +
+            s"Function name: ${u.name}; number of aliases: " +
             s"${u.outputNames.size}; number of output columns: ${outputAttrs.size}.")
         }
         val aliases = outputAttrs.zip(u.outputNames).map {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -120,13 +120,13 @@ case class UnresolvedInlineTable(
  *   select t.a from range(10) t(a);
  * }}}
  *
- * @param functionName name of this table-value function
+ * @param name qualified name of this table-value function
  * @param functionArgs list of function arguments
  * @param outputNames alias names of function output columns. If these names given, an analyzer
  *                    adds [[Project]] to rename the output columns.
  */
 case class UnresolvedTableValuedFunction(
-    functionName: String,
+    name: FunctionIdentifier,
     functionArgs: Seq[Expression],
     outputNames: Seq[String])
   extends LeafNode {
@@ -134,6 +134,15 @@ case class UnresolvedTableValuedFunction(
   override def output: Seq[Attribute] = Nil
 
   override lazy val resolved = false
+}
+
+object UnresolvedTableValuedFunction {
+  def apply(
+      name: String,
+      functionArgs: Seq[Expression],
+      outputNames: Seq[String]): UnresolvedTableValuedFunction = {
+    UnresolvedTableValuedFunction(FunctionIdentifier(name), functionArgs, outputNames)
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1144,7 +1144,9 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
     }
 
     val tvf = UnresolvedTableValuedFunction(
-      func.funcName.getText, func.expression.asScala.map(expression).toSeq, aliases)
+      getFunctionIdentifier(func.functionName),
+      func.expression.asScala.map(expression).toSeq,
+      aliases)
     tvf.optionalMap(func.tableAlias.strictIdentifier)(aliasPlan)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1142,11 +1142,13 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
     } else {
       Seq.empty
     }
+    val name = getFunctionIdentifier(func.functionName)
+    if (name.database.nonEmpty) {
+      operationNotAllowed(s"table valued function cannot specify database name: $name", ctx)
+    }
 
     val tvf = UnresolvedTableValuedFunction(
-      getFunctionIdentifier(func.functionName),
-      func.expression.asScala.map(expression).toSeq,
-      aliases)
+      name, func.expression.asScala.map(expression).toSeq, aliases)
     tvf.optionalMap(func.tableAlias.strictIdentifier)(aliasPlan)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -591,6 +591,9 @@ class PlanParserSuite extends AnalysisTest {
     assertEqual(
       "select * from range(2)",
       UnresolvedTableValuedFunction("range", Literal(2) :: Nil, Seq.empty).select(star()))
+    // SPARK-34627
+    intercept("select * from default.range(2)",
+      "table valued function cannot specify database name: default.range")
   }
 
   test("SPARK-20311 range(N) as alias") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR updates UnresolvedTableValuedFunction's name to be a FunctionIdentifier instead of a string.

### Why are the changes needed?
To make UnresolvedTableValuedFunction consistent with UnresolvedFunction that uses FunctionIdentifier as the function name.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test.
