### PR TITLE
[SPARK-34295][CORE] Exclude filesystems from token renewal at YARN

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -49,7 +49,7 @@ private[deploy] class HadoopFSDelegationTokenProvider
     try {
       val fileSystems = HadoopFSDelegationTokenProvider.hadoopFSsToAccess(sparkConf, hadoopConf)
       // The hosts on which the file systems to be excluded from token renewal
-      val fsToExclude = sparkConf.get(KERBEROS_FILESYSTEM_RENEWAL_EXCLUDE)
+      val fsToExclude = sparkConf.get(YARN_KERBEROS_FILESYSTEM_RENEWAL_EXCLUDE)
         .map(new Path(_).getFileSystem(hadoopConf).getUri.getHost)
         .toSet
       val fetchCreds = fetchDelegationTokens(getTokenRenewer(hadoopConf), fileSystems, creds,

--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -104,7 +104,7 @@ private[deploy] class HadoopFSDelegationTokenProvider
       hadoopConf: Configuration,
       sparkConf: SparkConf): Credentials = {
 
-    // The filesystems excluded from token renewal
+    // The hosts on which the file systems to be excluded from token renewal
     val fsToExclude = sparkConf.get(KERBEROS_FILESYSTEM_RENEWAL_EXCLUDE)
       .map(new Path(_).getFileSystem(hadoopConf).getUri.getHost)
       .toSet

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -694,7 +694,10 @@ package object config {
   private[spark] val KERBEROS_FILESYSTEM_RENEWAL_EXCLUDE =
     ConfigBuilder("spark.kerberos.renewal.exclude.hadoopFileSystems")
       .doc("The list of Hadoop filesystem URLs whose hosts will be excluded from " +
-        "delegation token renewal. This is known to work under YARN for now.")
+        "delegation token renewal at resource scheduler. Currently this is known to " +
+        "work under YARN, so YARN Resource Manager won't renew tokens for the application. " +
+        "Note that as resource scheduler does not renew token, the application might not be " +
+        "long running once the token expires.")
       .version("3.2.0")
       .stringConf
       .toSequence

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -693,7 +693,8 @@ package object config {
 
   private[spark] val KERBEROS_FILESYSTEM_RENEWAL_EXCLUDE =
     ConfigBuilder("spark.kerberos.renewal.exclude.hadoopFileSystems")
-      .doc("The list of Hadoop filesystem URLs for which to exclude from delegation token renewal.")
+      .doc("The list of Hadoop filesystem URLs whose hosts will be excluded from " +
+        "delegation token renewal.")
       .version("3.2.0")
       .stringConf
       .toSequence

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -691,13 +691,13 @@ package object config {
     .toSequence
     .createWithDefault(Nil)
 
-  private[spark] val KERBEROS_FILESYSTEM_RENEWAL_EXCLUDE =
-    ConfigBuilder("spark.kerberos.renewal.exclude.hadoopFileSystems")
+  private[spark] val YARN_KERBEROS_FILESYSTEM_RENEWAL_EXCLUDE =
+    ConfigBuilder("spark.yarn.kerberos.renewal.excludeHadoopFileSystems")
       .doc("The list of Hadoop filesystem URLs whose hosts will be excluded from " +
         "delegation token renewal at resource scheduler. Currently this is known to " +
         "work under YARN, so YARN Resource Manager won't renew tokens for the application. " +
-        "Note that as resource scheduler does not renew token, the application might not be " +
-        "long running once the token expires.")
+        "Note that as resource scheduler does not renew token, so any application running " +
+        "longer than the original token expiration that tries to use that token will likely fail.")
       .version("3.2.0")
       .stringConf
       .toSequence

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -694,7 +694,7 @@ package object config {
   private[spark] val KERBEROS_FILESYSTEM_RENEWAL_EXCLUDE =
     ConfigBuilder("spark.kerberos.renewal.exclude.hadoopFileSystems")
       .doc("The list of Hadoop filesystem URLs whose hosts will be excluded from " +
-        "delegation token renewal.")
+        "delegation token renewal. This is known to work under YARN for now.")
       .version("3.2.0")
       .stringConf
       .toSequence

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -691,6 +691,14 @@ package object config {
     .toSequence
     .createWithDefault(Nil)
 
+  private[spark] val KERBEROS_FILESYSTEM_RENEWAL_EXCLUDE =
+    ConfigBuilder("spark.kerberos.renewal.exclude.hadoopFileSystems")
+      .doc("The list of Hadoop filesystem URLs for which to exclude from delegation token renewal.")
+      .version("3.2.0")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
   private[spark] val EXECUTOR_INSTANCES = ConfigBuilder("spark.executor.instances")
     .version("1.0.0")
     .intConf

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -699,6 +699,18 @@ staging directory of the Spark application.
   </td>
   <td>2.3.0</td>
 </tr>
+<tr>
+  <td><code>spark.yarn.kerberos.renewal.excludeHadoopFileSystems</code></td>
+  <td>(none)</td>
+  <td>
+    A comma-separated list of Hadoop filesystems for whose hosts will be excluded from from delegation
+    token renewal at resource scheduler. For example, <code>spark.yarn.kerberos.renewal.excludeHadoopFileSystems=hdfs://nn1.com:8032,
+    hdfs://nn2.com:8032</code>. This is known to work under YARN for now, so YARN Resource Manager won't renew tokens for the application.
+    Note that as resource scheduler does not renew token, so any application running longer than the original token expiration that tries
+    to use that token will likely fail.
+  </td>
+  <td>3.2.0</td>
+</tr>
 </table>
 
 ## Troubleshooting Kerberos

--- a/docs/security.md
+++ b/docs/security.md
@@ -838,6 +838,16 @@ The following options provides finer-grained control for this feature:
   </td>
   <td>3.0.0</td>
 </tr>
+<tr>
+  <td><code>spark.kerberos.renewal.exclude.hadoopFileSystems</code></td>
+  <td>(none)</td>
+  <td>
+    A comma-separated list of Hadoop filesystems for whose hosts will be excluded from from delegation
+    token renewal. For example, <code>spark.kerberos.renewal.exclude.hadoopFileSystems=hdfs://nn1.com:8032,
+    hdfs://nn2.com:8032</code>.
+  </td>
+  <td>3.2.0</td>
+</tr>
 </table>
 
 ## Long-Running Applications

--- a/docs/security.md
+++ b/docs/security.md
@@ -844,7 +844,7 @@ The following options provides finer-grained control for this feature:
   <td>
     A comma-separated list of Hadoop filesystems for whose hosts will be excluded from from delegation
     token renewal. For example, <code>spark.kerberos.renewal.exclude.hadoopFileSystems=hdfs://nn1.com:8032,
-    hdfs://nn2.com:8032</code>.
+    hdfs://nn2.com:8032</code>. This is known to work under YARN for now.
   </td>
   <td>3.2.0</td>
 </tr>

--- a/docs/security.md
+++ b/docs/security.md
@@ -838,19 +838,10 @@ The following options provides finer-grained control for this feature:
   </td>
   <td>3.0.0</td>
 </tr>
-<tr>
-  <td><code>spark.yarn.kerberos.renewal.excludeHadoopFileSystems</code></td>
-  <td>(none)</td>
-  <td>
-    A comma-separated list of Hadoop filesystems for whose hosts will be excluded from from delegation
-    token renewal at resource scheduler. For example, <code>spark.yarn.kerberos.renewal.excludeHadoopFileSystems=hdfs://nn1.com:8032,
-    hdfs://nn2.com:8032</code>. This is known to work under YARN for now, so YARN Resource Manager won't renew tokens for the application.
-    Note that as resource scheduler does not renew token, so any application running longer than the original token expiration that tries
-    to use that token will likely fail.
-  </td>
-  <td>3.2.0</td>
-</tr>
 </table>
+
+Users can exclude Kerberos delegation token renewal at resource scheduler. Currently it is only supported
+on YARN. The configuration is covered in the [Running Spark on YARN](running-on-yarn.html#yarn-specific-kerberos-configuration) page.
 
 ## Long-Running Applications
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -839,13 +839,14 @@ The following options provides finer-grained control for this feature:
   <td>3.0.0</td>
 </tr>
 <tr>
-  <td><code>spark.kerberos.renewal.exclude.hadoopFileSystems</code></td>
+  <td><code>spark.yarn.kerberos.renewal.excludeHadoopFileSystems</code></td>
   <td>(none)</td>
   <td>
     A comma-separated list of Hadoop filesystems for whose hosts will be excluded from from delegation
-    token renewal at resource scheduler. For example, <code>spark.kerberos.renewal.exclude.hadoopFileSystems=hdfs://nn1.com:8032,
+    token renewal at resource scheduler. For example, <code>spark.yarn.kerberos.renewal.excludeHadoopFileSystems=hdfs://nn1.com:8032,
     hdfs://nn2.com:8032</code>. This is known to work under YARN for now, so YARN Resource Manager won't renew tokens for the application.
-    Note that as resource scheduler does not renew token, the application might not be long running once the token expires.
+    Note that as resource scheduler does not renew token, so any application running longer than the original token expiration that tries
+    to use that token will likely fail.
   </td>
   <td>3.2.0</td>
 </tr>

--- a/docs/security.md
+++ b/docs/security.md
@@ -843,8 +843,9 @@ The following options provides finer-grained control for this feature:
   <td>(none)</td>
   <td>
     A comma-separated list of Hadoop filesystems for whose hosts will be excluded from from delegation
-    token renewal. For example, <code>spark.kerberos.renewal.exclude.hadoopFileSystems=hdfs://nn1.com:8032,
-    hdfs://nn2.com:8032</code>. This is known to work under YARN for now.
+    token renewal at resource scheduler. For example, <code>spark.kerberos.renewal.exclude.hadoopFileSystems=hdfs://nn1.com:8032,
+    hdfs://nn2.com:8032</code>. This is known to work under YARN for now, so YARN Resource Manager won't renew tokens for the application.
+    Note that as resource scheduler does not renew token, the application might not be long running once the token expires.
   </td>
   <td>3.2.0</td>
 </tr>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch adds a config `spark.yarn.kerberos.renewal.excludeHadoopFileSystems` which lists the filesystems to be excluded from delegation token renewal at YARN.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

MapReduce jobs can instruct YARN to skip renewal of tokens obtained from certain hosts by specifying the hosts with configuration mapreduce.job.hdfs-servers.token-renewal.exclude=<host1>,<host2>,..,<hostN>.

But seems Spark lacks of similar option. So the job submission fails if YARN fails to renew DelegationToken for any of the remote HDFS cluster. The failure in DT renewal can happen due to many reason like Remote HDFS does not trust Kerberos identity of YARN etc. We have a customer facing such issue.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, if the config is not set. Yes, as users can use this config to instruct YARN not to renew delegation token from certain filesystems.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

It is hard to do unit test for this. We did verify it work from the customer using this fix in the production environment.