### PR TITLE
[SPARK-33114][CORE] Add metadata in MapStatus to support custom shuffle manager 

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -27,7 +27,9 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
+
 import org.apache.commons.io.output.{ByteArrayOutputStream => ApacheByteArrayOutputStream}
+
 import org.apache.spark.broadcast.{Broadcast, BroadcastManager}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -368,6 +368,15 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
       endPartition: Int): Iterator[(BlockManagerId, Seq[(BlockId, Long, Int)])]
 
   /**
+   * Get all map output statuses for the given shuffle id. This could be used by custom shuffle
+   * manager to get map output information. For example, remote shuffle service shuffle manager
+   * could use this method to get the information and figure out where the shuffle data is located.
+   * @param shuffleId
+   * @return An array of all map status objects.
+   */
+  def getAllMapOutputStatuses(shuffleId: Int): Array[MapStatus]
+
+  /**
    * Deletes map output status information for the specified shuffle stage.
    */
   def unregisterShuffle(shuffleId: Int): Unit
@@ -774,6 +783,18 @@ private[spark] class MapOutputTrackerMaster(
     }
   }
 
+  def getAllMapOutputStatuses(shuffleId: Int): Array[MapStatus] = {
+    logDebug(s"Fetching all output statuses for shuffle $shuffleId")
+    shuffleStatuses.get(shuffleId) match {
+      case Some(shuffleStatus) =>
+        shuffleStatus.withMapStatuses { statuses =>
+          MapOutputTracker.checkMapStatuses(statuses, shuffleId)
+          statuses.clone
+        }
+      case None => Array.empty
+    }
+  }
+
   override def stop(): Unit = {
     mapOutputRequests.offer(PoisonPill)
     threadpool.shutdown()
@@ -825,6 +846,13 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
         mapStatuses.clear()
         throw e
     }
+  }
+
+  override def getAllMapOutputStatuses(shuffleId: Int): Array[MapStatus] = {
+    logDebug(s"Fetching all output statuses for shuffle $shuffleId")
+    val statuses = getStatuses(shuffleId, conf)
+    MapOutputTracker.checkMapStatuses(statuses, shuffleId)
+    statuses
   }
 
   /**
@@ -1010,5 +1038,16 @@ private[spark] object MapOutputTracker extends Logging {
     }
 
     splitsByAddress.mapValues(_.toSeq).iterator
+  }
+
+  def checkMapStatuses(statuses: Array[MapStatus], shuffleId: Int): Unit = {
+    assert (statuses != null)
+    for (status <- statuses) {
+      if (status == null) {
+        val errorMessage = s"Missing an output location for shuffle $shuffleId"
+        logError(errorMessage)
+        throw new MetadataFetchFailedException(shuffleId, 0, errorMessage)
+      }
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -371,7 +371,7 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
    * manager could use this method to get the information and figure out where the shuffle data
    * is located.
    * @param shuffleId
-   * @return An array of all map status objects.
+   * @return An array of all map status metadata objects.
    */
   def getAllMapOutputStatusMetadata(shuffleId: Int): Array[Serializable]
 

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.scheduler
 
-import java.io.{Externalizable, ObjectInput, ObjectOutput}
+import java.io.{Externalizable, ObjectInput, ObjectOutput, Serializable}
 
 import scala.collection.mutable
 
@@ -52,6 +52,13 @@ private[spark] sealed trait MapStatus {
    * partitionId of the task or taskContext.taskAttemptId is used.
    */
   def mapId: Long
+
+  /**
+   * Extra metadata for map status. This could be used by different ShuffleManager implementation
+   * to store information they need. For example, a Remote Shuffle Service ShuffleManager could
+   * store shuffle server information and let reducer task know where to fetch shuffle data.
+   */
+  def metadata: Option[Serializable]
 }
 
 
@@ -73,6 +80,18 @@ private[spark] object MapStatus {
       HighlyCompressedMapStatus(loc, uncompressedSizes, mapTaskId)
     } else {
       new CompressedMapStatus(loc, uncompressedSizes, mapTaskId)
+    }
+  }
+
+  def apply(
+      loc: BlockManagerId,
+      uncompressedSizes: Array[Long],
+      mapTaskId: Long,
+      metadata: Option[Serializable]): MapStatus = {
+    if (uncompressedSizes.length > minPartitionsToUseHighlyCompressMapStatus) {
+      HighlyCompressedMapStatus(loc, uncompressedSizes, mapTaskId, metadata)
+    } else {
+      new CompressedMapStatus(loc, uncompressedSizes, mapTaskId, metadata)
     }
   }
 
@@ -117,7 +136,8 @@ private[spark] object MapStatus {
 private[spark] class CompressedMapStatus(
     private[this] var loc: BlockManagerId,
     private[this] var compressedSizes: Array[Byte],
-    private[this] var _mapTaskId: Long)
+    private[this] var _mapTaskId: Long,
+    private[this] var _metadata: Option[Serializable] = None)
   extends MapStatus with Externalizable {
 
   // For deserialization only
@@ -125,6 +145,11 @@ private[spark] class CompressedMapStatus(
 
   def this(loc: BlockManagerId, uncompressedSizes: Array[Long], mapTaskId: Long) = {
     this(loc, uncompressedSizes.map(MapStatus.compressSize), mapTaskId)
+  }
+
+  def this(loc: BlockManagerId, uncompressedSizes: Array[Long], mapTaskId: Long,
+           metadata: Option[Serializable]) {
+    this(loc, uncompressedSizes.map(MapStatus.compressSize), mapTaskId, metadata)
   }
 
   override def location: BlockManagerId = loc
@@ -139,11 +164,19 @@ private[spark] class CompressedMapStatus(
 
   override def mapId: Long = _mapTaskId
 
+  override def metadata: Option[Serializable] = _metadata
+
   override def writeExternal(out: ObjectOutput): Unit = Utils.tryOrIOException {
     loc.writeExternal(out)
     out.writeInt(compressedSizes.length)
     out.write(compressedSizes)
     out.writeLong(_mapTaskId)
+    if (_metadata.isEmpty) {
+      out.writeBoolean(false)
+    } else {
+      out.writeBoolean(true)
+      out.writeObject(_metadata.get)
+    }
   }
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
@@ -152,6 +185,10 @@ private[spark] class CompressedMapStatus(
     compressedSizes = new Array[Byte](len)
     in.readFully(compressedSizes)
     _mapTaskId = in.readLong()
+    val hasMetadata = in.readBoolean()
+    if (hasMetadata) {
+      _metadata = Some(in.readObject().asInstanceOf[Serializable])
+    }
   }
 }
 
@@ -173,7 +210,8 @@ private[spark] class HighlyCompressedMapStatus private (
     private[this] var emptyBlocks: RoaringBitmap,
     private[this] var avgSize: Long,
     private[this] var hugeBlockSizes: scala.collection.Map[Int, Byte],
-    private[this] var _mapTaskId: Long)
+    private[this] var _mapTaskId: Long,
+    private[this] var _metadata: Option[Serializable] = None)
   extends MapStatus with Externalizable {
 
   // loc could be null when the default constructor is called during deserialization
@@ -203,6 +241,8 @@ private[spark] class HighlyCompressedMapStatus private (
 
   override def mapId: Long = _mapTaskId
 
+  override def metadata: Option[Serializable] = _metadata
+
   override def writeExternal(out: ObjectOutput): Unit = Utils.tryOrIOException {
     loc.writeExternal(out)
     emptyBlocks.serialize(out)
@@ -213,6 +253,12 @@ private[spark] class HighlyCompressedMapStatus private (
       out.writeByte(kv._2)
     }
     out.writeLong(_mapTaskId)
+    if (_metadata.isEmpty) {
+      out.writeBoolean(false)
+    } else {
+      out.writeBoolean(true)
+      out.writeObject(_metadata.get)
+    }
   }
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
@@ -230,6 +276,10 @@ private[spark] class HighlyCompressedMapStatus private (
     }
     hugeBlockSizes = hugeBlockSizesImpl
     _mapTaskId = in.readLong()
+    val hasMetadata = in.readBoolean()
+    if (hasMetadata) {
+      _metadata = Some(in.readObject().asInstanceOf[Serializable])
+    }
   }
 }
 
@@ -237,7 +287,8 @@ private[spark] object HighlyCompressedMapStatus {
   def apply(
       loc: BlockManagerId,
       uncompressedSizes: Array[Long],
-      mapTaskId: Long): HighlyCompressedMapStatus = {
+      mapTaskId: Long,
+      metadata: Option[Serializable] = None): HighlyCompressedMapStatus = {
     // We must keep track of which blocks are empty so that we don't report a zero-sized
     // block as being non-empty (or vice-versa) when using the average block size.
     var i = 0
@@ -278,6 +329,6 @@ private[spark] object HighlyCompressedMapStatus {
     emptyBlocks.trim()
     emptyBlocks.runOptimize()
     new HighlyCompressedMapStatus(loc, numNonEmptyBlocks, emptyBlocks, avgSize,
-      hugeBlockSizes, mapTaskId)
+      hugeBlockSizes, mapTaskId, metadata)
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -171,12 +171,8 @@ private[spark] class CompressedMapStatus(
     out.writeInt(compressedSizes.length)
     out.write(compressedSizes)
     out.writeLong(_mapTaskId)
-    if (_metadata.isEmpty) {
-      out.writeBoolean(false)
-    } else {
-      out.writeBoolean(true)
-      out.writeObject(_metadata.get)
-    }
+    out.writeBoolean(_metadata.isDefined)
+    _metadata.foreach(out.writeObject)
   }
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
@@ -253,12 +249,8 @@ private[spark] class HighlyCompressedMapStatus private (
       out.writeByte(kv._2)
     }
     out.writeLong(_mapTaskId)
-    if (_metadata.isEmpty) {
-      out.writeBoolean(false)
-    } else {
-      out.writeBoolean(true)
-      out.writeObject(_metadata.get)
-    }
+    out.writeBoolean(_metadata.isDefined)
+    _metadata.foreach(out.writeObject)
   }
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -73,7 +73,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
           (BlockManagerId("b", "hostB", 1000),
             ArrayBuffer((ShuffleBlockId(10, 6, 0), size10000, 1)))).toSet)
     val allStatuses = tracker.getAllMapOutputStatuses(10)
-    assert(allStatuses.toSet === Set(mapStatus1, mapStatus2))
+    assert(allStatuses === Array(mapStatus1, mapStatus2))
     assert(0 == tracker.getNumCachedSerializedBroadcast)
     tracker.stop()
     rpcEnv.shutdown()
@@ -92,7 +92,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     tracker.registerMapOutput(10, 0, mapStatus1)
     tracker.registerMapOutput(10, 1, mapStatus2)
     val allStatuses = tracker.getAllMapOutputStatuses(10)
-    assert(allStatuses.toSet === Set(mapStatus1, mapStatus2))
+    assert(allStatuses === Array(mapStatus1, mapStatus2))
     assert(0 == tracker.getNumCachedSerializedBroadcast)
     tracker.stop()
     rpcEnv.shutdown()
@@ -387,7 +387,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
                 (ShuffleBlockId(10, 6, 2), size1000, 1)))
         )
     )
-    assert(tracker.getAllMapOutputStatuses(10).toSet === Set(mapStatus1, mapStatus2))
+    assert(tracker.getAllMapOutputStatuses(10) === Array(mapStatus1, mapStatus2))
 
     tracker.unregisterShuffle(10)
     tracker.stop()

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -93,7 +93,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     tracker.registerMapOutput(10, 1, mapStatus2)
     assert(0 == tracker.getNumCachedSerializedBroadcast)
     val allStatusMetadata = tracker.getAllMapOutputStatusMetadata(10)
-    assert(0 == allStatusMetadata.size)
+    assert(allStatusMetadata === Array(mapStatus1.metadata.get, mapStatus2.metadata.get))
     tracker.stop()
     rpcEnv.shutdown()
   }
@@ -215,7 +215,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     masterTracker.registerMapOutput(10, 0, mapStatus)
     val allMapOutputStatusMetadata = mapWorkerTracker.getAllMapOutputStatusMetadata(10)
     assert(allMapOutputStatusMetadata.size === 1)
-    assert(allMapOutputStatusMetadata(0) === mapStatus.metadata)
+    assert(allMapOutputStatusMetadata(0) === mapStatus.metadata.get)
 
     masterTracker.stop()
     mapWorkerTracker.stop()
@@ -381,7 +381,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
                 (ShuffleBlockId(10, 6, 2), size1000, 1)))
         )
     )
-    assert(0 == tracker.getAllMapOutputStatusMetadata(10))
+    assert(0 == tracker.getAllMapOutputStatusMetadata(10).size)
 
     tracker.unregisterShuffle(10)
     tracker.stop()

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -62,16 +62,37 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     assert(tracker.containsShuffle(10))
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
     val size10000 = MapStatus.decompressSize(MapStatus.compressSize(10000L))
-    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
-        Array(1000L, 10000L), 5))
-    tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
-        Array(10000L, 1000L), 6))
+    val mapStatus1 = MapStatus(BlockManagerId("a", "hostA", 1000), Array(1000L, 10000L), 5)
+    val mapStatus2 = MapStatus(BlockManagerId("b", "hostB", 1000), Array(10000L, 1000L), 6)
+    tracker.registerMapOutput(10, 0, mapStatus1)
+    tracker.registerMapOutput(10, 1, mapStatus2)
     val statuses = tracker.getMapSizesByExecutorId(10, 0)
     assert(statuses.toSet ===
       Seq((BlockManagerId("a", "hostA", 1000),
         ArrayBuffer((ShuffleBlockId(10, 5, 0), size1000, 0))),
           (BlockManagerId("b", "hostB", 1000),
             ArrayBuffer((ShuffleBlockId(10, 6, 0), size10000, 1)))).toSet)
+    val allStatuses = tracker.getAllMapOutputStatuses(10)
+    assert(allStatuses.toSet === Set(mapStatus1, mapStatus2))
+    assert(0 == tracker.getNumCachedSerializedBroadcast)
+    tracker.stop()
+    rpcEnv.shutdown()
+  }
+
+  test("master register shuffle with map status metadata") {
+    val rpcEnv = createRpcEnv("test")
+    val tracker = newTrackerMaster()
+    tracker.trackerEndpoint = rpcEnv.setupEndpoint(MapOutputTracker.ENDPOINT_NAME,
+      new MapOutputTrackerMasterEndpoint(rpcEnv, tracker, conf))
+    tracker.registerShuffle(10, 2)
+    val mapStatus1 = MapStatus(BlockManagerId("a", "hostA", 1000),
+      Array(1000L, 10000L), 5, Some("metadata1"))
+    val mapStatus2 = MapStatus(BlockManagerId("b", "hostB", 1000),
+      Array(10000L, 1000L), 6, Some(1001))
+    tracker.registerMapOutput(10, 0, mapStatus1)
+    tracker.registerMapOutput(10, 1, mapStatus2)
+    val allStatuses = tracker.getAllMapOutputStatuses(10)
+    assert(allStatuses.toSet === Set(mapStatus1, mapStatus2))
     assert(0 == tracker.getNumCachedSerializedBroadcast)
     tracker.stop()
     rpcEnv.shutdown()
@@ -91,10 +112,12 @@ class MapOutputTrackerSuite extends SparkFunSuite {
       Array(compressedSize10000, compressedSize1000), 6))
     assert(tracker.containsShuffle(10))
     assert(tracker.getMapSizesByExecutorId(10, 0).nonEmpty)
+    assert(tracker.getAllMapOutputStatuses(10).nonEmpty)
     assert(0 == tracker.getNumCachedSerializedBroadcast)
     tracker.unregisterShuffle(10)
     assert(!tracker.containsShuffle(10))
     assert(tracker.getMapSizesByExecutorId(10, 0).isEmpty)
+    assert(tracker.getAllMapOutputStatuses(11).isEmpty)
 
     tracker.stop()
     rpcEnv.shutdown()
@@ -122,6 +145,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     // this should cause it to fail, and the scheduler will ignore the failure due to the
     // stage already being aborted.
     intercept[FetchFailedException] { tracker.getMapSizesByExecutorId(10, 1) }
+    intercept[FetchFailedException] { tracker.getAllMapOutputStatuses(10) }
 
     tracker.stop()
     rpcEnv.shutdown()
@@ -146,13 +170,18 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     intercept[FetchFailedException] { mapWorkerTracker.getMapSizesByExecutorId(10, 0) }
 
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
-    masterTracker.registerMapOutput(10, 0, MapStatus(
-      BlockManagerId("a", "hostA", 1000), Array(1000L), 5))
+    val mapStatus = MapStatus(BlockManagerId("a", "hostA", 1000), Array(1000L), 5)
+    masterTracker.registerMapOutput(10, 0, mapStatus)
     mapWorkerTracker.updateEpoch(masterTracker.getEpoch)
     assert(mapWorkerTracker.getMapSizesByExecutorId(10, 0).toSeq ===
       Seq((BlockManagerId("a", "hostA", 1000),
         ArrayBuffer((ShuffleBlockId(10, 5, 0), size1000, 0)))))
-    assert(0 == masterTracker.getNumCachedSerializedBroadcast)
+    val allMapOutputStatuses = mapWorkerTracker.getAllMapOutputStatuses(10)
+    assert(allMapOutputStatuses.length === 1)
+    assert(allMapOutputStatuses(0).location === mapStatus.location)
+    assert(allMapOutputStatuses(0).getSizeForBlock(0) === mapStatus.getSizeForBlock(0))
+    assert(allMapOutputStatuses(0).mapId === mapStatus.mapId)
+    assert(allMapOutputStatuses(0).metadata === mapStatus.metadata)
 
     val masterTrackerEpochBeforeLossOfMapOutput = masterTracker.getEpoch
     masterTracker.unregisterMapOutput(10, 0, BlockManagerId("a", "hostA", 1000))
@@ -163,6 +192,36 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     // failure should be cached
     intercept[FetchFailedException] { mapWorkerTracker.getMapSizesByExecutorId(10, 0) }
     assert(0 == masterTracker.getNumCachedSerializedBroadcast)
+
+    masterTracker.stop()
+    mapWorkerTracker.stop()
+    rpcEnv.shutdown()
+    mapWorkerRpcEnv.shutdown()
+  }
+
+  test("remote get all map output statuses with metadata") {
+    val hostname = "localhost"
+    val rpcEnv = createRpcEnv("spark", hostname, 0, new SecurityManager(conf))
+
+    val masterTracker = newTrackerMaster()
+    masterTracker.trackerEndpoint = rpcEnv.setupEndpoint(MapOutputTracker.ENDPOINT_NAME,
+      new MapOutputTrackerMasterEndpoint(rpcEnv, masterTracker, conf))
+
+    val mapWorkerRpcEnv = createRpcEnv("spark-worker", hostname, 0, new SecurityManager(conf))
+    val mapWorkerTracker = new MapOutputTrackerWorker(conf)
+    mapWorkerTracker.trackerEndpoint =
+      mapWorkerRpcEnv.setupEndpointRef(rpcEnv.address, MapOutputTracker.ENDPOINT_NAME)
+
+    masterTracker.registerShuffle(10, 1)
+    val mapStatus = MapStatus(BlockManagerId("a", "hostA", 1000), Array(1000L), 5,
+      Some("metadata1"))
+    masterTracker.registerMapOutput(10, 0, mapStatus)
+    val allMapOutputStatuses = mapWorkerTracker.getAllMapOutputStatuses(10)
+    assert(allMapOutputStatuses.length === 1)
+    assert(allMapOutputStatuses(0).location === mapStatus.location)
+    assert(allMapOutputStatuses(0).getSizeForBlock(0) === mapStatus.getSizeForBlock(0))
+    assert(allMapOutputStatuses(0).mapId === mapStatus.mapId)
+    assert(allMapOutputStatuses(0).metadata === mapStatus.metadata)
 
     masterTracker.stop()
     mapWorkerTracker.stop()
@@ -311,10 +370,12 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     val size0 = MapStatus.decompressSize(MapStatus.compressSize(0L))
     val size1000 = MapStatus.decompressSize(MapStatus.compressSize(1000L))
     val size10000 = MapStatus.decompressSize(MapStatus.compressSize(10000L))
-    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
-      Array(size0, size1000, size0, size10000), 5))
-    tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
-      Array(size10000, size0, size1000, size0), 6))
+    val mapStatus1 = MapStatus(BlockManagerId("a", "hostA", 1000),
+      Array(size0, size1000, size0, size10000), 5)
+    val mapStatus2 = MapStatus(BlockManagerId("b", "hostB", 1000),
+      Array(size10000, size0, size1000, size0), 6)
+    tracker.registerMapOutput(10, 0, mapStatus1)
+    tracker.registerMapOutput(10, 1, mapStatus2)
     assert(tracker.containsShuffle(10))
     assert(tracker.getMapSizesByExecutorId(10, 0, 2, 0, 4).toSeq ===
         Seq(
@@ -326,6 +387,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
                 (ShuffleBlockId(10, 6, 2), size1000, 1)))
         )
     )
+    assert(tracker.getAllMapOutputStatuses(10).toSet === Set(mapStatus1, mapStatus2))
 
     tracker.unregisterShuffle(10)
     tracker.stop()


### PR DESCRIPTION
This PR is copied from https://github.com/apache/spark/pull/30004, with extra change addressing the comments. My git environment was messed up and could not update previous PR 30004. Thus create this new PR to replace the previous one.

### What changes were proposed in this pull request?
Add generic metadata in MapStatus class to support custom shuffle manager. Also add a new method to retrieve all map output statuses and their metadata. See Jira: https://issues.apache.org/jira/projects/SPARK/issues/SPARK-33114

### Why are the changes needed?
Current MapStatus class is tightly bound with local (sort merge) shuffle which uses BlockManagerId to store the shuffle data location. It could not support other custom shuffle manager implementation. 

For example, when we implement Remote Shuffle Service, we want to put remote shuffle server information into MapStatus so reducer could fetch that information and figure out where to fetch data. The added MapStatus.metadata field could store such information.

If people implement other shuffle manager, they could also store their related information into this metadata field.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added unit test
