### PR TITLE
[SPARK-33436][PYSPARK] PySpark equivalent of SparkContext.hadoopConfiguration

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1255,6 +1255,16 @@ class SparkContext(object):
         conf.setAll(self._conf.getAll())
         return conf
 
+    def hadoopConfiguration(self):
+        """
+        Returns the Hadoop configuration used for the Hadoop code (e.g. file systems) we reuse.
+
+        As it will be reused in all Hadoop RDDs, it's better not to modify it unless you
+        plan to set some global configurations for all Hadoop RDDs.
+        Return :class:`Configuration` object
+        """
+        return self._jsc.hadoopConfiguration()
+
     @property
     def resources(self):
         resources = {}


### PR DESCRIPTION
### What changes were proposed in this pull request?
The same method hadoopConfiguration() for pyspark SparkContext as present in Scala API

### Why are the changes needed?
PySpark should offer an API to hadoopConfiguration to match Scala's

Setting Hadoop configs within a job is handy for any configurations that are not appropriate as cluster defaults, or that will not be known until run time. The various fs.s3a.* configs are a good example of this.

Currently, what people are doing is setting things like this via SparkContext._jsc.hadoopConfiguration().

### Does this PR introduce _any_ user-facing change?
yes

was:
sc = SparkContext()
hadoop_config = sc._jsc.hadoopConfiguration()

after adding changes:
sc = SparkContext()
hadoop_config = sc.hadoopConfiguration()

### How was this patch tested?
existing tests
