### PR TITLE
[SPARK-34606][DOCS] Redirects for moved PySpark docs

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -193,6 +193,17 @@ for moved_page in ['', '.ml', '.mllib', '.sql', '.streaming']:
   </head>
   <body>
     This page has been moved to <a href="{new_url}">a new location</a>, you will be redirected automatically.
+
+    <script type='text/javascript'>
+    const hash = window.location.hash;
+    if (hash !== "") {{
+      const meta = document.getElementsByTagName("meta")[0];
+      const link = document.getElementsByTagName("a")[0];
+      const redirect = `reference/api/${{hash.slice(1)}}.html`;
+      meta.setAttribute("content", `5; url=${{redirect}}`);
+      link.setAttribute("href", redirect);
+    }}
+    </script>
   </body>
 </html>''')
 

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -177,7 +177,24 @@ html_css_files = [
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+redirects_dir = 'redirects'
+html_extra_path = [redirects_dir]
+
+os.makedirs(redirects_dir, exist_ok=True)
+for moved_page in ['', '.ml', '.mllib', '.sql', '.streaming']:
+    moved_file = f'pyspark{moved_page}.html'
+    redirect_file = os.path.join(redirects_dir, moved_file)
+    new_url = f'reference/{moved_file}'
+    with open(redirect_file, 'w') as fw:
+        fw.write(f'''<html>
+  <head>
+    <meta http-equiv="refresh" content="5; url={new_url}" />
+    <title>Page has been moved</title>
+  </head>
+  <body>
+    This page has been moved to <a href="{new_url}">a new location</a>, you will be redirected automatically.
+  </body>
+</html>''')
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
As noted in JIRA, a few links have broken since the latest migration of docs to a new format. This PR aims to fix that.

Some assorted notes:
- I don't know if I can run logic in the docs' `conf.py`, doesn't seem to be the right thing to do, but I didn't have any executable Python along the way to do this (and I didn't want a new Makefile target)
- I could have just placed the five simple HTML files in the `redirects` directory and called it a day?
- I could have used a Sphinx redirects library - I found two, but one was not maintained and the other didn't seem worth the hassle for five pages - or can we expect this trend of moving stuff around to continue?
- The redirect timeout is set for five seconds, so that a message is displayed. I saw some guidance that recommended zero seconds... I'd rather show a message, but you might be of a different opinion.
- I only redirected the API pages, I didn't redirect those module code pages (see the PR's comments) as I found them less user facing... was that the right call?

### Does this PR introduce _any_ user-facing change?

Yes, old links (indexed by Google etc.) will start working again.

### How was this patch tested?
Built the docs locally and tried accessing formerly dead links.