### PR TITLE
[WIP][SPARK-33851][SQL] Push partial aggregate bellow manually inserted repartition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1323,6 +1323,13 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val PUSH_DOWN_AGGREGATES_ENABLED = buildConf("spark.sql.execution.pushDownAggregates")
+    .internal()
+    .doc("Whether to push down aggregates through manually inserted exchanges.")
+    .version("3.2.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val STATE_STORE_PROVIDER_CLASS =
     buildConf("spark.sql.streaming.stateStore.providerClass")
       .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1328,7 +1328,7 @@ object SQLConf {
     .doc("Whether to push down aggregates through manually inserted exchanges.")
     .version("3.2.0")
     .booleanConf
-    .createWithDefault(false)
+    .createWithDefault(true)
 
   val STATE_STORE_PROVIDER_CLASS =
     buildConf("spark.sql.streaming.stateStore.providerClass")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/PushDownAggregates.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/PushDownAggregates.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, PartialMerge}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanExecBase
+import org.apache.spark.sql.execution.joins.BaseJoinExec
+import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Remove redundant ProjectExec node from the spark plan. A ProjectExec node is redundant when
+ * - It has the same output attributes and orders as its child's output and the ordering of
+ *   the attributes is required.
+ * - It has the same output attributes as its child's output when attribute output ordering
+ *   is not required.
+ * This rule needs to be a physical rule because project nodes are useful during logical
+ * optimization to prune data. During physical planning, redundant project nodes can be removed
+ * to simplify the query plan.
+ */
+object RemoveRedundantProjects extends Rule[SparkPlan] {
+  def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.getConf(SQLConf.REMOVE_REDUNDANT_PROJECTS_ENABLED)) {
+      plan
+    } else {
+      removeProject(plan, true)
+    }
+  }
+
+  private def removeProject(plan: SparkPlan, requireOrdering: Boolean): SparkPlan = {
+    plan match {
+      case p @ ProjectExec(_, child) =>
+        if (isRedundant(p, child, requireOrdering)) {
+          val newPlan = removeProject(child, requireOrdering)
+          newPlan.setLogicalLink(child.logicalLink.get)
+          newPlan
+        } else {
+          p.mapChildren(removeProject(_, false))
+        }
+      case op: TakeOrderedAndProjectExec =>
+        op.mapChildren(removeProject(_, false))
+      case a: BaseAggregateExec =>
+        // BaseAggregateExec require specific column ordering when mode is Final or PartialMerge.
+        // See comments in BaseAggregateExec inputAttributes method.
+        val keepOrdering = a.aggregateExpressions
+          .exists(ae => ae.mode.equals(Final) || ae.mode.equals(PartialMerge))
+        a.mapChildren(removeProject(_, keepOrdering))
+      case o =>
+        val required = if (canPassThrough(o)) requireOrdering else true
+        o.mapChildren(removeProject(_, requireOrdering = required))
+    }
+  }
+
+  /**
+   * Check if the given node can pass the ordering requirement from its parent.
+   */
+  private def canPassThrough(plan: SparkPlan): Boolean = plan match {
+    case _: FilterExec => true
+    // JoinExec ordering requirement should inherit from its parent. If there is no ProjectExec in
+    // its ancestors, JoinExec should require output columns to be ordered, and vice versa.
+    case _: BaseJoinExec => true
+    case _: WindowExec => true
+    case _: ExpandExec => true
+    case _ => false
+  }
+
+  /**
+   * Check if the nullability change is positive. It catches the case when the project output
+   * attribute is not nullable, but the child output attribute is nullable.
+   */
+  private def checkNullability(output: Seq[Attribute], childOutput: Seq[Attribute]): Boolean =
+    output.zip(childOutput).forall { case (attr1, attr2) => attr1.nullable || !attr2.nullable }
+
+  private def isRedundant(
+      project: ProjectExec,
+      child: SparkPlan,
+      requireOrdering: Boolean): Boolean = {
+    child match {
+      // If a DataSourceV2ScanExec node does not support columnar, a ProjectExec node is required
+      // to convert the rows to UnsafeRow. See DataSourceV2Strategy for more details.
+      case d: DataSourceV2ScanExecBase if !d.supportsColumnar => false
+      case _ =>
+        if (requireOrdering) {
+          project.output.map(_.exprId.id) == child.output.map(_.exprId.id) &&
+            checkNullability(project.output, child.output)
+        } else {
+          val orderedProjectOutput = project.output.sortBy(_.exprId.id)
+          val orderedChildOutput = child.output.sortBy(_.exprId.id)
+          orderedProjectOutput.map(_.exprId.id) == orderedChildOutput.map(_.exprId.id) &&
+            checkNullability(orderedProjectOutput, orderedChildOutput)
+        }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/PushDownAggregates.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/PushDownAggregates.scala
@@ -17,96 +17,26 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, PartialMerge}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
-import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanExecBase
-import org.apache.spark.sql.execution.joins.BaseJoinExec
-import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.execution.exchange.{REPARTITION, ShuffleExchangeExec}
 import org.apache.spark.sql.internal.SQLConf
 
-/**
- * Remove redundant ProjectExec node from the spark plan. A ProjectExec node is redundant when
- * - It has the same output attributes and orders as its child's output and the ordering of
- *   the attributes is required.
- * - It has the same output attributes as its child's output when attribute output ordering
- *   is not required.
- * This rule needs to be a physical rule because project nodes are useful during logical
- * optimization to prune data. During physical planning, redundant project nodes can be removed
- * to simplify the query plan.
- */
-object RemoveRedundantProjects extends Rule[SparkPlan] {
+object PushDownAggregates extends Rule[SparkPlan] {
   def apply(plan: SparkPlan): SparkPlan = {
-    if (!conf.getConf(SQLConf.REMOVE_REDUNDANT_PROJECTS_ENABLED)) {
-      plan
+    if (conf.getConf(SQLConf.PUSH_DOWN_AGGREGATES_ENABLED)) {
+      pushDownAggregates(plan)
     } else {
-      removeProject(plan, true)
+      plan
     }
   }
 
-  private def removeProject(plan: SparkPlan, requireOrdering: Boolean): SparkPlan = {
-    plan match {
-      case p @ ProjectExec(_, child) =>
-        if (isRedundant(p, child, requireOrdering)) {
-          val newPlan = removeProject(child, requireOrdering)
-          newPlan.setLogicalLink(child.logicalLink.get)
-          newPlan
-        } else {
-          p.mapChildren(removeProject(_, false))
-        }
-      case op: TakeOrderedAndProjectExec =>
-        op.mapChildren(removeProject(_, false))
-      case a: BaseAggregateExec =>
-        // BaseAggregateExec require specific column ordering when mode is Final or PartialMerge.
-        // See comments in BaseAggregateExec inputAttributes method.
-        val keepOrdering = a.aggregateExpressions
-          .exists(ae => ae.mode.equals(Final) || ae.mode.equals(PartialMerge))
-        a.mapChildren(removeProject(_, keepOrdering))
-      case o =>
-        val required = if (canPassThrough(o)) requireOrdering else true
-        o.mapChildren(removeProject(_, requireOrdering = required))
-    }
-  }
-
-  /**
-   * Check if the given node can pass the ordering requirement from its parent.
-   */
-  private def canPassThrough(plan: SparkPlan): Boolean = plan match {
-    case _: FilterExec => true
-    // JoinExec ordering requirement should inherit from its parent. If there is no ProjectExec in
-    // its ancestors, JoinExec should require output columns to be ordered, and vice versa.
-    case _: BaseJoinExec => true
-    case _: WindowExec => true
-    case _: ExpandExec => true
-    case _ => false
-  }
-
-  /**
-   * Check if the nullability change is positive. It catches the case when the project output
-   * attribute is not nullable, but the child output attribute is nullable.
-   */
-  private def checkNullability(output: Seq[Attribute], childOutput: Seq[Attribute]): Boolean =
-    output.zip(childOutput).forall { case (attr1, attr2) => attr1.nullable || !attr2.nullable }
-
-  private def isRedundant(
-      project: ProjectExec,
-      child: SparkPlan,
-      requireOrdering: Boolean): Boolean = {
-    child match {
-      // If a DataSourceV2ScanExec node does not support columnar, a ProjectExec node is required
-      // to convert the rows to UnsafeRow. See DataSourceV2Strategy for more details.
-      case d: DataSourceV2ScanExecBase if !d.supportsColumnar => false
-      case _ =>
-        if (requireOrdering) {
-          project.output.map(_.exprId.id) == child.output.map(_.exprId.id) &&
-            checkNullability(project.output, child.output)
-        } else {
-          val orderedProjectOutput = project.output.sortBy(_.exprId.id)
-          val orderedChildOutput = child.output.sortBy(_.exprId.id)
-          orderedProjectOutput.map(_.exprId.id) == orderedChildOutput.map(_.exprId.id) &&
-            checkNullability(orderedProjectOutput, orderedChildOutput)
-        }
+  private def pushDownAggregates(plan: SparkPlan): SparkPlan = {
+    plan transform  {
+      case UnaryExecNode(agg: BaseAggregateExec, UnaryExecNode(e: ShuffleExchangeExec, child))
+        if child.outputPartitioning.satisfies(agg.requiredChildDistribution.head)
+          && e.shuffleOrigin == REPARTITION =>
+        e.copy(child = agg.withNewChildren(child :: Nil))
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/PushDownAggregates.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/PushDownAggregates.scala
@@ -22,6 +22,10 @@ import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
 import org.apache.spark.sql.execution.exchange.{REPARTITION, ShuffleExchangeExec}
 import org.apache.spark.sql.internal.SQLConf
 
+/**
+ * Pushes (partial) aggregates bellow manually inserted repartition nodes
+ * to reduce the amount of data exchanged.
+ */
 object PushDownAggregates extends Rule[SparkPlan] {
   def apply(plan: SparkPlan): SparkPlan = {
     if (conf.getConf(SQLConf.PUSH_DOWN_AGGREGATES_ENABLED)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -347,6 +347,7 @@ object QueryExecution {
       // `RemoveRedundantSorts` needs to be added after `EnsureRequirements` to guarantee the same
       // number of partitions when instantiating PartitioningCollection.
       RemoveRedundantSorts,
+      PushDownAggregates,
       DisableUnnecessaryBucketedScan,
       ApplyColumnarRulesAndInsertTransitions(sparkSession.sessionState.columnarRules),
       CollapseCodegenStages(),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -88,6 +88,7 @@ case class AdaptiveSparkPlanExec(
     RemoveRedundantProjects,
     EnsureRequirements,
     RemoveRedundantSorts,
+    PushDownAggregates,
     DisableUnnecessaryBucketedScan
   ) ++ context.session.sessionState.queryStagePrepRules
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PushDownAggregatesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PushDownAggregatesSuite.scala
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.catalyst.plans.physical.{RangePartitioning, UnknownPartitioning}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
+import org.apache.spark.sql.execution.joins.ShuffledJoin
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+
+abstract class PushDownAggregateSuiteBase
+    extends QueryTest
+    with SharedSparkSession
+    with AdaptiveSparkPlanHelper {
+  import testImplicits._
+
+  private def checkNumSorts(df: DataFrame, count: Int): Unit = {
+    val plan = df.queryExecution.executedPlan
+    assert(collectWithSubqueries(plan) { case s: SortExec => s }.length == count)
+  }
+
+  private def checkSorts(query: String, enabledCount: Int, disabledCount: Int): Unit = {
+    withSQLConf(SQLConf.REMOVE_REDUNDANT_SORTS_ENABLED.key -> "true") {
+      val df = sql(query)
+      checkNumSorts(df, enabledCount)
+      val result = df.collect()
+      withSQLConf(SQLConf.REMOVE_REDUNDANT_SORTS_ENABLED.key -> "false") {
+        val df = sql(query)
+        checkNumSorts(df, disabledCount)
+        checkAnswer(df, result)
+      }
+    }
+  }
+
+  test("remove redundant sorts with limit") {
+    withTempView("t") {
+      spark.range(100).select('id as "key").createOrReplaceTempView("t")
+      val query =
+        """
+          |SELECT key FROM
+          | (SELECT key FROM t WHERE key > 10 ORDER BY key DESC LIMIT 10)
+          |ORDER BY key DESC
+          |""".stripMargin
+      checkSorts(query, 0, 1)
+    }
+  }
+
+  test("remove redundant sorts with broadcast hash join") {
+    withTempView("t1", "t2") {
+      spark.range(1000).select('id as "key").createOrReplaceTempView("t1")
+      spark.range(1000).select('id as "key").createOrReplaceTempView("t2")
+
+      val queryTemplate = """
+        |SELECT /*+ BROADCAST(%s) */ t1.key FROM
+        | (SELECT key FROM t1 WHERE key > 10 ORDER BY key DESC LIMIT 10) t1
+        |JOIN
+        | (SELECT key FROM t2 WHERE key > 50 ORDER BY key DESC LIMIT 100) t2
+        |ON t1.key = t2.key
+        |ORDER BY %s
+      """.stripMargin
+
+      // No sort should be removed since the stream side (t2) order DESC
+      // does not satisfy the required sort order ASC.
+      val buildLeftOrderByRightAsc = queryTemplate.format("t1", "t2.key ASC")
+      checkSorts(buildLeftOrderByRightAsc, 1, 1)
+
+      // The top sort node should be removed since the stream side (t2) order DESC already
+      // satisfies the required sort order DESC.
+      val buildLeftOrderByRightDesc = queryTemplate.format("t1", "t2.key DESC")
+      checkSorts(buildLeftOrderByRightDesc, 0, 1)
+
+      // No sort should be removed since the sort ordering from broadcast-hash join is based
+      // on the stream side (t2) and the required sort order is from t1.
+      val buildLeftOrderByLeftDesc = queryTemplate.format("t1", "t1.key DESC")
+      checkSorts(buildLeftOrderByLeftDesc, 1, 1)
+
+      // The top sort node should be removed since the stream side (t1) order DESC already
+      // satisfies the required sort order DESC.
+      val buildRightOrderByLeftDesc = queryTemplate.format("t2", "t1.key DESC")
+      checkSorts(buildRightOrderByLeftDesc, 0, 1)
+    }
+  }
+
+  test("remove redundant sorts with sort merge join") {
+    withTempView("t1", "t2") {
+      spark.range(1000).select('id as "key").createOrReplaceTempView("t1")
+      spark.range(1000).select('id as "key").createOrReplaceTempView("t2")
+      val query = """
+        |SELECT /*+ MERGE(t1) */ t1.key FROM
+        | (SELECT key FROM t1 WHERE key > 10 ORDER BY key DESC LIMIT 10) t1
+        |JOIN
+        | (SELECT key FROM t2 WHERE key > 50 ORDER BY key DESC LIMIT 100) t2
+        |ON t1.key = t2.key
+        |ORDER BY t1.key
+      """.stripMargin
+
+      val queryAsc = query + " ASC"
+      checkSorts(queryAsc, 2, 3)
+
+      // The top level sort should not be removed since the child output ordering is ASC and
+      // the required ordering is DESC.
+      val queryDesc = query + " DESC"
+      checkSorts(queryDesc, 3, 3)
+    }
+  }
+
+  test("cached sorted data doesn't need to be re-sorted") {
+    withSQLConf(SQLConf.REMOVE_REDUNDANT_SORTS_ENABLED.key -> "true") {
+      val df = spark.range(1000).select('id as "key").sort('key.desc).cache()
+      val resorted = df.sort('key.desc)
+      val sortedAsc = df.sort('key.asc)
+      checkNumSorts(df, 0)
+      checkNumSorts(resorted, 0)
+      checkNumSorts(sortedAsc, 1)
+      val result = resorted.collect()
+      withSQLConf(SQLConf.REMOVE_REDUNDANT_SORTS_ENABLED.key -> "false") {
+        val resorted = df.sort('key.desc)
+        checkNumSorts(resorted, 1)
+        checkAnswer(resorted, result)
+      }
+    }
+  }
+
+  test("SPARK-33472: shuffled join with different left and right side partition numbers") {
+    withTempView("t1", "t2") {
+      spark.range(0, 100, 1, 2).select('id as "key").createOrReplaceTempView("t1")
+      (0 to 100).toDF("key").createOrReplaceTempView("t2")
+
+      val queryTemplate = """
+        |SELECT /*+ %s(t1) */ t1.key
+        |FROM t1 JOIN t2 ON t1.key = t2.key
+        |WHERE t1.key > 10 AND t2.key < 50
+        |ORDER BY t1.key ASC
+      """.stripMargin
+
+      Seq(("MERGE", 3), ("SHUFFLE_HASH", 1)).foreach { case (hint, count) =>
+        val query = queryTemplate.format(hint)
+        val df = sql(query)
+        val sparkPlan = df.queryExecution.sparkPlan
+        val join = sparkPlan.collect { case j: ShuffledJoin => j }.head
+        val leftPartitioning = join.left.outputPartitioning
+        assert(leftPartitioning.isInstanceOf[RangePartitioning])
+        assert(leftPartitioning.numPartitions == 2)
+        assert(join.right.outputPartitioning == UnknownPartitioning(0))
+        checkSorts(query, count, count)
+      }
+    }
+  }
+}
+
+class PushDownAggregateSuite extends PushDownAggregateSuiteBase
+  with DisableAdaptiveExecutionSuite
+
+class PushDownAggregateSuiteAE extends PushDownAggregateSuiteBase
+  with EnableAdaptiveExecutionSuite

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PushDownAggregatesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PushDownAggregatesSuite.scala
@@ -18,155 +18,57 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.sql.{DataFrame, QueryTest}
-import org.apache.spark.sql.catalyst.plans.physical.{RangePartitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
-import org.apache.spark.sql.execution.joins.ShuffledJoin
+import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 
-abstract class PushDownAggregateSuiteBase
+abstract class PushDownAggregatesSuiteBase
     extends QueryTest
     with SharedSparkSession
     with AdaptiveSparkPlanHelper {
   import testImplicits._
 
-  private def checkNumSorts(df: DataFrame, count: Int): Unit = {
+  private def assertExchangeBetweenAggregates(df: DataFrame, expected: Boolean): Unit = {
     val plan = df.queryExecution.executedPlan
-    assert(collectWithSubqueries(plan) { case s: SortExec => s }.length == count)
+    assert(collectWithSubqueries(plan) {
+      case UnaryExecNode(agg: BaseAggregateExec, UnaryExecNode(_: BaseAggregateExec, _)) => agg
+    }.isEmpty == expected)
   }
 
-  private def checkSorts(query: String, enabledCount: Int, disabledCount: Int): Unit = {
-    withSQLConf(SQLConf.REMOVE_REDUNDANT_SORTS_ENABLED.key -> "true") {
-      val df = sql(query)
-      checkNumSorts(df, enabledCount)
-      val result = df.collect()
-      withSQLConf(SQLConf.REMOVE_REDUNDANT_SORTS_ENABLED.key -> "false") {
-        val df = sql(query)
-        checkNumSorts(df, disabledCount)
-        checkAnswer(df, result)
-      }
-    }
-  }
+  test("Partial aggregate is pushed bellow manually inserted exchange") {
+    withTempPath { path =>
+      spark.range(1000)
+        .select('id % 7 as "a")
+        .repartition()
+        .write.format("parquet").save(path.getAbsolutePath)
 
-  test("remove redundant sorts with limit") {
-    withTempView("t") {
-      spark.range(100).select('id as "key").createOrReplaceTempView("t")
-      val query =
-        """
-          |SELECT key FROM
-          | (SELECT key FROM t WHERE key > 10 ORDER BY key DESC LIMIT 10)
-          |ORDER BY key DESC
-          |""".stripMargin
-      checkSorts(query, 0, 1)
-    }
-  }
 
-  test("remove redundant sorts with broadcast hash join") {
-    withTempView("t1", "t2") {
-      spark.range(1000).select('id as "key").createOrReplaceTempView("t1")
-      spark.range(1000).select('id as "key").createOrReplaceTempView("t2")
+      withSQLConf(SQLConf.PUSH_DOWN_AGGREGATES_ENABLED.key -> "false") {
+        val df1 = spark.read.parquet(path.getAbsolutePath)
+          .repartition('a)
+          .groupBy('a)
+          .count()
 
-      val queryTemplate = """
-        |SELECT /*+ BROADCAST(%s) */ t1.key FROM
-        | (SELECT key FROM t1 WHERE key > 10 ORDER BY key DESC LIMIT 10) t1
-        |JOIN
-        | (SELECT key FROM t2 WHERE key > 50 ORDER BY key DESC LIMIT 100) t2
-        |ON t1.key = t2.key
-        |ORDER BY %s
-      """.stripMargin
+        assertExchangeBetweenAggregates(df1, false)
+        val result = df1.collect()
+        withSQLConf(SQLConf.PUSH_DOWN_AGGREGATES_ENABLED.key -> "true") {
+          val df2 = spark.read.parquet(path.getAbsolutePath)
+            .repartition('a)
+            .groupBy('a)
+            .count()
 
-      // No sort should be removed since the stream side (t2) order DESC
-      // does not satisfy the required sort order ASC.
-      val buildLeftOrderByRightAsc = queryTemplate.format("t1", "t2.key ASC")
-      checkSorts(buildLeftOrderByRightAsc, 1, 1)
-
-      // The top sort node should be removed since the stream side (t2) order DESC already
-      // satisfies the required sort order DESC.
-      val buildLeftOrderByRightDesc = queryTemplate.format("t1", "t2.key DESC")
-      checkSorts(buildLeftOrderByRightDesc, 0, 1)
-
-      // No sort should be removed since the sort ordering from broadcast-hash join is based
-      // on the stream side (t2) and the required sort order is from t1.
-      val buildLeftOrderByLeftDesc = queryTemplate.format("t1", "t1.key DESC")
-      checkSorts(buildLeftOrderByLeftDesc, 1, 1)
-
-      // The top sort node should be removed since the stream side (t1) order DESC already
-      // satisfies the required sort order DESC.
-      val buildRightOrderByLeftDesc = queryTemplate.format("t2", "t1.key DESC")
-      checkSorts(buildRightOrderByLeftDesc, 0, 1)
-    }
-  }
-
-  test("remove redundant sorts with sort merge join") {
-    withTempView("t1", "t2") {
-      spark.range(1000).select('id as "key").createOrReplaceTempView("t1")
-      spark.range(1000).select('id as "key").createOrReplaceTempView("t2")
-      val query = """
-        |SELECT /*+ MERGE(t1) */ t1.key FROM
-        | (SELECT key FROM t1 WHERE key > 10 ORDER BY key DESC LIMIT 10) t1
-        |JOIN
-        | (SELECT key FROM t2 WHERE key > 50 ORDER BY key DESC LIMIT 100) t2
-        |ON t1.key = t2.key
-        |ORDER BY t1.key
-      """.stripMargin
-
-      val queryAsc = query + " ASC"
-      checkSorts(queryAsc, 2, 3)
-
-      // The top level sort should not be removed since the child output ordering is ASC and
-      // the required ordering is DESC.
-      val queryDesc = query + " DESC"
-      checkSorts(queryDesc, 3, 3)
-    }
-  }
-
-  test("cached sorted data doesn't need to be re-sorted") {
-    withSQLConf(SQLConf.REMOVE_REDUNDANT_SORTS_ENABLED.key -> "true") {
-      val df = spark.range(1000).select('id as "key").sort('key.desc).cache()
-      val resorted = df.sort('key.desc)
-      val sortedAsc = df.sort('key.asc)
-      checkNumSorts(df, 0)
-      checkNumSorts(resorted, 0)
-      checkNumSorts(sortedAsc, 1)
-      val result = resorted.collect()
-      withSQLConf(SQLConf.REMOVE_REDUNDANT_SORTS_ENABLED.key -> "false") {
-        val resorted = df.sort('key.desc)
-        checkNumSorts(resorted, 1)
-        checkAnswer(resorted, result)
-      }
-    }
-  }
-
-  test("SPARK-33472: shuffled join with different left and right side partition numbers") {
-    withTempView("t1", "t2") {
-      spark.range(0, 100, 1, 2).select('id as "key").createOrReplaceTempView("t1")
-      (0 to 100).toDF("key").createOrReplaceTempView("t2")
-
-      val queryTemplate = """
-        |SELECT /*+ %s(t1) */ t1.key
-        |FROM t1 JOIN t2 ON t1.key = t2.key
-        |WHERE t1.key > 10 AND t2.key < 50
-        |ORDER BY t1.key ASC
-      """.stripMargin
-
-      Seq(("MERGE", 3), ("SHUFFLE_HASH", 1)).foreach { case (hint, count) =>
-        val query = queryTemplate.format(hint)
-        val df = sql(query)
-        val sparkPlan = df.queryExecution.sparkPlan
-        val join = sparkPlan.collect { case j: ShuffledJoin => j }.head
-        val leftPartitioning = join.left.outputPartitioning
-        assert(leftPartitioning.isInstanceOf[RangePartitioning])
-        assert(leftPartitioning.numPartitions == 2)
-        assert(join.right.outputPartitioning == UnknownPartitioning(0))
-        checkSorts(query, count, count)
+          assertExchangeBetweenAggregates(df2, true)
+          checkAnswer(df2, result)
+        }
       }
     }
   }
 }
 
-class PushDownAggregateSuite extends PushDownAggregateSuiteBase
+class PushDownAggregatesSuite extends PushDownAggregatesSuiteBase
   with DisableAdaptiveExecutionSuite
 
-class PushDownAggregateSuiteAE extends PushDownAggregateSuiteBase
+class PushDownAggregatesSuiteAE extends PushDownAggregatesSuiteBase
   with EnableAdaptiveExecutionSuite


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added physical optimization rule `PushDownAggregates`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
A common pattern I have encountered
```
dataset
    .groupBy(col("a"), col("b")).count()
    .groupBy(col("a")).agg(max("count"))
    .explain();
```
Produces a plan:
```
*(3) HashAggregate(keys=[a#53], functions=[max(count#119L)])
+- Exchange hashpartitioning(a#53, 1), ENSURE_REQUIREMENTS, [id=#98]
   +- *(2) HashAggregate(keys=[a#53], functions=[partial_max(count#119L)])
      +- *(2) HashAggregate(keys=[a#53, b#52], functions=[count(1)])
         +- Exchange hashpartitioning(a#53, b#52, 1), ENSURE_REQUIREMENTS, [id=#93]
            +- *(1) HashAggregate(keys=[a#53, b#52], functions=[partial_count(1)])
               +- FileScan parquet 
```
In most cases the second exchange could be avoided if the first exchange partitioned only by column `a` - reducing the total amount of data exchanged. Spark can not do this optimization on its own, because `a` could have low cardinality (less than the number of executors) or high skew. But if the user knows, that this is not the case, they could manually repartition it:
```
dataset
    .repartition(col("a"))
    .groupBy(col("a"), col("b")).count()
    .groupBy(col("a")).agg(max("count"))
    .explain();
```
This produces this plan:
```
*(2) HashAggregate(keys=[a#53], functions=[max(count#119L)])
+- *(2) HashAggregate(keys=[a#53], functions=[partial_max(count#119L)])
   +- *(2) HashAggregate(keys=[a#53, b#52], functions=[count(1)])
      +- *(2) HashAggregate(keys=[a#53, b#52], functions=[partial_count(1)])
         +- Exchange hashpartitioning(a#53, 1), REPARTITION, [id=#90]
            +- FileScan parquet
```
We have avoided one exchange and this has had positive performance impact on my queries. But this could be improved further, if the first partial aggregate would be before the manually inserted repartition - reducing the exchanged data even more. The proposed rule would push that partial aggregate bellow the exchange.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
A configuration parameter to disable this optimization.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT