### PR TITLE
[SPARK-34657][PYTHON][DOCS] Replace the tag of release to the hash to hide RC tags in Binder

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -97,6 +97,7 @@ git clone "$ASF_REPO"
 cd spark
 git checkout $GIT_REF
 git_hash=`git rev-parse --short HEAD`
+export GIT_HASH=$git_hash
 echo "Checked out Spark git hash $git_hash"
 
 if [ -z "$SPARK_VERSION" ]; then

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -57,7 +57,7 @@ numpydoc_show_class_members = False
 # These are defined here to allow link substitutions dynamically.
 rst_epilog = """
 .. |binder| replace:: Live Notebook
-.. _binder: https://mybinder.org/v2/gh/apache/spark/{2}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart.ipynb
+.. _binder: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart.ipynb
 .. |examples| replace:: Examples
 .. _examples: https://github.com/apache/spark/tree/{0}/examples/src/main/python
 .. |downloading| replace:: Downloading
@@ -65,9 +65,8 @@ rst_epilog = """
 .. |building_spark| replace:: Building Spark
 .. _building_spark: https://spark.apache.org/docs/{1}/#downloading
 """.format(
-    os.environ.get("RELEASE_TAG", "master"),
-    os.environ.get("RELEASE_VERSION", "latest"),
     os.environ.get("GIT_HASH", "master"),
+    os.environ.get("RELEASE_VERSION", "latest"),
 )
 
 # Add any paths that contain templates here, relative to this directory.

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -57,14 +57,18 @@ numpydoc_show_class_members = False
 # These are defined here to allow link substitutions dynamically.
 rst_epilog = """
 .. |binder| replace:: Live Notebook
-.. _binder: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart.ipynb
+.. _binder: https://mybinder.org/v2/gh/apache/spark/{2}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart.ipynb
 .. |examples| replace:: Examples
 .. _examples: https://github.com/apache/spark/tree/{0}/examples/src/main/python
 .. |downloading| replace:: Downloading
 .. _downloading: https://spark.apache.org/docs/{1}/building-spark.html
 .. |building_spark| replace:: Building Spark
 .. _building_spark: https://spark.apache.org/docs/{1}/#downloading
-""".format(os.environ.get("RELEASE_TAG", "master"), os.environ.get('RELEASE_VERSION', "latest"))
+""".format(
+    os.environ.get("RELEASE_TAG", "master"),
+    os.environ.get("RELEASE_VERSION", "latest"),
+    os.environ.get("GIT_HASH", "master"),
+)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently Binder link at Spark 3.1.1 (https://mybinder.org/v2/gh/apache/spark/v3.1.1-rc3?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart.ipynb) shows  `v3.1.1-rc3` like:
![Screen Shot 2021-03-08 at 10 10 55 AM](https://user-images.githubusercontent.com/6477701/110262729-ecb70880-7ff7-11eb-92ba-f151d74985a6.png)

After the fix, it will shows the explicit hash:

![Screen Shot 2021-03-08 at 10 17 25 AM](https://user-images.githubusercontent.com/6477701/110262740-f476ad00-7ff7-11eb-8632-5b418ff87024.png)

In addition, this also fixes the examples URL while I am fixing it. For example: https://github.com/apache/spark/tree/v3.1.1-rc3/examples/src/main/python -> https://github.com/apache/spark/tree/1d550c4e902/examples/src/main/python



Note that it is hash in order to make both dev and release easier.

### Why are the changes needed?

To hide RC tags.

### Does this PR introduce _any_ user-facing change?

It will just change the URL shown when Binder is being loaded.

### How was this patch tested?

Manually tested:

```bash
make clean html
```

![Screen Shot 2021-03-08 at 10 17 06 AM](https://user-images.githubusercontent.com/6477701/110262813-2ee04a00-7ff8-11eb-9983-c4484f7832c4.png)


```bash
git_hash=`git rev-parse --short HEAD`
export GIT_HASH=$git_hash
make clean html
```

![Screen Shot 2021-03-08 at 10 17 25 AM](https://user-images.githubusercontent.com/6477701/110262805-2982ff80-7ff8-11eb-8560-e1e2aa7b263a.png)

