### PR TITLE
[SPARK-34660][TESTS][3.1] Don't use ParVector with `withExistingConf` which is not thread-safe

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -962,7 +962,7 @@ abstract class AnsiCastSuiteBase extends CastSuiteBase {
 
   test("ANSI mode: cast string to timestamp with parse error") {
     val activeConf = conf
-    new ParVector(ALL_TIMEZONES.toVector).foreach { zid =>
+    ALL_TIMEZONES.foreach { zid =>
       def checkCastWithParseError(str: String): Unit = {
         checkExceptionInExpression[DateTimeException](
           cast(Literal(str), TimestampType, Option(zid.getId)),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `ParVector` usage with `withExistingConf` in `CastSuite` in order to fix UT failures.
- This was added by SPARK-33498 .
- `master` branch doesn't use `ParVector`.

```scala
- new ParVector(ALL_TIMEZONES.toVector).foreach { zid =>
+ ALL_TIMEZONES.foreach { zid =>
```

### Why are the changes needed?

`withExistingConf` is not thread-safe like the following. We should not use `ParVector` on it.
```scala
def withExistingConf[T](conf: SQLConf)(f: => T): T = {
  val old = existingConf.get()
  existingConf.set(conf)
  try {
    f
  } finally {
    if (old != null) {
      existingConf.set(old)
    } else {
      existingConf.remove()
    }
  }
}
```

### Does this PR introduce _any_ user-facing change?

**BEFORE**
```
$ build/sbt "catalyst/testOnly *AnsiCastSuiteWithAnsiModeOn *ExpressionEncoderSuite -- -z parse -z nested"
...
[info] *** 4 TESTS FAILED ***
[error] Failed: Total 8, Failed 4, Errors 0, Passed 4
[error] Failed tests:
[error] 	org.apache.spark.sql.catalyst.encoders.ExpressionEncoderSuite
```

**AFTER**
```
$ build/sbt "catalyst/testOnly *AnsiCastSuiteWithAnsiModeOn *ExpressionEncoderSuite -- -z parse -z nested"
...
[info] All tests passed.
```


### How was this patch tested?

Pass the CIs on `branch-3.1`. Currently, it's broken.