### PR TITLE
[SPARK-34666][SQL][TESTS] Test DayTimeIntervalType and YearMonthIntervalType as ordered and atomic types

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import java.math.MathContext
 import java.sql.{Date, Timestamp}
-import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
+import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period, ZoneId}
 
 import scala.collection.mutable
 import scala.util.{Random, Try}
@@ -271,6 +271,17 @@ object RandomDataGenerator {
         val days = rand.nextInt(10000)
         val ns = rand.nextLong()
         new CalendarInterval(months, days, ns)
+      })
+      case DayTimeIntervalType => Some(() => {
+        val maxSeconds = Duration.ofDays(106751991).getSeconds
+        val seconds = rand.nextLong() % maxSeconds
+        val nanoAdjustment = rand.nextLong() % 999999000
+        Duration.ofSeconds(seconds, nanoAdjustment)
+      })
+      case YearMonthIntervalType => Some(() => {
+        val years = rand.nextInt() % 178956970
+        val months = rand.nextInt() % 12
+        Period.of(years, months, 0)
       })
       case DecimalType.Fixed(precision, scale) => Some(
         () => BigDecimal.apply(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -60,7 +60,11 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     }
 
     atomicTypes.foreach(dt => checkNullCast(NullType, dt))
-    atomicTypes.foreach(dt => checkNullCast(dt, StringType))
+    (atomicTypes -- Set(
+      // TODO(SPARK-34668): Support casting of day-time intervals to strings
+      DayTimeIntervalType,
+      // TODO(SPARK-34667): Support casting of year-month intervals to strings
+      YearMonthIntervalType)).foreach(dt => checkNullCast(dt, StringType))
     checkNullCast(StringType, BinaryType)
     checkNullCast(StringType, BooleanType)
     numericTypes.foreach(dt => checkNullCast(dt, BooleanType))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.sql.{Date, Timestamp}
-import java.time.{Duration, Instant, LocalDate}
+import java.time.{Duration, Instant, LocalDate, Period}
 import java.util.concurrent.TimeUnit
 
 import org.scalacheck.{Arbitrary, Gen}
@@ -163,6 +163,24 @@ object LiteralGenerator {
   lazy val limitedIntegerLiteralGen: Gen[Literal] =
     for { i <- Gen.choose(-100, 100) } yield Literal.create(i, IntegerType)
 
+  lazy val dayTimeIntervalLiteralGen: Gen[Literal] = {
+    for {
+      seconds <- Gen.choose(
+        Duration.ofDays(-106751990).getSeconds,
+        Duration.ofDays(106751990).getSeconds)
+      nanoAdjustment <- Gen.choose(-999999000, 999999000)
+    } yield {
+      Literal.create(Duration.ofSeconds(seconds, nanoAdjustment), DayTimeIntervalType)
+    }
+  }
+
+  lazy val yearMonthIntervalLiteralGen: Gen[Literal] = {
+    for {
+      years <- Gen.choose(-178956969, 178956969)
+      months <- Gen.choose(-11, 11)
+    } yield Literal.create(Period.of(years, months, 0), YearMonthIntervalType)
+  }
+
   def randomGen(dt: DataType): Gen[Literal] = {
     dt match {
       case ByteType => byteLiteralGen
@@ -178,6 +196,8 @@ object LiteralGenerator {
       case BinaryType => binaryLiteralGen
       case CalendarIntervalType => calendarIntervalLiterGen
       case DecimalType.Fixed(precision, scale) => decimalLiteralGen(precision, scale)
+      case DayTimeIntervalType => dayTimeIntervalLiteralGen
+      case YearMonthIntervalType => yearMonthIntervalLiteralGen
       case dt => throw new IllegalArgumentException(s"not supported type $dt")
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
@@ -57,8 +57,14 @@ object DataTypeTestUtils {
   /**
    * All the types that support ordering
    */
-  val ordered: Set[DataType] =
-    numericTypeWithoutDecimal + BooleanType + TimestampType + DateType + StringType + BinaryType
+  val ordered: Set[DataType] = numericTypeWithoutDecimal ++ Set(
+    BooleanType,
+    TimestampType,
+    DateType,
+    StringType,
+    BinaryType,
+    DayTimeIntervalType,
+    YearMonthIntervalType)
 
   /**
    * All the types that we can use in a property check

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
@@ -79,7 +79,9 @@ object DataTypeTestUtils {
     BooleanType,
     DateType,
     StringType,
-    TimestampType
+    TimestampType,
+    DayTimeIntervalType,
+    YearMonthIntervalType
   )
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `DayTimeIntervalType` and `YearMonthIntervalType` to `DataTypeTestUtils.ordered`/`atomicTypes`, and implement values generation of those types in `LiteralGenerator`/`RandomDataGenerator`. In this way, the types will be tested automatically in:
1. ArithmeticExpressionSuite:
    - "function least"
    - "function greatest"
2. PredicateSuite
    - "BinaryComparison consistency check"
    - "AND, OR, EqualTo, EqualNullSafe consistency check"
3. ConditionalExpressionSuite
    - "if"
4. RandomDataGeneratorSuite
    - "Basic types"
5. CastSuite
    - "null cast"
    - "up-cast"
    - "SPARK-27671: cast from nested null type in struct"
6. OrderingSuite
    - "GenerateOrdering with DayTimeIntervalType"
    - "GenerateOrdering with YearMonthIntervalType"
7. PredicateSuite
    - "IN with different types"
8. UnsafeRowSuite
    - "calling get(ordinal, datatype) on null columns"
9. SortSuite
    - "sorting on YearMonthIntervalType ..."
    - "sorting on DayTimeIntervalType ..."

### Why are the changes needed?
To improve test coverage.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running the affected test suites.