### PR TITLE
[SPARK-34670][BUILD] Upgrade ZSTD-JNI to 1.4.9-1

### DIFF
--- a/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
@@ -6,22 +6,22 @@ OpenJDK 64-Bit Server VM 11.0.10+9-Ubuntu-0ubuntu1.18.04 on Linux 4.15.0-1044-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            800            801           1          0.0       80017.0       1.0X
-Compression 10000 times at level 2 without buffer pool            703            704           1          0.0       70331.6       1.1X
-Compression 10000 times at level 3 without buffer pool            935            938           5          0.0       93488.6       0.9X
-Compression 10000 times at level 1 with buffer pool               396            398           2          0.0       39645.3       2.0X
-Compression 10000 times at level 2 with buffer pool               477            477           0          0.0       47726.1       1.7X
-Compression 10000 times at level 3 with buffer pool               699            700           1          0.0       69906.8       1.1X
+Compression 10000 times at level 1 without buffer pool            798            810          11          0.0       79767.6       1.0X
+Compression 10000 times at level 2 without buffer pool            706            714           9          0.0       70554.1       1.1X
+Compression 10000 times at level 3 without buffer pool            934            934           0          0.0       93385.0       0.9X
+Compression 10000 times at level 1 with buffer pool               407            409           1          0.0       40749.3       2.0X
+Compression 10000 times at level 2 with buffer pool               478            481           2          0.0       47818.3       1.7X
+Compression 10000 times at level 3 with buffer pool               719            719           0          0.0       71861.2       1.1X
 
 OpenJDK 64-Bit Server VM 11.0.10+9-Ubuntu-0ubuntu1.18.04 on Linux 4.15.0-1044-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            784            785           1          0.0       78383.2       1.0X
-Decompression 10000 times from level 2 without buffer pool            785            785           0          0.0       78467.7       1.0X
-Decompression 10000 times from level 3 without buffer pool            785            785           0          0.0       78471.3       1.0X
-Decompression 10000 times from level 1 with buffer pool               573            574           0          0.0       57325.7       1.4X
-Decompression 10000 times from level 2 with buffer pool               575            575           0          0.0       57505.9       1.4X
-Decompression 10000 times from level 3 with buffer pool               575            576           1          0.0       57531.1       1.4X
+Decompression 10000 times from level 1 without buffer pool            787            787           0          0.0       78665.3       1.0X
+Decompression 10000 times from level 2 without buffer pool            784            785           1          0.0       78381.3       1.0X
+Decompression 10000 times from level 3 without buffer pool            785            786           1          0.0       78480.4       1.0X
+Decompression 10000 times from level 1 with buffer pool               571            572           0          0.0       57117.5       1.4X
+Decompression 10000 times from level 2 with buffer pool               572            573           1          0.0       57221.8       1.4X
+Decompression 10000 times from level 3 with buffer pool               572            572           0          0.0       57159.7       1.4X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -6,22 +6,22 @@ OpenJDK 64-Bit Server VM 1.8.0_282-8u282-b08-0ubuntu1~18.04-b08 on Linux 4.15.0-
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            830            855          21          0.0       83027.5       1.0X
-Compression 10000 times at level 2 without buffer pool            698            699           1          0.0       69824.4       1.2X
-Compression 10000 times at level 3 without buffer pool            929            930           1          0.0       92897.5       0.9X
-Compression 10000 times at level 1 with buffer pool               403            404           1          0.0       40329.7       2.1X
-Compression 10000 times at level 2 with buffer pool               489            490           1          0.0       48921.1       1.7X
-Compression 10000 times at level 3 with buffer pool               714            716           3          0.0       71353.6       1.2X
+Compression 10000 times at level 1 without buffer pool            851            865          13          0.0       85083.8       1.0X
+Compression 10000 times at level 2 without buffer pool            701            702           1          0.0       70107.3       1.2X
+Compression 10000 times at level 3 without buffer pool            946            947           1          0.0       94580.8       0.9X
+Compression 10000 times at level 1 with buffer pool               408            417           8          0.0       40774.3       2.1X
+Compression 10000 times at level 2 with buffer pool               489            490           1          0.0       48926.5       1.7X
+Compression 10000 times at level 3 with buffer pool               726            727           1          0.0       72586.8       1.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_282-8u282-b08-0ubuntu1~18.04-b08 on Linux 4.15.0-1044-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            790            791           1          0.0       79013.4       1.0X
-Decompression 10000 times from level 2 without buffer pool            788            789           1          0.0       78787.6       1.0X
-Decompression 10000 times from level 3 without buffer pool            787            787           1          0.0       78655.3       1.0X
-Decompression 10000 times from level 1 with buffer pool               573            574           1          0.0       57279.4       1.4X
-Decompression 10000 times from level 2 with buffer pool               582            582           1          0.0       58187.6       1.4X
-Decompression 10000 times from level 3 with buffer pool               583            584           1          0.0       58330.5       1.4X
+Decompression 10000 times from level 1 without buffer pool            793            793           0          0.0       79273.3       1.0X
+Decompression 10000 times from level 2 without buffer pool            797            798           0          0.0       79734.3       1.0X
+Decompression 10000 times from level 3 without buffer pool            796            797           0          0.0       79612.0       1.0X
+Decompression 10000 times from level 1 with buffer pool               577            578           1          0.0       57716.7       1.4X
+Decompression 10000 times from level 2 with buffer pool               580            581           1          0.0       57970.1       1.4X
+Decompression 10000 times from level 3 with buffer pool               580            581           1          0.0       58001.6       1.4X
 
 

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -243,4 +243,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.4.8-7//zstd-jni-1.4.8-7.jar
+zstd-jni/1.4.9-1//zstd-jni-1.4.9-1.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -211,4 +211,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.4.8-7//zstd-jni-1.4.8-7.jar
+zstd-jni/1.4.9-1//zstd-jni-1.4.9-1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -705,7 +705,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.4.8-7</version>
+        <version>1.4.9-1</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ZSTD-JNI to 1.4.9-1.

### Why are the changes needed?

ZStandard 1.4.9 and its corresponding JNI brings the following bug fixes and improvements.
- https://github.com/facebook/zstd/releases/tag/v1.4.9

One of notable improvement of ZStandard 1.4.9 is `2x faster Long Distance Mode`, but we are not using it yet.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the existing tests and there is no regression in ZStandardBenchmark.