### PR TITLE
[SPARK-34703][PYSPARK][2.4] Fix pyspark test when using sort_values on Pandas

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -5761,7 +5761,7 @@ class GroupedMapPandasUDFTests(ReusedSQLTestCase):
 
         result = df.groupby(col('id') % 2 == 0).apply(normalize).sort('id', 'v').toPandas()
         pdf = df.toPandas()
-        expected = pdf.groupby(pdf['id'] % 2 == 0).apply(normalize.func)
+        expected = pdf.groupby(pdf['id'] % 2 == 0, as_index=False).apply(normalize.func)
         expected = expected.sort_values(['id', 'v']).reset_index(drop=True)
         expected = expected.assign(norm=expected.norm.astype('float64'))
         self.assertPandasEqual(expected, result)
@@ -5917,21 +5917,21 @@ class GroupedMapPandasUDFTests(ReusedSQLTestCase):
 
         # Test groupby column
         result1 = df.groupby('id').apply(udf1).sort('id', 'v').toPandas()
-        expected1 = pdf.groupby('id')\
+        expected1 = pdf.groupby('id', as_index=False)\
             .apply(lambda x: udf1.func((x.id.iloc[0],), x))\
             .sort_values(['id', 'v']).reset_index(drop=True)
         self.assertPandasEqual(expected1, result1)
 
         # Test groupby expression
         result2 = df.groupby(df.id % 2).apply(udf1).sort('id', 'v').toPandas()
-        expected2 = pdf.groupby(pdf.id % 2)\
+        expected2 = pdf.groupby(pdf.id % 2, as_index=False)\
             .apply(lambda x: udf1.func((x.id.iloc[0] % 2,), x))\
             .sort_values(['id', 'v']).reset_index(drop=True)
         self.assertPandasEqual(expected2, result2)
 
         # Test complex groupby
         result3 = df.groupby(df.id, df.v % 2).apply(udf2).sort('id', 'v').toPandas()
-        expected3 = pdf.groupby([pdf.id, pdf.v % 2])\
+        expected3 = pdf.groupby([pdf.id, pdf.v % 2], as_index=False)\
             .apply(lambda x: udf2.func((x.id.iloc[0], (x.v % 2).iloc[0],), x))\
             .sort_values(['id', 'v']).reset_index(drop=True)
         self.assertPandasEqual(expected3, result3)
@@ -5953,7 +5953,7 @@ class GroupedMapPandasUDFTests(ReusedSQLTestCase):
 
         df = self.data
         grouped_df = df.groupby('id')
-        grouped_pdf = df.toPandas().groupby('id')
+        grouped_pdf = df.toPandas().groupby('id', as_index=False)
 
         # Function returns a pdf with required column names, but order could be arbitrary using dict
         def change_col_order(pdf):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch fixes a few PySpark test error related to Pandas, in order to restore 2.4 Jenkins builds.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There are APIs changed since Pandas 0.24. If there are index and column name are the same, `sort_values` will throw error.

Three PySpark tests are currently failed in Jenkins 2.4 build: `test_column_order`, `test_complex_groupby`, `test_udf_with_key`:

```
======================================================================                                                                                                                                                                 
ERROR: test_column_order (pyspark.sql.tests.GroupedMapPandasUDFTests)                                                                                                                                                                  
----------------------------------------------------------------------
Traceback (most recent call last):                                                                                 
  File "/spark/python/pyspark/sql/tests.py", line 5996, in test_column_order                                                                                                                                                           
    expected = pd_result.sort_values(['id', 'v']).reset_index(drop=True)                                           
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/frame.py", line 4711, in sort_values                    
    for x in by]                                       
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/generic.py", line 1702, in _get_label_or_level_values
    self._check_label_or_level_ambiguity(key, axis=axis)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/generic.py", line 1656, in _check_label_or_level_ambiguity
    raise ValueError(msg)                                                                                          
ValueError: 'id' is both an index level and a column label, which is ambiguous.
                                                         
======================================================================
ERROR: test_complex_groupby (pyspark.sql.tests.GroupedMapPandasUDFTests)
----------------------------------------------------------------------
Traceback (most recent call last):                      
  File "/spark/python/pyspark/sql/tests.py", line 5765, in test_complex_groupby
    expected = expected.sort_values(['id', 'v']).reset_index(drop=True)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/frame.py", line 4711, in sort_values
    for x in by]                                                                                                   
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/generic.py", line 1702, in _get_label_or_level_values                                                                                                                       
    self._check_label_or_level_ambiguity(key, axis=axis)                                                                                                                                                                               
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/generic.py", line 1656, in _check_label_or_level_ambiguity                                                                                                                  
    raise ValueError(msg)                                                                                                                                                                                                              
ValueError: 'id' is both an index level and a column label, which is ambiguous.                                                                                                                                                        
                                                                                                                                                                                                                                       
======================================================================                                             
ERROR: test_udf_with_key (pyspark.sql.tests.GroupedMapPandasUDFTests)                                                                                                                                                                  
----------------------------------------------------------------------                                             
Traceback (most recent call last):                                                                                                                                                                                                     
  File "/spark/python/pyspark/sql/tests.py", line 5922, in test_udf_with_key
    .sort_values(['id', 'v']).reset_index(drop=True)                                                                                                                                                                                   
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/frame.py", line 4711, in sort_values                                                                                                                                        
    for x in by]                                                                                                                                                                                                                       
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/generic.py", line 1702, in _get_label_or_level_values   
    self._check_label_or_level_ambiguity(key, axis=axis)                                                                                                                                                                               
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/generic.py", line 1656, in _check_label_or_level_ambiguity                                                                                                                  
    raise ValueError(msg)                                                                                                                                                                                                              
ValueError: 'id' is both an index level and a column label, which is ambiguous.   
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, dev only.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Verified by running the tests locally.