### PR TITLE
Fix avro decoding based on avro MAGIC_NUMBER presence

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -103,9 +103,8 @@ private[avro] case class AvroDataToCatalyst(
   private def getBinaryOffset(binary: Array[Byte]): Int = {
     // 2 magic number plus 8 fingerprint bytes
     val skipOffset = 10;
-    val magicBytes: Array[Byte] = Array(0xC3.toByte, 0x01.toByte)
     var offset = 0
-    if (binary(0) == magicBytes(0) && binary(1) == magicBytes(1)) {
+    if (binary(0) == 0xC3.toByte && binary(1) == 0x01.toByte) {
       offset = skipOffset
     }
     offset

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -96,7 +96,7 @@ private[avro] case class AvroDataToCatalyst(
    * defined in avro BinaryMessageEncoder.java as of now we are assuming that the binary
    * provided was encoded via avro BinaryEncoder.java. However some serializers use
    * the former strategy instead which prepend the binary with a magic number followed
-   * by a header and 8-byte schema fingerprint. This method detects the presence
+   * by a 8-byte schema fingerprint. This method detects the presence
    * of the magic number and if thats the case the offset returned skips the magic
    * plus fingerprint bytes.
    */

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -101,13 +101,10 @@ private[avro] case class AvroDataToCatalyst(
    * plus fingerprint bytes.
    */
   private def getBinaryOffset(binary: Array[Byte]): Int = {
-    // 2 magic number plus 8 fingerprint bytes
-    val skipOffset = 10;
-    var offset = 0
     if (binary(0) == 0xC3.toByte && binary(1) == 0x01.toByte) {
-      offset = skipOffset
+      return 10
     }
-    offset
+    return 0
   }
 
   override def nullSafeEval(input: Any): Any = {

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -104,7 +104,7 @@ private[avro] case class AvroDataToCatalyst(
     if (binary(0) == 0xC3.toByte && binary(1) == 0x01.toByte) {
       return 10
     }
-    return 0
+    0
   }
 
   override def nullSafeEval(input: Any): Any = {


### PR DESCRIPTION
Currently Avro serialization is being done in two distinct ways. One is by using the BinaryEncoder/BinaryDecoder strategies provided by avro. However Avro also has the BinaryMessageEncoder/BinaryMessageDecoder strategies that uses the BinaryEncoder/BinaryDecoder to codify avro payloads but [adds a fingerprint in the beginning of the binary](https://github.com/apache/avro/blob/master/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageEncoder.java) in this PR we use the MAGIC_NUMBER to decide if we need to strip or not the first 10 bytes that represent the MAGIC_NUMBER plus the 8 bytes of fingerprint.

This way we can, transparently decode avro payloads that are encoded via one of those strategies