### PR TITLE
[SPARK-34719][SQL][3.1] Correctly resolve the view query with duplicated column names

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/view.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/view.scala
@@ -83,7 +83,7 @@ object EliminateView extends Rule[LogicalPlan] with CastSupport {
           if (matchedCols.length - 1 < count) {
             throw new AnalysisException(s"The SQL query of view ${desc.identifier} has an " +
               s"incompatible schema change and column $colName cannot be resolved. Expect " +
-              s"more attributes named $colName")
+              s"more attributes named $colName in ${child.output.mkString("[", ",", "]")}")
           }
           nameToCounts(normalized) = count + 1
           matchedCols(count)
@@ -93,7 +93,7 @@ object EliminateView extends Rule[LogicalPlan] with CastSupport {
           if (count > 1 && nameToMatchedCols(colName).length != count) {
             throw new AnalysisException(s"The SQL query of view ${desc.identifier} has an " +
               s"incompatible schema change and column $colName cannot be resolved. Expect " +
-              s"less attributes named $colName")
+              s"less attributes named $colName in ${child.output.mkString("[", ",", "]")}")
           }
         }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/view.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/view.scala
@@ -17,7 +17,10 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.Alias
+import java.util.Locale
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, View}
 import org.apache.spark.sql.catalyst.rules.Rule
 
@@ -57,15 +60,43 @@ object EliminateView extends Rule[LogicalPlan] with CastSupport {
     // The child has the different output attributes with the View operator. Adds a Project over
     // the child of the view.
     case v @ View(desc, _, output, child) if child.resolved && !v.sameOutput(child) =>
+      // Use the stored view query output column names to find the matching attributes. The column
+      // names may have duplication, e.g. `CREATE VIEW v AS SELECT 1 col, 2 col`. We need to make
+      // sure the that matching attributes have the same number of duplications, and pick the
+      // corresponding attribute by ordinal.
       val resolver = conf.resolver
       val queryColumnNames = desc.viewQueryColumnNames
       val queryOutput = if (queryColumnNames.nonEmpty) {
-        // Find the attribute that has the expected attribute name from an attribute list, the names
-        // are compared using conf.resolver.
-        // `CheckAnalysis` already guarantees the expected attribute can be found for sure.
-        desc.viewQueryColumnNames.map { colName =>
-          child.output.find(attr => resolver(attr.name, colName)).get
+        val normalizeColName: String => String = if (conf.caseSensitiveAnalysis) {
+          identity
+        } else {
+          _.toLowerCase(Locale.ROOT)
         }
+        val nameToCounts = scala.collection.mutable.HashMap.empty[String, Int]
+        val nameToMatchedCols = scala.collection.mutable.HashMap.empty[String, Seq[Attribute]]
+
+        val outputAttrs = queryColumnNames.map { colName =>
+          val normalized = normalizeColName(colName)
+          val count = nameToCounts.getOrElse(normalized, 0)
+          val matchedCols = nameToMatchedCols.getOrElseUpdate(
+            normalized, child.output.filter(attr => resolver(attr.name, colName)))
+          if (matchedCols.length - 1 < count) {
+            throw new AnalysisException(s"The SQL query of view ${desc.identifier} has an " +
+              s"incompatible schema change and column $colName cannot be resolved.")
+          }
+          val col = matchedCols(count)
+          nameToCounts(normalized) = count + 1
+          col
+        }
+
+        nameToCounts.foreach { case (colName, count) =>
+          if (count > 1 && nameToMatchedCols(colName).length != count) {
+            throw new AnalysisException(s"The SQL query of view ${desc.identifier} has an " +
+              s"incompatible schema change and column $colName cannot be resolved.")
+          }
+        }
+
+        outputAttrs
       } else {
         // For view created before Spark 2.2.0, the view text is already fully qualified, the plan
         // output is the same with the view output.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -293,6 +293,40 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
       }
     }
   }
+
+  test("SPARK-34719: view query with duplicated output column names") {
+    withView("v1", "v2") {
+      sql("CREATE VIEW v1 AS SELECT 1 a, 2 b")
+      sql("CREATE VIEW v2 AS SELECT 1 col")
+
+      val viewName = createView(
+        viewName = "testView",
+        sqlText = "SELECT *, 1 col, 2 col FROM v1",
+        columnNames = Seq("c1", "c2", "c3", "c4"))
+      withView(viewName) {
+        checkViewOutput(viewName, Seq(Row(1, 2, 1, 2)))
+
+        // One more duplicated column `col`.
+        sql("CREATE OR REPLACE VIEW v1 AS SELECT 1 a, 2 b, 3 col")
+        val e = intercept[AnalysisException](spark.table(viewName).collect())
+        assert(e.message.contains("incompatible schema change"))
+      }
+
+      // v1 has 3 columns [a, b, col], v2 has one column [col], so `testView2` has two `col`.
+      val viewName2 = createView(
+        viewName = "testView2",
+        sqlText = "SELECT * FROM v1, v2",
+        columnNames = Seq("c1", "c2", "c3", "c4"))
+      withView(viewName2) {
+        checkViewOutput(viewName2, Seq(Row(1, 2, 3, 1)))
+
+        // One less duplicated column `col`.
+        sql("CREATE OR REPLACE VIEW v1 AS SELECT 1 a, 2 b")
+        val e = intercept[AnalysisException](spark.table(viewName2).collect())
+        assert(e.message.contains("incompatible schema change"))
+      }
+    }
+  }
 }
 
 class LocalTempViewTestSuite extends SQLViewTestSuite with SharedSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -295,35 +295,49 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("SPARK-34719: view query with duplicated output column names") {
-    withView("v1", "v2") {
-      sql("CREATE VIEW v1 AS SELECT 1 a, 2 b")
-      sql("CREATE VIEW v2 AS SELECT 1 col")
+    Seq(true, false).foreach { caseSensitive =>
+      withSQLConf(CASE_SENSITIVE.key -> caseSensitive.toString) {
+        withView("v1", "v2") {
+          sql("CREATE VIEW v1 AS SELECT 1 a, 2 b")
+          sql("CREATE VIEW v2 AS SELECT 1 col")
 
-      val viewName = createView(
-        viewName = "testView",
-        sqlText = "SELECT *, 1 col, 2 col FROM v1",
-        columnNames = Seq("c1", "c2", "c3", "c4"))
-      withView(viewName) {
-        checkViewOutput(viewName, Seq(Row(1, 2, 1, 2)))
+          val viewName = createView(
+            viewName = "testView",
+            sqlText = "SELECT *, 1 col, 2 col FROM v1",
+            columnNames = Seq("c1", "c2", "c3", "c4"))
+          withView(viewName) {
+            checkViewOutput(viewName, Seq(Row(1, 2, 1, 2)))
 
-        // One more duplicated column `col`.
-        sql("CREATE OR REPLACE VIEW v1 AS SELECT 1 a, 2 b, 3 col")
-        val e = intercept[AnalysisException](spark.table(viewName).collect())
-        assert(e.message.contains("incompatible schema change"))
-      }
+            // One more duplicated column `COL` if caseSensitive=false.
+            sql("CREATE OR REPLACE VIEW v1 AS SELECT 1 a, 2 b, 3 COL")
+            if (caseSensitive) {
+              checkViewOutput(viewName, Seq(Row(1, 2, 1, 2)))
+            } else {
+              val e = intercept[AnalysisException](spark.table(viewName).collect())
+              assert(e.message.contains("incompatible schema change"))
+            }
+          }
 
-      // v1 has 3 columns [a, b, col], v2 has one column [col], so `testView2` has two `col`.
-      val viewName2 = createView(
-        viewName = "testView2",
-        sqlText = "SELECT * FROM v1, v2",
-        columnNames = Seq("c1", "c2", "c3", "c4"))
-      withView(viewName2) {
-        checkViewOutput(viewName2, Seq(Row(1, 2, 3, 1)))
+          // v1 has 3 columns [a, b, COL], v2 has one column [col], so `testView2` has duplicated
+          // output column names if caseSensitive=false.
+          val viewName2 = createView(
+            viewName = "testView2",
+            sqlText = "SELECT * FROM v1, v2",
+            columnNames = Seq("c1", "c2", "c3", "c4"))
+          withView(viewName2) {
+            checkViewOutput(viewName2, Seq(Row(1, 2, 3, 1)))
 
-        // One less duplicated column `col`.
-        sql("CREATE OR REPLACE VIEW v1 AS SELECT 1 a, 2 b")
-        val e = intercept[AnalysisException](spark.table(viewName2).collect())
-        assert(e.message.contains("incompatible schema change"))
+            // One less duplicated column if caseSensitive=false.
+            sql("CREATE OR REPLACE VIEW v1 AS SELECT 1 a, 2 b")
+            if (caseSensitive) {
+              val e = intercept[AnalysisException](spark.table(viewName2).collect())
+              assert(e.message.contains("'COL' is not found in '(a,b,col)'"))
+            } else {
+              val e = intercept[AnalysisException](spark.table(viewName2).collect())
+              assert(e.message.contains("incompatible schema change"))
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
For permanent views (and the new SQL temp view in Spark 3.1), we store the view SQL text and re-parse/analyze the view SQL text when reading the view. In the case of `SELECT * FROM ...`, we want to avoid view schema change (e.g. the referenced table changes its schema) and will record the view query output column names when creating the view, so that when reading the view we can add a `SELECT recorded_column_names FROM ...` to retain the original view query schema.

In Spark 3.1 and before, the final SELECT is added after the analysis phase: https://github.com/apache/spark/blob/branch-3.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/view.scala#L67

If the view query has duplicated output column names, we always pick the first column when reading a view. A simple repro:
```
scala> sql("create view c(x, y) as select 1 a, 2 a")
res0: org.apache.spark.sql.DataFrame = []

scala> sql("select * from c").show
+---+---+
|  x|  y|
+---+---+
|  1|  1|
+---+---+
```

In the master branch, we will fail at the view reading time due to https://github.com/apache/spark/commit/b891862fb6b740b103d5a09530626ee4e0e8f6e3 , which adds the final SELECT during analysis, so that the query fails with `Reference 'a' is ambiguous`

This PR proposes to resolve the view query output column names from the matching attributes by ordinal.

For example,  `create view c(x, y) as select 1 a, 2 a`, the view query output column names are `[a, a]`. When we reading the view, there are 2 matching attributes (e.g.`[a#1, a#2]`) and we can simply match them by ordinal.

A negative example is
```
create table t(a int)
create view v as select *, 1 as col from t
replace table t(a int, col int)
```
When reading the view, the view query output column names are `[a, col]`, and there are two matching attributes of `col`, and we should fail the query. See the tests for details.

This PR targets branch 3.1 because it's not a correctness bug in master, and there are code conflicts. I'll fix master later.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
bug fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new test