### PR TITLE
[SPARK-34725][SQL] Do not show Statistics(sizeInBytes=8.0 EiB) if we don't have valid stats

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -40,7 +40,10 @@ abstract class LogicalPlan
   def isStreaming: Boolean = children.exists(_.isStreaming)
 
   override def verboseStringWithSuffix(maxFields: Int): String = {
-    super.verboseString(maxFields) + statsCache.map(", " + _.toString).getOrElse("")
+    // Do not show Statistics(sizeInBytes=8.0 EiB) if we don't have valid stats
+    val stats = statsCache.find(_.sizeInBytes != Long.MaxValue)
+      .map(", " + _.toString).getOrElse("")
+    super.verboseString(maxFields) + stats
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -454,7 +454,7 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     }
   }
 
-  test("Do not show Statistics(sizeInBytes=8.0 EiB) if we don't have valid stats") {
+  test("SPARK-34725: Do not show Statistics(sizeInBytes=8.0 EiB) if we don't have valid stats") {
     withTable("t1") {
       sql(s"CREATE TABLE t1 (c1 int) USING PARQUET PARTITIONED BY (p1 int)")
       val explainString = sql("SELECT * FROM t1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -453,6 +453,15 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
       checkKeywordsExistsInExplain(df2, keywords = "[key1=value1, KEY2=VALUE2]")
     }
   }
+
+  test("Do not show Statistics(sizeInBytes=8.0 EiB) if we don't have valid stats") {
+    withTable("t1") {
+      sql(s"CREATE TABLE t1 (c1 int) USING PARQUET PARTITIONED BY (p1 int)")
+      val explainString = sql("SELECT * FROM t1")
+        .queryExecution.explainString(ExplainMode.fromString("cost"))
+      assert(!explainString.contains("Statistics(sizeInBytes=8.0 EiB)"))
+    }
+  }
 }
 
 class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuite {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Skip `Long.MaxValue` sizeInBytes stats during generate tree string. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In cast explian mode, we might get such explain string if the table is partitioned and we have not stats. A simple example: 

```
== Optimized Logical Plan == 
GlobalLimit 21, Statistics(sizeInBytes=1008.0 B, rowCount=21)
 +- LocalLimit 21, Statistics(sizeInBytes=12.0 EiB)
 +- Project [cast(c1#52 as string) AS c1#259, pt#53], Statistics(sizeInBytes=12.0 EiB)
 +- Relation default.pt1[c1#52,pt#53] parquet, Statistics(sizeInBytes=8.0 EiB)
``` 

The reason is we use the `Long.MaxValue` as the stats with conf `spark.sql.defaultSizeInBytes`. It would be better to hide the default stat.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, make cost plan clearly.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add test.