### PR TITLE
[SPARK-34726][SQL][2.4] Fix collectToPython timeouts

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -878,6 +878,7 @@ private[spark] abstract class PythonServer[T](
 
 private[spark] object PythonServer {
 
+  // visible for testing
   private[spark] var timeout = 15000
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -878,6 +878,8 @@ private[spark] abstract class PythonServer[T](
 
 private[spark] object PythonServer {
 
+  private[spark] var timeout = 15000
+
   /**
    * Create a socket server and run user function on the socket in a background thread.
    *
@@ -896,7 +898,7 @@ private[spark] object PythonServer {
       (func: Socket => Unit): (Int, String) = {
     val serverSocket = new ServerSocket(0, 1, InetAddress.getByAddress(Array(127, 0, 0, 1)))
     // Close the socket if no connection in 15 seconds
-    serverSocket.setSoTimeout(15000)
+    serverSocket.setSoTimeout(timeout)
 
     new Thread(threadName) {
       setDaemon(true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3257,12 +3257,11 @@ class Dataset[T] private[sql](
 
   private[sql] def collectToPython(): Array[Any] = {
     EvaluatePython.registerPicklers()
-    withAction("collectToPython", queryExecution) { plan =>
+    val iter = withAction("collectToPython", queryExecution) { plan =>
       val toJava: (Any) => Any = EvaluatePython.toJava(_, schema)
-      val iter: Iterator[Array[Byte]] = new SerDeUtil.AutoBatchedPickler(
-        plan.executeCollect().iterator.map(toJava))
-      PythonRDD.serveIterator(iter, "serve-DataFrame")
+      new SerDeUtil.AutoBatchedPickler(plan.executeCollect().iterator.map(toJava))
     }
+    PythonRDD.serveIterator(iter, "serve-DataFrame")
   }
 
   private[sql] def getRowsToPython(


### PR DESCRIPTION
### What changes were proposed in this pull request?

One of our customers frequently encounters `"serve-DataFrame" java.net.SocketTimeoutException: Accept timed` errors in PySpark because `DataSet.collectToPython()` in Spark 2.4 does the following:
1. Collects the results
2. Opens up a socket server that is then listening to the connection from Python side
3. Runs the event listeners as part of `withAction` on the same thread as SPARK-25680 is not available in Spark 2.4
4. Returns the address of the socket server to Python
5. The Python side connects to the socket server and fetches the data

As the customer has a custom, long running event listener the time between 2. and 5. is frequently longer than the default connection timeout and increasing the connect timeout is not a good solution as we don't know how long running the listeners can take.

### Why are the changes needed?

This PR simply moves the socket server creation (2.) after running the listeners (3.). I think this approach has has a minor side effect that errors in socket server creation are not reported as `onFailure` events, but currently errors happening during opening the connection from Python side or data transfer from JVM to Python are also not reported as events so IMO this is not a big change.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added new UT + manual test.
