### PR TITLE
[SPARK-33482][SQL] Fix FileScan canonicalization

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -56,7 +56,8 @@ case class BatchScanExec(
           QueryPlan.normalizePredicates(s.dataFilters, output))
       case _ => scan
     }
-    this.copy(output = output.map(QueryPlan.normalizeExpressions(_, output)),
+    this.copy(
+      output = output.map(QueryPlan.normalizeExpressions(_, output)),
       scan = canonicalizedScan)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -51,7 +51,8 @@ case class BatchScanExec(
   override def doCanonicalize(): BatchScanExec = {
     val canonicalizedScan = scan match {
       case s: FileScan =>
-        s.withFilters(QueryPlan.normalizePredicates(s.partitionFilters, output),
+        s.withFilters(
+          QueryPlan.normalizePredicates(s.partitionFilters, output),
           QueryPlan.normalizePredicates(s.dataFilters, output))
       case _ => scan
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -49,6 +49,13 @@ case class BatchScanExec(
   }
 
   override def doCanonicalize(): BatchScanExec = {
-    this.copy(output = output.map(QueryPlan.normalizeExpressions(_, output)))
+    val canonicalizedScan = scan match {
+      case s: FileScan =>
+        s.withFilters(QueryPlan.normalizePredicates(s.partitionFilters, output),
+          QueryPlan.normalizePredicates(s.dataFilters, output))
+      case _ => scan
+    }
+    this.copy(output = output.map(QueryPlan.normalizeExpressions(_, output)),
+      scan = canonicalizedScan)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -86,7 +86,7 @@ trait FileScan extends Scan
 
   override def equals(obj: Any): Boolean = obj match {
     case f: FileScan =>
-      fileIndex == f.fileIndex && readSchema == f.readSchema
+      fileIndex == f.fileIndex && readSchema == f.readSchema &&
         ExpressionSet(partitionFilters) == ExpressionSet(f.partitionFilters) &&
         ExpressionSet(dataFilters) == ExpressionSet(f.dataFilters)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -86,7 +86,7 @@ trait FileScan extends Scan
 
   override def equals(obj: Any): Boolean = obj match {
     case f: FileScan =>
-      fileIndex == f.fileIndex && readSchema == f.readSchema &&
+      fileIndex == f.fileIndex && readSchema == f.readSchema
         ExpressionSet(partitionFilters) == ExpressionSet(f.partitionFilters) &&
         ExpressionSet(dataFilters) == ExpressionSet(f.dataFilters)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds canonicalization to `FileScan.partitionFilters` and `FileScan.dataFilters` in `BatchScanExec` nodes.

### Why are the changes needed?

Partition filters and data filters added to `FileScan` (in https://github.com/apache/spark/pull/27112 and https://github.com/apache/spark/pull/27157) caused that canonicalized form of some `BatchScanExec` nodes don't match and this prevents some reuse possibilities.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added new UT.
