### PR TITLE
[SPARK-34729][SQL] Faster execution for broadcast nested loop join (left semi/anti with no condition)

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
@@ -195,48 +195,90 @@ case class BroadcastNestedLoopJoinExec(
   /**
    * The implementation for these joins:
    *
-   *   LeftSemi with BuildRight
-   *   LeftAnti with BuildRight
+   *   LeftSemi
+   *   LeftAnti
    */
   private def leftExistenceJoin(
       relation: Broadcast[Array[InternalRow]],
       exists: Boolean): RDD[InternalRow] = {
-    assert(buildSide == BuildRight)
-    streamed.execute().mapPartitionsInternal { streamedIter =>
-      val buildRows = relation.value
-      val joinedRow = new JoinedRow
+    buildSide match {
+      case BuildRight =>
+        streamed.execute().mapPartitionsInternal { streamedIter =>
+          val buildRows = relation.value
+          val joinedRow = new JoinedRow
 
-      if (condition.isDefined) {
-        streamedIter.filter(l =>
-          buildRows.exists(r => boundCondition(joinedRow(l, r))) == exists
-        )
-      } else if (buildRows.nonEmpty == exists) {
-        streamedIter
-      } else {
-        Iterator.empty
-      }
+          if (condition.isDefined) {
+            streamedIter.filter(l =>
+              buildRows.exists(r => boundCondition(joinedRow(l, r))) == exists
+            )
+          } else if (buildRows.nonEmpty == exists) {
+            streamedIter
+          } else {
+            Iterator.empty
+          }
+        }
+      case BuildLeft if condition.isEmpty =>
+        // If condition is empty, do not need to read rows from streamed side at all.
+        // Only need to know whether streamed side is empty or not.
+        val streamExistsRDD: RDD[Boolean] = streamed.execute().mapPartitionsInternal {
+          streamedIter => Iterator.single(streamedIter.hasNext)
+        }
+        val streamExists = streamExistsRDD.fold(false)(_ || _)
+        if (streamExists == exists) {
+          sparkContext.makeRDD(relation.value)
+        } else {
+          sparkContext.emptyRDD
+        }
+      case BuildLeft =>
+        val matchedBroadcastRows = getMatchedBroadcastRowsBitSet(streamed.execute(), relation)
+        val buf: CompactBuffer[InternalRow] = new CompactBuffer()
+        var i = 0
+        val buildRows = relation.value
+        while (i < buildRows.length) {
+          if (matchedBroadcastRows.get(i) == exists) {
+            buf += buildRows(i).copy()
+          }
+          i += 1
+        }
+        sparkContext.makeRDD(buf)
     }
   }
 
+  /**
+   * The implementation for ExistenceJoin
+   */
   private def existenceJoin(relation: Broadcast[Array[InternalRow]]): RDD[InternalRow] = {
-    assert(buildSide == BuildRight)
-    streamed.execute().mapPartitionsInternal { streamedIter =>
-      val buildRows = relation.value
-      val joinedRow = new JoinedRow
+    buildSide match {
+      case BuildRight =>
+        streamed.execute().mapPartitionsInternal { streamedIter =>
+          val buildRows = relation.value
+          val joinedRow = new JoinedRow
 
-      if (condition.isDefined) {
-        val resultRow = new GenericInternalRow(Array[Any](null))
-        streamedIter.map { row =>
-          val result = buildRows.exists(r => boundCondition(joinedRow(row, r)))
-          resultRow.setBoolean(0, result)
-          joinedRow(row, resultRow)
+          if (condition.isDefined) {
+            val resultRow = new GenericInternalRow(Array[Any](null))
+            streamedIter.map { row =>
+              val result = buildRows.exists(r => boundCondition(joinedRow(row, r)))
+              resultRow.setBoolean(0, result)
+              joinedRow(row, resultRow)
+            }
+          } else {
+            val resultRow = new GenericInternalRow(Array[Any](buildRows.nonEmpty))
+            streamedIter.map { row =>
+              joinedRow(row, resultRow)
+            }
+          }
         }
-      } else {
-        val resultRow = new GenericInternalRow(Array[Any](buildRows.nonEmpty))
-        streamedIter.map { row =>
-          joinedRow(row, resultRow)
+      case BuildLeft =>
+        val matchedBroadcastRows = getMatchedBroadcastRowsBitSet(streamed.execute(), relation)
+        val buf: CompactBuffer[InternalRow] = new CompactBuffer()
+        var i = 0
+        val buildRows = relation.value
+        while (i < buildRows.length) {
+          val result = new GenericInternalRow(Array[Any](matchedBroadcastRows.get(i)))
+          buf += new JoinedRow(buildRows(i).copy(), result)
+          i += 1
         }
-      }
+        sparkContext.makeRDD(buf)
     }
   }
 
@@ -246,71 +288,10 @@ case class BroadcastNestedLoopJoinExec(
    *   LeftOuter with BuildLeft
    *   RightOuter with BuildRight
    *   FullOuter
-   *   LeftSemi with BuildLeft
-   *   LeftAnti with BuildLeft
-   *   ExistenceJoin with BuildLeft
    */
   private def defaultJoin(relation: Broadcast[Array[InternalRow]]): RDD[InternalRow] = {
     val streamRdd = streamed.execute()
-
-    val matchedBuildRows = streamRdd.mapPartitionsInternal { streamedIter =>
-      val buildRows = relation.value
-      val matched = new BitSet(buildRows.length)
-      val joinedRow = new JoinedRow
-
-      streamedIter.foreach { streamedRow =>
-        var i = 0
-        while (i < buildRows.length) {
-          if (boundCondition(joinedRow(streamedRow, buildRows(i)))) {
-            matched.set(i)
-          }
-          i += 1
-        }
-      }
-      Seq(matched).toIterator
-    }
-
-    val matchedBroadcastRows = matchedBuildRows.fold(
-      new BitSet(relation.value.length)
-    )(_ | _)
-
-    joinType match {
-      case LeftSemi =>
-        assert(buildSide == BuildLeft)
-        val buf: CompactBuffer[InternalRow] = new CompactBuffer()
-        var i = 0
-        val rel = relation.value
-        while (i < rel.length) {
-          if (matchedBroadcastRows.get(i)) {
-            buf += rel(i).copy()
-          }
-          i += 1
-        }
-        return sparkContext.makeRDD(buf)
-      case _: ExistenceJoin =>
-        val buf: CompactBuffer[InternalRow] = new CompactBuffer()
-        var i = 0
-        val rel = relation.value
-        while (i < rel.length) {
-          val result = new GenericInternalRow(Array[Any](matchedBroadcastRows.get(i)))
-          buf += new JoinedRow(rel(i).copy(), result)
-          i += 1
-        }
-        return sparkContext.makeRDD(buf)
-      case LeftAnti =>
-        val notMatched: CompactBuffer[InternalRow] = new CompactBuffer()
-        var i = 0
-        val rel = relation.value
-        while (i < rel.length) {
-          if (!matchedBroadcastRows.get(i)) {
-            notMatched += rel(i).copy()
-          }
-          i += 1
-        }
-        return sparkContext.makeRDD(notMatched)
-      case _ =>
-    }
-
+    val matchedBroadcastRows = getMatchedBroadcastRowsBitSet(streamRdd, relation)
     val notMatchedBroadcastRows: Seq[InternalRow] = {
       val nulls = new GenericInternalRow(streamed.output.size)
       val buf: CompactBuffer[InternalRow] = new CompactBuffer()
@@ -358,6 +339,34 @@ case class BroadcastNestedLoopJoinExec(
     )
   }
 
+  /**
+   * Get matched rows from broadcast side as a [[BitSet]].
+   * Create a local [[BitSet]] for broadcast side on each RDD partition,
+   * and merge all [[BitSet]]s together.
+   */
+  private def getMatchedBroadcastRowsBitSet(
+      streamRdd: RDD[InternalRow],
+      relation: Broadcast[Array[InternalRow]]): BitSet = {
+    val matchedBuildRows = streamRdd.mapPartitionsInternal { streamedIter =>
+      val buildRows = relation.value
+      val matched = new BitSet(buildRows.length)
+      val joinedRow = new JoinedRow
+
+      streamedIter.foreach { streamedRow =>
+        var i = 0
+        while (i < buildRows.length) {
+          if (boundCondition(joinedRow(streamedRow, buildRows(i)))) {
+            matched.set(i)
+          }
+          i += 1
+        }
+      }
+      Seq(matched).toIterator
+    }
+
+    matchedBuildRows.fold(new BitSet(relation.value.length))(_ | _)
+  }
+
   protected override def doExecute(): RDD[InternalRow] = {
     val broadcastedRelation = broadcast.executeBroadcast[Array[InternalRow]]()
 
@@ -366,20 +375,17 @@ case class BroadcastNestedLoopJoinExec(
         innerJoin(broadcastedRelation)
       case (LeftOuter, BuildRight) | (RightOuter, BuildLeft) =>
         outerJoin(broadcastedRelation)
-      case (LeftSemi, BuildRight) =>
+      case (LeftSemi, _) =>
         leftExistenceJoin(broadcastedRelation, exists = true)
-      case (LeftAnti, BuildRight) =>
+      case (LeftAnti, _) =>
         leftExistenceJoin(broadcastedRelation, exists = false)
-      case (_: ExistenceJoin, BuildRight) =>
+      case (_: ExistenceJoin, _) =>
         existenceJoin(broadcastedRelation)
       case _ =>
         /**
          * LeftOuter with BuildLeft
          * RightOuter with BuildRight
          * FullOuter
-         * LeftSemi with BuildLeft
-         * LeftAnti with BuildLeft
-         * ExistenceJoin with BuildLeft
          */
         defaultJoin(broadcastedRelation)
     }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
For `BroadcastNestedLoopJoinExec` left semi and left anti join without condition. If we broadcast left side. Currently we check whether every row from broadcast side has a match or not by [iterating broadcast side a lot of time](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala#L256-L275). This is unnecessary and very inefficient when there's no condition, as we only need to check whether stream side is empty or not. Create this PR to add the optimization. This can boost the affected query execution performance a lot.

In addition, create a common method `getMatchedBroadcastRowsBitSet()` shared by several methods.
Refactor `defaultJoin()` to move 
* left semi and left anti join related logic to `leftExistenceJoin`
* existence join related logic to `existenceJoin`.

After this, `defaultJoin()` holds logic only for outer join (left outer, right outer and full outer), which is much easier to read from my own opinion.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve the affected query performance a lot.
Test with a simple query by modifying `JoinBenchmark.scala` locally:

```
val N = 20 << 20
val M = 1 << 4
val dim = broadcast(spark.range(M).selectExpr("id as k"))
val df = dim.join(spark.range(N), Seq.empty, "left_semi")
df.noop()
```

See >30x run time improvement. Note the stream side is only `spark.range(N)`. For complicated query with non-trivial stream side, the saving would be much more.

```
Running benchmark: broadcast nested loop left semi join
  Running case: broadcast nested loop left semi join optimization off
  Stopped after 2 iterations, 3163 ms
  Running case: broadcast nested loop left semi join optimization on
  Stopped after 5 iterations, 366 ms

Java HotSpot(TM) 64-Bit Server VM 1.8.0_181-b13 on Mac OS X 10.15.7
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
broadcast nested loop left semi join:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------
broadcast nested loop left semi join optimization off           1568           1582          19         13.4          74.8       1.0X
broadcast nested loop left semi join optimization on              46             73          18        456.0           2.2      34.1X
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit test in `ExistenceJoinSuite.scala`.