### PR TITLE
[SPARK-34741][SQL] MergeIntoTable should avoid ambiguous reference in UpdateAction

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1662,6 +1662,9 @@ class Analyzer(override val catalogManager: CatalogManager)
         // implementation and should be resolved based on the table schema.
         o.copy(deleteExpr = resolveExpressionByPlanOutput(o.deleteExpr, o.table))
 
+      case m @ MergeIntoTable(targetTable, sourceTable, _, _, _) if !m.duplicateResolved =>
+        m.copy(sourceTable = dedupRight(targetTable, sourceTable))
+
       case m @ MergeIntoTable(targetTable, sourceTable, _, _, _)
         if !m.resolved && targetTable.resolved && sourceTable.resolved =>
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -404,6 +404,7 @@ case class MergeIntoTable(
     matchedActions: Seq[MergeAction],
     notMatchedActions: Seq[MergeAction]) extends Command with SupportsSubquery {
   override def children: Seq[LogicalPlan] = Seq(targetTable, sourceTable)
+  def duplicateResolved: Boolean = targetTable.outputSet.intersect(sourceTable.outputSet).isEmpty
 }
 
 sealed abstract class MergeAction extends Expression with Unevaluable {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -671,6 +671,15 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       Project(Seq(UnresolvedAttribute("temp0.a"), UnresolvedAttribute("temp1.a")), join))
   }
 
+  test("SPARK-34741: Avoid ambiguous reference in MergeIntoTable") {
+    val assignments = Assignment('a, 'a) :: Nil
+    val cond = 'a > 1
+    val matchedActions = UpdateAction(Some(cond), assignments) :: DeleteAction(Some(cond)) :: Nil
+    val notMatchedActions = InsertAction(Some(cond), assignments) :: Nil
+    val merge = MergeIntoTable(testRelation, testRelation, cond, matchedActions, notMatchedActions)
+    assertAnalysisError(merge, "Reference 'a' is ambiguous" :: Nil)
+  }
+
   test("SPARK-24488 Generator with multiple aliases") {
     assertAnalysisSuccess(
       listRelation.select(Explode($"list").as("first_alias").as("second_alias")))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -672,11 +672,16 @@ class AnalysisSuite extends AnalysisTest with Matchers {
   }
 
   test("SPARK-34741: Avoid ambiguous reference in MergeIntoTable") {
-    val assignments = Assignment('a, 'a) :: Nil
     val cond = 'a > 1
-    val actions = UpdateAction(Some(cond), assignments) :: DeleteAction(Some(cond)) :: Nil
-    val merge = MergeIntoTable(testRelation, testRelation, cond, actions, Nil)
-    assertAnalysisError(merge, "Reference 'a' is ambiguous" :: Nil)
+    assertAnalysisError(
+      MergeIntoTable(
+        testRelation,
+        testRelation,
+        cond,
+        UpdateAction(Some(cond), Assignment('a, 'a) :: Nil) :: Nil,
+        Nil
+      ),
+      "Reference 'a' is ambiguous" :: Nil)
   }
 
   test("SPARK-24488 Generator with multiple aliases") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -674,9 +674,8 @@ class AnalysisSuite extends AnalysisTest with Matchers {
   test("SPARK-34741: Avoid ambiguous reference in MergeIntoTable") {
     val assignments = Assignment('a, 'a) :: Nil
     val cond = 'a > 1
-    val matchedActions = UpdateAction(Some(cond), assignments) :: DeleteAction(Some(cond)) :: Nil
-    val notMatchedActions = InsertAction(Some(cond), assignments) :: Nil
-    val merge = MergeIntoTable(testRelation, testRelation, cond, matchedActions, notMatchedActions)
+    val actions = UpdateAction(Some(cond), assignments) :: DeleteAction(Some(cond)) :: Nil
+    val merge = MergeIntoTable(testRelation, testRelation, cond, actions, Nil)
     assertAnalysisError(merge, "Reference 'a' is ambiguous" :: Nil)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
@@ -459,10 +459,10 @@ class ReplaceNullWithFalseInPredicateSuite extends PlanTest {
       val target = rel.as("target")
       val source = rel.as("source")
       val assignments = Seq(
-        Assignment(UnresolvedAttribute("target.i"), UnresolvedAttribute("source.i")),
-        Assignment(UnresolvedAttribute("target.b"), UnresolvedAttribute("source.b")),
-        Assignment(UnresolvedAttribute("target.a"), UnresolvedAttribute("source.a")),
-        Assignment(UnresolvedAttribute("target.m"), UnresolvedAttribute("source.m"))
+        Assignment(UnresolvedAttribute("i"), UnresolvedAttribute("source.i")),
+        Assignment(UnresolvedAttribute("b"), UnresolvedAttribute("source.b")),
+        Assignment(UnresolvedAttribute("a"), UnresolvedAttribute("source.a")),
+        Assignment(UnresolvedAttribute("m"), UnresolvedAttribute("source.m"))
       )
       val matchedCond = expr.transform {
         case UnresolvedAttribute(nameParts) => new UnresolvedAttribute("target" +: nameParts)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
@@ -464,18 +464,13 @@ class ReplaceNullWithFalseInPredicateSuite extends PlanTest {
         Assignment(UnresolvedAttribute("a"), UnresolvedAttribute("source.a")),
         Assignment(UnresolvedAttribute("m"), UnresolvedAttribute("source.m"))
       )
-      val matchedCond = expr.transform {
-        case UnresolvedAttribute(nameParts) => new UnresolvedAttribute("target" +: nameParts)
-        case e => e
-      }
-      val notMatchedCond = expr.transform {
+      val cond = expr.transform {
         case UnresolvedAttribute(nameParts) => new UnresolvedAttribute("source" +: nameParts)
         case e => e
       }
-      val matchedActions = UpdateAction(Some(matchedCond), assignments) ::
-        DeleteAction(Some(matchedCond)) :: Nil
-      val notMatchedActions = InsertAction(Some(notMatchedCond), assignments) :: Nil
-      MergeIntoTable(target, source, matchedCond, matchedActions, notMatchedActions)
+      val matchedActions = UpdateAction(Some(cond), assignments) :: DeleteAction(Some(cond)) :: Nil
+      val notMatchedActions = InsertAction(Some(cond), assignments) :: Nil
+      MergeIntoTable(target, source, cond, matchedActions, notMatchedActions)
     }
     test(func, originalCond, expectedCond)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to deduplicate the source table when there're conflicting attributes between the target table and the source table.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When resolving the `UpdateAction`, which could reference attributes from both target and source tables,  Spark should know clearly where the attribute comes from when there're conflicting attributes instead of picking up a random one.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added a unit test and updated existing tests.
