### PR TITLE
[SPARK-34742][SQL] ANSI mode: Abs throws exception if input is out of range

### DIFF
--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -47,10 +47,20 @@ When `spark.sql.ansi.enabled` is set to `true` and an overflow occurs in numeric
 SELECT 2147483647 + 1;
 java.lang.ArithmeticException: integer overflow
 
+SELECT abs(-2147483648);
+java.lang.ArithmeticException: integer out of range
+
 -- `spark.sql.ansi.enabled=false`
 SELECT 2147483647 + 1;
 +----------------+
 |(2147483647 + 1)|
++----------------+
+|     -2147483648|
++----------------+
+
+SELECT abs(-2147483648);
++----------------+
+|abs(-2147483648)|
 +----------------+
 |     -2147483648|
 +----------------+

--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -48,7 +48,7 @@ SELECT 2147483647 + 1;
 java.lang.ArithmeticException: integer overflow
 
 SELECT abs(-2147483648);
-java.lang.ArithmeticException: integer out of range
+java.lang.ArithmeticException: integer overflow
 
 -- `spark.sql.ansi.enabled=false`
 SELECT 2147483647 + 1;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
@@ -249,7 +249,7 @@ object AnsiTypeCoercion extends TypeCoercionBase {
       case b @ BinaryOperator(left @ AtomicType(), right @ StringType()) if right.foldable =>
         b.makeCopy(Array(left, castExpr(right, left.dataType)))
 
-      case Abs(e @ StringType(), _) if e.foldable => Abs(Cast(e, DoubleType))
+      case Abs(e @ StringType(), failOnError) if e.foldable => Abs(Cast(e, DoubleType), failOnError)
       case m @ UnaryMinus(e @ StringType(), _) if e.foldable =>
         m.withNewChildren(Seq(Cast(e, DoubleType)))
       case UnaryPositive(e @ StringType()) if e.foldable => UnaryPositive(Cast(e, DoubleType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
@@ -249,7 +249,7 @@ object AnsiTypeCoercion extends TypeCoercionBase {
       case b @ BinaryOperator(left @ AtomicType(), right @ StringType()) if right.foldable =>
         b.makeCopy(Array(left, castExpr(right, left.dataType)))
 
-      case Abs(e @ StringType()) if e.foldable => Abs(Cast(e, DoubleType))
+      case Abs(e @ StringType(), _) if e.foldable => Abs(Cast(e, DoubleType))
       case m @ UnaryMinus(e @ StringType(), _) if e.foldable =>
         m.withNewChildren(Seq(Cast(e, DoubleType)))
       case UnaryPositive(e @ StringType()) if e.foldable => UnaryPositive(Cast(e, DoubleType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -1081,7 +1081,7 @@ object TypeCoercion extends TypeCoercionBase {
         val commonType = findCommonTypeForBinaryComparison(left.dataType, right.dataType, conf).get
         p.makeCopy(Array(castExpr(left, commonType), castExpr(right, commonType)))
 
-      case Abs(e @ StringType()) => Abs(Cast(e, DoubleType))
+      case Abs(e @ StringType(), _) => Abs(Cast(e, DoubleType))
       case Sum(e @ StringType()) => Sum(Cast(e, DoubleType))
       case Average(e @ StringType()) => Average(Cast(e, DoubleType))
       case s @ StddevPop(e @ StringType(), _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -1081,7 +1081,7 @@ object TypeCoercion extends TypeCoercionBase {
         val commonType = findCommonTypeForBinaryComparison(left.dataType, right.dataType, conf).get
         p.makeCopy(Array(castExpr(left, commonType), castExpr(right, commonType)))
 
-      case Abs(e @ StringType(), _) => Abs(Cast(e, DoubleType))
+      case Abs(e @ StringType(), failOnError) => Abs(Cast(e, DoubleType), failOnError)
       case Sum(e @ StringType()) => Sum(Cast(e, DoubleType))
       case Average(e @ StringType()) => Average(Cast(e, DoubleType))
       case s @ StddevPop(e @ StringType(), _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -184,10 +184,7 @@ case class Abs(child: Expression, failOnError: Boolean = SQLConf.get.ansiEnabled
           |}
           |""".stripMargin)
 
-    case _: IntegerType if failOnError =>
-      defineCodeGen(ctx, ev, c => s"$c < 0 ? java.lang.Math.negateExact($c) : $c")
-
-    case _: LongType if failOnError =>
+    case IntegerType | LongType if failOnError =>
       defineCodeGen(ctx, ev, c => s"$c < 0 ? java.lang.Math.negateExact($c) : $c")
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -99,6 +99,14 @@ private[sql] object IntegerExactNumeric extends IntIsIntegral with Ordering.IntO
   override def times(x: Int, y: Int): Int = Math.multiplyExact(x, y)
 
   override def negate(x: Int): Int = Math.negateExact(x)
+
+  override def abs(x: Int): Int = {
+    if (x == Int.MinValue) {
+      throw new ArithmeticException(s"integer out of range")
+    } else {
+      Math.abs(x)
+    }
+  }
 }
 
 private[sql] object LongExactNumeric extends LongIsIntegral with Ordering.LongOrdering {
@@ -116,6 +124,14 @@ private[sql] object LongExactNumeric extends LongIsIntegral with Ordering.LongOr
     } else {
       throw new ArithmeticException(s"Casting $x to int causes overflow")
     }
+
+  override def abs(x: Long): Long = {
+    if (x == Long.MinValue) {
+      throw new ArithmeticException(s"long integer out of range")
+    } else {
+      Math.abs(x)
+    }
+  }
 }
 
 private[sql] object FloatExactNumeric extends FloatIsFractional {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -99,14 +99,6 @@ private[sql] object IntegerExactNumeric extends IntIsIntegral with Ordering.IntO
   override def times(x: Int, y: Int): Int = Math.multiplyExact(x, y)
 
   override def negate(x: Int): Int = Math.negateExact(x)
-
-  override def abs(x: Int): Int = {
-    if (x == Int.MinValue) {
-      throw new ArithmeticException(s"integer out of range")
-    } else {
-      Math.abs(x)
-    }
-  }
 }
 
 private[sql] object LongExactNumeric extends LongIsIntegral with Ordering.LongOrdering {
@@ -124,14 +116,6 @@ private[sql] object LongExactNumeric extends LongIsIntegral with Ordering.LongOr
     } else {
       throw new ArithmeticException(s"Casting $x to int causes overflow")
     }
-
-  override def abs(x: Long): Long = {
-    if (x == Long.MinValue) {
-      throw new ArithmeticException(s"long integer out of range")
-    } else {
-      Math.abs(x)
-    }
-  }
 }
 
 private[sql] object FloatExactNumeric extends FloatIsFractional {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -260,7 +260,15 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Abs(negativeLongLit), - negativeLong)
 
     DataTypeTestUtils.numericTypeWithoutDecimal.foreach { tpe =>
-      checkConsistencyBetweenInterpretedAndCodegen(Abs, tpe)
+      checkConsistencyBetweenInterpretedAndCodegen((e: Expression) => Abs(e, false), tpe)
+    }
+  }
+
+  test("SPARK-34742: Abs throws exception when input is out of range in ANSI mode") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      Seq(Literal(Int.MinValue), Literal(Long.MinValue)).foreach { v =>
+        checkExceptionInExpression[ArithmeticException](Abs(v, true), "out of range")
+      }
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -265,9 +265,20 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
   }
 
   test("SPARK-34742: Abs throws exception when input is out of range in ANSI mode") {
+    val minValues = Seq(
+      Literal(Byte.MinValue, ByteType),
+      Literal(Short.MinValue, ShortType),
+      Literal(Int.MinValue),
+      Literal(Long.MinValue)
+    )
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      Seq(Literal(Int.MinValue), Literal(Long.MinValue)).foreach { v =>
-        checkExceptionInExpression[ArithmeticException](Abs(v, true), "out of range")
+      minValues.foreach { v =>
+        checkExceptionInExpression[ArithmeticException](Abs(v), "overflow")
+      }
+    }
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
+      minValues.foreach { v =>
+        checkEvaluation(Abs(v), v.value)
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
For the following cases, ABS should throw exceptions since the results are out of the range of the result data types in ANSI mode.
```
SELECT abs(${Int.MinValue});
SELECT abs(${Long.MinValue});
```
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Better ANSI compliance 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, Abs throws an exception if input is out of range in ANSI mode

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test