### PR TITLE
[SPARK-34747][SQL][DOCS] Add virtual operators to the built-in function document

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -229,8 +229,10 @@ case class ShowFunctionsCommand(
           case (f, "USER") if showUserFunctions => f.unquotedString
           case (f, "SYSTEM") if showSystemFunctions => f.unquotedString
         }
-    // Hard code "<>", "!=", "between", and "case" for now as there is no corresponding functions.
-    // "<>", "!=", "between", and "case" is SystemFunctions, only show when showSystemFunctions=true
+    // Hard code "<>", "!=", "between", "case", and "||"
+    // for now as there is no corresponding functions.
+    // "<>", "!=", "between", "case", and "||" is SystemFunctions,
+    // only show when showSystemFunctions=true
     if (showSystemFunctions) {
       (functionNames ++
         StringUtils.filterPattern(FunctionsCommand.virtualOperators, pattern.getOrElse("*")))

--- a/sql/gen-sql-api-docs.py
+++ b/sql/gen-sql-api-docs.py
@@ -105,7 +105,7 @@ _virtual_operator_infos = [
                  "WHEN 2 THEN 'two' END FROM VALUES 1, 2, 3;\n      " +
                  " one\n      " +
                  " two\n      " +
-                 " NULL" ,
+                 " NULL",
         note="",
         since="1.0.1",
         deprecated=""),

--- a/sql/gen-sql-api-docs.py
+++ b/sql/gen-sql-api-docs.py
@@ -24,6 +24,106 @@ from pyspark.java_gateway import launch_gateway
 ExpressionInfo = namedtuple(
     "ExpressionInfo", "className name usage arguments examples note since deprecated")
 
+_virtual_operator_infos = [
+    ExpressionInfo(
+        className="",
+        name="!=",
+        usage="expr1 != expr2 - Returns true if `expr1` is not equal to `expr2`, " +
+              "or false otherwise.",
+        arguments="\n    Arguments:\n      " +
+                  """* expr1, expr2 - the two expressions must be same type or can be casted to
+                       a common type, and must be a type that can be used in equality comparison.
+                       Map type is not supported. For complex types such array/struct,
+                       the data types of fields must be orderable.""",
+        examples="\n    Examples:\n      " +
+                 "> SELECT 1 != 2;\n      " +
+                 " true\n      " +
+                 "> SELECT 1 != '2';\n      " +
+                 " true\n      " +
+                 "> SELECT true != NULL;\n      " +
+                 " NULL\n      " +
+                 "> SELECT NULL != NULL;\n      " +
+                 " NULL",
+        note="",
+        since="1.0.0",
+        deprecated=""),
+    ExpressionInfo(
+        className="",
+        name="<>",
+        usage="expr1 != expr2 - Returns true if `expr1` is not equal to `expr2`, " +
+              "or false otherwise.",
+        arguments="\n    Arguments:\n      " +
+                  """* expr1, expr2 - the two expressions must be same type or can be casted to
+                       a common type, and must be a type that can be used in equality comparison.
+                       Map type is not supported. For complex types such array/struct,
+                       the data types of fields must be orderable.""",
+        examples="\n    Examples:\n      " +
+                 "> SELECT 1 != 2;\n      " +
+                 " true\n      " +
+                 "> SELECT 1 != '2';\n      " +
+                 " true\n      " +
+                 "> SELECT true != NULL;\n      " +
+                 " NULL\n      " +
+                 "> SELECT NULL != NULL;\n      " +
+                 " NULL",
+        note="",
+        since="1.0.0",
+        deprecated=""),
+    ExpressionInfo(
+        className="",
+        name="between",
+        usage="expr1 [NOT] BETWEEN expr2 AND expr3 - " +
+              "evaluate if `expr1` is [not] in between `expr2` and `expr3`.",
+        arguments="",
+        examples="\n    Examples:\n      " +
+                 "> SELECT col1 FROM VALUES 1, 3, 5, 7 WHERE col1 BETWEEN 2 AND 5;\n      " +
+                 " 3\n      " +
+                 " 5",
+        note="",
+        since="1.0.0",
+        deprecated=""),
+    ExpressionInfo(
+        className="",
+        name="case",
+        usage="CASE expr1 WHEN expr2 THEN expr3 " +
+              "[WHEN expr4 THEN expr5]* [ELSE expr6] END - " +
+              "When `expr1` = `expr2`, returns `expr3`; " +
+              "when `expr1` = `expr4`, return `expr5`; else return `expr6`.",
+        arguments="\n    Arguments:\n      " +
+                  "* expr1 - the expression which is one operand of comparison.\n      " +
+                  "* expr2, expr4 - the expressions each of which is the other " +
+                  "  operand of comparison.\n      " +
+                  "* expr3, expr5, expr6 - the branch value expressions and else value expression" +
+                  "  should all be same type or coercible to a common type.",
+        examples="\n    Examples:\n      " +
+                 "> SELECT CASE col1 WHEN 1 THEN 'one' " +
+                 "WHEN 2 THEN 'two' ELSE '?' END FROM VALUES 1, 2, 3;\n      " +
+                 " one\n      " +
+                 " two\n      " +
+                 " ?\n      " +
+                 "> SELECT CASE col1 WHEN 1 THEN 'one' " +
+                 "WHEN 2 THEN 'two' END FROM VALUES 1, 2, 3;\n      " +
+                 " one\n      " +
+                 " two\n      " +
+                 " NULL" ,
+        note="",
+        since="1.0.1",
+        deprecated=""),
+    ExpressionInfo(
+        className="",
+        name="||",
+        usage="expr1 || expr2 - Returns the concatenation of `expr1` and `expr2`.",
+        arguments="",
+        examples="\n    Examples:\n      " +
+                 "> SELECT 'Spark' || 'SQL';\n      " +
+                 " SparkSQL\n      " +
+                 "> SELECT array(1, 2, 3) || array(4, 5) || array(6);\n      " +
+                 " [1,2,3,4,5,6]",
+        note="\n    || for arrays is available since 2.4.0.\n",
+        since="2.3.0",
+        deprecated="")
+]
+
 
 def _list_function_infos(jvm):
     """
@@ -32,7 +132,7 @@ def _list_function_infos(jvm):
     """
 
     jinfos = jvm.org.apache.spark.sql.api.python.PythonSQLUtils.listBuiltinFunctionInfos()
-    infos = []
+    infos = _virtual_operator_infos
     for jinfo in jinfos:
         name = jinfo.getName()
         usage = jinfo.getUsage()


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fix an issue that virtual operators (`||`, `!=`, `<>`, `between` and `case`) are absent from the Spark SQL Built-in functions document.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The document should explain about all the supported built-in operators. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Built the document with `SKIP_SCALADOC=1 SKIP_RDOC=1 SKIP_PYTHONDOC=1 bundler exec jekyll build` and then, confirmed the document.

![neq1](https://user-images.githubusercontent.com/4736016/111192859-e2e76380-85fc-11eb-89c9-75916a5e856a.png)
![neq2](https://user-images.githubusercontent.com/4736016/111192874-e7ac1780-85fc-11eb-9a9b-c504265b373f.png)
![between](https://user-images.githubusercontent.com/4736016/111192898-eda1f880-85fc-11eb-992d-cf80c544ec27.png)
![case](https://user-images.githubusercontent.com/4736016/111192918-f266ac80-85fc-11eb-9306-5dbc413a0cdb.png)
![double_pipe](https://user-images.githubusercontent.com/4736016/111192952-fb577e00-85fc-11eb-932e-385e5c2a5205.png)
