### PR TITLE
[SPARK-34752][BUILD] Bump Jetty to 9.4.37 to address CVE-2020-27223

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.11.1</parquet.version>
     <orc.version>1.6.7</orc.version>
-    <jetty.version>9.4.36.v20210114</jetty.version>
+    <jetty.version>9.4.37.v20210219</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.9.5</chill.version>
     <ivy.version>2.4.0</ivy.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Jetty version from `9.4.36.v20210114` to `9.4.37.v20210219`.

### Why are the changes needed?
Current Jetty version is vulnerable to [CVE-2020-27223](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27223), see [Veracode](https://www.sourceclear.com/vulnerability-database/security/denial-of-servicedos/java/sid-29523) for more details.

### Does this PR introduce _any_ user-facing change?
No, minor Jetty version change. Release notes can be found [here](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.37.v20210219).

### How was this patch tested?
Will let GitHub run the unit tests.