### PR TITLE
[SPARK-34755][SQL] Support the utils for transform number format

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberUtils.scala
@@ -136,7 +136,7 @@ object NumberUtils {
       inputSplits(1).filterNot(isSign).length > scale) {
       throw QueryExecutionErrors.invalidNumberFormatError(numberFormat)
     }
-    val number = numberDecimalFormat.parse(inputStr, parsePosition)
+    val number = numberDecimalFormat.parse(inputStr, new ParsePosition(0))
     Decimal(number.asInstanceOf[BigDecimal])
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberUtils.scala
@@ -125,7 +125,6 @@ object NumberUtils {
     val numberDecimalFormat = numberFormatInstance.asInstanceOf[DecimalFormat]
     numberDecimalFormat.setParseBigDecimal(true)
     numberDecimalFormat.applyPattern(transformedFormat)
-    val parsePosition = new ParsePosition(0)
     val inputStr = input.toString.trim
     val inputSplits = inputStr.split(pointSign)
     if (inputSplits.length == 1) {
@@ -152,9 +151,9 @@ object NumberUtils {
    * 'G':  group separator (uses locale)
    * '$':  specifies that the input value has a leading $ (Dollar) sign.
    *
-   * @param input
-   * @param numberFormat
-   * @return
+   * @param input the decimal to format
+   * @param numberFormat the format string
+   * @return The string after formatting input decimal
    */
   def format(input: Decimal, numberFormat: String): String = {
     val normalizedFormat = normalize(numberFormat)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberUtils.scala
@@ -41,12 +41,12 @@ object NumberUtils {
     val normalizedFormat = format.toUpperCase(Locale.ROOT).map {
       case '9' if notFindDecimalPoint => '#'
       case '9' if !notFindDecimalPoint => '0'
-      case c if c == letterPointSign =>
+      case `letterPointSign` =>
         notFindDecimalPoint = false
         pointSign
-      case c if c == letterCommaSign => commaSign
-      case c if c == letterMinusSign => minusSign
-      case c if c == pointSign =>
+      case `letterCommaSign` => commaSign
+      case `letterMinusSign` => minusSign
+      case `pointSign` =>
         notFindDecimalPoint = false
         pointSign
       case other => other

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberUtils.scala
@@ -57,9 +57,8 @@ object NumberUtils {
     UTF8String.fromString(normalizedFormat).trim(UTF8String.fromString(commaSign.toString)).toString
   }
 
-  private def isSign(c: Char): Boolean = c match {
-    case c if c == pointSign || c == commaSign || c == minusSign || c == dollarSign => true
-    case _ => false
+  private def isSign(c: Char): Boolean = {
+    Set(pointSign, commaSign, minusSign, dollarSign).contains(c)
   }
 
   private def transform(format: String): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberUtils.scala
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import java.math.BigDecimal
+import java.text.{DecimalFormat, NumberFormat, ParsePosition}
+import java.util.Locale
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.types.Decimal
+import org.apache.spark.unsafe.types.UTF8String
+
+object NumberUtils {
+
+  private val pointSign = '.'
+  private val letterPointSign = 'D'
+  private val commaSign = ','
+  private val letterCommaSign = 'G'
+  private val minusSign = '-'
+  private val letterMinusSign = 'S'
+  private val dollarSign = '$'
+
+  private def normalize(format: String): String = {
+    var notFindDecimalPoint = true
+    val normalizedFormat = format.toUpperCase(Locale.ROOT).map {
+      case '9' if notFindDecimalPoint => '#'
+      case '9' if !notFindDecimalPoint => '0'
+      case c if c == letterPointSign =>
+        notFindDecimalPoint = false
+        pointSign
+      case c if c == letterCommaSign => commaSign
+      case c if c == letterMinusSign => minusSign
+      case c if c == pointSign =>
+        notFindDecimalPoint = false
+        pointSign
+      case other => other
+    }
+    // If the comma is at the beginning or end of number format, then DecimalFormat will be invalid.
+    // For example, "##,###," or ",###,###" for DecimalFormat is invalid, so we must use "##,###"
+    // or "###,###".
+    UTF8String.fromString(normalizedFormat).trim(UTF8String.fromString(commaSign.toString)).toString
+  }
+
+  private def isSign(c: Char): Boolean = c match {
+    case c if c == pointSign || c == commaSign || c == minusSign || c == dollarSign => true
+    case _ => false
+  }
+
+  private def transform(format: String): String = {
+    if (format.contains(minusSign)) {
+      val positiveFormatString = format.replaceAll("-", "")
+      s"$positiveFormatString;$format"
+    } else {
+      format
+    }
+  }
+
+  private def fail(message: String, numberFormat: String) =
+    throw new AnalysisException(s"Multiple $message in $numberFormat")
+
+  private def check(normalizedFormat: String, numberFormat: String) = {
+    def invalidSignPosition(format: String, c: Char): Boolean = {
+      val signIndex = format.indexOf(c)
+      signIndex > 0 && signIndex < format.length - 1
+    }
+
+    if (normalizedFormat.count(_ == pointSign) > 1) {
+      fail(s"'$letterPointSign' or '$pointSign'", numberFormat)
+    } else if (normalizedFormat.count(_ == minusSign) > 1) {
+      fail(s"'$letterMinusSign' or '$minusSign'", numberFormat)
+    } else if (normalizedFormat.count(_ == dollarSign) > 1) {
+      fail(s"'$dollarSign'", numberFormat)
+    } else if (invalidSignPosition(normalizedFormat, minusSign)) {
+      throw new AnalysisException(
+        s"'$letterMinusSign' or '$minusSign' must be the first or last char")
+    } else if (invalidSignPosition(normalizedFormat, dollarSign)) {
+      throw new AnalysisException(s"'$dollarSign' must be the first or last char")
+    }
+  }
+
+  /**
+   * Convert string to numeric based on the given number format.
+   * The format can consist of the following characters:
+   * '9':  digit position (can be dropped if insignificant)
+   * '0':  digit position (will not be dropped, even if insignificant)
+   * '.':  decimal point (only allowed once)
+   * ',':  group (thousands) separator
+   * 'S':  sign anchored to number (uses locale)
+   * 'D':  decimal point (uses locale)
+   * 'G':  group separator (uses locale)
+   * '$':  specifies that the input value has a leading $ (Dollar) sign.
+   *
+   * @param input the string need to converted
+   * @param numberFormat the given number format
+   * @return decimal obtained from string parsing
+   */
+  def parse(input: UTF8String, numberFormat: String): Decimal = {
+    val normalizedFormat = normalize(numberFormat)
+    check(normalizedFormat, numberFormat)
+
+    val precision = normalizedFormat.filterNot(isSign).length
+    val formatSplits = normalizedFormat.split(pointSign)
+    val scale = if (formatSplits.length == 1) {
+      0
+    } else {
+      formatSplits(1).filterNot(isSign).length
+    }
+    val transformedFormat = transform(normalizedFormat)
+    val numberFormatInstance = NumberFormat.getInstance()
+    val numberDecimalFormat = numberFormatInstance.asInstanceOf[DecimalFormat]
+    numberDecimalFormat.setParseBigDecimal(true)
+    numberDecimalFormat.applyPattern(transformedFormat)
+    val parsePosition = new ParsePosition(0)
+    val inputStr = input.toString.trim
+    val inputSplits = inputStr.split(pointSign)
+    if (inputSplits.length == 1) {
+      if (inputStr.filterNot(isSign).length > precision - scale) {
+        throw QueryExecutionErrors.invalidNumberFormatError(numberFormat)
+      }
+    } else if (inputSplits(0).filterNot(isSign).length > precision - scale ||
+      inputSplits(1).filterNot(isSign).length > scale) {
+      throw QueryExecutionErrors.invalidNumberFormatError(numberFormat)
+    }
+    val number = numberDecimalFormat.parse(inputStr, parsePosition)
+    Decimal(number.asInstanceOf[BigDecimal])
+  }
+
+  /**
+   * Convert numeric to string based on the given number format.
+   * The format can consist of the following characters:
+   * '9':  digit position (can be dropped if insignificant)
+   * '0':  digit position (will not be dropped, even if insignificant)
+   * '.':  decimal point (only allowed once)
+   * ',':  group (thousands) separator
+   * 'S':  sign anchored to number (uses locale)
+   * 'D':  decimal point (uses locale)
+   * 'G':  group separator (uses locale)
+   * '$':  specifies that the input value has a leading $ (Dollar) sign.
+   *
+   * @param input
+   * @param numberFormat
+   * @return
+   */
+  def format(input: Decimal, numberFormat: String): String = {
+    val normalizedFormat = normalize(numberFormat)
+    check(normalizedFormat, numberFormat)
+
+    val transformedFormat = transform(normalizedFormat)
+    val bigDecimal = input.toJavaBigDecimal
+    val decimalPlainStr = bigDecimal.toPlainString
+    if (decimalPlainStr.length > transformedFormat.length) {
+      transformedFormat.replaceAll("0", "#")
+    } else {
+      val decimalFormat = new DecimalFormat(transformedFormat)
+      var resultStr = decimalFormat.format(bigDecimal)
+      // Since we trimmed the comma at the beginning or end of number format in function
+      // `normalize`, we restore the comma to the result here.
+      // For example, if the specified number format is "99,999," or ",999,999", function
+      // `normalize` normalize them to "##,###" or "###,###".
+      // new DecimalFormat("##,###").parse(12454) and new DecimalFormat("###,###").parse(124546)
+      // will return "12,454" and "124,546" respectively. So we add ',' at the end and head of
+      // the result, then the final output are "12,454," or ",124,546".
+      if (numberFormat.last == commaSign || numberFormat.last == letterCommaSign) {
+        resultStr = resultStr + commaSign
+      }
+      if (numberFormat.charAt(0) == commaSign || numberFormat.charAt(0) == letterCommaSign) {
+        resultStr = commaSign + resultStr
+      }
+
+      resultStr
+    }
+  }
+
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2365,4 +2365,12 @@ object QueryCompilationErrors {
   def tableNotSupportTimeTravelError(tableName: Identifier): UnsupportedOperationException = {
     new UnsupportedOperationException(s"Table $tableName does not support time travel.")
   }
+
+  def multipleSignInNumberFormatError(message: String, numberFormat: String): Throwable = {
+    new AnalysisException(s"Multiple $message in '$numberFormat'")
+  }
+
+  def nonFistOrLastCharInNumberFormatError(message: String, numberFormat: String): Throwable = {
+    new AnalysisException(s"$message must be the first or last char in '$numberFormat'")
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1920,4 +1920,10 @@ object QueryExecutionErrors {
         s". To solve this try to set $maxDynamicPartitionsKey" +
         s" to at least $numWrittenParts.")
   }
+
+  def invalidNumberFormatError(format: String): Throwable = {
+    new IllegalArgumentException(
+      s"Format '$format' used for parsing string to number or " +
+        "formatting number to string is invalid")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/NumberUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/NumberUtilsSuite.scala
@@ -53,221 +53,265 @@ class NumberUtilsSuite extends SparkFunSuite {
     failParseWithInvalidInput(UTF8String.fromString("454"), "99",
       "Format '99' used for parsing string to number or formatting number to string is invalid")
 
-    assert(parse(UTF8String.fromString("454"), "999") === Decimal(454))
-    assert(parse(UTF8String.fromString("054"), "999") === Decimal(54))
-    assert(parse(UTF8String.fromString("404"), "999") === Decimal(404))
-    assert(parse(UTF8String.fromString("450"), "999") === Decimal(450))
-    assert(parse(UTF8String.fromString("454"), "9999") === Decimal(454))
-    assert(parse(UTF8String.fromString("054"), "9999") === Decimal(54))
-    assert(parse(UTF8String.fromString("404"), "9999") === Decimal(404))
-    assert(parse(UTF8String.fromString("450"), "9999") === Decimal(450))
+    Seq(
+      ("454", "999") -> Decimal(454),
+      ("054", "999") -> Decimal(54),
+      ("404", "999") -> Decimal(404),
+      ("450", "999") -> Decimal(450),
+      ("454", "9999") -> Decimal(454),
+      ("054", "9999") -> Decimal(54),
+      ("404", "9999") -> Decimal(404),
+      ("450", "9999") -> Decimal(450)
+    ).foreach { case ((str, format), expected) =>
+      assert(parse(UTF8String.fromString(str), format) === expected)
+    }
 
     failParseWithInvalidInput(UTF8String.fromString("454"), "0",
       "Format '0' used for parsing string to number or formatting number to string is invalid")
     failParseWithInvalidInput(UTF8String.fromString("454"), "00",
       "Format '00' used for parsing string to number or formatting number to string is invalid")
 
-    assert(parse(UTF8String.fromString("454"), "000") === Decimal(454))
-    assert(parse(UTF8String.fromString("054"), "000") === Decimal(54))
-    assert(parse(UTF8String.fromString("404"), "000") === Decimal(404))
-    assert(parse(UTF8String.fromString("450"), "000") === Decimal(450))
-    assert(parse(UTF8String.fromString("454"), "0000") === Decimal(454))
-    assert(parse(UTF8String.fromString("054"), "0000") === Decimal(54))
-    assert(parse(UTF8String.fromString("404"), "0000") === Decimal(404))
-    assert(parse(UTF8String.fromString("450"), "0000") === Decimal(450))
+    Seq(
+      ("454", "000") -> Decimal(454),
+      ("054", "000") -> Decimal(54),
+      ("404", "000") -> Decimal(404),
+      ("450", "000") -> Decimal(450),
+      ("454", "0000") -> Decimal(454),
+      ("054", "0000") -> Decimal(54),
+      ("404", "0000") -> Decimal(404),
+      ("450", "0000") -> Decimal(450)
+    ).foreach { case ((str, format), expected) =>
+      assert(parse(UTF8String.fromString(str), format) === expected)
+    }
 
     // Test '.' and 'D'
     failParseWithInvalidInput(UTF8String.fromString("454.2"), "999",
       "Format '999' used for parsing string to number or formatting number to string is invalid")
     failParseWithInvalidInput(UTF8String.fromString("454.23"), "999.9",
       "Format '999.9' used for parsing string to number or formatting number to string is invalid")
-    assert(parse(UTF8String.fromString("454.2"), "999.9") === Decimal(454.2))
-    assert(parse(UTF8String.fromString("454.2"), "000.0") === Decimal(454.2))
-    assert(parse(UTF8String.fromString("454.2"), "999D9") === Decimal(454.2))
-    assert(parse(UTF8String.fromString("454.2"), "000D0") === Decimal(454.2))
-    assert(parse(UTF8String.fromString("454.23"), "999.99") === Decimal(454.23))
-    assert(parse(UTF8String.fromString("454.23"), "000.00") === Decimal(454.23))
-    assert(parse(UTF8String.fromString("454.23"), "999D99") === Decimal(454.23))
-    assert(parse(UTF8String.fromString("454.23"), "000D00") === Decimal(454.23))
-    assert(parse(UTF8String.fromString("454.0"), "999.9") === Decimal(454))
-    assert(parse(UTF8String.fromString("454.0"), "000.0") === Decimal(454))
-    assert(parse(UTF8String.fromString("454.0"), "999D9") === Decimal(454))
-    assert(parse(UTF8String.fromString("454.0"), "000D0") === Decimal(454))
-    assert(parse(UTF8String.fromString("454.00"), "999.99") === Decimal(454))
-    assert(parse(UTF8String.fromString("454.00"), "000.00") === Decimal(454))
-    assert(parse(UTF8String.fromString("454.00"), "999D99") === Decimal(454))
-    assert(parse(UTF8String.fromString("454.00"), "000D00") === Decimal(454))
-    assert(parse(UTF8String.fromString(".4542"), ".9999") === Decimal(0.4542))
-    assert(parse(UTF8String.fromString(".4542"), ".0000") === Decimal(0.4542))
-    assert(parse(UTF8String.fromString(".4542"), "D9999") === Decimal(0.4542))
-    assert(parse(UTF8String.fromString(".4542"), "D0000") === Decimal(0.4542))
-    assert(parse(UTF8String.fromString("4542."), "9999.") === Decimal(4542))
-    assert(parse(UTF8String.fromString("4542."), "0000.") === Decimal(4542))
-    assert(parse(UTF8String.fromString("4542."), "9999D") === Decimal(4542))
-    assert(parse(UTF8String.fromString("4542."), "0000D") === Decimal(4542))
+
+    Seq(
+      ("454.2", "999.9") -> Decimal(454.2),
+      ("454.2", "000.0") -> Decimal(454.2),
+      ("454.2", "999D9") -> Decimal(454.2),
+      ("454.2", "000D0") -> Decimal(454.2),
+      ("454.23", "999.99") -> Decimal(454.23),
+      ("454.23", "000.00") -> Decimal(454.23),
+      ("454.23", "999D99") -> Decimal(454.23),
+      ("454.23", "000D00") -> Decimal(454.23),
+      ("454.0", "999.9") -> Decimal(454),
+      ("454.0", "000.0") -> Decimal(454),
+      ("454.0", "999D9") -> Decimal(454),
+      ("454.0", "000D0") -> Decimal(454),
+      ("454.00", "999.99") -> Decimal(454),
+      ("454.00", "000.00") -> Decimal(454),
+      ("454.00", "999D99") -> Decimal(454),
+      ("454.00", "000D00") -> Decimal(454),
+      (".4542", ".9999") -> Decimal(0.4542),
+      (".4542", ".0000") -> Decimal(0.4542),
+      (".4542", "D9999") -> Decimal(0.4542),
+      (".4542", "D0000") -> Decimal(0.4542),
+      ("4542.", "9999.") -> Decimal(4542),
+      ("4542.", "0000.") -> Decimal(4542),
+      ("4542.", "9999D") -> Decimal(4542),
+      ("4542.", "0000D") -> Decimal(4542),
+    ).foreach { case ((str, format), expected) =>
+      assert(parse(UTF8String.fromString(str), format) === expected)
+    }
 
     failParseWithAnalysisException(UTF8String.fromString("454.3.2"), "999.9.9",
-      "Multiple 'D' or '.' in 999.9.9")
+      "Multiple 'D' or '.' in '999.9.9'")
     failParseWithAnalysisException(UTF8String.fromString("454.3.2"), "999D9D9",
-      "Multiple 'D' or '.' in 999D9D9")
+      "Multiple 'D' or '.' in '999D9D9'")
     failParseWithAnalysisException(UTF8String.fromString("454.3.2"), "999.9D9",
-      "Multiple 'D' or '.' in 999.9D9")
+      "Multiple 'D' or '.' in '999.9D9'")
     failParseWithAnalysisException(UTF8String.fromString("454.3.2"), "999D9.9",
-      "Multiple 'D' or '.' in 999D9.9")
+      "Multiple 'D' or '.' in '999D9.9'")
 
     // Test ',' and 'G'
-    assert(parse(UTF8String.fromString("12,454"), "99,999") === Decimal(12454))
-    assert(parse(UTF8String.fromString("12,454"), "00,000") === Decimal(12454))
-    assert(parse(UTF8String.fromString("12,454"), "99G999") === Decimal(12454))
-    assert(parse(UTF8String.fromString("12,454"), "00G000") === Decimal(12454))
-    assert(parse(UTF8String.fromString("12,454,367"), "99,999,999") === Decimal(12454367))
-    assert(parse(UTF8String.fromString("12,454,367"), "00,000,000") === Decimal(12454367))
-    assert(parse(UTF8String.fromString("12,454,367"), "99G999G999") === Decimal(12454367))
-    assert(parse(UTF8String.fromString("12,454,367"), "00G000G000") === Decimal(12454367))
-    assert(parse(UTF8String.fromString("12,454,"), "99,999,") === Decimal(12454))
-    assert(parse(UTF8String.fromString("12,454,"), "00,000,") === Decimal(12454))
-    assert(parse(UTF8String.fromString("12,454,"), "99G999G") === Decimal(12454))
-    assert(parse(UTF8String.fromString("12,454,"), "00G000G") === Decimal(12454))
-    assert(parse(UTF8String.fromString(",454,367"), ",999,999") === Decimal(454367))
-    assert(parse(UTF8String.fromString(",454,367"), ",000,000") === Decimal(454367))
-    assert(parse(UTF8String.fromString(",454,367"), "G999G999") === Decimal(454367))
-    assert(parse(UTF8String.fromString(",454,367"), "G000G000") === Decimal(454367))
+    Seq(
+      ("12,454", "99,999") -> Decimal(12454),
+      ("12,454", "00,000") -> Decimal(12454),
+      ("12,454", "99G999") -> Decimal(12454),
+      ("12,454", "00G000") -> Decimal(12454),
+      ("12,454,367", "99,999,999") -> Decimal(12454367),
+      ("12,454,367", "00,000,000") -> Decimal(12454367),
+      ("12,454,367", "99G999G999") -> Decimal(12454367),
+      ("12,454,367", "00G000G000") -> Decimal(12454367),
+      ("12,454,", "99,999,") -> Decimal(12454),
+      ("12,454,", "00,000,") -> Decimal(12454),
+      ("12,454,", "99G999G") -> Decimal(12454),
+      ("12,454,", "00G000G") -> Decimal(12454),
+      (",454,367", ",999,999") -> Decimal(454367),
+      (",454,367", ",000,000") -> Decimal(454367),
+      (",454,367", "G999G999") -> Decimal(454367),
+      (",454,367", "G000G000") -> Decimal(454367),
+    ).foreach { case ((str, format), expected) =>
+      assert(parse(UTF8String.fromString(str), format) === expected)
+    }
 
     // Test '$'
-    assert(parse(UTF8String.fromString("$78.12"), "$99.99") === Decimal(78.12))
-    assert(parse(UTF8String.fromString("$78.12"), "$00.00") === Decimal(78.12))
-    assert(parse(UTF8String.fromString("78.12$"), "99.99$") === Decimal(78.12))
-    assert(parse(UTF8String.fromString("78.12$"), "00.00$") === Decimal(78.12))
+    Seq(
+      ("$78.12", "$99.99") -> Decimal(78.12),
+      ("$78.12", "$00.00") -> Decimal(78.12),
+      ("78.12$", "99.99$") -> Decimal(78.12),
+      ("78.12$", "00.00$") -> Decimal(78.12)
+    ).foreach { case ((str, format), expected) =>
+      assert(parse(UTF8String.fromString(str), format) === expected)
+    }
 
     failParseWithAnalysisException(UTF8String.fromString("78$.12"), "99$.99",
-      "'$' must be the first or last char")
+      "'$' must be the first or last char in '99$.99'")
     failParseWithAnalysisException(UTF8String.fromString("$78.12$"), "$99.99$",
-      "Multiple '$' in $99.99$")
+      "Multiple '$' in '$99.99$'")
 
     // Test '-' and 'S'
-    assert(parse(UTF8String.fromString("454-"), "999-") === Decimal(-454))
-    assert(parse(UTF8String.fromString("454-"), "999S") === Decimal(-454))
-    assert(parse(UTF8String.fromString("-454"), "-999") === Decimal(-454))
-    assert(parse(UTF8String.fromString("-454"), "S999") === Decimal(-454))
-    assert(parse(UTF8String.fromString("454-"), "000-") === Decimal(-454))
-    assert(parse(UTF8String.fromString("454-"), "000S") === Decimal(-454))
-    assert(parse(UTF8String.fromString("-454"), "-000") === Decimal(-454))
-    assert(parse(UTF8String.fromString("-454"), "S000") === Decimal(-454))
-    assert(parse(UTF8String.fromString("12,454.8-"), "99G999D9S") === Decimal(-12454.8))
-    assert(parse(UTF8String.fromString("00,454.8-"), "99G999.9S") === Decimal(-454.8))
+    Seq(
+      ("454-", "999-") -> Decimal(-454),
+      ("454-", "999S") -> Decimal(-454),
+      ("-454", "-999") -> Decimal(-454),
+      ("-454", "S999") -> Decimal(-454),
+      ("454-", "000-") -> Decimal(-454),
+      ("454-", "000S") -> Decimal(-454),
+      ("-454", "-000") -> Decimal(-454),
+      ("-454", "S000") -> Decimal(-454),
+      ("12,454.8-", "99G999D9S") -> Decimal(-12454.8),
+      ("00,454.8-", "99G999.9S") -> Decimal(-454.8)
+    ).foreach { case ((str, format), expected) =>
+      assert(parse(UTF8String.fromString(str), format) === expected)
+    }
 
     failParseWithAnalysisException(UTF8String.fromString("4-54"), "9S99",
-      "'S' or '-' must be the first or last char")
+      "'S' or '-' must be the first or last char in '9S99'")
     failParseWithAnalysisException(UTF8String.fromString("4-54"), "9-99",
-      "'S' or '-' must be the first or last char")
+      "'S' or '-' must be the first or last char in '9-99'")
     failParseWithAnalysisException(UTF8String.fromString("454.3--"), "999D9SS",
-      "Multiple 'S' or '-' in 999D9SS")
+      "Multiple 'S' or '-' in '999D9SS'")
   }
 
   test("format") {
     assert(format(Decimal(454), "") === "")
 
     // Test '9' and '0'
-    assert(format(Decimal(454), "9") === "#")
-    assert(format(Decimal(454), "99") === "##")
-    assert(format(Decimal(454), "999") === "454")
-    assert(format(Decimal(54), "999") === "54")
-    assert(format(Decimal(404), "999") === "404")
-    assert(format(Decimal(450), "999") === "450")
-    assert(format(Decimal(454), "9999") === "454")
-    assert(format(Decimal(54), "9999") === "54")
-    assert(format(Decimal(404), "9999") === "404")
-    assert(format(Decimal(450), "9999") === "450")
-
-    assert(format(Decimal(454), "0") === "#")
-    assert(format(Decimal(454), "00") === "##")
-    assert(format(Decimal(454), "000") === "454")
-    assert(format(Decimal(54), "000") === "054")
-    assert(format(Decimal(404), "000") === "404")
-    assert(format(Decimal(450), "000") === "450")
-    assert(format(Decimal(454), "0000") === "0454")
-    assert(format(Decimal(54), "0000") === "0054")
-    assert(format(Decimal(404), "0000") === "0404")
-    assert(format(Decimal(450), "0000") === "0450")
+    Seq(
+      (Decimal(454), "9") -> "#",
+      (Decimal(454), "99") -> "##",
+      (Decimal(454), "999") -> "454",
+      (Decimal(54), "999") -> "54",
+      (Decimal(404), "999") -> "404",
+      (Decimal(450), "999") -> "450",
+      (Decimal(454), "9999") -> "454",
+      (Decimal(54), "9999") -> "54",
+      (Decimal(404), "9999") -> "404",
+      (Decimal(450), "9999") -> "450",
+      (Decimal(454), "0") -> "#",
+      (Decimal(454), "00") -> "##",
+      (Decimal(454), "000") -> "454",
+      (Decimal(54), "000") -> "054",
+      (Decimal(404), "000") -> "404",
+      (Decimal(450), "000") -> "450",
+      (Decimal(454), "0000") -> "0454",
+      (Decimal(54), "0000") -> "0054",
+      (Decimal(404), "0000") -> "0404",
+      (Decimal(450), "0000") -> "0450",
+    ).foreach { case ((decimal, str), expected) =>
+      assert(format(decimal, str) === expected)
+    }
 
     // Test '.' and 'D'
-    assert(format(Decimal(454.2), "999.9") === "454.2")
-    assert(format(Decimal(454.2), "000.0") === "454.2")
-    assert(format(Decimal(454.2), "999D9") === "454.2")
-    assert(format(Decimal(454.2), "000D0") === "454.2")
-    assert(format(Decimal(454), "999.9") === "454.0")
-    assert(format(Decimal(454), "000.0") === "454.0")
-    assert(format(Decimal(454), "999D9") === "454.0")
-    assert(format(Decimal(454), "000D0") === "454.0")
-    assert(format(Decimal(454), "999.99") === "454.00")
-    assert(format(Decimal(454), "000.00") === "454.00")
-    assert(format(Decimal(454), "999D99") === "454.00")
-    assert(format(Decimal(454), "000D00") === "454.00")
-    assert(format(Decimal(0.4542), ".9999") === ".####")
-    assert(format(Decimal(0.4542), ".0000") === ".####")
-    assert(format(Decimal(0.4542), "D9999") === ".####")
-    assert(format(Decimal(0.4542), "D0000") === ".####")
-    assert(format(Decimal(4542), "9999.") === "4542.")
-    assert(format(Decimal(4542), "0000.") === "4542.")
-    assert(format(Decimal(4542), "9999D") === "4542.")
-    assert(format(Decimal(4542), "0000D") === "4542.")
+    Seq(
+      (Decimal(454.2), "999.9") -> "454.2",
+      (Decimal(454.2), "000.0") -> "454.2",
+      (Decimal(454.2), "999D9") -> "454.2",
+      (Decimal(454.2), "000D0") -> "454.2",
+      (Decimal(454), "999.9") -> "454.0",
+      (Decimal(454), "000.0") -> "454.0",
+      (Decimal(454), "999D9") -> "454.0",
+      (Decimal(454), "000D0") -> "454.0",
+      (Decimal(454), "999.99") -> "454.00",
+      (Decimal(454), "000.00") -> "454.00",
+      (Decimal(454), "999D99") -> "454.00",
+      (Decimal(454), "000D00") -> "454.00",
+      (Decimal(0.4542), ".9999") -> ".####",
+      (Decimal(0.4542), ".0000") -> ".####",
+      (Decimal(0.4542), "D9999") -> ".####",
+      (Decimal(0.4542), "D0000") -> ".####",
+      (Decimal(4542), "9999.") -> "4542.",
+      (Decimal(4542), "0000.") -> "4542.",
+      (Decimal(4542), "9999D") -> "4542.",
+      (Decimal(4542), "0000D") -> "4542."
+    ).foreach { case ((decimal, str), expected) =>
+      assert(format(decimal, str) === expected)
+    }
 
     failFormatWithAnalysisException(Decimal(454.32), "999.9.9",
-      "Multiple 'D' or '.' in 999.9.9")
+      "Multiple 'D' or '.' in '999.9.9'")
     failFormatWithAnalysisException(Decimal(454.32), "999D9D9",
-      "Multiple 'D' or '.' in 999D9D9")
+      "Multiple 'D' or '.' in '999D9D9'")
     failFormatWithAnalysisException(Decimal(454.32), "999.9D9",
-      "Multiple 'D' or '.' in 999.9D9")
+      "Multiple 'D' or '.' in '999.9D9'")
     failFormatWithAnalysisException(Decimal(454.32), "999D9.9",
-      "Multiple 'D' or '.' in 999D9.9")
+      "Multiple 'D' or '.' in '999D9.9'")
 
     // Test ',' and 'G'
-    assert(format(Decimal(12454), "99,999") === "12,454")
-    assert(format(Decimal(12454), "00,000") === "12,454")
-    assert(format(Decimal(12454), "99G999") === "12,454")
-    assert(format(Decimal(12454), "00G000") === "12,454")
-    assert(format(Decimal(12454367), "99,999,999") === "12,454,367")
-    assert(format(Decimal(12454367), "00,000,000") === "12,454,367")
-    assert(format(Decimal(12454367), "99G999G999") === "12,454,367")
-    assert(format(Decimal(12454367), "00G000G000") === "12,454,367")
-    assert(format(Decimal(12454), "99,999,") === "12,454,")
-    assert(format(Decimal(12454), "00,000,") === "12,454,")
-    assert(format(Decimal(12454), "99G999G") === "12,454,")
-    assert(format(Decimal(12454), "00G000G") === "12,454,")
-    assert(format(Decimal(454367), ",999,999") === ",454,367")
-    assert(format(Decimal(454367), ",000,000") === ",454,367")
-    assert(format(Decimal(454367), "G999G999") === ",454,367")
-    assert(format(Decimal(454367), "G000G000") === ",454,367")
+    Seq(
+      (Decimal(12454), "99,999") -> "12,454",
+      (Decimal(12454), "00,000") -> "12,454",
+      (Decimal(12454), "99G999") -> "12,454",
+      (Decimal(12454), "00G000") -> "12,454",
+      (Decimal(12454367), "99,999,999") -> "12,454,367",
+      (Decimal(12454367), "00,000,000") -> "12,454,367",
+      (Decimal(12454367), "99G999G999") -> "12,454,367",
+      (Decimal(12454367), "00G000G000") -> "12,454,367",
+      (Decimal(12454), "99,999,") -> "12,454,",
+      (Decimal(12454), "00,000,") -> "12,454,",
+      (Decimal(12454), "99G999G") -> "12,454,",
+      (Decimal(12454), "00G000G") -> "12,454,",
+      (Decimal(454367), ",999,999") -> ",454,367",
+      (Decimal(454367), ",000,000") -> ",454,367",
+      (Decimal(454367), "G999G999") -> ",454,367",
+      (Decimal(454367), "G000G000") -> ",454,367"
+    ).foreach { case ((decimal, str), expected) =>
+      assert(format(decimal, str) === expected)
+    }
 
     // Test '$'
-    assert(format(Decimal(78.12), "$99.99") === "$78.12")
-    assert(format(Decimal(78.12), "$00.00") === "$78.12")
-    assert(format(Decimal(78.12), "99.99$") === "78.12$")
-    assert(format(Decimal(78.12), "00.00$") === "78.12$")
+    Seq(
+      (Decimal(78.12), "$99.99") -> "$78.12",
+      (Decimal(78.12), "$00.00") -> "$78.12",
+      (Decimal(78.12), "99.99$") -> "78.12$",
+      (Decimal(78.12), "00.00$") -> "78.12$"
+    ).foreach { case ((decimal, str), expected) =>
+      assert(format(decimal, str) === expected)
+    }
 
     failFormatWithAnalysisException(Decimal(78.12), "99$.99",
-      "'$' must be the first or last char")
+      "'$' must be the first or last char in '99$.99'")
     failFormatWithAnalysisException(Decimal(78.12), "$99.99$",
-      "Multiple '$' in $99.99$")
+      "Multiple '$' in '$99.99$'")
 
     // Test '-' and 'S'
-    assert(format(Decimal(-454), "999-") === "454-")
-    assert(format(Decimal(-454), "999S") === "454-")
-    assert(format(Decimal(-454), "-999") === "-454")
-    assert(format(Decimal(-454), "S999") === "-454")
-    assert(format(Decimal(-454), "000-") === "454-")
-    assert(format(Decimal(-454), "000S") === "454-")
-    assert(format(Decimal(-454), "-000") === "-454")
-    assert(format(Decimal(-454), "S000") === "-454")
-    assert(format(Decimal(-12454.8), "99G999D9S") === "12,454.8-")
-    assert(format(Decimal(-454.8), "99G999.9S") === "454.8-")
+    Seq(
+      (Decimal(-454), "999-") -> "454-",
+      (Decimal(-454), "999S") -> "454-",
+      (Decimal(-454), "-999") -> "-454",
+      (Decimal(-454), "S999") -> "-454",
+      (Decimal(-454), "000-") -> "454-",
+      (Decimal(-454), "000S") -> "454-",
+      (Decimal(-454), "-000") -> "-454",
+      (Decimal(-454), "S000") -> "-454",
+      (Decimal(-12454.8), "99G999D9S") -> "12,454.8-",
+      (Decimal(-454.8), "99G999.9S") -> "454.8-"
+    ).foreach { case ((decimal, str), expected) =>
+      assert(format(decimal, str) === expected)
+    }
 
     failFormatWithAnalysisException(Decimal(-454), "9S99",
-      "'S' or '-' must be the first or last char")
+      "'S' or '-' must be the first or last char in '9S99'")
     failFormatWithAnalysisException(Decimal(-454), "9-99",
-      "'S' or '-' must be the first or last char")
+      "'S' or '-' must be the first or last char in '9-99'")
     failFormatWithAnalysisException(Decimal(-454.3), "999D9SS",
-      "Multiple 'S' or '-' in 999D9SS")
+      "Multiple 'S' or '-' in '999D9SS'")
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/NumberUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/NumberUtilsSuite.scala
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.util.NumberUtils.{format, parse}
+import org.apache.spark.sql.types.Decimal
+import org.apache.spark.unsafe.types.UTF8String
+
+class NumberUtilsSuite extends SparkFunSuite {
+
+  private def failParseWithInvalidInput(
+      input: UTF8String, numberFormat: String, errorMsg: String): Unit = {
+    val e = intercept[IllegalArgumentException](parse(input, numberFormat))
+    assert(e.getMessage.contains(errorMsg))
+  }
+
+  private def failParseWithAnalysisException(
+      input: UTF8String, numberFormat: String, errorMsg: String): Unit = {
+    val e = intercept[AnalysisException](parse(input, numberFormat))
+    assert(e.getMessage.contains(errorMsg))
+  }
+
+  private def failFormatWithAnalysisException(
+      input: Decimal, numberFormat: String, errorMsg: String): Unit = {
+    val e = intercept[AnalysisException](format(input, numberFormat))
+    assert(e.getMessage.contains(errorMsg))
+  }
+
+  test("parse") {
+    failParseWithInvalidInput(UTF8String.fromString("454"), "",
+      "Format '' used for parsing string to number or formatting number to string is invalid")
+
+    // Test '9' and '0'
+    failParseWithInvalidInput(UTF8String.fromString("454"), "9",
+      "Format '9' used for parsing string to number or formatting number to string is invalid")
+    failParseWithInvalidInput(UTF8String.fromString("454"), "99",
+      "Format '99' used for parsing string to number or formatting number to string is invalid")
+
+    assert(parse(UTF8String.fromString("454"), "999") === Decimal(454))
+    assert(parse(UTF8String.fromString("054"), "999") === Decimal(54))
+    assert(parse(UTF8String.fromString("404"), "999") === Decimal(404))
+    assert(parse(UTF8String.fromString("450"), "999") === Decimal(450))
+    assert(parse(UTF8String.fromString("454"), "9999") === Decimal(454))
+    assert(parse(UTF8String.fromString("054"), "9999") === Decimal(54))
+    assert(parse(UTF8String.fromString("404"), "9999") === Decimal(404))
+    assert(parse(UTF8String.fromString("450"), "9999") === Decimal(450))
+
+    failParseWithInvalidInput(UTF8String.fromString("454"), "0",
+      "Format '0' used for parsing string to number or formatting number to string is invalid")
+    failParseWithInvalidInput(UTF8String.fromString("454"), "00",
+      "Format '00' used for parsing string to number or formatting number to string is invalid")
+
+    assert(parse(UTF8String.fromString("454"), "000") === Decimal(454))
+    assert(parse(UTF8String.fromString("054"), "000") === Decimal(54))
+    assert(parse(UTF8String.fromString("404"), "000") === Decimal(404))
+    assert(parse(UTF8String.fromString("450"), "000") === Decimal(450))
+    assert(parse(UTF8String.fromString("454"), "0000") === Decimal(454))
+    assert(parse(UTF8String.fromString("054"), "0000") === Decimal(54))
+    assert(parse(UTF8String.fromString("404"), "0000") === Decimal(404))
+    assert(parse(UTF8String.fromString("450"), "0000") === Decimal(450))
+
+    // Test '.' and 'D'
+    failParseWithInvalidInput(UTF8String.fromString("454.2"), "999",
+      "Format '999' used for parsing string to number or formatting number to string is invalid")
+    failParseWithInvalidInput(UTF8String.fromString("454.23"), "999.9",
+      "Format '999.9' used for parsing string to number or formatting number to string is invalid")
+    assert(parse(UTF8String.fromString("454.2"), "999.9") === Decimal(454.2))
+    assert(parse(UTF8String.fromString("454.2"), "000.0") === Decimal(454.2))
+    assert(parse(UTF8String.fromString("454.2"), "999D9") === Decimal(454.2))
+    assert(parse(UTF8String.fromString("454.2"), "000D0") === Decimal(454.2))
+    assert(parse(UTF8String.fromString("454.23"), "999.99") === Decimal(454.23))
+    assert(parse(UTF8String.fromString("454.23"), "000.00") === Decimal(454.23))
+    assert(parse(UTF8String.fromString("454.23"), "999D99") === Decimal(454.23))
+    assert(parse(UTF8String.fromString("454.23"), "000D00") === Decimal(454.23))
+    assert(parse(UTF8String.fromString("454.0"), "999.9") === Decimal(454))
+    assert(parse(UTF8String.fromString("454.0"), "000.0") === Decimal(454))
+    assert(parse(UTF8String.fromString("454.0"), "999D9") === Decimal(454))
+    assert(parse(UTF8String.fromString("454.0"), "000D0") === Decimal(454))
+    assert(parse(UTF8String.fromString("454.00"), "999.99") === Decimal(454))
+    assert(parse(UTF8String.fromString("454.00"), "000.00") === Decimal(454))
+    assert(parse(UTF8String.fromString("454.00"), "999D99") === Decimal(454))
+    assert(parse(UTF8String.fromString("454.00"), "000D00") === Decimal(454))
+    assert(parse(UTF8String.fromString(".4542"), ".9999") === Decimal(0.4542))
+    assert(parse(UTF8String.fromString(".4542"), ".0000") === Decimal(0.4542))
+    assert(parse(UTF8String.fromString(".4542"), "D9999") === Decimal(0.4542))
+    assert(parse(UTF8String.fromString(".4542"), "D0000") === Decimal(0.4542))
+    assert(parse(UTF8String.fromString("4542."), "9999.") === Decimal(4542))
+    assert(parse(UTF8String.fromString("4542."), "0000.") === Decimal(4542))
+    assert(parse(UTF8String.fromString("4542."), "9999D") === Decimal(4542))
+    assert(parse(UTF8String.fromString("4542."), "0000D") === Decimal(4542))
+
+    failParseWithAnalysisException(UTF8String.fromString("454.3.2"), "999.9.9",
+      "Multiple 'D' or '.' in 999.9.9")
+    failParseWithAnalysisException(UTF8String.fromString("454.3.2"), "999D9D9",
+      "Multiple 'D' or '.' in 999D9D9")
+    failParseWithAnalysisException(UTF8String.fromString("454.3.2"), "999.9D9",
+      "Multiple 'D' or '.' in 999.9D9")
+    failParseWithAnalysisException(UTF8String.fromString("454.3.2"), "999D9.9",
+      "Multiple 'D' or '.' in 999D9.9")
+
+    // Test ',' and 'G'
+    assert(parse(UTF8String.fromString("12,454"), "99,999") === Decimal(12454))
+    assert(parse(UTF8String.fromString("12,454"), "00,000") === Decimal(12454))
+    assert(parse(UTF8String.fromString("12,454"), "99G999") === Decimal(12454))
+    assert(parse(UTF8String.fromString("12,454"), "00G000") === Decimal(12454))
+    assert(parse(UTF8String.fromString("12,454,367"), "99,999,999") === Decimal(12454367))
+    assert(parse(UTF8String.fromString("12,454,367"), "00,000,000") === Decimal(12454367))
+    assert(parse(UTF8String.fromString("12,454,367"), "99G999G999") === Decimal(12454367))
+    assert(parse(UTF8String.fromString("12,454,367"), "00G000G000") === Decimal(12454367))
+    assert(parse(UTF8String.fromString("12,454,"), "99,999,") === Decimal(12454))
+    assert(parse(UTF8String.fromString("12,454,"), "00,000,") === Decimal(12454))
+    assert(parse(UTF8String.fromString("12,454,"), "99G999G") === Decimal(12454))
+    assert(parse(UTF8String.fromString("12,454,"), "00G000G") === Decimal(12454))
+    assert(parse(UTF8String.fromString(",454,367"), ",999,999") === Decimal(454367))
+    assert(parse(UTF8String.fromString(",454,367"), ",000,000") === Decimal(454367))
+    assert(parse(UTF8String.fromString(",454,367"), "G999G999") === Decimal(454367))
+    assert(parse(UTF8String.fromString(",454,367"), "G000G000") === Decimal(454367))
+
+    // Test '$'
+    assert(parse(UTF8String.fromString("$78.12"), "$99.99") === Decimal(78.12))
+    assert(parse(UTF8String.fromString("$78.12"), "$00.00") === Decimal(78.12))
+    assert(parse(UTF8String.fromString("78.12$"), "99.99$") === Decimal(78.12))
+    assert(parse(UTF8String.fromString("78.12$"), "00.00$") === Decimal(78.12))
+
+    failParseWithAnalysisException(UTF8String.fromString("78$.12"), "99$.99",
+      "'$' must be the first or last char")
+    failParseWithAnalysisException(UTF8String.fromString("$78.12$"), "$99.99$",
+      "Multiple '$' in $99.99$")
+
+    // Test '-' and 'S'
+    assert(parse(UTF8String.fromString("454-"), "999-") === Decimal(-454))
+    assert(parse(UTF8String.fromString("454-"), "999S") === Decimal(-454))
+    assert(parse(UTF8String.fromString("-454"), "-999") === Decimal(-454))
+    assert(parse(UTF8String.fromString("-454"), "S999") === Decimal(-454))
+    assert(parse(UTF8String.fromString("454-"), "000-") === Decimal(-454))
+    assert(parse(UTF8String.fromString("454-"), "000S") === Decimal(-454))
+    assert(parse(UTF8String.fromString("-454"), "-000") === Decimal(-454))
+    assert(parse(UTF8String.fromString("-454"), "S000") === Decimal(-454))
+    assert(parse(UTF8String.fromString("12,454.8-"), "99G999D9S") === Decimal(-12454.8))
+    assert(parse(UTF8String.fromString("00,454.8-"), "99G999.9S") === Decimal(-454.8))
+
+    failParseWithAnalysisException(UTF8String.fromString("4-54"), "9S99",
+      "'S' or '-' must be the first or last char")
+    failParseWithAnalysisException(UTF8String.fromString("4-54"), "9-99",
+      "'S' or '-' must be the first or last char")
+    failParseWithAnalysisException(UTF8String.fromString("454.3--"), "999D9SS",
+      "Multiple 'S' or '-' in 999D9SS")
+  }
+
+  test("format") {
+    assert(format(Decimal(454), "") === "")
+
+    // Test '9' and '0'
+    assert(format(Decimal(454), "9") === "#")
+    assert(format(Decimal(454), "99") === "##")
+    assert(format(Decimal(454), "999") === "454")
+    assert(format(Decimal(54), "999") === "54")
+    assert(format(Decimal(404), "999") === "404")
+    assert(format(Decimal(450), "999") === "450")
+    assert(format(Decimal(454), "9999") === "454")
+    assert(format(Decimal(54), "9999") === "54")
+    assert(format(Decimal(404), "9999") === "404")
+    assert(format(Decimal(450), "9999") === "450")
+
+    assert(format(Decimal(454), "0") === "#")
+    assert(format(Decimal(454), "00") === "##")
+    assert(format(Decimal(454), "000") === "454")
+    assert(format(Decimal(54), "000") === "054")
+    assert(format(Decimal(404), "000") === "404")
+    assert(format(Decimal(450), "000") === "450")
+    assert(format(Decimal(454), "0000") === "0454")
+    assert(format(Decimal(54), "0000") === "0054")
+    assert(format(Decimal(404), "0000") === "0404")
+    assert(format(Decimal(450), "0000") === "0450")
+
+    // Test '.' and 'D'
+    assert(format(Decimal(454.2), "999.9") === "454.2")
+    assert(format(Decimal(454.2), "000.0") === "454.2")
+    assert(format(Decimal(454.2), "999D9") === "454.2")
+    assert(format(Decimal(454.2), "000D0") === "454.2")
+    assert(format(Decimal(454), "999.9") === "454.0")
+    assert(format(Decimal(454), "000.0") === "454.0")
+    assert(format(Decimal(454), "999D9") === "454.0")
+    assert(format(Decimal(454), "000D0") === "454.0")
+    assert(format(Decimal(454), "999.99") === "454.00")
+    assert(format(Decimal(454), "000.00") === "454.00")
+    assert(format(Decimal(454), "999D99") === "454.00")
+    assert(format(Decimal(454), "000D00") === "454.00")
+    assert(format(Decimal(0.4542), ".9999") === ".####")
+    assert(format(Decimal(0.4542), ".0000") === ".####")
+    assert(format(Decimal(0.4542), "D9999") === ".####")
+    assert(format(Decimal(0.4542), "D0000") === ".####")
+    assert(format(Decimal(4542), "9999.") === "4542.")
+    assert(format(Decimal(4542), "0000.") === "4542.")
+    assert(format(Decimal(4542), "9999D") === "4542.")
+    assert(format(Decimal(4542), "0000D") === "4542.")
+
+    failFormatWithAnalysisException(Decimal(454.32), "999.9.9",
+      "Multiple 'D' or '.' in 999.9.9")
+    failFormatWithAnalysisException(Decimal(454.32), "999D9D9",
+      "Multiple 'D' or '.' in 999D9D9")
+    failFormatWithAnalysisException(Decimal(454.32), "999.9D9",
+      "Multiple 'D' or '.' in 999.9D9")
+    failFormatWithAnalysisException(Decimal(454.32), "999D9.9",
+      "Multiple 'D' or '.' in 999D9.9")
+
+    // Test ',' and 'G'
+    assert(format(Decimal(12454), "99,999") === "12,454")
+    assert(format(Decimal(12454), "00,000") === "12,454")
+    assert(format(Decimal(12454), "99G999") === "12,454")
+    assert(format(Decimal(12454), "00G000") === "12,454")
+    assert(format(Decimal(12454367), "99,999,999") === "12,454,367")
+    assert(format(Decimal(12454367), "00,000,000") === "12,454,367")
+    assert(format(Decimal(12454367), "99G999G999") === "12,454,367")
+    assert(format(Decimal(12454367), "00G000G000") === "12,454,367")
+    assert(format(Decimal(12454), "99,999,") === "12,454,")
+    assert(format(Decimal(12454), "00,000,") === "12,454,")
+    assert(format(Decimal(12454), "99G999G") === "12,454,")
+    assert(format(Decimal(12454), "00G000G") === "12,454,")
+    assert(format(Decimal(454367), ",999,999") === ",454,367")
+    assert(format(Decimal(454367), ",000,000") === ",454,367")
+    assert(format(Decimal(454367), "G999G999") === ",454,367")
+    assert(format(Decimal(454367), "G000G000") === ",454,367")
+
+    // Test '$'
+    assert(format(Decimal(78.12), "$99.99") === "$78.12")
+    assert(format(Decimal(78.12), "$00.00") === "$78.12")
+    assert(format(Decimal(78.12), "99.99$") === "78.12$")
+    assert(format(Decimal(78.12), "00.00$") === "78.12$")
+
+    failFormatWithAnalysisException(Decimal(78.12), "99$.99",
+      "'$' must be the first or last char")
+    failFormatWithAnalysisException(Decimal(78.12), "$99.99$",
+      "Multiple '$' in $99.99$")
+
+    // Test '-' and 'S'
+    assert(format(Decimal(-454), "999-") === "454-")
+    assert(format(Decimal(-454), "999S") === "454-")
+    assert(format(Decimal(-454), "-999") === "-454")
+    assert(format(Decimal(-454), "S999") === "-454")
+    assert(format(Decimal(-454), "000-") === "454-")
+    assert(format(Decimal(-454), "000S") === "454-")
+    assert(format(Decimal(-454), "-000") === "-454")
+    assert(format(Decimal(-454), "S000") === "-454")
+    assert(format(Decimal(-12454.8), "99G999D9S") === "12,454.8-")
+    assert(format(Decimal(-454.8), "99G999.9S") === "454.8-")
+
+    failFormatWithAnalysisException(Decimal(-454), "9S99",
+      "'S' or '-' must be the first or last char")
+    failFormatWithAnalysisException(Decimal(-454), "9-99",
+      "'S' or '-' must be the first or last char")
+    failFormatWithAnalysisException(Decimal(-454.3), "999D9SS",
+      "Multiple 'S' or '-' in 999D9SS")
+  }
+
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/NumberUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/NumberUtilsSuite.scala
@@ -114,7 +114,7 @@ class NumberUtilsSuite extends SparkFunSuite {
       ("4542.", "9999.") -> Decimal(4542),
       ("4542.", "0000.") -> Decimal(4542),
       ("4542.", "9999D") -> Decimal(4542),
-      ("4542.", "0000D") -> Decimal(4542),
+      ("4542.", "0000D") -> Decimal(4542)
     ).foreach { case ((str, format), expected) =>
       assert(parse(UTF8String.fromString(str), format) === expected)
     }
@@ -145,7 +145,7 @@ class NumberUtilsSuite extends SparkFunSuite {
       (",454,367", ",999,999") -> Decimal(454367),
       (",454,367", ",000,000") -> Decimal(454367),
       (",454,367", "G999G999") -> Decimal(454367),
-      (",454,367", "G000G000") -> Decimal(454367),
+      (",454,367", "G000G000") -> Decimal(454367)
     ).foreach { case ((str, format), expected) =>
       assert(parse(UTF8String.fromString(str), format) === expected)
     }
@@ -213,7 +213,7 @@ class NumberUtilsSuite extends SparkFunSuite {
       (Decimal(454), "0000") -> "0454",
       (Decimal(54), "0000") -> "0054",
       (Decimal(404), "0000") -> "0404",
-      (Decimal(450), "0000") -> "0450",
+      (Decimal(450), "0000") -> "0450"
     ).foreach { case ((decimal, str), expected) =>
       assert(format(decimal, str) === expected)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Data Type Formatting Functions: `to_number` and `to_char` is very useful. 
The implement has many different between `Postgresql` ,`Oracle` and `Phoenix`.
So, this PR follows the implement of `to_number` in `Oracle` that give a strict parameter verification.
So, this PR follows the implement of `to_number` in `Phoenix` that uses BigDecimal.

This PR support the patterns for numeric formatting as follows:

Pattern | Description
-- | --
9 | Value with the specified number of digits
0 | Value with leading zeros
. (period) | Decimal point
, (comma) | Group (thousand) separator
S | Sign anchored to number (uses locale)
$ | a value with a leading dollar sign
D | Decimal point (uses locale)
G | Group separator (uses locale)

There are some mainstream database support the syntax.
**PostgreSQL:**
https://www.postgresql.org/docs/12/functions-formatting.html

**Oracle:**
https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/TO_NUMBER.html#GUID-D4807212-AFD7-48A7-9AED-BEC3E8809866

**Vertica**
https://www.vertica.com/docs/10.0.x/HTML/Content/Authoring/SQLReferenceManual/Functions/Formatting/TO_NUMBER.htm?tocpath=SQL%20Reference%20Manual%7CSQL%20Functions%7CFormatting%20Functions%7C_____7

**Redshift**
https://docs.aws.amazon.com/redshift/latest/dg/r_TO_NUMBER.html

**DB2**
https://www.ibm.com/support/knowledgecenter/SSGU8G_14.1.0/com.ibm.sqls.doc/ids_sqs_1544.htm

**Teradata**
https://docs.teradata.com/r/kmuOwjp1zEYg98JsB8fu_A/TH2cDXBn6tala29S536nqg

**Snowflake:**
https://docs.snowflake.net/manuals/sql-reference/functions/to_decimal.html

**Exasol**
https://docs.exasol.com/sql_references/functions/alphabeticallistfunctions/to_number.htm#TO_NUMBER

**Phoenix**
http://phoenix.incubator.apache.org/language/functions.html#to_number

**Singlestore**
https://docs.singlestore.com/v7.3/reference/sql-reference/numeric-functions/to-number/

**Intersystems**
https://docs.intersystems.com/latest/csp/docbook/DocBook.UI.Page.cls?KEY=RSQL_TONUMBER

Note: Based on discussion offline with @cloud-fan ten months ago, this PR only implement the utils for transform number format. Because the utils should be review better.

### Why are the changes needed?
`to_number` and `to_char` are very useful for formatted currency to number conversion.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Jenkins test
