### PR TITLE
[SPARK-34768][SQL] Respect the default input buffer size in Univocity

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -166,8 +166,6 @@ class CSVOptions(
 
   val quoteAll = getBool("quoteAll", false)
 
-  val inputBufferSize = 128
-
   /**
    * The max error content length in CSV parser/writer exception message.
    */
@@ -259,7 +257,6 @@ class CSVOptions(
     settings.setIgnoreLeadingWhitespaces(ignoreLeadingWhiteSpaceInRead)
     settings.setIgnoreTrailingWhitespaces(ignoreTrailingWhiteSpaceInRead)
     settings.setReadInputOnSeparateThread(false)
-    settings.setInputBufferSize(inputBufferSize)
     settings.setMaxColumns(maxColumns)
     settings.setNullValue(nullValue)
     settings.setEmptyValue(emptyValueInRead)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2469,7 +2469,6 @@ abstract class CSVSuite
       Seq(line).toDF.write.text(path.getAbsolutePath)
       assert(spark.read.format("csv")
         .option("delimiter", "|")
-        .option("inferSchema", "true")
         .option("ignoreTrailingWhiteSpace", "true").load(path.getAbsolutePath).count() == 1)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2452,6 +2452,27 @@ abstract class CSVSuite
       assert(result.sameElements(exceptResults))
     }
   }
+
+  test("SPARK-34768: counting a long record with ignoreTrailingWhiteSpace set to true") {
+    val line = "XX   |XXX-XXXX            |XXXXXX              " +
+      "|XXXXXXXX|XXXXX               |XXXXXX              " +
+      "|X|XXXXXXX|XXXXXXXX|XXXX|XXXXXXXXXXXXXXX     |XXXXXXXXXXX" +
+      "|XXXXXX              |XXXXXXXXXXXXXXXXXXXXXX|XXXXXX              " +
+      "|XXXXXXXXXXXXXX|XXXXXX              |XXXXXXXXXXXXXXXXXXXXXX" +
+      "|XXXXXX              |XXXXXXXXXXXXXXXXXXXXXX|XXXXXX              " +
+      "|XXXXXXXXX|XXXXXX              |XXXXXXX|                    " +
+      "||                    ||                    " +
+      "||                    ||XXXX-XX-XX XX:XX:XX.XXXXXXX" +
+      "||XXXXX.XXXXXXXXXXXXXXX|XXXXX.XXXXXXXXXXXXXX" +
+      "|XXXXX.XXXXXXXXXXXXXXX|X|XXXXXX              |X"
+    withTempPath { path =>
+      Seq(line).toDF.write.text(path.getAbsolutePath)
+      assert(spark.read.format("csv")
+        .option("delimiter", "|")
+        .option("inferSchema", "true")
+        .option("ignoreTrailingWhiteSpace", "true").load(path.getAbsolutePath).count() == 1)
+    }
+  }
 }
 
 class CSVv1Suite extends CSVSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2454,17 +2454,8 @@ abstract class CSVSuite
   }
 
   test("SPARK-34768: counting a long record with ignoreTrailingWhiteSpace set to true") {
-    val line = "XX   |XXX-XXXX            |XXXXXX              " +
-      "|XXXXXXXX|XXXXX               |XXXXXX              " +
-      "|X|XXXXXXX|XXXXXXXX|XXXX|XXXXXXXXXXXXXXX     |XXXXXXXXXXX" +
-      "|XXXXXX              |XXXXXXXXXXXXXXXXXXXXXX|XXXXXX              " +
-      "|XXXXXXXXXXXXXX|XXXXXX              |XXXXXXXXXXXXXXXXXXXXXX" +
-      "|XXXXXX              |XXXXXXXXXXXXXXXXXXXXXX|XXXXXX              " +
-      "|XXXXXXXXX|XXXXXX              |XXXXXXX|                    " +
-      "||                    ||                    " +
-      "||                    ||XXXX-XX-XX XX:XX:XX.XXXXXXX" +
-      "||XXXXX.XXXXXXXXXXXXXXX|XXXXX.XXXXXXXXXXXXXX" +
-      "|XXXXX.XXXXXXXXXXXXXXX|X|XXXXXX              |X"
+    val bufSize = 128
+    val line = "X" * (bufSize - 1) + "| |"
     withTempPath { path =>
       Seq(line).toDF.write.text(path.getAbsolutePath)
       assert(spark.read.format("csv")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to follow Univocity's input buffer.

### Why are the changes needed?

- Firstly, it's best to trust their judgement on the default values. Also 128 is too low.
- Default values arguably have more test coverage in Univocity.
- It will also fix https://github.com/uniVocity/univocity-parsers/issues/449
- ^ is a regression compared to Spark 2.4

### Does this PR introduce _any_ user-facing change?

No. In addition, It fixes a regression.

### How was this patch tested?

Manually tested, and added a unit test.