### PR TITLE
Revert "[SPARK-34739][SQL] Support add/subtract of a year-month interval to/from a timestamp"

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -340,8 +340,6 @@ class Analyzer(override val catalogManager: CatalogManager)
         case a @ Add(l, r, f) if a.childrenResolved => (l.dataType, r.dataType) match {
           case (DateType, YearMonthIntervalType) => DateAddYMInterval(l, r)
           case (YearMonthIntervalType, DateType) => DateAddYMInterval(r, l)
-          case (TimestampType, YearMonthIntervalType) => TimestampAddYMInterval(l, r)
-          case (YearMonthIntervalType, TimestampType) => TimestampAddYMInterval(r, l)
           case (CalendarIntervalType, CalendarIntervalType) => a
           case (DateType, CalendarIntervalType) => DateAddInterval(l, r, ansiEnabled = f)
           case (_, CalendarIntervalType) => Cast(TimeAdd(l, r), l.dataType)
@@ -354,8 +352,6 @@ class Analyzer(override val catalogManager: CatalogManager)
         case s @ Subtract(l, r, f) if s.childrenResolved => (l.dataType, r.dataType) match {
           case (DateType, YearMonthIntervalType) =>
             DatetimeSub(l, r, DateAddYMInterval(l, UnaryMinus(r, f)))
-          case (TimestampType, YearMonthIntervalType) =>
-            DatetimeSub(l, r, TimestampAddYMInterval(l, UnaryMinus(r, f)))
           case (CalendarIntervalType, CalendarIntervalType) => s
           case (DateType, CalendarIntervalType) =>
             DatetimeSub(l, r, DateAddInterval(l, UnaryMinus(r, f), ansiEnabled = f))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1522,40 +1522,6 @@ case class DateAddYMInterval(date: Expression, interval: Expression) extends Add
   override def sql: String = s"${left.sql} + ${right.sql}"
 }
 
-// Adds the year-month interval to the timestamp
-case class TimestampAddYMInterval(
-    timestamp: Expression,
-    interval: Expression,
-    timeZoneId: Option[String] = None)
-  extends BinaryExpression with TimeZoneAwareExpression with ExpectsInputTypes with NullIntolerant {
-
-  def this(timestamp: Expression, interval: Expression) = this(timestamp, interval, None)
-
-  override def left: Expression = timestamp
-  override def right: Expression = interval
-
-  override def toString: String = s"$left + $right"
-  override def sql: String = s"${left.sql} + ${right.sql}"
-  override def inputTypes: Seq[AbstractDataType] = Seq(TimestampType, YearMonthIntervalType)
-
-  override def dataType: DataType = TimestampType
-
-  override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
-    copy(timeZoneId = Option(timeZoneId))
-
-  override def nullSafeEval(micros: Any, months: Any): Any = {
-    timestampAddMonths(micros.asInstanceOf[Long], months.asInstanceOf[Int], zoneId)
-  }
-
-  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val zid = ctx.addReferenceObj("zoneId", zoneId, classOf[ZoneId].getName)
-    val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
-    defineCodeGen(ctx, ev, (micros, months) => {
-      s"""$dtu.timestampAddMonths($micros, $months, $zid)"""
-    })
-  }
-}
-
 /**
  * Returns number of months between times `timestamp1` and `timestamp2`.
  * If `timestamp1` is later than `timestamp2`, then the result is positive.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -578,20 +578,6 @@ object DateTimeUtils {
   }
 
   /**
-   * Adds months to a timestamp at the given time zone. It converts the input timestamp to a local
-   * timestamp at the given time zone, adds months, and converts the resulted local timestamp
-   * back to a timestamp, expressed in microseconds since 1970-01-01 00:00:00Z.
-   *
-   * @param micros The input timestamp value, expressed in microseconds since 1970-01-01 00:00:00Z
-   * @param months The amount of months to add. It can be positive or negative.
-   * @param zoneId The time zone ID at which the operation is performed.
-   * @return A timestamp value, expressed in microseconds since 1970-01-01 00:00:00Z.
-   */
-  def timestampAddMonths(micros: Long, months: Int, zoneId: ZoneId): Long = {
-    instantToMicros(microsToInstant(micros).atZone(zoneId).plusMonths(months).toInstant)
-  }
-
-  /**
    * Adds a full interval (months, days, microseconds) a timestamp represented as the number of
    * microseconds since 1970-01-01 00:00:00Z.
    * @return A timestamp value, expressed in microseconds since 1970-01-01 00:00:00Z.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -1500,42 +1500,4 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       }
     }
   }
-
-  test("SPARK-34739: add a year-month interval to a timestamp") {
-    val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
-    for (zid <- outstandingZoneIds) {
-      val timeZoneId = Option(zid.getId)
-      sdf.setTimeZone(TimeZone.getTimeZone(zid))
-
-      checkEvaluation(
-        TimestampAddYMInterval(
-          Literal(new Timestamp(sdf.parse("2016-01-29 10:11:12.123").getTime)),
-          Literal(Period.ofMonths(2)),
-          timeZoneId),
-        DateTimeUtils.fromJavaTimestamp(
-          new Timestamp(sdf.parse("2016-03-29 10:11:12.123").getTime)))
-
-      checkEvaluation(
-        TimestampAddYMInterval(
-          Literal.create(null, TimestampType),
-          Literal(Period.ofMonths(1)),
-          timeZoneId),
-        null)
-      checkEvaluation(
-        TimestampAddYMInterval(
-          Literal(new Timestamp(sdf.parse("2016-01-29 10:00:00.000").getTime)),
-          Literal.create(null, YearMonthIntervalType),
-          timeZoneId),
-        null)
-      checkEvaluation(
-        TimestampAddYMInterval(
-          Literal.create(null, TimestampType),
-          Literal.create(null, YearMonthIntervalType),
-          timeZoneId),
-        null)
-      checkConsistencyBetweenInterpretedAndCodegen(
-        (ts: Expression, interval: Expression) => TimestampAddYMInterval(ts, interval, timeZoneId),
-        TimestampType, YearMonthIntervalType)
-    }
-  }
-}
+ }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -393,22 +393,6 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     assert(dateAddMonths(input, -13) === days(1996, 1, 28))
   }
 
-  test("SPARK-34739: timestamp add months") {
-    outstandingZoneIds.foreach { zid =>
-      Seq(
-        (date(2021, 3, 13, 21, 28, 13, 123456, zid), 0, date(2021, 3, 13, 21, 28, 13, 123456, zid)),
-        (date(2021, 3, 31, 0, 0, 0, 123, zid), -1, date(2021, 2, 28, 0, 0, 0, 123, zid)),
-        (date(2020, 2, 29, 1, 2, 3, 4, zid), 12, date(2021, 2, 28, 1, 2, 3, 4, zid)),
-        (date(1, 1, 1, 0, 0, 0, 1, zid), 2020 * 12, date(2021, 1, 1, 0, 0, 0, 1, zid)),
-        (date(1581, 10, 7, 23, 59, 59, 999, zid), 12, date(1582, 10, 7, 23, 59, 59, 999, zid)),
-        (date(9999, 12, 31, 23, 59, 59, 999999, zid), -11,
-          date(9999, 1, 31, 23, 59, 59, 999999, zid))
-      ).foreach { case (timestamp, months, expected) =>
-        assert(timestampAddMonths(timestamp, months, zid) === expected)
-      }
-    }
-  }
-
   test("date add interval with day precision") {
     val input = days(1997, 2, 28)
     assert(dateAddInterval(input, new CalendarInterval(36, 0, 0)) === days(2000, 2, 28))
@@ -417,7 +401,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     intercept[IllegalArgumentException](dateAddInterval(input, new CalendarInterval(36, 47, 1)))
   }
 
-  test("timestamp add interval") {
+  test("timestamp add months") {
     val ts1 = date(1997, 2, 28, 10, 30, 0)
     val ts2 = date(2000, 2, 28, 10, 30, 0, 123000)
     assert(timestampAddInterval(ts1, 36, 0, 123000, defaultZoneId) === ts2)

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import java.sql.{Date, Timestamp}
-import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period}
+import java.time.{Duration, LocalDate, Period}
 import java.util.Locale
 
 import org.apache.hadoop.io.{LongWritable, Text}
@@ -28,7 +28,6 @@ import org.scalatest.matchers.should.Matchers._
 import org.apache.spark.SparkException
 import org.apache.spark.sql.UpdateFieldsBenchmark._
 import org.apache.spark.sql.catalyst.expressions.{InSet, Literal, NamedExpression}
-import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{outstandingTimezonesIds, outstandingZoneIds}
 import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -2392,23 +2391,17 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-34721: add a year-month interval to a date") {
     withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
-      outstandingTimezonesIds.foreach { zid =>
-        withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> zid) {
-          Seq(
-            (LocalDate.of(1900, 10, 1), Period.ofMonths(0)) -> LocalDate.of(1900, 10, 1),
-            (LocalDate.of(1970, 1, 1), Period.ofMonths(-1)) -> LocalDate.of(1969, 12, 1),
-            (LocalDate.of(2021, 3, 11), Period.ofMonths(1)) -> LocalDate.of(2021, 4, 11),
-            (LocalDate.of(2020, 12, 31), Period.ofMonths(2)) -> LocalDate.of(2021, 2, 28),
-            (LocalDate.of(2021, 5, 31), Period.ofMonths(-3)) -> LocalDate.of(2021, 2, 28),
-            (LocalDate.of(2020, 2, 29), Period.ofYears(1)) -> LocalDate.of(2021, 2, 28),
-            (LocalDate.of(1, 1, 1), Period.ofYears(2020)) -> LocalDate.of(2021, 1, 1)
-          ).foreach { case ((date, period), result) =>
-            val df = Seq((date, period)).toDF("date", "interval")
-            checkAnswer(
-              df.select($"date" + $"interval", $"interval" + $"date"),
-              Row(result, result))
-          }
-        }
+      Seq(
+        (LocalDate.of(1900, 10, 1), Period.ofMonths(0)) -> LocalDate.of(1900, 10, 1),
+        (LocalDate.of(1970, 1, 1), Period.ofMonths(-1)) -> LocalDate.of(1969, 12, 1),
+        (LocalDate.of(2021, 3, 11), Period.ofMonths(1)) -> LocalDate.of(2021, 4, 11),
+        (LocalDate.of(2020, 12, 31), Period.ofMonths(2)) -> LocalDate.of(2021, 2, 28),
+        (LocalDate.of(2021, 5, 31), Period.ofMonths(-3)) -> LocalDate.of(2021, 2, 28),
+        (LocalDate.of(2020, 2, 29), Period.ofYears(1)) -> LocalDate.of(2021, 2, 28),
+        (LocalDate.of(1, 1, 1), Period.ofYears(2020)) -> LocalDate.of(2021, 1, 1)
+      ).foreach { case ((date, period), result) =>
+        val df = Seq((date, period)).toDF("date", "interval")
+        checkAnswer(df.select($"date" + $"interval", $"interval" + $"date"), Row(result, result))
       }
 
       val e = intercept[SparkException] {
@@ -2424,21 +2417,17 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-34721: subtract a year-month interval from a date") {
     withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
-      outstandingTimezonesIds.foreach { zid =>
-        withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> zid) {
-          Seq(
-            (LocalDate.of(1582, 10, 4), Period.ofMonths(0)) -> LocalDate.of(1582, 10, 4),
-            (LocalDate.of(1582, 10, 15), Period.ofMonths(1)) -> LocalDate.of(1582, 9, 15),
-            (LocalDate.of(1, 1, 1), Period.ofMonths(-1)) -> LocalDate.of(1, 2, 1),
-            (LocalDate.of(9999, 10, 31), Period.ofMonths(-2)) -> LocalDate.of(9999, 12, 31),
-            (LocalDate.of(2021, 5, 31), Period.ofMonths(3)) -> LocalDate.of(2021, 2, 28),
-            (LocalDate.of(2021, 2, 28), Period.ofYears(1)) -> LocalDate.of(2020, 2, 28),
-            (LocalDate.of(2020, 2, 29), Period.ofYears(4)) -> LocalDate.of(2016, 2, 29)
-          ).foreach { case ((date, period), result) =>
-            val df = Seq((date, period)).toDF("date", "interval")
-            checkAnswer(df.select($"date" - $"interval"), Row(result))
-          }
-        }
+      Seq(
+        (LocalDate.of(1582, 10, 4), Period.ofMonths(0)) -> LocalDate.of(1582, 10, 4),
+        (LocalDate.of(1582, 10, 15), Period.ofMonths(1)) -> LocalDate.of(1582, 9, 15),
+        (LocalDate.of(1, 1, 1), Period.ofMonths(-1)) -> LocalDate.of(1, 2, 1),
+        (LocalDate.of(9999, 10, 31), Period.ofMonths(-2)) -> LocalDate.of(9999, 12, 31),
+        (LocalDate.of(2021, 5, 31), Period.ofMonths(3)) -> LocalDate.of(2021, 2, 28),
+        (LocalDate.of(2021, 2, 28), Period.ofYears(1)) -> LocalDate.of(2020, 2, 28),
+        (LocalDate.of(2020, 2, 29), Period.ofYears(4)) -> LocalDate.of(2016, 2, 29)
+      ).foreach { case ((date, period), result) =>
+        val df = Seq((date, period)).toDF("date", "interval")
+        checkAnswer(df.select($"date" - $"interval"), Row(result))
       }
 
       val e = intercept[SparkException] {
@@ -2449,81 +2438,6 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       }.getCause
       assert(e.isInstanceOf[ArithmeticException])
       assert(e.getMessage.contains("integer overflow"))
-    }
-  }
-
-  test("SPARK-34739: add a year-month interval to a timestamp") {
-    withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
-      outstandingZoneIds.foreach { zid =>
-        withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> zid.getId) {
-          Seq(
-            (LocalDateTime.of(1900, 1, 1, 0, 0, 0, 123456000), Period.ofMonths(0)) ->
-              LocalDateTime.of(1900, 1, 1, 0, 0, 0, 123456000),
-            (LocalDateTime.of(1970, 1, 1, 0, 0, 0, 1000), Period.ofMonths(-1)) ->
-              LocalDateTime.of(1969, 12, 1, 0, 0, 0, 1000),
-            (LocalDateTime.of(2021, 3, 14, 1, 2, 3, 0), Period.ofMonths(1)) ->
-              LocalDateTime.of(2021, 4, 14, 1, 2, 3, 0),
-            (LocalDateTime.of(2020, 12, 31, 23, 59, 59, 999999000), Period.ofMonths(2)) ->
-              LocalDateTime.of(2021, 2, 28, 23, 59, 59, 999999000),
-            (LocalDateTime.of(2021, 5, 31, 0, 0, 1, 0), Period.ofMonths(-3)) ->
-              LocalDateTime.of(2021, 2, 28, 0, 0, 1, 0),
-            (LocalDateTime.of(2020, 2, 29, 12, 13, 14), Period.ofYears(1)) ->
-              LocalDateTime.of(2021, 2, 28, 12, 13, 14),
-            (LocalDateTime.of(1, 1, 1, 1, 1, 1, 1000), Period.ofYears(2020)) ->
-              LocalDateTime.of(2021, 1, 1, 1, 1, 1, 1000)
-          ).foreach { case ((ldt, period), expected) =>
-            val df = Seq((ldt.atZone(zid).toInstant, period)).toDF("ts", "interval")
-            val result = expected.atZone(zid).toInstant
-            checkAnswer(df.select($"ts" + $"interval", $"interval" + $"ts"), Row(result, result))
-          }
-        }
-      }
-
-      val e = intercept[SparkException] {
-        Seq((Instant.parse("2021-03-14T18:55:00Z"), Period.ofMonths(Int.MaxValue)))
-          .toDF("ts", "interval")
-          .select($"ts" + $"interval")
-          .collect()
-      }.getCause
-      assert(e.isInstanceOf[ArithmeticException])
-      assert(e.getMessage.contains("long overflow"))
-    }
-  }
-
-  test("SPARK-34739: subtract a year-month interval from a timestamp") {
-    withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
-      outstandingZoneIds.foreach { zid =>
-        withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> zid.getId) {
-          Seq(
-            (LocalDateTime.of(1582, 10, 4, 0, 0, 0), Period.ofMonths(0)) ->
-              LocalDateTime.of(1582, 10, 4, 0, 0, 0),
-            (LocalDateTime.of(1582, 10, 15, 23, 59, 59, 999999000), Period.ofMonths(1)) ->
-              LocalDateTime.of(1582, 9, 15, 23, 59, 59, 999999000),
-            (LocalDateTime.of(1, 1, 1, 1, 1, 1, 1000), Period.ofMonths(-1)) ->
-              LocalDateTime.of(1, 2, 1, 1, 1, 1, 1000),
-            (LocalDateTime.of(9999, 10, 31, 23, 59, 59, 999000000), Period.ofMonths(-2)) ->
-              LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999000000),
-            (LocalDateTime.of(2021, 5, 31, 0, 0, 0, 1000), Period.ofMonths(3)) ->
-              LocalDateTime.of(2021, 2, 28, 0, 0, 0, 1000),
-            (LocalDateTime.of(2021, 2, 28, 11, 12, 13, 123456000), Period.ofYears(1)) ->
-              LocalDateTime.of(2020, 2, 28, 11, 12, 13, 123456000),
-            (LocalDateTime.of(2020, 2, 29, 1, 2, 3, 5000), Period.ofYears(4)) ->
-              LocalDateTime.of(2016, 2, 29, 1, 2, 3, 5000)
-          ).foreach { case ((ldt, period), expected) =>
-            val df = Seq((ldt.atZone(zid).toInstant, period)).toDF("ts", "interval")
-            checkAnswer(df.select($"ts" - $"interval"), Row(expected.atZone(zid).toInstant))
-          }
-        }
-      }
-
-      val e = intercept[SparkException] {
-        Seq((Instant.parse("2021-03-14T18:55:00Z"), Period.ofMonths(Int.MaxValue)))
-          .toDF("ts", "interval")
-          .select($"ts" - $"interval")
-          .collect()
-      }.getCause
-      assert(e.isInstanceOf[ArithmeticException])
-      assert(e.getMessage.contains("long overflow"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Revert the commit https://github.com/apache/spark/commit/9809a2f1c5187205c81542dbdc84b71db535f6e1

### Why are the changes needed?
It causes a build failure for scala 2.13.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running GA