### PR TITLE
[SPARK-34773][BUILD] change-scala-version.sh fails to modify pom.xml if it changes the version from 2.13 to 2.12

### DIFF
--- a/dev/change-scala-version.sh
+++ b/dev/change-scala-version.sh
@@ -60,17 +60,6 @@ BASEDIR=$(dirname $0)/..
 find "$BASEDIR" -name 'pom.xml' -not -path '*target*' -print \
   -exec bash -c "sed_i 's/\(artifactId.*\)_'$FROM_VERSION'/\1_'$TO_VERSION'/g' {}" \;
 
-# Update <scala.version> in parent POM
-# First find the right full version from the profile's build
-SCALA_VERSION=`build/mvn help:evaluate -Pscala-${TO_VERSION} -Dexpression=scala.version -q -DforceStdout`
-sed_i '1,/<scala\.version>[0-9]*\.[0-9]*\.[0-9]*</s/<scala\.version>[0-9]*\.[0-9]*\.[0-9]*</<scala.version>'$SCALA_VERSION'</' \
-  "$BASEDIR/pom.xml"
-
-# Also update <scala.binary.version> in parent POM
-# Match any scala binary version to ensure idempotency
-sed_i '1,/<scala\.binary\.version>[0-9]*\.[0-9]*</s/<scala\.binary\.version>[0-9]*\.[0-9]*</<scala.binary.version>'$TO_VERSION'</' \
-  "$BASEDIR/pom.xml"
-
 # Update source of scaladocs
 echo "$BASEDIR/docs/_plugins/copy_api_dirs.rb"
 if [ $TO_VERSION = "2.13" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes an issue that If we change the Scala version to `2.13` and then change the version to `2.12` using `change-scala-version.sh`, it fails to modify `pom.xml` and fails to build.

The reason seems that the following logic never be able to fetch `2.12.0` from `pom.xml` after it changes `2.13.5`.
```
# Update <scala.version> in parent POM
# First find the right full version from the profile's build
SCALA_VERSION=`build/mvn help:evaluate -Pscala-${TO_VERSION} -Dexpression=scala.version -q -DforceStdout`
sed_i '1,/<scala\.version>[0-9]*\.[0-9]*\.[0-9]*</s/<scala\.version>[0-9]*\.[0-9]*\.[0-9]*</<scala.version>'$SCALA_VERSION'</' \
  "$BASEDIR/pom.xml"
```

Further, I don't think this logic and the following logic are necessary because those versions are changed by `-Pscala-2.13` if we'd like to build with Scala 2.13.
```
# Also update <scala.binary.version> in parent POM
# Match any scala binary version to ensure idempotency
sed_i '1,/<scala\.binary\.version>[0-9]*\.[0-9]*</s/<scala\.binary\.version>[0-9]*\.[0-9]*</<scala.binary.version>'$TO_VERSION'</' \
  "$BASEDIR/pom.xml"
```

So I removed them to fix this issue.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's inconvenient if we'd like to change the version back to `2.12` in development.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I confirmed build for Scala 2.13 and 2.12 successfully finishes with both sbt and Maven.
```
./dev/change-scala-version 2.13
./build/sbt -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pdocker-integration-tests -Pkubernetes-integration-tests -Pspark-ganglia-lgpl -Pscala-2.13 compile test:compile 

./build/sbt -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pdocker-integration-tests -Pkubernetes-integration-tests -Pspark-ganglia-lgpl -Pscala-2.13 -DskipTests compile test-compile

./dev/change-scala-version 2.12
./build/sbt -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pdocker-integration-tests -Pkubernetes-integration-tests -Pspark-ganglia-lgpl  compile test:compile 

./build/sbt -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pdocker-integration-tests -Pkubernetes-integration-tests -Pspark-ganglia-lgpl  -DskipTests compile test-compile
```

I also confirmed Scala 2.13.5 is used.
```
sbt:spark-parent> scalaVersion
[info] core / scalaVersion
[info] 	2.13.5
[info] docker-integration-tests / scalaVersion
[info] 	2.13.5
[info] assembly / scalaVersion
[info] 	2.13.5
[info] mllib-local / scalaVersion
[info] 	2.13.5
[info] sketch / scalaVersion
[info] 	2.13.5
[info] sql-kafka-0-10 / scalaVersion
[info] 	2.13.5
[info] network-shuffle / scalaVersion
[info] 	2.13.5
[info] streaming-kafka-0-10-assembly / scalaVersion
[info] 	2.13.5
[info] streaming-kinesis-asl / scalaVersion
[info] 	2.13.5
[info] streaming-kinesis-asl-assembly / scalaVersion
[info] 	2.13.5
[info] kvstore / scalaVersion
[info] 	2.13.5
[info] token-provider-kafka-0-10 / scalaVersion
[info] 	2.13.5
[info] network-yarn / scalaVersion
[info] 	2.13.5
[info] graphx / scalaVersion
[info] 	2.13.5
[info] hive-thriftserver / scalaVersion
[info] 	2.13.5
[info] streaming-kafka-0-10 / scalaVersion
[info] 	2.13.5
[info] streaming / scalaVersion
[info] 	2.13.5
[info] tools / scalaVersion
[info] 	2.13.5
[info] unsafe / scalaVersion
[info] 	2.13.5
[info] mllib / scalaVersion
[info] 	2.13.5
[info] network-common / scalaVersion
[info] 	2.13.5
[info] repl / scalaVersion
[info] 	2.13.5
[info] yarn / scalaVersion
[info] 	2.13.5
[info] examples / scalaVersion
[info] 	2.13.5
[info] avro / scalaVersion
[info] 	2.13.5
[info] hadoop-cloud / scalaVersion
[info] 	2.13.5
[info] catalyst / scalaVersion
[info] 	2.13.5
[info] ganglia-lgpl / scalaVersion
[info] 	2.13.5
[info] sql / scalaVersion
[info] 	2.13.5
[info] mesos / scalaVersion
[info] 	2.13.5
[info] kubernetes / scalaVersion
[info] 	2.13.5
[info] kubernetes-integration-tests / scalaVersion
[info] 	2.13.5
[info] tags / scalaVersion
[info] 	2.13.5
[info] hive / scalaVersion
[info] 	2.13.5
[info] launcher / scalaVersion
[info] 	2.13.5
[info] scalaVersion
[info] 	2.13.5
```