### PR TITLE
[SPARK-34779][CORE] ExecutorMetricsPoller should keep stage entry in stageTCMP until a heartbeat occurs

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetricsPoller.scala
@@ -181,7 +181,7 @@ private[spark] class ExecutorMetricsPoller(
     }
 
     // Remove the entry from stageTCMP if the task count reaches zero.
-    executorUpdates.foreach { case (k, v) =>
+    executorUpdates.foreach { case (k, _) =>
       stageTCMP.computeIfPresent(k, removeIfInactive)
     }
 

--- a/core/src/test/scala/org/apache/spark/executor/ExecutorMetricsPollerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ExecutorMetricsPollerSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.executor
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.memory.TestMemoryManager
+
+class ExecutorMetricsPollerSuite extends SparkFunSuite {
+
+  test("stage entry shouldn't be removed before a heartbeat occurs") {
+    val testMemoryManager = new TestMemoryManager(new SparkConf())
+    val poller = new ExecutorMetricsPoller(testMemoryManager, 1000, None)
+
+    poller.onTaskStart(0L, 0, 0)
+    // stage (0, 0) has an active task, so it remains on stageTCMP after heartbeat.
+    assert(poller.getExecutorUpdates.size === 1)
+    assert(poller.stageTCMP.size === 1)
+
+    poller.onTaskCompletion(0L, 0, 0)
+    // stage (0, 0) doesn't have active tasks, but its entry will be kept until next
+    // heartbeat.
+    assert(poller.stageTCMP.size === 1)
+
+    // the next heartbeat will report the peak metrics of stage (0, 0) during the
+    // previous heartbeat interval, then remove it from stageTCMP.
+    assert(poller.getExecutorUpdates.size === 1)
+    assert(poller.stageTCMP.size === 0)
+
+    poller.stop
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Allow ExecutorMetricsPoller to keep stage entries in stageTCMP until a heartbeat occurs even if the entries have task count = 0.

### Why are the changes needed?
This is an improvement.

The current implementation of ExecutorMetricsPoller keeps a map, stageTCMP of (stageId, stageAttemptId) to (count of running tasks, executor metric peaks). The entry for the stage is removed on task completion if the task count decreases to 0. In the case of an executor with a single core, this leads to unnecessary removal and insertion of entries for a given stage.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
A new unit test is added.
