### PR TITLE
[SPARK-34783][K8S] Support remote template files via spark.jars

### DIFF
--- a/resource-managers/kubernetes/core/src/test/resources/template-file.yaml
+++ b/resource-managers/kubernetes/core/src/test/resources/template-file.yaml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+Kind: Pod
+metadata:
+  labels:
+    template-label-key: template-label-value
+spec:
+  containers:
+  - name: test-container
+    image: will-be-overwritten
+


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support remote driver/executor template files via `spark.jars`

### Why are the changes needed?

Currently, `KubernetesUtils.loadPodFromTemplate` supports only local files.

### Does this PR introduce _any_ user-facing change?

Yes, this is an improvement.

### How was this patch tested?

Pass the CIs with the newly added test cases.