### PR TITLE
[SPARK-34762][BUILD] Fix the build failure with Scala 2.13 which is related to commons-* with better solution

### DIFF
--- a/dev/change-scala-version.sh
+++ b/dev/change-scala-version.sh
@@ -64,7 +64,8 @@ find "$BASEDIR" -name 'pom.xml' -not -path '*target*' -print \
 # First find the right full version from the profile's build
 # NOTE: We used to fetch the value of scala.version before but sed is used now. This is a workaround for SPARK-34762.
 ESCAPED_TO_VERSION=$(echo $TO_VERSION | sed -n "s/\./\\\\./gp")
-SCALA_VERSION=$(sed -n "s;^.*<scala-$ESCAPED_TO_VERSION\.version>\(.*\)</scala-$ESCAPED_TO_VERSION\.version>.*$;\1;p" pom.xml)
+SCALA_VERSION=$(sed -n "/<id>scala-$ESCAPED_TO_VERSION<\/id>/,/<\/profile>/ \
+  s;^.*<scala\.version>\(.*\)</scala\.version>.*$;\1;p" pom.xml)
 sed_i '1,/<scala\.version>[0-9]*\.[0-9]*\.[0-9]*</s/<scala\.version>[0-9]*\.[0-9]*\.[0-9]*</<scala.version>'$SCALA_VERSION'</' \
   "$BASEDIR/pom.xml"
 

--- a/dev/change-scala-version.sh
+++ b/dev/change-scala-version.sh
@@ -62,7 +62,8 @@ find "$BASEDIR" -name 'pom.xml' -not -path '*target*' -print \
 
 # Update <scala.version> in parent POM
 # First find the right full version from the profile's build
-# NOTE: We used to fetch the value of scala.version before but sed is used now. This is a workaround for SPARK-34762.
+# NOTE: We used mvn help:evaluate to fetch the value of scala.version before but sed is used now.
+# This is a workaround for SPARK-34762.
 ESCAPED_TO_VERSION=$(echo $TO_VERSION | sed -n "s/\./\\\\./gp")
 SCALA_VERSION=$(sed -n "/<id>scala-$ESCAPED_TO_VERSION<\/id>/,/<\/profile>/ \
   s;^.*<scala\.version>\(.*\)</scala\.version>.*$;\1;p" pom.xml)

--- a/pom.xml
+++ b/pom.xml
@@ -162,9 +162,7 @@
     <commons.math3.version>3.4.1</commons.math3.version>
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
-    <scala-2.12.version>2.12.10</scala-2.12.version>
-    <scala-2.13.version>2.13.5</scala-2.13.version>
-    <scala.version>${scala-2.12.version}</scala.version>
+    <scala.version>2.12.10</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scalatest-maven-plugin.version>2.0.0</scalatest-maven-plugin.version>
     <scalafmt.parameters>--test</scalafmt.parameters>
@@ -3319,7 +3317,7 @@
     <profile>
       <id>scala-2.13</id>
       <properties>
-        <scala.version>${scala-2.13.version}</scala.version>
+        <scala.version>2.13.5</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
       </properties>
       <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,9 @@
     <commons.math3.version>3.4.1</commons.math3.version>
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
-    <scala.version>2.12.10</scala.version>
+    <scala-2.12.version>2.12.10</scala-2.12.version>
+    <scala-2.13.version>2.13.5</scala-2.13.version>
+    <scala.version>${scala-2.12.version}</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scalatest-maven-plugin.version>2.0.0</scalatest-maven-plugin.version>
     <scalafmt.parameters>--test</scalafmt.parameters>
@@ -3317,7 +3319,7 @@
     <profile>
       <id>scala-2.13</id>
       <properties>
-        <scala.version>2.13.5</scala.version>
+        <scala.version>${scala-2.13.version}</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
       </properties>
       <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes the issue that build fails with Scala 2.13 and sbt with better solution.
The issue was resolved in #31862 for `master` branch but it's still in `branch-3.1`.
The reason for `branch-3.1` is `mvn help` in `change-scala-version.sh` downloads the POM file of `commons-io` and the JAR file is not downloaded.
For `master` branch, it's not `commons-io` but `commons-cli`.

According to the result, the affected library seems to be subject to various factors but one factor is the maven help plugin.
So, I modified `change-scala-version.sh` to change the way to fetch `scala.version` to simply use `sed` rather than `mvn`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To fix the issue with more proper way.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I confirmed build succeed with the following procedure.

```
find ~/.m2 -name commons-cli -exec rm -rf {} \;
find ~/.ivy2 -name commons-cli -exec rm -rf {} \;
find ~/.cache/ -name commons-cli -exec rm -rf {} \; // For Linux
find ~/Library/Caches -name commons-cli -exec rm -rf {} \; // For macOS

dev/change-scala-version 2.13
./build/sbt -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pdocker-integration-tests -Pkubernetes-integration-tests -Pspark-ganglia-lgpl -Pscala-2.13 clean compile test:compile
```