### PR TITLE
[SPARK-34787] Option variable in Spark historyServer log should be displayed as actual value instead of Some(XX)

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -156,19 +156,18 @@ private[history] class ApplicationCache(
    */
   @throws[NoSuchElementException]
   private def loadApplicationEntry(appId: String, attemptId: Option[String]): CacheEntry = {
-    logDebug(s"Loading application Entry $appId" + attemptId.map { id => s"/$id" }.getOrElse(""))
+    logDebug(s"Loading application Entry $appId/${attemptId.mkString}")
     metrics.loadCount.inc()
     val loadedUI = time(metrics.loadTimer) {
       metrics.lookupCount.inc()
       operations.getAppUI(appId, attemptId) match {
         case Some(loadedUI) =>
-          logDebug(s"Loaded application $appId" + attemptId.map { id => s"/$id" }.getOrElse(""))
+          logDebug(s"Loaded application $appId/${attemptId.mkString}")
           loadedUI
         case None =>
           metrics.lookupFailureCount.inc()
           // guava's cache logs via java.util log, so is of limited use. Hence: our own message
-          logInfo(s"Failed to load application attempt $appId" +
-            attemptId.map { id => s"/$id" }.getOrElse(""))
+          logInfo(s"Failed to load application attempt $appId/${attemptId.mkString}")
           throw new NoSuchElementException(s"no application with application Id '$appId'" +
               attemptId.map { id => s" attemptId '$id'" }.getOrElse(" and no attempt Id"))
       }
@@ -183,8 +182,7 @@ private[history] class ApplicationCache(
       new CacheEntry(loadedUI, completed)
     } catch {
       case e: Exception =>
-        logWarning(s"Failed to initialize application UI for $appId" +
-          attemptId.map { id => s"/$id" }.getOrElse(""), e)
+        logWarning(s"Failed to initialize application UI for $appId/${attemptId.mkString}", e)
         operations.detachSparkUI(appId, attemptId, loadedUI.ui)
         throw e
     }

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -156,18 +156,18 @@ private[history] class ApplicationCache(
    */
   @throws[NoSuchElementException]
   private def loadApplicationEntry(appId: String, attemptId: Option[String]): CacheEntry = {
-    logDebug(s"Loading application Entry $appId/$attemptId")
+    logDebug(s"Loading application Entry $appId/${attemptId.getOrElse("")}")
     metrics.loadCount.inc()
     val loadedUI = time(metrics.loadTimer) {
       metrics.lookupCount.inc()
       operations.getAppUI(appId, attemptId) match {
         case Some(loadedUI) =>
-          logDebug(s"Loaded application $appId/$attemptId")
+          logDebug(s"Loaded application $appId/${attemptId.getOrElse("")}")
           loadedUI
         case None =>
           metrics.lookupFailureCount.inc()
           // guava's cache logs via java.util log, so is of limited use. Hence: our own message
-          logInfo(s"Failed to load application attempt $appId/$attemptId")
+          logInfo(s"Failed to load application attempt $appId/${attemptId.getOrElse("")}")
           throw new NoSuchElementException(s"no application with application Id '$appId'" +
               attemptId.map { id => s" attemptId '$id'" }.getOrElse(" and no attempt Id"))
       }
@@ -182,7 +182,7 @@ private[history] class ApplicationCache(
       new CacheEntry(loadedUI, completed)
     } catch {
       case e: Exception =>
-        logWarning(s"Failed to initialize application UI for $appId/$attemptId", e)
+        logWarning(s"Failed to initialize application UI for $appId/${attemptId.getOrElse("")}", e)
         operations.detachSparkUI(appId, attemptId, loadedUI.ui)
         throw e
     }

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -156,18 +156,19 @@ private[history] class ApplicationCache(
    */
   @throws[NoSuchElementException]
   private def loadApplicationEntry(appId: String, attemptId: Option[String]): CacheEntry = {
-    logDebug(s"Loading application Entry $appId/${attemptId.getOrElse("")}")
+    logDebug(s"Loading application Entry $appId" + attemptId.map { id => s"/$id" }.getOrElse(""))
     metrics.loadCount.inc()
     val loadedUI = time(metrics.loadTimer) {
       metrics.lookupCount.inc()
       operations.getAppUI(appId, attemptId) match {
         case Some(loadedUI) =>
-          logDebug(s"Loaded application $appId/${attemptId.getOrElse("")}")
+          logDebug(s"Loaded application $appId" + attemptId.map { id => s"/$id" }.getOrElse(""))
           loadedUI
         case None =>
           metrics.lookupFailureCount.inc()
           // guava's cache logs via java.util log, so is of limited use. Hence: our own message
-          logInfo(s"Failed to load application attempt $appId/${attemptId.getOrElse("")}")
+          logInfo(s"Failed to load application attempt $appId" +
+            attemptId.map { id => s"/$id" }.getOrElse(""))
           throw new NoSuchElementException(s"no application with application Id '$appId'" +
               attemptId.map { id => s" attemptId '$id'" }.getOrElse(" and no attempt Id"))
       }
@@ -182,7 +183,8 @@ private[history] class ApplicationCache(
       new CacheEntry(loadedUI, completed)
     } catch {
       case e: Exception =>
-        logWarning(s"Failed to initialize application UI for $appId/${attemptId.getOrElse("")}", e)
+        logWarning(s"Failed to initialize application UI for $appId" +
+          attemptId.map { id => s"/$id" }.getOrElse(""), e)
         operations.detachSparkUI(appId, attemptId, loadedUI.ui)
         throw e
     }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Make the attemptId in the log of historyServer to be more easily to read.


### Why are the changes needed?
Option variable in Spark historyServer log should be displayed as actual value instead of Some(XX)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
manual test 

