### PR TITLE
[SPARK-34774][BUILD][2.4] Ensure change-scala-version.sh update scala.version in parent POM correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2860,6 +2860,13 @@
     <!-- Exists for backwards compatibility; profile doesn't do anything -->
     <profile>
       <id>scala-2.11</id>
+      <properties>
+        <!-- 
+         SPARK-34774 Add this property to ensure change-scala-version.sh can replace the public `scala.version`
+         property correctly. 
+        -->
+        <scala.version>2.11.12</scala.version>
+      </properties>
     </profile>
 
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?
After SPARK-34507,  execute` change-scala-version.sh` script will update `scala.version` in parent pom, but if we execute the following commands in order：

```
dev/change-scala-version.sh 2.12
dev/change-scala-version.sh 2.11
git status
```

there will generate git diff as follow:

```
diff --git a/pom.xml b/pom.xml
index f4a50dc5c1..89fd7d88af 100644
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <commons.math3.version>3.4.1</commons.math3.version>
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
-    <scala.version>2.11.12</scala.version>
+    <scala.version>2.12.10</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
```

seem 'scala.version' property was not update correctly.

So this pr add an extra 'scala.version' to scala-2.11 profile to ensure change-scala-version.sh can update the public `scala.version` property correctly. 

### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
**Manual test**

Execute the following commands in order：

```
dev/change-scala-version.sh 2.12
dev/change-scala-version.sh 2.11
git status
```

**Before**

```
diff --git a/pom.xml b/pom.xml
index f4a50dc5c1..89fd7d88af 100644
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <commons.math3.version>3.4.1</commons.math3.version>
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
-    <scala.version>2.11.12</scala.version>
+    <scala.version>2.12.10</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
```

**After**

No git diff. 