### PR TITLE
[WIP][SPARK-32899][CORE] Support submit application with user-defined cluster manager

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -234,9 +234,7 @@ private[spark] class SparkSubmit extends Logging {
       case m if m.startsWith("mesos") => MESOS
       case m if m.startsWith("k8s") => KUBERNETES
       case m if m.startsWith("local") => LOCAL
-      case _ =>
-        error("Master must either be yarn or start with spark, mesos, k8s, or local")
-        -1
+      case _ => OTHER // this means the master is not the natively supported
     }
 
     // Set the deploy mode; default is client mode
@@ -605,13 +603,13 @@ private[spark] class SparkSubmit extends Logging {
       OptionAssigner(args.pyFiles, ALL_CLUSTER_MGRS, CLUSTER, confKey = SUBMIT_PYTHON_FILES.key),
 
       // Propagate attributes for dependency resolution at the driver side
-      OptionAssigner(args.packages, STANDALONE | MESOS | KUBERNETES,
+      OptionAssigner(args.packages, STANDALONE | MESOS | KUBERNETES | OTHER,
         CLUSTER, confKey = "spark.jars.packages"),
-      OptionAssigner(args.repositories, STANDALONE | MESOS | KUBERNETES,
+      OptionAssigner(args.repositories, STANDALONE | MESOS | KUBERNETES | OTHER,
         CLUSTER, confKey = "spark.jars.repositories"),
-      OptionAssigner(args.ivyRepoPath, STANDALONE | MESOS | KUBERNETES,
+      OptionAssigner(args.ivyRepoPath, STANDALONE | MESOS | KUBERNETES | OTHER,
         CLUSTER, confKey = "spark.jars.ivy"),
-      OptionAssigner(args.packagesExclusions, STANDALONE | MESOS | KUBERNETES,
+      OptionAssigner(args.packagesExclusions, STANDALONE | MESOS | KUBERNETES | OTHER,
         CLUSTER, confKey = "spark.jars.excludes"),
 
       // Yarn only
@@ -626,24 +624,22 @@ private[spark] class SparkSubmit extends Logging {
         mergeFn = Some(mergeFileLists(_, _))),
 
       // Other options
-      OptionAssigner(args.numExecutors, YARN | KUBERNETES, ALL_DEPLOY_MODES,
+      OptionAssigner(args.numExecutors, YARN | KUBERNETES | OTHER, ALL_DEPLOY_MODES,
         confKey = EXECUTOR_INSTANCES.key),
-      OptionAssigner(args.executorCores, STANDALONE | YARN | KUBERNETES, ALL_DEPLOY_MODES,
+      OptionAssigner(args.executorCores, STANDALONE | YARN | KUBERNETES | OTHER, ALL_DEPLOY_MODES,
         confKey = EXECUTOR_CORES.key),
-      OptionAssigner(args.executorMemory, STANDALONE | MESOS | YARN | KUBERNETES, ALL_DEPLOY_MODES,
-        confKey = EXECUTOR_MEMORY.key),
-      OptionAssigner(args.totalExecutorCores, STANDALONE | MESOS | KUBERNETES, ALL_DEPLOY_MODES,
-        confKey = CORES_MAX.key),
-      OptionAssigner(args.files, LOCAL | STANDALONE | MESOS | KUBERNETES, ALL_DEPLOY_MODES,
-        confKey = FILES.key),
-      OptionAssigner(args.archives, LOCAL | STANDALONE | MESOS | KUBERNETES, ALL_DEPLOY_MODES,
-        confKey = ARCHIVES.key),
+      OptionAssigner(args.executorMemory, STANDALONE | MESOS | YARN | KUBERNETES | OTHER,
+        ALL_DEPLOY_MODES, confKey = EXECUTOR_MEMORY.key),
+      OptionAssigner(args.totalExecutorCores, STANDALONE | MESOS | KUBERNETES | OTHER,
+        ALL_DEPLOY_MODES, confKey = CORES_MAX.key),
+      OptionAssigner(args.files, LOCAL | STANDALONE | MESOS | KUBERNETES | OTHER,
+        ALL_DEPLOY_MODES, confKey = FILES.key),
       OptionAssigner(args.jars, LOCAL, CLIENT, confKey = JARS.key),
-      OptionAssigner(args.jars, STANDALONE | MESOS | KUBERNETES, ALL_DEPLOY_MODES,
+      OptionAssigner(args.jars, STANDALONE | MESOS | KUBERNETES | OTHER, ALL_DEPLOY_MODES,
         confKey = JARS.key),
-      OptionAssigner(args.driverMemory, STANDALONE | MESOS | YARN | KUBERNETES, CLUSTER,
+      OptionAssigner(args.driverMemory, STANDALONE | MESOS | YARN | KUBERNETES | OTHER, CLUSTER,
         confKey = DRIVER_MEMORY.key),
-      OptionAssigner(args.driverCores, STANDALONE | MESOS | YARN | KUBERNETES, CLUSTER,
+      OptionAssigner(args.driverCores, STANDALONE | MESOS | YARN | KUBERNETES | OTHER, CLUSTER,
         confKey = DRIVER_CORES.key),
       OptionAssigner(args.supervise.toString, STANDALONE | MESOS, CLUSTER,
         confKey = DRIVER_SUPERVISE.key),
@@ -982,7 +978,8 @@ object SparkSubmit extends CommandLineUtils with Logging {
   private val MESOS = 4
   private val LOCAL = 8
   private val KUBERNETES = 16
-  private val ALL_CLUSTER_MGRS = YARN | STANDALONE | MESOS | LOCAL | KUBERNETES
+  private val OTHER = 32
+  private val ALL_CLUSTER_MGRS = YARN | STANDALONE | MESOS | LOCAL | KUBERNETES | OTHER
 
   // Deploy modes
   private val CLIENT = 1

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -856,7 +856,7 @@ private[spark] class SparkSubmit extends Logging {
       // user has provided the SparkSubmit plugin
       val plugin = getSubmitPlugin(sparkConf.get(SPARK_SUBMIT_PLUGIN).get, sparkConf)
       return plugin.prepareSubmitEnvironment(
-        args, sparkConf, childArgs, childClasspath, childMainClass)
+        args, sparkConf, childArgs.toSeq, childClasspath.toSeq, childMainClass)
     }
 
     (childArgs.toSeq, childClasspath.toSeq, sparkConf, childMainClass)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitPlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitPlugin.scala
@@ -36,14 +36,13 @@ private[spark] trait SparkSubmitPlugin {
    *        (2) a list of classpath entries for the child process
    *        (3) the updated SparkConf
    *        (4) the main class for the child
-   *
    */
   def prepareSubmitEnvironment(
       args: SparkSubmitArguments,
       sparkConf: SparkConf,
       childProcessArgs: Seq[String],
       childProcessClassPaths: Seq[String],
-      childProcessMainClass: String,
-  ) : (Seq[String], Seq[String], SparkConf, String)
+      childProcessMainClass: String
+  ): (Seq[String], Seq[String], SparkConf, String)
 
 }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitPlugin.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitPlugin.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy
+
+import org.apache.spark.SparkConf
+
+private[spark] trait SparkSubmitPlugin {
+
+  /**
+   * Prepare the environment for submitting an application. User should implement this when they
+   * want to customize the submit environments. And user should set the config
+   * "spark.deploy.sparkSubmitPlugin" to the implementation class.
+   *
+   * @param args the parsed SparkSubmitArguments used for environment preparation.
+   * @param sparkConf the SparkConf instance
+   * @param childProcessArgs the child process arguments with default preparing
+   * @param childProcessClassPaths the extra classpath of child process with default preparing
+   * @param childProcessMainClass the main class of child process with default preparing
+   * @return a 4-tuple:
+   *        (1) the arguments for the child process,
+   *        (2) a list of classpath entries for the child process
+   *        (3) the updated SparkConf
+   *        (4) the main class for the child
+   *
+   */
+  def prepareSubmitEnvironment(
+      args: SparkSubmitArguments,
+      sparkConf: SparkConf,
+      childProcessArgs: Seq[String],
+      childProcessClassPaths: Seq[String],
+      childProcessMainClass: String,
+  ) : (Seq[String], Seq[String], SparkConf, String)
+
+}

--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -75,5 +75,8 @@ private[spark] object Deploy {
     .intConf
     .createWithDefault(Int.MaxValue)
 
-
+  val SPARK_SUBMIT_PLUGIN = ConfigBuilder("spark.deploy.sparkSubmitPlugin")
+    .version("3.2.0")
+    .stringConf
+    .createOptional
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
@@ -48,7 +48,7 @@ class ExternalClusterManagerSuite extends SparkFunSuite with LocalSparkContext {
  * Note that if you want a special ClusterManager for tests, you are probably much more interested
  * in [[MockExternalClusterManager]] and the corresponding [[SchedulerIntegrationSuite]]
  */
-private class DummyExternalClusterManager extends ExternalClusterManager {
+class DummyExternalClusterManager extends ExternalClusterManager {
 
   def canCreate(masterURL: String): Boolean = masterURL == "myclusterManager"
 
@@ -66,7 +66,7 @@ private class DummyExternalClusterManager extends ExternalClusterManager {
 
 }
 
-private class DummySchedulerBackend extends SchedulerBackend {
+class DummySchedulerBackend extends SchedulerBackend {
   var initialized = false
   def start(): Unit = {}
   def stop(): Unit = {}
@@ -75,7 +75,7 @@ private class DummySchedulerBackend extends SchedulerBackend {
   def maxNumConcurrentTasks(rp: ResourceProfile): Int = 0
 }
 
-private class DummyTaskScheduler extends TaskScheduler {
+class DummyTaskScheduler extends TaskScheduler {
   var initialized = false
   override def schedulingMode: SchedulingMode = SchedulingMode.FIFO
   override def rootPool: Pool = new Pool("", schedulingMode, 0, 0)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add the support to submit applications to the user-defined cluster manager.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We have supported users to define the customed cluster manager with ExternalClusterManager trait. However, we can not submit the application with SparkSubmit. The reason is that we check the master whether is the natively support one in SparkSubmit. However, the customed cluster manager is checked in SparkContext. So we could not submit applications with 
`SparkSubmit` or pyspark to those user-defined cluster managers.

In this patch, we extend the existed plugin: `SparkSubmitOperations` to support customize of the submit operation. This makes the `SparkSubmitOperations` a developer API. And decouple the current spark submit preparing code into subclass which makes it easier for maintaining.  

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New UTs.