### PR TITLE
[MINOR][DOCS] Update sql-ref-syntax-dml-insert-into.md

### DIFF
--- a/docs/sql-ref-syntax-dml-insert-into.md
+++ b/docs/sql-ref-syntax-dml-insert-into.md
@@ -70,8 +70,8 @@ INSERT INTO [ TABLE ] table_identifier [ partition_spec ] [ ( column_list ) ]
 #### Single Row Insert Using a VALUES Clause
 
 ```sql
-CREATE TABLE students (name VARCHAR(64), address VARCHAR(64), student_id INT)
-    USING PARQUET PARTITIONED BY (student_id);
+CREATE TABLE students (name VARCHAR(64), address VARCHAR(64))
+    USING PARQUET PARTITIONED BY (student_id INT);
 
 INSERT INTO students VALUES
     ('Amy Smith', '123 Park Ave, San Jose', 111111);


### PR DESCRIPTION
### What changes were proposed in this pull request?

the given example uses a non-standard syntax for CREATE TABLE, by defining the partitioning column with the other columns, instead of in PARTITION BY.

This works is this case, because the partitioning column happens to be the last column defined, but it will break if instead 'name' would be used for partitioning.

I suggest therefore to change the example to use a standard syntax, like in 
https://spark.apache.org/docs/3.1.1/sql-ref-syntax-ddl-create-table-hiveformat.html


### Why are the changes needed?

To show the better documentation.

### Does this PR introduce _any_ user-facing change?

Yes, this fixes the user-facing docs.

### How was this patch tested?

CI should test it out.