### PR TITLE
[SPARK-34802][SQL] Move simplify expression rules before operator push down

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -74,6 +74,10 @@ abstract class Optimizer(catalogManager: CatalogManager)
         ReorderJoin,
         EliminateOuterJoin,
         // Simplify expressions
+        NullPropagation,
+        ConstantPropagation,
+        FoldablePropagation,
+        ConstantFolding,
         LikeSimplification,
         BooleanSimplification,
         SimplifyConditionals,
@@ -104,11 +108,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         // Constant folding and strength reduction
         OptimizeRepartition,
         TransposeWindow,
-        NullPropagation,
-        ConstantPropagation,
-        FoldablePropagation,
         OptimizeIn,
-        ConstantFolding,
         EliminateAggregateFilter,
         ReorderAssociativeOperator,
         PruneFilters,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -70,10 +70,19 @@ abstract class Optimizer(catalogManager: CatalogManager)
   def defaultBatches: Seq[Batch] = {
     val operatorOptimizationRuleSet =
       Seq(
-        // Operator push down
-        PushProjectionThroughUnion,
+        // Optimize join
         ReorderJoin,
         EliminateOuterJoin,
+        // Simplify expressions
+        BooleanSimplification,
+        SimplifyConditionals,
+        PushFoldableIntoBranches,
+        RemoveDispensableExpressions,
+        SimplifyBinaryComparison,
+        ReplaceNullWithFalseInPredicate,
+        SimplifyConditionalsInPredicate,
+        // Operator push down
+        PushProjectionThroughUnion,
         PushDownPredicates,
         PushDownLeftSemiAntiJoin,
         PushLeftSemiLeftAntiThroughJoin,
@@ -99,13 +108,6 @@ abstract class Optimizer(catalogManager: CatalogManager)
         EliminateAggregateFilter,
         ReorderAssociativeOperator,
         LikeSimplification,
-        BooleanSimplification,
-        SimplifyConditionals,
-        PushFoldableIntoBranches,
-        RemoveDispensableExpressions,
-        SimplifyBinaryComparison,
-        ReplaceNullWithFalseInPredicate,
-        SimplifyConditionalsInPredicate,
         PruneFilters,
         SimplifyCasts,
         SimplifyCaseConversionExpressions,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -74,6 +74,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         ReorderJoin,
         EliminateOuterJoin,
         // Simplify expressions
+        LikeSimplification,
         BooleanSimplification,
         SimplifyConditionals,
         PushFoldableIntoBranches,
@@ -81,6 +82,9 @@ abstract class Optimizer(catalogManager: CatalogManager)
         SimplifyBinaryComparison,
         ReplaceNullWithFalseInPredicate,
         SimplifyConditionalsInPredicate,
+        SimplifyCasts,
+        SimplifyCaseConversionExpressions,
+        SimplifyExtractValueOps,
         // Operator push down
         PushProjectionThroughUnion,
         PushDownPredicates,
@@ -107,10 +111,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         ConstantFolding,
         EliminateAggregateFilter,
         ReorderAssociativeOperator,
-        LikeSimplification,
         PruneFilters,
-        SimplifyCasts,
-        SimplifyCaseConversionExpressions,
         RewriteCorrelatedScalarSubquery,
         EliminateSerialization,
         RemoveRedundantAliases,
@@ -118,7 +119,6 @@ abstract class Optimizer(catalogManager: CatalogManager)
         UnwrapCastInBinaryComparison,
         RemoveNoopOperators,
         OptimizeUpdateFields,
-        SimplifyExtractValueOps,
         OptimizeCsvJsonExprs,
         CombineConcats) ++
         extendedOperatorOptimizationRules


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move simplify expression rules before push down rules.


### Why are the changes needed?

The current order will push down useless condition from join condition. For example:
```scala
spark.sql("SELECT * FROM t1 INNER JOIN t2 ON (a = b AND true)").explain
```

```
=== Applying Rule org.apache.spark.sql.catalyst.optimizer.PushDownPredicates ===
!Join Inner, ((a#4L = b#5L) AND true)   Join Inner, (a#4L = b#5L)
!:- Relation default.t1[a#4L] parquet   :- Filter true
!+- Relation default.t2[b#5L] parquet   :  +- Relation default.t1[a#4L] parquet
!                                       +- Relation default.t2[b#5L] parquet
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test:
```scala
spark.sql("set spark.sql.planChangeLog.level=ERROR")
spark.sql("CREATE TABLE t1 (a INT) USING parquet")
spark.sql("CREATE TABLE t2 (b INT) USING parquet")
spark.sql("SELECT * FROM t1 INNER JOIN t2 ON (a = b AND true)").explain
```
