### PR TITLE
[WIP][SPARK-34804] registerFunction shouldnt be logging warning message for same function being re-registered

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -45,7 +45,8 @@ public class ExpressionInfo {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExpressionInfo that = (ExpressionInfo) o;
-        return name.equals(that.name) &&
+        return className.equals(that.className) &&
+                name.equals(that.name) &&
                 arguments.equals(that.arguments) &&
                 examples.equals(that.examples) &&
                 note.equals(that.note) &&

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -38,6 +39,25 @@ public class ExpressionInfo {
     private String group;
     private String since;
     private String deprecated;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExpressionInfo that = (ExpressionInfo) o;
+        return name.equals(that.name) &&
+                arguments.equals(that.arguments) &&
+                examples.equals(that.examples) &&
+                note.equals(that.note) &&
+                group.equals(that.group) &&
+                since.equals(that.since) &&
+                deprecated.equals(that.deprecated);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className, usage, name, extended, db, arguments, examples, note, group, since, deprecated);
+    }
 
     private static final Set<String> validGroups =
         new HashSet<>(Arrays.asList("agg_funcs", "array_funcs", "binary_funcs", "bitwise_funcs",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -107,10 +107,16 @@ class SimpleFunctionRegistry extends FunctionRegistry with Logging {
     val normalizedName = normalizeFuncName(name)
     val newFunction = (info, builder)
     functionBuilders.put(normalizedName, newFunction) match {
-      case Some(previousFunction) if previousFunction != newFunction =>
+      case Some(previousFunction) if testFunctionEquality(previousFunction._1, newFunction._1) =>
+        logError("this")
         logWarning(s"The function $normalizedName replaced a previously registered function.")
       case _ =>
     }
+  }
+
+  private [catalyst] def testFunctionEquality(previousFunction: ExpressionInfo,
+                                              newFunction: ExpressionInfo): Boolean = {
+    previousFunction.equals(newFunction)
   }
 
   override def lookupFunction(name: FunctionIdentifier, children: Seq[Expression]): Expression = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -108,14 +108,12 @@ class SimpleFunctionRegistry extends FunctionRegistry with Logging {
     val newFunction = (info, builder)
     functionBuilders.put(normalizedName, newFunction) match {
       case Some(previousFunction) if testFunctionEquality(previousFunction._1, newFunction._1) =>
-        logError("this")
         logWarning(s"The function $normalizedName replaced a previously registered function.")
       case _ =>
     }
   }
 
-  private [catalyst] def testFunctionEquality(previousFunction: ExpressionInfo,
-                                              newFunction: ExpressionInfo): Boolean = {
+  private [catalyst] def testFunctionEquality(previousFunction: ExpressionInfo, newFunction: ExpressionInfo): Boolean = {
     previousFunction.equals(newFunction)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -107,7 +107,7 @@ class SimpleFunctionRegistry extends FunctionRegistry with Logging {
     val normalizedName = normalizeFuncName(name)
     val newFunction = (info, builder)
     functionBuilders.put(normalizedName, newFunction) match {
-      case Some(previousFunction) if testFunctionEquality(previousFunction._1, newFunction._1) =>
+      case Some(previousFunction) if !testFunctionEquality(previousFunction._1, newFunction._1) =>
         logWarning(s"The function $normalizedName replaced a previously registered function.")
       case _ =>
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistryTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistryTest.scala
@@ -17,10 +17,15 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
+import org.scalatestplus.mockito.MockitoSugar
+import scala.util.Try
+
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, ScalaReflection}
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo, ScalaUDF}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 
-class FunctionRegistryTest extends PlanTest{
+class FunctionRegistryTest extends PlanTest with MockitoSugar{
 
   test("SPARK-34804 should return true for same functions") {
     val functionRegistry = new SimpleFunctionRegistry
@@ -34,6 +39,31 @@ class FunctionRegistryTest extends PlanTest{
     val input = new ExpressionInfo("testClass", null, "testName", null, "", "", "", "", "", "")
     val input2 = new ExpressionInfo("testClass", null, "testName", null, "a,b", "", "", "", "", "")
     assert(!functionRegistry.testFunctionEquality(input, input2))
+  }
+
+  test("SPARK-34804 test with udf registration call") {
+    val func = (i: Int) => (i*2)
+    val ScalaReflection.Schema(dataType, nullable) = ScalaReflection.schemaFor[Int]
+    val inputEncoders = Try(ExpressionEncoder[Int]()).toOption :: Nil
+    val builder = (e: Seq[Expression]) => ScalaUDF(
+      func,
+      dataType,
+      e,
+      inputEncoders,
+      udfName = Some("test_func"),
+      nullable = nullable)
+    var equality = false
+    val functionRegistry = new SimpleFunctionRegistry {
+      override def testFunctionEquality(previousFunction: ExpressionInfo,
+                                        newFunction: ExpressionInfo): Boolean = {
+        val r = super.testFunctionEquality(previousFunction, newFunction)
+        equality = r
+        r
+      }
+    }
+    functionRegistry.registerFunction(FunctionIdentifier("test_func"), builder)
+    functionRegistry.registerFunction(FunctionIdentifier("test_func"), builder)
+    assert(equality)
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistryTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistryTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
+import org.apache.spark.sql.catalyst.plans.PlanTest
+
+class FunctionRegistryTest extends PlanTest{
+
+  test("SPARK-34804 should return true for same functions") {
+    val functionRegistry = new SimpleFunctionRegistry
+    val input = new ExpressionInfo("testClass", null, "testName", null, "", "", "", "", "", "")
+    val input2 = new ExpressionInfo("testClass", null, "testName", null, "", "", "", "", "", "")
+    assert(functionRegistry.testFunctionEquality(input, input2))
+  }
+
+  test("SPARK-34804 should return false for different functions") {
+    val functionRegistry = new SimpleFunctionRegistry
+    val input = new ExpressionInfo("testClass", null, "testName", null, "", "", "", "", "", "")
+    val input2 = new ExpressionInfo("testClass", null, "testName", null, "a,b", "", "", "", "", "")
+    assert(!functionRegistry.testFunctionEquality(input, input2))
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
Basically added a method to test function equality and use only expressioninfo for the equality test. Added an equals method implementation on the ExpressionInfo class checking on the required non null fields.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
This will not log unnecessary warnings for the same function registered again.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Unit tests are added
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
