### PR TITLE
[SPARK-34813][INFRA][3.1] Remove Scala 2.13 build GitHub Action job from branch-3.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -388,28 +388,6 @@ jobs:
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Djava.version=11 install
         rm -rf ~/.m2/repository/org/apache/spark
 
-  scala-213:
-    name: Scala 2.13 build with SBT
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-    - name: Cache Coursier local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/coursier
-        key: scala-213-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-        restore-keys: |
-          scala-213-coursier-
-    - name: Install Java 8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - name: Build with SBT
-      run: |
-        ./dev/change-scala-version.sh 2.13
-        ./build/sbt -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pdocker-integration-tests -Pkubernetes-integration-tests -Pspark-ganglia-lgpl -Pscala-2.13 compile test:compile
-
   hadoop-2:
     name: Hadoop 2 build with SBT
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apache Spark 3.1.x doesn't support Scala 2.13.

### Why are the changes needed?

Currently, Scala 2.13 Build GitHub Action job is broken.
We had better focus on Apache Spark 3.2.0 because branch-3.1 has old SBT/Scala versions and we don't support Scala 2.13 officially.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a removal from GitHub Action jobs.

**BEFORE**
<img width="530" alt="Screen Shot 2021-03-21 at 2 29 40 PM" src="https://user-images.githubusercontent.com/9700541/111921457-ec842780-8a51-11eb-80ff-f07f0f103db9.png">

**AFTER**
<img width="834" alt="Screen Shot 2021-03-21 at 2 29 10 PM" src="https://user-images.githubusercontent.com/9700541/111921464-f73ebc80-8a51-11eb-81f0-f6751db69911.png">
