### PR TITLE
[SPARK-34818][PYTHON][DOCS] Reorder the items in User Guide at PySpark documentation

### DIFF
--- a/python/docs/source/user_guide/index.rst
+++ b/python/docs/source/user_guide/index.rst
@@ -20,17 +20,8 @@
 User Guide
 ==========
 
-This page is the guide for PySpark users which contains PySpark specific topics.
-
-.. toctree::
-    :maxdepth: 2
-
-    arrow_pandas
-    python_packaging
-
-
-There are more guides shared with other languages in Programming Guides
-at `the Spark documentation <https://spark.apache.org/docs/latest/index.html#where-to-go-from-here>`_.
+There are basic guides shared with other languages in Programming Guides
+at `the Spark documentation <https://spark.apache.org/docs/latest/index.html#where-to-go-from-here>`_ as below:
 
 - `RDD Programming Guide <https://spark.apache.org/docs/latest/rdd-programming-guide.html>`_
 - `Spark SQL, DataFrames and Datasets Guide <https://spark.apache.org/docs/latest/sql-programming-guide.html>`_
@@ -38,3 +29,10 @@ at `the Spark documentation <https://spark.apache.org/docs/latest/index.html#whe
 - `Spark Streaming Programming Guide <https://spark.apache.org/docs/latest/streaming-programming-guide.html>`_
 - `Machine Learning Library (MLlib) Guide <https://spark.apache.org/docs/latest/ml-guide.html>`_
 
+PySpark specific user guide is as follows:
+
+.. toctree::
+    :maxdepth: 2
+
+    python_packaging
+    arrow_pandas


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to reorder the items in User Guide in PySpark documentation in order to place general guides first and advance ones later.

### Why are the changes needed?

For users to more easily follow.

### Does this PR introduce _any_ user-facing change?

Yes, it changes the order in the items in documentation .

### How was this patch tested?

Manually verified the documentation after building:

<img width="768" alt="Screen Shot 2021-03-22 at 2 38 41 PM" src="https://user-images.githubusercontent.com/6477701/111945072-5537d680-8b1c-11eb-9f43-02f3ad63a509.png">

FWIW, the current page: https://spark.apache.org/docs/latest/api/python/user_guide/index.html
