### PR TITLE
[SPARK-34820][K8S][R] add apt-update before gnupg install

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
@@ -27,8 +27,9 @@ RUN mkdir ${SPARK_HOME}/R
 
 # Install R 3.6.3 (http://cloud.r-project.org/bin/linux/debian/)
 RUN \
-  echo "deb http://cloud.r-project.org/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list && \
+  apt-get update && \
   apt install -y gnupg && \
+  echo "deb http://cloud.r-project.org/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list && \
   (apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF' || apt-key adv --keyserver keys.openpgp.org --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF') && \
   apt-get update && \
   apt install -y -t buster-cran35 r-base r-base-dev && \


### PR DESCRIPTION
### What changes were proposed in this pull request?
We added the gnupg installation in https://github.com/apache/spark/pull/30130 , we should do apt update before gnupg isntallation, otherwise we will get a fetch error when package is updated.

See more in:
[1] http://apache-spark-developers-list.1001551.n3.nabble.com/K8s-Integration-test-is-unable-to-run-because-of-the-unavailable-libs-td30986.html


### Why are the changes needed?
add a apt-update cmd before gnupg installation to avoid invaild package cache list.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
K8s Integration test passed