### PR TITLE
[SPARK-34824][SQL] Support multiply an year-month interval by a numeric

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -372,6 +372,8 @@ class Analyzer(override val catalogManager: CatalogManager)
         case m @ Multiply(l, r, f) if m.childrenResolved => (l.dataType, r.dataType) match {
           case (CalendarIntervalType, _) => MultiplyInterval(l, r, f)
           case (_, CalendarIntervalType) => MultiplyInterval(r, l, f)
+          case (YearMonthIntervalType, _) => MultiplyYMInterval(l, r)
+          case (_, YearMonthIntervalType) => MultiplyYMInterval(r, l)
           case _ => m
         }
         case d @ Divide(l, r, f) if d.childrenResolved => (l.dataType, r.dataType) match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -263,15 +263,12 @@ case class MultiplyYMInterval(
 
   @transient
   private lazy val evalFunc: (Int, Any) => Any = right.dataType match {
-    case ByteType => (months: Int, num) => Math.multiplyExact(months, num.asInstanceOf[Byte])
-    case ShortType => (months: Int, num) => Math.multiplyExact(months, num.asInstanceOf[Short])
-    case IntegerType => (months: Int, num) => Math.multiplyExact(months, num.asInstanceOf[Int])
-    case LongType =>
-      (months: Int, num) => Math.toIntExact(Math.multiplyExact(months, num.asInstanceOf[Long]))
-    case FloatType => (months: Int, num) =>
-      Math.toIntExact(Math.round(months * num.asInstanceOf[Float].toDouble))
-    case DoubleType => (months: Int, num) =>
-      Math.toIntExact(Math.round(months * num.asInstanceOf[Double]))
+    case ByteType | ShortType | IntegerType => (months: Int, num) =>
+      Math.multiplyExact(months, num.asInstanceOf[Number].intValue())
+    case LongType => (months: Int, num) =>
+      Math.toIntExact(Math.multiplyExact(months, num.asInstanceOf[Long]))
+    case FloatType | DoubleType => (months: Int, num) =>
+      Math.toIntExact(Math.round(months * num.asInstanceOf[Number].doubleValue()))
     case _: DecimalType => (months: Int, num) =>
       val decimalRes = ((new Decimal).set(months) * num.asInstanceOf[Decimal]).toJavaBigDecimal
       decimalRes.setScale(0, java.math.RoundingMode.HALF_UP).intValueExact()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -293,5 +293,5 @@ case class MultiplyYMInterval(
         ".setScale(0, java.math.RoundingMode.HALF_UP).intValueExact()")
   }
 
-  override def prettyName: String = "multiply_ym_interval"
+  override def toString: String = s"($left * $right)"
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -26,7 +26,8 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
 import org.apache.spark.sql.catalyst.util.IntervalUtils.{safeStringToInterval, stringToInterval}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.Decimal
+import org.apache.spark.sql.types.{Decimal, YearMonthIntervalType}
+import org.apache.spark.sql.types.DataTypeTestUtils.numericTypes
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -296,6 +297,12 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     ).foreach { case ((period, num), expected) =>
       checkExceptionInExpression[ArithmeticException](
         MultiplyYMInterval(Literal(period), Literal(num)), expected)
+    }
+
+    numericTypes.foreach { numType =>
+      checkConsistencyBetweenInterpretedAndCodegenAllowingException(
+        (interval: Expression, num: Expression) => MultiplyYMInterval(interval, num),
+        YearMonthIntervalType, numType)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -297,11 +297,10 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       (Period.ofMonths(2), Int.MaxValue),
       (Period.ofMonths(Int.MinValue), 10d),
       (Period.ofMonths(200), Double.PositiveInfinity),
-      (Period.ofMonths(200), Float.NegativeInfinity),
+      (Period.ofMonths(-200), Float.NegativeInfinity)
     ).foreach { case (period, num) =>
       checkExceptionInExpression[ArithmeticException](
-        MultiplyYMInterval(Literal(period), Literal(num)),
-        "overflow")
+        MultiplyYMInterval(Literal(period), Literal(num)), "overflow")
     }
 
     numericTypes.foreach { numType =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2574,4 +2574,43 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-34824: multiply year-month interval by numeric") {
+    checkAnswer(
+      Seq((Period.ofYears(0), 0)).toDF("i", "n").select($"i" * $"n"),
+      Row(Period.ofYears(0)))
+    checkAnswer(
+      Seq((Period.ofMonths(0), 10.toByte)).toDF("i", "n").select($"i" * $"n"),
+      Row(Period.ofMonths(0)))
+    checkAnswer(
+      Seq((Period.ofMonths(5), 3.toShort)).toDF("i", "n").select($"n" * $"i"),
+      Row(Period.ofYears(1).plusMonths(3)))
+    checkAnswer(
+      Seq((Period.ofYears(1000), "2")).toDF("i", "n").select($"i" * $"n"),
+      Row(Period.ofYears(2000)))
+    checkAnswer(
+      Seq((Period.ofMonths(1), 12L)).toDF("i", "n").select($"n" * $"i"),
+      Row(Period.ofYears(1)))
+    checkAnswer(
+      Seq((Period.ofYears(100).plusMonths(11), Short.MaxValue)).toDF("i", "n").select($"n" * $"i"),
+      Row(Period.ofYears(100).plusMonths(11).multipliedBy(Short.MaxValue).normalized()))
+    checkAnswer(
+      Seq((Period.ofMonths(-1), 0.499f)).toDF("i", "n").select($"i" * $"n"),
+      Row(Period.ofMonths(0)))
+    checkAnswer(
+      Seq((Period.ofMonths(10000000), 0.0000001d)).toDF("i", "n").select($"i" * $"n"),
+      Row(Period.ofMonths(1)))
+    checkAnswer(
+      Seq((Period.ofMonths(-10000000), BigDecimal(0.0000001d))).toDF("i", "n").select($"i" * $"n"),
+      Row(Period.ofMonths(-1)))
+    checkAnswer(
+      Seq((Period.ofMonths(-1), BigDecimal(0.5))).toDF("i", "n").select($"i" * $"n"),
+      Row(Period.ofMonths(-1)))
+
+    val e = intercept[SparkException] {
+      Seq((Period.ofYears(9999), Long.MinValue)).toDF("i", "n").select($"n" * $"i").collect()
+    }.getCause
+    assert(e.isInstanceOf[ArithmeticException])
+    assert(e.getMessage.contains("overflow"))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add new expression `MultiplyYMInterval` which multiplies a `YearMonthIntervalType` expression by a `NumericType` expression including ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType, DecimalType.
2. Extend binary arithmetic rules to support `numeric * year-month interval` and `year-month interval * numeric`.

### Why are the changes needed?
To conform the ANSI SQL standard which requires such operation over year-month intervals:
<img width="667" alt="Screenshot 2021-03-22 at 16 33 16" src="https://user-images.githubusercontent.com/1580697/111997810-77d1eb80-8b2c-11eb-951d-e43911d9c5db.png">

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running new tests:
```
$ build/sbt "test:testOnly *IntervalExpressionsSuite"
$ build/sbt "test:testOnly *ColumnExpressionSuite"
```