### PR TITLE
[SPARK-34637][SQL] Improve the performance of AQE and DPP through logical optimization.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -277,6 +277,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val DYNAMIC_PARTITION_PRUNING_CREATE_BROADCAST_ENABLED =
+    buildConf("spark.sql.optimizer.dynamicPartitionPruning.createBroadcastEnabled")
+      .doc(s"When true, we will create a broadcast stage for dynamic partition pruning when " +
+        "the AQE stageCache does't exist the broadcast stage. This configuration only has an " +
+        s"effect when 'spark.sql.adaptive.enabled' is true.")
+      .version("3.0.2")
+      .booleanConf
+      .createWithDefault(true)
+
   val DYNAMIC_PARTITION_PRUNING_USE_STATS =
     buildConf("spark.sql.optimizer.dynamicPartitionPruning.useStats")
       .internal()
@@ -3240,6 +3249,9 @@ class SQLConf extends Serializable with Logging {
   def planChangeBatches: Option[String] = getConf(PLAN_CHANGE_LOG_BATCHES)
 
   def dynamicPartitionPruningEnabled: Boolean = getConf(DYNAMIC_PARTITION_PRUNING_ENABLED)
+
+  def dynamicPartitionPruningCreateBroadcastEnabled: Boolean =
+    getConf(DYNAMIC_PARTITION_PRUNING_CREATE_BROADCAST_ENABLED)
 
   def dynamicPartitionPruningUseStats: Boolean = getConf(DYNAMIC_PARTITION_PRUNING_USE_STATS)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
@@ -20,16 +20,32 @@ package org.apache.spark.sql.execution.adaptive
 import scala.collection.concurrent.TrieMap
 
 import org.apache.spark.sql.catalyst.expressions.{BindReferences, DynamicPruningExpression, Literal}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
-import org.apache.spark.sql.execution.joins.{HashedRelationBroadcastMode, HashJoin}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, HashedRelationBroadcastMode, HashJoin}
 
 /**
  * A rule to insert dynamic pruning predicates in order to reuse the results of broadcast.
  */
-case class PlanAdaptiveDynamicPruningFilters(
+case class PlanAdaptiveDynamicPruningFilters(fullPlan: SparkPlan,
     stageCache: TrieMap[SparkPlan, QueryStageExec]) extends Rule[SparkPlan] {
+
+  @transient lazy val allBroadcastHashJoins =
+    fullPlan.collect { case b: BroadcastHashJoinExec => b }
+
+  private def hasBroadcastHashJoinExec(currentPhysicalPlan: SparkPlan): Boolean = {
+    val found = allBroadcastHashJoins.exists {
+      case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+        left.sameResult(currentPhysicalPlan)
+      case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+        right.sameResult(currentPhysicalPlan)
+    }
+    logDebug(s"PlanAdaptiveDynamicPruningFilters: hasBroadcastHashJoinExec => $found")
+    found
+  }
+
   def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.dynamicPartitionPruningEnabled) {
       return plan
@@ -39,21 +55,51 @@ case class PlanAdaptiveDynamicPruningFilters(
       case DynamicPruningExpression(InSubqueryExec(
           value, SubqueryAdaptiveBroadcastExec(name, index, buildKeys,
           adaptivePlan: AdaptiveSparkPlanExec), exprId, _)) =>
+        val currentPhysicalPlan = adaptivePlan.executedPlan
         val packedKeys = BindReferences.bindReferences(
-          HashJoin.rewriteKeyExpr(buildKeys), adaptivePlan.executedPlan.output)
-        val mode = HashedRelationBroadcastMode(packedKeys)
-        // plan a broadcast exchange of the build side of the join
-        val exchange = BroadcastExchangeExec(mode, adaptivePlan.executedPlan)
-        val existingStage = stageCache.get(exchange.canonicalized)
-        if (existingStage.nonEmpty && conf.exchangeReuseEnabled) {
-          val name = s"dynamicpruning#${exprId.id}"
-          val reuseQueryStage = existingStage.get.newReuseInstance(0, exchange.output)
-          val broadcastValues =
-            SubqueryBroadcastExec(name, index, buildKeys, reuseQueryStage)
-          DynamicPruningExpression(InSubqueryExec(value, broadcastValues, exprId))
+          HashJoin.rewriteKeyExpr(buildKeys), currentPhysicalPlan.output)
+        val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
+          hasBroadcastHashJoinExec(currentPhysicalPlan)
+
+        logDebug(s"PlanAdaptiveDynamicPruningFilters: canReuseExchange => $canReuseExchange " +
+          s"currentPhysicalPlan => ${currentPhysicalPlan}  " +
+          s"plan => $plan")
+
+        var dynamicPruningExpression = DynamicPruningExpression(Literal.TrueLiteral)
+        if (canReuseExchange) {
+          val mode = HashedRelationBroadcastMode(packedKeys)
+          // plan a broadcast exchange of the build side of the join
+          val exchange = BroadcastExchangeExec(mode, currentPhysicalPlan)
+          val existingStage = stageCache.get(exchange.canonicalized)
+          val broadcastQueryStage = if (existingStage.isDefined) {
+            val reuseQueryStage = adaptivePlan.reuseQueryStage(existingStage.get, exchange)
+            logDebug(s"PlanAdaptiveDynamicPruningFilters: reuseQueryStage => $reuseQueryStage")
+            Option(reuseQueryStage)
+          } else if (conf.dynamicPartitionPruningCreateBroadcastEnabled) {
+            var newStage = adaptivePlan.newQueryStage(exchange)
+            val queryStage = stageCache.getOrElseUpdate(exchange.canonicalized, newStage)
+            if (queryStage.ne(newStage)) {
+              logDebug(s"PlanAdaptiveDynamicPruningFilters: the $exchange already exists in " +
+                s"the stageCache.")
+              newStage = adaptivePlan.reuseQueryStage(queryStage, exchange)
+            }
+            logDebug(s"PlanAdaptiveDynamicPruningFilters: newStage => $newStage ")
+            Option(newStage)
+          } else {
+            None
+          }
+          if (broadcastQueryStage.isDefined) {
+            val broadcastValues = SubqueryBroadcastExec(
+              name, index, buildKeys, broadcastQueryStage.get)
+            dynamicPruningExpression =
+              DynamicPruningExpression(InSubqueryExec(value, broadcastValues, exprId))
+          }
         } else {
-          DynamicPruningExpression(Literal.TrueLiteral)
+          // TODO: we need to apply an aggregate on the buildPlan in order to be column
+          // pruned.
+          logInfo(s"DPP cannot reuse broadcast in AQE and the adaptivePlan is $adaptivePlan.")
         }
+        dynamicPruningExpression
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Both AQE and DPP can be applied at the same time in https://issues.apache.org/jira/browse/SPARK-34168, while AQE and DPP can only enable when the join is Broadcast hash join at the beginning.

This pr supports Dynamic Partition Pruning in Adaptive Execution  can be applied at the same time in more scenarios , the processing idea is as follows:
1. Firstly, we should check whether the inputPlan has a BroadcastHashJoinExec of the build side before the adaptive dynamic pruning optimizer rule.
2. When the above broadcastHashJoinExec exists but the broadcastQueryStage of the build side of join has't created, we should create a broadcastQueryStage of the build side for the DPP optimizer, and cache it for AQE reuse.
3. When the above broadcastHashJoinExec exists and the broadcastQueryStage of the build side of join has created, we can reuse it again for the DPP optimizer
4. When the above broadcastHashJoinExec does't exist, we should fallback the DPP optimizer.


### Why are the changes needed?

To support Dynamic Partition Pruning in Adaptive Execution  can be applied at the same time in more scenarios.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?

Add unittests.
