### PR TITLE
[SPARK-34834][NETWORK] Fix a potential Netty memory leak in TransportResponseHandler.

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -188,6 +188,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
       if (listener == null) {
         logger.warn("Ignoring response for RPC {} from {} ({} bytes) since it is not outstanding",
           resp.requestId, getRemoteAddress(channel), resp.body().size());
+        resp.body().release();
       } else {
         outstandingRpcs.remove(resp.requestId);
         try {


### PR DESCRIPTION

### What changes were proposed in this pull request?
There is a potential Netty memory leak in TransportResponseHandler.


### Why are the changes needed?
Fix a potential Netty memory leak in TransportResponseHandler.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
NO
