### PR TITLE
[SPARK-34854][SQL][SS] Expose source metrics via progress report and add Kafka use-case to report delay.

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -18,13 +18,16 @@
 package org.apache.spark.sql.kafka010
 
 import java.{util => ju}
+import java.util.Optional
+
+import scala.collection.JavaConverters._
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.Network.NETWORK_TIMEOUT
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReaderFactory}
-import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset, ReadAllAvailable, ReadLimit, ReadMaxRows, SupportsAdmissionControl}
+import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset, ReadAllAvailable, ReadLimit, ReadMaxRows, ReportsSourceMetrics, SupportsAdmissionControl}
 import org.apache.spark.sql.kafka010.KafkaSourceProvider._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.UninterruptibleThread
@@ -51,7 +54,8 @@ private[kafka010] class KafkaMicroBatchStream(
     options: CaseInsensitiveStringMap,
     metadataPath: String,
     startingOffsets: KafkaOffsetRangeLimit,
-    failOnDataLoss: Boolean) extends SupportsAdmissionControl with MicroBatchStream with Logging {
+    failOnDataLoss: Boolean)
+  extends SupportsAdmissionControl with ReportsSourceMetrics with MicroBatchStream with Logging {
 
   private[kafka010] val pollTimeoutMs = options.getLong(
     KafkaSourceProvider.CONSUMER_POLL_TIMEOUT,
@@ -132,6 +136,10 @@ private[kafka010] class KafkaMicroBatchStream(
   }
 
   override def toString(): String = s"KafkaV2[$kafkaOffsetReader]"
+
+  override def metrics(latestOffset: Optional[Offset]): ju.Map[String, String] = {
+    KafkaMicroBatchStream.metrics(latestOffset, latestPartitionOffsets)
+  }
 
   /**
    * Read initial partition offsets from the checkpoint, or decide the offsets and write them to
@@ -216,5 +224,38 @@ private[kafka010] class KafkaMicroBatchStream(
     } else {
       logWarning(message + s". $INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE")
     }
+  }
+}
+
+object KafkaMicroBatchStream extends Logging {
+
+  /**
+   * Compute the difference of offset per partition between latestAvailablePartitionOffsets
+   * and latestConsumedPartitionOffsets.
+   * Because of rate limit, latest consumed offset per partition can be smaller than
+   * the latest available offset per partition.
+   * @param latestConsumedOffset latest consumed offset
+   * @param latestAvailablePartitionOffsets latest available offset per partition
+   * @return the generated metrics map
+   */
+  def metrics(latestConsumedOffset: Optional[Offset],
+              latestAvailablePartitionOffsets: PartitionOffsetMap): ju.Map[String, String] = {
+    val offset = Option(latestConsumedOffset.orElse(null))
+
+    if (offset.nonEmpty) {
+      val consumedPartitionOffsets = offset.map(KafkaSourceOffset(_)).get.partitionToOffsets
+      val offsetsBehindLatest = latestAvailablePartitionOffsets
+        .filter(partitionOffset => consumedPartitionOffsets.contains(partitionOffset._1))
+        .map(partitionOffset =>
+          partitionOffset._2 - consumedPartitionOffsets.get(partitionOffset._1).get)
+      if (offsetsBehindLatest.size > 0) {
+        val avgOffsetBehindLatest = offsetsBehindLatest.sum.toDouble / offsetsBehindLatest.size
+        return Map[String, String](
+          "minOffsetsBehindLatest" -> offsetsBehindLatest.min.toString,
+          "maxOffsetsBehindLatest" -> offsetsBehindLatest.max.toString,
+          "avgOffsetsBehindLatest" -> avgOffsetBehindLatest.toString).asJava
+      }
+    }
+    Map[String, String]().asJava
   }
 }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -243,7 +243,7 @@ object KafkaMicroBatchStream extends Logging {
       latestAvailablePartitionOffsets: PartitionOffsetMap): ju.Map[String, String] = {
     val offset = Option(latestConsumedOffset.orElse(null))
 
-    if (offset.nonEmpty) {
+    if (offset.nonEmpty && latestAvailablePartitionOffsets != null) {
       val consumedPartitionOffsets = offset.map(KafkaSourceOffset(_)).get.partitionToOffsets
       val offsetsBehindLatest = latestAvailablePartitionOffsets
         .map(partitionOffset => partitionOffset._2 - consumedPartitionOffsets(partitionOffset._1))

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -246,9 +246,7 @@ object KafkaMicroBatchStream extends Logging {
     if (offset.nonEmpty) {
       val consumedPartitionOffsets = offset.map(KafkaSourceOffset(_)).get.partitionToOffsets
       val offsetsBehindLatest = latestAvailablePartitionOffsets
-        .filter(partitionOffset => consumedPartitionOffsets.contains(partitionOffset._1))
-        .map(partitionOffset =>
-          partitionOffset._2 - consumedPartitionOffsets.get(partitionOffset._1).get)
+        .map(partitionOffset => partitionOffset._2 - consumedPartitionOffsets(partitionOffset._1))
       if (offsetsBehindLatest.nonEmpty) {
         val avgOffsetBehindLatest = offsetsBehindLatest.sum.toDouble / offsetsBehindLatest.size
         return Map[String, String](

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -238,8 +238,9 @@ object KafkaMicroBatchStream extends Logging {
    * @param latestAvailablePartitionOffsets latest available offset per partition
    * @return the generated metrics map
    */
-  def metrics(latestConsumedOffset: Optional[Offset],
-              latestAvailablePartitionOffsets: PartitionOffsetMap): ju.Map[String, String] = {
+  def metrics(
+      latestConsumedOffset: Optional[Offset],
+      latestAvailablePartitionOffsets: PartitionOffsetMap): ju.Map[String, String] = {
     val offset = Option(latestConsumedOffset.orElse(null))
 
     if (offset.nonEmpty) {
@@ -248,7 +249,7 @@ object KafkaMicroBatchStream extends Logging {
         .filter(partitionOffset => consumedPartitionOffsets.contains(partitionOffset._1))
         .map(partitionOffset =>
           partitionOffset._2 - consumedPartitionOffsets.get(partitionOffset._1).get)
-      if (offsetsBehindLatest.size > 0) {
+      if (offsetsBehindLatest.nonEmpty) {
         val avgOffsetBehindLatest = offsetsBehindLatest.sum.toDouble / offsetsBehindLatest.size
         return Map[String, String](
           "minOffsetsBehindLatest" -> offsetsBehindLatest.min.toString,
@@ -256,6 +257,6 @@ object KafkaMicroBatchStream extends Logging {
           "avgOffsetsBehindLatest" -> avgOffsetBehindLatest.toString).asJava
       }
     }
-    Map[String, String]().asJava
+    ju.Collections.emptyMap()
   }
 }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -137,8 +137,8 @@ private[kafka010] class KafkaMicroBatchStream(
 
   override def toString(): String = s"KafkaV2[$kafkaOffsetReader]"
 
-  override def metrics(latestOffset: Optional[Offset]): ju.Map[String, String] = {
-    KafkaMicroBatchStream.metrics(latestOffset, latestPartitionOffsets)
+  override def metrics(latestConsumedOffset: Optional[Offset]): ju.Map[String, String] = {
+    KafkaMicroBatchStream.metrics(latestConsumedOffset, latestPartitionOffsets)
   }
 
   /**
@@ -231,7 +231,9 @@ object KafkaMicroBatchStream extends Logging {
 
   /**
    * Compute the difference of offset per partition between latestAvailablePartitionOffsets
-   * and latestConsumedPartitionOffsets.
+   * and partition offsets in the latestConsumedOffset.
+   * Report min/max/avg offsets behind the latest for all the partitions in the Kafka stream.
+   *
    * Because of rate limit, latest consumed offset per partition can be smaller than
    * the latest available offset per partition.
    * @param latestConsumedOffset latest consumed offset

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceOffset.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceOffset.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.kafka010
 
 import org.apache.kafka.common.TopicPartition
 
+import org.apache.spark.sql.connector.read.streaming
 import org.apache.spark.sql.connector.read.streaming.PartitionOffset
 import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset}
 
@@ -62,4 +63,17 @@ private[kafka010] object KafkaSourceOffset {
    */
   def apply(offset: SerializedOffset): KafkaSourceOffset =
     KafkaSourceOffset(JsonUtils.partitionOffsets(offset.json))
+
+  /**
+   * Returns [[KafkaSourceOffset]] from a streaming.Offset
+   */
+  def apply(offset: streaming.Offset): KafkaSourceOffset = {
+    offset match {
+      case k: KafkaSourceOffset => k
+      case so: SerializedOffset => apply(so)
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Invalid conversion from offset of ${offset.getClass} to KafkaSourceOffset")
+    }
+  }
 }

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -1404,6 +1404,9 @@ class KafkaMicroBatchV2SourceSuite extends KafkaMicroBatchSourceSuiteBase {
           "maxOffsetsBehindLatest" -> "4",
           "avgOffsetsBehindLatest" -> "3.0").asJava)
 
+    // test null latestAvailablePartitionOffsets
+    assert(KafkaMicroBatchStream.metrics(Optional.ofNullable(offset), null).isEmpty)
+
     // test a topic is missing in both the latestConsumedOffset and latestAvailableOffset.
     val topicPartition3 = new TopicPartition(newTopic(), 0)
     val offset2 =

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -1390,10 +1390,6 @@ class KafkaMicroBatchV2SourceSuite extends KafkaMicroBatchSourceSuiteBase {
     // test empty offset.
     assert(KafkaMicroBatchStream.metrics(Optional.ofNullable(null), latestOffset).isEmpty)
 
-    // test empty offsetsBehindLatest && topics are missing in the latestConsumedOffset.
-    val emptyOffset = KafkaSourceOffset(Map[TopicPartition, Long]())
-    assert(KafkaMicroBatchStream.metrics(Optional.ofNullable(emptyOffset), latestOffset).isEmpty)
-
     // test valid offsetsBehindLatest
     val offset = KafkaSourceOffset(
       Map[TopicPartition, Long]((topicPartition1, 1L), (topicPartition2, 2L)))
@@ -1406,19 +1402,6 @@ class KafkaMicroBatchV2SourceSuite extends KafkaMicroBatchSourceSuiteBase {
 
     // test null latestAvailablePartitionOffsets
     assert(KafkaMicroBatchStream.metrics(Optional.ofNullable(offset), null).isEmpty)
-
-    // test a topic is missing in both the latestConsumedOffset and latestAvailableOffset.
-    val topicPartition3 = new TopicPartition(newTopic(), 0)
-    val offset2 =
-      KafkaSourceOffset(Map[TopicPartition, Long]((topicPartition1, 1L), (topicPartition3, 2L)))
-    val latestAvailableOffsets = Map[TopicPartition, Long](
-      (topicPartition2, 3L), (topicPartition3, 6L))
-    assert(
-      KafkaMicroBatchStream.metrics(Optional.ofNullable(offset2), latestAvailableOffsets) ===
-        Map[String, String](
-          "minOffsetsBehindLatest" -> "4",
-          "maxOffsetsBehindLatest" -> "4",
-          "avgOffsetsBehindLatest" -> "4.0").asJava)
   }
 }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ReportsSourceMetrics.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ReportsSourceMetrics.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read.streaming;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.spark.annotation.Evolving;
+
+/**
+ * A mix-in interface for {@link SparkDataStream} streaming sources to signal that they can report
+ * metrics.
+ */
+@Evolving
+public interface ReportsSourceMetrics extends SparkDataStream {
+    /**
+     * Returns the metrics reported by the streaming source with respect to the latest offset.
+     *
+     * @param latestOffset the end offset (exclusive) of the latest triggered batch.
+     */
+    Map<String, String> metrics(Optional<Offset> latestOffset);
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ReportsSourceMetrics.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ReportsSourceMetrics.java
@@ -29,9 +29,10 @@ import org.apache.spark.annotation.Evolving;
 @Evolving
 public interface ReportsSourceMetrics extends SparkDataStream {
     /**
-     * Returns the metrics reported by the streaming source with respect to the latest consumed offset.
+     * Returns the metrics reported by the streaming source with respect to
+     * the latest consumed offset.
      *
-     * @param latestConsumedOffset the end offset (exclusive) consumed of the latest triggered batch.
+     * @param latestConsumedOffset the end offset (exclusive) of the latest triggered batch.
      */
     Map<String, String> metrics(Optional<Offset> latestConsumedOffset);
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ReportsSourceMetrics.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ReportsSourceMetrics.java
@@ -29,9 +29,9 @@ import org.apache.spark.annotation.Evolving;
 @Evolving
 public interface ReportsSourceMetrics extends SparkDataStream {
     /**
-     * Returns the metrics reported by the streaming source with respect to the latest offset.
+     * Returns the metrics reported by the streaming source with respect to the latest consumed offset.
      *
-     * @param latestOffset the end offset (exclusive) of the latest triggered batch.
+     * @param latestConsumedOffset the end offset (exclusive) consumed of the latest triggered batch.
      */
-    Map<String, String> metrics(Optional<Offset> latestOffset);
+    Map<String, String> metrics(Optional<Offset> latestConsumedOffset);
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.streaming
 
 import java.text.SimpleDateFormat
-import java.util.{Date, UUID}
+import java.util.{Date, Optional, UUID}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, LogicalP
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.MILLIS_PER_SECOND
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.Table
-import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, SparkDataStream}
+import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, ReportsSourceMetrics, SparkDataStream}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.datasources.v2.{MicroBatchScanExec, StreamingDataSourceV2Relation, StreamWriterCommitProgress}
 import org.apache.spark.sql.streaming._
@@ -101,6 +101,8 @@ trait ProgressReporter extends Logging {
       isTriggerActive = false)
   }
 
+  private var latestStreamProgress: StreamProgress = _
+
   /** Returns the current status of the query. */
   def status: StreamingQueryStatus = currentStatus
 
@@ -136,6 +138,7 @@ trait ProgressReporter extends Logging {
     currentTriggerStartOffsets = from.mapValues(_.json).toMap
     currentTriggerEndOffsets = to.mapValues(_.json).toMap
     currentTriggerLatestOffsets = latest.mapValues(_.json).toMap
+    latestStreamProgress = to
   }
 
   private def updateProgress(newProgress: StreamingQueryProgress): Unit = {
@@ -175,6 +178,11 @@ trait ProgressReporter extends Logging {
 
     val sourceProgress = sources.distinct.map { source =>
       val numRecords = executionStats.inputRows.getOrElse(source, 0L)
+      val sourceMetrics = source match {
+        case withMetrics: ReportsSourceMetrics =>
+          withMetrics.metrics(Optional.ofNullable(latestStreamProgress.get(source).orNull))
+        case _ => Map[String, String]().asJava
+      }
       new SourceProgress(
         description = source.toString,
         startOffset = currentTriggerStartOffsets.get(source).orNull,
@@ -182,7 +190,8 @@ trait ProgressReporter extends Logging {
         latestOffset = currentTriggerLatestOffsets.get(source).orNull,
         numInputRows = numRecords,
         inputRowsPerSecond = numRecords / inputTimeSec,
-        processedRowsPerSecond = numRecords / processingTimeSec
+        processedRowsPerSecond = numRecords / processingTimeSec,
+        metrics = sourceMetrics
       )
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -33,6 +33,7 @@ import org.json4s.jackson.JsonMethods._
 import org.apache.spark.annotation.Evolving
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.streaming.SafeJsonSerializer.{safeDoubleToJValue, safeMapToJValue}
 import org.apache.spark.sql.streaming.SinkProgress.DEFAULT_NUM_OUTPUT_ROWS
 
 /**
@@ -144,15 +145,14 @@ class StreamingQueryProgress private[sql](
     ("timestamp" -> JString(timestamp)) ~
     ("batchId" -> JInt(batchId)) ~
     ("numInputRows" -> JInt(numInputRows)) ~
-    ("inputRowsPerSecond" -> SafeJsonSerializer.safeDoubleToJValue(inputRowsPerSecond)) ~
-    ("processedRowsPerSecond" -> SafeJsonSerializer.safeDoubleToJValue(processedRowsPerSecond)) ~
-    ("durationMs" -> SafeJsonSerializer.safeMapToJValue[JLong](durationMs, v => JInt(v.toLong))) ~
-    ("eventTime" -> SafeJsonSerializer.safeMapToJValue[String](eventTime, s => JString(s))) ~
+    ("inputRowsPerSecond" -> safeDoubleToJValue(inputRowsPerSecond)) ~
+    ("processedRowsPerSecond" -> safeDoubleToJValue(processedRowsPerSecond)) ~
+    ("durationMs" -> safeMapToJValue[JLong](durationMs, v => JInt(v.toLong))) ~
+    ("eventTime" -> safeMapToJValue[String](eventTime, s => JString(s))) ~
     ("stateOperators" -> JArray(stateOperators.map(_.jsonValue).toList)) ~
     ("sources" -> JArray(sources.map(_.jsonValue).toList)) ~
     ("sink" -> sink.jsonValue) ~
-    ("observedMetrics" ->
-      SafeJsonSerializer.safeMapToJValue[Row](observedMetrics, row => row.jsonValue))
+    ("observedMetrics" -> safeMapToJValue[Row](observedMetrics, row => row.jsonValue))
   }
 }
 
@@ -195,9 +195,9 @@ class SourceProgress protected[sql](
     ("endOffset" -> tryParse(endOffset)) ~
     ("latestOffset" -> tryParse(latestOffset)) ~
     ("numInputRows" -> JInt(numInputRows)) ~
-    ("inputRowsPerSecond" -> SafeJsonSerializer.safeDoubleToJValue(inputRowsPerSecond)) ~
-    ("processedRowsPerSecond" -> SafeJsonSerializer.safeDoubleToJValue(processedRowsPerSecond)) ~
-    ("metrics" -> SafeJsonSerializer.safeMapToJValue[String](metrics, s => JString(s)))
+    ("inputRowsPerSecond" -> safeDoubleToJValue(inputRowsPerSecond)) ~
+    ("processedRowsPerSecond" -> safeDoubleToJValue(processedRowsPerSecond)) ~
+    ("metrics" -> safeMapToJValue[String](metrics, s => JString(s)))
   }
 
   private def tryParse(json: String) = try {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request proposes a new API for streaming sources to signal that they can report metrics, and adds a use case to support Kafka micro batch stream to report the stats of # of offsets for the current offset falling behind the latest.

A public interface is added.

`metrics`: returns the metrics reported by the streaming source with given offset.

### Why are the changes needed?
The new API can expose any custom metrics for the "current" offset for streaming sources. Different from #31398, this PR makes metrics available to user through progress report, not through spark UI. A use case is that people want to know how the current offset falls behind the latest offset.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit test for Kafka micro batch source v2 are added to test the Kafka use case.
