### PR TITLE
[SPARK-34845][CORE] ProcfsMetricsGetter shouldn't return partial procfs metrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
@@ -214,8 +214,8 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
     for (p <- pids) {
       try {
         allMetrics = addProcfsMetricsFromOneProcess(allMetrics, p)
-        // if we had an error getting any of the metrics, we don't want to report partial metrics, as
-        // that would be misleading.
+        // if we had an error getting any of the metrics, we don't want to
+        // report partial metrics, as that would be misleading.
         if (!isAvailable) {
           return ProcfsMetrics(0, 0, 0, 0, 0, 0)
         }

--- a/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
@@ -220,7 +220,7 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
           return ProcfsMetrics(0, 0, 0, 0, 0, 0)
         }
       } catch {
-        case f: IOException =>
+        case _: IOException =>
           return ProcfsMetrics(0, 0, 0, 0, 0, 0)
       }
     }

--- a/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
@@ -101,7 +101,8 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
     }
   }
 
-  private def computeProcessTree(): Set[Int] = {
+  // Exposed for testing
+  private[executor] def computeProcessTree(): Set[Int] = {
     if (!isAvailable || testing) {
       return Set()
     }
@@ -159,7 +160,8 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
     }
   }
 
-  def addProcfsMetricsFromOneProcess(
+  // Exposed for testing
+  private[executor] def addProcfsMetricsFromOneProcess(
       allMetrics: ProcfsMetrics,
       pid: Int): ProcfsMetrics = {
 
@@ -199,6 +201,7 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
       case f: IOException =>
         logWarning("There was a problem with reading" +
           " the stat file of the process. ", f)
+        isAvailable = false
         ProcfsMetrics(0, 0, 0, 0, 0, 0)
     }
   }

--- a/core/src/test/scala/org/apache/spark/executor/ProcfsMetricsGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ProcfsMetricsGetterSuite.scala
@@ -41,7 +41,7 @@ class ProcfsMetricsGetterSuite extends SparkFunSuite {
     assert(r.jvmRSSTotal == 262610944)
   }
 
-  test("partial metrics shouldn't be returned") {
+  test("SPARK-34845: partial metrics shouldn't be returned") {
     val p = new ProcfsMetricsGetter(getTestResourcePath("ProcfsMetrics"))
     val mockedP = spy(p)
 

--- a/core/src/test/scala/org/apache/spark/executor/ProcfsMetricsGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ProcfsMetricsGetterSuite.scala
@@ -54,7 +54,7 @@ class ProcfsMetricsGetterSuite extends SparkFunSuite {
     assert(r.pythonRSSTotal == 7831552)
 
     // proc file of pid 22764 doesn't exist, so partial metrics shouldn't be returned
-    ptree = Set(26109, 22763, 22764)
+    ptree = Set(26109, 22764, 22763)
     when(mockedP.computeProcessTree).thenReturn(ptree)
     r = mockedP.computeAllMetrics
     assert(r.jvmVmemTotal == 0)

--- a/core/src/test/scala/org/apache/spark/executor/ProcfsMetricsGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ProcfsMetricsGetterSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.executor
 
+import org.mockito.Mockito.{spy, when}
+
 import org.apache.spark.SparkFunSuite
 
 
@@ -37,5 +39,27 @@ class ProcfsMetricsGetterSuite extends SparkFunSuite {
     assert(r.pythonRSSTotal == 7831552)
     assert(r.jvmVmemTotal == 4769947648L)
     assert(r.jvmRSSTotal == 262610944)
+  }
+
+  test("partial metrics shouldn't be returned") {
+    val p = new ProcfsMetricsGetter(getTestResourcePath("ProcfsMetrics"))
+    val mockedP = spy(p)
+
+    var ptree: Set[Int] = Set(26109, 22763)
+    when(mockedP.computeProcessTree).thenReturn(ptree)
+    var r = mockedP.computeAllMetrics
+    assert(r.jvmVmemTotal == 4769947648L)
+    assert(r.jvmRSSTotal == 262610944)
+    assert(r.pythonVmemTotal == 360595456)
+    assert(r.pythonRSSTotal == 7831552)
+
+    // proc file of pid 22764 doesn't exist, so partial metrics shouldn't be returned
+    ptree = Set(26109, 22763, 22764)
+    when(mockedP.computeProcessTree).thenReturn(ptree)
+    r = mockedP.computeAllMetrics
+    assert(r.jvmVmemTotal == 0)
+    assert(r.jvmRSSTotal == 0)
+    assert(r.pythonVmemTotal == 0)
+    assert(r.pythonRSSTotal == 0)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In ProcfsMetricsGetter.scala, propogating IOException from addProcfsMetricsFromOneProcess to computeAllMetrics when the child pid's proc stat file is unavailable. As a result, the for-loop in computeAllMetrics() can terminate earlier and return an all-0 procfs metric.

### Why are the changes needed?
In the case of a child pid's stat file missing and the subsequent child pids' stat files exist, ProcfsMetricsGetter.computeAllMetrics() will return partial metrics (the sum of a subset of child pids), which can be misleading and is undesired per the existing code comments in https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala#L214.

Also, a side effect of this bug is that it can lead to a verbose warning log if many pids' stat files are missing. An early terminating can make the warning logs more concise.

The unit test can also explain the bug well.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
A unit test is added.
