### PR TITLE
[SPARK-34819][SQL] MapType supports orderable semantics

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -639,14 +639,6 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
                  |Conflicting attributes: ${conflictingAttributes.mkString(",")}
                """.stripMargin)
 
-          // TODO: although map type is not orderable, technically map type should be able to be
-          // used in equality comparison, remove this type check once we support it.
-          case o if mapColumnInSetOperation(o).isDefined =>
-            val mapCol = mapColumnInSetOperation(o).get
-            failAnalysis("Cannot have map type columns in DataFrame which calls " +
-              s"set operations(intersect, except, etc.), but the type of column ${mapCol.name} " +
-              "is " + mapCol.dataType.catalogString)
-
           case o if o.expressions.exists(!_.deterministic) &&
             !o.isInstanceOf[Project] && !o.isInstanceOf[Filter] &&
             !o.isInstanceOf[Aggregate] && !o.isInstanceOf[Window] =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -731,8 +731,8 @@ class CodegenContext extends Logging {
            |
            |   @Override
            |   public int compare(Object a, Object b) {
-           |     Integer indexA = (Integer)a;
-           |     Integer indexB = (Integer)b;
+           |     int indexA = ((Integer)a).intValue();
+           |     int indexB = ((Integer)b).intValue();
            |     ${javaType(keyType)} keyA = ${getValue("array", keyType, "indexA")};
            |     ${javaType(keyType)} keyB = ${getValue("array", keyType, "indexB")};
            |     return ${genComp(keyType, "keyA", "keyB")};

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ordering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ordering.scala
@@ -65,6 +65,10 @@ class InterpretedOrdering(ordering: Seq[SortOrder]) extends BaseOrdering {
             a.interpretedOrdering.asInstanceOf[Ordering[Any]].compare(left, right)
           case a: ArrayType if order.direction == Descending =>
             - a.interpretedOrdering.asInstanceOf[Ordering[Any]].compare(left, right)
+          case a: MapType if order.direction == Ascending =>
+            a.interpretedOrdering.asInstanceOf[Ordering[Any]].compare(left, right)
+          case a: MapType if order.direction == Descending =>
+            - a.interpretedOrdering.asInstanceOf[Ordering[Any]].compare(left, right)
           case s: StructType if order.direction == Ascending =>
             s.interpretedOrdering.asInstanceOf[Ordering[Any]].compare(left, right)
           case s: StructType if order.direction == Descending =>
@@ -104,6 +108,7 @@ object RowOrdering extends CodeGeneratorWithInterpretedFallback[Seq[SortOrder], 
     case dt: AtomicType => true
     case struct: StructType => struct.fields.forall(f => isOrderable(f.dataType))
     case array: ArrayType => isOrderable(array.elementType)
+    case map: MapType => isOrderable(map.keyType) && isOrderable(map.valueType)
     case udt: UserDefinedType[_] => isOrderable(udt.sqlType)
     case _ => false
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, ArrayTransform, CaseWhen, Coalesce, CreateArray, CreateMap, CreateNamedStruct, EqualTo, ExpectsInputTypes, Expression, GetStructField, If, IsNull, KnownFloatingPointNormalized, LambdaFunction, Literal, NamedLambdaVariable, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, ArrayTransform, CaseWhen, Coalesce, CreateArray, CreateMap, CreateNamedStruct, EqualTo, ExpectsInputTypes, Expression, GetStructField, If, IsNull, KnownFloatingPointNormalized, LambdaFunction, Literal, NamedLambdaVariable, TransformKeys, TransformValues, UnaryExpression}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Window}
@@ -95,9 +95,7 @@ object NormalizeFloatingNumbers extends Rule[LogicalPlan] {
     case FloatType | DoubleType => true
     case StructType(fields) => fields.exists(f => needNormalize(f.dataType))
     case ArrayType(et, _) => needNormalize(et)
-    // Currently MapType is not comparable and analyzer should fail earlier if this case happens.
-    case _: MapType =>
-      throw new IllegalStateException("grouping/join/window partition keys cannot be map type.")
+    case MapType(kt, vt, _) => needNormalize(kt) || needNormalize(vt)
     case _ => false
   }
 
@@ -140,6 +138,27 @@ object NormalizeFloatingNumbers extends Rule[LogicalPlan] {
       val lv = NamedLambdaVariable("arg", et, containsNull)
       val function = normalize(lv)
       KnownFloatingPointNormalized(ArrayTransform(expr, LambdaFunction(function, Seq(lv))))
+
+    case _ if expr.dataType.isInstanceOf[MapType] =>
+      val MapType(kt, vt, containsNull) = expr.dataType
+      var normalized = if (needNormalize(kt)) {
+        val lv1 = NamedLambdaVariable("arg1", kt, false)
+        val lv2 = NamedLambdaVariable("arg2", vt, containsNull)
+        val function = normalize(lv1)
+        TransformKeys(expr, LambdaFunction(function, Seq(lv1, lv2)))
+      } else {
+        expr
+      }
+
+      normalized = if (needNormalize(vt)) {
+        val lv1 = NamedLambdaVariable("arg1", kt, false)
+        val lv2 = NamedLambdaVariable("arg2", vt, containsNull)
+        val function = normalize(lv2)
+        TransformValues(normalized, LambdaFunction(function, Seq(lv1, lv2)))
+      } else {
+        normalized
+      }
+      KnownFloatingPointNormalized(normalized)
 
     case _ => throw new IllegalStateException(s"fail to normalize $expr")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeMapType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeMapType.scala
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import scala.math.Ordering
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, EqualTo, ExpectsInputTypes, Expression, NamedExpression, NamedLambdaVariable, TaggingExpression, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator.{getValue, javaType}
+import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode
+import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Distinct, LogicalPlan, Project, Window}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapBuilder, MapData, TypeUtils}
+import org.apache.spark.sql.types.{AbstractDataType, DataType, MapType}
+
+case class KeyOrderedMap(child: Expression) extends TaggingExpression
+
+/**
+ * Spark SQL turns grouping/join/window partition keys into binary `UnsafeRow` and compare the
+ * binary data directly instead of using MapType's ordering. So in order to make sure two maps
+ * have the same key value pairs but with different key ordering generate right result, we have
+ * to insert an expression to sort map entries by key.
+ *
+ * Note that, this rule must be executed at the end of optimizer, because the optimizer may create
+ * new joins(the subquery rewrite) and new join conditions(the join reorder).
+ */
+object NormalizeMapType extends Rule[LogicalPlan] {
+  def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+    case w: Window if w.partitionSpec.exists(p => needNormalize(p)) =>
+      w.copy(partitionSpec = w.partitionSpec.map(normalize))
+
+    case j @ ExtractEquiJoinKeys(_, leftKeys, rightKeys, condition, _, _, _)
+      // The analyzer guarantees left and right joins keys are of the same data type.
+      if leftKeys.exists(k => needNormalize(k)) =>
+      val newLeftJoinKeys = leftKeys.map(normalize)
+      val newRightJoinKeys = rightKeys.map(normalize)
+      val newConditions = newLeftJoinKeys.zip(newRightJoinKeys).map {
+        case (l, r) => EqualTo(l, r)
+      } ++ condition
+      j.copy(condition = Some(newConditions.reduce(And)))
+
+    case agg: Aggregate if agg.aggregateExpressions.exists(needNormalize) =>
+      val replacements = agg.groupingExpressions.collect {
+        case e if needNormalize(e) => e
+      }
+
+      agg.transformExpressionsUp {
+        case e =>
+          replacements
+            .find(_.semanticEquals(e))
+            .map(_ => normalize(e))
+            .getOrElse(e)
+      }
+
+    case Distinct(child) if child.output.exists(needNormalize) =>
+      val projectList = child.output.map(normalize).asInstanceOf[Seq[NamedExpression]]
+      Distinct(Project(projectList, child))
+  }
+
+  private def needNormalize(expr: Expression): Boolean = expr match {
+    case ReorderMapKey(_) => false
+    case Alias(ReorderMapKey(_), _) => false
+    case e if e.dataType.isInstanceOf[MapType] => true
+    case _ => false
+  }
+
+  private[sql] def normalize(expr: Expression): Expression = expr match {
+    case _ if !needNormalize(expr) => expr
+    case a: Attribute if a.dataType.isInstanceOf[MapType] =>
+      val newAttr = a.withExprId(NamedExpression.newExprId)
+      Alias(ReorderMapKey(newAttr), a.name)(exprId = a.exprId, qualifier = a.qualifier)
+    case a: Alias =>
+      a.withNewChildren(Seq(ReorderMapKey(a.child)))
+    case a: NamedLambdaVariable =>
+      val newNLV = a.copy(exprId = NamedExpression.newExprId)
+      Alias(ReorderMapKey(newNLV), a.name)(exprId = a.exprId, qualifier = a.qualifier)
+    case e if e.dataType.isInstanceOf[MapType] =>
+      ReorderMapKey(e)
+  }
+}
+
+case class ReorderMapKey(child: Expression) extends UnaryExpression with ExpectsInputTypes {
+  private lazy val MapType(keyType, valueType, valueContainsNull) = dataType.asInstanceOf[MapType]
+  private lazy val keyOrdering: Ordering[Any] = TypeUtils.getInterpretedOrdering(keyType)
+  private lazy val mapBuilder = new ArrayBasedMapBuilder(keyType, valueType)
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(MapType)
+
+  override def dataType: DataType = child.dataType
+
+  override def nullSafeEval(input: Any): Any = {
+    val childMap = input.asInstanceOf[MapData]
+    val keys = childMap.keyArray()
+    val values = childMap.valueArray()
+    val sortedKeyIndex = (0 until childMap.numElements()).toArray.sorted(new Ordering[Int] {
+      override def compare(a: Int, b: Int): Int = {
+        keyOrdering.compare(keys.get(a, keyType), keys.get(b, keyType))
+      }
+    })
+
+    var i = 0
+    while (i < childMap.numElements()) {
+      val index = sortedKeyIndex(i)
+      mapBuilder.put(
+        keys.get(index, keyType),
+        if (values.isNullAt(index)) null else values.get(index, valueType))
+
+      i += 1
+    }
+
+    mapBuilder.build()
+  }
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val initIndexArrayFunc = ctx.freshName("initIndexArray")
+    val numElements = ctx.freshName("numElements")
+    val sortedKeyIndex = ctx.freshName("sortedKeyIndex")
+    val keyArray = ctx.freshName("keyArray")
+    val valueArray = ctx.freshName("valueArray")
+    val idx = ctx.freshName("idx")
+    val index = ctx.freshName("index")
+    val builderTerm = ctx.addReferenceObj("mapBuilder", mapBuilder)
+    ctx.addNewFunction(initIndexArrayFunc,
+      s"""
+         |private Integer[] $initIndexArrayFunc(int n) {
+         |  Integer[] arr = new Integer[n];
+         |  for (int i = 0; i < n; i++) {
+         |    arr[i] = i;
+         |  }
+         |  return arr;
+         |}""".stripMargin)
+
+    val codeToNormalize = (f: String) => {
+      s"""
+         |int $numElements = $f.numElements();
+         |Integer[] $sortedKeyIndex = $initIndexArrayFunc($numElements);
+         |final ArrayData $keyArray = $f.keyArray();
+         |final ArrayData $valueArray = $f.valueArray();
+         |java.util.Arrays.sort($sortedKeyIndex, new java.util.Comparator<Integer>() {
+         |   @Override
+         |   public int compare(Object a, Object b) {
+         |     int indexA = ((Integer)a).intValue();
+         |     int indexB = ((Integer)b).intValue();
+         |     ${javaType(keyType)} keyA = ${getValue(keyArray, keyType, "indexA")};
+         |     ${javaType(keyType)} keyB = ${getValue(keyArray, keyType, "indexB")};
+         |     return ${ctx.genComp(keyType, "keyA", "keyB")};
+         |   }
+         |});
+         |
+         |for (int $idx = 0; $idx < $numElements; $idx++) {
+         |  Integer $index = $sortedKeyIndex[$idx];
+         |  $builderTerm.put(
+         |    ${getValue(keyArray, keyType, index)},
+         |    $valueArray.isNullAt($index) ? null : ${getValue(valueArray, valueType, index)});
+         |}
+         |
+         |${ev.value} = $builderTerm.build();
+         |""".stripMargin
+    }
+
+    nullSafeCodeGen(ctx, ev, codeToNormalize)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -230,9 +230,11 @@ abstract class Optimizer(catalogManager: CatalogManager)
       ColumnPruning,
       CollapseProject,
       RemoveNoopOperators) :+
-    // This batch must be executed after the `RewriteSubquery` batch, which creates joins.
+    // Following batches must be executed after the `RewriteSubquery` batch, which creates joins.
     Batch("NormalizeFloatingNumbers", Once, NormalizeFloatingNumbers) :+
+    Batch("NormalizeMapType", Once, NormalizeMapType) :+
     Batch("ReplaceUpdateFieldsExpression", Once, ReplaceUpdateFieldsExpression)
+
 
     // remove any batches with no rules. this may happen when subclasses do not add optional rules.
     batches.filter(_.rules.nonEmpty)
@@ -266,7 +268,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
       RewriteCorrelatedScalarSubquery.ruleName ::
       RewritePredicateSubquery.ruleName ::
       NormalizeFloatingNumbers.ruleName ::
-      ReplaceUpdateFieldsExpression.ruleName :: Nil
+      ReplaceUpdateFieldsExpression.ruleName ::
+      NormalizeMapType.ruleName :: Nil
 
   /**
    * Optimize all the subqueries inside expression.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
@@ -73,6 +73,7 @@ object TypeUtils {
     t match {
       case i: AtomicType => i.ordering.asInstanceOf[Ordering[Any]]
       case a: ArrayType => a.interpretedOrdering.asInstanceOf[Ordering[Any]]
+      case m: MapType => m.interpretedOrdering.asInstanceOf[Ordering[Any]]
       case s: StructType => s.interpretedOrdering.asInstanceOf[Ordering[Any]]
       case udt: UserDefinedType[_] => getInterpretedOrdering(udt.sqlType)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
@@ -17,10 +17,13 @@
 
 package org.apache.spark.sql.types
 
+import scala.math.Ordering
+
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Stable
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData, TypeUtils}
 import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 
 /**
@@ -78,6 +81,69 @@ case class MapType(
 
   override private[spark] def existsRecursively(f: (DataType) => Boolean): Boolean = {
     f(this) || keyType.existsRecursively(f) || valueType.existsRecursively(f)
+  }
+
+  @transient
+  private[sql] lazy val keyOrdering: Ordering[Any] =
+    TypeUtils.getInterpretedOrdering(keyType)
+
+  @transient
+  private[sql] lazy val valueOrdering: Ordering[Any] =
+    TypeUtils.getInterpretedOrdering(valueType)
+
+  @transient
+  private[sql] lazy val interpretedOrdering: Ordering[MapData] = new Ordering[MapData] {
+    def compare(left: MapData, right: MapData): Int = {
+      if (left.numElements() != right.numElements()) {
+        return left.numElements() - right.numElements()
+      }
+
+      val numElements = left.numElements()
+      val leftKeys = left.keyArray()
+      val rightKeys = right.keyArray()
+      val leftValues = left.valueArray()
+      val rightValues = right.valueArray()
+
+      val keyIndexOrdering = (keys: ArrayData) => new Ordering[Int] {
+        override def compare(a: Int, b: Int): Int = {
+          keyOrdering.compare(keys.get(a, keyType), keys.get(b, keyType))
+        }
+      }
+      val leftSortedKeyIndex = (0 until numElements).toArray.sorted(keyIndexOrdering(leftKeys))
+      val rightSortedKeyIndex = (0 until numElements).toArray.sorted(keyIndexOrdering(rightKeys))
+      var i = 0
+      while (i < numElements) {
+        val leftIndex = leftSortedKeyIndex(i)
+        val rightIndex = rightSortedKeyIndex(i)
+
+        val leftKey = leftKeys.get(leftIndex, keyType)
+        val rightKey = rightKeys.get(rightIndex, keyType)
+        val keyComp = keyOrdering.compare(leftKey, rightKey)
+        if (keyComp != 0) {
+          return keyComp
+        } else {
+          val leftValueIsNull = leftValues.isNullAt(leftIndex)
+          val rightValueIsNull = rightValues.isNullAt(rightIndex)
+          if (leftValueIsNull && rightValueIsNull) {
+            // do nothing
+          } else if (leftValueIsNull) {
+            return -1
+          } else if (rightValueIsNull) {
+            return 1
+          } else {
+            val leftValue = leftValues.get(leftIndex, valueType)
+            val rightValue = rightValues.get(rightIndex, valueType)
+            val valueComp = valueOrdering.compare(leftValue, rightValue)
+            if (valueComp != 0) {
+              return valueComp
+            }
+          }
+        }
+        i += 1
+      }
+
+      0
+    }
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -298,11 +298,6 @@ class AnalysisErrorSuite extends AnalysisTest {
     "Invalid usage of '*'" :: "in expression 'sum'" :: Nil)
 
   errorTest(
-    "sorting by unsupported column types",
-    mapRelation.orderBy($"map".asc),
-    "sort" :: "type" :: "map<int,int>" :: Nil)
-
-  errorTest(
     "sorting by attributes are not from grouping expressions",
     testRelation2.groupBy($"a", $"c")($"a", $"c", count($"a").as("a3")).orderBy($"b".asc),
     "cannot resolve" :: "'b'" :: "given input columns" :: "[a, a3, c]" :: Nil)
@@ -621,24 +616,6 @@ class AnalysisErrorSuite extends AnalysisTest {
       plan,
       "It is not allowed to use an aggregate function in the argument of " +
         "another aggregate function." :: Nil)
-  }
-
-  test("Join can work on binary types but can't work on map types") {
-    val left = LocalRelation(Symbol("a").binary, Symbol("b").map(StringType, StringType))
-    val right = LocalRelation(Symbol("c").binary, Symbol("d").map(StringType, StringType))
-
-    val plan1 = left.join(
-      right,
-      joinType = Cross,
-      condition = Some(Symbol("a") === Symbol("c")))
-
-    assertAnalysisSuccess(plan1)
-
-    val plan2 = left.join(
-      right,
-      joinType = Cross,
-      condition = Some(Symbol("b") === Symbol("d")))
-    assertAnalysisError(plan2, "EqualTo does not support ordering on type map" :: Nil)
   }
 
   test("PredicateSubQuery is used outside of a filter") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -113,19 +113,6 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
     assertErrorForDifferingTypes(GreaterThan(Symbol("intField"), Symbol("booleanField")))
     assertErrorForDifferingTypes(GreaterThanOrEqual(Symbol("intField"), Symbol("booleanField")))
 
-    assertError(EqualTo(Symbol("mapField"), Symbol("mapField")),
-      "EqualTo does not support ordering on type map")
-    assertError(EqualNullSafe(Symbol("mapField"), Symbol("mapField")),
-      "EqualNullSafe does not support ordering on type map")
-    assertError(LessThan(Symbol("mapField"), Symbol("mapField")),
-      "LessThan does not support ordering on type map")
-    assertError(LessThanOrEqual(Symbol("mapField"), Symbol("mapField")),
-      "LessThanOrEqual does not support ordering on type map")
-    assertError(GreaterThan(Symbol("mapField"), Symbol("mapField")),
-      "GreaterThan does not support ordering on type map")
-    assertError(GreaterThanOrEqual(Symbol("mapField"), Symbol("mapField")),
-      "GreaterThanOrEqual does not support ordering on type map")
-
     assertError(If(Symbol("intField"), Symbol("stringField"), Symbol("stringField")),
       "type of predicate expression in If should be boolean")
     assertErrorForDifferingTypes(
@@ -227,8 +214,6 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
       assertError(operator(Seq(Symbol("booleanField"))), "requires at least two arguments")
       assertError(operator(Seq(Symbol("intField"), Symbol("stringField"))),
         "should all have the same type")
-      assertError(operator(Seq(Symbol("mapField"), Symbol("mapField"))),
-        "does not support ordering")
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -143,8 +143,8 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
     assertSuccess(new BoolAnd(Symbol("booleanField")))
     assertSuccess(new BoolOr(Symbol("booleanField")))
 
-    assertError(Min(Symbol("mapField")), "min does not support ordering on type")
-    assertError(Max(Symbol("mapField")), "max does not support ordering on type")
+    assertSuccess(Min(Symbol("mapField")))
+    assertSuccess(Max(Symbol("mapField")))
     assertError(Sum(Symbol("booleanField")), "function sum requires numeric type")
     assertError(Average(Symbol("booleanField")), "function average requires numeric type")
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -233,14 +233,6 @@ class PredicateSuite extends SparkFunSuite with ExpressionEvalHelper {
         StructField("a", colOneType) :: StructField("b", colTwoType) :: Nil)
       testWithRandomDataGeneration(structType, nullable)
     }
-
-    // In doesn't support map type and will fail the analyzer.
-    val map = Literal.create(create_map(1 -> 1), MapType(IntegerType, IntegerType))
-    In(map, Seq(map)).checkInputDataTypes() match {
-      case TypeCheckResult.TypeCheckFailure(msg) =>
-        assert(msg.contains("function in does not support ordering on type map"))
-      case _ => fail("In should not work on map type")
-    }
   }
 
   test("switch statements in InSet for bytes, shorts, ints, dates") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeMapTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeMapTypeSuite.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types.{MapType, StringType}
+
+class NormalizeMapTypeSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("NormalizeMapType", Once, NormalizeMapType) :: Nil
+  }
+
+  val testRelation1 = LocalRelation('a.int, 'm.map(MapType(StringType, StringType, false)))
+  val a1 = testRelation1.output(0)
+  val m1 = testRelation1.output(1)
+
+  val testRelation2 = LocalRelation('a.int, 'm.map(MapType(StringType, StringType, false)))
+  val a2 = testRelation2.output(0)
+  val m2 = testRelation2.output(1)
+
+  test("normalize map types in window function expressions") {
+    val query = testRelation1.window(Seq(sum(a1).as("sum")), Seq(m1), Seq(m1.asc))
+    val optimized = Optimize.execute(query)
+    val correctAnswer = testRelation1.window(Seq(sum(a1).as("sum")),
+      Seq(SortMapKey(m1)), Seq(m1.asc))
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("normalize map types in window function expressions - idempotence") {
+    val query = testRelation1.window(Seq(sum(a1).as("sum")), Seq(m1), Seq(m1.asc))
+    val optimized = Optimize.execute(query)
+    val doubleOptimized = Optimize.execute(optimized)
+    val correctAnswer = testRelation1.window(Seq(sum(a1).as("sum")),
+      Seq(SortMapKey(m1)), Seq(m1.asc))
+
+    comparePlans(doubleOptimized, correctAnswer)
+  }
+
+  test("normalize map types in join keys") {
+    val query = testRelation1.join(testRelation2, condition = Some(m1 === m2))
+
+    val optimized = Optimize.execute(query)
+    val joinCond = Some(SortMapKey(m1) === SortMapKey(m2))
+    val correctAnswer = testRelation1.join(testRelation2, condition = joinCond)
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("normalize map types in join keys - idempotence") {
+    val query = testRelation1.join(testRelation2, condition = Some(m1 === m2))
+
+    val optimized = Optimize.execute(query)
+    val doubleOptimized = Optimize.execute(optimized)
+    val joinCond = Some(SortMapKey(m1) === SortMapKey(m2))
+    val correctAnswer = testRelation1.join(testRelation2, condition = joinCond)
+
+    comparePlans(doubleOptimized, correctAnswer)
+  }
+}
+
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -333,8 +333,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
 
         val stateVersion = conf.getConf(SQLConf.STREAMING_AGGREGATION_STATE_FORMAT_VERSION)
 
-        // Ideally this should be done in `NormalizeFloatingNumbers`, but we do it here because
-        // `groupingExpressions` is not extracted during logical phase.
+        // Ideally this should be done in `NormalizeFloatingNumbers` and `NormalizeMapType`,
+        // but we do it here because `groupingExpressions` is not extracted during logical phase.
         val normalizedGroupingExpressions = namedGroupingExpressions.map { e =>
           NormalizeFloatingNumbers.normalize(e) match {
             case n: NamedExpression => n
@@ -446,8 +446,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
               "Spark user mailing list.")
         }
 
-        // Ideally this should be done in `NormalizeFloatingNumbers`, but we do it here because
-        // `groupingExpressions` is not extracted during logical phase.
+        // Ideally this should be done in `NormalizeFloatingNumbers` and `NormalizeMapType`,
+        // but we do it here because `groupingExpressions` is not extracted during logical phase.
         val normalizedGroupingExpressions = groupingExpressions.map { e =>
           NormalizeFloatingNumbers.normalize(e) match {
             case n: NamedExpression => n
@@ -478,8 +478,9 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             val distinctExpressions =
               functionsWithDistinct.head.aggregateFunction.children.filterNot(_.foldable)
             val normalizedNamedDistinctExpressions = distinctExpressions.map { e =>
-              // Ideally this should be done in `NormalizeFloatingNumbers`, but we do it here
-              // because `distinctExpressions` is not extracted during logical phase.
+              // Ideally this should be done in `NormalizeFloatingNumbers` and `NormalizeMapType`,
+              // but we do it here because `distinctExpressions` is not extracted during
+              // logical phase.
               NormalizeFloatingNumbers.normalize(e) match {
                 case ne: NamedExpression => ne
                 case other =>

--- a/sql/core/src/test/resources/sql-tests/results/pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pivot.sql.out
@@ -455,10 +455,10 @@ PIVOT (
   FOR m IN (map('1', 1), map('2', 2))
 )
 -- !query schema
-struct<>
+struct<year:int,{1 -> 1}:bigint,{2 -> 2}:bigint>
 -- !query output
-org.apache.spark.sql.AnalysisException
-Invalid pivot column 'm#x'. Pivot columns must be comparable.
+2012	35000	NULL
+2013	NULL	78000
 
 
 -- !query
@@ -472,10 +472,10 @@ PIVOT (
   FOR (course, m) IN (('dotNET', map('1', 1)), ('Java', map('2', 2)))
 )
 -- !query schema
-struct<>
+struct<year:int,{dotNET, {1 -> 1}}:bigint,{Java, {2 -> 2}}:bigint>
 -- !query output
-org.apache.spark.sql.AnalysisException
-Invalid pivot column 'named_struct(course, course#x, m, m#x)'. Pivot columns must be comparable.
+2012	15000	NULL
+2013	NULL	30000
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-pivot.sql.out
@@ -421,10 +421,10 @@ PIVOT (
   FOR m IN (map('1', 1), map('2', 2))
 )
 -- !query schema
-struct<>
+struct<year:int,{1 -> 1}:bigint,{2 -> 2}:bigint>
 -- !query output
-org.apache.spark.sql.AnalysisException
-Invalid pivot column 'm#x'. Pivot columns must be comparable.
+2012	35000	NULL
+2013	NULL	78000
 
 
 -- !query
@@ -438,10 +438,10 @@ PIVOT (
   FOR (course, m) IN (('dotNET', map('1', 1)), ('Java', map('2', 2)))
 )
 -- !query schema
-struct<>
+struct<year:int,{dotNET, {1 -> 1}}:bigint,{Java, {2 -> 2}}:bigint>
 -- !query output
-org.apache.spark.sql.AnalysisException
-Invalid pivot column 'named_struct(course, course#x, m, m#x)'. Pivot columns must be comparable.
+2012	15000	NULL
+2013	NULL	30000
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -3038,11 +3038,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
       df.select(map_zip_with(col("mis"), col("i"), (x, y, z) => concat(x, y, z)))
     }
     assert(ex4a.getMessage.contains("type mismatch: argument 2 requires map type"))
-
-    val ex5 = intercept[AnalysisException] {
-      df.selectExpr("map_zip_with(mmi, mmi, (x, y, z) -> x)")
-    }
-    assert(ex5.getMessage.contains("function map_zip_with does not support ordering on type map"))
   }
 
   test("transform keys function - primitive data types") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -347,23 +347,24 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
     dates.intersect(widenTypedRows).collect()
   }
 
-  test("SPARK-19893: cannot run set operations with map type") {
-    val df = spark.range(1).select(map(lit("key"), $"id").as("m"))
-    val e = intercept[AnalysisException](df.intersect(df))
-    assert(e.message.contains(
-      "Cannot have map type columns in DataFrame which calls set operations"))
-    val e2 = intercept[AnalysisException](df.except(df))
-    assert(e2.message.contains(
-      "Cannot have map type columns in DataFrame which calls set operations"))
-    val e3 = intercept[AnalysisException](df.distinct())
-    assert(e3.message.contains(
-      "Cannot have map type columns in DataFrame which calls set operations"))
-    withTempView("v") {
-      df.createOrReplaceTempView("v")
-      val e4 = intercept[AnalysisException](sql("SELECT DISTINCT m FROM v"))
-      assert(e4.message.contains(
-        "Cannot have map type columns in DataFrame which calls set operations"))
-    }
+  test("SPARK-34819: set operations with map type") {
+    val df = spark.range(0, 2).select(map(lit("key"), $"id").as("m"))
+    val df2 = spark.range(1, 2).select(map(lit("key"), $"id").as("m"))
+    checkAnswer(
+      df.intersect(df2),
+      Row(Map("key" -> "1")) :: Nil
+    )
+
+    checkAnswer(
+      df.except(df2),
+      Row(Map("key" -> "0")) :: Nil
+    )
+
+    checkAnswer(
+      df.distinct(),
+      Row(Map("key" -> "0")) ::
+        Row(Map("key" -> "1")) :: Nil
+    )
   }
 
   test("union all") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -348,22 +348,22 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-34819: set operations with map type") {
-    val df = spark.range(0, 2).select(map(lit("key"), $"id").as("m"))
-    val df2 = spark.range(1, 2).select(map(lit("key"), $"id").as("m"))
+    val df = Seq(Map("a" -> 1, "b" -> 2), Map("c" -> 3)).toDF("m")
+    val df2 = Seq(Map("b" -> 2, "a" -> 1), Map("c" -> 4)).toDF("m")
     checkAnswer(
       df.intersect(df2),
-      Row(Map("key" -> "1")) :: Nil
+      Row(Map("a" -> 1, "b" -> 2)) :: Nil
     )
 
     checkAnswer(
       df.except(df2),
-      Row(Map("key" -> "0")) :: Nil
+      Row(Map("c" -> 3)) :: Nil
     )
 
     checkAnswer(
       df.distinct(),
-      Row(Map("key" -> "0")) ::
-        Row(Map("key" -> "1")) :: Nil
+      Row(Map("a" -> 1, "b" -> 2)) ::
+        Row(Map("c" -> 3)) :: Nil
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -1043,6 +1043,18 @@ class DataFrameWindowFunctionsSuite extends QueryTest
       Seq(
         Row(Seq(-0.0f, 0.0f), Row(-0.0d, Double.NaN), Seq(Row(-0.0d, Double.NaN)), 2),
         Row(Seq(0.0f, -0.0f), Row(0.0d, Double.NaN), Seq(Row(0.0d, 0.0/0.0)), 2)))
+
+    // test with df with map type columns.
+    val df3 = Seq(
+      (Map("a" -> 0.0f, "b" -> -0.0f), Map(-0.0d -> Double.NaN)),
+      (Map("a" -> -0.0f, "b" -> 0.0f), Map(0.0d -> 0.0/0.0))
+    ).toDF("m1", "m2")
+    val windowSpec4 = Window.partitionBy("m1", "m2")
+    checkAnswer(
+      df3.select($"m1", $"m2", count(lit(1)).over(windowSpec4)),
+      Seq(
+        Row(Map("a" -> 0.0f, "b" -> -0.0f), Map(-0.0d -> Double.NaN), 2),
+        Row(Map("a" -> -0.0f, "b" -> 0.0f), Map(0.0d -> 0.0/0.0), 2)))
   }
 
   test("SPARK-34227: WindowFunctionFrame should clear its states during preparation") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -513,7 +513,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       Row("1"))
   }
 
-  def sorttest(): Unit = {
+  def sortTest(): Unit = {
     checkAnswer(
       sql("SELECT * FROM testData2 ORDER BY a ASC, b ASC"),
       Seq(Row(1, 1), Row(1, 2), Row(2, 1), Row(2, 2), Row(3, 1), Row(3, 2)))
@@ -556,7 +556,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   }
 
   test("external sorting") {
-    sorttest()
+    sortTest()
   }
 
   test("CTE feature") {
@@ -4119,7 +4119,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       }
     }
   }
-  
+
   test("SPARK-33482: Fix FileScan canonicalization") {
     withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
       withTempPath { path =>
@@ -4147,8 +4147,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     Seq(CodegenObjectFactoryMode.CODEGEN_ONLY.toString,
       CodegenObjectFactoryMode.NO_CODEGEN.toString).foreach {
       case codegenMode =>
-        withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> codegenMode,
-          SQLConf.USE_OBJECT_HASH_AGG.key -> "false") {
+        withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> codegenMode) {
           withTable("t", "t2") {
             val df = Seq(
               Map("a" -> 1, "b" -> 2, "c" -> 3),
@@ -4156,9 +4155,10 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
               Map("d" -> 4),
               Map("a" -> 1, "e" -> 2),
               Map("d" -> 4),
-              Map("d" -> 5)).toDF("m")
+              Map("d" -> 5)
+            ).toDF("m")
             val df2 = Seq(
-              Map("b" -> 2, "a" -> 1, "c" -> 3),
+              Map("b" -> 2, "a" -> 1, "c" -> 3)
             ).toDF("m2")
             df.createOrReplaceTempView("t")
             df2.createOrReplaceTempView("t2")
@@ -4210,7 +4210,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
                   |)
                   |group by m2
                   |""".stripMargin),
-                Row(Map("a" -> 1, "b" -> 2, "c" -> 3), 6, 1.0)
+                Row(Map("a" -> 1, "b" -> 2, "c" -> 3), 6, 1.0) :: Nil
             )
 
             checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4226,8 +4226,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
             checkAnswer(
               sql("select m from t where m = map('b', 2, 'a', 1, 'c', 3)"),
-              Row(Map('a' -> 1, 'b' -> 2, 'c' -> 3)) ::
-                Row(Map('c' -> 3, 'b' -> 2, 'a' -> 3)) :: Nil
+              Row(Map("a" -> 1, "b" -> 2, "c" -> 3)) ::
+                Row(Map("c" -> 3, "b" -> 2, "a" -> 1)) :: Nil
             )
           }
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
@@ -91,11 +91,6 @@ abstract class BucketedWriteSuite extends QueryTest with SQLTestUtils {
     assert(e.getMessage == "sortBy must be used together with bucketBy")
   }
 
-  test("sorting by non-orderable column") {
-    val df = Seq("a" -> Map(1 -> 1), "b" -> Map(2 -> 2)).toDF("i", "j")
-    intercept[AnalysisException](df.write.bucketBy(2, "i").sortBy("j").saveAsTable("tt"))
-  }
-
   test("write bucketed data using save()") {
     val df = Seq(1 -> "a", 2 -> "b").toDF("i", "j")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently MapType doesn't support orderable semantics, while it's supported in Hive/Presto. This makes it hard to migrate from Hive to SparkSQL if user have groupby/orderby map type in their sql.


### Why are the changes needed?
Generally,  we compare two maps by the following steps:
1. If the size of two maps are not equal, compare them by size.
2. Otherwise, sort each map entry by map key, then compare two map entries one by one, first compare by key, then value.

We have to specially handle this in grouping/join/window because Spark SQL turns grouping/join/window partition keys into binary `UnsafeRow` and compare the binary data directly instead of using MapType's ordering. In this case, we have to insert a `SortMapKey` expression to sort map entry by key. This is very similiar to `NormalizeFloatingNumbers` 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add more UTs