### PR TITLE
[SPARK-34874][INFRA] Recover test reports for failed GA builds

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -15,6 +15,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         workflow: ${{ github.event.workflow_run.workflow_id }}
         commit: ${{ github.event.workflow_run.head_commit.id }}
+        workflow_conclusion: completed
     - name: Publish test report
       uses: scacap/action-surefire-report@v1
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://github.com/dawidd6/action-download-artifact/commit/621becc6d7c440318382ce6f4cb776f27dd3fef3#r48726074
there was a behaviour change in the download artifact plugin and it disabled the test reporting in failed builds.

This PR recovers it by explicitly setting the conclusion from the workflow runs to search for the artifacts to download.

### Why are the changes needed?

In order to properly report the failed test cases.

### Does this PR introduce _any_ user-facing change?

No, it's dev only.

### How was this patch tested?

Manually tested at https://github.com/HyukjinKwon/spark/pull/30

Before:

![Screen Shot 2021-03-26 at 10 54 48 AM](https://user-images.githubusercontent.com/6477701/112566110-b7951d80-8e21-11eb-8fad-f637db9314d5.png)

After:

![Screen Shot 2021-03-26 at 5 04 01 PM](https://user-images.githubusercontent.com/6477701/112606215-7588cd80-8e5b-11eb-8fdd-3afebd629f4f.png)


