### PR TITLE
[SPARK-34879][SQL] HiveInspector supports DayTimeIntervalType and YearMonthIntervalType

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -348,14 +348,14 @@ private[hive] trait HiveInspectors {
       case _: TimestampObjectInspector =>
         withNullSafe(o => DateTimeUtils.toJavaTimestamp(o.asInstanceOf[Long]))
       case _: HiveIntervalDayTimeObjectInspector  if x.preferWritable() =>
-        withNullSafe(o => getDayTimeIntervalWritable(o))
+        withNullSafe(o => getHiveIntervalDayTimeWritable(o))
       case _: HiveIntervalDayTimeObjectInspector =>
         withNullSafe(o => {
           val duration = IntervalUtils.microsToDuration(o.asInstanceOf[Long])
           new HiveIntervalDayTime(duration.getSeconds, duration.getNano)
         })
       case _: HiveIntervalYearMonthObjectInspector if x.preferWritable() =>
-        withNullSafe(o => getYearMonthIntervalWritable(o))
+        withNullSafe(o => getHiveIntervalYearMonthWritable(o))
       case _: HiveIntervalYearMonthObjectInspector =>
         withNullSafe(o => new HiveIntervalYearMonth(o.asInstanceOf[Int]))
       case _: VoidObjectInspector =>
@@ -890,9 +890,9 @@ private[hive] trait HiveInspectors {
     case Literal(_, NullType) =>
       getPrimitiveNullWritableConstantObjectInspector
     case Literal(_, DayTimeIntervalType) =>
-      getPrimitiveDayTimeIntervalWritableConstantObjectInspector
+      getHiveIntervalDayTimeWritableConstantObjectInspector
     case Literal(_, YearMonthIntervalType) =>
-      getPrimitiveYearMonthIntervalWritableConstantObjectInspector
+      getHiveIntervalYearMonthWritableConstantObjectInspector
     case Literal(value, ArrayType(dt, _)) =>
       val listObjectInspector = toInspector(dt)
       if (value == null) {
@@ -1034,11 +1034,11 @@ private[hive] trait HiveInspectors {
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
       TypeInfoFactory.voidTypeInfo, null)
 
-  private def getPrimitiveDayTimeIntervalWritableConstantObjectInspector: ObjectInspector =
+  private def getHiveIntervalDayTimeWritableConstantObjectInspector: ObjectInspector =
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
       TypeInfoFactory.intervalDayTimeTypeInfo, null)
 
-  private def getPrimitiveYearMonthIntervalWritableConstantObjectInspector: ObjectInspector =
+  private def getHiveIntervalYearMonthWritableConstantObjectInspector: ObjectInspector =
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
       TypeInfoFactory.intervalYearMonthTypeInfo, null)
 
@@ -1099,7 +1099,7 @@ private[hive] trait HiveInspectors {
       new hiveIo.TimestampWritable(DateTimeUtils.toJavaTimestamp(value.asInstanceOf[Long]))
     }
 
-  private def getDayTimeIntervalWritable(value: Any): hiveIo.HiveIntervalDayTimeWritable =
+  private def getHiveIntervalDayTimeWritable(value: Any): hiveIo.HiveIntervalDayTimeWritable =
     if (value == null) {
       null
     } else {
@@ -1108,7 +1108,7 @@ private[hive] trait HiveInspectors {
         new HiveIntervalDayTime(duration.getSeconds, duration.getNano))
     }
 
-  private def getYearMonthIntervalWritable(value: Any): hiveIo.HiveIntervalYearMonthWritable =
+  private def getHiveIntervalYearMonthWritable(value: Any): hiveIo.HiveIntervalYearMonthWritable =
     if (value == null) {
       null
     } else {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -18,11 +18,12 @@
 package org.apache.spark.sql.hive
 
 import java.lang.reflect.{ParameterizedType, Type, WildcardType}
+import java.time.Duration
 
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.{io => hadoopIo}
-import org.apache.hadoop.hive.common.`type`.{HiveChar, HiveDecimal, HiveVarchar}
+import org.apache.hadoop.hive.common.`type`.{HiveChar, HiveDecimal, HiveIntervalDayTime, HiveIntervalYearMonth, HiveVarchar}
 import org.apache.hadoop.hive.serde2.{io => hiveIo}
 import org.apache.hadoop.hive.serde2.objectinspector.{StructField => HiveStructField, _}
 import org.apache.hadoop.hive.serde2.objectinspector.primitive._
@@ -346,6 +347,20 @@ private[hive] trait HiveInspectors {
         withNullSafe(o => getTimestampWritable(o))
       case _: TimestampObjectInspector =>
         withNullSafe(o => DateTimeUtils.toJavaTimestamp(o.asInstanceOf[Long]))
+      case _: HiveIntervalDayTimeObjectInspector  if x.preferWritable() =>
+        withNullSafe(o => getDayTimeIntervalWritable(o))
+      case _: HiveIntervalDayTimeObjectInspector =>
+        withNullSafe(o => {
+          val duration = Duration.ofNanos(o.asInstanceOf[Long])
+          new HiveIntervalDayTime(duration.getSeconds, duration.getNano)
+        })
+      case _: HiveIntervalYearMonthObjectInspector if x.preferWritable() =>
+        withNullSafe(o => getYearMonthIntervalWritable(o))
+      case _: HiveIntervalYearMonthObjectInspector =>
+        withNullSafe(o => {
+          val period = IntervalUtils.monthsToPeriod(o.asInstanceOf[Int])
+          new HiveIntervalYearMonth(period.getYears, period.getMonths)
+        })
       case _: VoidObjectInspector =>
         (_: Any) => null // always be null for void object inspector
     }
@@ -512,6 +527,12 @@ private[hive] trait HiveInspectors {
         _ => constant
       case poi: VoidObjectInspector =>
         _ => null // always be null for void object inspector
+      case ym: WritableConstantHiveIntervalDayTimeObjectInspector =>
+        val constant = ym.getWritableConstantValue.asInstanceOf[HiveIntervalDayTime]
+        _ => constant.getTotalSeconds * DateTimeConstants.NANOS_PER_MICROS + constant.getNanos
+      case dt: WritableConstantHiveIntervalYearMonthObjectInspector =>
+        val constant = dt.getWritableConstantValue.asInstanceOf[HiveIntervalYearMonth]
+        _ => constant.getTotalMonths
       case pi: PrimitiveObjectInspector => pi match {
         // We think HiveVarchar/HiveChar is also a String
         case hvoi: HiveVarcharObjectInspector if hvoi.preferWritable() =>
@@ -643,6 +664,40 @@ private[hive] trait HiveInspectors {
           data: Any => {
             if (data != null) {
               DateTimeUtils.fromJavaTimestamp(ti.getPrimitiveJavaObject(data))
+            } else {
+              null
+            }
+          }
+        case dt: HiveIntervalDayTimeObjectInspector if dt.preferWritable() =>
+          data: Any => {
+            if (data != null) {
+              val dayTime = dt.getPrimitiveWritableObject(data).getHiveIntervalDayTime
+              dayTime.getTotalSeconds * DateTimeConstants.NANOS_PER_SECOND + dayTime.getNanos
+            } else {
+              null
+            }
+          }
+        case dt: HiveIntervalDayTimeObjectInspector =>
+          data: Any => {
+            if (data != null) {
+              val dayTime = dt.getPrimitiveJavaObject(data).asInstanceOf[HiveIntervalDayTime]
+              dayTime.getTotalSeconds * DateTimeConstants.NANOS_PER_SECOND + dayTime.getNanos
+            } else {
+              null
+            }
+          }
+        case ym: HiveIntervalYearMonthObjectInspector if ym.preferWritable() =>
+          data: Any => {
+            if (data != null) {
+              ym.getPrimitiveWritableObject(data).getHiveIntervalYearMonth.getTotalMonths
+            } else {
+              null
+            }
+          }
+        case ym: HiveIntervalYearMonthObjectInspector =>
+          data: Any => {
+            if (data != null) {
+              ym.getPrimitiveJavaObject(data).asInstanceOf[HiveIntervalYearMonth].getTotalMonths
             } else {
               null
             }
@@ -785,6 +840,10 @@ private[hive] trait HiveInspectors {
     case BinaryType => PrimitiveObjectInspectorFactory.javaByteArrayObjectInspector
     case DateType => PrimitiveObjectInspectorFactory.javaDateObjectInspector
     case TimestampType => PrimitiveObjectInspectorFactory.javaTimestampObjectInspector
+    case DayTimeIntervalType =>
+      PrimitiveObjectInspectorFactory.javaHiveIntervalDayTimeObjectInspector
+    case YearMonthIntervalType =>
+      PrimitiveObjectInspectorFactory.javaHiveIntervalYearMonthObjectInspector
     // TODO decimal precision?
     case DecimalType() => PrimitiveObjectInspectorFactory.javaHiveDecimalObjectInspector
     case StructType(fields) =>
@@ -830,6 +889,10 @@ private[hive] trait HiveInspectors {
       getDecimalWritableConstantObjectInspector(value)
     case Literal(_, NullType) =>
       getPrimitiveNullWritableConstantObjectInspector
+    case Literal(_, DayTimeIntervalType) =>
+      getPrimitiveDayTimeIntervalWritableConstantObjectInspector
+    case Literal(_, YearMonthIntervalType) =>
+      getPrimitiveYearMonthIntervalWritableConstantObjectInspector
     case Literal(value, ArrayType(dt, _)) =>
       val listObjectInspector = toInspector(dt)
       if (value == null) {
@@ -906,6 +969,10 @@ private[hive] trait HiveInspectors {
     case _: JavaDateObjectInspector => DateType
     case _: WritableTimestampObjectInspector => TimestampType
     case _: JavaTimestampObjectInspector => TimestampType
+    case _: WritableHiveIntervalDayTimeObjectInspector => DayTimeIntervalType
+    case _: JavaHiveIntervalDayTimeObjectInspector => DayTimeIntervalType
+    case _: WritableHiveIntervalYearMonthObjectInspector => YearMonthIntervalType
+    case _: JavaHiveIntervalYearMonthObjectInspector => YearMonthIntervalType
     case _: WritableVoidObjectInspector => NullType
     case _: JavaVoidObjectInspector => NullType
   }
@@ -967,6 +1034,14 @@ private[hive] trait HiveInspectors {
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
       TypeInfoFactory.voidTypeInfo, null)
 
+  private def getPrimitiveDayTimeIntervalWritableConstantObjectInspector: ObjectInspector =
+    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
+      TypeInfoFactory.intervalDayTimeTypeInfo, null)
+
+  private def getPrimitiveYearMonthIntervalWritableConstantObjectInspector: ObjectInspector =
+    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
+      TypeInfoFactory.intervalYearMonthTypeInfo, null)
+
   private def getStringWritable(value: Any): hadoopIo.Text =
     if (value == null) null else new hadoopIo.Text(value.asInstanceOf[UTF8String].getBytes)
 
@@ -1024,6 +1099,24 @@ private[hive] trait HiveInspectors {
       new hiveIo.TimestampWritable(DateTimeUtils.toJavaTimestamp(value.asInstanceOf[Long]))
     }
 
+  private def getDayTimeIntervalWritable(value: Any): hiveIo.HiveIntervalDayTimeWritable =
+    if (value == null) {
+      null
+    } else {
+      val duration = Duration.ofNanos(value.asInstanceOf[Long])
+      new hiveIo.HiveIntervalDayTimeWritable(
+        new HiveIntervalDayTime(duration.getSeconds, duration.getNano))
+    }
+
+  private def getYearMonthIntervalWritable(value: Any): hiveIo.HiveIntervalYearMonthWritable =
+    if (value == null) {
+      null
+    } else {
+      val period = IntervalUtils.monthsToPeriod(value.asInstanceOf[Int])
+      new hiveIo.HiveIntervalYearMonthWritable(
+        new HiveIntervalYearMonth(period.getYears, period.getMonths))
+    }
+
   private def getDecimalWritable(value: Any): hiveIo.HiveDecimalWritable =
     if (value == null) {
       null
@@ -1064,6 +1157,8 @@ private[hive] trait HiveInspectors {
       case DateType => dateTypeInfo
       case TimestampType => timestampTypeInfo
       case NullType => voidTypeInfo
+      case DayTimeIntervalType => intervalDayTimeTypeInfo
+      case YearMonthIntervalType => intervalYearMonthTypeInfo
       case dt =>
         throw new AnalysisException(
           s"${dt.catalogString} cannot be converted to Hive TypeInfo")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -357,10 +357,7 @@ private[hive] trait HiveInspectors {
       case _: HiveIntervalYearMonthObjectInspector if x.preferWritable() =>
         withNullSafe(o => getYearMonthIntervalWritable(o))
       case _: HiveIntervalYearMonthObjectInspector =>
-        withNullSafe(o => {
-          val period = IntervalUtils.monthsToPeriod(o.asInstanceOf[Int])
-          new HiveIntervalYearMonth(period.getYears, period.getMonths)
-        })
+        withNullSafe(o => new HiveIntervalYearMonth(o.asInstanceOf[Int]))
       case _: VoidObjectInspector =>
         (_: Any) => null // always be null for void object inspector
     }
@@ -527,12 +524,12 @@ private[hive] trait HiveInspectors {
         _ => constant
       case poi: VoidObjectInspector =>
         _ => null // always be null for void object inspector
-      case ym: WritableConstantHiveIntervalDayTimeObjectInspector =>
-        val constant = ym.getWritableConstantValue.asInstanceOf[HiveIntervalDayTime]
+      case dt: WritableConstantHiveIntervalDayTimeObjectInspector =>
+        val constant = dt.getWritableConstantValue.asInstanceOf[HiveIntervalDayTime]
         _ => IntervalUtils.durationToMicros(
           Duration.ofSeconds(constant.getTotalSeconds).plusNanos(constant.getNanos.toLong))
-      case dt: WritableConstantHiveIntervalYearMonthObjectInspector =>
-        val constant = dt.getWritableConstantValue.asInstanceOf[HiveIntervalYearMonth]
+      case ym: WritableConstantHiveIntervalYearMonthObjectInspector =>
+        val constant = ym.getWritableConstantValue.asInstanceOf[HiveIntervalYearMonth]
         _ => constant.getTotalMonths
       case pi: PrimitiveObjectInspector => pi match {
         // We think HiveVarchar/HiveChar is also a String
@@ -1115,9 +1112,7 @@ private[hive] trait HiveInspectors {
     if (value == null) {
       null
     } else {
-      val period = IntervalUtils.monthsToPeriod(value.asInstanceOf[Int])
-      new hiveIo.HiveIntervalYearMonthWritable(
-        new HiveIntervalYearMonth(period.getYears, period.getMonths))
+      new hiveIo.HiveIntervalYearMonthWritable(new HiveIntervalYearMonth(value.asInstanceOf[Int]))
     }
 
   private def getDecimalWritable(value: Any): hiveIo.HiveDecimalWritable =

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
@@ -530,7 +530,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
 
   }
 
-  test("SPARK-34879: Hive inspect support DayTimeIntervalType and YearMonthIntervalType") {
+  test("SPARK-34879: Hive inspect supports DayTimeIntervalType and YearMonthIntervalType") {
     assume(TestUtils.testCommandAvailable("/bin/bash"))
     withTempView("v") {
       val df = Seq(
@@ -539,7 +539,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
       ).toDF("a", "b").select('a, 'b)
       df.createTempView("v")
 
-      // Hive serde support ArrayType/MapType/StructType as input and output data type
+      // Hive serde supports DayTimeIntervalType/YearMonthIntervalType as input and output data type
       checkAnswer(
         df,
         (child: SparkPlan) => createScriptTransformationExec(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
@@ -532,7 +532,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
 
   }
 
-  test("SPARK-34879: HiveInspector supports DayTimeIntervalType and YearMonthIntervalType") {
+  test("SPARK-34879: HiveInspectors supports DayTimeIntervalType and YearMonthIntervalType") {
     assume(TestUtils.testCommandAvailable("/bin/bash"))
     withTempView("v") {
       val df = Seq(
@@ -545,7 +545,6 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
           Duration.ofSeconds(Long.MaxValue / DateTimeConstants.MICROS_PER_SECOND),
           Period.ofMonths(10))
       ).toDF("a", "b", "c", "d")
-        .select($"a", $"b", $"c".cast(DayTimeIntervalType).as("c_1"), $"d")
       df.createTempView("v")
 
       // Hive serde supports DayTimeIntervalType/YearMonthIntervalType as input and output data type
@@ -555,21 +554,21 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
           input = Seq(
             df.col("a").expr,
             df.col("b").expr,
-            df.col("c_1").expr,
+            df.col("c").expr,
             df.col("d").expr),
           script = "cat",
           output = Seq(
             AttributeReference("a", DayTimeIntervalType)(),
             AttributeReference("b", DayTimeIntervalType)(),
-            AttributeReference("c_1", DayTimeIntervalType)(),
+            AttributeReference("c", DayTimeIntervalType)(),
             AttributeReference("d", YearMonthIntervalType)()),
           child = child,
           ioschema = hiveIOSchema),
-        df.select($"a", $"b", $"c_1", $"d").collect())
+        df.select($"a", $"b", $"c", $"d").collect())
     }
   }
 
-  test("SPARK-34879: HiveInceptor throw overflow when" +
+  test("SPARK-34879: HiveInspectors throw overflow when" +
     " HiveIntervalDayTime overflow then DayTimeIntervalType") {
     withTempView("v") {
       val df = Seq(("579025220 15:30:06.000001000")).toDF("a")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make HiveInspector support DayTimeIntervalType and YearMonthIntervalType.
Then we can use these two types in HiveUDF and HiveScriptTransformation


### Why are the changes needed?
Support more data type when use hive serde


### Does this PR introduce _any_ user-facing change?
User can use  `DayTimeIntervalType` and `YearMonthIntervalType` in HiveUDF and  HiveScriptTransformation


### How was this patch tested?
Added UT
