### PR TITLE
[SPARK-34888][SS] Introduce UpdatingSessionIterator adjusting session window on elements

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2000,6 +2000,26 @@ object SQLConf {
       .intConf
       .createWithDefault(SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD.defaultValue.get)
 
+  val SESSION_WINDOW_BUFFER_IN_MEMORY_THRESHOLD =
+    buildConf("spark.sql.sessionWindow.buffer.in.memory.threshold")
+      .internal()
+      .doc("Threshold for number of windows guaranteed to be held in memory by the " +
+        "session window operator. Note that the buffer is used only for the query Spark " +
+        "cannot apply aggregations on classifying session window.")
+      .version("3.2.0")
+      .intConf
+      .createWithDefault(4096)
+
+  val SESSION_WINDOW_BUFFER_SPILL_THRESHOLD =
+    buildConf("spark.sql.sessionWindow.buffer.spill.threshold")
+      .internal()
+      .doc("Threshold for number of rows to be spilled by window operator. Note that " +
+        "the buffer is used only for the query Spark cannot apply aggregations on classifying " +
+        "session window.")
+      .version("3.2.0")
+      .intConf
+      .createWithDefault(SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD.defaultValue.get)
+
   val SORT_MERGE_JOIN_EXEC_BUFFER_IN_MEMORY_THRESHOLD =
     buildConf("spark.sql.sortMergeJoinExec.buffer.in.memory.threshold")
       .internal()
@@ -3665,6 +3685,10 @@ class SQLConf extends Serializable with Logging {
   def windowExecBufferInMemoryThreshold: Int = getConf(WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD)
 
   def windowExecBufferSpillThreshold: Int = getConf(WINDOW_EXEC_BUFFER_SPILL_THRESHOLD)
+
+  def sessionWindowBufferInMemoryThreshold: Int = getConf(SESSION_WINDOW_BUFFER_IN_MEMORY_THRESHOLD)
+
+  def sessionWindowBufferSpillThreshold: Int = getConf(SESSION_WINDOW_BUFFER_SPILL_THRESHOLD)
 
   def sortMergeJoinExecBufferInMemoryThreshold: Int =
     getConf(SORT_MERGE_JOIN_EXEC_BUFFER_IN_MEMORY_THRESHOLD)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2005,7 +2005,7 @@ object SQLConf {
       .internal()
       .doc("Threshold for number of windows guaranteed to be held in memory by the " +
         "session window operator. Note that the buffer is used only for the query Spark " +
-        "cannot apply aggregations on classifying session window.")
+        "cannot apply aggregations on determining session window.")
       .version("3.2.0")
       .intConf
       .createWithDefault(4096)
@@ -2014,7 +2014,7 @@ object SQLConf {
     buildConf("spark.sql.sessionWindow.buffer.spill.threshold")
       .internal()
       .doc("Threshold for number of rows to be spilled by window operator. Note that " +
-        "the buffer is used only for the query Spark cannot apply aggregations on classifying " +
+        "the buffer is used only for the query Spark cannot apply aggregations on determining " +
         "session window.")
       .version("3.2.0")
       .intConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsExec.scala
@@ -73,4 +73,7 @@ case class UpdatingSessionsExec(
     Seq((groupingWithoutSessionAttributes ++ Seq(sessionExpression))
       .map(SortOrder(_, Ascending)))
   }
+
+  override protected def withNewChildInternal(newChild: SparkPlan): UpdatingSessionsExec =
+    copy(child = newChild)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsExec.scala
@@ -68,7 +68,8 @@ case class UpdatingSessionsExec(
   }
 
   override def requiredChildOrdering: Seq[Seq[SortOrder]] = {
-    Seq(groupingExpression.map(SortOrder(_, Ascending)))
+    Seq((groupingWithoutSessionAttributes ++ Seq(sessionExpression))
+      .map(SortOrder(_, Ascending)))
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): UpdatingSessionsExec =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsExec.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.aggregate
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, SortOrder}
+import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, Partitioning}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+
+/**
+ * This node updates the session window spec of each input rows via analyzing neighbor rows and
+ * determining rows belong to the same session window. The number of input rows remains the same.
+ * This node requires sort on input rows by group keys + the start time of session window.
+ *
+ * There are lots of overhead compared to [[MergingSessionsExec]]. Use [[MergingSessionsExec]]
+ * instead whenever possible. Use this node only when we cannot apply both calculations
+ * determining session windows and aggregating rows in session window altogether.
+ *
+ * Refer [[UpdatingSessionsIterator]] for more details.
+ */
+case class UpdatingSessionsExec(
+    keyExpressions: Seq[Attribute],
+    sessionExpression: Attribute,
+    child: SparkPlan) extends UnaryExecNode {
+
+  private val groupWithoutSessionExpression = keyExpressions.filterNot {
+    p => p.semanticEquals(sessionExpression)
+  }
+  private val groupingWithoutSessionAttributes = groupWithoutSessionExpression.map(_.toAttribute)
+
+  val childOrdering = Seq((groupingWithoutSessionAttributes ++ Seq(sessionExpression))
+    .map(SortOrder(_, Ascending)))
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    val inMemoryThreshold = sqlContext.conf.windowExecBufferInMemoryThreshold
+    val spillThreshold = sqlContext.conf.windowExecBufferSpillThreshold
+
+    child.execute().mapPartitions { iter =>
+      new UpdatingSessionsIterator(iter, keyExpressions, sessionExpression,
+        child.output, inMemoryThreshold, spillThreshold)
+    }
+  }
+
+  override def output: Seq[Attribute] = child.output
+
+  override def outputPartitioning: Partitioning = child.outputPartitioning
+
+  override def requiredChildDistribution: Seq[Distribution] = {
+    if (groupWithoutSessionExpression.isEmpty) {
+      AllTuples :: Nil
+    } else {
+      ClusteredDistribution(groupWithoutSessionExpression) :: Nil
+    }
+  }
+
+  override def requiredChildOrdering: Seq[Seq[SortOrder]] = {
+    Seq((groupingWithoutSessionAttributes ++ Seq(sessionExpression))
+      .map(SortOrder(_, Ascending)))
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsIterator.scala
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.aggregate
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
+import org.apache.spark.sql.execution.ExternalAppendOnlyUnsafeRowArray
+
+/**
+ * This class calculates and updates the session window for each element in the given iterator,
+ * which makes elements in the same session window having same session spec. Downstream can apply
+ * aggregation to finally merge these elements bound to the same session window.
+ *
+ * This class works on the precondition that given iterator is sorted by "group keys + start time
+ * of session window", and this iterator still retains the characteristic of the sort.
+ *
+ * This class copies the elements to safely update on each element, as well as buffers elements
+ * which are bound to the same session window. Due to such overheads, [[MergingSessionsIterator]]
+ * should be used whenever possible.
+ */
+class UpdatingSessionsIterator(
+    iter: Iterator[InternalRow],
+    groupingExpressions: Seq[NamedExpression],
+    sessionExpression: NamedExpression,
+    inputSchema: Seq[Attribute],
+    inMemoryThreshold: Int,
+    spillThreshold: Int) extends Iterator[InternalRow] {
+
+  private val groupingWithoutSession: Seq[NamedExpression] =
+    groupingExpressions.diff(Seq(sessionExpression))
+  private val groupingWithoutSessionAttributes: Seq[Attribute] =
+    groupingWithoutSession.map(_.toAttribute)
+  private[this] val groupingWithoutSessionProjection: UnsafeProjection =
+    UnsafeProjection.create(groupingWithoutSession, inputSchema)
+
+  private val valuesExpressions: Seq[Attribute] = inputSchema.diff(groupingWithoutSession)
+
+  private[this] val sessionProjection: UnsafeProjection =
+    UnsafeProjection.create(Seq(sessionExpression), inputSchema)
+
+  private var currentKeys: InternalRow = _
+  private var currentSession: UnsafeRow = _
+
+  private var currentRows: ExternalAppendOnlyUnsafeRowArray = new ExternalAppendOnlyUnsafeRowArray(
+    inMemoryThreshold, spillThreshold)
+
+  private var returnRows: ExternalAppendOnlyUnsafeRowArray = _
+  private var returnRowsIter: Iterator[InternalRow] = _
+  private var errorOnIterator: Boolean = false
+
+  private val processedKeys: mutable.HashSet[InternalRow] = new mutable.HashSet[InternalRow]()
+
+  override def hasNext: Boolean = {
+    assertIteratorNotCorrupted()
+
+    if (returnRowsIter != null && returnRowsIter.hasNext) {
+      return true
+    }
+
+    if (returnRowsIter != null) {
+      returnRowsIter = null
+      returnRows.clear()
+    }
+
+    iter.hasNext
+  }
+
+  override def next(): InternalRow = {
+    assertIteratorNotCorrupted()
+
+    if (returnRowsIter != null && returnRowsIter.hasNext) {
+      return returnRowsIter.next()
+    }
+
+    var exitCondition = false
+    while (iter.hasNext && !exitCondition) {
+      // we are going to modify the row, so we should make sure multiple objects are not
+      // referencing same memory, which could be possible when optimizing iterator
+      // without this, multiple rows in same key will be returned with same content
+      val row = iter.next().copy()
+
+      val keys = groupingWithoutSessionProjection(row)
+      val session = sessionProjection(row)
+      val sessionStruct = session.getStruct(0, 2)
+      val sessionStart = getSessionStart(sessionStruct)
+      val sessionEnd = getSessionEnd(sessionStruct)
+
+      if (currentKeys == null) {
+        startNewSession(row, keys, sessionStruct)
+      } else if (keys != currentKeys) {
+        closeCurrentSession(keyChanged = true)
+        processedKeys.add(currentKeys)
+        startNewSession(row, keys, sessionStruct)
+        exitCondition = true
+      } else {
+        if (sessionStart < getSessionStart(currentSession)) {
+          handleBrokenPreconditionForSort()
+        } else if (sessionStart <= getSessionEnd(currentSession)) {
+          // expanding session length if needed
+          expandEndOfCurrentSession(sessionEnd)
+          currentRows.add(row.asInstanceOf[UnsafeRow])
+        } else {
+          closeCurrentSession(keyChanged = false)
+          startNewSession(row, keys, sessionStruct)
+          exitCondition = true
+        }
+      }
+    }
+
+    if (!iter.hasNext) {
+      // no further row: closing session
+      closeCurrentSession(keyChanged = false)
+    }
+
+    // here returnRowsIter should be able to provide at least one row
+    require(returnRowsIter != null && returnRowsIter.hasNext)
+
+    returnRowsIter.next()
+  }
+
+  private def startNewSession(
+      currentRow: InternalRow,
+      groupingKey: UnsafeRow,
+      sessionStruct: UnsafeRow): Unit = {
+    if (processedKeys.contains(groupingKey)) {
+      handleBrokenPreconditionForSort()
+    }
+
+    currentKeys = groupingKey.copy()
+    currentSession = sessionStruct.copy()
+
+    currentRows.clear()
+    currentRows.add(currentRow.asInstanceOf[UnsafeRow])
+  }
+
+  private def getSessionStart(sessionStruct: UnsafeRow): Long = {
+    sessionStruct.getLong(0)
+  }
+
+  private def getSessionEnd(sessionStruct: UnsafeRow): Long = {
+    sessionStruct.getLong(1)
+  }
+
+  def updateSessionEnd(sessionStruct: UnsafeRow, sessionEnd: Long): Unit = {
+    sessionStruct.setLong(1, sessionEnd)
+  }
+
+  private def expandEndOfCurrentSession(sessionEnd: Long): Unit = {
+    if (sessionEnd > getSessionEnd(currentSession)) {
+      updateSessionEnd(currentSession, sessionEnd)
+    }
+  }
+
+  private def handleBrokenPreconditionForSort(): Unit = {
+    errorOnIterator = true
+    throw new IllegalStateException("The iterator must be sorted by key and session start!")
+  }
+
+  private val join = new JoinedRow
+  private val join2 = new JoinedRow
+
+  private val groupingKeyProj = GenerateUnsafeProjection.generate(groupingExpressions,
+    groupingWithoutSessionAttributes :+ sessionExpression.toAttribute)
+  private val valueProj = GenerateUnsafeProjection.generate(valuesExpressions, inputSchema)
+  private val restoreProj = GenerateUnsafeProjection.generate(inputSchema,
+    groupingExpressions.map(_.toAttribute) ++ valuesExpressions.map(_.toAttribute))
+
+  private def generateGroupingKey(): UnsafeRow = {
+    val newRow = new SpecificInternalRow(Seq(sessionExpression.toAttribute).toStructType)
+    newRow.update(0, currentSession)
+    val joined = join(currentKeys, newRow)
+
+    groupingKeyProj(joined)
+  }
+
+  private def closeCurrentSession(keyChanged: Boolean): Unit = {
+    returnRows = currentRows
+    currentRows = new ExternalAppendOnlyUnsafeRowArray(
+      inMemoryThreshold, spillThreshold)
+
+    val groupingKey = generateGroupingKey()
+
+    val currentRowsIter = returnRows.generateIterator().map { internalRow =>
+      val valueRow = valueProj(internalRow)
+      restoreProj(join2(groupingKey, valueRow)).copy()
+    }
+
+    if (returnRowsIter != null && returnRowsIter.hasNext) {
+      returnRowsIter = returnRowsIter ++ currentRowsIter
+    } else {
+      returnRowsIter = currentRowsIter
+    }
+
+    if (keyChanged) processedKeys.add(currentKeys)
+
+    currentKeys = null
+    currentSession = null
+  }
+
+  private def assertIteratorNotCorrupted(): Unit = {
+    if (errorOnIterator) {
+      throw new IllegalStateException("The iterator is already corrupted.")
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/UpdatingSessionsIteratorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/UpdatingSessionsIteratorSuite.scala
@@ -1,0 +1,433 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import java.util.Properties
+
+import org.apache.spark._
+import org.apache.spark.memory.{TaskMemoryManager, TestMemoryManager}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
+import org.apache.spark.sql.execution.aggregate.UpdatingSessionsIterator
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+
+class UpdatingSessionsIteratorSuite extends SharedSparkSession {
+
+  val rowSchema = new StructType().add("key1", StringType).add("key2", IntegerType)
+    .add("session", new StructType().add("start", LongType).add("end", LongType))
+    .add("aggVal1", LongType).add("aggVal2", DoubleType)
+  val rowAttributes = rowSchema.toAttributes
+
+  val keysWithSessionSchema = rowSchema.filter { attr =>
+    List("key1", "key2", "session").contains(attr.name)
+  }
+  val keysWithSessionAttributes = rowAttributes.filter { attr =>
+    List("key1", "key2", "session").contains(attr.name)
+  }
+
+  val sessionSchema = rowSchema.filter(st => st.name == "session").head
+  val sessionAttribute = rowAttributes.filter(attr => attr.name == "session").head
+
+  val valuesSchema = rowSchema.filter(st => List("aggVal1", "aggVal2").contains(st.name))
+  val valuesAttributes = rowAttributes.filter {
+    attr => List("aggVal1", "aggVal2").contains(attr.name)
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val taskManager = new TaskMemoryManager(new TestMemoryManager(sqlContext.sparkContext.conf), 0)
+    TaskContext.setTaskContext(
+      new TaskContextImpl(0, 0, 0, 0, 0, taskManager, new Properties, null))
+  }
+
+  override def afterAll(): Unit = try {
+    TaskContext.unset()
+  } finally {
+    super.afterAll()
+  }
+
+  // just copying default values to avoid bothering with SQLContext
+  val inMemoryThreshold = 4096
+  val spillThreshold = Int.MaxValue
+
+  test("no row") {
+    val iterator = new UpdatingSessionsIterator(None.iterator, keysWithSessionAttributes,
+      sessionAttribute, rowAttributes, inMemoryThreshold, spillThreshold)
+
+    assert(!iterator.hasNext)
+  }
+
+  test("only one row") {
+    val rows = List(createRow("a", 1, 100, 110, 10, 1.1))
+
+    val iterator = new UpdatingSessionsIterator(rows.iterator, keysWithSessionAttributes,
+      sessionAttribute, rowAttributes, inMemoryThreshold, spillThreshold)
+
+    assert(iterator.hasNext)
+
+    val retRow = iterator.next()
+    assertRowsEquals(retRow, rows.head)
+
+    assert(!iterator.hasNext)
+  }
+
+  test("one session per key, one key") {
+    val row1 = createRow("a", 1, 100, 110, 10, 1.1)
+    val row2 = createRow("a", 1, 100, 110, 20, 1.2)
+    val row3 = createRow("a", 1, 105, 115, 30, 1.3)
+    val row4 = createRow("a", 1, 113, 123, 40, 1.4)
+    val rows = List(row1, row2, row3, row4)
+
+    val iterator = new UpdatingSessionsIterator(rows.iterator, keysWithSessionAttributes,
+      sessionAttribute, rowAttributes, inMemoryThreshold, spillThreshold)
+
+    val retRows = rows.indices.map { _ =>
+      assert(iterator.hasNext)
+      iterator.next()
+    }
+
+    retRows.zip(rows).foreach { case (retRow, expectedRow) =>
+      // session being expanded to (100 ~ 123)
+      assertRowsEqualsWithNewSession(expectedRow, retRow, 100, 123)
+    }
+
+    assert(iterator.hasNext === false)
+  }
+
+  test("one session per key, multi keys") {
+    val row1 = createRow("a", 1, 100, 110, 10, 1.1)
+    val row2 = createRow("a", 1, 100, 110, 20, 1.2)
+    val row3 = createRow("a", 1, 105, 115, 30, 1.3)
+    val row4 = createRow("a", 1, 113, 123, 40, 1.4)
+    val rows1 = List(row1, row2, row3, row4)
+
+    val row5 = createRow("a", 2, 110, 120, 10, 1.1)
+    val row6 = createRow("a", 2, 115, 125, 20, 1.2)
+    val row7 = createRow("a", 2, 117, 127, 30, 1.3)
+    val row8 = createRow("a", 2, 125, 135, 40, 1.4)
+    val rows2 = List(row5, row6, row7, row8)
+
+    val rowsAll = rows1 ++ rows2
+
+    val iterator = new UpdatingSessionsIterator(rowsAll.iterator, keysWithSessionAttributes,
+      sessionAttribute, rowAttributes, inMemoryThreshold, spillThreshold)
+
+    val retRows1 = rows1.indices.map { _ =>
+      assert(iterator.hasNext)
+      iterator.next()
+    }
+    val retRows2 = rows2.indices.map { _ =>
+      assert(iterator.hasNext)
+      iterator.next()
+    }
+
+    retRows1.zip(rows1).foreach { case (retRow, expectedRow) =>
+      // session being expanded to (100 ~ 123)
+      assertRowsEqualsWithNewSession(expectedRow, retRow, 100, 123)
+    }
+
+    retRows2.zip(rows2).foreach { case (retRow, expectedRow) =>
+      // session being expanded to (110 ~ 135)
+      assertRowsEqualsWithNewSession(expectedRow, retRow, 110, 135)
+    }
+
+    assert(iterator.hasNext === false)
+  }
+
+  test("multiple sessions per key, single key") {
+    val row1 = createRow("a", 1, 100, 110, 10, 1.1)
+    val row2 = createRow("a", 1, 105, 115, 20, 1.2)
+    val rows1 = List(row1, row2)
+
+    val row3 = createRow("a", 1, 125, 135, 30, 1.3)
+    val row4 = createRow("a", 1, 127, 137, 40, 1.4)
+    val rows2 = List(row3, row4)
+
+    val rowsAll = rows1 ++ rows2
+
+    val iterator = new UpdatingSessionsIterator(rowsAll.iterator, keysWithSessionAttributes,
+      sessionAttribute, rowAttributes, inMemoryThreshold, spillThreshold)
+
+    val retRows1 = rows1.indices.map { _ =>
+      assert(iterator.hasNext)
+      iterator.next()
+    }
+
+    val retRows2 = rows2.indices.map { _ =>
+      assert(iterator.hasNext)
+      iterator.next()
+    }
+
+    retRows1.zip(rows1).foreach { case (retRow, expectedRow) =>
+      // session being expanded to (100 ~ 115)
+      assertRowsEqualsWithNewSession(expectedRow, retRow, 100, 115)
+    }
+
+    retRows2.zip(rows2).foreach { case (retRow, expectedRow) =>
+      // session being expanded to (125 ~ 137)
+      assertRowsEqualsWithNewSession(expectedRow, retRow, 125, 137)
+    }
+
+    assert(iterator.hasNext === false)
+  }
+
+  test("multiple sessions per key, multi keys") {
+    val row1 = createRow("a", 1, 100, 110, 10, 1.1)
+    val row2 = createRow("a", 1, 100, 110, 20, 1.2)
+    val rows1 = List(row1, row2)
+
+    val row3 = createRow("a", 1, 115, 125, 30, 1.3)
+    val row4 = createRow("a", 1, 119, 129, 40, 1.4)
+    val rows2 = List(row3, row4)
+
+    val row5 = createRow("a", 2, 110, 120, 10, 1.1)
+    val row6 = createRow("a", 2, 115, 125, 20, 1.2)
+    val rows3 = List(row5, row6)
+
+    val row7 = createRow("a", 2, 127, 137, 30, 1.3)
+    val row8 = createRow("a", 2, 135, 145, 40, 1.4)
+    val rows4 = List(row7, row8)
+
+    val rowsAll = rows1 ++ rows2 ++ rows3 ++ rows4
+
+    val iterator = new UpdatingSessionsIterator(rowsAll.iterator, keysWithSessionAttributes,
+      sessionAttribute, rowAttributes, inMemoryThreshold, spillThreshold)
+
+    val retRows1 = rows1.indices.map { _ =>
+      assert(iterator.hasNext)
+      iterator.next()
+    }
+
+    val retRows2 = rows2.indices.map { _ =>
+      assert(iterator.hasNext)
+      iterator.next()
+    }
+
+    val retRows3 = rows3.indices.map { _ =>
+      assert(iterator.hasNext)
+      iterator.next()
+    }
+
+    val retRows4 = rows4.indices.map { _ =>
+      assert(iterator.hasNext)
+      iterator.next()
+    }
+
+    retRows1.zip(rows1).foreach { case (retRow, expectedRow) =>
+      // session being expanded to (100 ~ 110)
+      assertRowsEqualsWithNewSession(expectedRow, retRow, 100, 110)
+    }
+
+    retRows2.zip(rows2).foreach { case (retRow, expectedRow) =>
+      // session being expanded to (115 ~ 129)
+      assertRowsEqualsWithNewSession(expectedRow, retRow, 115, 129)
+    }
+
+    retRows3.zip(rows3).foreach { case (retRow, expectedRow) =>
+      // session being expanded to (110 ~ 125)
+      assertRowsEqualsWithNewSession(expectedRow, retRow, 110, 125)
+    }
+
+    retRows4.zip(rows4).foreach { case (retRow, expectedRow) =>
+      // session being expanded to (127 ~ 145)
+      assertRowsEqualsWithNewSession(expectedRow, retRow, 127, 145)
+    }
+
+    assert(iterator.hasNext === false)
+  }
+
+  test("throws exception if data is not sorted by session start") {
+    val row1 = createRow("a", 1, 100, 110, 10, 1.1)
+    val row2 = createRow("a", 1, 100, 110, 20, 1.2)
+    val row3 = createRow("a", 1, 95, 105, 30, 1.3)
+    val row4 = createRow("a", 1, 113, 123, 40, 1.4)
+    val rows = List(row1, row2, row3, row4)
+
+    val iterator = new UpdatingSessionsIterator(rows.iterator, keysWithSessionAttributes,
+      sessionAttribute, rowAttributes, inMemoryThreshold, spillThreshold)
+
+    // UpdatingSessionIterator can't detect error on hasNext
+    assert(iterator.hasNext)
+
+    // when calling next() it can detect error and throws IllegalStateException
+    intercept[IllegalStateException] {
+      iterator.next()
+    }
+
+    // afterwards, calling either hasNext() or next() will throw IllegalStateException
+    intercept[IllegalStateException] {
+      iterator.hasNext
+    }
+
+    intercept[IllegalStateException] {
+      iterator.next()
+    }
+  }
+
+  test("throws exception if data is not sorted by key") {
+    val row1 = createRow("a", 1, 100, 110, 10, 1.1)
+    val row2 = createRow("a", 2, 100, 110, 20, 1.2)
+    val row3 = createRow("a", 1, 113, 123, 40, 1.4)
+    val rows = List(row1, row2, row3)
+
+    val iterator = new UpdatingSessionsIterator(rows.iterator, keysWithSessionAttributes,
+      sessionAttribute, rowAttributes, inMemoryThreshold, spillThreshold)
+
+    // UpdatingSessionIterator can't detect error on hasNext
+    assert(iterator.hasNext)
+
+    assertRowsEquals(row1, iterator.next())
+
+    assert(iterator.hasNext)
+
+    // second row itself is OK but while finding end of session it reads third row, and finds
+    // its key is already finished processing, hence precondition for sorting is broken, and
+    // it throws IllegalStateException
+    intercept[IllegalStateException] {
+      iterator.next()
+    }
+
+    // afterwards, calling either hasNext() or next() will throw IllegalStateException
+    intercept[IllegalStateException] {
+      iterator.hasNext
+    }
+
+    intercept[IllegalStateException] {
+      iterator.next()
+    }
+  }
+
+  test("no key") {
+    val noKeyRowSchema = new StructType()
+      .add("session", new StructType().add("start", LongType).add("end", LongType))
+      .add("aggVal1", LongType).add("aggVal2", DoubleType)
+    val noKeyRowAttributes = noKeyRowSchema.toAttributes
+
+    val noKeySessionAttribute = noKeyRowAttributes.filter(attr => attr.name == "session").head
+
+    def createNoKeyRow(
+        sessionStart: Long,
+        sessionEnd: Long,
+        aggVal1: Long,
+        aggVal2: Double): UnsafeRow = {
+      val genericRow = new GenericInternalRow(4)
+      val session: Array[Any] = new Array[Any](2)
+      session(0) = sessionStart
+      session(1) = sessionEnd
+
+      val sessionRow = new GenericInternalRow(session)
+      genericRow.update(0, sessionRow)
+
+      genericRow.setLong(1, aggVal1)
+      genericRow.setDouble(2, aggVal2)
+
+      val rowProjection = GenerateUnsafeProjection.generate(noKeyRowAttributes, noKeyRowAttributes)
+      rowProjection(genericRow)
+    }
+
+    def assertNoKeyRowsEqualsWithNewSession(
+        expectedRow: InternalRow,
+        retRow: InternalRow,
+        newSessionStart: Long,
+        newSessionEnd: Long): Unit = {
+      assert(retRow.getStruct(0, 2).getLong(0) == newSessionStart)
+      assert(retRow.getStruct(0, 2).getLong(1) == newSessionEnd)
+      assert(retRow.getLong(1) === expectedRow.getLong(1))
+      assert(doubleEquals(retRow.getDouble(2), expectedRow.getDouble(2)))
+    }
+
+    val row1 = createNoKeyRow(100, 110, 10, 1.1)
+    val row2 = createNoKeyRow(100, 110, 20, 1.2)
+    val row3 = createNoKeyRow(105, 115, 30, 1.3)
+    val row4 = createNoKeyRow(113, 123, 40, 1.4)
+    val rows = List(row1, row2, row3, row4)
+
+    val iterator = new UpdatingSessionsIterator(rows.iterator, Seq(noKeySessionAttribute),
+      noKeySessionAttribute, noKeyRowAttributes, inMemoryThreshold, spillThreshold)
+
+    val retRows = rows.indices.map { _ =>
+      assert(iterator.hasNext)
+      iterator.next()
+    }
+
+    retRows.zip(rows).foreach { case (retRow, expectedRow) =>
+      // session being expanded to (100 ~ 123)
+      assertNoKeyRowsEqualsWithNewSession(expectedRow, retRow, 100, 123)
+    }
+
+    assert(iterator.hasNext === false)
+  }
+
+  private def createRow(
+      key1: String,
+      key2: Int,
+      sessionStart: Long,
+      sessionEnd: Long,
+      aggVal1: Long,
+      aggVal2: Double): UnsafeRow = {
+    val genericRow = new GenericInternalRow(6)
+    if (key1 != null) {
+      genericRow.update(0, UTF8String.fromString(key1))
+    } else {
+      genericRow.setNullAt(0)
+    }
+    genericRow.setInt(1, key2)
+
+    val session: Array[Any] = new Array[Any](2)
+    session(0) = sessionStart
+    session(1) = sessionEnd
+
+    val sessionRow = new GenericInternalRow(session)
+    genericRow.update(2, sessionRow)
+
+    genericRow.setLong(3, aggVal1)
+    genericRow.setDouble(4, aggVal2)
+
+    val rowProjection = GenerateUnsafeProjection.generate(rowAttributes, rowAttributes)
+    rowProjection(genericRow)
+  }
+
+  private def doubleEquals(value1: Double, value2: Double): Boolean = {
+    value1 > value2 - 0.000001 && value1 < value2 + 0.000001
+  }
+
+  private def assertRowsEquals(expectedRow: InternalRow, retRow: InternalRow): Unit = {
+    assert(retRow.getString(0) === expectedRow.getString(0))
+    assert(retRow.getInt(1) === expectedRow.getInt(1))
+    assert(retRow.getStruct(2, 2).getLong(0) == expectedRow.getStruct(2, 2).getLong(0))
+    assert(retRow.getStruct(2, 2).getLong(1) == expectedRow.getStruct(2, 2).getLong(1))
+    assert(retRow.getLong(3) === expectedRow.getLong(3))
+    assert(doubleEquals(retRow.getDouble(3), expectedRow.getDouble(3)))
+  }
+
+  private def assertRowsEqualsWithNewSession(
+      expectedRow: InternalRow,
+      retRow: InternalRow,
+      newSessionStart: Long,
+      newSessionEnd: Long): Unit = {
+    assert(retRow.getString(0) === expectedRow.getString(0))
+    assert(retRow.getInt(1) === expectedRow.getInt(1))
+    assert(retRow.getStruct(2, 2).getLong(0) == newSessionStart)
+    assert(retRow.getStruct(2, 2).getLong(1) == newSessionEnd)
+    assert(retRow.getLong(3) === expectedRow.getLong(3))
+    assert(doubleEquals(retRow.getDouble(3), expectedRow.getDouble(3)))
+  }
+}


### PR DESCRIPTION
Introduction: this PR is a part of SPARK-10816 (`EventTime based sessionization (session window)`). Please refer #31937 to see the overall view of the code change. (Note that code diff could be diverged a bit.)

### What changes were proposed in this pull request?

This PR introduces UpdatingSessionsIterator, which analyzes neighbor elements and adjust session information on elements.

UpdatingSessionsIterator calculates and updates the session window for each element in the given iterator, which makes elements in the same session window having same session spec. Downstream can apply aggregation to finally merge these elements bound to the same session window.

UpdatingSessionsIterator works on the precondition that given iterator is sorted by "group keys + start time of session window", and the iterator still retains the characteristic of the sort.

UpdatingSessionsIterator copies the elements to safely update on each element, as well as buffers elements which are bound to the same session window. Due to such overheads, MergingSessionsIterator which will be introduced via SPARK-34889 should be used whenever possible.

This PR also introduces UpdatingSessionsExec which is the physical node on leveraging UpdatingSessionsIterator to sort the input rows and updates session information on input rows.

### Why are the changes needed?

This part is a one of required on implementing SPARK-10816.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test suite added.