### PR TITLE
[SPARK-34899][SQL] Use origin plan if we can not coalesce shuffle partition

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -72,14 +72,20 @@ case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffl
           validMetrics.toArray,
           advisoryTargetSize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES),
           minNumPartitions = minPartitionNum)
-        // This transformation adds new nodes, so we must use `transformUp` here.
-        val stageIds = shuffleStages.map(_.id).toSet
-        plan.transformUp {
-          // even for shuffle exchange whose input RDD has 0 partition, we should still update its
-          // `partitionStartIndices`, so that all the leaf shuffles in a stage have the same
-          // number of output partitions.
-          case stage: ShuffleQueryStageExec if stageIds.contains(stage.id) =>
-            CustomShuffleReaderExec(stage, partitionSpecs)
+        // We can never extend the shuffle partition number, so if we get the same number here,
+        // that means we can not coalesce shuffle partition. Just return the origin plan.
+        if (partitionSpecs.length == validMetrics.head.bytesByPartitionId.length) {
+          plan
+        } else {
+          // This transformation adds new nodes, so we must use `transformUp` here.
+          val stageIds = shuffleStages.map(_.id).toSet
+          plan.transformUp {
+            // even for shuffle exchange whose input RDD has 0 partition, we should still update its
+            // `partitionStartIndices`, so that all the leaf shuffles in a stage have the same
+            // number of output partitions.
+            case stage: ShuffleQueryStageExec if stageIds.contains(stage.id) =>
+              CustomShuffleReaderExec(stage, partitionSpecs)
+          }
         }
       } else {
         plan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -74,7 +74,7 @@ case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffl
           minNumPartitions = minPartitionNum)
         // We can never extend the shuffle partition number, so if we get the same number here,
         // that means we can not coalesce shuffle partition. Just return the origin plan.
-        if (partitionSpecs.length == validMetrics.head.bytesByPartitionId.length) {
+        if (partitionSpecs.length == distinctNumPreShufflePartitions.head) {
           plan
         } else {
           // This transformation adds new nodes, so we must use `transformUp` here.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
@@ -94,7 +94,7 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterAl
     }
 
     test(s"determining the number of reducers: aggregate operator$testNameNote") {
-      val test = { spark: SparkSession =>
+      val test: SparkSession => Unit = { spark: SparkSession =>
         val df =
           spark
             .range(0, 1000, 1, numInputPartitions)
@@ -113,14 +113,13 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterAl
         val shuffleReaders = finalPlan.collect {
           case r @ CoalescedShuffleReader() => r
         }
-        assert(shuffleReaders.length === 1)
+
         minNumPostShufflePartitions match {
           case Some(numPartitions) =>
-            shuffleReaders.foreach { reader =>
-              assert(reader.outputPartitioning.numPartitions === numPartitions)
-            }
+            assert(shuffleReaders.isEmpty)
 
           case None =>
+            assert(shuffleReaders.length === 1)
             shuffleReaders.foreach { reader =>
               assert(reader.outputPartitioning.numPartitions === 3)
             }
@@ -131,7 +130,7 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterAl
     }
 
     test(s"determining the number of reducers: join operator$testNameNote") {
-      val test = { spark: SparkSession =>
+      val test: SparkSession => Unit = { spark: SparkSession =>
         val df1 =
           spark
             .range(0, 1000, 1, numInputPartitions)
@@ -160,14 +159,13 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterAl
         val shuffleReaders = finalPlan.collect {
           case r @ CoalescedShuffleReader() => r
         }
-        assert(shuffleReaders.length === 2)
+
         minNumPostShufflePartitions match {
           case Some(numPartitions) =>
-            shuffleReaders.foreach { reader =>
-              assert(reader.outputPartitioning.numPartitions === numPartitions)
-            }
+            assert(shuffleReaders.isEmpty)
 
           case None =>
+            assert(shuffleReaders.length === 2)
             shuffleReaders.foreach { reader =>
               assert(reader.outputPartitioning.numPartitions === 2)
             }
@@ -212,14 +210,13 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterAl
         val shuffleReaders = finalPlan.collect {
           case r @ CoalescedShuffleReader() => r
         }
-        assert(shuffleReaders.length === 2)
+
         minNumPostShufflePartitions match {
           case Some(numPartitions) =>
-            shuffleReaders.foreach { reader =>
-              assert(reader.outputPartitioning.numPartitions === numPartitions)
-            }
+            assert(shuffleReaders.isEmpty)
 
           case None =>
+            assert(shuffleReaders.length === 2)
             shuffleReaders.foreach { reader =>
               assert(reader.outputPartitioning.numPartitions === 2)
             }
@@ -264,14 +261,13 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterAl
         val shuffleReaders = finalPlan.collect {
           case r @ CoalescedShuffleReader() => r
         }
-        assert(shuffleReaders.length === 2)
+
         minNumPostShufflePartitions match {
           case Some(numPartitions) =>
-            shuffleReaders.foreach { reader =>
-              assert(reader.outputPartitioning.numPartitions === numPartitions)
-            }
+            assert(shuffleReaders.isEmpty)
 
           case None =>
+            assert(shuffleReaders.length === 2)
             shuffleReaders.foreach { reader =>
               assert(reader.outputPartitioning.numPartitions === 3)
             }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1563,13 +1563,15 @@ class AdaptiveQueryExecSuite
 
     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "true",
-      SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "10",
+      SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "2258",
       SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1",
       SQLConf.SHUFFLE_PARTITIONS.key -> "2") {
       val df = spark.sparkContext.parallelize(
         (1 to 100).map(i => TestData(i, i.toString)), 10).toDF()
 
+      // partition size [1420, 1420]
       checkNoCoalescePartitions(df.repartition(), REPARTITION)
+      // partition size [1140, 1119]
       checkNoCoalescePartitions(df.sort($"key"), ENSURE_REQUIREMENTS)
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add check if `CoalesceShufflePartitions` really coalesce shuffle partition number.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The `CoalesceShufflePartitions` can not coalesce such case if the total shuffle partitions size of mappers are big enough. Then it's confused to use `CustomShuffleReaderExec` which marked as `coalesced` but has no affect with partition number.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Probably yes, the plan changed.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add test.