### PR TITLE
[SPARK-34902][SQL] Support cast between LongType & DayTimeIntervalType and IntegerType & YearMonthIntervalType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -534,17 +534,13 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   }
 
   private[this] def castToDayTimeInterval(from: DataType): Any => Any = from match {
-    case x: IntegralType if ansiEnabled =>
-      b => x.exactNumeric.asInstanceOf[Numeric[Any]].toLong(b)
     case x: IntegralType =>
-      b => x.numeric.asInstanceOf[Numeric[Any]].toLong(b)
+      b => x.exactNumeric.asInstanceOf[Numeric[Any]].toLong(b)
   }
 
   private[this] def castToYearMonthInterval(from: DataType): Any => Any = from match {
-    case x: IntegralType if ansiEnabled =>
-      b => x.exactNumeric.asInstanceOf[Numeric[Any]].toInt(b)
     case x: IntegralType =>
-      b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b)
+      b => x.exactNumeric.asInstanceOf[Numeric[Any]].toInt(b)
   }
 
   // LongConverter
@@ -646,12 +642,13 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case x: NumericType =>
       b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toShort
     case DayTimeIntervalType if ansiEnabled =>
-      b => val intValue = try {
-        LongExactNumeric.toInt(b.asInstanceOf[Long])
-      } catch {
-        case _: ArithmeticException =>
-          throw QueryExecutionErrors.castingCauseOverflowError(b, ShortType.catalogString)
-      }
+      b =>
+        val intValue = try {
+          LongExactNumeric.toInt(b.asInstanceOf[Long])
+        } catch {
+          case _: ArithmeticException =>
+            throw QueryExecutionErrors.castingCauseOverflowError(b, ShortType.catalogString)
+        }
         if (intValue == intValue.toShort) {
           intValue.toShort
         } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -592,10 +592,8 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       b => x.exactNumeric.asInstanceOf[Numeric[Any]].toInt(b)
     case x: NumericType =>
       b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b)
-    case DayTimeIntervalType if ansiEnabled =>
-      b => LongExactNumeric.toInt(b.asInstanceOf[Long])
     case DayTimeIntervalType =>
-      b => implicitly[Numeric[Long]].toInt(b.asInstanceOf[Long])
+      b => LongExactNumeric.toInt(b.asInstanceOf[Long])
     case YearMonthIntervalType =>
       b => b
   }
@@ -641,7 +639,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
         }
     case x: NumericType =>
       b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toShort
-    case DayTimeIntervalType if ansiEnabled =>
+    case DayTimeIntervalType =>
       b =>
         val intValue = try {
           LongExactNumeric.toInt(b.asInstanceOf[Long])
@@ -654,9 +652,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
         } else {
           throw QueryExecutionErrors.castingCauseOverflowError(b, ShortType.catalogString)
         }
-    case DayTimeIntervalType =>
-      b => implicitly[Numeric[Long]].toInt(b.asInstanceOf[Long]).toShort
-    case YearMonthIntervalType if ansiEnabled =>
+    case YearMonthIntervalType =>
       b =>
         val intValue = try {
           IntegerExactNumeric.toInt(b.asInstanceOf[Int])
@@ -669,8 +665,6 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
         } else {
           throw QueryExecutionErrors.castingCauseOverflowError(b, ShortType.catalogString)
         }
-    case YearMonthIntervalType =>
-      b => implicitly[Numeric[Int]].toInt(b.asInstanceOf[Int]).toShort
   }
 
   // ByteConverter
@@ -714,7 +708,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
         }
     case x: NumericType =>
       b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toByte
-    case DayTimeIntervalType if ansiEnabled =>
+    case DayTimeIntervalType =>
       b =>
         val intValue = try {
           LongExactNumeric.toInt(b.asInstanceOf[Long])
@@ -727,9 +721,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
         } else {
           throw QueryExecutionErrors.castingCauseOverflowError(b, ByteType.catalogString)
         }
-    case DayTimeIntervalType =>
-      b => implicitly[Numeric[Long]].toInt(b.asInstanceOf[Long]).toByte
-    case YearMonthIntervalType if ansiEnabled =>
+    case YearMonthIntervalType =>
       b =>
         val intValue = try {
           IntegerExactNumeric.toInt(b.asInstanceOf[Int])
@@ -742,8 +734,6 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
         } else {
           throw QueryExecutionErrors.castingCauseOverflowError(b, ByteType.catalogString)
         }
-    case YearMonthIntervalType =>
-      b => implicitly[Numeric[Int]].toInt(b.asInstanceOf[Int]).toByte
   }
 
   /**
@@ -1435,10 +1425,8 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   }
 
   private[this] def castToYearMonthIntervalCode(from: DataType): CastFunction = from match {
-    case LongType if ansiEnabled =>
-      castIntegralTypeToIntegralTypeExactCode("int", IntegerType.catalogString)
-    case x: IntegralType =>
-      (c, evPrim, evNull) => code"$evPrim = (int) $c;"
+    case _: IntegralType =>
+      castIntegralTypeToIntegralTypeExactCode("int", IntegerType.catalogString, true)
   }
 
   private[this] def decimalToTimestampCode(d: ExprValue): Block = {
@@ -1514,8 +1502,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
 
   private[this] def castIntegralTypeToIntegralTypeExactCode(
       integralType: String,
-      catalogType: String): CastFunction = {
-    assert(ansiEnabled)
+      catalogType: String,
+      strictMode: Boolean = false): CastFunction = {
+    assert(ansiEnabled || strictMode)
     (c, evPrim, evNull) =>
       code"""
         if ($c == ($integralType) $c) {
@@ -1584,10 +1573,8 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       castFractionToIntegralTypeCode("byte", ByteType.catalogString)
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (byte) $c;"
-    case DayTimeIntervalType | YearMonthIntervalType if ansiEnabled =>
-      castIntegralTypeToIntegralTypeExactCode("byte", ByteType.catalogString)
     case DayTimeIntervalType | YearMonthIntervalType =>
-      (c, evPrim, evNull) => code"$evPrim = (byte) $c;"
+      castIntegralTypeToIntegralTypeExactCode("byte", ByteType.catalogString, true)
   }
 
   private[this] def castToShortCode(
@@ -1619,10 +1606,8 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       castFractionToIntegralTypeCode("short", ShortType.catalogString)
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (short) $c;"
-    case DayTimeIntervalType | YearMonthIntervalType if ansiEnabled =>
-      castIntegralTypeToIntegralTypeExactCode("short", ShortType.catalogString)
     case DayTimeIntervalType | YearMonthIntervalType =>
-      (c, evPrim, evNull) => code"$evPrim = (short) $c;"
+      castIntegralTypeToIntegralTypeExactCode("short", ShortType.catalogString, true)
   }
 
   private[this] def castToIntCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
@@ -1652,10 +1637,8 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       castFractionToIntegralTypeCode("int", IntegerType.catalogString)
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (int) $c;"
-    case DayTimeIntervalType if ansiEnabled =>
-      castIntegralTypeToIntegralTypeExactCode("int", IntegerType.catalogString)
     case DayTimeIntervalType =>
-      (c, evPrim, evNull) => code"$evPrim = (int) $c;"
+      castIntegralTypeToIntegralTypeExactCode("int", IntegerType.catalogString, true)
     case YearMonthIntervalType =>
       (c, evPrim, evNull) => code"$evPrim = $c;"
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.sql.{Date, Timestamp}
-import java.time.DateTimeException
+import java.time.{DateTimeException, Duration, Period}
 import java.util.{Calendar, TimeZone}
 
 import scala.collection.parallel.immutable.ParVector
@@ -1711,6 +1711,20 @@ class CastSuite extends CastSuiteBase {
       }.getMessage
       assert(e3.contains("Casting 2147483648 to int causes overflow"))
     }
+  }
+
+  test("SPARK-34902: Cast support DayTimeIntervalType and YearMonthIntervalType") {
+    // DayTimeIntervalType
+    checkEvaluation(cast(12345723121L, DayTimeIntervalType),
+      12345723121L)
+    checkEvaluation(cast(Literal.create(Duration.ofMinutes(10), DayTimeIntervalType), LongType),
+      600000000L)
+
+    // YearMonthIntervaltype
+    checkEvaluation(cast(12345, YearMonthIntervalType),
+      12345)
+    checkEvaluation(cast(Literal.create(Period.ofMonths(10), YearMonthIntervalType), IntegerType),
+      10)
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1833,15 +1833,15 @@ class CastSuite extends CastSuiteBase {
       Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
       LongType), Long.MaxValue)
 
-    castExceptionWhenCodegen(checkEvaluation(cast(
+    castExceptionInExtractNumeric(checkEvaluation(cast(
       Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      ByteType), -1))
-    castExceptionWhenCodegen(checkEvaluation(cast(
+      ByteType), -1), ByteType)
+    castExceptionInExtractNumeric(checkEvaluation(cast(
       Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      ShortType), -1))
-    checkEvaluation(cast(
+      ShortType), -1), ShortType)
+    castExceptionInExtractNumeric(checkEvaluation(cast(
       Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      IntegerType), -1)
+      IntegerType), -1), IntegerType)
 
     // YearMonthIntervalType
     checkEvaluation(cast(cast(Byte.MaxValue, ByteType), YearMonthIntervalType),
@@ -1867,12 +1867,12 @@ class CastSuite extends CastSuiteBase {
       Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
       LongType), Int.MaxValue))
 
-    castExceptionWhenCodegen(checkEvaluation(cast(
+    castExceptionInExtractNumeric(checkEvaluation(cast(
       Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      ByteType), -1))
-    castExceptionWhenCodegen(checkEvaluation(cast(
+      ByteType), -1), ByteType)
+    castExceptionInExtractNumeric(checkEvaluation(cast(
       Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      ShortType), -1))
+      ShortType), -1), ShortType)
     castExceptionWhenCodegen(checkEvaluation(cast(
       Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
       LongType), Int.MaxValue))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1838,8 +1838,9 @@ class CastSuite extends CastSuiteBase {
       Short.MaxValue.toInt)
     checkEvaluation(cast(cast(Int.MaxValue, IntegerType), YearMonthIntervalType),
       Int.MaxValue.toInt)
-    checkEvaluation(cast(cast(Long.MaxValue, LongType), YearMonthIntervalType),
-      -1)
+    castExceptionInExtractNumeric(
+      checkEvaluation(cast(cast(Long.MaxValue, LongType), YearMonthIntervalType),
+        -1), IntegerType)
 
     checkEvaluation(cast(
       Literal.create(Period.ofMonths(Byte.MaxValue), YearMonthIntervalType),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1196,6 +1196,12 @@ abstract class AnsiCastSuiteBase extends CastSuiteBase {
   test("SPARK-34902: Cast support DayTimeIntervalType and YearMonthIntervalType") {
     // DayTimeIntervalType
     checkEvaluation(
+      cast(cast(0, IntegerType), DayTimeIntervalType), 0L)
+    checkEvaluation(
+      cast(cast(null, IntegerType), DayTimeIntervalType), null)
+    checkEvaluation(
+      cast(cast(Int.MinValue, IntegerType), DayTimeIntervalType), -2147483648L)
+    checkEvaluation(
       cast(cast(Byte.MaxValue, ByteType), DayTimeIntervalType), Byte.MaxValue.toLong)
     checkEvaluation(
       cast(cast(Short.MaxValue, ShortType), DayTimeIntervalType), Short.MaxValue.toLong)
@@ -1799,6 +1805,12 @@ class CastSuite extends CastSuiteBase {
 
   test("SPARK-34902: Cast support DayTimeIntervalType and YearMonthIntervalType") {
     // DayTimeIntervalType
+    checkEvaluation(
+      cast(cast(0, IntegerType), DayTimeIntervalType), 0L)
+    checkEvaluation(
+      cast(cast(null, IntegerType), DayTimeIntervalType), null)
+    checkEvaluation(
+      cast(cast(Int.MinValue, IntegerType), DayTimeIntervalType), -2147483648L)
     checkEvaluation(
       cast(cast(Byte.MaxValue, ByteType), DayTimeIntervalType), Byte.MaxValue.toLong)
     checkEvaluation(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -812,6 +812,81 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       }
     }
   }
+
+  test("SPARK-34902: Cast support DayTimeIntervalType and YearMonthIntervalType") {
+    // DayTimeIntervalType
+    checkEvaluation(
+      cast(cast(0, IntegerType), DayTimeIntervalType), 0L)
+    checkEvaluation(
+      cast(cast(null, IntegerType), DayTimeIntervalType), null)
+    checkEvaluation(
+      cast(cast(Int.MinValue, IntegerType), DayTimeIntervalType), Int.MinValue.toLong)
+    checkEvaluation(
+      cast(cast(Byte.MaxValue, ByteType), DayTimeIntervalType), Byte.MaxValue.toLong)
+    checkEvaluation(
+      cast(cast(Short.MaxValue, ShortType), DayTimeIntervalType), Short.MaxValue.toLong)
+    checkEvaluation(
+      cast(cast(Int.MaxValue, IntegerType), DayTimeIntervalType), Int.MaxValue.toLong)
+    checkEvaluation(
+      cast(cast(Long.MaxValue, LongType), DayTimeIntervalType), Long.MaxValue)
+
+    checkEvaluation(cast(
+      Literal.create(Duration.of(Byte.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
+      ByteType), Byte.MaxValue)
+    checkEvaluation(cast(
+      Literal.create(Duration.of(Short.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
+      ShortType), Short.MaxValue)
+    checkEvaluation(cast(
+      Literal.create(Duration.of(Int.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
+      IntegerType), Int.MaxValue)
+    checkEvaluation(cast(
+      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
+      LongType), Long.MaxValue)
+
+    castExceptionInExtractNumeric(checkEvaluation(cast(
+      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
+      ByteType), -1), ByteType)
+    castExceptionInExtractNumeric(checkEvaluation(cast(
+      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
+      ShortType), -1), ShortType)
+    castExceptionInExtractNumeric(checkEvaluation(cast(
+      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
+      IntegerType), -1), IntegerType)
+
+    // YearMonthIntervalType
+    checkEvaluation(cast(cast(Byte.MaxValue, ByteType), YearMonthIntervalType),
+      Byte.MaxValue.toInt)
+    checkEvaluation(cast(cast(Short.MaxValue, ShortType), YearMonthIntervalType),
+      Short.MaxValue.toInt)
+    checkEvaluation(cast(cast(Int.MaxValue, IntegerType), YearMonthIntervalType),
+      Int.MaxValue.toInt)
+    castExceptionInExtractNumeric(
+      checkEvaluation(cast(cast(Long.MaxValue, LongType), YearMonthIntervalType),
+        -1), IntegerType)
+
+    checkEvaluation(cast(
+      Literal.create(Period.ofMonths(Byte.MaxValue), YearMonthIntervalType),
+      ByteType), Byte.MaxValue)
+    checkEvaluation(cast(
+      Literal.create(Period.ofMonths(Short.MaxValue), YearMonthIntervalType),
+      ShortType), Short.MaxValue)
+    checkEvaluation(cast(
+      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
+      IntegerType), Int.MaxValue)
+    castExceptionWhenCodegen(checkEvaluation(cast(
+      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
+      LongType), Int.MaxValue))
+
+    castExceptionInExtractNumeric(checkEvaluation(cast(
+      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
+      ByteType), -1), ByteType)
+    castExceptionInExtractNumeric(checkEvaluation(cast(
+      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
+      ShortType), -1), ShortType)
+    castExceptionWhenCodegen(checkEvaluation(cast(
+      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
+      LongType), Int.MaxValue))
+  }
 }
 
 abstract class AnsiCastSuiteBase extends CastSuiteBase {
@@ -1191,81 +1266,6 @@ abstract class AnsiCastSuiteBase extends CastSuiteBase {
   test("SPARK-26218: Fix the corner case of codegen when casting float to Integer") {
     checkExceptionInExpression[ArithmeticException](
       cast(cast(Literal("2147483648"), FloatType), IntegerType), "overflow")
-  }
-
-  test("SPARK-34902: Cast support DayTimeIntervalType and YearMonthIntervalType") {
-    // DayTimeIntervalType
-    checkEvaluation(
-      cast(cast(0, IntegerType), DayTimeIntervalType), 0L)
-    checkEvaluation(
-      cast(cast(null, IntegerType), DayTimeIntervalType), null)
-    checkEvaluation(
-      cast(cast(Int.MinValue, IntegerType), DayTimeIntervalType), Int.MinValue.toLong)
-    checkEvaluation(
-      cast(cast(Byte.MaxValue, ByteType), DayTimeIntervalType), Byte.MaxValue.toLong)
-    checkEvaluation(
-      cast(cast(Short.MaxValue, ShortType), DayTimeIntervalType), Short.MaxValue.toLong)
-    checkEvaluation(
-      cast(cast(Int.MaxValue, IntegerType), DayTimeIntervalType), Int.MaxValue.toLong)
-    checkEvaluation(
-      cast(cast(Long.MaxValue, LongType), DayTimeIntervalType), Long.MaxValue)
-
-    checkEvaluation(cast(
-      Literal.create(Duration.of(Byte.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      ByteType), Byte.MaxValue)
-    checkEvaluation(cast(
-      Literal.create(Duration.of(Short.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      ShortType), Short.MaxValue)
-    checkEvaluation(cast(
-      Literal.create(Duration.of(Int.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      IntegerType), Int.MaxValue)
-    checkEvaluation(cast(
-      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      LongType), Long.MaxValue)
-
-    castExceptionInExtractNumeric(checkEvaluation(cast(
-      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      ByteType), -1), ByteType)
-    castExceptionInExtractNumeric(checkEvaluation(cast(
-      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      ShortType), -1), ShortType)
-    castExceptionInExtractNumeric(checkEvaluation(cast(
-      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      IntegerType), -1), IntegerType)
-
-    // YearMonthIntervalType
-    checkEvaluation(cast(cast(Byte.MaxValue, ByteType), YearMonthIntervalType),
-      Byte.MaxValue.toInt)
-    checkEvaluation(cast(cast(Short.MaxValue, ShortType), YearMonthIntervalType),
-      Short.MaxValue.toInt)
-    checkEvaluation(cast(cast(Int.MaxValue, IntegerType), YearMonthIntervalType),
-      Int.MaxValue.toInt)
-    castExceptionInExtractNumeric(
-      checkEvaluation(cast(cast(Long.MaxValue, LongType), YearMonthIntervalType),
-        -1), IntegerType)
-
-    checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Byte.MaxValue), YearMonthIntervalType),
-      ByteType), Byte.MaxValue)
-    checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Short.MaxValue), YearMonthIntervalType),
-      ShortType), Short.MaxValue)
-    checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      IntegerType), Int.MaxValue)
-    castExceptionWhenCodegen(checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      LongType), Int.MaxValue))
-
-    castExceptionInExtractNumeric(checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      ByteType), -1), ByteType)
-    castExceptionInExtractNumeric(checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      ShortType), -1), ShortType)
-    castExceptionWhenCodegen(checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      LongType), Int.MaxValue))
   }
 }
 
@@ -1801,81 +1801,6 @@ class CastSuite extends CastSuiteBase {
       }.getMessage
       assert(e3.contains("Casting 2147483648 to int causes overflow"))
     }
-  }
-
-  test("SPARK-34902: Cast support DayTimeIntervalType and YearMonthIntervalType") {
-    // DayTimeIntervalType
-    checkEvaluation(
-      cast(cast(0, IntegerType), DayTimeIntervalType), 0L)
-    checkEvaluation(
-      cast(cast(null, IntegerType), DayTimeIntervalType), null)
-    checkEvaluation(
-      cast(cast(Int.MinValue, IntegerType), DayTimeIntervalType), Int.MinValue.toLong)
-    checkEvaluation(
-      cast(cast(Byte.MaxValue, ByteType), DayTimeIntervalType), Byte.MaxValue.toLong)
-    checkEvaluation(
-      cast(cast(Short.MaxValue, ShortType), DayTimeIntervalType), Short.MaxValue.toLong)
-    checkEvaluation(
-      cast(cast(Int.MaxValue, IntegerType), DayTimeIntervalType), Int.MaxValue.toLong)
-    checkEvaluation(
-      cast(cast(Long.MaxValue, LongType), DayTimeIntervalType), Long.MaxValue)
-
-    checkEvaluation(cast(
-      Literal.create(Duration.of(Byte.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      ByteType), Byte.MaxValue)
-    checkEvaluation(cast(
-      Literal.create(Duration.of(Short.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      ShortType), Short.MaxValue)
-    checkEvaluation(cast(
-      Literal.create(Duration.of(Int.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      IntegerType), Int.MaxValue)
-    checkEvaluation(cast(
-      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      LongType), Long.MaxValue)
-
-    castExceptionInExtractNumeric(checkEvaluation(cast(
-      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      ByteType), -1), ByteType)
-    castExceptionInExtractNumeric(checkEvaluation(cast(
-      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      ShortType), -1), ShortType)
-    castExceptionInExtractNumeric(checkEvaluation(cast(
-      Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType),
-      IntegerType), -1), IntegerType)
-
-    // YearMonthIntervalType
-    checkEvaluation(cast(cast(Byte.MaxValue, ByteType), YearMonthIntervalType),
-      Byte.MaxValue.toInt)
-    checkEvaluation(cast(cast(Short.MaxValue, ShortType), YearMonthIntervalType),
-      Short.MaxValue.toInt)
-    checkEvaluation(cast(cast(Int.MaxValue, IntegerType), YearMonthIntervalType),
-      Int.MaxValue.toInt)
-    castExceptionInExtractNumeric(
-      checkEvaluation(cast(cast(Long.MaxValue, LongType), YearMonthIntervalType),
-        -1), IntegerType)
-
-    checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Byte.MaxValue), YearMonthIntervalType),
-      ByteType), Byte.MaxValue)
-    checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Short.MaxValue), YearMonthIntervalType),
-      ShortType), Short.MaxValue)
-    checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      IntegerType), Int.MaxValue)
-    castExceptionWhenCodegen(checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      LongType), Int.MaxValue))
-
-    castExceptionInExtractNumeric(checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      ByteType), -1), ByteType)
-    castExceptionInExtractNumeric(checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      ShortType), -1), ShortType)
-    castExceptionWhenCodegen(checkEvaluation(cast(
-      Literal.create(Period.ofMonths(Int.MaxValue), YearMonthIntervalType),
-      LongType), Int.MaxValue))
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1200,7 +1200,7 @@ abstract class AnsiCastSuiteBase extends CastSuiteBase {
     checkEvaluation(
       cast(cast(null, IntegerType), DayTimeIntervalType), null)
     checkEvaluation(
-      cast(cast(Int.MinValue, IntegerType), DayTimeIntervalType), -2147483648L)
+      cast(cast(Int.MinValue, IntegerType), DayTimeIntervalType), Int.MinValue.toLong)
     checkEvaluation(
       cast(cast(Byte.MaxValue, ByteType), DayTimeIntervalType), Byte.MaxValue.toLong)
     checkEvaluation(
@@ -1810,7 +1810,7 @@ class CastSuite extends CastSuiteBase {
     checkEvaluation(
       cast(cast(null, IntegerType), DayTimeIntervalType), null)
     checkEvaluation(
-      cast(cast(Int.MinValue, IntegerType), DayTimeIntervalType), -2147483648L)
+      cast(cast(Int.MinValue, IntegerType), DayTimeIntervalType), Int.MinValue.toLong)
     checkEvaluation(
       cast(cast(Byte.MaxValue, ByteType), DayTimeIntervalType), Byte.MaxValue.toLong)
     checkEvaluation(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Before this pr, if we want to cast LongType to DayTimeIntervalType will got error
```
[info]   org.apache.spark.sql.AnalysisException: cannot resolve 'CAST(a AS DAY-TIME INTERVAL)' due to data type mismatch: cannot cast bigint to day-time interval;
[info] 'Project [cast(a#4L as day-time interval) AS b#6]
[info] +- Project [value#1L AS a#4L]
[info]    +- LocalRelation [value#1L]
```

Since DayTimeIntervalType store value as Long and  YearMonthIntervalType store value as Int, in this pr we support cast between them.

### Why are the changes needed?
User can  cast between LongType & DayTimeIntervalType and IntegerType & YearMonthIntervalType

```
SELECT cast(123L to day-time interval)
```

### Does this PR introduce _any_ user-facing change?
Support cast between LongType & DayTimeIntervalType and IntegerType & YearMonthIntervalType


### How was this patch tested?
added UT
