### PR TITLE
[SPARK-33350][SHUFFLE] Add support to DiskBlockManager to create merge directory and to get the local shuffle merged data

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -75,6 +75,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
   private static final Logger logger = LoggerFactory.getLogger(RemoteBlockPushResolver.class);
   @VisibleForTesting
   static final String MERGE_MANAGER_DIR = "merge_manager";
+  static final String MERGED_SHUFFLE_FILE_NAME_PREFIX = "shuffleMerged";
 
   private final ConcurrentMap<String, AppPathsInfo> appsPathInfo;
   private final ConcurrentMap<AppShuffleId, Map<Integer, AppShufflePartitionInfo>> partitions;
@@ -432,8 +433,8 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       executorInfo.subDirsPerLocalDir));
   }
   private static String generateFileName(AppShuffleId appShuffleId, int reduceId) {
-    return String.format("shuffleMerged_%s_%d_%d", appShuffleId.appId, appShuffleId.shuffleId,
-      reduceId);
+    return String.format("%s_%s_%d_%d", MERGED_SHUFFLE_FILE_NAME_PREFIX, appShuffleId.appId,
+      appShuffleId.shuffleId, reduceId);
   }
 
   /**

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -75,7 +75,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
   private static final Logger logger = LoggerFactory.getLogger(RemoteBlockPushResolver.class);
   @VisibleForTesting
   static final String MERGE_MANAGER_DIR = "merge_manager";
-  static final String MERGED_SHUFFLE_FILE_NAME_PREFIX = "shuffleMerged";
+  public static final String MERGED_SHUFFLE_FILE_NAME_PREFIX = "shuffleMerged";
 
   private final ConcurrentMap<String, AppPathsInfo> appsPathInfo;
   private final ConcurrentMap<AppShuffleId, Map<Integer, AppShufflePartitionInfo>> partitions;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -211,7 +211,8 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
 
   /**
    * The logic here is consistent with
-   * org.apache.spark.storage.DiskBlockManager#getMergedShuffleFile
+   * @see [[org.apache.spark.storage.DiskBlockManager#getMergedShuffleFile(
+   *      org.apache.spark.storage.BlockId, scala.Option)]]
    */
   private File getFile(String appId, String filename) {
     // TODO: [SPARK-33236] Change the message when this service is able to handle NM restart
@@ -431,7 +432,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       executorInfo.subDirsPerLocalDir));
   }
   private static String generateFileName(AppShuffleId appShuffleId, int reduceId) {
-    return String.format("mergedShuffle_%s_%d_%d", appShuffleId.appId, appShuffleId.shuffleId,
+    return String.format("shuffleMerged_%s_%d_%d", appShuffleId.appId, appShuffleId.shuffleId,
       reduceId);
   }
 

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -1290,7 +1290,7 @@ private[spark] object MapOutputTracker extends Logging {
   private val DIRECT = 0
   private val BROADCAST = 1
 
-  private val SHUFFLE_PUSH_MAP_ID = -1
+  val SHUFFLE_PUSH_MAP_ID = -1
 
   // Serialize an array of map/merge output locations into an efficient byte format so that we can
   // send it to reduce tasks. We do this by compressing the serialized bytes using Zstd. They will

--- a/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
@@ -22,7 +22,7 @@ import scala.reflect.ClassTag
 import org.apache.spark.TaskContext
 import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.client.StreamCallbackWithID
-import org.apache.spark.storage.{BlockId, StorageLevel}
+import org.apache.spark.storage.{BlockId, ShuffleBlockId, StorageLevel}
 
 private[spark]
 trait BlockDataManager {
@@ -71,4 +71,9 @@ trait BlockDataManager {
    * Release locks acquired by [[putBlockData()]] and [[getLocalBlockData()]].
    */
   def releaseLock(blockId: BlockId, taskContext: Option[TaskContext]): Unit
+
+  /**
+   * Get the local merged shuffle block data
+   */
+  def getMergedBlockData(blockId: ShuffleBlockId): Seq[ManagedBuffer]
 }

--- a/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
@@ -22,7 +22,7 @@ import scala.reflect.ClassTag
 import org.apache.spark.TaskContext
 import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.client.StreamCallbackWithID
-import org.apache.spark.storage.{BlockId, ShuffleBlockId, StorageLevel}
+import org.apache.spark.storage.{BlockId, StorageLevel}
 
 private[spark]
 trait BlockDataManager {
@@ -71,9 +71,4 @@ trait BlockDataManager {
    * Release locks acquired by [[putBlockData()]] and [[getLocalBlockData()]].
    */
   def releaseLock(blockId: BlockId, taskContext: Option[TaskContext]): Unit
-
-  /**
-   * Get the local merged shuffle block data
-   */
-  def getMergedBlockData(blockId: ShuffleBlockId): Seq[ManagedBuffer]
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
@@ -18,7 +18,8 @@
 package org.apache.spark.shuffle
 
 import org.apache.spark.network.buffer.ManagedBuffer
-import org.apache.spark.storage.BlockId
+import org.apache.spark.network.shuffle.MergedBlockMeta
+import org.apache.spark.storage.{BlockId, ShuffleBlockId}
 
 private[spark]
 /**
@@ -39,6 +40,16 @@ trait ShuffleBlockResolver {
    * If the data for that block is not available, throws an unspecified exception.
    */
   def getBlockData(blockId: BlockId, dirs: Option[Array[String]] = None): ManagedBuffer
+
+  /**
+   * Retrieve the data for the specified merged shuffle block as multiple chunks.
+   */
+  def getMergedBlockData(blockId: ShuffleBlockId): Seq[ManagedBuffer]
+
+  /**
+   * Retrieve the meta data for the specified merged shuffle block.
+   */
+  def getMergedBlockMeta(blockId: ShuffleBlockId): MergedBlockMeta
 
   def stop(): Unit
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
@@ -44,12 +44,12 @@ trait ShuffleBlockResolver {
   /**
    * Retrieve the data for the specified merged shuffle block as multiple chunks.
    */
-  def getMergedBlockData(blockId: ShuffleBlockId): Seq[ManagedBuffer]
+  def getMergedBlockData(blockId: ShuffleBlockId, dirs: Option[Array[String]]): Seq[ManagedBuffer]
 
   /**
    * Retrieve the meta data for the specified merged shuffle block.
    */
-  def getMergedBlockMeta(blockId: ShuffleBlockId): MergedBlockMeta
+  def getMergedBlockMeta(blockId: ShuffleBlockId, dirs: Option[Array[String]]): MergedBlockMeta
 
   def stop(): Unit
 }

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -89,7 +89,7 @@ case class ShufflePushBlockId(shuffleId: Int, mapIndex: Int, reduceId: Int) exte
 
 @Since("3.2.0")
 @DeveloperApi
-case class ShuffleMergedBlockId(appId: String, shuffleId: Int, reduceId: Int) extends BlockId {
+case class ShuffleMergedDataBlockId(appId: String, shuffleId: Int, reduceId: Int) extends BlockId {
   override def name: String = "shuffleMerged_" + appId + "_" + shuffleId + "_" + reduceId + ".data"
 }
 
@@ -155,6 +155,9 @@ object BlockId {
   val SHUFFLE_DATA = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).data".r
   val SHUFFLE_INDEX = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).index".r
   val SHUFFLE_PUSH = "shufflePush_([0-9]+)_([0-9]+)_([0-9]+)".r
+  val SHUFFLE_MERGED = "shuffleMerged_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).data".r
+  val SHUFFLE_MERGED_INDEX = "shuffleMerged_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).index".r
+  val SHUFFLE_MERGED_META = "shuffleMerged_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).meta".r
   val BROADCAST = "broadcast_([0-9]+)([_A-Za-z0-9]*)".r
   val TASKRESULT = "taskresult_([0-9]+)".r
   val STREAM = "input-([0-9]+)-([0-9]+)".r
@@ -175,6 +178,12 @@ object BlockId {
       ShuffleIndexBlockId(shuffleId.toInt, mapId.toLong, reduceId.toInt)
     case SHUFFLE_PUSH(shuffleId, mapIndex, reduceId) =>
       ShufflePushBlockId(shuffleId.toInt, mapIndex.toInt, reduceId.toInt)
+    case SHUFFLE_MERGED(appId, shuffleId, reduceId) =>
+      ShuffleMergedDataBlockId(appId, shuffleId.toInt, reduceId.toInt)
+    case SHUFFLE_MERGED_INDEX(appId, shuffleId, reduceId) =>
+      ShuffleMergedIndexBlockId(appId, shuffleId.toInt, reduceId.toInt)
+    case SHUFFLE_MERGED_META(appId, shuffleId, reduceId) =>
+      ShuffleMergedMetaBlockId(appId, shuffleId.toInt, reduceId.toInt)
     case BROADCAST(broadcastId, field) =>
       BroadcastBlockId(broadcastId.toLong, field.stripPrefix("_"))
     case TASKRESULT(taskId) =>

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -90,7 +90,7 @@ case class ShufflePushBlockId(shuffleId: Int, mapIndex: Int, reduceId: Int) exte
 @Since("3.2.0")
 @DeveloperApi
 case class ShuffleMergedBlockId(appId: String, shuffleId: Int, reduceId: Int) extends BlockId {
-  override def name: String = "mergedShuffle_" + appId + "_" + shuffleId + "_" + reduceId + ".data"
+  override def name: String = "shuffleMerged_" + appId + "_" + shuffleId + "_" + reduceId + ".data"
 }
 
 @Since("3.2.0")
@@ -100,7 +100,7 @@ case class ShuffleMergedIndexBlockId(
     shuffleId: Int,
     reduceId: Int) extends BlockId {
   override def name: String =
-    "mergedShuffle_" + appId + "_" + shuffleId + "_" + reduceId + ".index"
+    "shuffleMerged_" + appId + "_" + shuffleId + "_" + reduceId + ".index"
 }
 
 @Since("3.2.0")
@@ -110,7 +110,7 @@ case class ShuffleMergedMetaBlockId(
     shuffleId: Int,
     reduceId: Int) extends BlockId {
   override def name: String =
-    "mergedShuffle_" + appId + "_" + shuffleId + "_" + reduceId + ".meta"
+    "shuffleMerged_" + appId + "_" + shuffleId + "_" + reduceId + ".meta"
 }
 
 @DeveloperApi
@@ -155,9 +155,6 @@ object BlockId {
   val SHUFFLE_DATA = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).data".r
   val SHUFFLE_INDEX = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).index".r
   val SHUFFLE_PUSH = "shufflePush_([0-9]+)_([0-9]+)_([0-9]+)".r
-  val SHUFFLE_MERGED = "mergedShuffle_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).data".r
-  val SHUFFLE_MERGED_INDEX = "mergedShuffle_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).index".r
-  val SHUFFLE_MERGED_META = "mergedShuffle_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).meta".r
   val BROADCAST = "broadcast_([0-9]+)([_A-Za-z0-9]*)".r
   val TASKRESULT = "taskresult_([0-9]+)".r
   val STREAM = "input-([0-9]+)-([0-9]+)".r
@@ -178,12 +175,6 @@ object BlockId {
       ShuffleIndexBlockId(shuffleId.toInt, mapId.toLong, reduceId.toInt)
     case SHUFFLE_PUSH(shuffleId, mapIndex, reduceId) =>
       ShufflePushBlockId(shuffleId.toInt, mapIndex.toInt, reduceId.toInt)
-    case SHUFFLE_MERGED(appId, shuffleId, reduceId) =>
-      ShuffleMergedBlockId(appId, shuffleId.toInt, reduceId.toInt)
-    case SHUFFLE_MERGED_INDEX(appId, shuffleId, reduceId) =>
-      ShuffleMergedIndexBlockId(appId, shuffleId.toInt, reduceId.toInt)
-    case SHUFFLE_MERGED_META(appId, shuffleId, reduceId) =>
-      ShuffleMergedMetaBlockId(appId, shuffleId.toInt, reduceId.toInt)
     case BROADCAST(broadcastId, field) =>
       BroadcastBlockId(broadcastId.toLong, field.stripPrefix("_"))
     case TASKRESULT(taskId) =>

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -153,7 +153,7 @@ object BlockId {
   val SHUFFLE_INDEX = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).index".r
   val SHUFFLE_PUSH = "shufflePush_([0-9]+)_([0-9]+)_([0-9]+)".r
   val SHUFFLE_MERGED = "mergedShuffle_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).data".r
-  val SHUFFLE__MERGED_INDEX = "mergedShuffle_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).index".r
+  val SHUFFLE_MERGED_INDEX = "mergedShuffle_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).index".r
   val SHUFFLE_MERGED_META = "mergedShuffle_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).meta".r
   val BROADCAST = "broadcast_([0-9]+)([_A-Za-z0-9]*)".r
   val TASKRESULT = "taskresult_([0-9]+)".r
@@ -177,7 +177,7 @@ object BlockId {
       ShufflePushBlockId(shuffleId.toInt, mapIndex.toInt, reduceId.toInt)
     case SHUFFLE_MERGED(appId, shuffleId, reduceId) =>
       ShuffleMergedBlockId(appId, shuffleId.toInt, reduceId.toInt)
-    case SHUFFLE__MERGED_INDEX(appId, shuffleId, reduceId) =>
+    case SHUFFLE_MERGED_INDEX(appId, shuffleId, reduceId) =>
       ShuffleMergedIndexBlockId(appId, shuffleId.toInt, reduceId.toInt)
     case SHUFFLE_MERGED_META(appId, shuffleId, reduceId) =>
       ShuffleMergedMetaBlockId(appId, shuffleId.toInt, reduceId.toInt)

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -155,7 +155,7 @@ object BlockId {
   val SHUFFLE_DATA = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).data".r
   val SHUFFLE_INDEX = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).index".r
   val SHUFFLE_PUSH = "shufflePush_([0-9]+)_([0-9]+)_([0-9]+)".r
-  val SHUFFLE_MERGED = "shuffleMerged_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).data".r
+  val SHUFFLE_MERGED_DATA = "shuffleMerged_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).data".r
   val SHUFFLE_MERGED_INDEX = "shuffleMerged_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).index".r
   val SHUFFLE_MERGED_META = "shuffleMerged_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).meta".r
   val BROADCAST = "broadcast_([0-9]+)([_A-Za-z0-9]*)".r
@@ -178,7 +178,7 @@ object BlockId {
       ShuffleIndexBlockId(shuffleId.toInt, mapId.toLong, reduceId.toInt)
     case SHUFFLE_PUSH(shuffleId, mapIndex, reduceId) =>
       ShufflePushBlockId(shuffleId.toInt, mapIndex.toInt, reduceId.toInt)
-    case SHUFFLE_MERGED(appId, shuffleId, reduceId) =>
+    case SHUFFLE_MERGED_DATA(appId, shuffleId, reduceId) =>
       ShuffleMergedDataBlockId(appId, shuffleId.toInt, reduceId.toInt)
     case SHUFFLE_MERGED_INDEX(appId, shuffleId, reduceId) =>
       ShuffleMergedIndexBlockId(appId, shuffleId.toInt, reduceId.toInt)

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -88,6 +88,29 @@ case class ShufflePushBlockId(shuffleId: Int, mapIndex: Int, reduceId: Int) exte
 }
 
 @DeveloperApi
+case class ShuffleMergedBlockId(appId: String, shuffleId: Int, reduceId: Int) extends BlockId {
+  override def name: String = "mergedShuffle_" + appId + "_" + shuffleId + "_" + reduceId + ".data"
+}
+
+@DeveloperApi
+case class ShuffleMergedIndexBlockId(
+  appId: String,
+  shuffleId: Int,
+  reduceId: Int) extends BlockId {
+  override def name: String =
+    "mergedShuffle_" + appId + "_" + shuffleId + "_" + reduceId + ".index"
+}
+
+@DeveloperApi
+case class ShuffleMergedMetaBlockId(
+  appId: String,
+  shuffleId: Int,
+  reduceId: Int) extends BlockId {
+  override def name: String =
+    "mergedShuffle_" + appId + "_" + shuffleId + "_" + reduceId + ".meta"
+}
+
+@DeveloperApi
 case class BroadcastBlockId(broadcastId: Long, field: String = "") extends BlockId {
   override def name: String = "broadcast_" + broadcastId + (if (field == "") "" else "_" + field)
 }
@@ -129,6 +152,9 @@ object BlockId {
   val SHUFFLE_DATA = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).data".r
   val SHUFFLE_INDEX = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).index".r
   val SHUFFLE_PUSH = "shufflePush_([0-9]+)_([0-9]+)_([0-9]+)".r
+  val SHUFFLE_MERGED = "mergedShuffle_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).data".r
+  val SHUFFLE__MERGED_INDEX = "mergedShuffle_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).index".r
+  val SHUFFLE_MERGED_META = "mergedShuffle_([_A-Za-z0-9]*)_([0-9]+)_([0-9]+).meta".r
   val BROADCAST = "broadcast_([0-9]+)([_A-Za-z0-9]*)".r
   val TASKRESULT = "taskresult_([0-9]+)".r
   val STREAM = "input-([0-9]+)-([0-9]+)".r
@@ -149,6 +175,12 @@ object BlockId {
       ShuffleIndexBlockId(shuffleId.toInt, mapId.toLong, reduceId.toInt)
     case SHUFFLE_PUSH(shuffleId, mapIndex, reduceId) =>
       ShufflePushBlockId(shuffleId.toInt, mapIndex.toInt, reduceId.toInt)
+    case SHUFFLE_MERGED(appId, shuffleId, reduceId) =>
+      ShuffleMergedBlockId(appId, shuffleId.toInt, reduceId.toInt)
+    case SHUFFLE__MERGED_INDEX(appId, shuffleId, reduceId) =>
+      ShuffleMergedIndexBlockId(appId, shuffleId.toInt, reduceId.toInt)
+    case SHUFFLE_MERGED_META(appId, shuffleId, reduceId) =>
+      ShuffleMergedMetaBlockId(appId, shuffleId.toInt, reduceId.toInt)
     case BROADCAST(broadcastId, field) =>
       BroadcastBlockId(broadcastId.toLong, field.stripPrefix("_"))
     case TASKRESULT(taskId) =>

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.{DeveloperApi, Since}
+import org.apache.spark.network.shuffle.RemoteBlockPushResolver
 
 /**
  * :: DeveloperApi ::
@@ -90,7 +91,8 @@ case class ShufflePushBlockId(shuffleId: Int, mapIndex: Int, reduceId: Int) exte
 @Since("3.2.0")
 @DeveloperApi
 case class ShuffleMergedDataBlockId(appId: String, shuffleId: Int, reduceId: Int) extends BlockId {
-  override def name: String = "shuffleMerged_" + appId + "_" + shuffleId + "_" + reduceId + ".data"
+  override def name: String = RemoteBlockPushResolver.MERGED_SHUFFLE_FILE_NAME_PREFIX + "_" +
+    appId + "_" + shuffleId + "_" + reduceId + ".data"
 }
 
 @Since("3.2.0")
@@ -99,8 +101,8 @@ case class ShuffleMergedIndexBlockId(
     appId: String,
     shuffleId: Int,
     reduceId: Int) extends BlockId {
-  override def name: String =
-    "shuffleMerged_" + appId + "_" + shuffleId + "_" + reduceId + ".index"
+  override def name: String = RemoteBlockPushResolver.MERGED_SHUFFLE_FILE_NAME_PREFIX + "_" +
+    appId + "_" + shuffleId + "_" + reduceId + ".index"
 }
 
 @Since("3.2.0")
@@ -109,8 +111,8 @@ case class ShuffleMergedMetaBlockId(
     appId: String,
     shuffleId: Int,
     reduceId: Int) extends BlockId {
-  override def name: String =
-    "shuffleMerged_" + appId + "_" + shuffleId + "_" + reduceId + ".meta"
+  override def name: String = RemoteBlockPushResolver.MERGED_SHUFFLE_FILE_NAME_PREFIX + "_" +
+    appId + "_" + shuffleId + "_" + reduceId + ".meta"
 }
 
 @DeveloperApi

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -87,25 +87,28 @@ case class ShufflePushBlockId(shuffleId: Int, mapIndex: Int, reduceId: Int) exte
   override def name: String = "shufflePush_" + shuffleId + "_" + mapIndex + "_" + reduceId
 }
 
+@Since("3.2.0")
 @DeveloperApi
 case class ShuffleMergedBlockId(appId: String, shuffleId: Int, reduceId: Int) extends BlockId {
   override def name: String = "mergedShuffle_" + appId + "_" + shuffleId + "_" + reduceId + ".data"
 }
 
+@Since("3.2.0")
 @DeveloperApi
 case class ShuffleMergedIndexBlockId(
-  appId: String,
-  shuffleId: Int,
-  reduceId: Int) extends BlockId {
+    appId: String,
+    shuffleId: Int,
+    reduceId: Int) extends BlockId {
   override def name: String =
     "mergedShuffle_" + appId + "_" + shuffleId + "_" + reduceId + ".index"
 }
 
+@Since("3.2.0")
 @DeveloperApi
 case class ShuffleMergedMetaBlockId(
-  appId: String,
-  shuffleId: Int,
-  reduceId: Int) extends BlockId {
+    appId: String,
+    shuffleId: Int,
+    reduceId: Int) extends BlockId {
   override def name: String =
     "mergedShuffle_" + appId + "_" + shuffleId + "_" + reduceId + ".meta"
 }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -503,8 +503,8 @@ private[spark] class BlockManager(
     }
 
     hostLocalDirManager = {
-      if (conf.get(config.SHUFFLE_HOST_LOCAL_DISK_READING_ENABLED) &&
-          !conf.get(config.SHUFFLE_USE_OLD_FETCH_PROTOCOL) ||
+      if ((conf.get(config.SHUFFLE_HOST_LOCAL_DISK_READING_ENABLED) &&
+          !conf.get(config.SHUFFLE_USE_OLD_FETCH_PROTOCOL)) ||
           Utils.isPushBasedShuffleEnabled(conf)) {
         Some(new HostLocalDirManager(
           futureExecutionContext,

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -735,17 +735,20 @@ private[spark] class BlockManager(
    * Instead of reading the entire file as a single block, we split it into smaller chunks
    * which will be memory efficient when performing certain operations.
    */
-  override def getMergedBlockData(blockId: ShuffleBlockId): Seq[ManagedBuffer] = {
-    shuffleManager.shuffleBlockResolver.getMergedBlockData(blockId)
+  def getLocalMergedBlockData(
+      blockId: ShuffleBlockId,
+      dirs: Array[String]): Seq[ManagedBuffer] = {
+    shuffleManager.shuffleBlockResolver.getMergedBlockData(blockId, Some(dirs))
   }
 
   /**
-   * Get the local merged shuffle block metada data for the given block ID.
+   * Get the local merged shuffle block meta data for the given block ID.
    */
-  def getMergedBlockMeta(blockId: ShuffleBlockId): MergedBlockMeta = {
-    shuffleManager.shuffleBlockResolver.getMergedBlockMeta(blockId)
+  def getLocalMergedBlockMeta(
+      blockId: ShuffleBlockId,
+      dirs: Array[String]): MergedBlockMeta = {
+    shuffleManager.shuffleBlockResolver.getMergedBlockMeta(blockId, Some(dirs))
   }
-
 
   /**
    * Get the BlockStatus for the block identified by the given ID, if it exists.

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -504,7 +504,8 @@ private[spark] class BlockManager(
 
     hostLocalDirManager = {
       if (conf.get(config.SHUFFLE_HOST_LOCAL_DISK_READING_ENABLED) &&
-          !conf.get(config.SHUFFLE_USE_OLD_FETCH_PROTOCOL)) {
+          !conf.get(config.SHUFFLE_USE_OLD_FETCH_PROTOCOL) ||
+          Utils.isPushBasedShuffleEnabled(conf)) {
         Some(new HostLocalDirManager(
           futureExecutionContext,
           conf.get(config.STORAGE_LOCAL_DISK_BY_EXECUTORS_CACHE_SIZE),

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -729,6 +729,24 @@ private[spark] class BlockManager(
   }
 
   /**
+   * Get the local merged shuffle block data for the given block ID as multiple chunks.
+   * A merged shuffle file is divided into multiple chunks according to the index file.
+   * Instead of reading the entire file as a single block, we split it into smaller chunks
+   * which will be memory efficient when performing certain operations.
+   */
+  override def getMergedBlockData(blockId: ShuffleBlockId): Seq[ManagedBuffer] = {
+    shuffleManager.shuffleBlockResolver.getMergedBlockData(blockId)
+  }
+
+  /**
+   * Get the local merged shuffle block metada data for the given block ID.
+   */
+  def getMergedBlockMeta(blockId: ShuffleBlockId): MergedBlockMeta = {
+    shuffleManager.shuffleBlockResolver.getMergedBlockMeta(blockId)
+  }
+
+
+  /**
    * Get the BlockStatus for the block identified by the given ID, if it exists.
    * NOTE: This is mainly for testing.
    */

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -205,7 +205,7 @@ private[spark] class DiskBlockManager(conf: SparkConf, var deleteFilesOnStop: Bo
             // This executor does not find merge_manager directory, it will try to create
             // the merge_manager directory and the sub directories.
             logDebug(s"Try to create $mergeDir and its sub dirs since the " +
-              s"merge_manager dir does not exist")
+              s"$MERGE_MANAGER_DIR dir does not exist")
             for (dirNum <- 0 until subDirsPerLocalDir) {
               val subDir = new File(mergeDir, "%02x".format(dirNum))
               if (!subDir.exists()) {
@@ -219,7 +219,7 @@ private[spark] class DiskBlockManager(conf: SparkConf, var deleteFilesOnStop: Bo
         } catch {
           case e: IOException =>
             logError(
-              s"Failed to create merge dir in $rootDir. Ignoring this directory.", e)
+              s"Failed to create $MERGE_MANAGER_DIR dir in $rootDir. Ignoring this directory.", e)
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -227,13 +227,13 @@ private[spark] class DiskBlockManager(conf: SparkConf, var deleteFilesOnStop: Bo
 
   /**
    * Create a directory that is writable by the group.
-   * Grant the customized permission so the shuffle server can
+   * Grant the permission 770 "rwxrwx---" to the directory so the shuffle server can
    * create subdirs/files within the merge folder.
    * TODO: Find out why can't we create a dir using java api with permission 770
    *  Files.createDirectories(mergeDir.toPath, PosixFilePermissions.asFileAttribute(
    *  PosixFilePermissions.fromString("rwxrwx---")))
    */
-  def createDirWithCustomizedPermission(dirToCreate: File, permission: String): Unit = {
+  def createDirWithPermission770(dirToCreate: File): Unit = {
     var attempts = 0
     val maxAttempts = Utils.MAX_DIR_CREATION_ATTEMPTS
     var created: File = null
@@ -242,11 +242,11 @@ private[spark] class DiskBlockManager(conf: SparkConf, var deleteFilesOnStop: Bo
       if (attempts > maxAttempts) {
         throw new IOException(
           s"Failed to create directory ${dirToCreate.getAbsolutePath} with permission " +
-            s"$permission after $maxAttempts attempts!")
+            s"770 after $maxAttempts attempts!")
       }
       try {
         val builder = new ProcessBuilder().command(
-          "mkdir", "-p", "-m" + permission, dirToCreate.getAbsolutePath)
+          "mkdir", "-p", "-m770", dirToCreate.getAbsolutePath)
         val proc = builder.start()
         val exitCode = proc.waitFor()
         if (dirToCreate.exists()) {
@@ -254,11 +254,11 @@ private[spark] class DiskBlockManager(conf: SparkConf, var deleteFilesOnStop: Bo
         }
         logDebug(
           s"Created directory at ${dirToCreate.getAbsolutePath} with permission " +
-            s"$permission and exitCode $exitCode")
+            s"770 and exitCode $exitCode")
       } catch {
         case e: SecurityException =>
           logWarning(s"Failed to create directory ${dirToCreate.getAbsolutePath} " +
-            s"with permission $permission", e)
+            s"with permission 770", e)
           created = null;
       }
     }

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -211,7 +211,7 @@ private[spark] class DiskBlockManager(conf: SparkConf, var deleteFilesOnStop: Bo
               if (!subDir.exists()) {
                 // Only one container will create this directory. The filesystem will handle
                 // any race conditions.
-                createDirWithCustomizedPermission(subDir, "770")
+                createDirWithPermission770(subDir)
               }
             }
           }

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -24,6 +24,7 @@ import java.util.UUID
 import org.apache.spark.SparkConf
 import org.apache.spark.executor.ExecutorExitCode
 import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.network.shuffle.ExecutorDiskUtils
 import org.apache.spark.storage.DiskBlockManager.MERGE_MANAGER_DIR
 import org.apache.spark.util.{ShutdownHookManager, Utils}
 
@@ -59,10 +60,8 @@ private[spark] class DiskBlockManager(conf: SparkConf, var deleteFilesOnStop: Bo
   /**
    * Create merge directories
    */
-  createLocalDirsForMergedShuffleBlocks(conf)
-
-  private[spark] lazy val activeMergedShuffleDirs: Option[Array[File]] =
-    findActiveMergedShuffleDirs(conf)
+  private[spark] val activeMergedShuffleDirs: Option[Array[File]] =
+    createLocalDirsForMergedShuffleBlocks(conf)
 
   private val shutdownHook = addShutdownHook()
 
@@ -108,21 +107,18 @@ private[spark] class DiskBlockManager(conf: SparkConf, var deleteFilesOnStop: Bo
       case mergedMetaBlockId: ShuffleMergedMetaBlockId =>
         getMergedShuffleFile(mergedMetaBlockId.appId, mergedMetaBlockId.name)
       case _ =>
-        throw new RuntimeException(s"Only merged block ID is supported, but got ${blockId}")
+        throw new IllegalArgumentException(
+          s"Only merged block ID is supported, but got ${blockId}")
     }
   }
 
   private def getMergedShuffleFile(appId: String, filename: String): File = {
     if (activeMergedShuffleDirs.isEmpty) {
-      throw new RuntimeException(
+      throw new IllegalArgumentException(
         s"Cannot read $filename because active merged shuffle dirs is empty")
     }
-    val localDirsForMergedShuffleBlock = activeMergedShuffleDirs.get
-    val hash = Utils.nonNegativeHash(filename)
-    val mergedDir = localDirsForMergedShuffleBlock(hash % localDirsForMergedShuffleBlock.length)
-    val subDirNum = (hash / localDirsForMergedShuffleBlock.length) % subDirsPerLocalDir
-    val subDir = new File(mergedDir, "%02x".format(subDirNum))
-    new File(subDir, filename)
+    val localDirsForMergedShuffleBlock = activeMergedShuffleDirs.get.map(_.getPath)
+    ExecutorDiskUtils.getFile(localDirsForMergedShuffleBlock, subDirsPerLocalDir, filename)
   }
 
 
@@ -197,56 +193,57 @@ private[spark] class DiskBlockManager(conf: SparkConf, var deleteFilesOnStop: Bo
   }
 
   /**
-   * Get the list of configured local dirs storing merged shuffle blocks created by external
-   * shuffle services if push based shuffle is enabled. Note that the files in this directory
-   * will be created by the external shuffle services. We only create the merge_manager directories
-   * here because currently the shuffle service doesn't have permission to create directories
-   * under application local directories.
+   * Get the list of configured local dirs storing merged shuffle blocks created by executors
+   * if push based shuffle is enabled. Note that the files in this directory will be created
+   * by the external shuffle services. We only create the merge_manager directories and
+   * subdirectories here because currently the shuffle service doesn't have permission to
+   * create directories under application local directories.
    */
-  private def createLocalDirsForMergedShuffleBlocks(conf: SparkConf): Unit = {
+  private def createLocalDirsForMergedShuffleBlocks(conf: SparkConf): Option[Array[File]] = {
     if (Utils.isPushBasedShuffleEnabled(conf)) {
       // Will create the merge_manager directory only if it doesn't exist under any local dir.
       val localDirs = Utils.getConfiguredLocalDirs(conf)
+      var mergeDirCreated = false;
       for (rootDir <- localDirs) {
         val mergeDir = new File(rootDir, MERGE_MANAGER_DIR)
         if (mergeDir.exists()) {
           logDebug(s"Not creating $mergeDir as it already exists")
-          return
+          mergeDirCreated = true
         }
       }
-      // Since this executor didn't see any merge_manager directories, it will start creating them.
-      // It's possible that the other executors launched at the same time may also reach here but
-      // we are working on the assumption that the executors launched around the same time will
-      // have the same set of application local directories.
-      localDirs.flatMap { rootDir =>
-        try {
-          val mergeDir = new File(rootDir, MERGE_MANAGER_DIR)
-          // Only one container will create this directory. The filesystem will handle any race
-          // conditions.
-          if (!mergeDir.exists()) {
-            for (dirNum <- 0 until subDirsPerLocalDir) {
-              val sudDir = new File(mergeDir, "%02x".format(dirNum))
-              Utils.createDirWith770(sudDir)
+      if (!mergeDirCreated) {
+        // This executor didn't see any merge_manager directories, it will start creating them.
+        // It's possible that the other executors launched at the same time may also reach here but
+        // we are working on the assumption that the executors launched around the same time will
+        // have the same set of application local directories.
+        localDirs.foreach { rootDir =>
+          try {
+            val mergeDir = new File(rootDir, MERGE_MANAGER_DIR)
+            // Only one container will create this directory. The filesystem will handle any race
+            // conditions.
+            if (!mergeDir.exists()) {
+              Utils.createDirWith770(mergeDir)
+              for (dirNum <- 0 until subDirsPerLocalDir) {
+                val sudDir = new File(mergeDir, "%02x".format(dirNum))
+                Utils.createDirWith770(sudDir)
+              }
             }
+            logInfo(s"Merge directory at $mergeDir")
+          } catch {
+            case e: IOException =>
+              logError(
+                s"Failed to create merge dir in $rootDir. Ignoring this directory.", e)
           }
-          logInfo(s"Merge directory at $mergeDir")
-          Some(mergeDir)
-        } catch {
-          case e: IOException =>
-            logError(
-              s"Failed to create merge dir in $rootDir. Ignoring this directory.", e)
-            None
         }
       }
-      Utils.getConfiguredLocalDirs(conf).map(rootDir => new File(rootDir, MERGE_MANAGER_DIR))
     }
+    findActiveMergedShuffleDirs(conf)
   }
 
   private def findActiveMergedShuffleDirs(conf: SparkConf): Option[Array[File]] = {
     Option(Utils.getConfiguredLocalDirs(conf).map(
-      rootDir => new File(rootDir, "merge_manager")).filter(mergeDir => mergeDir.exists()))
+      rootDir => new File(rootDir, MERGE_MANAGER_DIR)).filter(mergeDir => mergeDir.exists()))
   }
-
 
   private def addShutdownHook(): AnyRef = {
     logDebug("Adding shutdown hook") // force eager creation of logger

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2585,7 +2585,8 @@ private[spark] object Utils extends Logging {
    * Push based shuffle can only be enabled when the application is submitted
    * to run in YARN mode, with external shuffle service enabled and
    * spark.yarn.maxAttempts or the yarn cluster default max attempts is set to 1.
-   * TODO: SPARK-35546 Support push based shuffle with multiple app attempts
+   * TODO: Remove the requirement on spark.yarn.maxAttempts after SPARK-35546
+   * Support push based shuffle with multiple app attempts
    */
   def isPushBasedShuffleEnabled(conf: SparkConf): Boolean = {
     conf.get(PUSH_BASED_SHUFFLE_ENABLED) &&
@@ -2595,7 +2596,11 @@ private[spark] object Utils extends Logging {
           getYarnMaxAttempts(conf) == 1))
   }
 
-  /** Returns the maximum number of attempts to register the AM in YARN mode. */
+  /**
+   * Returns the maximum number of attempts to register the AM in YARN mode.
+   * TODO: Remove this method after SPARK-35546 Support push based shuffle
+   * with multiple app attempts
+   */
   def getYarnMaxAttempts(conf: SparkConf): Int = {
     val sparkMaxAttempts = conf.getOption("spark.yarn.maxAttempts").map(_.toInt)
     val yarnMaxAttempts = getSparkOrYarnConfig(conf, YarnConfiguration.RM_AM_MAX_ATTEMPTS,

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -346,7 +346,6 @@ private[spark] object Utils extends Logging {
     }
   }
 
-
   /**
    * Create a temporary directory inside the given parent directory. The directory will be
    * automatically deleted when the VM shuts down.

--- a/core/src/test/scala/org/apache/spark/shuffle/HostLocalShuffleReadingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/HostLocalShuffleReadingSuite.scala
@@ -133,4 +133,13 @@ class HostLocalShuffleReadingSuite extends SparkFunSuite with Matchers with Loca
       assert(remoteBytesRead.sum === 0 && remoteBlocksFetched.sum === 0)
     }
   }
+
+  test("Enable host local shuffle reading when Push based shuffle is enabled") {
+    val conf = new SparkConf()
+      .set(SHUFFLE_SERVICE_ENABLED, true)
+      .set("spark.yarn.maxAttempts", "1")
+      .set(PUSH_BASED_SHUFFLE_ENABLED, true)
+    sc = new SparkContext("local-cluster[2,1,1024]", "test-host-local-shuffle-reading", conf)
+    sc.env.blockManager.hostLocalDirManager.isDefined should equal(true)
+  }
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/HostLocalShuffleReadingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/HostLocalShuffleReadingSuite.scala
@@ -139,7 +139,7 @@ class HostLocalShuffleReadingSuite extends SparkFunSuite with Matchers with Loca
       .set(SHUFFLE_SERVICE_ENABLED, true)
       .set("spark.yarn.maxAttempts", "1")
       .set(PUSH_BASED_SHUFFLE_ENABLED, true)
-    sc = new SparkContext("local-cluster[2,1,1024]", "test-host-local-shuffle-reading", conf)
+    sc = new SparkContext("local-cluster[2, 1, 1024]", "test-host-local-shuffle-reading", conf)
     sc.env.blockManager.hostLocalDirManager.isDefined should equal(true)
   }
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/HostLocalShuffleReadingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/HostLocalShuffleReadingSuite.scala
@@ -134,7 +134,7 @@ class HostLocalShuffleReadingSuite extends SparkFunSuite with Matchers with Loca
     }
   }
 
-  test("Enable host local shuffle reading when Push based shuffle is enabled") {
+  test("Enable host local shuffle reading when push based shuffle is enabled") {
     val conf = new SparkConf()
       .set(SHUFFLE_SERVICE_ENABLED, true)
       .set("spark.yarn.maxAttempts", "1")

--- a/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
@@ -104,6 +104,42 @@ class BlockIdSuite extends SparkFunSuite {
     assertSame(id, BlockId(id.toString))
   }
 
+  test("shuffle merged") {
+    val id = ShuffleMergedBlockId("app_000", 8, 9)
+    assertSame(id, ShuffleMergedBlockId("app_000", 8, 9))
+    assertDifferent(id, ShuffleMergedBlockId("app_000", 9, 9))
+    assert(id.name === "mergedShuffle_app_000_8_9.data")
+    assert(id.asRDDId === None)
+    assert(id.appId === "app_000")
+    assert(id.shuffleId=== 8)
+    assert(id.reduceId === 9)
+    assertSame(id, BlockId(id.toString))
+  }
+
+  test("shuffle merged index") {
+    val id = ShuffleMergedIndexBlockId("app_000", 8, 9)
+    assertSame(id, ShuffleMergedIndexBlockId("app_000", 8, 9))
+    assertDifferent(id, ShuffleMergedIndexBlockId("app_000", 9, 9))
+    assert(id.name === "mergedShuffle_app_000_8_9.index")
+    assert(id.asRDDId === None)
+    assert(id.appId === "app_000")
+    assert(id.shuffleId=== 8)
+    assert(id.reduceId === 9)
+    assertSame(id, BlockId(id.toString))
+  }
+
+  test("shuffle merged meta") {
+    val id = ShuffleMergedMetaBlockId("app_000", 8, 9)
+    assertSame(id, ShuffleMergedMetaBlockId("app_000", 8, 9))
+    assertDifferent(id, ShuffleMergedMetaBlockId("app_000", 9, 9))
+    assert(id.name === "mergedShuffle_app_000_8_9.meta")
+    assert(id.asRDDId === None)
+    assert(id.appId === "app_000")
+    assert(id.shuffleId=== 8)
+    assert(id.reduceId === 9)
+    assertSame(id, BlockId(id.toString))
+  }
+
   test("broadcast") {
     val id = BroadcastBlockId(42)
     assertSame(id, BroadcastBlockId(42))

--- a/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
@@ -104,11 +104,11 @@ class BlockIdSuite extends SparkFunSuite {
     assertSame(id, BlockId(id.toString))
   }
 
-  test("shuffle merged") {
-    val id = ShuffleMergedBlockId("app_000", 8, 9)
-    assertSame(id, ShuffleMergedBlockId("app_000", 8, 9))
-    assertDifferent(id, ShuffleMergedBlockId("app_000", 9, 9))
-    assert(id.name === "mergedShuffle_app_000_8_9.data")
+  test("shuffle merged data") {
+    val id = ShuffleMergedDataBlockId("app_000", 8, 9)
+    assertSame(id, ShuffleMergedDataBlockId("app_000", 8, 9))
+    assertDifferent(id, ShuffleMergedDataBlockId("app_000", 9, 9))
+    assert(id.name === "shuffleMerged_app_000_8_9.data")
     assert(id.asRDDId === None)
     assert(id.appId === "app_000")
     assert(id.shuffleId=== 8)
@@ -120,7 +120,7 @@ class BlockIdSuite extends SparkFunSuite {
     val id = ShuffleMergedIndexBlockId("app_000", 8, 9)
     assertSame(id, ShuffleMergedIndexBlockId("app_000", 8, 9))
     assertDifferent(id, ShuffleMergedIndexBlockId("app_000", 9, 9))
-    assert(id.name === "mergedShuffle_app_000_8_9.index")
+    assert(id.name === "shuffleMerged_app_000_8_9.index")
     assert(id.asRDDId === None)
     assert(id.appId === "app_000")
     assert(id.shuffleId=== 8)
@@ -132,7 +132,7 @@ class BlockIdSuite extends SparkFunSuite {
     val id = ShuffleMergedMetaBlockId("app_000", 8, 9)
     assertSame(id, ShuffleMergedMetaBlockId("app_000", 8, 9))
     assertDifferent(id, ShuffleMergedMetaBlockId("app_000", 9, 9))
-    assert(id.name === "mergedShuffle_app_000_8_9.meta")
+    assert(id.name === "shuffleMerged_app_000_8_9.meta")
     assert(id.asRDDId === None)
     assert(id.appId === "app_000")
     assert(id.shuffleId=== 8)

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -18,12 +18,16 @@
 package org.apache.spark.storage
 
 import java.io.{File, FileWriter}
-import java.nio.file.Files
+import java.nio.file.{Files, Paths}
+import java.nio.file.attribute.PosixFilePermissions
 
+import org.apache.commons.io.FileUtils
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.internal.config
 import org.apache.spark.util.Utils
+
 
 class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with BeforeAndAfterAll {
   private val testConf = new SparkConf(false)
@@ -97,11 +101,27 @@ class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with B
     }
     testConf.set("spark.local.dir", rootDirs)
     testConf.set("spark.shuffle.push.enabled", "true")
-    testConf.set("spark.shuffle.service.enabled", "true")
+    testConf.set(config.Tests.IS_TESTING, true)
     diskBlockManager = new DiskBlockManager(testConf, deleteFilesOnStop = true)
-    Utils.getConfiguredLocalDirs(testConf).map(
+    assert(Utils.getConfiguredLocalDirs(testConf).map(
       rootDir => new File(rootDir, DiskBlockManager.MERGE_MANAGER_DIR))
-      .filter(mergeDir => mergeDir.exists())
+      .filter(mergeDir => mergeDir.exists()).length === 2)
+    // mergeDir0 will be skipped as it already exists
+    assert(mergeDir0.list().length === 0)
+    // Sub directories get created under mergeDir1
+    assert(mergeDir1.list().length === testConf.get(config.DISKSTORE_SUB_DIRECTORIES))
+  }
+
+  test("Test dir creation with permission 770") {
+    val testDir = new File("target/testDir");
+    FileUtils.deleteQuietly(testDir)
+    diskBlockManager = new DiskBlockManager(testConf, deleteFilesOnStop = true)
+    diskBlockManager.createDirWithCustomizedPermission(testDir, "770")
+    assert(testDir.exists && testDir.isDirectory)
+    val permission = PosixFilePermissions.toString(
+      Files.getPosixFilePermissions(Paths.get("target/testDir")))
+    assert(permission.equals("rwxrwx---"))
+    FileUtils.deleteQuietly(testDir)
   }
 
   def writeToFile(file: File, numBytes: Int): Unit = {

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -116,7 +116,7 @@ class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with B
     val testDir = new File("target/testDir");
     FileUtils.deleteQuietly(testDir)
     diskBlockManager = new DiskBlockManager(testConf, deleteFilesOnStop = true)
-    diskBlockManager.createDirWithCustomizedPermission(testDir, "770")
+    diskBlockManager.createDirWithPermission770(testDir)
     assert(testDir.exists && testDir.isDirectory)
     val permission = PosixFilePermissions.toString(
       Files.getPosixFilePermissions(Paths.get("target/testDir")))

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -22,9 +22,6 @@ import java.lang.reflect.Field
 import java.net.{BindException, ServerSocket, URI}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.{Files => JavaFiles}
-import java.nio.file.Paths
-import java.nio.file.attribute.PosixFilePermissions
 import java.text.DecimalFormatSymbols
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -34,7 +31,7 @@ import scala.collection.mutable.ListBuffer
 import scala.util.Random
 
 import com.google.common.io.Files
-import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.commons.io.IOUtils
 import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 import org.apache.commons.math3.stat.inference.ChiSquareTest
 import org.apache.hadoop.conf.Configuration
@@ -1455,20 +1452,6 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     conf.set("spark.yarn.maxAttempts", "2")
     assert(Utils.isPushBasedShuffleEnabled(conf) === false)
   }
-
-  test("Test create dir with 770") {
-    val testDir = new File("target/testDir");
-    FileUtils.deleteQuietly(testDir)
-    Utils.createDirWithCustomizedPermission(testDir, "770")
-    val permission = PosixFilePermissions.toString(
-      JavaFiles.getPosixFilePermissions(Paths.get("target/testDir")))
-    assert(permission.equals("rwxrwx---"))
-    val foo = new File(testDir, "foo.txt")
-    Files.touch(foo)
-    assert(testDir.exists && testDir.isDirectory)
-    FileUtils.deleteQuietly(testDir)
-  }
-
 }
 
 private class SimpleExtension

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -17,11 +17,14 @@
 
 package org.apache.spark.util
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataOutput, DataOutputStream, File, FileOutputStream, PrintStream, SequenceInputStream}
+import java.io._
 import java.lang.reflect.Field
 import java.net.{BindException, ServerSocket, URI}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files => JavaFiles}
+import java.nio.file.Paths
+import java.nio.file.attribute.PosixFilePermissions
 import java.text.DecimalFormatSymbols
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -29,16 +32,19 @@ import java.util.zip.GZIPOutputStream
 
 import scala.collection.mutable.ListBuffer
 import scala.util.Random
+
 import com.google.common.io.Files
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 import org.apache.commons.math3.stat.inference.ChiSquareTest
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Tests.IS_TESTING
+import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.scheduler.SparkListener
 import org.apache.spark.util.io.ChunkedByteBufferInputStream
@@ -1435,21 +1441,28 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     assert(message.contains(expected))
   }
 
-  test("isPushBasedShuffleEnabled when both PUSH_BASED_SHUFFLE_ENABLED" +
-    " and SHUFFLE_SERVICE_ENABLED are true") {
+  test("isPushBasedShuffleEnabled when PUSH_BASED_SHUFFLE_ENABLED " +
+    "and SHUFFLE_SERVICE_ENABLED are both set to true in YARN mode with maxAttempts set to 1") {
     val conf = new SparkConf()
     assert(Utils.isPushBasedShuffleEnabled(conf) === false)
     conf.set(PUSH_BASED_SHUFFLE_ENABLED, true)
     conf.set(IS_TESTING, false)
     assert(Utils.isPushBasedShuffleEnabled(conf) === false)
     conf.set(SHUFFLE_SERVICE_ENABLED, true)
+    conf.set(SparkLauncher.SPARK_MASTER, "yarn")
+    conf.set("spark.yarn.maxAttempts", "1")
     assert(Utils.isPushBasedShuffleEnabled(conf) === true)
+    conf.set("spark.yarn.maxAttempts", "2")
+    assert(Utils.isPushBasedShuffleEnabled(conf) === false)
   }
 
   test("Test create dir with 770") {
     val testDir = new File("target/testDir");
     FileUtils.deleteQuietly(testDir)
-    Utils.createDirWith770(testDir)
+    Utils.createDirWithCustomizedPermission(testDir, "770")
+    val permission = PosixFilePermissions.toString(
+      JavaFiles.getPosixFilePermissions(Paths.get("target/testDir")))
+    assert(permission.equals("rwxrwx---"))
     val foo = new File(testDir, "foo.txt")
     Files.touch(foo)
     assert(testDir.exists && testDir.isDirectory)

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.util
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataOutput, DataOutputStream, File,
-  FileOutputStream, PrintStream, SequenceInputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataOutput, DataOutputStream, File, FileOutputStream, PrintStream, SequenceInputStream}
 import java.lang.reflect.Field
 import java.net.{BindException, ServerSocket, URI}
 import java.nio.{ByteBuffer, ByteOrder}
@@ -30,14 +29,12 @@ import java.util.zip.GZIPOutputStream
 
 import scala.collection.mutable.ListBuffer
 import scala.util.Random
-
 import com.google.common.io.Files
-import org.apache.commons.io.IOUtils
+import org.apache.commons.io.{FileUtils, IOUtils}
 import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 import org.apache.commons.math3.stat.inference.ChiSquareTest
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
@@ -1448,6 +1445,17 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     conf.set(SHUFFLE_SERVICE_ENABLED, true)
     assert(Utils.isPushBasedShuffleEnabled(conf) === true)
   }
+
+  test("Test create dir with 770") {
+    val testDir = new File("target/testDir");
+    FileUtils.deleteQuietly(testDir)
+    Utils.createDirWith770(testDir)
+    val foo = new File(testDir, "foo.txt")
+    Files.touch(foo)
+    assert(testDir.exists && testDir.isDirectory)
+    FileUtils.deleteQuietly(testDir)
+  }
+
 }
 
 private class SimpleExtension


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is one of the patches for SPIP SPARK-30602 which is needed for push-based shuffle.

### Summary of changes:
Executor will create the merge directories under the application temp directory provided by YARN. The access control of the folder will be set to 770, where Shuffle Service can create merged shuffle files and write merge shuffle data in to those files.

Serve the merged shuffle blocks fetch request, read the merged shuffle blocks.

### Why are the changes needed?
Refer to the SPIP in SPARK-30602.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Added unit tests.
The reference PR with the consolidated changes covering the complete implementation is also provided in SPARK-30602.
We have already verified the functionality and the improved performance as documented in the SPIP doc.

Lead-authored-by: Min Shen mshen@linkedin.com
Co-authored-by: Chandni Singh chsingh@linkedin.com
Co-authored-by: Ye Zhou yezhou@linkedin.com