### PR TITLE
[WIP][SPARK-34920][SQL] Add SQLSTATE and ERRORCODE to SQL exception

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -25,7 +25,7 @@ import java.util.ConcurrentModificationException
 
 import org.apache.spark.errors.{DEFAULT, ErrorCode, INTERNAL_ERROR}
 
-private[spark] class SparkException(
+class SparkException(
     message: String,
     cause: Throwable,
     val errorCode: ErrorCode = DEFAULT)

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -17,10 +17,20 @@
 
 package org.apache.spark
 
-class SparkException(message: String, cause: Throwable)
+import java.io.{FileNotFoundException, IOException}
+import java.nio.file.FileAlreadyExistsException
+import java.sql.SQLFeatureNotSupportedException
+import java.time.DateTimeException
+import java.util.ConcurrentModificationException
+
+import org.apache.spark.errors.{DEFAULT, ErrorCode, INTERNAL_ERROR}
+
+class SparkException(message: String, cause: Throwable, val errorCode: ErrorCode = DEFAULT)
   extends Exception(message, cause) {
 
   def this(message: String) = this(message, null)
+
+  def this(cause: Throwable) = this(cause.toString, cause)
 }
 
 /**
@@ -48,5 +58,128 @@ private[spark] case class ExecutorDeadException(message: String)
  * Exception thrown when Spark returns different result after upgrading to a new version.
  */
 private[spark] class SparkUpgradeException(version: String, message: String, cause: Throwable)
-  extends RuntimeException("You may get a different result due to the upgrading of Spark" +
-    s" $version: $message", cause)
+  extends SparkRuntimeException("You may get a different result due to the upgrading of Spark" +
+    s" $version: $message", cause, INTERNAL_ERROR)
+
+
+private[spark] class SparkRuntimeException(
+    val reason: String,
+    val cause: Throwable,
+    val errorCode: ErrorCode = DEFAULT) extends RuntimeException(reason, cause) {
+  def this() = this("unknown reason", null)
+  def this(reason: String) = this(reason, null)
+  def this(cause: Throwable) = this(cause.toString, cause)
+}
+
+private[spark] class SparkIllegalArgumentException(
+    message: String,
+    cause: Throwable,
+    val errorCode: ErrorCode = DEFAULT) extends IllegalArgumentException(message, cause) {
+
+  def this(message: String) = this(message, null)
+
+  def this(cause: Throwable) = this(cause.toString, cause)
+}
+
+private[spark] class SparkIllegalStateException(
+    message: String,
+    val errorCode: ErrorCode = DEFAULT) extends IllegalStateException(message) {
+}
+
+private[spark] class SparkUnsupportedOperationException(
+    message: String, cause: Throwable, val errorCode: ErrorCode = DEFAULT)
+  extends UnsupportedOperationException(message, cause) {
+
+  def this(message: String) = this(message, null)
+
+  def this(cause: Throwable) = this(cause.toString, cause)
+}
+
+private[spark] class SparkNullPointerException(message: String, val errorCode: ErrorCode = DEFAULT)
+  extends NullPointerException(message) {
+}
+
+private[spark] class SparkArrayIndexOutOfBoundsException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends ArrayIndexOutOfBoundsException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkIndexOutOfBoundsException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends IndexOutOfBoundsException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkDateTimeException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends DateTimeException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkConcurrentModificationException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends ConcurrentModificationException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkSecurityException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends SecurityException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkFileNotFoundException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends FileNotFoundException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkSQLFeatureNotSupportedException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends SQLFeatureNotSupportedException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkIOException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends IOException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkFileAlreadyExistsException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends FileAlreadyExistsException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkArithmeticException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends ArithmeticException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkCloneNotSupportedException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends CloneNotSupportedException(message) {
+
+  def this(message: String) = this(message, null)
+}
+
+private[spark] class SparkNumberFormatException(
+    message: String, val errorCode: ErrorCode = DEFAULT)
+  extends NumberFormatException(message) {
+
+  def this(message: String) = this(message, null)
+}
+

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -25,12 +25,14 @@ import java.util.ConcurrentModificationException
 
 import org.apache.spark.errors.{DEFAULT, ErrorCode, INTERNAL_ERROR}
 
-class SparkException(message: String, cause: Throwable, val errorCode: ErrorCode = DEFAULT)
+private[spark] class SparkException(
+    message: String,
+    cause: Throwable,
+    val errorCode: ErrorCode = DEFAULT)
   extends Exception(message, cause) {
 
-  def this(message: String) = this(message, null)
-
-  def this(cause: Throwable) = this(cause.toString, cause)
+  def this(message: String) = this(message, null, DEFAULT)
+  def this(message: String, cause: Throwable) = this(message, cause, DEFAULT)
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/errors/ErrorCode.scala
+++ b/core/src/main/scala/org/apache/spark/errors/ErrorCode.scala
@@ -14,16 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.spark.errors
 
-package org.apache.spark
-
-import org.apache.spark.annotation.DeveloperApi
-
-/**
- * :: DeveloperApi ::
- * Exception thrown when a task is explicitly killed (i.e., task failure is expected).
- */
-@DeveloperApi
-class TaskKilledException(override val reason: String) extends SparkRuntimeException {
-  def this() = this("unknown reason")
-}
+abstract class ErrorCode(val id: Int, val sqlState: String) {}

--- a/core/src/main/scala/org/apache/spark/errors/ErrorCode.scala
+++ b/core/src/main/scala/org/apache/spark/errors/ErrorCode.scala
@@ -16,4 +16,6 @@
  */
 package org.apache.spark.errors
 
-abstract class ErrorCode(val id: Int, val sqlState: String) {}
+abstract class ErrorCode(val id: Int, val sqlState: String) {
+  def this() = this(DEFAULT.id, DEFAULT.sqlState)
+}

--- a/core/src/main/scala/org/apache/spark/errors/coreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/coreErrors.scala
@@ -14,16 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.spark.errors
 
-package org.apache.spark
-
-import org.apache.spark.annotation.DeveloperApi
-
-/**
- * :: DeveloperApi ::
- * Exception thrown when a task is explicitly killed (i.e., task failure is expected).
- */
-@DeveloperApi
-class TaskKilledException(override val reason: String) extends SparkRuntimeException {
-  def this() = this("unknown reason")
-}
+case object DEFAULT extends ErrorCode(0, null)
+case object INTERNAL_ERROR extends ErrorCode(100001, "XX000")

--- a/core/src/main/scala/org/apache/spark/util/SparkFatalException.scala
+++ b/core/src/main/scala/org/apache/spark/util/SparkFatalException.scala
@@ -16,6 +16,9 @@
  */
 package org.apache.spark.util
 
+import org.apache.spark.errors.{DEFAULT, ErrorCode}
+
+
 /**
  * SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we catch
  * fatal throwable in {@link scala.concurrent.Future}'s body, and re-throw
@@ -24,4 +27,6 @@ package org.apache.spark.util
  * which is run by using ThreadUtils.awaitResult. ThreadUtils.awaitResult will catch
  * it and re-throw the original exception/error.
  */
-private[spark] final class SparkFatalException(val throwable: Throwable) extends Exception
+private[spark] final class SparkFatalException(
+    val throwable: Throwable,
+    val errorCode: ErrorCode = DEFAULT) extends Exception

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -17,9 +17,8 @@
 
 package org.apache.spark.sql
 
-import java.sql.SQLException
-
 import org.apache.spark.annotation.Stable
+import org.apache.spark.errors.{DEFAULT, ErrorCode}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
 /**
@@ -34,10 +33,9 @@ class AnalysisException protected[sql] (
     val startPosition: Option[Int] = None,
     // Some plans fail to serialize due to bugs in scala collections.
     @transient val plan: Option[LogicalPlan] = None,
-    val sqlState: String = "",
-    val errorCode: Int = 0,
+    val errorCode: ErrorCode = DEFAULT,
     val cause: Option[Throwable] = None)
-  extends SQLException(message, sqlState, errorCode, cause.orNull) with Serializable {
+  extends Exception(message, cause.orNull) with Serializable {
 
   def withPosition(line: Option[Int], startPosition: Option[Int]): AnalysisException = {
     val newException = new AnalysisException(message, line, startPosition)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql
 
+import java.sql.SQLException
+
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
@@ -32,8 +34,10 @@ class AnalysisException protected[sql] (
     val startPosition: Option[Int] = None,
     // Some plans fail to serialize due to bugs in scala collections.
     @transient val plan: Option[LogicalPlan] = None,
+    val sqlState: String = "",
+    val errorCode: Int = 0,
     val cause: Option[Throwable] = None)
-  extends Exception(message, cause.orNull) with Serializable {
+  extends SQLException(message, sqlState, errorCode, cause.orNull) with Serializable {
 
   def withPosition(line: Option[Int], startPosition: Option[Int]): AnalysisException = {
     val newException = new AnalysisException(message, line, startPosition)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.errors.catalystErrors.INVALID_PARAMETER_VALUE
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -774,7 +775,8 @@ abstract class TypeCoercionBase {
           AnsiCast(r, IntegerType).eval().asInstanceOf[Int]
         } catch {
           case e: NumberFormatException => throw new AnalysisException(
-            "The second argument of 'date_add' function needs to be an integer.", cause = Some(e))
+            "The second argument of 'date_add' function needs to be an integer.",
+            errorCode = INVALID_PARAMETER_VALUE, cause = Some(e))
         }
         DateAdd(l, Literal(days))
       case DateSub(l, r) if r.dataType == StringType && r.foldable =>
@@ -783,7 +785,7 @@ abstract class TypeCoercionBase {
         } catch {
           case e: NumberFormatException => throw new AnalysisException(
             "The second argument of 'date_sub' function needs to be an integer.",
-            sqlState = "22023", errorCode = 1001, cause = Some(e))
+            errorCode = INVALID_PARAMETER_VALUE, cause = Some(e))
         }
         DateSub(l, Literal(days))
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -782,7 +782,8 @@ abstract class TypeCoercionBase {
           AnsiCast(r, IntegerType).eval().asInstanceOf[Int]
         } catch {
           case e: NumberFormatException => throw new AnalysisException(
-            "The second argument of 'date_sub' function needs to be an integer.", cause = Some(e))
+            "The second argument of 'date_sub' function needs to be an integer.",
+            sqlState = "22023", errorCode = 1001, cause = Some(e))
         }
         DateSub(l, Literal(days))
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/package.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst
 
+import org.apache.spark.errors.{DEFAULT, ErrorCode}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.trees.TreeNode
 
@@ -40,9 +41,9 @@ package object analysis {
     /** Fails the analysis at the point where a specific tree node was parsed. */
     def failAnalysis(
         msg: String, cause: Throwable = null,
-        sqlState: String = null, errorCode: Int = 0): Nothing = {
+        errorCode: ErrorCode = DEFAULT): Nothing = {
       throw new AnalysisException(
-        msg, t.origin.line, t.origin.startPosition, sqlState = sqlState, errorCode = errorCode,
+        msg, t.origin.line, t.origin.startPosition, errorCode = errorCode,
         cause = Option(cause))
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/package.scala
@@ -38,13 +38,12 @@ package object analysis {
 
   implicit class AnalysisErrorAt(t: TreeNode[_]) {
     /** Fails the analysis at the point where a specific tree node was parsed. */
-    def failAnalysis(msg: String): Nothing = {
-      throw new AnalysisException(msg, t.origin.line, t.origin.startPosition)
-    }
-
-    /** Fails the analysis at the point where a specific tree node was parsed. */
-    def failAnalysis(msg: String, cause: Throwable): Nothing = {
-      throw new AnalysisException(msg, t.origin.line, t.origin.startPosition, cause = Some(cause))
+    def failAnalysis(
+        msg: String, cause: Throwable = null,
+        sqlState: String = null, errorCode: Int = 0): Nothing = {
+      throw new AnalysisException(
+        msg, t.origin.line, t.origin.startPosition, sqlState = sqlState, errorCode = errorCode,
+        cause = Option(cause))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InvalidUDFClassException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InvalidUDFClassException.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.catalog
 
+import org.apache.spark.errors.DEFAULT
 import org.apache.spark.sql.AnalysisException
 
 /**
@@ -24,5 +25,5 @@ import org.apache.spark.sql.AnalysisException
  * function's class does not follow the rules of the UDF/UDAF/UDTF class definition.
  */
 class InvalidUDFClassException private[sql](message: String)
-  extends AnalysisException(message, None, None, None, "U0000", 1000, None) {
+  extends AnalysisException(message, None, None, None, DEFAULT, None) {
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import scala.collection.mutable
 
+import org.apache.spark.SparkIllegalStateException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
@@ -28,6 +29,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.errors.catalystErrors.INVALID_PARAMETER_VALUE
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
@@ -1568,7 +1570,8 @@ object PushPredicateThroughJoin extends Rule[LogicalPlan] with PredicateHelper {
             reduceLeftOption(And).map(Filter(_, newJoin)).getOrElse(newJoin)
 
         case other =>
-          throw new IllegalStateException(s"Unexpected join type: $other")
+          throw new SparkIllegalStateException(
+            s"Unexpected join type: $other", INVALID_PARAMETER_VALUE)
       }
 
     // push down the join filter into sub query scanning if applicable

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/catalystErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/catalystErrors.scala
@@ -14,16 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.spark.sql.errors
 
-package org.apache.spark
+import org.apache.spark.errors.ErrorCode
 
-import org.apache.spark.annotation.DeveloperApi
-
-/**
- * :: DeveloperApi ::
- * Exception thrown when a task is explicitly killed (i.e., task failure is expected).
- */
-@DeveloperApi
-class TaskKilledException(override val reason: String) extends SparkRuntimeException {
-  def this() = this("unknown reason")
+object catalystErrors {
+  case object INVALID_PARAMETER_VALUE extends ErrorCode(200001, "22023")
+  case object DIVISION_BY_ZERO extends ErrorCode(200002, "22012")
+  case object INVALID_DATETIME_FORMAT extends ErrorCode(200003, "22007")
+  case object INVALID_INTERVAL_FORMAT extends ErrorCode(200004, "22006")
+  case object NULL_VALUE_NOT_ALLOWED extends ErrorCode(200005, "22004")
+  case object NUMERIC_VALUE_OUT_OF_RANGE extends ErrorCode(200006, "22003")
+  case object SUBSTRING_ERROR extends ErrorCode(200007, "22011")
+  case object TRIM_ERROR extends ErrorCode(200008, "22027")
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/errors/sqlCoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/errors/sqlCoreErrors.scala
@@ -14,16 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.spark.sql.errors
 
-package org.apache.spark
+import org.apache.spark.errors.ErrorCode
 
-import org.apache.spark.annotation.DeveloperApi
-
-/**
- * :: DeveloperApi ::
- * Exception thrown when a task is explicitly killed (i.e., task failure is expected).
- */
-@DeveloperApi
-class TaskKilledException(override val reason: String) extends SparkRuntimeException {
-  def this() = this("unknown reason")
+object sqlCoreErrors {
+  case object OUT_OF_MEMORY extends ErrorCode(300001, "HY001")
+  case object UNKNOWN_ERROR extends ErrorCode(300002, "HY000")
+  case object NO_SUCH_TABLE extends ErrorCode(300003, "42S02")
 }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SQLExceptionUtils.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SQLExceptionUtils.scala
@@ -15,14 +15,28 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.catalyst.catalog
+package org.apache.spark.sql.hive.thriftserver
 
-import org.apache.spark.sql.AnalysisException
+import java.sql.SQLException
 
-/**
- * Thrown when a query failed for invalid function class, usually because a SQL
- * function's class does not follow the rules of the UDF/UDAF/UDTF class definition.
- */
-class InvalidUDFClassException private[sql](message: String)
-  extends AnalysisException(message, None, None, None, "U0000", 1000, None) {
+import org.apache.hive.service.cli.HiveSQLException
+
+import org.apache.spark.{SparkException, SparkUpgradeException}
+
+private[hive] object SQLExceptionUtils {
+
+  def toHiveSQLException(reason: String, cause: Throwable): HiveSQLException = {
+    cause match {
+      case e: HiveSQLException =>
+        e
+      case e: SparkException =>
+        new HiveSQLException(reason, "undefined", 0, e)
+      case e: SparkUpgradeException =>
+        new HiveSQLException(reason, "undefined", 1, e)
+      case e: SQLException =>
+        new HiveSQLException(reason, e.getSQLState, e.getErrorCode, e)
+      case e =>
+        new HiveSQLException(reason, e)
+    }
+  }
 }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -319,10 +319,7 @@ private[hive] class SparkExecuteStatementOperation(
           setState(OperationState.ERROR)
           HiveThriftServer2.eventManager.onStatementError(
             statementId, e.getMessage, SparkUtils.exceptionString(e))
-          e match {
-            case _: HiveSQLException => throw e
-            case _ => throw new HiveSQLException("Error running query: " + e.toString, e)
-          }
+          throw SQLExceptionUtils.toHiveSQLException(s"Error running query: ${e.toString}", e)
         }
     } finally {
       synchronized {

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -82,6 +82,8 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
         .contains("The second argument of 'date_sub' function needs to be an integer."))
       assert(e.getMessage.contains("" +
         "java.lang.NumberFormatException: invalid input syntax for type numeric: 1.2"))
+      assert(e.getSQLState.equals("22023"))
+      assert(e.getErrorCode === 1001)
     }
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -83,7 +83,7 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
       assert(e.getMessage.contains("" +
         "java.lang.NumberFormatException: invalid input syntax for type numeric: 1.2"))
       assert(e.getSQLState.equals("22023"))
-      assert(e.getErrorCode === 1001)
+      assert(e.getErrorCode === 200001)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

SQLSTATE is defined by the ANSI/ISO SQL-99 standard as a 5-character string value. The characters of an SQLSTATE code are divided logically into two categories:
- A 2-character class value.
The first two characters of the SQLSTATE code are any one of the ANSI/ISO SQL-99-defined SQLSTATE classes ([see SQLSTATE Class Definitions](https://docs.teradata.com/r/EClCkxtGMW6hxXXtL8sBfA/SdcEvzV7jTN1Z4K5QGgUWg?section=xtg1472241406415__BHBJGDBE_xreftarget)).

- A 3-character subclass value.
Subclass values can be any numeric or simple uppercase LATIN character string.



Please see [ANSI.pdf](https://github.com/apache/spark/files/6236838/ANSI.pdf) for more details.



This pr adds SQLSTATE and ERRORCODE to SQL exception to follow SQL standard by following steps:

1. Add a new abstract class `ErrorCode`. Each module has its own implementation. For example: [core module](https://github.com/apache/spark/blob/89c6f523c832daf7cff5c1ba8aecfbcd5494d5af/core/src/main/scala/org/apache/spark/errors/coreErrors.scala#L19-L20) and [catalyst module](https://github.com/apache/spark/blob/89c6f523c832daf7cff5c1ba8aecfbcd5494d5af/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/catalystErrors.scala#L22-L29).
2. Add `ErrorCode` to each Spark Exception. For example [SparkUpgradeException](https://github.com/apache/spark/blob/89c6f523c832daf7cff5c1ba8aecfbcd5494d5af/core/src/main/scala/org/apache/spark/SparkException.scala#L62-L64) , [SparkRuntimeException](https://github.com/apache/spark/blob/89c6f523c832daf7cff5c1ba8aecfbcd5494d5af/core/src/main/scala/org/apache/spark/SparkException.scala#L67-L74) and [AnalysisException](https://github.com/apache/spark/blob/89c6f523c832daf7cff5c1ba8aecfbcd5494d5af/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala#L30-L60)
3. Convert Spark Exception to `HiveSQLException` with `ErrorCode`. For example: [SQLExceptionUtils.toHiveSQLException](https://github.com/apache/spark/blob/89c6f523c832daf7cff5c1ba8aecfbcd5494d5af/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SQLExceptionUtils.scala#L33-L40).




After this pr:
![image](https://user-images.githubusercontent.com/5399861/113589012-6ed03680-9663-11eb-94ab-e0add6560abc.png)


Some references:
https://github.com/mysql/mysql-connector-j/blob/8.0.23/src/main/core-api/java/com/mysql/cj/exceptions/MysqlErrorNumbers.java
https://github.com/snowflakedb/snowflake-jdbc/blob/v3.13.2/src/main/java/net/snowflake/client/jdbc/ErrorCode.java

### Why are the changes needed?

1. Follow SQL standard.
2. Some JDBC/ODBC user need SQLSTATE.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

// TODO
