### PR TITLE
[SPARK-34881][SQL][FOLLOW-UP] Use multiline string for TryCast' expression description

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryCast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryCast.scala
@@ -32,9 +32,9 @@ import org.apache.spark.sql.types.DataType
 @ExpressionDescription(
   usage = """
     _FUNC_(expr AS type) - Casts the value `expr` to the target data type `type`.
-      "This expression is identical to CAST with configuration `spark.sql.ansi.enabled` as
-      "true, except it returns NULL instead of raising an error. Note that the behavior of this
-      "expression doesn't depend on configuration `spark.sql.ansi.enabled`.
+      This expression is identical to CAST with configuration `spark.sql.ansi.enabled` as
+      true, except it returns NULL instead of raising an error. Note that the behavior of this
+      expression doesn't depend on configuration `spark.sql.ansi.enabled`.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryCast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryCast.scala
@@ -30,10 +30,12 @@ import org.apache.spark.sql.types.DataType
  * session local timezone by an analyzer [[ResolveTimeZone]].
  */
 @ExpressionDescription(
-  usage = "_FUNC_(expr AS type) - Casts the value `expr` to the target data type `type`. " +
-    "This expression is identical to CAST with configuration `spark.sql.ansi.enabled` as " +
-    "true, except it returns NULL instead of raising an error. Note that the behavior of this " +
-    "expression doesn't depend on configuration `spark.sql.ansi.enabled`.",
+  usage = """
+    _FUNC_(expr AS type) - Casts the value `expr` to the target data type `type`.
+      "This expression is identical to CAST with configuration `spark.sql.ansi.enabled` as
+      "true, except it returns NULL instead of raising an error. Note that the behavior of this
+      "expression doesn't depend on configuration `spark.sql.ansi.enabled`.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_('10' as int);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes JDK 11 compilation failed:

```
/home/runner/work/spark/spark/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryCast.scala:35: error: annotation argument needs to be a constant; found: "_FUNC_(expr AS type) - Casts the value `expr` to the target data type `type`. ".+("This expression is identical to CAST with configuration `spark.sql.ansi.enabled` as ").+("true, except it returns NULL instead of raising an error. Note that the behavior of this ").+("expression doesn\'t depend on configuration `spark.sql.ansi.enabled`.")
    "true, except it returns NULL instead of raising an error. Note that the behavior of this " +
```

For whatever reason, it doesn't know that the string is actually a constant. This PR simply switches it to multi-line style (which is actually more correct).

Reference:

https://github.com/apache/spark/blob/bd0990e3e813d17065c593fc74f383b494fe8146/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala#L53-L57

### Why are the changes needed?

To recover the build.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

 CI in this PR