### PR TITLE
[SPARK-34947][SQL] Streaming write to a V2 table should invalidate its associated cache

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/WriteToStream.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/WriteToStream.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.streaming
 
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
-import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog}
 import org.apache.spark.sql.streaming.OutputMode
 
 /**
@@ -31,7 +31,8 @@ case class WriteToStream(
     sink: Table,
     outputMode: OutputMode,
     deleteCheckpointOnStop: Boolean,
-    inputQuery: LogicalPlan) extends UnaryNode {
+    inputQuery: LogicalPlan,
+    catalogAndIdent: Option[(TableCatalog, Identifier)] = None) extends UnaryNode {
 
   override def isStreaming: Boolean = true
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/WriteToStreamStatement.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/WriteToStreamStatement.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
-import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog}
 import org.apache.spark.sql.streaming.OutputMode
 
 /**
@@ -40,6 +40,7 @@ import org.apache.spark.sql.streaming.OutputMode
  * @param hadoopConf  The Hadoop Configuration to get a FileSystem instance
  * @param isContinuousTrigger  Whether the statement is triggered by a continuous query or not.
  * @param inputQuery  The analyzed query plan from the streaming DataFrame.
+ * @param catalogAndIdent Catalog and identifier for the sink, set when it is a V2 catalog table
  */
 case class WriteToStreamStatement(
     userSpecifiedName: Option[String],
@@ -50,7 +51,8 @@ case class WriteToStreamStatement(
     outputMode: OutputMode,
     hadoopConf: Configuration,
     isContinuousTrigger: Boolean,
-    inputQuery: LogicalPlan) extends UnaryNode {
+    inputQuery: LogicalPlan,
+    catalogAndIdent: Option[(TableCatalog, Identifier)] = None) extends UnaryNode {
 
   override def isStreaming: Boolean = true
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -138,8 +138,12 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
 
       withProjection :: Nil
 
-    case WriteToDataSourceV2(writer, query) =>
-      WriteToDataSourceV2Exec(writer, planLater(query)) :: Nil
+    case WriteToDataSourceV2(relationOpt, writer, query) =>
+      val refreshCacheFunc: () => Unit = relationOpt match {
+        case Some(r) => refreshCache(r)
+        case None => () => ()
+      }
+      WriteToDataSourceV2Exec(writer, refreshCacheFunc, planLater(query)) :: Nil
 
     case CreateV2Table(catalog, ident, schema, parts, props, ifNotExists) =>
       val propsWithOwner = CatalogV2Util.withDefaultOwnership(props)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -139,9 +139,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       withProjection :: Nil
 
     case WriteToDataSourceV2(relationOpt, writer, query) =>
-      val refreshCacheFunc: () => Unit = relationOpt match {
-        case Some(r) => refreshCache(r)
-        case None => () => ()
+      val refreshCacheFunc: () => Unit = () => relationOpt match {
+        case Some(r) => session.sharedState.cacheManager.uncacheQuery(session, r, cascade = true)
+        case None => ()
       }
       WriteToDataSourceV2Exec(writer, refreshCacheFunc, planLater(query)) :: Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -139,11 +139,11 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       withProjection :: Nil
 
     case WriteToDataSourceV2(relationOpt, writer, query) =>
-      val refreshCacheFunc: () => Unit = () => relationOpt match {
+      val invalidateCacheFunc: () => Unit = () => relationOpt match {
         case Some(r) => session.sharedState.cacheManager.uncacheQuery(session, r, cascade = true)
         case None => ()
       }
-      WriteToDataSourceV2Exec(writer, refreshCacheFunc, planLater(query)) :: Nil
+      WriteToDataSourceV2Exec(writer, invalidateCacheFunc, planLater(query)) :: Nil
 
     case CreateV2Table(catalog, ident, schema, parts, props, ifNotExists) =>
       val propsWithOwner = CatalogV2Util.withDefaultOwnership(props)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, CurrentBatch
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.streaming.{StreamingRelationV2, WriteToStream}
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, SupportsRead, SupportsWrite, TableCapability}
+import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, TableCapability}
 import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset => OffsetV2, ReadLimit, SparkDataStream, SupportsAdmissionControl}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, StreamingDataSourceV2Relation, StreamWriterCommitProgress, WriteToDataSourceV2Exec}
@@ -39,8 +39,7 @@ class MicroBatchExecution(
     trigger: Trigger,
     triggerClock: Clock,
     extraOptions: Map[String, String],
-    plan: WriteToStream,
-    catalogAndIdent: Option[(CatalogPlugin, Identifier)] = None)
+    plan: WriteToStream)
   extends StreamExecution(
     sparkSession, plan.name, plan.resolvedCheckpointLocation, plan.inputQuery, plan.sink, trigger,
     triggerClock, plan.outputMode, plan.deleteCheckpointOnStop) {
@@ -138,7 +137,7 @@ class MicroBatchExecution(
     sink match {
       case s: SupportsWrite =>
         val streamingWrite = createStreamingWrite(s, extraOptions, _logicalPlan)
-        val relationOpt = catalogAndIdent.map {
+        val relationOpt = plan.catalogAndIdent.map {
           case (catalog, ident) => DataSourceV2Relation.create(s, Some(catalog), Some(ident))
         }
         WriteToMicroBatchDataSource(relationOpt, streamingWrite, _logicalPlan)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ResolveWriteToStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ResolveWriteToStream.scala
@@ -61,7 +61,8 @@ object ResolveWriteToStream extends Rule[LogicalPlan] with SQLConfHelper {
         s.sink,
         s.outputMode,
         deleteCheckpointOnStop,
-        s.inputQuery)
+        s.inputQuery,
+        s.catalogAndIdent)
   }
 
   def resolveCheckpointLocation(s: WriteToStreamStatement): (String, Boolean) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/WriteToMicroBatchDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/WriteToMicroBatchDataSource.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.streaming.sources
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite
-import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, WriteToDataSourceV2}
 
 /**
  * The logical plan for writing data to a micro-batch stream.
@@ -28,12 +28,15 @@ import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2
  * Note that this logical plan does not have a corresponding physical plan, as it will be converted
  * to [[WriteToDataSourceV2]] with [[MicroBatchWrite]] before execution.
  */
-case class WriteToMicroBatchDataSource(write: StreamingWrite, query: LogicalPlan)
+case class WriteToMicroBatchDataSource(
+    relation: Option[DataSourceV2Relation],
+    write: StreamingWrite,
+    query: LogicalPlan)
   extends UnaryNode {
   override def child: LogicalPlan = query
   override def output: Seq[Attribute] = Nil
 
   def createPlan(batchId: Long): WriteToDataSourceV2 = {
-    WriteToDataSourceV2(new MicroBatchWrite(batchId, write), query)
+    WriteToDataSourceV2(relation, new MicroBatchWrite(batchId, write), query)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.plans.logical.CreateTableStatement
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table, TableProvider, V1Table, V2TableWithV1Fallback}
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, SupportsWrite, Table, TableProvider, V1Table, V2TableWithV1Fallback}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.DataSource
@@ -374,7 +374,8 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
 
     import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits._
     tableInstance match {
-      case t: SupportsWrite if t.supports(STREAMING_WRITE) => startQuery(t, extraOptions)
+      case t: SupportsWrite if t.supports(STREAMING_WRITE) =>
+        startQuery(t, extraOptions, catalogAndIdent = Some(catalog, identifier))
       case t: V2TableWithV1Fallback =>
         writeToV1Table(t.v1Table)
       case t: V1Table =>
@@ -460,7 +461,8 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
   private def startQuery(
       sink: Table,
       newOptions: CaseInsensitiveMap[String],
-      recoverFromCheckpoint: Boolean = true): StreamingQuery = {
+      recoverFromCheckpoint: Boolean = true,
+      catalogAndIdent: Option[(CatalogPlugin, Identifier)] = None): StreamingQuery = {
     val useTempCheckpointLocation = SOURCES_ALLOW_ONE_TIME_QUERY.contains(source)
 
     df.sparkSession.sessionState.streamingQueryManager.startQuery(
@@ -472,7 +474,8 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
       outputMode,
       useTempCheckpointLocation = useTempCheckpointLocation,
       recoverFromCheckpointLocation = recoverFromCheckpoint,
-      trigger = trigger)
+      trigger = trigger,
+      catalogAndIdent = catalogAndIdent)
   }
 
   private def createV1Sink(optionsWithPath: CaseInsensitiveMap[String]): Sink = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -29,7 +29,7 @@ import org.apache.spark.annotation.Evolving
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.streaming.{WriteToStream, WriteToStreamStatement}
-import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table}
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, SupportsWrite, Table}
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.continuous.ContinuousExecution
 import org.apache.spark.sql.execution.streaming.state.StateStoreCoordinatorRef
@@ -226,6 +226,7 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
     listenerBus.post(event)
   }
 
+  // scalastyle:off argcount
   private def createQuery(
       userSpecifiedName: Option[String],
       userSpecifiedCheckpointLocation: Option[String],
@@ -236,7 +237,8 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
       useTempCheckpointLocation: Boolean,
       recoverFromCheckpointLocation: Boolean,
       trigger: Trigger,
-      triggerClock: Clock): StreamingQueryWrapper = {
+      triggerClock: Clock,
+      catalogAndIdent: Option[(CatalogPlugin, Identifier)] = None): StreamingQueryWrapper = {
     val analyzedPlan = df.queryExecution.analyzed
     df.queryExecution.assertAnalyzed()
 
@@ -269,10 +271,13 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
           trigger,
           triggerClock,
           extraOptions,
-          analyzedStreamWritePlan))
+          analyzedStreamWritePlan,
+          catalogAndIdent))
     }
   }
+  // scalastyle:on argcount
 
+  // scalastyle:off argcount
   /**
    * Start a [[StreamingQuery]].
    *
@@ -288,6 +293,7 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
    *                                       will be thrown.
    * @param trigger [[Trigger]] for the query.
    * @param triggerClock [[Clock]] to use for the triggering.
+   * @param catalogAndIdent Catalog and identifier for the sink, set when it is a V2 catalog table
    */
   @throws[TimeoutException]
   private[sql] def startQuery(
@@ -300,7 +306,8 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
       useTempCheckpointLocation: Boolean = false,
       recoverFromCheckpointLocation: Boolean = true,
       trigger: Trigger = Trigger.ProcessingTime(0),
-      triggerClock: Clock = new SystemClock()): StreamingQuery = {
+      triggerClock: Clock = new SystemClock(),
+      catalogAndIdent: Option[(CatalogPlugin, Identifier)] = None): StreamingQuery = {
     val query = createQuery(
       userSpecifiedName,
       userSpecifiedCheckpointLocation,
@@ -311,7 +318,9 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
       useTempCheckpointLocation,
       recoverFromCheckpointLocation,
       trigger,
-      triggerClock)
+      triggerClock,
+      catalogAndIdent)
+    // scalastyle:on argcount
 
     // The following code block checks if a stream with the same name or id is running. Then it
     // returns an Option of an already active stream to stop outside of the lock

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -871,7 +871,7 @@ class DataSourceV2SQLSuite
         query.stop()
 
         assert(!spark.catalog.isCached("testcat.ns.t"))
-        checkAnswer(spark.table(t), Row(1L, "a") :: Row(2L, "b") :: Nil)
+        checkAnswer(sql(s"SELECT * FROM $t"), Row(1L, "a") :: Row(2L, "b") :: Nil)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.connector.catalog.CatalogV2Util.withDefaultOwnership
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
+import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.internal.SQLConf.{PARTITION_OVERWRITE_MODE, PartitionOverwriteMode, V2_SESSION_CATALOG_IMPLEMENTATION}
 import org.apache.spark.sql.internal.connector.SimpleTableProvider
@@ -843,6 +844,34 @@ class DataSourceV2SQLSuite
         assert(spark.sharedState.cacheManager.lookupCachedData(spark.table(view)).isDefined)
         checkAnswer(sql(s"SELECT * FROM $t"), Row(2, "b", 1) :: Nil)
         checkAnswer(sql(s"SELECT * FROM $view"), Row(2) :: Nil)
+      }
+    }
+  }
+
+  test("SPARK-34947: micro batch streaming write should refresh cache") {
+    import testImplicits._
+
+    val t = "testcat.ns.t"
+    withTable(t) {
+      withTempDir { checkpointDir =>
+        sql(s"CREATE TABLE $t (id bigint, data string) USING foo")
+        sql(s"INSERT INTO $t VALUES (1L, 'a')")
+        sql(s"CACHE TABLE $t")
+
+        val inputData = MemoryStream[(Long, String)]
+        val df = inputData.toDF().toDF("id", "data")
+        val query = df
+          .writeStream
+          .option("checkpointLocation", checkpointDir.getAbsolutePath)
+          .toTable(t)
+
+        val newData = Seq((2L, "b"))
+        inputData.addData(newData)
+        query.processAllAvailable()
+        query.stop()
+
+        assert(!spark.sharedState.cacheManager.isEmpty)
+        checkAnswer(spark.table(t), Row(1L, "a") :: Row(2L, "b") :: Nil)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -848,7 +848,7 @@ class DataSourceV2SQLSuite
     }
   }
 
-  test("SPARK-34947: micro batch streaming write should refresh cache") {
+  test("SPARK-34947: micro batch streaming write should invalidate cache") {
     import testImplicits._
 
     val t = "testcat.ns.t"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -870,7 +870,7 @@ class DataSourceV2SQLSuite
         query.processAllAvailable()
         query.stop()
 
-        assert(!spark.sharedState.cacheManager.isEmpty)
+        assert(!spark.catalog.isCached("testcat.ns.t"))
         checkAnswer(spark.table(t), Row(1L, "a") :: Row(2L, "b") :: Nil)
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Populate table catalog and identifier from `DataStreamWriter` to `WriteToMicroBatchDataSource` so that we can invalidate cache for tables that are updated by a streaming write. 

This is somewhat related [SPARK-27484](https://issues.apache.org/jira/browse/SPARK-27484) and [SPARK-34183](https://issues.apache.org/jira/browse/SPARK-34183) (#31700), as ideally we may want to replace `WriteToMicroBatchDataSource` and `WriteToDataSourceV2` with logical write nodes and feed them to analyzer. That will potentially change the code path involved in this PR.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently `WriteToDataSourceV2` doesn't have cache invalidation logic, and therefore, when the target table for a micro batch streaming job is cached, the cache entry won't be removed when the table is updated. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes now when a DSv2 table which supports streaming write is updated by a streaming job, its cache will also be invalidated.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added a new UT.