### PR TITLE
[SPARK-34701][SQL] Introduce CommandWithAnalyzedChildren for a command to have its children only analyzed but not optimized

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Command.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Command.scala
@@ -37,3 +37,9 @@ trait Command extends LogicalPlan {
 trait LeafCommand extends Command with LeafLike[LogicalPlan]
 trait UnaryCommand extends Command with UnaryLike[LogicalPlan]
 trait BinaryCommand extends Command with BinaryLike[LogicalPlan]
+
+trait CommandWithAnalyzedChildren extends Command {
+  def childrenToAnalyze: Seq[LogicalPlan] = Nil
+
+  override final def children: Seq[LogicalPlan] = childrenToAnalyze.filter(!_.analyzed)
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -866,7 +866,9 @@ case class CacheTableAsSelect(
     plan: LogicalPlan,
     originalText: String,
     isLazy: Boolean,
-    options: Map[String, String]) extends LeafCommand
+    options: Map[String, String]) extends CommandWithAnalyzedChildren {
+  override def childrenToAnalyze: Seq[LogicalPlan] = plan :: Nil
+}
 
 /**
  * The logical plan of the UNCACHE TABLE command.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -111,14 +111,14 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     tags -= tag
   }
 
-  @transient private var cachedChildren: Seq[BaseType] = null
+  private var cachedChildren: Seq[BaseType] = null
 
   /**
    * Returns a Seq of the children of this node.
    */
   def children: Seq[BaseType]
 
-  @transient private var cachedChildrenSet: Set[TreeNode[_]] = null
+  private var cachedChildrenSet: Set[TreeNode[_]] = null
 
   private def containsChild: Set[TreeNode[_]] = {
     if (updateChildrenIfChanged() || cachedChildrenSet == null) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -111,13 +111,45 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     tags -= tag
   }
 
+  @transient private var cachedChildren: Seq[BaseType] = null
+
   /**
    * Returns a Seq of the children of this node.
-   * Children should not change. Immutability required for containsChild optimization
    */
   def children: Seq[BaseType]
 
-  lazy val containsChild: Set[TreeNode[_]] = children.toSet
+  @transient private var cachedChildrenSet: Set[TreeNode[_]] = null
+
+  private def containsChild: Set[TreeNode[_]] = {
+    if (updateChildrenIfChanged() || cachedChildrenSet == null) {
+      cachedChildrenSet = cachedChildren.toSet
+    }
+    cachedChildrenSet
+  }
+
+  @transient private var cachedAllChildren: Set[TreeNode[_]] = null
+
+  private def allChildren: Set[TreeNode[_]] = {
+    if (updateChildrenIfChanged() || cachedAllChildren == null) {
+      cachedAllChildren = (cachedChildren ++ innerChildren).toSet[TreeNode[_]]
+    }
+    cachedAllChildren
+  }
+
+  // Returns true if children have changed after updating the cached children.
+  private def updateChildrenIfChanged(): Boolean = {
+    def fastEquals(l: Seq[BaseType], r: Seq[BaseType]): Boolean = {
+      l.length == r.length && l.zip(r).forall {
+        case (a1, a2) => a1 fastEquals a2
+      }
+    }
+    val curChildren = children
+    val changed = cachedChildren == null || !fastEquals(cachedChildren, children)
+    if (changed) {
+      cachedChildren = curChildren
+    }
+    changed
+  }
 
   // Copied from Scala 2.13.1
   // github.com/scala/scala/blob/v2.13.1/src/library/scala/util/hashing/MurmurHash3.scala#L56-L73
@@ -531,8 +563,6 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
    * The arguments that should be included in the arg string.  Defaults to the `productIterator`.
    */
   protected def stringArgs: Iterator[Any] = productIterator
-
-  private lazy val allChildren: Set[TreeNode[_]] = (children ++ innerChildren).toSet[TreeNode[_]]
 
   /** Returns a string representing the arguments to this node, minus any children */
   def argString(maxFields: Int): String = stringArgs.flatMap {

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -482,7 +482,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
     case CreateViewStatement(
       tbl, userSpecifiedColumns, comment, properties,
-      originalText, child, allowExisting, replace, viewType) if child.resolved =>
+      originalText, child, allowExisting, replace, viewType) =>
 
       val v1TableName = if (viewType != PersistedView) {
         // temp view doesn't belong to any catalog and we shouldn't resolve catalog in the name.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.logical.{LeafCommand, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{CommandWithAnalyzedChildren, LogicalPlan}
 import org.apache.spark.sql.connector.ExternalCommandRunner
 import org.apache.spark.sql.execution.{ExplainMode, LeafExecNode, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -37,7 +37,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  * A logical command that is executed for its side-effects.  `RunnableCommand`s are
  * wrapped in `ExecutedCommand` during execution.
  */
-trait RunnableCommand extends LeafCommand {
+trait RunnableCommand extends CommandWithAnalyzedChildren {
 
   // The map used to record the metrics of running the command. This will be passed to
   // `ExecutedCommand` during query planning.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -72,6 +72,8 @@ case class CreateViewCommand(
 
   override def innerChildren: Seq[QueryPlan[_]] = Seq(child)
 
+  override def childrenToAnalyze: Seq[LogicalPlan] = child :: Nil
+
   if (viewType == PersistedView) {
     require(originalText.isDefined, "'originalText' must be provided to create permanent view")
   }
@@ -96,10 +98,7 @@ case class CreateViewCommand(
   }
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    // If the plan cannot be analyzed, throw an exception and don't proceed.
-    val qe = sparkSession.sessionState.executePlan(child)
-    qe.assertAnalyzed()
-    val analyzedPlan = qe.analyzed
+    val analyzedPlan = child
 
     if (userSpecifiedColumns.nonEmpty &&
         userSpecifiedColumns.length != analyzedPlan.output.length) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Note that this PR proposes an alternate solution to #32032.

This PR proposes to introduce the `CommandWithAnalyzedChildren` trait such that a command that extends the trait will have its children only analyzed, but not optimized. This can be useful if a logical plan has children where they need to be only analyzed, but not optimized - e.g., `CREATE VIEW` or `CACHE TABLE AS`. This also addresses the issue found in #31933.

This PR also updates `CreateViewCommand` and `CacheTableAsSelect` to use the new trait such that their children are only analyzed.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To address the issue where the plan is unnecessarily re-analyzed in `CreateViewCommand`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing tests should cover the changes.