### PR TITLE
[SPARK-34479][FOLLOWUP][DOC] Add zstandard codec to AvroOptions.compression comment.

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -101,9 +101,9 @@ private[sql] class AvroOptions(
 
   /**
    * The `compression` option allows to specify a compression codec used in write.
-   * Currently supported codecs are `uncompressed`, `snappy`, `deflate`, `bzip2` and `xz`.
-   * If the option is not set, the `spark.sql.avro.compression.codec` config is taken into
-   * account. If the former one is not set too, the `snappy` codec is used by default.
+   * Currently supported codecs are `uncompressed`, `snappy`, `deflate`, `bzip2`, `xz` and
+   * `zstandard`. If the option is not set, the `spark.sql.avro.compression.codec` config is
+   * taken into account. If the former one is not set too, the `snappy` codec is used by default.
    */
   val compression: String = {
     parameters.get("compression").getOrElse(SQLConf.get.avroCompressionCodec)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add zstandard codec to the `AvroOptions.compression` comment. 


### Why are the changes needed?

SPARK-34479 added zstandard codec.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
N/A