### PR TITLE
[SPARK-34493][DOCS] Add "TEXT Files" page for Data Source documents

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -34,6 +34,8 @@
       url: sql-data-sources-json.html
     - text: CSV Files
       url: sql-data-sources-csv.html
+    - text: Text Files
+      url: sql-data-sources-text.html
     - text: Hive Tables
       url: sql-data-sources-hive-tables.html
     - text: JDBC To Other Databases

--- a/docs/sql-data-sources-text.md
+++ b/docs/sql-data-sources-text.md
@@ -1,0 +1,40 @@
+---
+layout: global
+title: Text Files
+displayTitle: Text Files
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+ 
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+Spark SQL provides `spark.read().text("file_name")` to read a file or directory of text files into a Spark DataFrame, and `dataframe.write().text("path")` to write to a text file. When reading a text file, each line becomes each row that has string "value" column by default. The line separator can be changed as shown in the example below. The `option()` function can be used to customize the behavior of reading or writing, such as controlling behavior of the line separator, compression, and so on.
+
+<!--TODO(SPARK-34491): add `option()` document reference-->
+
+<div class="codetabs">
+
+<div data-lang="scala"  markdown="1">
+{% include_example text_dataset scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala %}
+</div>
+
+<div data-lang="java"  markdown="1">
+{% include_example text_dataset java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java %}
+</div>
+
+<div data-lang="python"  markdown="1">
+{% include_example text_dataset python/sql/datasource.py %}
+</div>
+
+</div>

--- a/docs/sql-data-sources-text.md
+++ b/docs/sql-data-sources-text.md
@@ -19,7 +19,7 @@ license: |
   limitations under the License.
 ---
 
-Spark SQL provides `spark.read().text("file_name")` to read a file or directory of text files into a Spark DataFrame, and `dataframe.write().text("path")` to write to a text file. When reading a text file, each line becomes each row that has string "value" column by default. The line separator can be changed as shown in the example below. The `option()` function can be used to customize the behavior of reading or writing, such as controlling behavior of the line separator, compression, and so on.
+Spark SQL provides `spark.read().text("file_name")` to read a file or directory of text files into a Spark DataFrame, and `dataframe.write().text("path")` to write to a text file. When reading a text file, each line becomes each row that has string "value" column by default. The line separator can be changed as shown in the example below. When specifying a directory as a file path, make sure that the files included in the directory do not contain a format that is inappropriate for reading text, such as ORC or Parquet. The `option()` function can be used to customize the behavior of reading or writing, such as controlling behavior of the line separator, compression, and so on.
 
 <!--TODO(SPARK-34491): add `option()` document reference-->
 

--- a/docs/sql-data-sources-text.md
+++ b/docs/sql-data-sources-text.md
@@ -19,7 +19,7 @@ license: |
   limitations under the License.
 ---
 
-Spark SQL provides `spark.read().text("file_name")` to read a file or directory of text files into a Spark DataFrame, and `dataframe.write().text("path")` to write to a text file. When reading a text file, each line becomes each row that has string "value" column by default. The line separator can be changed as shown in the example below. When specifying a directory as a file path, make sure that the files included in the directory do not contain a format that is inappropriate for reading text, such as ORC or Parquet. The `option()` function can be used to customize the behavior of reading or writing, such as controlling behavior of the line separator, compression, and so on.
+Spark SQL provides `spark.read().text("file_name")` to read a file or directory of text files into a Spark DataFrame, and `dataframe.write().text("path")` to write to a text file. When reading a text file, each line becomes each row that has string "value" column by default. The line separator can be changed as shown in the example below. The `option()` function can be used to customize the behavior of reading or writing, such as controlling behavior of the line separator, compression, and so on.
 
 <!--TODO(SPARK-34491): add `option()` document reference-->
 

--- a/docs/sql-data-sources.md
+++ b/docs/sql-data-sources.md
@@ -47,6 +47,7 @@ goes into specific options that are available for the built-in data sources.
 * [ORC Files](sql-data-sources-orc.html)
 * [JSON Files](sql-data-sources-json.html)
 * [CSV Files](sql-data-sources-csv.html)
+* [TEXT Files](sql-data-sources-text.html)
 * [Hive Tables](sql-data-sources-hive-tables.html)
   * [Specifying storage format for Hive tables](sql-data-sources-hive-tables.html#specifying-storage-format-for-hive-tables)
   * [Interacting with Different Versions of Hive Metastore](sql-data-sources-hive-tables.html#interacting-with-different-versions-of-hive-metastore)

--- a/docs/sql-data-sources.md
+++ b/docs/sql-data-sources.md
@@ -47,7 +47,7 @@ goes into specific options that are available for the built-in data sources.
 * [ORC Files](sql-data-sources-orc.html)
 * [JSON Files](sql-data-sources-json.html)
 * [CSV Files](sql-data-sources-csv.html)
-* [TEXT Files](sql-data-sources-text.html)
+* [Text Files](sql-data-sources-text.html)
 * [Hive Tables](sql-data-sources-hive-tables.html)
   * [Specifying storage format for Hive tables](sql-data-sources-hive-tables.html#specifying-storage-format-for-hive-tables)
   * [Interacting with Different Versions of Hive Metastore](sql-data-sources-hive-tables.html#interacting-with-different-versions-of-hive-metastore)

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -409,7 +409,7 @@ public class JavaSQLDataSourceExample {
     // +-----------+
 
     // You can use 'lineSep' option to define the line separator.
-    // If None is set, it covers all `\r`, `\r\n` and `\n` (default).
+    // If None is set, the line separator handles all `\r`, `\r\n` and `\n` by default.
     Dataset<Row> df2 = spark.read().option("lineSep", ",").text(path);
     df2.show();
     // +-----------+

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -436,20 +436,6 @@ public class JavaSQLDataSourceExample {
     // You can specify the compression format using the 'compression' option.
     df1.write().option("compression", "gzip").text("output_compressed");
 
-    // Read all files in a folder.
-    String folderPath = "examples/src/main/resources";
-    Dataset<Row> df = spark.read().text(folderPath);
-    df.show();
-    // +-----------+
-    // |      value|
-    // +-----------+
-    // |238val_238|
-    // |  86val_86|
-    // |311val_311|
-    // |  27val_27|
-    // |165val_165|
-    // +-----------+
-
     // $example off:text_dataset$
   }
 

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -30,8 +30,10 @@ import org.apache.spark.sql.Encoders;
 // $example on:schema_merging$
 // $example on:json_dataset$
 // $example on:csv_dataset$
+// $example on:text_dataset$
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+// $example off:text_dataset$
 // $example off:csv_dataset$
 // $example off:json_dataset$
 // $example off:schema_merging$
@@ -105,6 +107,7 @@ public class JavaSQLDataSourceExample {
     runParquetSchemaMergingExample(spark);
     runJsonDatasetExample(spark);
     runCsvDatasetExample(spark);
+    runTextDatasetExample(spark);
     runJdbcDatasetExample(spark);
 
     spark.stop();
@@ -387,6 +390,67 @@ public class JavaSQLDataSourceExample {
     // +-----------+
 
     // $example off:csv_dataset$
+  }
+
+  private static void runTextDatasetExample(SparkSession spark) {
+    // $example on:text_dataset$
+    // A text dataset is pointed to by path.
+    // The path can be either a single text file or a directory of text files
+    String path = "examples/src/main/resources/people.txt";
+
+    Dataset<Row> df1 = spark.read().text(path);
+    df1.show();
+    // +-----------+
+    // |      value|
+    // +-----------+
+    // |Michael, 29|
+    // |   Andy, 30|
+    // | Justin, 19|
+    // +-----------+
+
+    // You can use 'lineSep' option to define the line separator.
+    // If None is set, it covers all `\r`, `\r\n` and `\n` (default).
+    Dataset<Row> df2 = spark.read().option("lineSep", ",").text(path);
+    df2.show();
+    // +-----------+
+    // |      value|
+    // +-----------+
+    // |    Michael|
+    // |   29\nAndy|
+    // | 30\nJustin|
+    // |       19\n|
+    // +-----------+
+
+    // You can also use 'wholetext' option to read each input file as a single row.
+    Dataset<Row> df3 = spark.read().option("wholetext", "true").text(path);
+    df3.show();
+    //  +--------------------+
+    //  |               value|
+    //  +--------------------+
+    //  |Michael, 29\nAndy...|
+    //  +--------------------+
+
+    // "output" is a folder which contains multiple text files and a _SUCCESS file.
+    df1.write().text("output");
+
+    // You can specify the compression format using the 'compression' option.
+    df1.write().option("compression", "gzip").text("output_compressed");
+
+    // Read all files in a folder.
+    String folderPath = "examples/src/main/resources";
+    Dataset<Row> df = spark.read().text(folderPath);
+    df.show();
+    // +-----------+
+    // |      value|
+    // +-----------+
+    // |238val_238|
+    // |  86val_86|
+    // |311val_311|
+    // |  27val_27|
+    // |165val_165|
+    // +-----------+
+
+    // $example off:text_dataset$
   }
 
   private static void runJdbcDatasetExample(SparkSession spark) {

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -409,7 +409,7 @@ public class JavaSQLDataSourceExample {
     // +-----------+
 
     // You can use 'lineSep' option to define the line separator.
-    // If None is set, the line separator handles all `\r`, `\r\n` and `\n` by default.
+    // The line separator handles all `\r`, `\r\n` and `\n` by default.
     Dataset<Row> df2 = spark.read().option("lineSep", ",").text(path);
     df2.show();
     // +-----------+

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -298,6 +298,70 @@ def csv_dataset_example(spark):
     # $example off:csv_dataset$
 
 
+def text_dataset_example(spark):
+    # $example on:text_dataset$
+    # spark is from the previous example
+    sc = spark.sparkContext
+
+    # A text dataset is pointed to by path.
+    # The path can be either a single text file or a directory of text files
+    path = "examples/src/main/resources/people.txt"
+
+    df1 = spark.read.text(path)
+    df1.show()
+    # +-----------+
+    # |      value|
+    # +-----------+
+    # |Michael, 29|
+    # |   Andy, 30|
+    # | Justin, 19|
+    # +-----------+
+
+    # You can use 'lineSep' option to define the line separator.
+    # If None is set, it covers all `\r`, `\r\n` and `\n` (default).
+    df2 = spark.read.text(path, lineSep=",")
+    df2.show()
+    # +-----------+
+    # |      value|
+    # +-----------+
+    # |    Michael|
+    # |   29\nAndy|
+    # | 30\nJustin|
+    # |       19\n|
+    # +-----------+
+
+    # You can also use 'wholetext' option to read each input file as a single row.
+    df3 = spark.read.text(path, wholetext=True)
+    df3.show()
+    # +--------------------+
+    # |               value|
+    # +--------------------+
+    # |Michael, 29\nAndy...|
+    # +--------------------+
+
+    # "output" is a folder which contains multiple text files and a _SUCCESS file.
+    df1.write.csv("output")
+
+    # You can specify the compression format using the 'compression' option.
+    df1.write.text("output_compressed", compression="gzip")
+
+    # Read all files in a folder.
+    folderPath = "examples/src/main/resources"
+    df = spark.read.text(folderPath)
+    df.show()
+    # +-----------+
+    # |      value|
+    # +-----------+
+    # |238val_238|
+    # |  86val_86|
+    # |311val_311|
+    # |  27val_27|
+    # |165val_165|
+    # +-----------+
+
+    # $example off:text_dataset$
+
+
 def jdbc_dataset_example(spark):
     # $example on:jdbc_dataset$
     # Note: JDBC loading and saving can be achieved via either the load/save or jdbc methods
@@ -357,6 +421,7 @@ if __name__ == "__main__":
     parquet_schema_merging_example(spark)
     json_dataset_example(spark)
     csv_dataset_example(spark)
+    text_dataset_example(spark)
     jdbc_dataset_example(spark)
 
     spark.stop()

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -318,7 +318,7 @@ def text_dataset_example(spark):
     # +-----------+
 
     # You can use 'lineSep' option to define the line separator.
-    # If None is set, the line separator handles all `\r`, `\r\n` and `\n` by default
+    # The line separator handles all `\r`, `\r\n` and `\n` by default.
     df2 = spark.read.text(path, lineSep=",")
     df2.show()
     # +-----------+

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -318,7 +318,7 @@ def text_dataset_example(spark):
     # +-----------+
 
     # You can use 'lineSep' option to define the line separator.
-    # If None is set, it covers all `\r`, `\r\n` and `\n` (default).
+    # If None is set, the line separator handles all `\r`, `\r\n` and `\n` by default
     df2 = spark.read.text(path, lineSep=",")
     df2.show()
     # +-----------+

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -345,20 +345,6 @@ def text_dataset_example(spark):
     # You can specify the compression format using the 'compression' option.
     df1.write.text("output_compressed", compression="gzip")
 
-    # Read all files in a folder.
-    folderPath = "examples/src/main/resources"
-    df = spark.read.text(folderPath)
-    df.show()
-    # +-----------+
-    # |      value|
-    # +-----------+
-    # |238val_238|
-    # |  86val_86|
-    # |311val_311|
-    # |  27val_27|
-    # |165val_165|
-    # +-----------+
-
     # $example off:text_dataset$
 
 

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -354,20 +354,6 @@ object SQLDataSourceExample {
     // You can specify the compression format using the 'compression' option.
     df1.write.option("compression", "gzip").text("output_compressed")
 
-    // Read all files in a folder.
-    val folderPath = "examples/src/main/resources";
-    val df = spark.read.text(folderPath);
-    df.show();
-    // +-----------+
-    // |      value|
-    // +-----------+
-    // |238val_238|
-    // |  86val_86|
-    // |311val_311|
-    // |  27val_27|
-    // |165val_165|
-    // +-----------+
-
     // $example off:text_dataset$
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -340,7 +340,7 @@ object SQLDataSourceExample {
     // +-----------+
 
     // You can also use 'wholetext' option to read each input file as a single row.
-    val df3 = spark.read.option("wholetext", "true").text(path)
+    val df3 = spark.read.option("wholetext", true).text(path)
     df3.show()
     //  +--------------------+
     //  |               value|

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -327,7 +327,7 @@ object SQLDataSourceExample {
     // +-----------+
 
     // You can use 'lineSep' option to define the line separator.
-    // If None is set, the line separator handles all `\r`, `\r\n` and `\n` by default.
+    // The line separator handles all `\r`, `\r\n` and `\n` by default.
     val df2 = spark.read.option("lineSep", ",").text(path)
     df2.show()
     // +-----------+

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -37,6 +37,7 @@ object SQLDataSourceExample {
     runParquetSchemaMergingExample(spark)
     runJsonDatasetExample(spark)
     runCsvDatasetExample(spark)
+    runTextDatasetExample(spark)
     runJdbcDatasetExample(spark)
 
     spark.stop()
@@ -307,6 +308,67 @@ object SQLDataSourceExample {
     // +-----------+
 
     // $example off:csv_dataset$
+  }
+
+  private def runTextDatasetExample(spark: SparkSession): Unit = {
+    // $example on:text_dataset$
+    // A text dataset is pointed to by path.
+    // The path can be either a single text file or a directory of text files
+    val path = "examples/src/main/resources/people.txt"
+
+    val df1 = spark.read.text(path)
+    df1.show()
+    // +-----------+
+    // |      value|
+    // +-----------+
+    // |Michael, 29|
+    // |   Andy, 30|
+    // | Justin, 19|
+    // +-----------+
+
+    // You can use 'lineSep' option to define the line separator.
+    // If None is set, the line separator handles all `\r`, `\r\n` and `\n` by default.
+    val df2 = spark.read.option("lineSep", ",").text(path)
+    df2.show()
+    // +-----------+
+    // |      value|
+    // +-----------+
+    // |    Michael|
+    // |   29\nAndy|
+    // | 30\nJustin|
+    // |       19\n|
+    // +-----------+
+
+    // You can also use 'wholetext' option to read each input file as a single row.
+    val df3 = spark.read.option("wholetext", "true").text(path)
+    df3.show()
+    //  +--------------------+
+    //  |               value|
+    //  +--------------------+
+    //  |Michael, 29\nAndy...|
+    //  +--------------------+
+
+    // "output" is a folder which contains multiple text files and a _SUCCESS file.
+    df1.write.text("output")
+
+    // You can specify the compression format using the 'compression' option.
+    df1.write.option("compression", "gzip").text("output_compressed")
+
+    // Read all files in a folder.
+    val folderPath = "examples/src/main/resources";
+    val df = spark.read.text(folderPath);
+    df.show();
+    // +-----------+
+    // |      value|
+    // +-----------+
+    // |238val_238|
+    // |  86val_86|
+    // |311val_311|
+    // |  27val_27|
+    // |165val_165|
+    // +-----------+
+
+    // $example off:text_dataset$
   }
 
   private def runJdbcDatasetExample(spark: SparkSession): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a documentation on how to read and write TEXT files through various APIs such as Scala, Python and JAVA in Spark to [Data Source documents](https://spark.apache.org/docs/latest/sql-data-sources.html#data-sources).

### Why are the changes needed?

Documentation on how Spark handles TEXT files is missing. It should be added to the document for user convenience.

### Does this PR introduce _any_ user-facing change?

Yes, this PR adds a new page to Data Sources documents.

### How was this patch tested?

Manually build documents and check the page on local as below.

![Screen Shot 2021-04-07 at 4 05 01 PM](https://user-images.githubusercontent.com/44108233/113824674-085e2c00-97bb-11eb-91ae-d2cc19dfd369.png)