### PR TITLE
[SPARK-34961][SQL] Migrate First function from DeclarativeAggregate to TypedImperativeAggregate to improve performance

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -775,7 +775,7 @@ class Analyzer(override val catalogManager: CatalogManager)
                 // Assumption is the aggregate function ignores nulls. This is true for all current
                 // AggregateFunction's with the exception of First and Last in their default mode
                 // (which we handle) and possibly some Hive UDAF's.
-                case First(expr, _) =>
+                case First(expr, _, _, _) =>
                   First(ifExpr(expr), true)
                 case Last(expr, _) =>
                   Last(ifExpr(expr), true)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The main objective of this change is to improve performance in some cases.
We have three possibilities when we plan an aggregation. In the first case, with mutable primitive types, HashAggregate is used.
When we are not using these types we have two options. If the function implements TypedImperativeAggregate we use ObjectHashAggregate. Otherwise, we use SortAggregate that is less efficient.
In this PR I propose to migrate First function to implement TypedImperativeAggregate to take advantage of this feature (ObjectAggregateExec)

Before the change:
```
scala> Seq((0, "value")).toDF("key", "value").groupBy("key").agg(first("value")).explain()
== Physical Plan ==
SortAggregate(key=[key#130], functions=[first(value#131, false)])
+- *(2) Sort [key#130 ASC NULLS FIRST], false, 0
   +- Exchange hashpartitioning(key#130, 200), true, [id=#114]
      +- SortAggregate(key=[key#130], functions=[partial_first(value#131, false)])
         +- *(1) Sort [key#130 ASC NULLS FIRST], false, 0
            +- *(1) LocalTableScan [key#130, value#131]
```

After the change:
```
scala> Seq((0, "value")).toDF("key", "value").groupBy("key").agg(first("value")).explain()
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- ObjectHashAggregate(keys=[key#313], functions=[first(value#314, false, 0, 0)])
   +- Exchange hashpartitioning(key#313, 200), ENSURE_REQUIREMENTS, [id=#208]
      +- ObjectHashAggregate(keys=[key#313], functions=[partial_first(value#314, false, 0, 0)])
         +- LocalTableScan [key#313, value#314]
```



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To improve the performance of the first function when we are not using mutable primitive types

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the behavior remains equal

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manually and with all the tests we have that ensure that the behavior remains equal.