### PR TITLE
[SPARK-34916][SQL] Add condition lambda and rule id to the transform family for early stopping

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
@@ -236,6 +236,17 @@ class BitSet(numBits: Int) extends Serializable {
     -1
   }
 
+  /**
+   * Bit-wise OR with another bit set.
+   */
+  def union(other: BitSet): Unit = {
+    var ind = 0
+    while( ind < this.numWords ) {
+      this.words(ind) = this.words(ind) | other.words(ind)
+      ind += 1
+    }
+  }
+
   /** Return the number of longs it would take to hold numBits. */
   private def bit2words(numBits: Int) = ((numBits - 1) >> 6) + 1
 }

--- a/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
@@ -237,7 +237,7 @@ class BitSet(numBits: Int) extends Serializable {
   }
 
   /**
-   * Bit-wise OR with another bit set.
+   * Compute bit-wise union with another bit set and overwrite bits in this BitSet with the result.
    */
   def union(other: BitSet): Unit = {
     var ind = 0

--- a/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
@@ -237,9 +237,10 @@ class BitSet(numBits: Int) extends Serializable {
   }
 
   /**
-   * Compute bit-wise union with another bit set and overwrite bits in this BitSet with the result.
+   * Compute bit-wise union with another BitSet and overwrite bits in this BitSet with the result.
    */
   def union(other: BitSet): Unit = {
+    require(this.numWords <= other.numWords)
     var ind = 0
     while( ind < this.numWords ) {
       this.words(ind) = this.words(ind) | other.words(ind)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReference
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LeafNode, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -427,6 +428,8 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
 
   override def nullable: Boolean = children.exists(_.nullable)
   override def foldable: Boolean = children.forall(_.foldable)
+
+  override val nodePatterns: Seq[TreePattern] = Seq(IN)
 
   override def toString: String = s"$value IN ${list.mkString("(", ",", ")")}"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReference
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LeafNode, LogicalPlan, Project}
-import org.apache.spark.sql.catalyst.trees.TreePattern._
+import org.apache.spark.sql.catalyst.trees.TreePattern.{IN, TreePattern}
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -34,18 +34,17 @@ abstract class PlanExpression[T <: QueryPlan[_]] extends Expression {
   // Override `treePatternBits` to propagate bits for its internal plan.
   override lazy val treePatternBits: BitSet = {
     val bits: BitSet = new BitSet(TreePattern.maxId)
-    // Propagate node type bits
+    // Propagate node pattern bits
     val nodeTypeIterator = nodePatterns.iterator
     while (nodeTypeIterator.hasNext) {
       bits.set(nodeTypeIterator.next().id)
     }
-    // Propagate children bits
+    // Propagate children's bits
     val childIterator = children.iterator
     while (childIterator.hasNext) {
       bits.union(childIterator.next().treePatternBits)
     }
-
-    // Propagate plan bits
+    // Propagate its query plan's pattern bits
     bits.union(plan.treePatternBits)
     bits
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -22,12 +22,34 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan}
+import org.apache.spark.sql.catalyst.trees.TreePattern
 import org.apache.spark.sql.types._
+import org.apache.spark.util.collection.BitSet
 
 /**
  * An interface for expressions that contain a [[QueryPlan]].
  */
 abstract class PlanExpression[T <: QueryPlan[_]] extends Expression {
+
+  // Override `treePatternBits` to propagate bits for its internal plan.
+  override lazy val treePatternBits: BitSet = {
+    val bits: BitSet = new BitSet(TreePattern.maxId)
+    // Propagate node type bits
+    val nodeTypeIterator = nodePatterns.iterator
+    while (nodeTypeIterator.hasNext) {
+      bits.set(nodeTypeIterator.next().id)
+    }
+    // Propagate children bits
+    val childIterator = children.iterator
+    while (childIterator.hasNext) {
+      bits.union(childIterator.next().treePatternBits)
+    }
+
+    // Propagate plan bits
+    bits.union(plan.treePatternBits)
+    bits
+  }
+
   /**  The id of the subquery expression. */
   def exprId: ExprId
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -48,7 +48,6 @@ object CostBasedJoinReorder extends Rule[LogicalPlan] with PredicateHelper {
           if projectList.forall(_.isInstanceOf[Attribute]) =>
           reorder(p, p.output)
       }
-
       // After reordering is finished, convert OrderedJoin back to Join.
       result transform {
         case OrderedJoin(left, right, jt, cond) => Join(left, right, jt, cond, JoinHint.NONE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/CostBasedJoinReorder.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeSet, 
 import org.apache.spark.sql.catalyst.plans.{Inner, InnerLike, JoinType}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreePattern._
+import org.apache.spark.sql.catalyst.trees.TreePattern.INNER_LIKE_JOIN
 import org.apache.spark.sql.internal.SQLConf
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreePattern._
+import org.apache.spark.sql.catalyst.trees.TreePattern.LEFT_SEMI_OR_ANTI_JOIN
 
 /**
  * This rule is a variant of [[PushPredicateThroughNonJoin]] which can handle

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
@@ -35,7 +35,8 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.LEFT_SEMI_OR_ANTI_JOIN
 object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
   with PredicateHelper
   with JoinSelectionHelper {
-  def apply(plan: LogicalPlan): LogicalPlan = plan transform ({
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
+    _.containsPattern(LEFT_SEMI_OR_ANTI_JOIN), ruleId) {
     // LeftSemi/LeftAnti over Project
     case Join(p @ Project(pList, gChild), rightOp, LeftSemiOrAnti(joinType), joinCond, hint)
         if pList.forall(_.deterministic) &&
@@ -101,7 +102,7 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
         if PushPredicateThroughNonJoin.canPushThrough(u) && u.expressions.forall(_.deterministic) =>
       val validAttrs = u.child.outputSet ++ rightOp.outputSet
       pushDownJoin(join, _.references.subsetOf(validAttrs), _.reduce(And))
-  }, _.containsPattern(LEFT_SEMI_OR_ANTI_JOIN), ruleId)
+  }
 
   /**
    * Check if we can safely push a join through a project or union by making sure that attributes

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushExtraPredicateThroughJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushExtraPredicateThroughJoin.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
-import org.apache.spark.sql.catalyst.trees.TreePattern._
+import org.apache.spark.sql.catalyst.trees.TreePattern.JOIN
 
 /**
  * Try pushing down disjunctive join condition into left and right child.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushExtraPredicateThroughJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushExtraPredicateThroughJoin.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
+import org.apache.spark.sql.catalyst.trees.TreePattern._
 
 /**
  * Try pushing down disjunctive join condition into left and right child.
@@ -37,7 +38,7 @@ object PushExtraPredicateThroughJoin extends Rule[LogicalPlan] with PredicateHel
     case _ => false
   }
 
-  def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+  def apply(plan: LogicalPlan): LogicalPlan = plan transform ({
     case j @ Join(left, right, joinType, Some(joinCondition), hint)
         if canPushThrough(joinType) =>
       val alreadyProcessed = j.getTagValue(processedJoinConditionTag).exists { condition =>
@@ -74,5 +75,5 @@ object PushExtraPredicateThroughJoin extends Rule[LogicalPlan] with PredicateHel
         newJoin.setTagValue(processedJoinConditionTag, joinCondition)
         newJoin
     }
-  }
+  }, _.containsPattern(JOIN), ruleId)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushExtraPredicateThroughJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushExtraPredicateThroughJoin.scala
@@ -38,7 +38,8 @@ object PushExtraPredicateThroughJoin extends Rule[LogicalPlan] with PredicateHel
     case _ => false
   }
 
-  def apply(plan: LogicalPlan): LogicalPlan = plan transform ({
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
+    _.containsPattern(JOIN), ruleId) {
     case j @ Join(left, right, joinType, Some(joinCondition), hint)
         if canPushThrough(joinType) =>
       val alreadyProcessed = j.getTagValue(processedJoinConditionTag).exists { condition =>
@@ -75,5 +76,5 @@ object PushExtraPredicateThroughJoin extends Rule[LogicalPlan] with PredicateHel
         newJoin.setTagValue(processedJoinConditionTag, joinCondition)
         newJoin
     }
-  }, _.containsPattern(JOIN), ruleId)
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.objects.AssertNotNull
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
+import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -249,8 +250,8 @@ object ReorderAssociativeOperator extends Rule[LogicalPlan] {
  *    [[InSet (value, HashSet[Literal])]] which is much faster.
  */
 object OptimizeIn extends Rule[LogicalPlan] {
-  def apply(plan: LogicalPlan): LogicalPlan = plan transform {
-    case q: LogicalPlan => q transformExpressionsDown {
+  def apply(plan: LogicalPlan): LogicalPlan = plan transform ({
+    case q: LogicalPlan => q transformExpressionsDown ({
       case In(v, list) if list.isEmpty =>
         // When v is not nullable, the following expression will be optimized
         // to FalseLiteral which is tested in OptimizeInSuite.scala
@@ -271,8 +272,8 @@ object OptimizeIn extends Rule[LogicalPlan] {
         } else { // newList.length == list.length && newList.length > 1
           expr
         }
-    }
-  }
+    }, _.containsPattern(IN), ruleId)
+  }, _.containsPattern(IN), ruleId)
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -250,8 +250,9 @@ object ReorderAssociativeOperator extends Rule[LogicalPlan] {
  *    [[InSet (value, HashSet[Literal])]] which is much faster.
  */
 object OptimizeIn extends Rule[LogicalPlan] {
-  def apply(plan: LogicalPlan): LogicalPlan = plan transform ({
-    case q: LogicalPlan => q transformExpressionsDown ({
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
+    _.containsPattern(IN), ruleId) {
+    case q: LogicalPlan => q.transformExpressionsDownWithPruning(_.containsPattern(IN), ruleId) {
       case In(v, list) if list.isEmpty =>
         // When v is not nullable, the following expression will be optimized
         // to FalseLiteral which is tested in OptimizeInSuite.scala
@@ -272,8 +273,8 @@ object OptimizeIn extends Rule[LogicalPlan] {
         } else { // newList.length == list.length && newList.length > 1
           expr
         }
-    }, _.containsPattern(IN), ruleId)
-  }, _.containsPattern(IN), ruleId)
+    }
+  }
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.objects.AssertNotNull
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
-import org.apache.spark.sql.catalyst.trees.TreePattern._
+import org.apache.spark.sql.catalyst.trees.TreePattern.IN
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.planning.ExtractFiltersAndInnerJoins
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
-import org.apache.spark.sql.catalyst.trees.TreePattern._
+import org.apache.spark.sql.catalyst.trees.TreePattern.{INNER_LIKE_JOIN, OUTER_JOIN}
 import org.apache.spark.sql.internal.SQLConf
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -100,8 +100,8 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
   final def missingInput: AttributeSet = references -- inputSet
 
   /**
-   * Runs [[transformExpressionsDown]] with `rule` on all expressions present in this query
-   * operator.
+   * Runs [[transformExpressionsDown]] with `rule` on all expressions present
+   * in this query operator.
    * Users should not expect a specific directionality. If a specific directionality is needed,
    * transformExpressionsDown or transformExpressionsUp should be used.
    *
@@ -127,7 +127,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
    */
-  def transformExpressionsWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+  def transformExpressionsWithPruning(cond: TreePatternBits => Boolean,
     ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[Expression, Expression])
   : this.type = {
     transformExpressionsDownWithPruning(cond, ruleId)(rule)
@@ -136,7 +136,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
   /**
    * Runs [[transformDown]] with `rule` on all expressions present in this query operator.
    *
-   * @param rule   the rule to be applied to every expression in this operator.
+   * @param rule the rule to be applied to every expression in this operator.
    */
   def transformExpressionsDown(rule: PartialFunction[Expression, Expression]): this.type = {
     transformExpressionsDownWithPruning(AlwaysProcess.fn, UnknownRuleId)(rule)
@@ -156,7 +156,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
    */
-  def transformExpressionsDownWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+  def transformExpressionsDownWithPruning(cond: TreePatternBits => Boolean,
     ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[Expression, Expression])
   : this.type = {
     mapExpressions(_.transformDownWithPruning(cond, ruleId)(rule))
@@ -185,7 +185,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
    */
-  def transformExpressionsUpWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+  def transformExpressionsUpWithPruning(cond: TreePatternBits => Boolean,
     ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[Expression, Expression])
   : this.type = {
     mapExpressions(_.transformUpWithPruning(cond, ruleId)(rule))
@@ -238,7 +238,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * Returns the result of running [[transformExpressionsWithPruning]] on this node
    * and all its children. Note that this method skips expressions inside subqueries.
    */
-  def transformAllExpressionsWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+  def transformAllExpressionsWithPruning(cond: TreePatternBits => Boolean,
     ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[Expression, Expression])
   : this.type = {
     transformWithPruning(cond, ruleId) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -105,7 +105,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * transformExpressionsDown or transformExpressionsUp should be used.
    *
    * @param rule the rule to be applied to every expression in this operator.
-   * @param cond  a Lambda expression to stop traversals early on. If `cond.apply` returns false
+   * @param cond  a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *              on an expression T, skips processing T and its subtree; otherwise, processes
    *              T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
@@ -124,7 +124,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * Runs [[transformDown]] with `rule` on all expressions present in this query operator.
    *
    * @param rule the rule to be applied to every expression in this operator.
-   * @param cond a Lambda expression to stop traversals early on. If `cond.apply` returns false
+   * @param cond a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *             on an expression T, skips processing T and its subtree; otherwise, processes
    *             T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
@@ -143,7 +143,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * Runs [[transformUp]] with `rule` on all expressions present in this query operator.
    *
    * @param rule the rule to be applied to every expression in this operator.
-   * @param cond a Lambda expression to stop traversals early on. If `cond.apply` returns false
+   * @param cond a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *             on an expression T, skips processing T and its subtree; otherwise, processes
    *             T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -55,18 +55,17 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
   // Override `treePatternBits` to propagate bits for its expressions.
   override lazy val treePatternBits: BitSet = {
     val bits: BitSet = new BitSet(TreePattern.maxId)
-    // Propagate node type bits
+    // Propagate node pattern bits
     val nodeTypeIterator = nodePatterns.iterator
     while (nodeTypeIterator.hasNext) {
       bits.set(nodeTypeIterator.next().id)
     }
-    // Propagate children bits
+    // Propagate children's pattern bits
     val childIterator = children.iterator
     while (childIterator.hasNext) {
       bits.union(childIterator.next().treePatternBits)
     }
-
-    // Propagate expression bits
+    // Propagate expressions' pattern bits
     val exprIterator = expressions.iterator
     while (exprIterator.hasNext) {
       bits.union(exprIterator.next.treePatternBits)
@@ -106,11 +105,11 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * transformExpressionsDown or transformExpressionsUp should be used.
    *
    * @param rule the rule to be applied to every expression in this operator.
-   * @param cond  a Lambda expression to stop transform early on. If `cond.apply` returns false
+   * @param cond  a Lambda expression to stop traversals early on. If `cond.apply` returns false
    *              on an expression T, skips processing T and its subtree; otherwise, processes
    *              T and its subtree recursively.
-   * @param ruleId is a unique Id for the rule to prune unnecessary tree traversals. When it is
-   *        RuleId.UnknownId, no pruning happens. Otherwise, if a rule with id `ruleId` has been
+   * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
+   *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on an expression T, skips processing T and its subtree. Do not
    *        pass it if the rule is not purely functional not purely functional and reads a
    *        varying initial state for every invocation.
@@ -125,11 +124,11 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * Runs [[transformDown]] with `rule` on all expressions present in this query operator.
    *
    * @param rule the rule to be applied to every expression in this operator.
-   * @param cond a Lambda expression to stop transform early on. If `cond.apply` returns false
+   * @param cond a Lambda expression to stop traversals early on. If `cond.apply` returns false
    *             on an expression T, skips processing T and its subtree; otherwise, processes
    *             T and its subtree recursively.
-   * @param ruleId is a unique Id for the rule to prune unnecessary tree traversals. When it is
-   *        RuleId.UnknownId, no pruning happens. Otherwise, if a rule with id `ruleId` has been
+   * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
+   *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on an expression T, skips processing T and its subtree. Do not
    *        pass it if the rule is not purely functional not purely functional and reads a
    *        varying initial state for every invocation.
@@ -144,11 +143,11 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * Runs [[transformUp]] with `rule` on all expressions present in this query operator.
    *
    * @param rule the rule to be applied to every expression in this operator.
-   * @param cond a Lambda expression to stop transform early on. If `cond.apply` returns false
+   * @param cond a Lambda expression to stop traversals early on. If `cond.apply` returns false
    *             on an expression T, skips processing T and its subtree; otherwise, processes
    *             T and its subtree recursively.
-   * @param ruleId is a unique Id for the rule to prune unnecessary tree traversals. When it is
-   *        RuleId.UnknownId, no pruning happens. Otherwise, if a rule with id `ruleId` has been
+   * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
+   *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on an expression T, skips processing T and its subtree. Do not
    *        pass it if the rule is not purely functional and reads a varying inital state for
    *        every invocation.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -22,7 +22,8 @@ import scala.collection.mutable
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.rules.RuleIdCollection
+import org.apache.spark.sql.catalyst.rules.RuleId
+import org.apache.spark.sql.catalyst.rules.UnknownRuleId
 import org.apache.spark.sql.catalyst.trees.{AlwaysProcess, CurrentOrigin, TreeNode, TreeNodeTag}
 import org.apache.spark.sql.catalyst.trees.TreePattern
 import org.apache.spark.sql.catalyst.trees.TreePatternBits
@@ -105,19 +106,9 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * transformExpressionsDown or transformExpressionsUp should be used.
    *
    * @param rule the rule to be applied to every expression in this operator.
-   * @param cond   a Lambda expression to prune tree traversals. If `cond.apply` returns false
-   *               on an expression T, skips processing T and its subtree; otherwise, processes
-   *               T and its subtree recursively.
-   * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
-   *               RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
-   *               has been marked as in effective on an expression T, skips processing T and its
-   *               subtree. Do not pass it if the rule is not purely functional and reads a
-   *               varying initial state for different invocations.
    */
-  def transformExpressions(rule: PartialFunction[Expression, Expression],
-    cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId): this.type = {
-    transformExpressionsWithPruning(cond, ruleId)(rule)
+  def transformExpressions(rule: PartialFunction[Expression, Expression]): this.type = {
+    transformExpressionsWithPruning(AlwaysProcess.fn, UnknownRuleId)(rule)
   }
 
   /**
@@ -131,13 +122,13 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    *               on an expression T, skips processing T and its subtree; otherwise, processes
    *               T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
-   *               RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
+   *               UnknownRuleId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
    *               has been marked as in effective on an expression T, skips processing T and its
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
    */
   def transformExpressionsWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId)(rule: PartialFunction[Expression, Expression])
+    ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[Expression, Expression])
   : this.type = {
     transformExpressionsDownWithPruning(cond, ruleId)(rule)
   }
@@ -146,19 +137,9 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * Runs [[transformDown]] with `rule` on all expressions present in this query operator.
    *
    * @param rule   the rule to be applied to every expression in this operator.
-   * @param cond   a Lambda expression to prune tree traversals. If `cond.apply` returns false
-   *               on an expression T, skips processing T and its subtree; otherwise, processes
-   *               T and its subtree recursively.
-   * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
-   *               RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
-   *               has been marked as in effective on an expression T, skips processing T and its
-   *               subtree. Do not pass it if the rule is not purely functional and reads a
-   *               varying initial state for different invocations.
    */
-  def transformExpressionsDown(rule: PartialFunction[Expression, Expression],
-    cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId): this.type = {
-    transformExpressionsDownWithPruning(cond, ruleId)(rule)
+  def transformExpressionsDown(rule: PartialFunction[Expression, Expression]): this.type = {
+    transformExpressionsDownWithPruning(AlwaysProcess.fn, UnknownRuleId)(rule)
   }
 
   /**
@@ -169,13 +150,13 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    *               on an expression T, skips processing T and its subtree; otherwise, processes
    *               T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
-   *               RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
+   *               UnknownRuleId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
    *               has been marked as in effective on an expression T, skips processing T and its
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
    */
   def transformExpressionsDownWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId)(rule: PartialFunction[Expression, Expression])
+    ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[Expression, Expression])
   : this.type = {
     mapExpressions(_.transformDownWithPruning(cond, ruleId)(rule))
   }
@@ -184,19 +165,9 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * Runs [[transformUp]] with `rule` on all expressions present in this query operator.
    *
    * @param rule the rule to be applied to every expression in this operator.
-   * @param cond   a Lambda expression to prune tree traversals. If `cond.apply` returns false
-   *               on an expression T, skips processing T and its subtree; otherwise, processes
-   *               T and its subtree recursively.
-   * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
-   *               RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
-   *               has been marked as in effective on an expression T, skips processing T and its
-   *               subtree. Do not pass it if the rule is not purely functional and reads a
-   *               varying initial state for different invocations.
    */
-  def transformExpressionsUp(rule: PartialFunction[Expression, Expression],
-    cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId): this.type = {
-    transformExpressionsUpWithPruning(cond, ruleId)(rule)
+  def transformExpressionsUp(rule: PartialFunction[Expression, Expression]): this.type = {
+    transformExpressionsUpWithPruning(AlwaysProcess.fn, UnknownRuleId)(rule)
   }
 
   /**
@@ -207,13 +178,13 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    *               on an expression T, skips processing T and its subtree; otherwise, processes
    *               T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
-   *               RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
+   *               UnknownRuleId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
    *               has been marked as in effective on an expression T, skips processing T and its
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
    */
   def transformExpressionsUpWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId)(rule: PartialFunction[Expression, Expression])
+    ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[Expression, Expression])
   : this.type = {
     mapExpressions(_.transformUpWithPruning(cond, ruleId)(rule))
   }
@@ -257,10 +228,8 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * Returns the result of running [[transformExpressions]] on this node
    * and all its children. Note that this method skips expressions inside subqueries.
    */
-  def transformAllExpressions(rule: PartialFunction[Expression, Expression],
-    cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId): this.type = {
-    transformAllExpressionsWithPruning(cond, ruleId)(rule)
+  def transformAllExpressions(rule: PartialFunction[Expression, Expression]): this.type = {
+    transformAllExpressionsWithPruning(AlwaysProcess.fn, UnknownRuleId)(rule)
   }
 
   /**
@@ -268,7 +237,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * and all its children. Note that this method skips expressions inside subqueries.
    */
   def transformAllExpressionsWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId)(rule: PartialFunction[Expression, Expression])
+    ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[Expression, Expression])
   : this.type = {
     transformWithPruning(cond, ruleId) {
       case q: QueryPlan[_] =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -111,8 +111,8 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
    *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on an expression T, skips processing T and its subtree. Do not
-   *        pass it if the rule is not purely functional not purely functional and reads a
-   *        varying initial state for every invocation.
+   *        pass it if the rule is not purely functional and reads a varying initial state for
+   *        different invocations.
    */
   def transformExpressions(rule: PartialFunction[Expression, Expression],
     cond: TreePatternBits => Boolean = AlwaysProcess.fn,
@@ -130,8 +130,8 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
    *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on an expression T, skips processing T and its subtree. Do not
-   *        pass it if the rule is not purely functional not purely functional and reads a
-   *        varying initial state for every invocation.
+   *        pass it if the rule is not purely functional and reads a varying initial state for
+   *        different invocations.
    */
   def transformExpressionsDown(rule: PartialFunction[Expression, Expression],
     cond: TreePatternBits => Boolean = AlwaysProcess.fn,
@@ -149,8 +149,8 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
    *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on an expression T, skips processing T and its subtree. Do not
-   *        pass it if the rule is not purely functional and reads a varying inital state for
-   *        every invocation.
+   *        pass it if the rule is not purely functional and reads a varying initial state for
+   *        different invocations.
    */
   def transformExpressionsUp(rule: PartialFunction[Expression, Expression],
     cond: TreePatternBits => Boolean = AlwaysProcess.fn,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -100,8 +100,8 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
   final def missingInput: AttributeSet = references -- inputSet
 
   /**
-   * Runs [[transformExpressionsDown]] with `rule` on all expressions present
-   * in this query operator.
+   * Runs [[transformExpressionsDown]] with `rule` on all expressions present in this query
+   * operator.
    * Users should not expect a specific directionality. If a specific directionality is needed,
    * transformExpressionsDown or transformExpressionsUp should be used.
    *
@@ -112,7 +112,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
   }
 
   /**
-   * Runs [[transformExpressionsDown]] with `rule` on all expressions present
+   * Runs [[transformExpressionsDownWithPruning]] with `rule` on all expressions present
    * in this query operator.
    * Users should not expect a specific directionality. If a specific directionality is needed,
    * transformExpressionsDown or transformExpressionsUp should be used.
@@ -143,14 +143,15 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
   }
 
   /**
-   * Runs [[transformDown]] with `rule` on all expressions present in this query operator.
+   * Runs [[transformDownWithPruning]] with `rule` on all expressions present in this query
+   * operator.
    *
    * @param rule   the rule to be applied to every expression in this operator.
    * @param cond   a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *               on an expression T, skips processing T and its subtree; otherwise, processes
    *               T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
-   *               UnknownRuleId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
+   *               UnknownRuleId, no pruning happens. Otherwise, if `rule` (with id `ruleId`)
    *               has been marked as in effective on an expression T, skips processing T and its
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
@@ -171,14 +172,15 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
   }
 
   /**
-   * Runs [[transformUp]] with `rule` on all expressions present in this query operator.
+   * Runs [[transformExpressionsUpWithPruning]] with `rule` on all expressions present in this
+   * query operator.
    *
    * @param rule the rule to be applied to every expression in this operator.
    * @param cond   a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *               on an expression T, skips processing T and its subtree; otherwise, processes
    *               T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
-   *               UnknownRuleId, no pruning happens. Otherwise, if `rule`(with id `ruleId`)
+   *               UnknownRuleId, no pruning happens. Otherwise, if `rule` (with id `ruleId`)
    *               has been marked as in effective on an expression T, skips processing T and its
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
@@ -233,7 +235,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
   }
 
   /**
-   * Returns the result of running [[transformExpressions]] on this node
+   * Returns the result of running [[transformExpressionsWithPruning]] on this node
    * and all its children. Note that this method skips expressions inside subqueries.
    */
   def transformAllExpressionsWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AnalysisHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AnalysisHelper.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, Expre
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.rules.RuleId
 import org.apache.spark.sql.catalyst.rules.UnknownRuleId
-import org.apache.spark.sql.catalyst.trees.{AlwaysProcess, CurrentOrigin, TreePatternBits}
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, TreePatternBits}
 import org.apache.spark.util.Utils
 
 
@@ -175,7 +175,7 @@ trait AnalysisHelper extends QueryPlan[LogicalPlan] { self: LogicalPlan =>
    * the scope of a [[resolveOperatorsDown()]] call.
    * @see [[org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning()]].
    */
-  override def transformDownWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+  override def transformDownWithPruning(cond: TreePatternBits => Boolean,
     ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[LogicalPlan, LogicalPlan])
   : LogicalPlan = {
     assertNotAnalysisRule()
@@ -187,7 +187,7 @@ trait AnalysisHelper extends QueryPlan[LogicalPlan] { self: LogicalPlan =>
    *
    * @see [[org.apache.spark.sql.catalyst.trees.TreeNode.transformUpWithPruning()]]
    */
-  override def transformUpWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+  override def transformUpWithPruning(cond: TreePatternBits => Boolean,
     ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[LogicalPlan, LogicalPlan])
   : LogicalPlan = {
     assertNotAnalysisRule()
@@ -199,7 +199,7 @@ trait AnalysisHelper extends QueryPlan[LogicalPlan] { self: LogicalPlan =>
    * @see [[QueryPlan.transformAllExpressionsWithPruning()]]
    */
   override def transformAllExpressionsWithPruning(
-    cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+    cond: TreePatternBits => Boolean,
     ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[Expression, Expression])
   : this.type = {
     assertNotAnalysisRule()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AnalysisHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AnalysisHelper.scala
@@ -172,36 +172,37 @@ trait AnalysisHelper extends QueryPlan[LogicalPlan] { self: LogicalPlan =>
    * In analyzer, use [[resolveOperatorsDown()]] instead. If this is used in the analyzer,
    * an exception will be thrown in test mode. It is however OK to call this function within
    * the scope of a [[resolveOperatorsDown()]] call.
-   * @see [[org.apache.spark.sql.catalyst.trees.TreeNode.transformDown()]].
+   * @see [[org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning()]].
    */
-  override def transformDown(rule: PartialFunction[LogicalPlan, LogicalPlan],
-    cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId): LogicalPlan = {
+  override def transformDownWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+    ruleId: Int = RuleIdCollection.UnknownId)(rule: PartialFunction[LogicalPlan, LogicalPlan])
+  : LogicalPlan = {
     assertNotAnalysisRule()
-    super.transformDown(rule, cond, ruleId)
+    super.transformDownWithPruning(cond, ruleId)(rule)
   }
 
   /**
    * Use [[resolveOperators()]] in the analyzer.
    *
-   * @see [[org.apache.spark.sql.catalyst.trees.TreeNode.transformUp()]]
+   * @see [[org.apache.spark.sql.catalyst.trees.TreeNode.transformUpWithPruning()]]
    */
-  override def transformUp(rule: PartialFunction[LogicalPlan, LogicalPlan],
-    cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId): LogicalPlan = {
+  override def transformUpWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+    ruleId: Int = RuleIdCollection.UnknownId)(rule: PartialFunction[LogicalPlan, LogicalPlan])
+  : LogicalPlan = {
     assertNotAnalysisRule()
-    super.transformUp(rule, cond, ruleId)
+    super.transformUpWithPruning(cond, ruleId)(rule)
   }
 
   /**
    * Use [[resolveExpressions()]] in the analyzer.
-   * @see [[QueryPlan.transformAllExpressions()]]
+   * @see [[QueryPlan.transformAllExpressionsWithPruning()]]
    */
-  override def transformAllExpressions(rule: PartialFunction[Expression, Expression],
+  override def transformAllExpressionsWithPruning(
     cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId): this.type = {
+    ruleId: Int = RuleIdCollection.UnknownId)(rule: PartialFunction[Expression, Expression])
+  : this.type = {
     assertNotAnalysisRule()
-    super.transformAllExpressions(rule, cond, ruleId)
+    super.transformAllExpressionsWithPruning(cond, ruleId)(rule)
   }
 
   override def clone(): LogicalPlan = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AnalysisHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AnalysisHelper.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, Expression}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.rules.RuleIdCollection
+import org.apache.spark.sql.catalyst.rules.RuleId
+import org.apache.spark.sql.catalyst.rules.UnknownRuleId
 import org.apache.spark.sql.catalyst.trees.{AlwaysProcess, CurrentOrigin, TreePatternBits}
 import org.apache.spark.util.Utils
 
@@ -175,7 +176,7 @@ trait AnalysisHelper extends QueryPlan[LogicalPlan] { self: LogicalPlan =>
    * @see [[org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning()]].
    */
   override def transformDownWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId)(rule: PartialFunction[LogicalPlan, LogicalPlan])
+    ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[LogicalPlan, LogicalPlan])
   : LogicalPlan = {
     assertNotAnalysisRule()
     super.transformDownWithPruning(cond, ruleId)(rule)
@@ -187,7 +188,7 @@ trait AnalysisHelper extends QueryPlan[LogicalPlan] { self: LogicalPlan =>
    * @see [[org.apache.spark.sql.catalyst.trees.TreeNode.transformUpWithPruning()]]
    */
   override def transformUpWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId)(rule: PartialFunction[LogicalPlan, LogicalPlan])
+    ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[LogicalPlan, LogicalPlan])
   : LogicalPlan = {
     assertNotAnalysisRule()
     super.transformUpWithPruning(cond, ruleId)(rule)
@@ -199,7 +200,7 @@ trait AnalysisHelper extends QueryPlan[LogicalPlan] { self: LogicalPlan =>
    */
   override def transformAllExpressionsWithPruning(
     cond: TreePatternBits => Boolean = AlwaysProcess.fn,
-    ruleId: Int = RuleIdCollection.UnknownId)(rule: PartialFunction[Expression, Expression])
+    ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[Expression, Expression])
   : this.type = {
     assertNotAnalysisRule()
     super.transformAllExpressionsWithPruning(cond, ruleId)(rule)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AnalysisHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AnalysisHelper.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, Expression}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.trees.CurrentOrigin
+import org.apache.spark.sql.catalyst.rules.RuleIdCollection
+import org.apache.spark.sql.catalyst.trees.{AlwaysProcess, CurrentOrigin, TreePatternBits}
 import org.apache.spark.util.Utils
 
 
@@ -173,27 +174,34 @@ trait AnalysisHelper extends QueryPlan[LogicalPlan] { self: LogicalPlan =>
    * the scope of a [[resolveOperatorsDown()]] call.
    * @see [[org.apache.spark.sql.catalyst.trees.TreeNode.transformDown()]].
    */
-  override def transformDown(rule: PartialFunction[LogicalPlan, LogicalPlan]): LogicalPlan = {
+  override def transformDown(rule: PartialFunction[LogicalPlan, LogicalPlan],
+    cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+    ruleId: Int = RuleIdCollection.UnknownId): LogicalPlan = {
     assertNotAnalysisRule()
-    super.transformDown(rule)
+    super.transformDown(rule, cond, ruleId)
   }
 
   /**
    * Use [[resolveOperators()]] in the analyzer.
+   *
    * @see [[org.apache.spark.sql.catalyst.trees.TreeNode.transformUp()]]
    */
-  override def transformUp(rule: PartialFunction[LogicalPlan, LogicalPlan]): LogicalPlan = {
+  override def transformUp(rule: PartialFunction[LogicalPlan, LogicalPlan],
+    cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+    ruleId: Int = RuleIdCollection.UnknownId): LogicalPlan = {
     assertNotAnalysisRule()
-    super.transformUp(rule)
+    super.transformUp(rule, cond, ruleId)
   }
 
   /**
    * Use [[resolveExpressions()]] in the analyzer.
    * @see [[QueryPlan.transformAllExpressions()]]
    */
-  override def transformAllExpressions(rule: PartialFunction[Expression, Expression]): this.type = {
+  override def transformAllExpressions(rule: PartialFunction[Expression, Expression],
+    cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+    ruleId: Int = RuleIdCollection.UnknownId): this.type = {
     assertNotAnalysisRule()
-    super.transformAllExpressions(rule)
+    super.transformAllExpressions(rule, cond, ruleId)
   }
 
   override def clone(): LogicalPlan = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -25,7 +25,8 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning, RoundRobinPartitioning, SinglePartition}
-import org.apache.spark.sql.catalyst.trees.TreePattern._
+import org.apache.spark.sql.catalyst.trees.TreePattern.{INNER_LIKE_JOIN, JOIN,
+  LEFT_SEMI_OR_ANTI_JOIN, OUTER_JOIN, TreePattern}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning, RoundRobinPartitioning, SinglePartition}
+import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -405,6 +406,17 @@ case class Join(
     case NaturalJoin(_) => false
     case UsingJoin(_, _) => false
     case _ => resolvedExceptNatural
+  }
+
+  override val nodePatterns : Seq[TreePattern] = {
+    var types = Seq(JOIN)
+    joinType match {
+      case _: InnerLike => types = types :+ INNER_LIKE_JOIN
+      case LeftOuter | FullOuter | RightOuter => types = types :+ OUTER_JOIN
+      case LeftSemiOrAnti(_) => types = types :+ LEFT_SEMI_OR_ANTI_JOIN
+      case _ =>
+    }
+    types
   }
 
   // Ignore hint for canonicalization

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/Rule.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/Rule.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.trees.TreeNode
 abstract class Rule[TreeType <: TreeNode[_]] extends SQLConfHelper with Logging {
 
   // The integer id of a rule, for pruning unnecessary tree traversals.
-  protected lazy val ruleId: Int = RuleIdCollection.getRuleId(this.ruleName)
+  protected lazy val ruleId = RuleIdCollection.getRuleId(this.ruleName)
 
   /** Name for this rule, automatically inferred based on class name. */
   val ruleName: String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.rules
+
+import scala.collection.mutable
+
+import org.apache.spark.internal.Logging
+
+// A collection of rules that use rule ids to prune tree traversals.
+object RuleIdCollection extends Logging {
+
+  // The rules listed here need a rule id. Rules are in alphabetical order.
+  private val rulesWithIds: Seq[String] = {
+      // Catalyst Optimizer rules
+      "org.apache.spark.sql.catalyst.optimizer.CostBasedJoinReorder" ::
+      "org.apache.spark.sql.catalyst.optimizer.EliminateOuterJoin" ::
+      "org.apache.spark.sql.catalyst.optimizer.PushDownLeftSemiAntiJoin" ::
+      "org.apache.spark.sql.catalyst.optimizer.PushLeftSemiLeftAntiThroughJoin" ::
+      "org.apache.spark.sql.catalyst.optimizer.ReorderJoin" :: Nil
+  }
+
+  // Maps rule names to ids. Rule ids are continuous natural numbers starting from 0.
+  private val ruleToId = new mutable.HashMap[String, Int]
+
+  // Maps rule ids to names. Rule ids are continuous natural numbers starting from 0.
+  private val ruleIdToName = new mutable.HashMap[Int, String]
+
+  // Unknown rule id which does not prune tree traversal. It is used as the default rule id for
+  // tree transformation functions.
+  val UnknownId: Int = -1
+
+  // The total number of rules with ids.
+  val NumRules: Int = {
+    var ruleId = 0
+    rulesWithIds.foreach(ruleName => {
+      ruleToId.put(ruleName, ruleId)
+      ruleIdToName.put(ruleId, ruleName)
+      ruleId = ruleId + 1
+    })
+    assert(ruleId < 192) // The assertion can be relaxed when we have more rules.
+    ruleId
+  }
+
+  // Return the rule Id for a rule name.
+  def getRuleId(ruleName: String): Int = {
+    val ruleIdOpt = ruleToId.get(ruleName)
+    // Please add the rule name to `rulesWithIds` if this assert fails.
+    assert(ruleIdOpt.isDefined)
+    ruleIdOpt.get
+  }
+
+  // Return the rule name from its id. It is for debugging purpose.
+  def getRuleName(ruleId: Int): String = {
+    val ruleNameOpt = ruleIdToName.get(ruleId)
+    assert(ruleNameOpt.isDefined) // Add the rule name to ruleIdToName if this assert fails.
+    ruleNameOpt.get
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.rules
 
 import scala.collection.mutable
 
-// Represent unique rule ids for rules that can be invoked multiple times.
+// Represent unique rule ids for rules that are invoked multiple times.
 case class RuleId(id: Int) {
   // Currently, there are more than 128 but less than 192 rules needing an id. However, the
   // requirement can be relaxed when we have more such rules. Note that increasing the max id can
@@ -27,7 +27,7 @@ case class RuleId(id: Int) {
   require(id >= -1 && id < 192)
 }
 
-// Unknown rule id which does not prune tree traversal. It is used as the default rule id for
+// Unknown rule id which does not prune tree traversals. It is used as the default rule id for
 // tree transformation functions.
 object UnknownRuleId extends RuleId(-1)
 
@@ -62,7 +62,7 @@ object RuleIdCollection {
     id
   }
 
-  // Return the rule Id for a rule name.
+  // Return the rule id for a rule name.
   def getRuleId(ruleName: String): RuleId = {
     val ruleIdOpt = ruleToId.get(ruleName)
     // Please add the rule name to `rulesWithIds` if rule id is not found.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -19,10 +19,8 @@ package org.apache.spark.sql.catalyst.rules
 
 import scala.collection.mutable
 
-import org.apache.spark.internal.Logging
-
 // A collection of rules that use rule ids to prune tree traversals.
-object RuleIdCollection extends Logging {
+object RuleIdCollection {
 
   // The rules listed here need a rule id. Rules are in alphabetical order.
   private val rulesNeedingIds: Seq[String] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -69,7 +69,7 @@ object RuleIdCollection extends Logging {
   // Return the rule name from its id. It is for debugging purpose.
   def getRuleName(ruleId: Int): String = {
     val ruleNameOpt = ruleIdToName.get(ruleId)
-    assert(ruleNameOpt.isDefined) // Add the rule name to ruleIdToName if this assert fails.
+    assert(ruleNameOpt.isDefined, s"rule id $ruleId does not exist")
     ruleNameOpt.get
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -25,11 +25,13 @@ import org.apache.spark.internal.Logging
 object RuleIdCollection extends Logging {
 
   // The rules listed here need a rule id. Rules are in alphabetical order.
-  private val rulesWithIds: Seq[String] = {
+  private val rulesNeedingIds: Seq[String] = {
       // Catalyst Optimizer rules
       "org.apache.spark.sql.catalyst.optimizer.CostBasedJoinReorder" ::
       "org.apache.spark.sql.catalyst.optimizer.EliminateOuterJoin" ::
+      "org.apache.spark.sql.catalyst.optimizer.OptimizeIn" ::
       "org.apache.spark.sql.catalyst.optimizer.PushDownLeftSemiAntiJoin" ::
+      "org.apache.spark.sql.catalyst.optimizer.PushExtraPredicateThroughJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.PushLeftSemiLeftAntiThroughJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.ReorderJoin" :: Nil
   }
@@ -47,7 +49,7 @@ object RuleIdCollection extends Logging {
   // The total number of rules with ids.
   val NumRules: Int = {
     var ruleId = 0
-    rulesWithIds.foreach(ruleName => {
+    rulesNeedingIds.foreach(ruleName => {
       ruleToId.put(ruleName, ruleId)
       ruleIdToName.put(ruleId, ruleName)
       ruleId = ruleId + 1
@@ -60,7 +62,7 @@ object RuleIdCollection extends Logging {
   def getRuleId(ruleName: String): Int = {
     val ruleIdOpt = ruleToId.get(ruleName)
     // Please add the rule name to `rulesWithIds` if this assert fails.
-    assert(ruleIdOpt.isDefined)
+    assert(ruleIdOpt.isDefined, s"add $ruleName into `rulesNeedingIds`")
     ruleIdOpt.get
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.catalyst.rules
 
 import scala.collection.mutable
 
-// Represent the unique id of a rule for tree traversal pruning.
+// Represent unique rule ids for rules that can be invoked multiple times.
 case class RuleId(id: Int) {
   // Currently, there are more than 128 but less than 192 rules needing an id. However, the
-  // assertion can be relaxed when we have more such rules. Note that increasing the max id can
+  // requirement can be relaxed when we have more such rules. Note that increasing the max id can
   // result in increased memory consumption from every TreeNode.
   require(id >= -1 && id < 192)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -22,7 +22,10 @@ import scala.collection.mutable
 // A collection of rules that use rule ids to prune tree traversals.
 object RuleIdCollection {
 
-  // The rules listed here need a rule id. Rules are in alphabetical order.
+  // The rules listed here need a rule id. Typically, rules that are in a fixed point batch or
+  // invoked multiple times by Analyzer/Optimizer/Planner need a rule id to prune unnecessary
+  // tree traversals in the transform function family. Note that those rules should not depend on
+  // a changing, external state. Rules here are in alphabetical order.
   private val rulesNeedingIds: Seq[String] = {
       // Catalyst Optimizer rules
       "org.apache.spark.sql.catalyst.optimizer.CostBasedJoinReorder" ::
@@ -52,7 +55,10 @@ object RuleIdCollection {
       ruleIdToName.put(ruleId, ruleName)
       ruleId = ruleId + 1
     })
-    assert(ruleId < 192) // The assertion can be relaxed when we have more rules.
+    // Currently, there are more than 128 but less than 192 rules needing an id. However, the
+    // assertion can be relaxed when we have more such rules. Note that increasing the max id can
+    // result in increased memory consumption from every TreeNode.
+    assert(ruleId < 192)
     ruleId
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -82,7 +82,7 @@ object CurrentOrigin {
 // A tag of a `TreeNode`, which defines name and type
 case class TreeNodeTag[T](name: String)
 
-// A wrapper of Bitset for pattern enums.
+// A wrapper of BitSet for pattern enums.
 trait TreePatternBits {
   protected val treePatternBits: BitSet
 
@@ -142,7 +142,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
   private val tags: mutable.Map[TreeNodeTag[_], Any] = mutable.Map.empty
 
   /**
-   * A bit set of tree patterns for this TreeNode and its subtree. If this TreeNode node and its
+   * A BitSet of tree patterns for this TreeNode and its subtree. If this TreeNode and its
    * subtree contains a pattern `P`, the corresponding bit for `P.id` is set in this BitSet.
    */
   override lazy val treePatternBits: BitSet = {
@@ -161,10 +161,11 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
   }
 
   /**
-   *  A BitSet of rule ids to record ineffective rules for this TreeNode and its subtree.
-   *  If a rule R (which does not read a varying state for each invocation) is ineffective in one
-   *  apply call for this TreeNode and its subtree, R will still be ineffective for subsequent
-   *  apply calls on this tree because query plan structures are immutable.
+   * A BitSet of rule ids to record ineffective rules for this TreeNode and its subtree.
+   * If a rule R (which does not read a varying, external state for each invocation) is
+   * ineffective in one apply call for this TreeNode and its subtree, R will still be
+   * ineffective for subsequent apply calls on this tree because query plan structures are
+   * immutable.
    */
   private val ineffectiveRules: BitSet = new BitSet(RuleIdCollection.NumRules)
 
@@ -410,7 +411,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * Users should not expect a specific directionality. If a specific directionality is needed,
    * transformDown or transformUp should be used.
    *
-   * @param rule   the function use to transform this nodes children
+   * @param rule the function used to transform this nodes children
    */
   def transform(rule: PartialFunction[BaseType, BaseType]): BaseType = {
     transformDown(rule)
@@ -422,7 +423,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * Users should not expect a specific directionality. If a specific directionality is needed,
    * transformDown or transformUp should be used.
    *
-   * @param rule   the function use to transform this nodes children
+   * @param rule   the function used to transform this nodes children
    * @param cond   a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *               on a TreeNode T, skips processing T and its subtree; otherwise, processes
    *               T and its subtree recursively.
@@ -442,7 +443,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * Returns a copy of this node where `rule` has been recursively applied to it and all of its
    * children (pre-order). When `rule` does not apply to a given node it is left unchanged.
    *
-   * @param rule   the function use to transform this nodes children
+   * @param rule the function used to transform this nodes children
    */
   def transformDown(rule: PartialFunction[BaseType, BaseType]): BaseType = {
     transformDownWithPruning(AlwaysProcess.fn, UnknownRuleId)(rule)
@@ -452,7 +453,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * Returns a copy of this node where `rule` has been recursively applied to it and all of its
    * children (pre-order). When `rule` does not apply to a given node it is left unchanged.
    *
-   * @param rule   the function use to transform this nodes children
+   * @param rule   the function used to transform this nodes children
    * @param cond   a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *               on a TreeNode T, skips processing T and its subtree; otherwise, processes
    *               T and its subtree recursively.
@@ -493,7 +494,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * children and then itself (post-order). When `rule` does not apply to a given node, it is left
    * unchanged.
    *
-   * @param rule   the function use to transform this nodes children
+   * @param rule   the function used to transform this nodes children
    */
   def transformUp(rule: PartialFunction[BaseType, BaseType]): BaseType = {
     transformUpWithPruning(AlwaysProcess.fn, UnknownRuleId)(rule)
@@ -504,7 +505,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * children and then itself (post-order). When `rule` does not apply to a given node, it is left
    * unchanged.
    *
-   * @param rule   the function use to transform this nodes children
+   * @param rule   the function used to transform this nodes children
    * @param cond   a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *               on a TreeNode T, skips processing T and its subtree; otherwise, processes
    *               T and its subtree recursively.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -159,12 +159,6 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
   }
 
   /**
-   * @return a sequence of tree pattern enums in a TreeNode T. It does not include propagated
-   *         patterns in the subtree of T.
-   */
-  protected val nodePatterns: Seq[TreePattern] = Seq()
-
-  /**
    *  A BitSet of rule ids to record ineffective rules for this TreeNode and its subtree.
    *  If a rule R (which does not read a varying state for each invocation) is ineffective in one
    *  apply call for this TreeNode and its subtree, R will still be ineffective for subsequent
@@ -173,11 +167,17 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
   private val ineffectiveRules: BitSet = new BitSet(RuleIdCollection.NumRules)
 
   /**
+   * @return a sequence of tree pattern enums in a TreeNode T. It does not include propagated
+   *         patterns in the subtree of T.
+   */
+  protected val nodePatterns: Seq[TreePattern] = Seq()
+
+  /**
    * Mark that a rule (with id `ruleId`) is ineffective for this TreeNode and its subtree.
    *
    * @param ruleId the unique identifier of the rule. If `ruleId` is UnknownId, it is a no-op.
    */
-  def markRuleAsIneffective(ruleId : Int): Unit = {
+  private def markRuleAsIneffective(ruleId : Int): Unit = {
     if (ruleId == RuleIdCollection.UnknownId ) {
       return
     }
@@ -192,7 +192,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * @return true if the rule has been marked as ineffective; false otherwise. If `ruleId` is
    *         UnknownId, it returns false.
    */
-  def isRuleIneffective(ruleId : Int): Boolean = {
+  private def isRuleIneffective(ruleId : Int): Boolean = {
     if (ruleId == RuleIdCollection.UnknownId) {
       return false
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -433,7 +433,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
    */
-  def transformWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+  def transformWithPruning(cond: TreePatternBits => Boolean,
     ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[BaseType, BaseType])
   : BaseType = {
     transformDownWithPruning(cond, ruleId)(rule)
@@ -463,7 +463,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
    */
-  def transformDownWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+  def transformDownWithPruning(cond: TreePatternBits => Boolean,
     ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[BaseType, BaseType])
   : BaseType = {
     if (!cond.apply(this) || isRuleIneffective(ruleId)) {
@@ -515,7 +515,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    *               subtree. Do not pass it if the rule is not purely functional and reads a
    *               varying initial state for different invocations.
    */
-  def transformUpWithPruning(cond: TreePatternBits => Boolean = AlwaysProcess.fn,
+  def transformUpWithPruning(cond: TreePatternBits => Boolean,
     ruleId: RuleId = UnknownRuleId)(rule: PartialFunction[BaseType, BaseType])
   : BaseType = {
     if (!cond.apply(this) || isRuleIneffective(ruleId)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -409,7 +409,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * transformDown or transformUp should be used.
    *
    * @param rule the function use to transform this nodes children
-   * @param cond a Lambda expression to stop traversals early on. If `cond.apply` returns false
+   * @param cond a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *             on a TreeNode T, skips processing T and its subtree; otherwise, processes
    *             T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
@@ -429,7 +429,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * children (pre-order). When `rule` does not apply to a given node it is left unchanged.
    *
    * @param rule the function use to transform this nodes children
-   * @param cond a Lambda expression to stop traversals early on. If `cond.apply` returns false
+   * @param cond a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *             on a TreeNode T, skips processing T and its subtree; otherwise, processes
    *             T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
@@ -470,7 +470,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * unchanged.
    *
    * @param rule the function use to transform this nodes children
-   * @param cond a Lambda expression to stop traversals early on. If `cond.apply` returns false
+   * @param cond a Lambda expression to prune tree traversals. If `cond.apply` returns false
    *             on a TreeNode T, skips processing T and its subtree; otherwise, processes
    *             T and its subtree recursively.
    * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -82,7 +82,7 @@ case class TreeNodeTag[T](name: String)
 
 // A wrapper of Bitset for pattern enums.
 trait TreePatternBits {
-  val treePatternBits: BitSet
+  protected val treePatternBits: BitSet
 
   /**
    * @param t, the tree pattern enum to be tested.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -141,7 +141,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
 
   /**
    * A bit set of tree patterns for this TreeNode and its subtree. If this TreeNode node and its
-   * subtree contains a pattern `P`, the corresponding bit for `P.id` is set in this bitset.
+   * subtree contains a pattern `P`, the corresponding bit for `P.id` is set in this BitSet.
    */
   override lazy val treePatternBits: BitSet = {
     val bits: BitSet = new BitSet(TreePattern.maxId)
@@ -416,7 +416,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on a TreeNode T, skips processing T and its subtree. Do not
    *        pass it if the rule is not purely functional and reads a varying initial state for
-   *        every invocation.
+   *        different invocations.
    */
   def transform(rule: PartialFunction[BaseType, BaseType],
     cond: TreePatternBits => Boolean = AlwaysProcess.fn,
@@ -436,7 +436,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on a TreeNode T, skips processing T and its subtree. Do not
    *        pass it if the rule is not purely functional and reads a varying initial state for
-   *        every invocation.
+   *        different invocations.
    */
   def transformDown(rule: PartialFunction[BaseType, BaseType],
     cond: TreePatternBits => Boolean = AlwaysProcess.fn,
@@ -477,7 +477,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on a TreeNode T, skips processing T and its subtree. Do not
    *        pass it if the rule is not purely functional and reads a varying initial state for
-   *        every invocation.
+   *        different invocations.
    */
   def transformUp(rule: PartialFunction[BaseType, BaseType],
     cond: TreePatternBits => Boolean = AlwaysProcess.fn,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -126,14 +126,18 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    */
   private val tags: mutable.Map[TreeNodeTag[_], Any] = mutable.Map.empty
 
+  /**
+   * A bit set of tree patterns for this TreeNode and its subtree. If this TreeNode node and its
+   * subtree contains a pattern `P`, the corresponding bit for `P.id` is set in this bitset.
+   */
   override lazy val treePatternBits: BitSet = {
     val bits: BitSet = new BitSet(TreePattern.maxId)
-    // Propagate node type bits
+    // Propagate node pattern bits
     val nodePatternIterator = nodePatterns.iterator
     while (nodePatternIterator.hasNext) {
       bits.set(nodePatternIterator.next().id)
     }
-    // Propagate children bits
+    // Propagate children's pattern bits
     val childIterator = children.iterator
     while (childIterator.hasNext) {
       bits.union(childIterator.next().treePatternBits)
@@ -141,6 +145,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
     bits
   }
 
+  /**
+   * @return a sequence of tree pattern enums in a TreeNode T. It does not include propagated
+   *         patterns in the subtree of T.
+   */
   protected val nodePatterns: Seq[TreePattern] = Seq()
 
   /**
@@ -387,11 +395,11 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * transformDown or transformUp should be used.
    *
    * @param rule the function use to transform this nodes children
-   * @param cond a Lambda expression to stop transform early on. If `cond.apply` returns false
+   * @param cond a Lambda expression to stop traversals early on. If `cond.apply` returns false
    *             on a TreeNode T, skips processing T and its subtree; otherwise, processes
    *             T and its subtree recursively.
-   * @param ruleId is a unique Id for the rule to prune unnecessary tree traversals. When it is
-   *        RuleId.UnknownId, no pruning happens. Otherwise, if a rule with id `ruleId` has been
+   * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
+   *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on a TreeNode T, skips processing T and its subtree. Do not
    *        pass it if the rule is not purely functional and reads a varying initial state for
    *        every invocation.
@@ -407,11 +415,11 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * children (pre-order). When `rule` does not apply to a given node it is left unchanged.
    *
    * @param rule the function use to transform this nodes children
-   * @param cond a Lambda expression to stop transform early on. If `cond.apply` returns false
+   * @param cond a Lambda expression to stop traversals early on. If `cond.apply` returns false
    *             on a TreeNode T, skips processing T and its subtree; otherwise, processes
    *             T and its subtree recursively.
-   * @param ruleId is a unique Id for the rule to prune unnecessary tree traversals. When it is
-   *        RuleId.UnknownId, no pruning happens. Otherwise, if a rule with id `ruleId` has been
+   * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
+   *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on a TreeNode T, skips processing T and its subtree. Do not
    *        pass it if the rule is not purely functional and reads a varying initial state for
    *        every invocation.
@@ -448,11 +456,11 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * unchanged.
    *
    * @param rule the function use to transform this nodes children
-   * @param cond a Lambda expression to stop transform early on. If `cond.apply` returns false
+   * @param cond a Lambda expression to stop traversals early on. If `cond.apply` returns false
    *             on a TreeNode T, skips processing T and its subtree; otherwise, processes
    *             T and its subtree recursively.
-   * @param ruleId is a unique Id for the rule to prune unnecessary tree traversals. When it is
-   *        RuleId.UnknownId, no pruning happens. Otherwise, if a rule with id `ruleId` has been
+   * @param ruleId is a unique Id for `rule` to prune unnecessary tree traversals. When it is
+   *        RuleId.UnknownId, no pruning happens. Otherwise, if `rule`(with id `ruleId`) has been
    *        marked as in effective on a TreeNode T, skips processing T and its subtree. Do not
    *        pass it if the rule is not purely functional and reads a varying initial state for
    *        every invocation.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -143,7 +143,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * A bit set of tree patterns for this TreeNode and its subtree. If this TreeNode node and its
    * subtree contains a pattern `P`, the corresponding bit for `P.id` is set in this BitSet.
    */
-  lazy val treePatternBits: BitSet = {
+  override lazy val treePatternBits: BitSet = {
     val bits: BitSet = new BitSet(TreePattern.maxId)
     // Propagate node pattern bits
     val nodePatternIterator = nodePatterns.iterator

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -143,7 +143,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
    * A bit set of tree patterns for this TreeNode and its subtree. If this TreeNode node and its
    * subtree contains a pattern `P`, the corresponding bit for `P.id` is set in this BitSet.
    */
-  override lazy val treePatternBits: BitSet = {
+  lazy val treePatternBits: BitSet = {
     val bits: BitSet = new BitSet(TreePattern.maxId)
     // Propagate node pattern bits
     val nodePatternIterator = nodePatterns.iterator

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -88,7 +88,7 @@ object AlwaysProcess {
 }
 
 // scalastyle:off
-abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with TreePatternBits{
+abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with TreePatternBits {
 // scalastyle:on
   self: BaseType =>
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -82,49 +82,8 @@ object CurrentOrigin {
 // A tag of a `TreeNode`, which defines name and type
 case class TreeNodeTag[T](name: String)
 
-// A wrapper of BitSet for pattern enums.
-trait TreePatternBits {
-  protected val treePatternBits: BitSet
-
-  /**
-   * @param t, the tree pattern enum to be tested.
-   * @return true if the bit for `t` is set; false otherwise.
-   */
-  @inline final def containsPattern(t: TreePattern): Boolean = {
-    treePatternBits.get(t.id)
-  }
-
-  /**
-   * @param patterns, a sequence of tree pattern enums to be tested.
-   * @return true if every bit for `patterns` is set; false otherwise.
-   */
-  final def containsAllPatterns(patterns: TreePattern*): Boolean = {
-    val iterator = patterns.iterator
-    while (iterator.hasNext) {
-      if (!containsPattern(iterator.next)) {
-        return false
-      }
-    }
-    true
-  }
-
-  /**
-   * @param patterns, a sequence of tree pattern enums to be tested.
-   * @return true if at least one bit for `patterns` is set; false otherwise.
-   */
-  final def containsAnyPattern(patterns: TreePattern*): Boolean = {
-    val iterator = patterns.iterator
-    while (iterator.hasNext) {
-      if (containsPattern(iterator.next)) {
-        return true
-      }
-    }
-    false
-  }
-}
-
 // A functor that always returns true.
-object AlwaysProcess{
+object AlwaysProcess {
   val fn: TreePatternBits => Boolean = { _ => true}
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatternBits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatternBits.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.trees
+
+import org.apache.spark.sql.catalyst.trees.TreePattern.TreePattern
+import org.apache.spark.util.collection.BitSet
+
+// A wrapper of BitSet for pattern enums.
+trait TreePatternBits {
+  protected val treePatternBits: BitSet
+
+  /**
+   * @param t, the tree pattern enum to be tested.
+   * @return true if the bit for `t` is set; false otherwise.
+   */
+  @inline final def containsPattern(t: TreePattern): Boolean = {
+    treePatternBits.get(t.id)
+  }
+
+  /**
+   * @param patterns, a sequence of tree pattern enums to be tested.
+   * @return true if every bit for `patterns` is set; false otherwise.
+   */
+  final def containsAllPatterns(patterns: TreePattern*): Boolean = {
+    val iterator = patterns.iterator
+    while (iterator.hasNext) {
+      if (!containsPattern(iterator.next)) {
+        return false
+      }
+    }
+    true
+  }
+
+  /**
+   * @param patterns, a sequence of tree pattern enums to be tested.
+   * @return true if at least one bit for `patterns` is set; false otherwise.
+   */
+  final def containsAnyPattern(patterns: TreePattern*): Boolean = {
+    val iterator = patterns.iterator
+    while (iterator.hasNext) {
+      if (containsPattern(iterator.next)) {
+        return true
+      }
+    }
+    false
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -25,11 +25,8 @@ object TreePattern extends Enumeration  {
   val IN: Value = Value(0)
 
   // Logical plan patterns (alphabetically ordered)
-  val LATERAL_JOIN: Value = Value
-  val LEFT_SEMI_OR_ANTI_JOIN: Value = Value
-  val CROSS_JOIN: Value = Value
   val INNER_LIKE_JOIN: Value = Value
   val JOIN: Value = Value
+  val LEFT_SEMI_OR_ANTI_JOIN: Value = Value
   val OUTER_JOIN: Value = Value
-  val NATURAL_LIKE_JOIN: Value = Value
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -15,22 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.catalyst.rules
+package org.apache.spark.sql.catalyst.trees
 
-import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.SQLConfHelper
-import org.apache.spark.sql.catalyst.trees.TreeNode
+// Enums for tree patterns.
+object TreePattern extends Enumeration  {
+  type TreePattern = Value
 
-abstract class Rule[TreeType <: TreeNode[_]] extends SQLConfHelper with Logging {
+  // Expression patterns (alphabetically ordered)
+  val IN: Value = Value(0)
 
-  // The integer id of a rule, for pruning unnecessary tree traversals.
-  protected lazy val ruleId: Int = RuleIdCollection.getRuleId(this.ruleName)
-
-  /** Name for this rule, automatically inferred based on class name. */
-  val ruleName: String = {
-    val className = getClass.getName
-    if (className endsWith "$") className.dropRight(1) else className
-  }
-
-  def apply(plan: TreeType): TreeType
+  // Logical plan patterns (alphabetically ordered)
+  val LATERAL_JOIN: Value = Value
+  val LEFT_SEMI_OR_ANTI_JOIN: Value = Value
+  val CROSS_JOIN: Value = Value
+  val INNER_LIKE_JOIN: Value = Value
+  val JOIN: Value = Value
+  val OUTER_JOIN: Value = Value
+  val NATURAL_LIKE_JOIN: Value = Value
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -17,10 +17,11 @@
 
 package org.apache.spark.sql.catalyst.trees
 
-// Enums for tree patterns.
+// Enums for commonly encountered tree patterns.
 object TreePattern extends Enumeration  {
   type TreePattern = Value
 
+  // Enum Ids start from 0.
   // Expression patterns (alphabetically ordered)
   val IN: Value = Value(0)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.trees
 
-// Enums for commonly encountered tree patterns.
+// Enums for commonly encountered tree patterns in rewrite rules.
 object TreePattern extends Enumeration  {
   type TreePattern = Value
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
@@ -169,24 +169,33 @@ class OptimizeInSuite extends PlanTest {
   }
 
   test("OptimizedIn test: Setting the threshold for turning Set into InSet.") {
-    val plan =
-      testRelation
-        .where(In(UnresolvedAttribute("a"), Seq(Literal(1), Literal(2), Literal(3))))
-        .analyze
+    {
+      val plan =
+        testRelation
+          .where(In(UnresolvedAttribute("a"), Seq(Literal(1), Literal(2), Literal(3))))
+          .analyze
 
-    withSQLConf(OPTIMIZER_INSET_CONVERSION_THRESHOLD.key -> "10") {
-      val notOptimizedPlan = OptimizeIn(plan)
-      comparePlans(notOptimizedPlan, plan)
+      withSQLConf(OPTIMIZER_INSET_CONVERSION_THRESHOLD.key -> "10") {
+        val notOptimizedPlan = OptimizeIn(plan)
+        comparePlans(notOptimizedPlan, plan)
+      }
     }
 
-    // Reduce the threshold to turning into InSet.
-    withSQLConf(OPTIMIZER_INSET_CONVERSION_THRESHOLD.key -> "2") {
-      val optimizedPlan = OptimizeIn(plan)
-      optimizedPlan match {
-        case Filter(cond, _)
-          if cond.isInstanceOf[InSet] && cond.asInstanceOf[InSet].set.size == 3 =>
-        // pass
-        case _ => fail("Unexpected result for OptimizedIn")
+    {
+      val plan =
+        testRelation
+          .where(In(UnresolvedAttribute("a"), Seq(Literal(1), Literal(2), Literal(3))))
+          .analyze
+
+      // Reduce the threshold to turning into InSet.
+      withSQLConf(OPTIMIZER_INSET_CONVERSION_THRESHOLD.key -> "2") {
+        val optimizedPlan = OptimizeIn(plan)
+        optimizedPlan match {
+          case Filter(cond, _)
+            if cond.isInstanceOf[InSet] && cond.asInstanceOf[InSet].set.size == 3 =>
+          // pass
+          case _ => fail("Unexpected result for OptimizedIn")
+        }
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
@@ -181,6 +181,10 @@ class OptimizeInSuite extends PlanTest {
       }
     }
 
+    // Since OptimizeIn has been marked as ineffective for `plan` in the preceding test, we need
+    // a new `plan` to run the next test. Here, OptimizeIn depends on a changing, external state,
+    // i.e., conf OPTIMIZER_INSET_CONVERSION_THRESHOLD, which however cannot happen in the
+    // production code path.
     {
       val plan =
         testRelation


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR contains:
- TreeNode, QueryPlan, AnalysisHelper changes to allow the transform function family to stop earlier without traversing the entire tree;
- Example changes in a few rules to support such pruning, e.g., ReorderJoin and OptimizeIn.

Here is a [design doc](https://docs.google.com/document/d/1SEUhkbo8X-0cYAJFYFDQhxUnKJBz4lLn3u4xR2qfWqk) that elaborates the ideas and benchmark numbers.

### Why are the changes needed?

It's a framework-level change for reducing the query compilation time.
In particular, if we update existing rules and transform call sites as per the examples in this PR, the analysis time and query optimization time can be reduced as described in this [doc](https://docs.google.com/document/d/1SEUhkbo8X-0cYAJFYFDQhxUnKJBz4lLn3u4xR2qfWqk) .

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

It is tested by existing tests.
