### PR TITLE
[SPARK-34966][SQL] Avoid shuffle if possible when bucket join type do not match

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.physical
 
+import org.apache.spark.sql.catalyst.analysis.TypeCoercion
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{DataType, IntegerType}
 
@@ -221,6 +222,8 @@ case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
       required match {
         case h: HashClusteredDistribution =>
           expressions.length == h.expressions.length && expressions.zip(h.expressions).forall {
+            case (l: Expression, Cast(r: Expression, dataType, _)) if l.semanticEquals(r) =>
+              TypeCoercion.findTightestCommonType(l.dataType, dataType).contains(dataType)
             case (l, r) => l.semanticEquals(r)
           }
         case ClusteredDistribution(requiredClustering, _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -222,7 +222,7 @@ case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
       required match {
         case h: HashClusteredDistribution =>
           expressions.length == h.expressions.length && expressions.zip(h.expressions).forall {
-            case (l: Expression, Cast(r: Expression, dataType, _)) if l.semanticEquals(r) =>
+            case (l, c @ Cast(r, dataType, _)) if !l.semanticEquals(c) && l.semanticEquals(r) =>
               TypeCoercion.findTightestCommonType(l.dataType, dataType).contains(dataType)
             case (l, r) => l.semanticEquals(r)
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid shuffle if possible when bucket join type do not match. For example:
```sql
set spark.sql.autoBroadcastJoinThreshold=-1;
CREATE TABLE t1 using parquet clustered by (id) into 200 buckets AS SELECT cast(id as bigint) FROM range(1000);
CREATE TABLE t2 using parquet clustered by (id) into 200 buckets AS SELECT cast(id as int) FROM range(500);
SELECT * FROM t1 JOIN t2 ON (t1.id = t2.id);
```

Before this pr:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortMergeJoin [id#14L], [cast(id#15 as bigint)], Inner
   :- Sort [id#14L ASC NULLS FIRST], false, 0
   :  +- Filter isnotnull(id#14L)
   :     +- FileScan parquet default.t1[id#14L] SelectedBucketsCount: 200 out of 200
   +- Sort [cast(id#15 as bigint) ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(cast(id#15 as bigint), 200), ENSURE_REQUIREMENTS, [id=#58]
         +- Filter isnotnull(id#15)
            +- FileScan parquet default.t2[id#15]
```
After this pr:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortMergeJoin [id#14L], [cast(id#15 as bigint)], Inner
   :- Sort [id#14L ASC NULLS FIRST], false, 0
   :  +- Filter isnotnull(id#14L)
   :     +- FileScan parquet default.t1[id#14L] SelectedBucketsCount: 200 out of 200
   +- Sort [cast(id#15 as bigint) ASC NULLS FIRST], false, 0
      +- Filter isnotnull(id#15)
         +- FileScan parquet default.t2[id#15] SelectedBucketsCount: 200 out of 200
```


### Why are the changes needed?

Avoid shuffle to improve query performance.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
