### PR TITLE
[SPARK-34968][TEST][PYTHON] Add the `-fr` argument to xargs rm

### DIFF
--- a/python/run-tests-with-coverage
+++ b/python/run-tests-with-coverage
@@ -56,7 +56,7 @@ export COVERAGE_PROCESS_START="$FWDIR/.coveragerc"
 unset COVERAGE_PROCESS_START
 
 # Coverage could generate empty coverage data files. Remove it to get rid of warnings when combining.
-find $COVERAGE_DIR/coverage_data -size 0 -print0 | xargs -0 rm
+find $COVERAGE_DIR/coverage_data -size 0 -print0 | xargs -0 rm -fr
 echo "Combining collected coverage data under $COVERAGE_DIR/coverage_data"
 $COV_EXEC combine
 echo "Reporting the coverage data at $COVERAGE_DIR/coverage_data/coverage"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch add  the `-fr` argument to `xargs rm`. 

### Why are the changes needed?

This cmd is unavailable in basic case. If the find command does not get any search results, the rm command is invoked with an empty argument list, and then we will get a `rm: missing operand` and break, then the coverage report does not generate.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
python/run-tests-with-coverage --testnames pyspark.sql.tests.test_arrow --python-executables=python

The coverage report result is generated without break.