### PR TITLE
[SPARK-34910][SQL] Add an option for different stride orders

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -118,6 +118,9 @@ class JDBCOptions(
   // ------------------------------------------------------------
   // Optional parameters only for reading
   // ------------------------------------------------------------
+
+  // the ordering of strides (by default, strides are read in a sequential and ascending order)
+  val strideOrder = parameters.getOrElse(JDBC_STRIDE_ORDER, "ascending")
   // the column used to partition
   val partitionColumn = parameters.get(JDBC_PARTITION_COLUMN)
   // the lower bound of partition column
@@ -246,6 +249,7 @@ object JDBCOptions {
   val JDBC_LOWER_BOUND = newOption("lowerBound")
   val JDBC_UPPER_BOUND = newOption("upperBound")
   val JDBC_NUM_PARTITIONS = newOption("numPartitions")
+  val JDBC_STRIDE_ORDER = newOption("strideOrder")
   val JDBC_QUERY_TIMEOUT = newOption("queryTimeout")
   val JDBC_BATCH_FETCH_SIZE = newOption("fetchsize")
   val JDBC_TRUNCATE = newOption("truncate")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -119,7 +119,7 @@ class JDBCOptions(
   // Optional parameters only for reading
   // ------------------------------------------------------------
 
-  // the ordering of strides (by default, strides are read in a sequential and ascending order)
+  // the ordering of strides (by default, strides are read in ascending order)
   val strideOrder = parameters.getOrElse(JDBC_STRIDE_ORDER, "ascending")
   // the column used to partition
   val partitionColumn = parameters.get(JDBC_PARTITION_COLUMN)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -177,8 +177,7 @@ private[sql] object JDBCRelation extends Logging {
    */
   implicit class ArrayPartitionOps(partitions: Array[Partition]) {
     /**
-     * An extension method that utilizes the stride order selector to order the array
-     * of partitions
+     * An extension method that orders an array of partitions in the stride order provided.
      *
      * @param partitionColumn The column used for partitioning.
      * @param strideOrder The stride order from JDBC options.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -175,7 +175,7 @@ private[sql] object JDBCRelation extends Logging {
    *
    * @param partitions The object being extended.
    */
-  implicit class ArrayPartitionOps(partitions: Array[Partition]) {
+  private implicit class ArrayPartitionOps(partitions: Array[Partition]) {
     /**
      * An extension method that orders an array of partitions in the stride order provided.
      *


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, the JDBCRelation columnPartition function orders the strides in ascending order, starting from the lower bound and working its way towards the upper bound.

I'm proposing leaving that as the default, but adding a new option in JDBCOptions called strideOrder. Since it will default to the current behavior, this will keep people's current code working as expected. However, people who may have data skew closer to the upper bound might appreciate being able to have the strides in descending order, thus filling up the first partition with the last stride and so forth. Also, people with nondeterministic data skew or sporadic data density might be able to benefit from a random ordering of the strides.


### Why are the changes needed?
It provides options to the end-user to have more control over the JDBC partitioning.


### Does this PR introduce _any_ user-facing change?
It adds an option called "strideOrder" in JDBCOptions. However, by default the code will order the strides/partitions in the same order it did before this PR (ascending). Therefore, it will not require any changes to users' current code, unless they want to take advantage of these new options.


### How was this patch tested?
I've created two new unit tests.

### Example
Say we have 11 partitions, 5 cores total, and the last partition has triple the amount of data as the first 10 due to data skew. We'll say partitions 1 through 10 take 10 minutes a core, so partition 11 would take 30 minutes on a core.

Current stride order of **ascending**:

_Group 1_
5 cores x 10 minutes = 10 minutes 

(all running concurrently) total of 10 minutes

_Group 2_
5 x 10 = 10 

(all running concurrently) total of 10 minutes

_Group 3_
1 x 30 = 30

4 cores sitting idle

total of 30 minutes

Group 1 (10) + Group 2 (10) + Group 3 (30)

**Total of 50 minutes**


Stride order of **descending**:

_Group 1_
1 core x 30 minutes = 30 minutes 
4 x 10 = 10 (running concurrently with the first core)
4 x 10 = 10 (running concurrently with the first core)
2 x 10 = 10 (running concurrently with the first core)

**Total of 30 minutes**
