### PR TITLE
[SPARK-33357][K8S] Support Spark application managing with SparkAppHandle on Kubernetes

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/PodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/PodStatusWatcher.scala
@@ -24,10 +24,12 @@ import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.KubernetesDriverConf
 import org.apache.spark.deploy.k8s.KubernetesUtils._
 import org.apache.spark.internal.Logging
+import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
 
-private[k8s] trait LoggingPodStatusWatcher extends Watcher[Pod] {
+private[k8s] trait PodStatusWatcher extends Watcher[Pod] {
   def watchOrStop(submissionId: String): Boolean
   def reset(): Unit
+  def registerLauncherBackend(launcherBackend: LauncherBackend): Unit
 }
 
 /**
@@ -36,8 +38,8 @@ private[k8s] trait LoggingPodStatusWatcher extends Watcher[Pod] {
  *
  * @param conf kubernetes driver conf.
  */
-private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
-  extends LoggingPodStatusWatcher with Logging {
+private[k8s] class PodStatusWatcherImpl(conf: KubernetesDriverConf)
+  extends PodStatusWatcher with Logging {
 
   private val appId = conf.appId
 
@@ -47,21 +49,31 @@ private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
 
   private var pod = Option.empty[Pod]
 
+  private var launcherBackend = Option.empty[LauncherBackend]
+
+  private var latestPhase: String = _
+
   private def phase: String = pod.map(_.getStatus.getPhase).getOrElse("unknown")
 
   override def reset(): Unit = {
     resourceTooOldReceived = false
   }
 
+  override def registerLauncherBackend(launcherBackend: LauncherBackend): Unit = {
+    this.launcherBackend = Option(launcherBackend)
+  }
+
   override def eventReceived(action: Action, pod: Pod): Unit = {
     this.pod = Option(pod)
     action match {
       case Action.DELETED | Action.ERROR =>
+        notifyStatusChanged()
         closeWatch()
 
       case _ =>
         logLongStatus()
-        if (hasCompleted()) {
+        notifyStatusChanged()
+        if (hasCompleted) {
           closeWatch()
         }
     }
@@ -82,11 +94,29 @@ private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
     closeWatch()
   }
 
+  private def notifyStatusChanged(): Unit = {
+    if (phase != latestPhase) {
+      latestPhase = phase
+      latestPhase match {
+        case "Pending" => reportStatusChanged(SparkAppHandle.State.SUBMITTED)
+        case "Running" => reportStatusChanged(SparkAppHandle.State.RUNNING)
+        case "Succeeded" => reportStatusChanged(SparkAppHandle.State.FINISHED)
+        case "Failed" => reportStatusChanged(SparkAppHandle.State.FAILED)
+        case "Unknown" => reportStatusChanged(SparkAppHandle.State.LOST)
+        case _ => reportStatusChanged(SparkAppHandle.State.UNKNOWN)
+      }
+    }
+  }
+
+  def reportStatusChanged(state: SparkAppHandle.State): Unit = {
+    launcherBackend.foreach(_.setState(state))
+  }
+
   private def logLongStatus(): Unit = {
     logInfo("State changed, new state: " + pod.map(formatPodState).getOrElse("unknown"))
   }
 
-  private def hasCompleted(): Boolean = {
+  private def hasCompleted: Boolean = {
     phase == "Succeeded" || phase == "Failed"
   }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -19,7 +19,9 @@ package org.apache.spark.deploy.k8s.submit
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+
 import scala.collection.JavaConverters._
+
 import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.client.{KubernetesClient, Watch}
 import io.fabric8.kubernetes.client.dsl.PodResource
@@ -27,6 +29,7 @@ import org.mockito.{ArgumentCaptor, Mock, MockitoAnnotations}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar._
+
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Constants._

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/PodStatusWatcherSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/PodStatusWatcherSuite.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.submit
+
+import java.util
+
+import io.fabric8.kubernetes.api.model.{ObjectMeta, Pod, PodSpec, PodStatus}
+import io.fabric8.kubernetes.client.Watcher.Action.{ADDED, MODIFIED}
+import org.mockito.Mock
+import org.mockito.Mockito.{times, verify}
+import org.mockito.MockitoAnnotations
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.deploy.k8s.KubernetesTestConf
+import org.apache.spark.launcher.SparkAppHandle
+
+class PodStatusWatcherSuite extends SparkFunSuite with BeforeAndAfter {
+
+  @Mock
+  private var launcherBackend: KubernetesLauncherBackend = _
+
+  private val podStatusWatcher = new PodStatusWatcherImpl(k8sDriverConf)
+
+  before {
+    MockitoAnnotations.openMocks(this).close()
+    podStatusWatcher.registerLauncherBackend(launcherBackend)
+  }
+
+  test("The pod status watcher should notify launcher backend about status change.") {
+    podStatusWatcher.eventReceived(ADDED, podWithPhase("Running"))
+    verify(launcherBackend).setState(SparkAppHandle.State.RUNNING)
+  }
+
+  test("The pod status watcher should not notify launcher backend if status is not changed.") {
+    podStatusWatcher.eventReceived(MODIFIED, podWithPhase("Succeeded"))
+    podStatusWatcher.eventReceived(MODIFIED, podWithPhase("Succeeded"))
+    verify(launcherBackend, times(1)).setState(SparkAppHandle.State.FINISHED)
+  }
+
+  test("The pod status watcher should notify launcher backend " +
+    "with unknown state if pod status is not known.") {
+    podStatusWatcher.eventReceived(ADDED, podWithPhase("SomeUnknownPodStatus"))
+    verify(launcherBackend).setState(SparkAppHandle.State.UNKNOWN)
+  }
+
+  private def k8sDriverConf = KubernetesTestConf.createDriverConf(
+    resourceNamePrefix = Some("resource-example")
+  )
+
+  private def podWithPhase(phase: String): Pod = {
+    new Pod() {
+      setMetadata(new ObjectMeta() {
+        setName("pod")
+        setNamespace("namespace")
+        setLabels(new util.HashMap())
+        setUid("uid")
+        setCreationTimestamp("now")
+      })
+      setSpec(new PodSpec() {
+        setServiceAccountName("sa")
+        setNodeName("nodeName")
+      })
+      setStatus(new PodStatus() {
+        setPhase(phase)
+        setStartTime("now")
+      })
+    }
+  }
+
+}


### PR DESCRIPTION
Co-authored-by: hongdd <hongdongdong@cmss.chinamobile.com>

### What changes were proposed in this pull request?
Supporting `SparkAppHandle` object to be able to manage a running Spark application on Kubernetes. It can be used to monitor the application changes and to stop the application by pod deletion.

This Pull Request has been raised due to a inactivity of a previous one - https://github.com/apache/spark/pull/30520


### Why are the changes needed?
There is an inconsistency in the Spark application managing with `SparkAppHandle` object between Kubernetes and other resource managers such as Yarn/Mesos.

Currently, this feature is not properly implemented on Kubernetes which may cause some issues. 


### Does this PR introduce _any_ user-facing change?
Yes, it changes the behavior of `SparkAppHandle` object which the user may use to communicate with the launched Spark application. Its interface is remained as it is. Some missing functionalities have been implemented.



### How was this patch tested?
Few unit tests has been added. May be found in `org.apache.spark.deploy.k8s.submit` package:
- `PodStatusWatcherSuite` - new ones
- `ClientSuite` - added some
