### PR TITLE
[SPARK-34674][CORE][K8S] Close SparkContext after the Main method has finished

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -954,7 +954,7 @@ private[spark] class SparkSubmit extends Logging {
         throw findCause(t)
     } finally {
       try {
-        org.apache.spark.SparkContext.getOrCreate().stop()
+        SparkContext.getActive.foreach(_.stop())
       } catch {
         case e: Throwable => logError(s"Failed to close SparkContext: $e")
       }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -952,6 +952,12 @@ private[spark] class SparkSubmit extends Logging {
     } catch {
       case t: Throwable =>
         throw findCause(t)
+    } finally {
+      try {
+        org.apache.spark.SparkContext.getOrCreate().stop()
+      } catch {
+        case e: Throwable => logError(s"Failed to close SparkContext: $e")
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Close SparkContext after the Main method has finished, to allow SparkApplication on K8S to complete

### Why are the changes needed?
if I don't call the method sparkContext.stop() explicitly, then a Spark driver process doesn't terminate even after its Main method has been completed. This behaviour is different from spark on yarn, where the manual sparkContext stopping is not required. It looks like, the problem is in using non-daemon threads, which prevent the driver jvm process from terminating.
So I have inserted code that closes sparkContext automatically.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually on the production AWS EKS environment in my company.
