### PR TITLE
[SPARK-34983][PYTHON] Renaming the package alias from pp to ps

### DIFF
--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -265,7 +265,7 @@ class KoalasFrameMethods(object):
         DataFrame.applymap: For elementwise operations.
         DataFrame.aggregate: Only perform aggregating type operations.
         DataFrame.transform: Only perform transforming type operations.
-        Series.koalas.transform_batch: transform the search as each pandas chunpp.
+        Series.koalas.transform_batch: transform the search as each pandas chunks.
 
         Examples
         --------
@@ -474,7 +474,7 @@ class KoalasFrameMethods(object):
         See Also
         --------
         DataFrame.koalas.apply_batch: For row/columnwise operations.
-        Series.koalas.transform_batch: transform the search as each pandas chunpp.
+        Series.koalas.transform_batch: transform the search as each pandas chunks.
 
         Examples
         --------

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -89,7 +89,7 @@ class KoalasFrameMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame({"x": ['a', 'b', 'c']})
+        >>> df = ps.DataFrame({"x": ['a', 'b', 'c']})
         >>> df.koalas.attach_id_column(id_type="sequence", column="id")
            x  id
         0  a   0
@@ -111,7 +111,7 @@ class KoalasFrameMethods(object):
 
         For multi-index columns:
 
-        >>> df = pp.DataFrame({("x", "y"): ['a', 'b', 'c']})
+        >>> df = ps.DataFrame({("x", "y"): ['a', 'b', 'c']})
         >>> df.koalas.attach_id_column(id_type="sequence", column=("id-x", "id-y"))
            x id-x
            y id-y
@@ -203,10 +203,10 @@ class KoalasFrameMethods(object):
 
             >>> # This case does not return the length of whole frame but of the batch internally
             ... # used.
-            ... def length(pdf) -> pp.DataFrame[int]:
+            ... def length(pdf) -> ps.DataFrame[int]:
             ...     return pd.DataFrame([len(pdf)])
             ...
-            >>> df = pp.DataFrame({'A': range(1000)})
+            >>> df = ps.DataFrame({'A': range(1000)})
             >>> df.koalas.apply_batch(length)  # doctest: +SKIP
                 c0
             0   83
@@ -222,7 +222,7 @@ class KoalasFrameMethods(object):
 
             To avoid this, specify return type in ``func``, for instance, as below:
 
-            >>> def plus_one(x) -> pp.DataFrame[float, float]:
+            >>> def plus_one(x) -> ps.DataFrame[float, float]:
             ...     return x + 1
 
             If the return type is specified, the output column names become
@@ -231,11 +231,11 @@ class KoalasFrameMethods(object):
 
             To specify the column names, you can assign them in a pandas friendly style as below:
 
-            >>> def plus_one(x) -> pp.DataFrame["a": float, "b": float]:
+            >>> def plus_one(x) -> ps.DataFrame["a": float, "b": float]:
             ...     return x + 1
 
             >>> pdf = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 4, 5]})
-            >>> def plus_one(x) -> pp.DataFrame[zip(pdf.dtypes, pdf.columns)]:
+            >>> def plus_one(x) -> ps.DataFrame[zip(pdf.dtypes, pdf.columns)]:
             ...     return x + 1
 
             When the given function has the return type annotated, the original index of the
@@ -269,20 +269,20 @@ class KoalasFrameMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(1, 2), (3, 4), (5, 6)], columns=['A', 'B'])
+        >>> df = ps.DataFrame([(1, 2), (3, 4), (5, 6)], columns=['A', 'B'])
         >>> df
            A  B
         0  1  2
         1  3  4
         2  5  6
 
-        >>> def query_func(pdf) -> pp.DataFrame[int, int]:
+        >>> def query_func(pdf) -> ps.DataFrame[int, int]:
         ...     return pdf.query('A == 1')
         >>> df.koalas.apply_batch(query_func)
            c0  c1
         0   1   2
 
-        >>> def query_func(pdf) -> pp.DataFrame["A": int, "B": int]:
+        >>> def query_func(pdf) -> ps.DataFrame["A": int, "B": int]:
         ...     return pdf.query('A == 1')
         >>> df.koalas.apply_batch(query_func)
            A  B
@@ -296,7 +296,7 @@ class KoalasFrameMethods(object):
 
         You can also specify extra arguments.
 
-        >>> def calculation(pdf, y, z) -> pp.DataFrame[int, int]:
+        >>> def calculation(pdf, y, z) -> ps.DataFrame[int, int]:
         ...     return pdf ** y + z
         >>> df.koalas.apply_batch(calculation, args=(10,), z=20)
                 c0        c1
@@ -323,7 +323,7 @@ class KoalasFrameMethods(object):
 
         from pyspark.pandas.groupby import GroupBy
         from pyspark.pandas.frame import DataFrame
-        from pyspark import pandas as pp
+        from pyspark import pandas as ps
 
         if not isinstance(func, types.FunctionType):
             assert callable(func), "the first argument should be a callable function."
@@ -343,7 +343,7 @@ class KoalasFrameMethods(object):
         if should_infer_schema:
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
-            limit = pp.get_option("compute.shortcut_limit")
+            limit = ps.get_option("compute.shortcut_limit")
             pdf = self_applied.head(limit + 1)._to_internal_pandas()
             applied = func(pdf)
             if not isinstance(applied, pd.DataFrame):
@@ -351,7 +351,7 @@ class KoalasFrameMethods(object):
                     "The given function should return a frame; however, "
                     "the return type was %s." % type(applied)
                 )
-            kdf = pp.DataFrame(applied)  # type: DataFrame
+            kdf = ps.DataFrame(applied)  # type: DataFrame
             if len(pdf) <= limit:
                 return kdf
 
@@ -419,10 +419,10 @@ class KoalasFrameMethods(object):
 
             >>> # This case does not return the length of whole frame but of the batch internally
             ... # used.
-            ... def length(pdf) -> pp.DataFrame[int]:
+            ... def length(pdf) -> ps.DataFrame[int]:
             ...     return pd.DataFrame([len(pdf)] * len(pdf))
             ...
-            >>> df = pp.DataFrame({'A': range(1000)})
+            >>> df = ps.DataFrame({'A': range(1000)})
             >>> df.koalas.transform_batch(length)  # doctest: +SKIP
                 c0
             0   83
@@ -436,7 +436,7 @@ class KoalasFrameMethods(object):
 
             To avoid this, specify return type in ``func``, for instance, as below:
 
-            >>> def plus_one(x) -> pp.DataFrame[float, float]:
+            >>> def plus_one(x) -> ps.DataFrame[float, float]:
             ...     return x + 1
 
             If the return type is specified, the output column names become
@@ -445,11 +445,11 @@ class KoalasFrameMethods(object):
 
             To specify the column names, you can assign them in a pandas friendly style as below:
 
-            >>> def plus_one(x) -> pp.DataFrame['a': float, 'b': float]:
+            >>> def plus_one(x) -> ps.DataFrame['a': float, 'b': float]:
             ...     return x + 1
 
             >>> pdf = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 4, 5]})
-            >>> def plus_one(x) -> pp.DataFrame[zip(pdf.dtypes, pdf.columns)]:
+            >>> def plus_one(x) -> ps.DataFrame[zip(pdf.dtypes, pdf.columns)]:
             ...     return x + 1
 
             When the given function returns DataFrame and has the return type annotated, the
@@ -478,14 +478,14 @@ class KoalasFrameMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(1, 2), (3, 4), (5, 6)], columns=['A', 'B'])
+        >>> df = ps.DataFrame([(1, 2), (3, 4), (5, 6)], columns=['A', 'B'])
         >>> df
            A  B
         0  1  2
         1  3  4
         2  5  6
 
-        >>> def plus_one_func(pdf) -> pp.DataFrame[int, int]:
+        >>> def plus_one_func(pdf) -> ps.DataFrame[int, int]:
         ...     return pdf + 1
         >>> df.koalas.transform_batch(plus_one_func)
            c0  c1
@@ -493,7 +493,7 @@ class KoalasFrameMethods(object):
         1   4   5
         2   6   7
 
-        >>> def plus_one_func(pdf) -> pp.DataFrame['A': int, 'B': int]:
+        >>> def plus_one_func(pdf) -> ps.DataFrame['A': int, 'B': int]:
         ...     return pdf + 1
         >>> df.koalas.transform_batch(plus_one_func)
            A  B
@@ -501,7 +501,7 @@ class KoalasFrameMethods(object):
         1  4  5
         2  6  7
 
-        >>> def plus_one_func(pdf) -> pp.Series[int]:
+        >>> def plus_one_func(pdf) -> ps.Series[int]:
         ...     return pdf.B + 1
         >>> df.koalas.transform_batch(plus_one_func)
         0    3
@@ -542,7 +542,7 @@ class KoalasFrameMethods(object):
         from pyspark.pandas.groupby import GroupBy
         from pyspark.pandas.frame import DataFrame
         from pyspark.pandas.series import first_series
-        from pyspark import pandas as pp
+        from pyspark import pandas as ps
 
         assert callable(func), "the first argument should be a callable function."
         spec = inspect.getfullargspec(func)
@@ -583,7 +583,7 @@ class KoalasFrameMethods(object):
         if should_infer_schema:
             # Here we execute with the first 1000 to get the return type.
             # If the records were less than 1000, it uses pandas API directly for a shortcut.
-            limit = pp.get_option("compute.shortcut_limit")
+            limit = ps.get_option("compute.shortcut_limit")
             pdf = self._kdf.head(limit + 1)._to_internal_pandas()
             transformed = func(pdf)
             if not isinstance(transformed, (pd.DataFrame, pd.Series)):
@@ -593,10 +593,10 @@ class KoalasFrameMethods(object):
                 )
             if len(transformed) != len(pdf):
                 raise ValueError("transform_batch cannot produce aggregated results")
-            kdf_or_kser = pp.from_pandas(transformed)
+            kdf_or_kser = ps.from_pandas(transformed)
 
-            if isinstance(kdf_or_kser, pp.Series):
-                kser = cast(pp.Series, kdf_or_kser)
+            if isinstance(kdf_or_kser, ps.Series):
+                kser = cast(ps.Series, kdf_or_kser)
 
                 spark_return_type = force_decimal_precision_scale(
                     as_nullable_spark_type(kser.spark.data_type)
@@ -763,10 +763,10 @@ class KoalasSeriesMethods(object):
 
             >>> # This case does not return the length of whole frame but of the batch internally
             ... # used.
-            ... def length(pser) -> pp.Series[int]:
+            ... def length(pser) -> ps.Series[int]:
             ...     return pd.Series([len(pser)] * len(pser))
             ...
-            >>> df = pp.DataFrame({'A': range(1000)})
+            >>> df = ps.DataFrame({'A': range(1000)})
             >>> df.A.koalas.transform_batch(length)  # doctest: +SKIP
                 c0
             0   83
@@ -780,7 +780,7 @@ class KoalasSeriesMethods(object):
 
             To avoid this, specify return type in ``func``, for instance, as below:
 
-            >>> def plus_one(x) -> pp.Series[int]:
+            >>> def plus_one(x) -> ps.Series[int]:
             ...     return x + 1
 
         Parameters
@@ -802,14 +802,14 @@ class KoalasSeriesMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(1, 2), (3, 4), (5, 6)], columns=['A', 'B'])
+        >>> df = ps.DataFrame([(1, 2), (3, 4), (5, 6)], columns=['A', 'B'])
         >>> df
            A  B
         0  1  2
         1  3  4
         2  5  6
 
-        >>> def plus_one_func(pser) -> pp.Series[np.int64]:
+        >>> def plus_one_func(pser) -> ps.Series[np.int64]:
         ...     return pser + 1
         >>> df.A.koalas.transform_batch(plus_one_func)
         0    2
@@ -827,7 +827,7 @@ class KoalasSeriesMethods(object):
 
         You can also specify extra arguments.
 
-        >>> def plus_one_func(pser, a, b, c=3) -> pp.Series[np.int64]:
+        >>> def plus_one_func(pser, a, b, c=3) -> ps.Series[np.int64]:
         ...     return pser + a + b + c
         >>> df.A.koalas.transform_batch(plus_one_func, 1, b=2)
         0     7
@@ -875,7 +875,7 @@ class KoalasSeriesMethods(object):
     def _transform_batch(self, func, return_type: Optional[Union[SeriesType, ScalarType]]):
         from pyspark.pandas.groupby import GroupBy
         from pyspark.pandas.series import Series, first_series
-        from pyspark import pandas as pp
+        from pyspark import pandas as ps
 
         if not isinstance(func, types.FunctionType):
             f = func
@@ -886,7 +886,7 @@ class KoalasSeriesMethods(object):
             #  because it returns a series from a different DataFrame and it has a different
             #  anchor. We should fix this to allow the shortcut or only allow to infer
             #  schema.
-            limit = pp.get_option("compute.shortcut_limit")
+            limit = ps.get_option("compute.shortcut_limit")
             pser = self._kser.head(limit + 1)._to_internal_pandas()
             transformed = pser.transform(func)
             kser = Series(transformed)  # type: Series
@@ -940,7 +940,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.accessors.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.accessors tests")

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -42,7 +42,7 @@ from pyspark.sql.types import (
     TimestampType,
 )
 
-from pyspark import pandas as pp  # For running doctests and reference resolution in PyCharm.
+from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas import numpy_compat
 from pyspark.pandas.config import get_option, option_context
 from pyspark.pandas.internal import (
@@ -727,15 +727,15 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 3])
+        >>> s = ps.Series([1, 2, 3])
         >>> s.dtype
         dtype('int64')
 
-        >>> s = pp.Series(list('abc'))
+        >>> s = ps.Series(list('abc'))
         >>> s.dtype
         dtype('O')
 
-        >>> s = pp.Series(pd.date_range('20130101', periods=3))
+        >>> s = ps.Series(pd.date_range('20130101', periods=3))
         >>> s.dtype
         dtype('<M8[ns]')
 
@@ -749,13 +749,13 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         """
         Returns true if the current object is empty. Otherwise, returns false.
 
-        >>> pp.range(10).id.empty
+        >>> ps.range(10).id.empty
         False
 
-        >>> pp.range(0).id.empty
+        >>> ps.range(0).id.empty
         True
 
-        >>> pp.DataFrame({}, index=list('abc')).index.empty
+        >>> ps.DataFrame({}, index=list('abc')).index.empty
         False
         """
         return self._internal.resolved_copy.spark_frame.rdd.isEmpty()
@@ -765,22 +765,22 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         """
         Return True if it has any missing values. Otherwise, it returns False.
 
-        >>> pp.DataFrame({}, index=list('abc')).index.hasnans
+        >>> ps.DataFrame({}, index=list('abc')).index.hasnans
         False
 
-        >>> pp.Series(['a', None]).hasnans
+        >>> ps.Series(['a', None]).hasnans
         True
 
-        >>> pp.Series([1.0, 2.0, np.nan]).hasnans
+        >>> ps.Series([1.0, 2.0, np.nan]).hasnans
         True
 
-        >>> pp.Series([1, 2, 3]).hasnans
+        >>> ps.Series([1, 2, 3]).hasnans
         False
 
-        >>> (pp.Series([1.0, 2.0, np.nan]) + 1).hasnans
+        >>> (ps.Series([1.0, 2.0, np.nan]) + 1).hasnans
         True
 
-        >>> pp.Series([1, 2, 3]).rename("a").to_frame().set_index("a").index.hasnans
+        >>> ps.Series([1, 2, 3]).rename("a").to_frame().set_index("a").index.hasnans
         False
         """
         sdf = self._internal.spark_frame
@@ -810,29 +810,29 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> ser = pp.Series(['1/1/2018', '3/1/2018', '4/1/2018'])
+        >>> ser = ps.Series(['1/1/2018', '3/1/2018', '4/1/2018'])
         >>> ser.is_monotonic
         True
 
-        >>> df = pp.DataFrame({'dates': [None, '1/1/2018', '2/1/2018', '3/1/2018']})
+        >>> df = ps.DataFrame({'dates': [None, '1/1/2018', '2/1/2018', '3/1/2018']})
         >>> df.dates.is_monotonic
         False
 
         >>> df.index.is_monotonic
         True
 
-        >>> ser = pp.Series([1])
+        >>> ser = ps.Series([1])
         >>> ser.is_monotonic
         True
 
-        >>> ser = pp.Series([])
+        >>> ser = ps.Series([])
         >>> ser.is_monotonic
         True
 
         >>> ser.rename("a").to_frame().set_index("a").index.is_monotonic
         True
 
-        >>> ser = pp.Series([5, 4, 3, 2, 1], index=[1, 2, 3, 4, 5])
+        >>> ser = ps.Series([5, 4, 3, 2, 1], index=[1, 2, 3, 4, 5])
         >>> ser.is_monotonic
         False
 
@@ -841,7 +841,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Support for MultiIndex
 
-        >>> midx = pp.MultiIndex.from_tuples(
+        >>> midx = ps.MultiIndex.from_tuples(
         ... [('x', 'a'), ('x', 'b'), ('y', 'c'), ('y', 'd'), ('z', 'e')])
         >>> midx  # doctest: +SKIP
         MultiIndex([('x', 'a'),
@@ -853,7 +853,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         >>> midx.is_monotonic
         True
 
-        >>> midx = pp.MultiIndex.from_tuples(
+        >>> midx = ps.MultiIndex.from_tuples(
         ... [('z', 'a'), ('z', 'b'), ('y', 'c'), ('y', 'd'), ('x', 'e')])
         >>> midx  # doctest: +SKIP
         MultiIndex([('z', 'a'),
@@ -888,29 +888,29 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> ser = pp.Series(['4/1/2018', '3/1/2018', '1/1/2018'])
+        >>> ser = ps.Series(['4/1/2018', '3/1/2018', '1/1/2018'])
         >>> ser.is_monotonic_decreasing
         True
 
-        >>> df = pp.DataFrame({'dates': [None, '3/1/2018', '2/1/2018', '1/1/2018']})
+        >>> df = ps.DataFrame({'dates': [None, '3/1/2018', '2/1/2018', '1/1/2018']})
         >>> df.dates.is_monotonic_decreasing
         False
 
         >>> df.index.is_monotonic_decreasing
         False
 
-        >>> ser = pp.Series([1])
+        >>> ser = ps.Series([1])
         >>> ser.is_monotonic_decreasing
         True
 
-        >>> ser = pp.Series([])
+        >>> ser = ps.Series([])
         >>> ser.is_monotonic_decreasing
         True
 
         >>> ser.rename("a").to_frame().set_index("a").index.is_monotonic_decreasing
         True
 
-        >>> ser = pp.Series([5, 4, 3, 2, 1], index=[1, 2, 3, 4, 5])
+        >>> ser = ps.Series([5, 4, 3, 2, 1], index=[1, 2, 3, 4, 5])
         >>> ser.is_monotonic_decreasing
         True
 
@@ -919,7 +919,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Support for MultiIndex
 
-        >>> midx = pp.MultiIndex.from_tuples(
+        >>> midx = ps.MultiIndex.from_tuples(
         ... [('x', 'a'), ('x', 'b'), ('y', 'c'), ('y', 'd'), ('z', 'e')])
         >>> midx  # doctest: +SKIP
         MultiIndex([('x', 'a'),
@@ -931,7 +931,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         >>> midx.is_monotonic_decreasing
         False
 
-        >>> midx = pp.MultiIndex.from_tuples(
+        >>> midx = ps.MultiIndex.from_tuples(
         ... [('z', 'e'), ('z', 'd'), ('y', 'c'), ('y', 'b'), ('x', 'a')])
         >>> midx  # doctest: +SKIP
         MultiIndex([('z', 'a'),
@@ -1030,7 +1030,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         For Series
 
-        >>> s = pp.Series([None, 1, 2, 3, 4], index=[4, 5, 2, 1, 8])
+        >>> s = ps.Series([None, 1, 2, 3, 4], index=[4, 5, 2, 1, 8])
         >>> s.ndim
         1
 
@@ -1045,7 +1045,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         ...                       ['speed', 'weight', 'length']],
         ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [1, 1, 1, 1, 1, 2, 1, 2, 2]])
-        >>> s = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        >>> s = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
         >>> s.index.ndim
         1
         """
@@ -1071,7 +1071,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> ser = pp.Series([1, 2], dtype='int32')
+        >>> ser = ps.Series([1, 2], dtype='int32')
         >>> ser
         0    1
         1    2
@@ -1091,7 +1091,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         if isinstance(self.dtype, CategoricalDtype):
             if isinstance(dtype, CategoricalDtype) and dtype.categories is None:
-                return cast(Union[pp.Index, pp.Series], self).copy()
+                return cast(Union[ps.Index, ps.Series], self).copy()
 
             categories = self.dtype.categories
             if len(categories) == 0:
@@ -1202,7 +1202,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> s = pp.Series(['lama', 'cow', 'lama', 'beetle', 'lama',
+        >>> s = ps.Series(['lama', 'cow', 'lama', 'beetle', 'lama',
         ...                'hippo'], name='animal')
         >>> s.isin(['cow', 'lama'])
         0     True
@@ -1254,7 +1254,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> ser = pp.Series([5, 6, np.NaN])
+        >>> ser = ps.Series([5, 6, np.NaN])
         >>> ser.isna()  # doctest: +NORMALIZE_WHITESPACE
         0    False
         1    False
@@ -1293,7 +1293,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         --------
         Show which entries in a Series are not NA.
 
-        >>> ser = pp.Series([5, 6, np.NaN])
+        >>> ser = ps.Series([5, 6, np.NaN])
         >>> ser
         0    5.0
         1    6.0
@@ -1337,31 +1337,31 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> pp.Series([True, True]).all()
+        >>> ps.Series([True, True]).all()
         True
 
-        >>> pp.Series([True, False]).all()
+        >>> ps.Series([True, False]).all()
         False
 
-        >>> pp.Series([0, 1]).all()
+        >>> ps.Series([0, 1]).all()
         False
 
-        >>> pp.Series([1, 2, 3]).all()
+        >>> ps.Series([1, 2, 3]).all()
         True
 
-        >>> pp.Series([True, True, None]).all()
+        >>> ps.Series([True, True, None]).all()
         True
 
-        >>> pp.Series([True, False, None]).all()
+        >>> ps.Series([True, False, None]).all()
         False
 
-        >>> pp.Series([]).all()
+        >>> ps.Series([]).all()
         True
 
-        >>> pp.Series([np.nan]).all()
+        >>> ps.Series([np.nan]).all()
         True
 
-        >>> df = pp.Series([True, False, None]).rename("a").to_frame()
+        >>> df = ps.Series([True, False, None]).rename("a").to_frame()
         >>> df.set_index("a").index.all()
         False
         """
@@ -1400,31 +1400,31 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> pp.Series([False, False]).any()
+        >>> ps.Series([False, False]).any()
         False
 
-        >>> pp.Series([True, False]).any()
+        >>> ps.Series([True, False]).any()
         True
 
-        >>> pp.Series([0, 0]).any()
+        >>> ps.Series([0, 0]).any()
         False
 
-        >>> pp.Series([0, 1, 2]).any()
+        >>> ps.Series([0, 1, 2]).any()
         True
 
-        >>> pp.Series([False, False, None]).any()
+        >>> ps.Series([False, False, None]).any()
         False
 
-        >>> pp.Series([True, False, None]).any()
+        >>> ps.Series([True, False, None]).any()
         True
 
-        >>> pp.Series([]).any()
+        >>> ps.Series([]).any()
         False
 
-        >>> pp.Series([np.nan]).any()
+        >>> ps.Series([np.nan]).any()
         False
 
-        >>> df = pp.Series([True, False, None]).rename("a").to_frame()
+        >>> df = ps.Series([True, False, None]).rename("a").to_frame()
         >>> df.set_index("a").index.any()
         True
         """
@@ -1469,7 +1469,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'Col1': [10, 20, 15, 30, 45],
+        >>> df = ps.DataFrame({'Col1': [10, 20, 15, 30, 45],
         ...                    'Col2': [13, 23, 18, 33, 48],
         ...                    'Col3': [17, 27, 22, 37, 52]},
         ...                   columns=['Col1', 'Col2', 'Col3'])
@@ -1544,7 +1544,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         --------
         For Series
 
-        >>> df = pp.DataFrame({'x':[0, 0, 1, 1, 1, np.nan]})
+        >>> df = ps.DataFrame({'x':[0, 0, 1, 1, 1, np.nan]})
         >>> df.x.value_counts()  # doctest: +NORMALIZE_WHITESPACE
         1.0    3
         0.0    2
@@ -1569,7 +1569,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         For Index
 
-        >>> idx = pp.Index([3, 1, 2, 3, 4, np.nan])
+        >>> idx = ps.Index([3, 1, 2, 3, 4, np.nan])
         >>> idx
         Float64Index([3.0, 1.0, 2.0, 3.0, 4.0, nan], dtype='float64')
 
@@ -1621,7 +1621,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         ...                       ['speed', 'weight', 'length']],
         ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [1, 1, 1, 1, 1, 2, 1, 2, 2]])
-        >>> s = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        >>> s = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
         >>> s.index  # doctest: +SKIP
         MultiIndex([(  'lama', 'weight'),
                     (  'lama', 'weight'),
@@ -1652,7 +1652,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         If Index has name, keep the name up.
 
-        >>> idx = pp.Index([0, 0, 0, 1, 1, 2, 3], name='koalas')
+        >>> idx = ps.Index([0, 0, 0, 1, 1, 2, 3], name='koalas')
         >>> idx.value_counts().sort_index()
         0    3
         1    2
@@ -1721,19 +1721,19 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> pp.Series([1, 2, 3, np.nan]).nunique()
+        >>> ps.Series([1, 2, 3, np.nan]).nunique()
         3
 
-        >>> pp.Series([1, 2, 3, np.nan]).nunique(dropna=False)
+        >>> ps.Series([1, 2, 3, np.nan]).nunique(dropna=False)
         4
 
         On big data, we recommend using the approximate algorithm to speed up this function.
         The result will be very close to the exact unique count.
 
-        >>> pp.Series([1, 2, 3, np.nan]).nunique(approx=True)
+        >>> ps.Series([1, 2, 3, np.nan]).nunique(approx=True)
         3
 
-        >>> idx = pp.Index([1, 1, 2, None])
+        >>> idx = ps.Index([1, 1, 2, None])
         >>> idx
         Float64Index([1.0, 1.0, 2.0, nan], dtype='float64')
 
@@ -1788,7 +1788,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Series
 
-        >>> kser = pp.Series([100, 200, 300, 400, 500])
+        >>> kser = ps.Series([100, 200, 300, 400, 500])
         >>> kser
         0    100
         1    200
@@ -1805,7 +1805,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Index
 
-        >>> kidx = pp.Index([100, 200, 300, 400, 500])
+        >>> kidx = ps.Index([100, 200, 300, 400, 500])
         >>> kidx
         Int64Index([100, 200, 300, 400, 500], dtype='int64')
 
@@ -1814,7 +1814,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         MultiIndex
 
-        >>> kmidx = pp.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "c")])
+        >>> kmidx = ps.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "c")])
         >>> kmidx  # doctest: +SKIP
         MultiIndex([('x', 'a'),
                     ('x', 'b'),
@@ -1828,8 +1828,8 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         """
         if not is_list_like(indices) or isinstance(indices, (dict, set)):
             raise ValueError("`indices` must be a list-like except dict or set")
-        if isinstance(self, pp.Series):
-            return cast(pp.Series, self.iloc[indices])
+        if isinstance(self, ps.Series):
+            return cast(ps.Series, self.iloc[indices])
         else:
             return self._kdf.iloc[indices].index
 
@@ -1864,7 +1864,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> kser = pp.Series(['b', None, 'a', 'c', 'b'])
+        >>> kser = ps.Series(['b', None, 'a', 'c', 'b'])
         >>> codes, uniques = kser.factorize()
         >>> codes
         0    1
@@ -1900,7 +1900,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         For Index:
 
-        >>> kidx = pp.Index(['b', None, 'a', 'c', 'b'])
+        >>> kidx = ps.Index(['b', None, 'a', 'c', 'b'])
         >>> codes, uniques = kidx.factorize()
         >>> codes
         Int64Index([1, -1, 0, 2, 1], dtype='int64')
@@ -2005,7 +2005,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.base.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.base tests").getOrCreate()
     )

--- a/python/pyspark/pandas/categorical.py
+++ b/python/pyspark/pandas/categorical.py
@@ -29,7 +29,7 @@ class CategoricalAccessor(object):
 
     Examples
     --------
-    >>> s = pp.Series(list("abbccc"), dtype="category")
+    >>> s = ps.Series(list("abbccc"), dtype="category")
     >>> s  # doctest: +SKIP
     0    a
     1    b

--- a/python/pyspark/pandas/categorical.py
+++ b/python/pyspark/pandas/categorical.py
@@ -20,7 +20,7 @@ import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 if TYPE_CHECKING:
-    import pyspark.pandas as pp  # noqa: F401 (SPARK-34943)
+    import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
 
 
 class CategoricalAccessor(object):
@@ -53,7 +53,7 @@ class CategoricalAccessor(object):
     dtype: int8
     """
 
-    def __init__(self, series: "pp.Series"):
+    def __init__(self, series: "ps.Series"):
         if not isinstance(series.dtype, CategoricalDtype):
             raise ValueError("Cannot call CategoricalAccessor on type {}".format(series.dtype))
         self._data = series
@@ -65,7 +65,7 @@ class CategoricalAccessor(object):
 
         Examples
         --------
-        >>> s = pp.Series(list("abbccc"), dtype="category")
+        >>> s = ps.Series(list("abbccc"), dtype="category")
         >>> s  # doctest: +SKIP
         0    a
         1    b
@@ -92,7 +92,7 @@ class CategoricalAccessor(object):
 
         Examples
         --------
-        >>> s = pp.Series(list("abbccc"), dtype="category")
+        >>> s = ps.Series(list("abbccc"), dtype="category")
         >>> s  # doctest: +SKIP
         0    a
         1    b
@@ -109,13 +109,13 @@ class CategoricalAccessor(object):
         return self._data.dtype.ordered
 
     @property
-    def codes(self) -> "pp.Series":
+    def codes(self) -> "ps.Series":
         """
         Return Series of codes as well as the index.
 
         Examples
         --------
-        >>> s = pp.Series(list("abbccc"), dtype="category")
+        >>> s = ps.Series(list("abbccc"), dtype="category")
         >>> s  # doctest: +SKIP
         0    a
         1    b
@@ -174,7 +174,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.categorical.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.categorical tests")

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -452,7 +452,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.config.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.config tests").getOrCreate()
     )

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -396,7 +396,7 @@ class DatetimeMethods(object):
         This method is available on Series with datetime values under
         the ``.dt`` accessor.
 
-        >>> dates = pp.Series(pd.date_range("2017-12-30", periods=3))
+        >>> dates = ps.Series(pd.date_range("2017-12-30", periods=3))
         >>> dates
         0   2017-12-30
         1   2017-12-31

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -26,13 +26,13 @@ import pyspark.sql.functions as F
 from pyspark.sql.types import DateType, TimestampType, LongType
 
 if TYPE_CHECKING:
-    import pyspark.pandas as pp  # noqa: F401 (SPARK-34943)
+    import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
 
 
 class DatetimeMethods(object):
     """Date/Time methods for Koalas Series"""
 
-    def __init__(self, series: "pp.Series"):
+    def __init__(self, series: "ps.Series"):
         if not isinstance(series.spark.data_type, (DateType, TimestampType)):
             raise ValueError(
                 "Cannot call DatetimeMethods on type {}".format(series.spark.data_type)
@@ -41,7 +41,7 @@ class DatetimeMethods(object):
 
     # Properties
     @property
-    def date(self) -> "pp.Series":
+    def date(self) -> "ps.Series":
         """
         Returns a Series of python datetime.date objects (namely, the date
         part of Timestamps without timezone information).
@@ -51,85 +51,85 @@ class DatetimeMethods(object):
         return self._data.spark.transform(F.to_date)
 
     @property
-    def time(self) -> "pp.Series":
+    def time(self) -> "ps.Series":
         raise NotImplementedError()
 
     @property
-    def timetz(self) -> "pp.Series":
+    def timetz(self) -> "ps.Series":
         raise NotImplementedError()
 
     @property
-    def year(self) -> "pp.Series":
+    def year(self) -> "ps.Series":
         """
         The year of the datetime.
         """
         return self._data.spark.transform(lambda c: F.year(c).cast(LongType()))
 
     @property
-    def month(self) -> "pp.Series":
+    def month(self) -> "ps.Series":
         """
         The month of the timestamp as January = 1 December = 12.
         """
         return self._data.spark.transform(lambda c: F.month(c).cast(LongType()))
 
     @property
-    def day(self) -> "pp.Series":
+    def day(self) -> "ps.Series":
         """
         The days of the datetime.
         """
         return self._data.spark.transform(lambda c: F.dayofmonth(c).cast(LongType()))
 
     @property
-    def hour(self) -> "pp.Series":
+    def hour(self) -> "ps.Series":
         """
         The hours of the datetime.
         """
         return self._data.spark.transform(lambda c: F.hour(c).cast(LongType()))
 
     @property
-    def minute(self) -> "pp.Series":
+    def minute(self) -> "ps.Series":
         """
         The minutes of the datetime.
         """
         return self._data.spark.transform(lambda c: F.minute(c).cast(LongType()))
 
     @property
-    def second(self) -> "pp.Series":
+    def second(self) -> "ps.Series":
         """
         The seconds of the datetime.
         """
         return self._data.spark.transform(lambda c: F.second(c).cast(LongType()))
 
     @property
-    def microsecond(self) -> "pp.Series":
+    def microsecond(self) -> "ps.Series":
         """
         The microseconds of the datetime.
         """
 
-        def pandas_microsecond(s) -> "pp.Series[np.int64]":
+        def pandas_microsecond(s) -> "ps.Series[np.int64]":
             return s.dt.microsecond
 
         return self._data.koalas.transform_batch(pandas_microsecond)
 
     @property
-    def nanosecond(self) -> "pp.Series":
+    def nanosecond(self) -> "ps.Series":
         raise NotImplementedError()
 
     @property
-    def week(self) -> "pp.Series":
+    def week(self) -> "ps.Series":
         """
         The week ordinal of the year.
         """
         return self._data.spark.transform(lambda c: F.weekofyear(c).cast(LongType()))
 
     @property
-    def weekofyear(self) -> "pp.Series":
+    def weekofyear(self) -> "ps.Series":
         return self.week
 
     weekofyear.__doc__ = week.__doc__
 
     @property
-    def dayofweek(self) -> "pp.Series":
+    def dayofweek(self) -> "ps.Series":
         """
         The day of the week with Monday=0, Sunday=6.
 
@@ -151,7 +151,7 @@ class DatetimeMethods(object):
 
         Examples
         --------
-        >>> s = pp.from_pandas(pd.date_range('2016-12-31', '2017-01-08', freq='D').to_series())
+        >>> s = ps.from_pandas(pd.date_range('2016-12-31', '2017-01-08', freq='D').to_series())
         >>> s.dt.dayofweek
         2016-12-31    5
         2017-01-01    6
@@ -165,41 +165,41 @@ class DatetimeMethods(object):
         dtype: int64
         """
 
-        def pandas_dayofweek(s) -> "pp.Series[np.int64]":
+        def pandas_dayofweek(s) -> "ps.Series[np.int64]":
             return s.dt.dayofweek
 
         return self._data.koalas.transform_batch(pandas_dayofweek)
 
     @property
-    def weekday(self) -> "pp.Series":
+    def weekday(self) -> "ps.Series":
         return self.dayofweek
 
     weekday.__doc__ = dayofweek.__doc__
 
     @property
-    def dayofyear(self) -> "pp.Series":
+    def dayofyear(self) -> "ps.Series":
         """
         The ordinal day of the year.
         """
 
-        def pandas_dayofyear(s) -> "pp.Series[np.int64]":
+        def pandas_dayofyear(s) -> "ps.Series[np.int64]":
             return s.dt.dayofyear
 
         return self._data.koalas.transform_batch(pandas_dayofyear)
 
     @property
-    def quarter(self) -> "pp.Series":
+    def quarter(self) -> "ps.Series":
         """
         The quarter of the date.
         """
 
-        def pandas_quarter(s) -> "pp.Series[np.int64]":
+        def pandas_quarter(s) -> "ps.Series[np.int64]":
             return s.dt.quarter
 
         return self._data.koalas.transform_batch(pandas_quarter)
 
     @property
-    def is_month_start(self) -> "pp.Series":
+    def is_month_start(self) -> "ps.Series":
         """
         Indicates whether the date is the first day of the month.
 
@@ -218,7 +218,7 @@ class DatetimeMethods(object):
         This method is available on Series with datetime values under
         the ``.dt`` accessor.
 
-        >>> s = pp.Series(pd.date_range("2018-02-27", periods=3))
+        >>> s = ps.Series(pd.date_range("2018-02-27", periods=3))
         >>> s
         0   2018-02-27
         1   2018-02-28
@@ -232,13 +232,13 @@ class DatetimeMethods(object):
         dtype: bool
         """
 
-        def pandas_is_month_start(s) -> "pp.Series[bool]":
+        def pandas_is_month_start(s) -> "ps.Series[bool]":
             return s.dt.is_month_start
 
         return self._data.koalas.transform_batch(pandas_is_month_start)
 
     @property
-    def is_month_end(self) -> "pp.Series":
+    def is_month_end(self) -> "ps.Series":
         """
         Indicates whether the date is the last day of the month.
 
@@ -257,7 +257,7 @@ class DatetimeMethods(object):
         This method is available on Series with datetime values under
         the ``.dt`` accessor.
 
-        >>> s = pp.Series(pd.date_range("2018-02-27", periods=3))
+        >>> s = ps.Series(pd.date_range("2018-02-27", periods=3))
         >>> s
         0   2018-02-27
         1   2018-02-28
@@ -271,13 +271,13 @@ class DatetimeMethods(object):
         dtype: bool
         """
 
-        def pandas_is_month_end(s) -> "pp.Series[bool]":
+        def pandas_is_month_end(s) -> "ps.Series[bool]":
             return s.dt.is_month_end
 
         return self._data.koalas.transform_batch(pandas_is_month_end)
 
     @property
-    def is_quarter_start(self) -> "pp.Series":
+    def is_quarter_start(self) -> "ps.Series":
         """
         Indicator for whether the date is the first day of a quarter.
 
@@ -297,7 +297,7 @@ class DatetimeMethods(object):
         This method is available on Series with datetime values under
         the ``.dt`` accessor.
 
-        >>> df = pp.DataFrame({'dates': pd.date_range("2017-03-30",
+        >>> df = ps.DataFrame({'dates': pd.date_range("2017-03-30",
         ...                   periods=4)})
         >>> df
                dates
@@ -321,13 +321,13 @@ class DatetimeMethods(object):
         Name: dates, dtype: bool
         """
 
-        def pandas_is_quarter_start(s) -> "pp.Series[bool]":
+        def pandas_is_quarter_start(s) -> "ps.Series[bool]":
             return s.dt.is_quarter_start
 
         return self._data.koalas.transform_batch(pandas_is_quarter_start)
 
     @property
-    def is_quarter_end(self) -> "pp.Series":
+    def is_quarter_end(self) -> "ps.Series":
         """
         Indicator for whether the date is the last day of a quarter.
 
@@ -347,7 +347,7 @@ class DatetimeMethods(object):
         This method is available on Series with datetime values under
         the ``.dt`` accessor.
 
-        >>> df = pp.DataFrame({'dates': pd.date_range("2017-03-30",
+        >>> df = ps.DataFrame({'dates': pd.date_range("2017-03-30",
         ...                   periods=4)})
         >>> df
                dates
@@ -371,13 +371,13 @@ class DatetimeMethods(object):
         Name: dates, dtype: bool
         """
 
-        def pandas_is_quarter_end(s) -> "pp.Series[bool]":
+        def pandas_is_quarter_end(s) -> "ps.Series[bool]":
             return s.dt.is_quarter_end
 
         return self._data.koalas.transform_batch(pandas_is_quarter_end)
 
     @property
-    def is_year_start(self) -> "pp.Series":
+    def is_year_start(self) -> "ps.Series":
         """
         Indicate whether the date is the first day of a year.
 
@@ -410,13 +410,13 @@ class DatetimeMethods(object):
         dtype: bool
         """
 
-        def pandas_is_year_start(s) -> "pp.Series[bool]":
+        def pandas_is_year_start(s) -> "ps.Series[bool]":
             return s.dt.is_year_start
 
         return self._data.koalas.transform_batch(pandas_is_year_start)
 
     @property
-    def is_year_end(self) -> "pp.Series":
+    def is_year_end(self) -> "ps.Series":
         """
         Indicate whether the date is the last day of the year.
 
@@ -435,7 +435,7 @@ class DatetimeMethods(object):
         This method is available on Series with datetime values under
         the ``.dt`` accessor.
 
-        >>> dates = pp.Series(pd.date_range("2017-12-30", periods=3))
+        >>> dates = ps.Series(pd.date_range("2017-12-30", periods=3))
         >>> dates
         0   2017-12-30
         1   2017-12-31
@@ -449,13 +449,13 @@ class DatetimeMethods(object):
         dtype: bool
         """
 
-        def pandas_is_year_end(s) -> "pp.Series[bool]":
+        def pandas_is_year_end(s) -> "ps.Series[bool]":
             return s.dt.is_year_end
 
         return self._data.koalas.transform_batch(pandas_is_year_end)
 
     @property
-    def is_leap_year(self) -> "pp.Series":
+    def is_leap_year(self) -> "ps.Series":
         """
         Boolean indicator if the date belongs to a leap year.
 
@@ -474,7 +474,7 @@ class DatetimeMethods(object):
         This method is available on Series with datetime values under
         the ``.dt`` accessor.
 
-        >>> dates_series = pp.Series(pd.date_range("2012-01-01", "2015-01-01", freq="Y"))
+        >>> dates_series = ps.Series(pd.date_range("2012-01-01", "2015-01-01", freq="Y"))
         >>> dates_series
         0   2012-12-31
         1   2013-12-31
@@ -488,45 +488,45 @@ class DatetimeMethods(object):
         dtype: bool
         """
 
-        def pandas_is_leap_year(s) -> "pp.Series[bool]":
+        def pandas_is_leap_year(s) -> "ps.Series[bool]":
             return s.dt.is_leap_year
 
         return self._data.koalas.transform_batch(pandas_is_leap_year)
 
     @property
-    def daysinmonth(self) -> "pp.Series":
+    def daysinmonth(self) -> "ps.Series":
         """
         The number of days in the month.
         """
 
-        def pandas_daysinmonth(s) -> "pp.Series[np.int64]":
+        def pandas_daysinmonth(s) -> "ps.Series[np.int64]":
             return s.dt.daysinmonth
 
         return self._data.koalas.transform_batch(pandas_daysinmonth)
 
     @property
-    def days_in_month(self) -> "pp.Series":
+    def days_in_month(self) -> "ps.Series":
         return self.daysinmonth
 
     days_in_month.__doc__ = daysinmonth.__doc__
 
     # Methods
 
-    def tz_localize(self, tz) -> "pp.Series":
+    def tz_localize(self, tz) -> "ps.Series":
         """
         Localize tz-naive Datetime column to tz-aware Datetime column.
         """
         # Neither tz-naive or tz-aware datetime exists in Spark
         raise NotImplementedError()
 
-    def tz_convert(self, tz) -> "pp.Series":
+    def tz_convert(self, tz) -> "ps.Series":
         """
         Convert tz-aware Datetime column from one time zone to another.
         """
         # tz-aware datetime doesn't exist in Spark
         raise NotImplementedError()
 
-    def normalize(self) -> "pp.Series":
+    def normalize(self) -> "ps.Series":
         """
         Convert times to midnight.
 
@@ -551,7 +551,7 @@ class DatetimeMethods(object):
 
         Examples
         --------
-        >>> series = pp.Series(pd.Series(pd.date_range('2012-1-1 12:45:31', periods=3, freq='M')))
+        >>> series = ps.Series(pd.Series(pd.date_range('2012-1-1 12:45:31', periods=3, freq='M')))
         >>> series.dt.normalize()
         0   2012-01-31
         1   2012-02-29
@@ -559,12 +559,12 @@ class DatetimeMethods(object):
         dtype: datetime64[ns]
         """
 
-        def pandas_normalize(s) -> "pp.Series[np.datetime64]":
+        def pandas_normalize(s) -> "ps.Series[np.datetime64]":
             return s.dt.normalize()
 
         return self._data.koalas.transform_batch(pandas_normalize)
 
-    def strftime(self, date_format) -> "pp.Series":
+    def strftime(self, date_format) -> "ps.Series":
         """
         Convert to a string Series using specified date_format.
 
@@ -592,7 +592,7 @@ class DatetimeMethods(object):
 
         Examples
         --------
-        >>> series = pp.Series(pd.date_range(pd.Timestamp("2018-03-10 09:00"),
+        >>> series = ps.Series(pd.date_range(pd.Timestamp("2018-03-10 09:00"),
         ...                                  periods=3, freq='s'))
         >>> series
         0   2018-03-10 09:00:00
@@ -607,12 +607,12 @@ class DatetimeMethods(object):
         dtype: object
         """
 
-        def pandas_strftime(s) -> "pp.Series[str]":
+        def pandas_strftime(s) -> "ps.Series[str]":
             return s.dt.strftime(date_format)
 
         return self._data.koalas.transform_batch(pandas_strftime)
 
-    def round(self, freq, *args, **kwargs) -> "pp.Series":
+    def round(self, freq, *args, **kwargs) -> "ps.Series":
         """
         Perform round operation on the data to the specified freq.
 
@@ -648,7 +648,7 @@ class DatetimeMethods(object):
 
         Examples
         --------
-        >>> series = pp.Series(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
+        >>> series = ps.Series(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
         >>> series
         0   2018-01-01 11:59:00
         1   2018-01-01 12:00:00
@@ -662,12 +662,12 @@ class DatetimeMethods(object):
         dtype: datetime64[ns]
         """
 
-        def pandas_round(s) -> "pp.Series[np.datetime64]":
+        def pandas_round(s) -> "ps.Series[np.datetime64]":
             return s.dt.round(freq, *args, **kwargs)
 
         return self._data.koalas.transform_batch(pandas_round)
 
-    def floor(self, freq, *args, **kwargs) -> "pp.Series":
+    def floor(self, freq, *args, **kwargs) -> "ps.Series":
         """
         Perform floor operation on the data to the specified freq.
 
@@ -703,7 +703,7 @@ class DatetimeMethods(object):
 
         Examples
         --------
-        >>> series = pp.Series(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
+        >>> series = ps.Series(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
         >>> series
         0   2018-01-01 11:59:00
         1   2018-01-01 12:00:00
@@ -717,12 +717,12 @@ class DatetimeMethods(object):
         dtype: datetime64[ns]
         """
 
-        def pandas_floor(s) -> "pp.Series[np.datetime64]":
+        def pandas_floor(s) -> "ps.Series[np.datetime64]":
             return s.dt.floor(freq, *args, **kwargs)
 
         return self._data.koalas.transform_batch(pandas_floor)
 
-    def ceil(self, freq, *args, **kwargs) -> "pp.Series":
+    def ceil(self, freq, *args, **kwargs) -> "ps.Series":
         """
         Perform ceil operation on the data to the specified freq.
 
@@ -758,7 +758,7 @@ class DatetimeMethods(object):
 
         Examples
         --------
-        >>> series = pp.Series(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
+        >>> series = ps.Series(pd.date_range('1/1/2018 11:59:00', periods=3, freq='min'))
         >>> series
         0   2018-01-01 11:59:00
         1   2018-01-01 12:00:00
@@ -772,12 +772,12 @@ class DatetimeMethods(object):
         dtype: datetime64[ns]
         """
 
-        def pandas_ceil(s) -> "pp.Series[np.datetime64]":
+        def pandas_ceil(s) -> "ps.Series[np.datetime64]":
             return s.dt.ceil(freq, *args, **kwargs)
 
         return self._data.koalas.transform_batch(pandas_ceil)
 
-    def month_name(self, locale=None) -> "pp.Series":
+    def month_name(self, locale=None) -> "ps.Series":
         """
         Return the month names of the series with specified locale.
 
@@ -794,7 +794,7 @@ class DatetimeMethods(object):
 
         Examples
         --------
-        >>> series = pp.Series(pd.date_range(start='2018-01', freq='M', periods=3))
+        >>> series = ps.Series(pd.date_range(start='2018-01', freq='M', periods=3))
         >>> series
         0   2018-01-31
         1   2018-02-28
@@ -808,12 +808,12 @@ class DatetimeMethods(object):
         dtype: object
         """
 
-        def pandas_month_name(s) -> "pp.Series[str]":
+        def pandas_month_name(s) -> "ps.Series[str]":
             return s.dt.month_name(locale=locale)
 
         return self._data.koalas.transform_batch(pandas_month_name)
 
-    def day_name(self, locale=None) -> "pp.Series":
+    def day_name(self, locale=None) -> "ps.Series":
         """
         Return the day names of the series with specified locale.
 
@@ -830,7 +830,7 @@ class DatetimeMethods(object):
 
         Examples
         --------
-        >>> series = pp.Series(pd.date_range(start='2018-01-01', freq='D', periods=3))
+        >>> series = ps.Series(pd.date_range(start='2018-01-01', freq='D', periods=3))
         >>> series
         0   2018-01-01
         1   2018-01-02
@@ -844,7 +844,7 @@ class DatetimeMethods(object):
         dtype: object
         """
 
-        def pandas_day_name(s) -> "pp.Series[str]":
+        def pandas_day_name(s) -> "ps.Series[str]":
             return s.dt.day_name(locale=locale)
 
         return self._data.koalas.transform_batch(pandas_day_name)
@@ -860,7 +860,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.datetimes.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.datetimes tests")

--- a/python/pyspark/pandas/exceptions.py
+++ b/python/pyspark/pandas/exceptions.py
@@ -116,7 +116,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.exceptions.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.exceptions tests")

--- a/python/pyspark/pandas/extensions.py
+++ b/python/pyspark/pandas/extensions.py
@@ -354,7 +354,7 @@ def _test():
 
     globs = pyspark.pandas.extensions.__dict__.copy()
     globs["np"] = numpy
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.extensions tests")

--- a/python/pyspark/pandas/extensions.py
+++ b/python/pyspark/pandas/extensions.py
@@ -93,7 +93,7 @@ def _register_accessor(name, cls):
     Ultimately, you can structure this however you like, but Koalas would likely do something like
     this:
 
-    >>> pp.Series(['a', 'b']).dt
+    >>> ps.Series(['a', 'b']).dt
     ...
     Traceback (most recent call last):
         ...
@@ -151,7 +151,7 @@ def register_dataframe_accessor(name):
     Ultimately, you can structure this however you like, but Koalas would likely do something like
     this:
 
-    >>> pp.Series(['a', 'b']).dt
+    >>> ps.Series(['a', 'b']).dt
     ...
     Traceback (most recent call last):
         ...
@@ -185,7 +185,7 @@ def register_dataframe_accessor(name):
 
         >>> ## Import if the accessor is in the other file.
         >>> # from my_ext_lib import GeoAccessor
-        >>> kdf = pp.DataFrame({"longitude": np.linspace(0,10),
+        >>> kdf = ps.DataFrame({"longitude": np.linspace(0,10),
         ...                     "latitude": np.linspace(0, 20)})
         >>> kdf.geo.center  # doctest: +SKIP
         (5.0, 10.0)
@@ -232,7 +232,7 @@ def register_series_accessor(name):
     Ultimately, you can structure this however you like, but Koalas would likely do something like
     this:
 
-    >>> pp.Series(['a', 'b']).dt
+    >>> ps.Series(['a', 'b']).dt
     ...
     Traceback (most recent call last):
         ...
@@ -259,7 +259,7 @@ def register_series_accessor(name):
 
         >>> ## Import if the accessor is in the other file.
         >>> # from my_ext_lib import GeoAccessor
-        >>> kdf = pp.DataFrame({"longitude": np.linspace(0,10),
+        >>> kdf = ps.DataFrame({"longitude": np.linspace(0,10),
         ...                     "latitude": np.linspace(0, 20)})
         >>> kdf.longitude.geo.is_valid  # doctest: +SKIP
         True
@@ -304,7 +304,7 @@ def register_index_accessor(name):
     Ultimately, you can structure this however you like, but Koalas would likely do something like
     this:
 
-    >>> pp.Series(['a', 'b']).dt
+    >>> ps.Series(['a', 'b']).dt
     ...
     Traceback (most recent call last):
         ...
@@ -332,7 +332,7 @@ def register_index_accessor(name):
 
         >>> ## Import if the accessor is in the other file.
         >>> # from my_ext_lib import CustomAccessor
-        >>> kdf = pp.DataFrame({"longitude": np.linspace(0,10),
+        >>> kdf = ps.DataFrame({"longitude": np.linspace(0,10),
         ...                     "latitude": np.linspace(0, 20)})
         >>> kdf.index.foo.bar  # doctest: +SKIP
         'baz'

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -2372,7 +2372,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             In case when axis is 1, it requires to specify `DataFrame` or scalar value
             with type hints as below:
 
-            >>> def plus_one(x) -> pss.DataFrame[float, float]:
+            >>> def plus_one(x) -> ps.DataFrame[float, float]:
             ...     return x + 1
 
             If the return type is specified as `DataFrame`, the output column names become

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -78,7 +78,7 @@ from pyspark.sql.types import (
 )
 from pyspark.sql.window import Window
 
-from pyspark import pandas as pp  # For running doctests and reference resolution in PyCharm.
+from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.accessors import KoalasFrameMethods
 from pyspark.pandas.config import option_context, get_option
 from pyspark.pandas.spark import functions as SF
@@ -157,7 +157,7 @@ DataFrame
 
 Examples
 --------
->>> df = pp.DataFrame({{'angles': [0, 3, 4],
+>>> df = ps.DataFrame({{'angles': [0, 3, 4],
 ...                    'degrees': [360, 180, 360]}},
 ...                   index=['circle', 'triangle', 'rectangle'],
 ...                   columns=['angles', 'degrees'])
@@ -437,7 +437,7 @@ class DataFrame(Frame, Generic[T]):
     Constructing DataFrame from a dictionary.
 
     >>> d = {'col1': [1, 2], 'col2': [3, 4]}
-    >>> df = pp.DataFrame(data=d, columns=['col1', 'col2'])
+    >>> df = ps.DataFrame(data=d, columns=['col1', 'col2'])
     >>> df
        col1  col2
     0     1     3
@@ -445,7 +445,7 @@ class DataFrame(Frame, Generic[T]):
 
     Constructing DataFrame from pandas DataFrame
 
-    >>> df = pp.DataFrame(pd.DataFrame(data=d, columns=['col1', 'col2']))
+    >>> df = ps.DataFrame(pd.DataFrame(data=d, columns=['col1', 'col2']))
     >>> df
        col1  col2
     0     1     3
@@ -460,7 +460,7 @@ class DataFrame(Frame, Generic[T]):
 
     To enforce a single dtype:
 
-    >>> df = pp.DataFrame(data=d, dtype=np.int8)
+    >>> df = ps.DataFrame(data=d, dtype=np.int8)
     >>> df.dtypes
     col1    int8
     col2    int8
@@ -468,7 +468,7 @@ class DataFrame(Frame, Generic[T]):
 
     Constructing DataFrame from numpy ndarray:
 
-    >>> df2 = pp.DataFrame(np.random.randint(low=0, high=10, size=(5, 5)),
+    >>> df2 = ps.DataFrame(np.random.randint(low=0, high=10, size=(5, 5)),
     ...                    columns=['a', 'b', 'c', 'd', 'e'])
     >>> df2  # doctest: +SKIP
        a  b  c  d  e
@@ -492,7 +492,7 @@ class DataFrame(Frame, Generic[T]):
             assert dtype is None
             assert not copy
             internal = InternalFrame(spark_frame=data, index_spark_columns=None)
-        elif isinstance(data, pp.Series):
+        elif isinstance(data, ps.Series):
             assert index is None
             assert columns is None
             assert dtype is None
@@ -599,7 +599,7 @@ class DataFrame(Frame, Generic[T]):
         Examples
         --------
 
-        >>> df = pp.DataFrame([[1, 2], [4, 5], [7, 8]],
+        >>> df = ps.DataFrame([[1, 2], [4, 5], [7, 8]],
         ...                   index=['cobra', 'viper', None],
         ...                   columns=['max_speed', 'shield'])
         >>> df
@@ -623,7 +623,7 @@ class DataFrame(Frame, Generic[T]):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        >>> df = ps.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
         >>> df.axes
         [Int64Index([0, 1], dtype='int64'), Index(['col1', 'col2'], dtype='object')]
         """
@@ -686,7 +686,7 @@ class DataFrame(Frame, Generic[T]):
             sdf = self._internal.spark_frame.select(*exprs)
 
             # The data is expected to be small so it's fine to transpose/use default index.
-            with pp.option_context("compute.max_rows", 1):
+            with ps.option_context("compute.max_rows", 1):
                 internal = InternalFrame(
                     spark_frame=sdf,
                     index_spark_columns=[scol_for(sdf, SPARK_DEFAULT_INDEX_NAME)],
@@ -736,7 +736,7 @@ class DataFrame(Frame, Generic[T]):
 
         For example, in some method, self is like:
 
-        >>> self = pp.range(3)
+        >>> self = ps.range(3)
 
         `self._kser_for(label)` can be used with `InternalFrame.column_labels`:
 
@@ -1034,7 +1034,7 @@ class DataFrame(Frame, Generic[T]):
         """
         Compare if the current value is equal to the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -1053,7 +1053,7 @@ class DataFrame(Frame, Generic[T]):
         """
         Compare if the current value is greater than the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -1070,7 +1070,7 @@ class DataFrame(Frame, Generic[T]):
         """
         Compare if the current value is greater than or equal to the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -1087,7 +1087,7 @@ class DataFrame(Frame, Generic[T]):
         """
         Compare if the current value is less than the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -1104,7 +1104,7 @@ class DataFrame(Frame, Generic[T]):
         """
         Compare if the current value is less than or equal to the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -1121,7 +1121,7 @@ class DataFrame(Frame, Generic[T]):
         """
         Compare if the current value is not equal to the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -1164,7 +1164,7 @@ class DataFrame(Frame, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame([[1, 2.12], [3.356, 4.567]])
+        >>> df = ps.DataFrame([[1, 2.12], [3.356, 4.567]])
         >>> df
                0      1
         0  1.000  2.120
@@ -1227,7 +1227,7 @@ class DataFrame(Frame, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame([[1, 2, 3],
+        >>> df = ps.DataFrame([[1, 2, 3],
         ...                    [4, 5, 6],
         ...                    [7, 8, 9],
         ...                    [np.nan, np.nan, np.nan]],
@@ -1318,7 +1318,7 @@ class DataFrame(Frame, Generic[T]):
             else:
                 pdf = kdf._to_internal_pandas().stack()
                 pdf.index = pdf.index.droplevel()
-                return pp.from_pandas(pdf[list(func.keys())])
+                return ps.from_pandas(pdf[list(func.keys())])
 
     agg = aggregate
 
@@ -1342,7 +1342,7 @@ class DataFrame(Frame, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'])
         >>> df.corr('pearson')
                   dogs      cats
@@ -1364,7 +1364,7 @@ class DataFrame(Frame, Generic[T]):
 
           * `min_periods` argument is not supported
         """
-        return pp.from_pandas(corr(self, method))
+        return ps.from_pandas(corr(self, method))
 
     def iteritems(self) -> Iterator:
         """
@@ -1382,7 +1382,7 @@ class DataFrame(Frame, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'species': ['bear', 'bear', 'marsupial'],
+        >>> df = ps.DataFrame({'species': ['bear', 'bear', 'marsupial'],
         ...                    'population': [1864, 22000, 80000]},
         ...                   index=['panda', 'polar', 'koala'],
         ...                   columns=['species', 'population'])
@@ -1431,7 +1431,7 @@ class DataFrame(Frame, Generic[T]):
            it does **not** preserve dtypes across the rows (dtypes are
            preserved across columns for DataFrames). For example,
 
-           >>> df = pp.DataFrame([[1, 1.5]], columns=['int', 'float'])
+           >>> df = ps.DataFrame([[1, 1.5]], columns=['int', 'float'])
            >>> row = next(df.iterrows())[1]
            >>> row
            int      1.0
@@ -1505,7 +1505,7 @@ class DataFrame(Frame, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'num_legs': [4, 2], 'num_wings': [0, 2]},
+        >>> df = ps.DataFrame({'num_legs': [4, 2], 'num_wings': [0, 2]},
         ...                   index=['dog', 'hawk'])
         >>> df
               num_legs  num_wings
@@ -1611,7 +1611,7 @@ class DataFrame(Frame, Generic[T]):
         --------
         Copy the contents of a DataFrame to the clipboard.
 
-        >>> df = pp.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])  # doctest: +SKIP
+        >>> df = ps.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])  # doctest: +SKIP
         >>> df.to_clipboard(sep=',')  # doctest: +SKIP
         ... # Wrote the following to the system clipboard:
         ... # ,A,B,C
@@ -1629,7 +1629,7 @@ class DataFrame(Frame, Generic[T]):
 
         This function also works for Series:
 
-        >>> df = pp.Series([1, 2, 3, 4, 5, 6, 7], name='x')  # doctest: +SKIP
+        >>> df = ps.Series([1, 2, 3, 4, 5, 6, 7], name='x')  # doctest: +SKIP
         >>> df.to_clipboard(sep=',')  # doctest: +SKIP
         ... # Wrote the following to the system clipboard:
         ... # 0, 1
@@ -1859,7 +1859,7 @@ class DataFrame(Frame, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'col1': [1, 2, 3], 'col2': [4, 5, 6]}, columns=['col1', 'col2'])
+        >>> df = ps.DataFrame({'col1': [1, 2, 3], 'col2': [4, 5, 6]}, columns=['col1', 'col2'])
         >>> print(df.to_string())
            col1  col2
         0     1     4
@@ -1923,7 +1923,7 @@ class DataFrame(Frame, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'col1': [1, 2],
+        >>> df = ps.DataFrame({'col1': [1, 2],
         ...                    'col2': [0.5, 0.75]},
         ...                   index=['row1', 'row2'],
         ...                   columns=['col1', 'col2'])
@@ -2081,7 +2081,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'name': ['Raphael', 'Donatello'],
+        >>> df = ps.DataFrame({'name': ['Raphael', 'Donatello'],
         ...                    'mask': ['red', 'purple'],
         ...                    'weapon': ['sai', 'bo staff']},
         ...                   columns=['name', 'mask', 'weapon'])
@@ -2120,7 +2120,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
                 >>> from pyspark.pandas.config import option_context
                 >>> with option_context('compute.max_rows', 1000):  # doctest: +NORMALIZE_WHITESPACE
-                ...     pp.DataFrame({'a': range(1001)}).transpose()
+                ...     ps.DataFrame({'a': range(1001)}).transpose()
                 Traceback (most recent call last):
                   ...
                 ValueError: Current DataFrame has more then the given limit 1000 rows.
@@ -2150,7 +2150,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         **Square DataFrame with homogeneous dtype**
 
         >>> d1 = {'col1': [1, 2], 'col2': [3, 4]}
-        >>> df1 = pp.DataFrame(data=d1, columns=['col1', 'col2'])
+        >>> df1 = ps.DataFrame(data=d1, columns=['col1', 'col2'])
         >>> df1
            col1  col2
         0     1     3
@@ -2179,7 +2179,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> d2 = {'score': [9.5, 8],
         ...       'kids': [0, 0],
         ...       'age': [12, 22]}
-        >>> df2 = pp.DataFrame(data=d2, columns=['score', 'kids', 'age'])
+        >>> df2 = ps.DataFrame(data=d2, columns=['score', 'kids', 'age'])
         >>> df2
            score  kids  age
         0    9.5     0   12
@@ -2347,7 +2347,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             ... def length(s) -> int:
             ...     return len(s)
             ...
-            >>> df = pp.DataFrame({'A': range(1000)})
+            >>> df = ps.DataFrame({'A': range(1000)})
             >>> df.apply(length, axis=0)  # doctest: +SKIP
             0     83
             1     83
@@ -2364,7 +2364,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             To avoid this, specify the return type as `Series` or scalar value in ``func``,
             for instance, as below:
 
-            >>> def square(s) -> pp.Series[np.int32]:
+            >>> def square(s) -> ps.Series[np.int32]:
             ...     return s ** 2
 
             Koalas uses return type hint and does not try to infer the type.
@@ -2372,7 +2372,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             In case when axis is 1, it requires to specify `DataFrame` or scalar value
             with type hints as below:
 
-            >>> def plus_one(x) -> pp.DataFrame[float, float]:
+            >>> def plus_one(x) -> pss.DataFrame[float, float]:
             ...     return x + 1
 
             If the return type is specified as `DataFrame`, the output column names become
@@ -2381,11 +2381,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             To specify the column names, you can assign them in a pandas friendly style as below:
 
-            >>> def plus_one(x) -> pp.DataFrame["a": float, "b": float]:
+            >>> def plus_one(x) -> ps.DataFrame["a": float, "b": float]:
             ...     return x + 1
 
             >>> pdf = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 4, 5]})
-            >>> def plus_one(x) -> pp.DataFrame[zip(pdf.dtypes, pdf.columns)]:
+            >>> def plus_one(x) -> ps.DataFrame[zip(pdf.dtypes, pdf.columns)]:
             ...     return x + 1
 
             However, this way switches the index type to default index type in the output
@@ -2428,7 +2428,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame([[4, 9]] * 3, columns=['A', 'B'])
+        >>> df = ps.DataFrame([[4, 9]] * 3, columns=['A', 'B'])
         >>> df
            A  B
         0  4  9
@@ -2438,7 +2438,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Using a numpy universal function (in this case the same as
         ``np.sqrt(df)``):
 
-        >>> def sqrt(x) -> pp.Series[float]:
+        >>> def sqrt(x) -> ps.Series[float]:
         ...     return np.sqrt(x)
         ...
         >>> df.apply(sqrt, axis=0)
@@ -2491,7 +2491,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         In order to specify the types when `axis` is '1', it should use DataFrame[...]
         annotation. In this case, the column names are automatically generated.
 
-        >>> def identify(x) -> pp.DataFrame['A': np.int64, 'B': np.int64]:
+        >>> def identify(x) -> ps.DataFrame['A': np.int64, 'B': np.int64]:
         ...     return x
         ...
         >>> df.apply(identify, axis=1)
@@ -2502,7 +2502,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         You can also specify extra arguments.
 
-        >>> def plus_two(a, b, c) -> pp.DataFrame[np.int64, np.int64]:
+        >>> def plus_two(a, b, c) -> ps.DataFrame[np.int64, np.int64]:
         ...     return a + b + c
         ...
         >>> df.apply(plus_two, axis=1, args=(1,), c=3)
@@ -2542,12 +2542,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             limit = get_option("compute.shortcut_limit")
             pdf = self_applied.head(limit + 1)._to_internal_pandas()
             applied = pdf.apply(func, axis=axis, args=args, **kwds)
-            kser_or_kdf = pp.from_pandas(applied)
+            kser_or_kdf = ps.from_pandas(applied)
             if len(pdf) <= limit:
                 return kser_or_kdf
 
             kdf = kser_or_kdf
-            if isinstance(kser_or_kdf, pp.Series):
+            if isinstance(kser_or_kdf, ps.Series):
                 should_return_series = True
                 kdf = kser_or_kdf._kdf
 
@@ -2652,7 +2652,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
              To avoid this, specify return type in ``func``, for instance, as below:
 
-             >>> def square(x) -> pp.Series[np.int32]:
+             >>> def square(x) -> ps.Series[np.int32]:
              ...     return x ** 2
 
              Koalas uses return type hint and does not try to infer the type.
@@ -2663,7 +2663,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             does work as a global aggregation but an aggregation of each segment. See
             below:
 
-            >>> def func(x) -> pp.Series[np.int32]:
+            >>> def func(x) -> ps.Series[np.int32]:
             ...     return x + sum(x)
 
         Parameters
@@ -2695,14 +2695,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': range(3), 'B': range(1, 4)}, columns=['A', 'B'])
+        >>> df = ps.DataFrame({'A': range(3), 'B': range(1, 4)}, columns=['A', 'B'])
         >>> df
            A  B
         0  0  1
         1  1  2
         2  2  3
 
-        >>> def square(x) -> pp.Series[np.int32]:
+        >>> def square(x) -> ps.Series[np.int32]:
         ...     return x ** 2
         >>> df.transform(square)
            A  B
@@ -2737,7 +2737,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         You can also specify extra arguments.
 
-        >>> def calculation(x, y, z) -> pp.Series[int]:
+        >>> def calculation(x, y, z) -> ps.Series[int]:
         ...     return x ** y + z
         >>> df.transform(calculation, y=10, z=20)  # doctest: +NORMALIZE_WHITESPACE
               X
@@ -2819,7 +2819,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame([('falcon', 'bird', 389.0),
+        >>> df = ps.DataFrame([('falcon', 'bird', 389.0),
         ...                    ('parrot', 'bird', 24.0),
         ...                    ('lion', 'mammal', 80.5),
         ...                    ('monkey','mammal', np.nan)],
@@ -2848,7 +2848,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Also support for MultiIndex
 
-        >>> df = pp.DataFrame([('falcon', 'bird', 389.0),
+        >>> df = ps.DataFrame([('falcon', 'bird', 389.0),
         ...                    ('parrot', 'bird', 24.0),
         ...                    ('lion', 'mammal', 80.5),
         ...                    ('monkey','mammal', np.nan)],
@@ -2921,7 +2921,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...      'class': ['mammal', 'mammal', 'mammal', 'bird'],
         ...      'animal': ['cat', 'dog', 'bat', 'penguin'],
         ...      'locomotion': ['walks', 'walks', 'flies', 'walks']}
-        >>> df = pp.DataFrame(data=d)
+        >>> df = ps.DataFrame(data=d)
         >>> df = df.set_index(['class', 'animal', 'locomotion'])
         >>> df  # doctest: +NORMALIZE_WHITESPACE
                                    num_legs  num_wings
@@ -3059,7 +3059,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Examples
         --------
         >>> idx = pd.date_range('2018-04-09', periods=4, freq='1D20min')
-        >>> kdf = pp.DataFrame({'A': [1, 2, 3, 4]}, index=idx)
+        >>> kdf = ps.DataFrame({'A': [1, 2, 3, 4]}, index=idx)
         >>> kdf
                              A
         2018-04-09 00:00:00  1
@@ -3085,14 +3085,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if axis != 0:
             raise NotImplementedError("between_time currently only works for axis=0")
 
-        if not isinstance(self.index, pp.DatetimeIndex):
+        if not isinstance(self.index, ps.DatetimeIndex):
             raise TypeError("Index must be DatetimeIndex")
 
         kdf = self.copy()
         kdf.index.name = verify_temp_column_name(kdf, "__index_name__")
         return_types = [kdf.index.dtype] + list(kdf.dtypes)
 
-        def pandas_between_time(pdf) -> pp.DataFrame[return_types]:  # type: ignore
+        def pandas_between_time(pdf) -> ps.DataFrame[return_types]:  # type: ignore
             return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
         # apply_batch will remove the index of the Koalas DataFrame and attach a default index,
@@ -3138,7 +3138,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Examples
         --------
         >>> idx = pd.date_range('2018-04-09', periods=4, freq='12H')
-        >>> kdf = pp.DataFrame({'A': [1, 2, 3, 4]}, index=idx)
+        >>> kdf = ps.DataFrame({'A': [1, 2, 3, 4]}, index=idx)
         >>> kdf
                              A
         2018-04-09 00:00:00  1
@@ -3159,7 +3159,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if axis != 0:
             raise NotImplementedError("at_time currently only works for axis=0")
 
-        if not isinstance(self.index, pp.DatetimeIndex):
+        if not isinstance(self.index, ps.DatetimeIndex):
             raise TypeError("Index must be DatetimeIndex")
 
         kdf = self.copy()
@@ -3168,12 +3168,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if LooseVersion(pd.__version__) < LooseVersion("0.24"):
 
-            def pandas_at_time(pdf) -> pp.DataFrame[return_types]:  # type: ignore
+            def pandas_at_time(pdf) -> ps.DataFrame[return_types]:  # type: ignore
                 return pdf.at_time(time, asof).reset_index()
 
         else:
 
-            def pandas_at_time(pdf) -> pp.DataFrame[return_types]:  # type: ignore
+            def pandas_at_time(pdf) -> ps.DataFrame[return_types]:  # type: ignore
                 return pdf.at_time(time, asof, axis).reset_index()
 
         # apply_batch will remove the index of the Koalas DataFrame and attach a default index,
@@ -3210,8 +3210,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> from pyspark.pandas.config import set_option, reset_option
         >>> set_option("compute.ops_on_diff_frames", True)
-        >>> df1 = pp.DataFrame({'A': [0, 1, 2, 3, 4], 'B':[100, 200, 300, 400, 500]})
-        >>> df2 = pp.DataFrame({'A': [0, -1, -2, -3, -4], 'B':[-100, -200, -300, -400, -500]})
+        >>> df1 = ps.DataFrame({'A': [0, 1, 2, 3, 4], 'B':[100, 200, 300, 400, 500]})
+        >>> df2 = ps.DataFrame({'A': [0, -1, -2, -3, -4], 'B':[-100, -200, -300, -400, -500]})
         >>> df1
            A    B
         0  0  100
@@ -3261,7 +3261,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         When the column name of cond is different from self, it treats all values are False
 
-        >>> cond = pp.DataFrame({'C': [0, -1, -2, -3, -4], 'D':[4, 3, 2, 1, 0]}) % 3 == 0
+        >>> cond = ps.DataFrame({'C': [0, -1, -2, -3, -4], 'D':[4, 3, 2, 1, 0]}) % 3 == 0
         >>> cond
                C      D
         0   True  False
@@ -3280,7 +3280,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         When the type of cond is Series, it just check boolean regardless of column name
 
-        >>> cond = pp.Series([1, 2]) > 1
+        >>> cond = ps.Series([1, 2]) > 1
         >>> cond
         0    False
         1     True
@@ -3401,8 +3401,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> from pyspark.pandas.config import set_option, reset_option
         >>> set_option("compute.ops_on_diff_frames", True)
-        >>> df1 = pp.DataFrame({'A': [0, 1, 2, 3, 4], 'B':[100, 200, 300, 400, 500]})
-        >>> df2 = pp.DataFrame({'A': [0, -1, -2, -3, -4], 'B':[-100, -200, -300, -400, -500]})
+        >>> df1 = ps.DataFrame({'A': [0, 1, 2, 3, 4], 'B':[100, 200, 300, 400, 500]})
+        >>> df2 = ps.DataFrame({'A': [0, -1, -2, -3, -4], 'B':[-100, -200, -300, -400, -500]})
         >>> df1
            A    B
         0  0  100
@@ -3481,13 +3481,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> pp.range(10).empty
+        >>> ps.range(10).empty
         False
 
-        >>> pp.range(0).empty
+        >>> ps.range(0).empty
         True
 
-        >>> pp.DataFrame({}, index=list('abc')).empty
+        >>> ps.DataFrame({}, index=list('abc')).empty
         True
         """
         return (
@@ -3506,7 +3506,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> pp.range(1001).style  # doctest: +SKIP
+        >>> ps.range(1001).style  # doctest: +SKIP
         <pandas.io.formats.style.Styler object at ...>
         """
         max_results = get_option("compute.max_rows")
@@ -3547,7 +3547,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'month': [1, 4, 7, 10],
+        >>> df = ps.DataFrame({'month': [1, 4, 7, 10],
         ...                    'year': [2012, 2014, 2013, 2014],
         ...                    'sale': [55, 40, 84, 31]},
         ...                   columns=['month', 'year', 'sale'])
@@ -3661,7 +3661,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame([('bird', 389.0),
+        >>> df = ps.DataFrame([('bird', 389.0),
         ...                    ('bird', 24.0),
         ...                    ('mammal', 80.5),
         ...                    ('mammal', np.nan)],
@@ -3704,7 +3704,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...                                   names=['class', 'name'])
         >>> columns = pd.MultiIndex.from_tuples([('speed', 'max'),
         ...                                      ('species', 'type')])
-        >>> df = pp.DataFrame([(389.0, 'fly'),
+        >>> df = ps.DataFrame([(389.0, 'fly'),
         ...                    ( 24.0, 'fly'),
         ...                    ( 80.5, 'run'),
         ...                    (np.nan, 'jump')],
@@ -3908,7 +3908,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, None), (.6, None), (.2, .1)])
+        >>> df = ps.DataFrame([(.2, .3), (.0, None), (.6, None), (.2, .1)])
         >>> df.isnull()
                0      1
         0  False  False
@@ -3916,7 +3916,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2  False   True
         3  False  False
 
-        >>> df = pp.DataFrame([[None, 'bee', None], ['dog', None, 'fly']])
+        >>> df = ps.DataFrame([[None, 'bee', None], ['dog', None, 'fly']])
         >>> df.isnull()
                0      1      2
         0   True  False   True
@@ -3940,7 +3940,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, None), (.6, None), (.2, .1)])
+        >>> df = ps.DataFrame([(.2, .3), (.0, None), (.6, None), (.2, .1)])
         >>> df.notnull()
               0      1
         0  True   True
@@ -3948,7 +3948,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2  True  False
         3  True   True
 
-        >>> df = pp.DataFrame([['ant', 'bee', 'cat'], ['dog', None, 'fly']])
+        >>> df = ps.DataFrame([['ant', 'bee', 'cat'], ['dog', None, 'fly']])
         >>> df.notnull()
               0      1     2
         0  True   True  True
@@ -3982,7 +3982,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> kdf = pp.DataFrame([1, 2, 3])
+        >>> kdf = ps.DataFrame([1, 2, 3])
         >>> kdf.sort_index()
            0
         0  1
@@ -4005,7 +4005,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1  4  6  2
         2  4  7  3
 
-        >>> kdf.insert(2, 'z', pp.Series([8, 9, 10]))
+        >>> kdf.insert(2, 'z', ps.Series([8, 9, 10]))
         >>> kdf.sort_index()
            x  y   z  0
         0  4  5   8  1
@@ -4063,7 +4063,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'Col1': [10, 20, 15, 30, 45],
+        >>> df = ps.DataFrame({'Col1': [10, 20, 15, 30, 45],
         ...                    'Col2': [13, 23, 18, 33, 48],
         ...                    'Col3': [17, 27, 22, 37, 52]},
         ...                   columns=['Col1', 'Col2', 'Col3'])
@@ -4115,7 +4115,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4, 5, 6],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4, 5, 6],
         ...                    'b': [1, 1, 2, 3, 5, 8],
         ...                    'c': [1, 4, 9, 16, 25, 36]}, columns=['a', 'b', 'c'])
         >>> df
@@ -4198,7 +4198,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 2, 3], 'B': [np.nan, 3, np.nan]})
+        >>> df = ps.DataFrame({'A': [1, 2, 3], 'B': [np.nan, 3, np.nan]})
         >>> df.nunique()
         A    3
         B    1
@@ -4231,7 +4231,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
         # The data is expected to be small so it's fine to transpose/use default index.
-        with pp.option_context("compute.max_rows", 1):
+        with ps.option_context("compute.max_rows", 1):
             internal = self._internal.copy(
                 spark_frame=sdf,
                 index_spark_columns=[scol_for(sdf, SPARK_DEFAULT_INDEX_NAME)],
@@ -4273,7 +4273,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A':[0.028208, 0.038683, 0.877076],
+        >>> df = ps.DataFrame({'A':[0.028208, 0.038683, 0.877076],
         ...                    'B':[0.992815, 0.645646, 0.149370],
         ...                    'C':[0.173891, 0.577595, 0.491027]},
         ...                    columns=['A', 'B', 'C'],
@@ -4296,14 +4296,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         second  0.0  0.645646  0.58
         third   0.9  0.149370  0.49
 
-        >>> decimals = pp.Series([1, 0, 2], index=['A', 'B', 'C'])
+        >>> decimals = ps.Series([1, 0, 2], index=['A', 'B', 'C'])
         >>> df.round(decimals)
                   A    B     C
         first   0.0  1.0  0.17
         second  0.0  1.0  0.58
         third   0.9  0.0  0.49
         """
-        if isinstance(decimals, pp.Series):
+        if isinstance(decimals, ps.Series):
             decimals = {
                 k if isinstance(k, tuple) else (k,): v
                 for k, v in decimals._to_internal_pandas().items()
@@ -4385,7 +4385,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 1, 1, 3], 'b': [1, 1, 1, 4], 'c': [1, 1, 1, 5]},
+        >>> df = ps.DataFrame({'a': [1, 1, 1, 3], 'b': [1, 1, 1, 4], 'c': [1, 1, 1, 5]},
         ...                   columns = ['a', 'b', 'c'])
         >>> df
            a  b  c
@@ -4461,8 +4461,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 >>> with option_context(
                 ...     'compute.max_rows', 1000, "compute.ops_on_diff_frames", True
                 ... ):  # doctest: +NORMALIZE_WHITESPACE
-                ...     kdf = pp.DataFrame({'a': range(1001)})
-                ...     kser = pp.Series([2], index=['a'])
+                ...     kdf = ps.DataFrame({'a': range(1001)})
+                ...     kser = ps.Series([2], index=['a'])
                 ...     kdf.dot(kser)
                 Traceback (most recent call last):
                   ...
@@ -4499,8 +4499,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
         >>> from pyspark.pandas.config import set_option, reset_option
         >>> set_option("compute.ops_on_diff_frames", True)
-        >>> kdf = pp.DataFrame([[0, 1, -2, -1], [1, 1, 1, 1]])
-        >>> kser = pp.Series([1, 1, 2, 1])
+        >>> kdf = ps.DataFrame([[0, 1, -2, -1], [1, 1, 1, 1]])
+        >>> kser = ps.Series([1, 1, 2, 1])
         >>> kdf.dot(kser)
         0   -4
         1    5
@@ -4519,10 +4519,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         dtype: int64
         >>> reset_option("compute.ops_on_diff_frames")
         """
-        if not isinstance(other, pp.Series):
+        if not isinstance(other, ps.Series):
             raise TypeError("Unsupported type {}".format(type(other).__name__))
         else:
-            return cast(pp.Series, other.dot(self.transpose())).rename(None)
+            return cast(ps.Series, other.dot(self.transpose())).rename(None)
 
     def __matmul__(self, other):
         """
@@ -4553,7 +4553,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'col1': [1, 2], 'col2': [3, 4]}, columns=['col1', 'col2'])
+        >>> df = ps.DataFrame({'col1': [1, 2], 'col2': [3, 4]}, columns=['col1', 'col2'])
         >>> df
            col1  col2
         0     1     3
@@ -4682,7 +4682,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Examples
         --------
 
-        >>> df = pp.DataFrame(dict(
+        >>> df = ps.DataFrame(dict(
         ...    date=list(pd.date_range('2012-1-1 12:00:00', periods=3, freq='M')),
         ...    country=['KR', 'US', 'JP'],
         ...    code=[1, 2 ,3]), columns=['date', 'country', 'code'])
@@ -4763,7 +4763,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame(dict(
+        >>> df = ps.DataFrame(dict(
         ...    date=list(pd.date_range('2012-1-1 12:00:00', periods=3, freq='M')),
         ...    country=['KR', 'US', 'JP'],
         ...    code=[1, 2 ,3]), columns=['date', 'country', 'code'])
@@ -4831,7 +4831,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame(dict(
+        >>> df = ps.DataFrame(dict(
         ...    date=list(pd.date_range('2012-1-1 12:00:00', periods=3, freq='M')),
         ...    country=['KR', 'US', 'JP'],
         ...    code=[1, 2 ,3]), columns=['date', 'country', 'code'])
@@ -4887,7 +4887,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'])
         >>> df.to_pandas()
            dogs  cats
@@ -4934,7 +4934,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'temp_c': [17.0, 25.0]},
+        >>> df = ps.DataFrame({'temp_c': [17.0, 25.0]},
         ...                   index=['Portland', 'Berkeley'])
         >>> df
                   temp_c
@@ -5064,7 +5064,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
         Use dict as input
 
-        >>> pp.DataFrame.from_records({'A': [1, 2, 3]})
+        >>> ps.DataFrame.from_records({'A': [1, 2, 3]})
            A
         0  1
         1  2
@@ -5072,14 +5072,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Use list of tuples as input
 
-        >>> pp.DataFrame.from_records([(1, 2), (3, 4)])
+        >>> ps.DataFrame.from_records([(1, 2), (3, 4)])
            0  1
         0  1  2
         1  3  4
 
         Use NumPy array as input
 
-        >>> pp.DataFrame.from_records(np.eye(3))
+        >>> ps.DataFrame.from_records(np.eye(3))
              0    1    2
         0  1.0  0.0  0.0
         1  0.0  1.0  0.0
@@ -5130,7 +5130,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 2], 'B': [0.5, 0.75]},
+        >>> df = ps.DataFrame({'A': [1, 2], 'B': [0.5, 0.75]},
         ...                   index=['a', 'b'])
         >>> df
            A     B
@@ -5183,7 +5183,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
+        >>> df = ps.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
         ...                   columns=['x', 'y', 'z', 'w'])
         >>> df
            x  y  z  w
@@ -5238,7 +5238,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({"name": ['Alfred', 'Batman', 'Catwoman'],
+        >>> df = ps.DataFrame({"name": ['Alfred', 'Batman', 'Catwoman'],
         ...                    "toy": [None, 'Batmobile', 'Bullwhip'],
         ...                    "born": [None, "1940-04-25", None]},
         ...                   columns=['name', 'toy', 'born'])
@@ -5441,7 +5441,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'A': [None, 3, None, None],
         ...     'B': [2, 4, None, 3],
         ...     'C': [None, None, None, 1],
@@ -5551,7 +5551,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({"name": ['Ironman', 'Captain America', 'Thor', 'Hulk'],
+        >>> df = ps.DataFrame({"name": ['Ironman', 'Captain America', 'Thor', 'Hulk'],
         ...                    "weapon": ['Mark-45', 'Shield', 'Mjolnir', 'Smash']},
         ...                   columns=['name', 'weapon'])
         >>> df
@@ -5669,7 +5669,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> pp.DataFrame({'A': [0, 2, 4]}).clip(1, 3)
+        >>> ps.DataFrame({'A': [0, 2, 4]}).clip(1, 3)
            A
         0  1
         1  2
@@ -5679,7 +5679,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         -----
         One difference between this implementation and pandas is that running
         pd.DataFrame({'A': ['a', 'b']}).clip(0, 1) will crash with "TypeError: '<=' not supported
-        between instances of 'str' and 'int'" while pp.DataFrame({'A': ['a', 'b']}).clip(0, 1)
+        between instances of 'str' and 'int'" while ps.DataFrame({'A': ['a', 'b']}).clip(0, 1)
         will output the original DataFrame, simply ignoring the incompatible types.
         """
         if is_list_like(lower) or is_list_like(upper):
@@ -5712,7 +5712,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'animal':['alligator', 'bee', 'falcon', 'lion',
+        >>> df = ps.DataFrame({'animal':['alligator', 'bee', 'falcon', 'lion',
         ...                    'monkey', 'parrot', 'shark', 'whale', 'zebra']})
         >>> df
               animal
@@ -5781,7 +5781,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
 
         >>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
-        >>> kdf = pp.DataFrame({'A': [1, 2, 3, 4]}, index=index)
+        >>> kdf = ps.DataFrame({'A': [1, 2, 3, 4]}, index=index)
         >>> kdf
                     A
         2018-04-09  1
@@ -5801,7 +5801,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         not returned.
         """
         # Check index type should be format DateTime
-        if not isinstance(self.index, pp.DatetimeIndex):
+        if not isinstance(self.index, ps.DatetimeIndex):
             raise TypeError("'last' only supports a DatetimeIndex")
 
         offset = to_offset(offset)
@@ -5836,7 +5836,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
 
         >>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
-        >>> kdf = pp.DataFrame({'A': [1, 2, 3, 4]}, index=index)
+        >>> kdf = ps.DataFrame({'A': [1, 2, 3, 4]}, index=index)
         >>> kdf
                     A
         2018-04-09  1
@@ -5856,7 +5856,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         not returned.
         """
         # Check index type should be format DatetimeIndex
-        if not isinstance(self.index, pp.DatetimeIndex):
+        if not isinstance(self.index, ps.DatetimeIndex):
             raise TypeError("'first' only supports a DatetimeIndex")
 
         offset = to_offset(offset)
@@ -5894,7 +5894,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({"A": ["foo", "foo", "foo", "foo", "foo",
+        >>> df = ps.DataFrame({"A": ["foo", "foo", "foo", "foo", "foo",
         ...                          "bar", "bar", "bar", "bar"],
         ...                    "B": ["one", "one", "one", "two", "two",
         ...                          "one", "one", "two", "two"],
@@ -6182,7 +6182,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'foo': ['one', 'one', 'one', 'two', 'two',
+        >>> df = ps.DataFrame({'foo': ['one', 'one', 'one', 'two', 'two',
         ...                            'two'],
         ...                    'bar': ['A', 'B', 'C', 'A', 'B', 'C'],
         ...                    'baz': [1, 2, 3, 4, 5, 6],
@@ -6218,7 +6218,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         is an expensive operation and it is preferred to permissively execute over failing fast
         when processing large data.
 
-        >>> df = pp.DataFrame({"foo": ['one', 'one', 'two', 'two'],
+        >>> df = ps.DataFrame({"foo": ['one', 'one', 'two', 'two'],
         ...                    "bar": ['A', 'A', 'B', 'C'],
         ...                    "baz": [1, 2, 3, 4]}, columns=['foo', 'bar', 'baz'])
         >>> df
@@ -6342,7 +6342,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': list('abc'),
+        >>> df = ps.DataFrame({'a': list('abc'),
         ...                    'b': list(range(1, 4)),
         ...                    'c': np.arange(3, 6).astype('i1'),
         ...                    'd': np.arange(4.0, 7.0, dtype='float64'),
@@ -6407,7 +6407,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ValueError
             * If both of ``include`` and ``exclude`` are empty
 
-                >>> df = pp.DataFrame({'a': [1, 2] * 3,
+                >>> df = ps.DataFrame({'a': [1, 2] * 3,
                 ...                    'b': [True, False] * 3,
                 ...                    'c': [1.0, 2.0] * 3})
                 >>> df.select_dtypes()
@@ -6417,7 +6417,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             * If ``include`` and ``exclude`` have overlapping elements
 
-                >>> df = pp.DataFrame({'a': [1, 2] * 3,
+                >>> df = ps.DataFrame({'a': [1, 2] * 3,
                 ...                    'b': [True, False] * 3,
                 ...                    'c': [1.0, 2.0] * 3})
                 >>> df.select_dtypes(include='a', exclude='a')
@@ -6432,7 +6432,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 2] * 3,
+        >>> df = ps.DataFrame({'a': [1, 2] * 3,
         ...                    'b': [True, False] * 3,
         ...                    'c': [1.0, 2.0] * 3,
         ...                    'd': ['a', 'b'] * 3}, columns=['a', 'b', 'c', 'd'])
@@ -6569,7 +6569,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame(
+        >>> df = ps.DataFrame(
         ...     [[3, 4], [7, 8], [11, 12]],
         ...     index=pd.MultiIndex.from_tuples([(1, 2), (5, 6), (9, 10)], names=["a", "b"]),
         ... )
@@ -6693,7 +6693,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
+        >>> df = ps.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
         ...                   columns=['x', 'y', 'z', 'w'])
         >>> df
            x  y  z  w
@@ -6717,7 +6717,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Also support for MultiIndex
 
-        >>> df = pp.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
+        >>> df = ps.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
         ...                   columns=['x', 'y', 'z', 'w'])
         >>> columns = [('a', 'x'), ('a', 'y'), ('b', 'z'), ('b', 'w')]
         >>> df.columns = pd.MultiIndex.from_tuples(columns)
@@ -6828,7 +6828,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'col1': ['A', 'B', None, 'D', 'C'],
         ...     'col2': [2, 9, 8, 7, 4],
         ...     'col3': [0, 9, 4, 2, 3],
@@ -6864,7 +6864,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Sort by multiple columns
 
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'col1': ['A', 'A', 'B', None, 'D', 'C'],
         ...     'col2': [2, 1, 9, 8, 7, 4],
         ...     'col3': [0, 1, 9, 4, 2, 3],
@@ -6888,7 +6888,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         new_by = []
         for colname in by:
             ser = self[colname]
-            if not isinstance(ser, pp.Series):
+            if not isinstance(ser, ps.Series):
                 raise ValueError(
                     "The column %s is not unique. For a multi-index, the label must be a tuple "
                     "with elements corresponding to each level." % name_like_string(colname)
@@ -6930,7 +6930,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [2, 1, np.nan]}, index=['b', 'a', np.nan])
+        >>> df = ps.DataFrame({'A': [2, 1, np.nan]}, index=['b', 'a', np.nan])
 
         >>> df.sort_index()
                A
@@ -6957,7 +6957,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         b    2.0
         NaN  NaN
 
-        >>> df = pp.DataFrame({'A': range(4), 'B': range(4)[::-1]},
+        >>> df = ps.DataFrame({'A': range(4), 'B': range(4)[::-1]},
         ...                   index=[['b', 'b', 'a', 'a'], [1, 0, 1, 0]],
         ...                   columns=['A', 'B'])
 
@@ -7028,7 +7028,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Swap levels in a MultiIndex on index.
 
-        >>> kdf = pp.DataFrame({'x': [5, 6], 'y':[5, 6]}, index=midx)
+        >>> kdf = ps.DataFrame({'x': [5, 6], 'y':[5, 6]}, index=midx)
         >>> kdf  # doctest: +NORMALIZE_WHITESPACE
                            x  y
         color number size
@@ -7055,7 +7055,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Swap levels in a MultiIndex on columns.
 
-        >>> kdf = pp.DataFrame({'x': [5, 6], 'y':[5, 6]})
+        >>> kdf = ps.DataFrame({'x': [5, 6], 'y':[5, 6]})
         >>> kdf.columns = midx
         >>> kdf
         color  red blue
@@ -7112,7 +7112,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
                 >>> from pyspark.pandas.config import option_context
                 >>> with option_context('compute.max_rows', 1000):  # doctest: +NORMALIZE_WHITESPACE
-                ...     pp.DataFrame({'a': range(1001)}).swapaxes(i=0, j=1)
+                ...     ps.DataFrame({'a': range(1001)}).swapaxes(i=0, j=1)
                 Traceback (most recent call last):
                   ...
                 ValueError: Current DataFrame has more then the given limit 1000 rows.
@@ -7132,7 +7132,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> kdf = pp.DataFrame(
+        >>> kdf = ps.DataFrame(
         ...     [[1, 2, 3], [4, 5, 6], [7, 8, 9]], index=['x', 'y', 'z'], columns=['a', 'b', 'c']
         ... )
         >>> kdf
@@ -7189,7 +7189,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return internal
 
     def _swaplevel_index(self, i, j) -> InternalFrame:
-        assert isinstance(self.index, pp.MultiIndex)
+        assert isinstance(self.index, ps.MultiIndex)
         for index in (i, j):
             if not isinstance(index, int) and index not in self.index.names:
                 raise KeyError("Level %s not found" % index)
@@ -7263,7 +7263,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'X': [1, 2, 3, 5, 6, 7, np.nan],
+        >>> df = ps.DataFrame({'X': [1, 2, 3, 5, 6, 7, np.nan],
         ...                    'Y': [6, 7, 8, 9, 10, 11, 12]})
         >>> df
              X   Y
@@ -7326,7 +7326,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'X': [1, 2, 3, 5, 6, 7, np.nan],
+        >>> df = ps.DataFrame({'X': [1, 2, 3, 5, 6, 7, np.nan],
         ...                    'Y': [6, 7, 8, 9, 10, 11, 12]})
         >>> df
              X   Y
@@ -7377,7 +7377,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'num_legs': [2, 4], 'num_wings': [2, 0]},
+        >>> df = ps.DataFrame({'num_legs': [2, 4], 'num_wings': [2, 0]},
         ...                   index=['falcon', 'dog'],
         ...                   columns=['num_legs', 'num_wings'])
         >>> df
@@ -7444,11 +7444,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        >>> df = ps.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
         >>> df.shape
         (2, 2)
 
-        >>> df = pp.DataFrame({'col1': [1, 2], 'col2': [3, 4],
+        >>> df = ps.DataFrame({'col1': [1, 2], 'col2': [3, 4],
         ...                    'col3': [5, 6]})
         >>> df.shape
         (2, 3)
@@ -7522,10 +7522,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df1 = pp.DataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
+        >>> df1 = ps.DataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
         ...                     'value': [1, 2, 3, 5]},
         ...                    columns=['lkey', 'value'])
-        >>> df2 = pp.DataFrame({'rkey': ['foo', 'bar', 'baz', 'foo'],
+        >>> df2 = ps.DataFrame({'rkey': ['foo', 'bar', 'baz', 'foo'],
         ...                     'value': [5, 6, 7, 8]},
         ...                    columns=['rkey', 'value'])
         >>> df1
@@ -7554,8 +7554,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...foo        5  foo        5
         ...foo        5  foo        8
 
-        >>> left_kdf = pp.DataFrame({'A': [1, 2]})
-        >>> right_kdf = pp.DataFrame({'B': ['x', 'y']}, index=[1, 2])
+        >>> left_kdf = ps.DataFrame({'A': [1, 2]})
+        >>> right_kdf = ps.DataFrame({'B': ['x', 'y']}, index=[1, 2])
 
         >>> left_kdf.merge(right_kdf, left_index=True, right_index=True).sort_index()
            A  B
@@ -7593,7 +7593,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             else:
                 return [o if is_name_like_tuple(o) else (o,) for o in os]
 
-        if isinstance(right, pp.Series):
+        if isinstance(right, ps.Series):
             right = right.to_frame()
 
         if on:
@@ -7839,10 +7839,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> kdf1 = pp.DataFrame({'key': ['K0', 'K1', 'K2', 'K3'],
+        >>> kdf1 = ps.DataFrame({'key': ['K0', 'K1', 'K2', 'K3'],
         ...                      'A': ['A0', 'A1', 'A2', 'A3']},
         ...                     columns=['key', 'A'])
-        >>> kdf2 = pp.DataFrame({'key': ['K0', 'K1', 'K2'],
+        >>> kdf2 = ps.DataFrame({'key': ['K0', 'K1', 'K2'],
         ...                      'B': ['B0', 'B1', 'B2']},
         ...                     columns=['key', 'B'])
         >>> kdf1
@@ -7887,7 +7887,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> join_kdf.index
         Int64Index([0, 1, 2, 3], dtype='int64')
         """
-        if isinstance(right, pp.Series):
+        if isinstance(right, ps.Series):
             common = list(self.columns.intersection([right.name]))
         else:
             common = list(self.columns.intersection(right.columns))
@@ -7945,7 +7945,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame([[1, 2], [3, 4]], columns=list('AB'))
+        >>> df = ps.DataFrame([[1, 2], [3, 4]], columns=list('AB'))
 
         >>> df.append(df)
            A  B
@@ -7961,7 +7961,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2  1  2
         3  3  4
         """
-        if isinstance(other, pp.Series):
+        if isinstance(other, ps.Series):
             raise ValueError("DataFrames.append() does not support appending Series to DataFrames")
         if sort:
             raise NotImplementedError("The 'sort' parameter is currently not supported")
@@ -8016,8 +8016,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 2, 3], 'B': [400, 500, 600]}, columns=['A', 'B'])
-        >>> new_df = pp.DataFrame({'B': [4, 5, 6], 'C': [7, 8, 9]}, columns=['B', 'C'])
+        >>> df = ps.DataFrame({'A': [1, 2, 3], 'B': [400, 500, 600]}, columns=['A', 'B'])
+        >>> new_df = ps.DataFrame({'B': [4, 5, 6], 'C': [7, 8, 9]}, columns=['B', 'C'])
         >>> df.update(new_df)
         >>> df.sort_index()
            A  B
@@ -8028,8 +8028,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         The DataFrame's length does not increase as a result of the update,
         only values at matching index/column labels are updated.
 
-        >>> df = pp.DataFrame({'A': ['a', 'b', 'c'], 'B': ['x', 'y', 'z']}, columns=['A', 'B'])
-        >>> new_df = pp.DataFrame({'B': ['d', 'e', 'f', 'g', 'h', 'i']}, columns=['B'])
+        >>> df = ps.DataFrame({'A': ['a', 'b', 'c'], 'B': ['x', 'y', 'z']}, columns=['A', 'B'])
+        >>> new_df = ps.DataFrame({'B': ['d', 'e', 'f', 'g', 'h', 'i']}, columns=['B'])
         >>> df.update(new_df)
         >>> df.sort_index()
            A  B
@@ -8039,8 +8039,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         For Series, it's name attribute must be set.
 
-        >>> df = pp.DataFrame({'A': ['a', 'b', 'c'], 'B': ['x', 'y', 'z']}, columns=['A', 'B'])
-        >>> new_column = pp.Series(['d', 'e'], name='B', index=[0, 2])
+        >>> df = ps.DataFrame({'A': ['a', 'b', 'c'], 'B': ['x', 'y', 'z']}, columns=['A', 'B'])
+        >>> new_column = ps.Series(['d', 'e'], name='B', index=[0, 2])
         >>> df.update(new_column)
         >>> df.sort_index()
            A  B
@@ -8050,8 +8050,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         If `other` contains None the corresponding values are not updated in the original dataframe.
 
-        >>> df = pp.DataFrame({'A': [1, 2, 3], 'B': [400, 500, 600]}, columns=['A', 'B'])
-        >>> new_df = pp.DataFrame({'B': [4, None, 6]}, columns=['B'])
+        >>> df = ps.DataFrame({'A': [1, 2, 3], 'B': [400, 500, 600]}, columns=['A', 'B'])
+        >>> new_df = ps.DataFrame({'B': [4, None, 6]}, columns=['B'])
         >>> df.update(new_df)
         >>> df.sort_index()
            A      B
@@ -8062,7 +8062,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if join != "left":
             raise NotImplementedError("Only left join is supported")
 
-        if isinstance(other, pp.Series):
+        if isinstance(other, ps.Series):
             other = other.to_frame()
 
         update_columns = list(
@@ -8131,7 +8131,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'num_legs': [2, 4, 8, 0],
+        >>> df = ps.DataFrame({'num_legs': [2, 4, 8, 0],
         ...                    'num_wings': [2, 0, 0, 0],
         ...                    'num_specimen_seen': [10, 2, 1, 8]},
         ...                   index=['falcon', 'dog', 'spider', 'fish'],
@@ -8206,7 +8206,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 2, 3], 'b': [1, 2, 3]}, dtype='int64')
+        >>> df = ps.DataFrame({'a': [1, 2, 3], 'b': [1, 2, 3]}, dtype='int64')
         >>> df
            a  b
         0  1  1
@@ -8281,7 +8281,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 2, 3, 4], 'B': [3, 4, 5, 6]}, columns=['A', 'B'])
+        >>> df = ps.DataFrame({'A': [1, 2, 3, 4], 'B': [3, 4, 5, 6]}, columns=['A', 'B'])
         >>> df
            A  B
         0  1  3
@@ -8326,7 +8326,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 2, 3, 4], 'B': [3, 4, 5, 6]}, columns=['A', 'B'])
+        >>> df = ps.DataFrame({'A': [1, 2, 3, 4], 'B': [3, 4, 5, 6]}, columns=['A', 'B'])
         >>> df
            A  B
         0  1  3
@@ -8387,7 +8387,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
         Describing a numeric ``Series``.
 
-        >>> s = pp.Series([1, 2, 3])
+        >>> s = ps.Series([1, 2, 3])
         >>> s.describe()
         count    3.0
         mean     2.0
@@ -8401,7 +8401,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Describing a ``DataFrame``. Only numeric fields are returned.
 
-        >>> df = pp.DataFrame({'numeric1': [1, 2, 3],
+        >>> df = ps.DataFrame({'numeric1': [1, 2, 3],
         ...                    'numeric2': [4.0, 5.0, 6.0],
         ...                    'object': ['a', 'b', 'c']
         ...                   },
@@ -8445,7 +8445,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Describing a ``DataFrame`` and selecting custom percentiles.
 
-        >>> df = pp.DataFrame({'numeric1': [1, 2, 3],
+        >>> df = ps.DataFrame({'numeric1': [1, 2, 3],
         ...                    'numeric2': [4.0, 5.0, 6.0]
         ...                   },
         ...                   columns=['numeric1', 'numeric2'])
@@ -8553,7 +8553,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         DataFrame
             DataFrame with duplicates removed or None if ``inplace=True``.
 
-        >>> df = pp.DataFrame(
+        >>> df = ps.DataFrame(
         ...     {'a': [1, 2, 2, 2, 3], 'b': ['a', 'a', 'a', 'c', 'd']}, columns = ['a', 'b'])
         >>> df
            a  b
@@ -8662,7 +8662,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Create a dataframe with some fictional data.
 
         >>> index = ['Firefox', 'Chrome', 'Safari', 'IE10', 'Konqueror']
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...      'http_status': [200, 200, 404, 404, 301],
         ...      'response_time': [0.04, 0.02, 0.07, 0.08, 1.0]},
         ...       index=index,
@@ -8726,7 +8726,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         of dates).
 
         >>> date_index = pd.date_range('1/1/2010', periods=6, freq='D')
-        >>> df2 = pp.DataFrame({"prices": [100, 101, np.nan, 100, 89, 88]},
+        >>> df2 = ps.DataFrame({"prices": [100, 101, np.nan, 100, 89, 88]},
         ...                    index=date_index)
         >>> df2.sort_index()
                     prices
@@ -8798,13 +8798,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         # When axis is index, we can mimic pandas' by a right outer join.
         nlevels = self._internal.index_level
         assert nlevels <= 1 or (
-            isinstance(index, pp.MultiIndex) and nlevels == index.nlevels
+            isinstance(index, ps.MultiIndex) and nlevels == index.nlevels
         ), "MultiIndex DataFrame can only be reindexed with a similar Koalas MultiIndex."
 
         index_columns = self._internal.index_spark_column_names
         frame = self._internal.resolved_copy.spark_frame.drop(NATURAL_ORDER_COLUMN_NAME)
 
-        if isinstance(index, pp.Index):
+        if isinstance(index, ps.Index):
             if nlevels != index.nlevels:
                 return DataFrame(index._internal.with_new_columns([])).reindex(
                     columns=self.columns, fill_value=fill_value
@@ -8816,7 +8816,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 [scol.alias(index_column) for scol, index_column in zip(scols, index_columns)]
             )
         else:
-            kser = pp.Series(list(index))
+            kser = ps.Series(list(index))
             labels = kser._internal.spark_frame.select(kser.spark.column.alias(index_columns[0]))
             index_names = self._internal.index_names
 
@@ -8949,7 +8949,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Examples
         --------
 
-        >>> df1 = pp.DataFrame([[24.3, 75.7, 'high'],
+        >>> df1 = ps.DataFrame([[24.3, 75.7, 'high'],
         ...                     [31, 87.8, 'high'],
         ...                     [22, 71.6, 'medium'],
         ...                     [35, 95, 'medium']],
@@ -8964,7 +8964,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2014-02-14          22.0             71.6    medium
         2014-02-15          35.0             95.0    medium
 
-        >>> df2 = pp.DataFrame([[28, 'low'],
+        >>> df2 = ps.DataFrame([[28, 'low'],
         ...                     [30, 'low'],
         ...                     [35.1, 'medium']],
         ...                    columns=['temp_celsius', 'windspeed'],
@@ -9021,7 +9021,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': {0: 'a', 1: 'b', 2: 'c'},
+        >>> df = ps.DataFrame({'A': {0: 'a', 1: 'b', 2: 'c'},
         ...                    'B': {0: 1, 1: 3, 2: 5},
         ...                    'C': {0: 2, 1: 4, 2: 6}},
         ...                   columns=['A', 'B', 'C'])
@@ -9031,7 +9031,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1  b  3  4
         2  c  5  6
 
-        >>> pp.melt(df)
+        >>> ps.melt(df)
           variable value
         0        A     a
         1        B     1
@@ -9058,7 +9058,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1        A     b
         2        A     c
 
-        >>> pp.melt(df, id_vars=['A', 'B'])
+        >>> ps.melt(df, id_vars=['A', 'B'])
            A  B variable  value
         0  a  1        C      2
         1  b  3        C      4
@@ -9072,7 +9072,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         The names of 'variable' and 'value' columns can be customized:
 
-        >>> pp.melt(df, id_vars=['A'], value_vars=['B'],
+        >>> ps.melt(df, id_vars=['A'], value_vars=['B'],
         ...         var_name='myVarname', value_name='myValname')
            A myVarname  myValname
         0  a         B          1
@@ -9245,7 +9245,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
         **Single level columns**
 
-        >>> df_single_level_cols = pp.DataFrame([[0, 1], [2, 3]],
+        >>> df_single_level_cols = ps.DataFrame([[0, 1], [2, 3]],
         ...                                     index=['cat', 'dog'],
         ...                                     columns=['weight', 'height'])
 
@@ -9266,7 +9266,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> multicol1 = pd.MultiIndex.from_tuples([('weight', 'kg'),
         ...                                        ('weight', 'pounds')])
-        >>> df_multi_level_cols1 = pp.DataFrame([[1, 2], [2, 4]],
+        >>> df_multi_level_cols1 = ps.DataFrame([[1, 2], [2, 4]],
         ...                                     index=['cat', 'dog'],
         ...                                     columns=multicol1)
 
@@ -9288,7 +9288,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> multicol2 = pd.MultiIndex.from_tuples([('weight', 'kg'),
         ...                                        ('height', 'm')])
-        >>> df_multi_level_cols2 = pp.DataFrame([[1.0, 2.0], [3.0, 4.0]],
+        >>> df_multi_level_cols2 = ps.DataFrame([[1.0, 2.0], [3.0, 4.0]],
         ...                                     index=['cat', 'dog'],
         ...                                     columns=multicol2)
 
@@ -9409,7 +9409,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({"A": {"0": "a", "1": "b", "2": "c"},
+        >>> df = ps.DataFrame({"A": {"0": "a", "1": "b", "2": "c"},
         ...                    "B": {"0": "1", "1": "3", "2": "5"},
         ...                    "C": {"0": "2", "1": "4", "2": "6"}},
         ...                   columns=["A", "B", "C"])
@@ -9446,7 +9446,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         For MultiIndex case:
 
-        >>> df = pp.DataFrame({"A": ["a", "b", "c"],
+        >>> df = ps.DataFrame({"A": ["a", "b", "c"],
         ...                    "B": [1, 3, 5],
         ...                    "C": [2, 4, 6]},
         ...                   columns=["A", "B", "C"])
@@ -9569,7 +9569,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
         Create a dataframe from a dictionary.
 
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...    'col1': [True, True, True],
         ...    'col2': [True, False, False],
         ...    'col3': [0, 0, 0],
@@ -9656,7 +9656,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
         Create a dataframe from a dictionary.
 
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...    'col1': [False, False, False],
         ...    'col2': [True, False, False],
         ...    'col3': [0, 0, 1],
@@ -9747,7 +9747,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 2, 2, 3], 'B': [4, 3, 2, 1]}, columns= ['A', 'B'])
+        >>> df = ps.DataFrame({'A': [1, 2, 2, 3], 'B': [4, 3, 2, 1]}, columns= ['A', 'B'])
         >>> df
            A  B
         0  1  4
@@ -9831,7 +9831,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame(np.array(([1, 2, 3], [4, 5, 6])),
+        >>> df = ps.DataFrame(np.array(([1, 2, 3], [4, 5, 6])),
         ...                   index=['mouse', 'rabbit'],
         ...                   columns=['one', 'two', 'three'])
 
@@ -9997,7 +9997,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> kdf1 = pp.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        >>> kdf1 = ps.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
         >>> kdf1.rename(columns={"A": "a", "B": "c"})  # doctest: +NORMALIZE_WHITESPACE
            a  c
         0  1  4
@@ -10027,14 +10027,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         20  3  6
 
         >>> idx = pd.MultiIndex.from_tuples([('X', 'A'), ('X', 'B'), ('Y', 'C'), ('Y', 'D')])
-        >>> kdf2 = pp.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=idx)
+        >>> kdf2 = ps.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=idx)
         >>> kdf2.rename(columns=str_lower, level=0)  # doctest: +NORMALIZE_WHITESPACE
            x     y
            A  B  C  D
         0  1  2  3  4
         1  5  6  7  8
 
-        >>> kdf3 = pp.DataFrame([[1, 2], [3, 4], [5, 6], [7, 8]], index=idx, columns=list('ab'))
+        >>> kdf3 = ps.DataFrame([[1, 2], [3, 4], [5, 6], [7, 8]], index=idx, columns=list('ab'))
         >>> kdf3.rename(index=str_lower)  # doctest: +NORMALIZE_WHITESPACE
              a  b
         x a  1  2
@@ -10231,7 +10231,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({"num_legs": [4, 4, 2],
+        >>> df = ps.DataFrame({"num_legs": [4, 4, 2],
         ...                    "num_arms": [0, 0, 2]},
         ...                   index=["dog", "cat", "monkey"],
         ...                   columns=["num_legs", "num_arms"])
@@ -10262,7 +10262,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> index = pd.MultiIndex.from_product([['mammal'],
         ...                                     ['dog', 'cat', 'monkey']],
         ...                                    names=['type', 'name'])
-        >>> df = pp.DataFrame({"num_legs": [4, 4, 2],
+        >>> df = ps.DataFrame({"num_legs": [4, 4, 2],
         ...                    "num_arms": [0, 0, 2]},
         ...                   index=index,
         ...                   columns=["num_legs", "num_arms"])
@@ -10349,7 +10349,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame([[1, 2], [4, 5], [7, 8]],
+        >>> df = ps.DataFrame([[1, 2], [4, 5], [7, 8]],
         ...                   index=['cobra', 'viper', 'sidewinder'],
         ...                   columns=['max_speed', 'shield'])
         >>> df
@@ -10386,7 +10386,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Percentage change in French franc, Deutsche Mark, and Italian lira
         from 1980-01-01 to 1980-03-01.
 
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'FR': [4.0405, 4.0963, 4.3149],
         ...     'GR': [1.7246, 1.7482, 1.8519],
         ...     'IT': [804.74, 810.01, 860.13]},
@@ -10445,7 +10445,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({'a': [1, 2, 3, 2],
+        >>> kdf = ps.DataFrame({'a': [1, 2, 3, 2],
         ...                     'b': [4.0, 2.0, 3.0, 1.0],
         ...                     'c': [300, 200, 400, 200]})
         >>> kdf
@@ -10463,7 +10463,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         For Multi-column Index
 
-        >>> kdf = pp.DataFrame({'a': [1, 2, 3, 2],
+        >>> kdf = ps.DataFrame({'a': [1, 2, 3, 2],
         ...                     'b': [4.0, 2.0, 3.0, 1.0],
         ...                     'c': [300, 200, 400, 200]})
         >>> kdf.columns = pd.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
@@ -10497,7 +10497,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = DataFrame(self._internal.with_filter(cond))  # type: "DataFrame"
 
-        return cast(pp.Series, pp.from_pandas(kdf._to_internal_pandas().idxmax()))
+        return cast(ps.Series, ps.from_pandas(kdf._to_internal_pandas().idxmax()))
 
     # TODO: axis = 1
     def idxmin(self, axis=0) -> "Series":
@@ -10523,7 +10523,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({'a': [1, 2, 3, 2],
+        >>> kdf = ps.DataFrame({'a': [1, 2, 3, 2],
         ...                     'b': [4.0, 2.0, 3.0, 1.0],
         ...                     'c': [300, 200, 400, 200]})
         >>> kdf
@@ -10541,7 +10541,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         For Multi-column Index
 
-        >>> kdf = pp.DataFrame({'a': [1, 2, 3, 2],
+        >>> kdf = ps.DataFrame({'a': [1, 2, 3, 2],
         ...                     'b': [4.0, 2.0, 3.0, 1.0],
         ...                     'c': [300, 200, 400, 200]})
         >>> kdf.columns = pd.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
@@ -10569,7 +10569,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         kdf = DataFrame(self._internal.with_filter(cond))  # type: "DataFrame"
 
-        return cast(pp.Series, pp.from_pandas(kdf._to_internal_pandas().idxmin()))
+        return cast(ps.Series, ps.from_pandas(kdf._to_internal_pandas().idxmin()))
 
     def info(self, verbose=None, buf=None, max_cols=None, null_counts=None) -> None:
         """
@@ -10608,7 +10608,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> int_values = [1, 2, 3, 4, 5]
         >>> text_values = ['alpha', 'beta', 'gamma', 'delta', 'epsilon']
         >>> float_values = [0.0, 0.25, 0.5, 0.75, 1.0]
-        >>> df = pp.DataFrame(
+        >>> df = ps.DataFrame(
         ...     {"int_col": int_values, "text_col": text_values, "float_col": float_values},
         ...     columns=['int_col', 'text_col', 'float_col'])
         >>> df
@@ -10723,7 +10723,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({'a': [1, 2, 3, 4, 5], 'b': [6, 7, 8, 9, 0]})
+        >>> kdf = ps.DataFrame({'a': [1, 2, 3, 4, 5], 'b': [6, 7, 8, 9, 0]})
         >>> kdf
            a  b
         0  1  6
@@ -10859,7 +10859,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             So, for example, to use `@` syntax, make sure the variable is serialized by, for
             example, putting it within the closure as below.
 
-            >>> df = pp.DataFrame({'A': range(2000), 'B': range(2000)})
+            >>> df = ps.DataFrame({'A': range(2000), 'B': range(2000)})
             >>> def query_func(pdf):
             ...     num = 1995
             ...     return pdf.query('A > @num')
@@ -10892,7 +10892,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': range(1, 6),
+        >>> df = ps.DataFrame({'A': range(1, 6),
         ...                    'B': range(10, 0, -2),
         ...                    'C C': range(10, 5, -1)})
         >>> df
@@ -10991,7 +10991,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame([('falcon', 'bird', 389.0),
+        >>> df = ps.DataFrame([('falcon', 'bird', 389.0),
         ...                    ('parrot', 'bird', 24.0),
         ...                    ('lion', 'mammal', 80.5),
         ...                    ('monkey', 'mammal', np.nan)],
@@ -11072,7 +11072,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': range(1, 6), 'B': range(10, 0, -2)})
+        >>> df = ps.DataFrame({'A': range(1, 6), 'B': range(10, 0, -2)})
         >>> df
            A   B
         0  1  10
@@ -11182,7 +11182,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [[1, 2, 3], [], [3, 4]], 'B': 1})
+        >>> df = ps.DataFrame({'A': [[1, 2, 3], [], [3, 4]], 'B': 1})
         >>> df
                    A  B
         0  [1, 2, 3]  1
@@ -11234,7 +11234,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
+        >>> df = ps.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
         ...                   columns=['a', 'b'])
 
         >>> df.mad()
@@ -11290,7 +11290,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
 
             # The data is expected to be small so it's fine to transpose/use default index.
-            with pp.option_context("compute.max_rows", 1):
+            with ps.option_context("compute.max_rows", 1):
                 internal = InternalFrame(
                     spark_frame=sdf,
                     index_spark_columns=[scol_for(sdf, SPARK_DEFAULT_INDEX_NAME)],
@@ -11344,7 +11344,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = pp.DataFrame({'animal': ['alligator', 'bee', 'falcon', 'lion',
+        >>> df = ps.DataFrame({'animal': ['alligator', 'bee', 'falcon', 'lion',
         ...                    'monkey', 'parrot', 'shark', 'whale', 'zebra']})
         >>> df
               animal
@@ -11394,7 +11394,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if n < 0:
             n = len(self) + n
         if n <= 0:
-            return pp.DataFrame(self._internal.with_filter(F.lit(False)))
+            return ps.DataFrame(self._internal.with_filter(F.lit(False)))
         # Should use `resolved_copy` here for the case like `(kdf + 1).tail()`
         sdf = self._internal.resolved_copy.spark_frame
         rows = sdf.tail(n)
@@ -11431,9 +11431,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> pp.set_option("compute.ops_on_diff_frames", True)
-        >>> df1 = pp.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}, index=[10, 20, 30])
-        >>> df2 = pp.DataFrame({"a": [4, 5, 6], "c": ["d", "e", "f"]}, index=[10, 11, 12])
+        >>> ps.set_option("compute.ops_on_diff_frames", True)
+        >>> df1 = ps.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}, index=[10, 20, 30])
+        >>> df2 = ps.DataFrame({"a": [4, 5, 6], "c": ["d", "e", "f"]}, index=[10, 11, 12])
 
         Align both axis:
 
@@ -11497,7 +11497,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Align with a Series:
 
-        >>> s = pp.Series([7, 8, 9], index=[10, 11, 12])
+        >>> s = ps.Series([7, 8, 9], index=[10, 11, 12])
         >>> aligned_l, aligned_r = df1.align(s, axis=0)
         >>> aligned_l.sort_index()
               a     b
@@ -11514,7 +11514,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         30    NaN
         dtype: float64
 
-        >>> pp.reset_option("compute.ops_on_diff_frames")
+        >>> ps.reset_option("compute.ops_on_diff_frames")
         """
         from pyspark.pandas.series import Series, first_series
 
@@ -11615,7 +11615,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         By default the keys of the dict become the DataFrame columns:
 
         >>> data = {'col_1': [3, 2, 1, 0], 'col_2': [10, 20, 30, 40]}
-        >>> pp.DataFrame.from_dict(data)
+        >>> ps.DataFrame.from_dict(data)
            col_1  col_2
         0      3     10
         1      2     20
@@ -11626,7 +11626,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         keys as rows:
 
         >>> data = {'row_1': [3, 2, 1, 0], 'row_2': [10, 20, 30, 40]}
-        >>> pp.DataFrame.from_dict(data, orient='index').sort_index()
+        >>> ps.DataFrame.from_dict(data, orient='index').sort_index()
                 0   1   2   3
         row_1   3   2   1   0
         row_2  10  20  30  40
@@ -11634,7 +11634,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         When using the 'index' orientation, the column names can be
         specified manually:
 
-        >>> pp.DataFrame.from_dict(data, orient='index',
+        >>> ps.DataFrame.from_dict(data, orient='index',
         ...                        columns=['A', 'B', 'C', 'D']).sort_index()
                 A   B   C   D
         row_1   3   2   1   0
@@ -11754,7 +11754,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 True,
             ):
                 kdf = self.reset_index()
-                kdf[key] = pp.DataFrame(value)
+                kdf[key] = ps.DataFrame(value)
                 kdf = kdf.set_index(kdf.columns[: self._internal.index_level])
                 kdf.index.names = self.index.names
 
@@ -11990,7 +11990,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.frame.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.frame tests").getOrCreate()
     )

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -10876,7 +10876,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             The query string to evaluate.
 
             You can refer to column names that contain spaces by surrounding
-            them in backticpp.
+            them in backticks.
 
             For example, if one of your columns is called ``a a`` and you want
             to sum it with ``b``, your query should be ```a a` + b``.

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -41,7 +41,7 @@ from pyspark.sql.types import (
     NumericType,
 )
 
-from pyspark import pandas as pp  # For running doctests and reference resolution in PyCharm.
+from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from pyspark.pandas.internal import InternalFrame
 from pyspark.pandas.spark import functions as SF
@@ -147,7 +147,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame([[2.0, 1.0], [3.0, None], [1.0, 0.0]], columns=list('AB'))
+        >>> df = ps.DataFrame([[2.0, 1.0], [3.0, None], [1.0, 0.0]], columns=list('AB'))
         >>> df
              A    B
         0  2.0  1.0
@@ -208,7 +208,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame([[2.0, 1.0], [3.0, None], [1.0, 0.0]], columns=list('AB'))
+        >>> df = ps.DataFrame([[2.0, 1.0], [3.0, None], [1.0, 0.0]], columns=list('AB'))
         >>> df
              A    B
         0  2.0  1.0
@@ -269,7 +269,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame([[2.0, 1.0], [3.0, None], [1.0, 0.0]], columns=list('AB'))
+        >>> df = ps.DataFrame([[2.0, 1.0], [3.0, None], [1.0, 0.0]], columns=list('AB'))
         >>> df
              A    B
         0  2.0  1.0
@@ -337,7 +337,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame([[2.0, 1.0], [3.0, None], [4.0, 10.0]], columns=list('AB'))
+        >>> df = ps.DataFrame([[2.0, 1.0], [3.0, None], [4.0, 10.0]], columns=list('AB'))
         >>> df
              A     B
         0  2.0   1.0
@@ -383,7 +383,7 @@ class Frame(object, metaclass=ABCMeta):
         Examples
         --------
         >>> a = [['a', 1, 1], ['b', 2, 2], ['c', 3, 3]]
-        >>> df = pp.DataFrame(a, columns=['str', 'int1', 'int2'])
+        >>> df = ps.DataFrame(a, columns=['str', 'int1', 'int2'])
         >>> df
           str  int1  int2
         0   a     1     1
@@ -437,7 +437,7 @@ class Frame(object, metaclass=ABCMeta):
         Use ``.pipe`` when chaining together functions that expect
         Series, DataFrames or GroupBy objects. For example, given
 
-        >>> df = pp.DataFrame({'category': ['A', 'A', 'B'],
+        >>> df = ps.DataFrame({'category': ['A', 'A', 'B'],
         ...                    'col1': [1, 2, 3],
         ...                    'col2': [4, 5, 6]},
         ...                   columns=['category', 'col1', 'col2'])
@@ -488,7 +488,7 @@ class Frame(object, metaclass=ABCMeta):
 
         You can use lambda as wel
 
-        >>> pp.Series([1, 2, 3]).pipe(lambda x: (x + 1).rename("value"))
+        >>> ps.Series([1, 2, 3]).pipe(lambda x: (x + 1).rename("value"))
         0    2
         1    3
         2    4
@@ -517,26 +517,26 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> pp.DataFrame({"A": [1, 2], "B": [3, 4]}).to_numpy()
+        >>> ps.DataFrame({"A": [1, 2], "B": [3, 4]}).to_numpy()
         array([[1, 3],
                [2, 4]])
 
         With heterogeneous data, the lowest common type will have to be used.
 
-        >>> pp.DataFrame({"A": [1, 2], "B": [3.0, 4.5]}).to_numpy()
+        >>> ps.DataFrame({"A": [1, 2], "B": [3.0, 4.5]}).to_numpy()
         array([[1. , 3. ],
                [2. , 4.5]])
 
         For a mix of numeric and non-numeric types, the output array will have object dtype.
 
-        >>> df = pp.DataFrame({"A": [1, 2], "B": [3.0, 4.5], "C": pd.date_range('2000', periods=2)})
+        >>> df = ps.DataFrame({"A": [1, 2], "B": [3.0, 4.5], "C": pd.date_range('2000', periods=2)})
         >>> df.to_numpy()
         array([[1, 3.0, Timestamp('2000-01-01 00:00:00')],
                [2, 4.5, Timestamp('2000-01-02 00:00:00')]], dtype=object)
 
         For Series,
 
-        >>> pp.Series(['a', 'b', 'a']).to_numpy()
+        >>> ps.Series(['a', 'b', 'a']).to_numpy()
         array(['a', 'b', 'a'], dtype=object)
         """
         return self.to_pandas().values
@@ -560,7 +560,7 @@ class Frame(object, metaclass=ABCMeta):
         A DataFrame where all columns are the same type (e.g., int64) results in an array of
         the same type.
 
-        >>> df = pp.DataFrame({'age':    [ 3,  29],
+        >>> df = ps.DataFrame({'age':    [ 3,  29],
         ...                    'height': [94, 170],
         ...                    'weight': [31, 115]})
         >>> df
@@ -579,7 +579,7 @@ class Frame(object, metaclass=ABCMeta):
         A DataFrame with mixed type columns(e.g., str/object, int64, float32) results in an ndarray
         of the broadest type that accommodates these mixed types (e.g., object).
 
-        >>> df2 = pp.DataFrame([('parrot',   24.0, 'second'),
+        >>> df2 = ps.DataFrame([('parrot',   24.0, 'second'),
         ...                     ('lion',     80.5, 'first'),
         ...                     ('monkey', np.nan, None)],
         ...                   columns=('name', 'max_speed', 'rank'))
@@ -595,10 +595,10 @@ class Frame(object, metaclass=ABCMeta):
 
         For Series,
 
-        >>> pp.Series([1, 2, 3]).values
+        >>> ps.Series([1, 2, 3]).values
         array([1, 2, 3])
 
-        >>> pp.Series(list('aabc')).values
+        >>> ps.Series(list('aabc')).values
         array(['a', 'a', 'b', 'c'], dtype=object)
         """
         warnings.warn("We recommend using `{}.to_numpy()` instead.".format(type(self).__name__))
@@ -687,7 +687,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame(dict(
+        >>> df = ps.DataFrame(dict(
         ...    date=list(pd.date_range('2012-1-1 12:00:00', periods=3, freq='M')),
         ...    country=['KR', 'US', 'JP'],
         ...    code=[1, 2 ,3]), columns=['date', 'country', 'code'])
@@ -704,7 +704,7 @@ class Frame(object, metaclass=ABCMeta):
         2012-03-31 12:00:00,JP,3
 
         >>> df.cummax().to_csv(path=r'%s/to_csv/foo.csv' % path, num_files=1)
-        >>> pp.read_csv(
+        >>> ps.read_csv(
         ...    path=r'%s/to_csv/foo.csv' % path
         ... ).sort_values(by="date")  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
                            date country  code
@@ -721,7 +721,7 @@ class Frame(object, metaclass=ABCMeta):
         2012-03-31 12:00:00
 
         >>> df.date.to_csv(path=r'%s/to_csv/foo.csv' % path, num_files=1)
-        >>> pp.read_csv(
+        >>> ps.read_csv(
         ...     path=r'%s/to_csv/foo.csv' % path
         ... ).sort_values(by="date")  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
                            date
@@ -736,7 +736,7 @@ class Frame(object, metaclass=ABCMeta):
         ...     path=r'%s/to_csv/bar.csv' % path,
         ...     num_files=1,
         ...     index_col=["index1", "index2"])
-        >>> pp.read_csv(
+        >>> ps.read_csv(
         ...     path=r'%s/to_csv/bar.csv' % path, index_col=["index1", "index2"]
         ... ).sort_values(by="date")  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
                                      date
@@ -752,7 +752,7 @@ class Frame(object, metaclass=ABCMeta):
             # If path is none, just collect and use pandas's to_csv.
             kdf_or_ser = self
             if (LooseVersion("0.24") > LooseVersion(pd.__version__)) and isinstance(
-                self, pp.Series
+                self, ps.Series
             ):
                 # 0.23 seems not having 'columns' parameter in Series' to_csv.
                 return kdf_or_ser.to_pandas().to_csv(  # type: ignore
@@ -777,7 +777,7 @@ class Frame(object, metaclass=ABCMeta):
                 )
 
         kdf = self
-        if isinstance(self, pp.Series):
+        if isinstance(self, ps.Series):
             kdf = self.to_frame()
 
         if columns is None:
@@ -911,7 +911,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame([['a', 'b'], ['c', 'd']],
+        >>> df = ps.DataFrame([['a', 'b'], ['c', 'd']],
         ...                   columns=['col 1', 'col 2'])
         >>> df.to_json()
         '[{"col 1":"a","col 2":"b"},{"col 1":"c","col 2":"d"}]'
@@ -920,7 +920,7 @@ class Frame(object, metaclass=ABCMeta):
         '[{"col 1":"a"},{"col 1":"c"}]'
 
         >>> df.to_json(path=r'%s/to_json/foo.json' % path, num_files=1)
-        >>> pp.read_json(
+        >>> ps.read_json(
         ...     path=r'%s/to_json/foo.json' % path
         ... ).sort_values(by="col 1")
           col 1 col 2
@@ -928,7 +928,7 @@ class Frame(object, metaclass=ABCMeta):
         1     c     d
 
         >>> df['col 1'].to_json(path=r'%s/to_json/foo.json' % path, num_files=1, index_col="index")
-        >>> pp.read_json(
+        >>> ps.read_json(
         ...     path=r'%s/to_json/foo.json' % path, index_col="index"
         ... ).sort_values(by="col 1")  # doctest: +NORMALIZE_WHITESPACE
               col 1
@@ -949,14 +949,14 @@ class Frame(object, metaclass=ABCMeta):
             # If path is none, just collect and use pandas's to_json.
             kdf_or_ser = self
             pdf = kdf_or_ser.to_pandas()  # type: ignore
-            if isinstance(self, pp.Series):
+            if isinstance(self, ps.Series):
                 pdf = pdf.to_frame()
             # To make the format consistent and readable by `read_json`, convert it to pandas' and
             # use 'records' orient for now.
             return pdf.to_json(orient="records")
 
         kdf = self
-        if isinstance(self, pp.Series):
+        if isinstance(self, ps.Series):
             kdf = self.to_frame()
         sdf = kdf.to_spark(index_col=index_col)  # type: ignore
 
@@ -1062,7 +1062,7 @@ class Frame(object, metaclass=ABCMeta):
         --------
         Create, write to and save a workbook:
 
-        >>> df1 = pp.DataFrame([['a', 'b'], ['c', 'd']],
+        >>> df1 = ps.DataFrame([['a', 'b'], ['c', 'd']],
         ...                    index=['row 1', 'row 2'],
         ...                    columns=['col 1', 'col 2'])
         >>> df1.to_excel("output.xlsx")  # doctest: +SKIP
@@ -1090,9 +1090,9 @@ class Frame(object, metaclass=ABCMeta):
         args = locals()
         kdf = self
 
-        if isinstance(self, pp.DataFrame):
+        if isinstance(self, ps.DataFrame):
             f = pd.DataFrame.to_excel
-        elif isinstance(self, pp.Series):
+        elif isinstance(self, ps.Series):
             f = pd.Series.to_excel
         else:
             raise TypeError(
@@ -1123,7 +1123,7 @@ class Frame(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
+        >>> df = ps.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
         ...                   columns=['a', 'b'])
 
         On a DataFrame:
@@ -1189,7 +1189,7 @@ class Frame(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, np.nan, 0.3, np.nan]},
+        >>> df = ps.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, np.nan, 0.3, np.nan]},
         ...                   columns=['a', 'b'])
 
         On a DataFrame:
@@ -1276,7 +1276,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Non-numeric type column is not included to the result.
 
-        >>> kdf = pp.DataFrame({'A': [1, 2, 3, 4, 5],
+        >>> kdf = ps.DataFrame({'A': [1, 2, 3, 4, 5],
         ...                     'B': [10, 20, 30, 40, 50],
         ...                     'C': ['a', 'b', 'c', 'd', 'e']})
         >>> kdf
@@ -1294,22 +1294,22 @@ class Frame(object, metaclass=ABCMeta):
 
         If there is no numeric type columns, returns empty Series.
 
-        >>> pp.DataFrame({"key": ['a', 'b', 'c'], "val": ['x', 'y', 'z']}).prod()
+        >>> ps.DataFrame({"key": ['a', 'b', 'c'], "val": ['x', 'y', 'z']}).prod()
         Series([], dtype: float64)
 
         On a Series:
 
-        >>> pp.Series([1, 2, 3, 4, 5]).prod()
+        >>> ps.Series([1, 2, 3, 4, 5]).prod()
         120
 
         By default, the product of an empty or all-NA Series is ``1``
 
-        >>> pp.Series([]).prod()
+        >>> ps.Series([]).prod()
         1.0
 
         This can be controlled with the ``min_count`` parameter
 
-        >>> pp.Series([]).prod(min_count=1)
+        >>> ps.Series([]).prod(min_count=1)
         nan
         """
         axis = validate_axis(axis)
@@ -1370,7 +1370,7 @@ class Frame(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
+        >>> df = ps.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
         ...                   columns=['a', 'b'])
 
         On a DataFrame:
@@ -1427,7 +1427,7 @@ class Frame(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
+        >>> df = ps.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
         ...                   columns=['a', 'b'])
 
         On a DataFrame:
@@ -1486,7 +1486,7 @@ class Frame(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
+        >>> df = ps.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
         ...                   columns=['a', 'b'])
 
         On a DataFrame:
@@ -1541,7 +1541,7 @@ class Frame(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
+        >>> df = ps.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
         ...                   columns=['a', 'b'])
 
         On a DataFrame:
@@ -1606,7 +1606,7 @@ class Frame(object, metaclass=ABCMeta):
         --------
         Constructing DataFrame from a dictionary:
 
-        >>> df = pp.DataFrame({"Person":
+        >>> df = ps.DataFrame({"Person":
         ...                    ["John", "Myla", "Lewis", "John", "Myla"],
         ...                    "Age": [24., np.nan, 21., 33, 26],
         ...                    "Single": [False, True, True, True, False]},
@@ -1672,7 +1672,7 @@ class Frame(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
+        >>> df = ps.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
         ...                   columns=['a', 'b'])
 
         On a DataFrame:
@@ -1751,7 +1751,7 @@ class Frame(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
+        >>> df = ps.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]},
         ...                   columns=['a', 'b'])
 
         On a DataFrame:
@@ -1833,7 +1833,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'a': [24., 21., 25., 33., 26.], 'b': [1, 2, 3, 4, 5]}, columns=['a', 'b'])
         >>> df
               a  b
@@ -1938,7 +1938,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        >>> kdf = ps.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         >>> kdf
            a  b
         0  1  4
@@ -2016,15 +2016,15 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> s = pp.Series({'a': 1, 'b': 2, 'c': None})
+        >>> s = ps.Series({'a': 1, 'b': 2, 'c': None})
         >>> s.size
         3
 
-        >>> df = pp.DataFrame({'col1': [1, 2, None], 'col2': [3, 4, None]})
+        >>> df = ps.DataFrame({'col1': [1, 2, None], 'col2': [3, 4, None]})
         >>> df.size
         6
 
-        >>> df = pp.DataFrame(index=[1, 2, None])
+        >>> df = ps.DataFrame(index=[1, 2, None])
         >>> df.size
         0
         """
@@ -2047,7 +2047,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Absolute numeric values in a Series.
 
-        >>> s = pp.Series([-1.10, 2, -3.33, 4])
+        >>> s = ps.Series([-1.10, 2, -3.33, 4])
         >>> s.abs()
         0    1.10
         1    2.00
@@ -2057,7 +2057,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Absolute numeric values in a DataFrame.
 
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'a': [4, 5, 6, 7],
         ...     'b': [10, 20, 30, 40],
         ...     'c': [100, 50, -30, -50]
@@ -2129,7 +2129,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'Animal': ['Falcon', 'Falcon',
+        >>> df = ps.DataFrame({'Animal': ['Falcon', 'Falcon',
         ...                               'Parrot', 'Parrot'],
         ...                    'Max Speed': [380., 370., 24., 26.]},
         ...                   columns=['Animal', 'Max Speed'])
@@ -2156,7 +2156,7 @@ class Frame(object, metaclass=ABCMeta):
         the default setting is True:
 
         >>> l = [[1, 2, 3], [1, None, 4], [2, 1, 3], [1, 2, 2]]
-        >>> df = pp.DataFrame(l, columns=["a", "b", "c"])
+        >>> df = ps.DataFrame(l, columns=["a", "b", "c"])
         >>> df.groupby(by=["b"]).sum().sort_index()  # doctest: +NORMALIZE_WHITESPACE
              a  c
         b
@@ -2172,33 +2172,33 @@ class Frame(object, metaclass=ABCMeta):
         """
         from pyspark.pandas.groupby import DataFrameGroupBy, SeriesGroupBy
 
-        if isinstance(by, pp.DataFrame):
+        if isinstance(by, ps.DataFrame):
             raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by).__name__))
-        elif isinstance(by, pp.Series):
+        elif isinstance(by, ps.Series):
             by = [by]
         elif is_name_like_tuple(by):
-            if isinstance(self, pp.Series):
+            if isinstance(self, ps.Series):
                 raise KeyError(by)
             by = [by]
         elif is_name_like_value(by):
-            if isinstance(self, pp.Series):
+            if isinstance(self, ps.Series):
                 raise KeyError(by)
             by = [(by,)]
         elif is_list_like(by):
-            new_by = []  # type: List[Union[Tuple, pp.Series]]
+            new_by = []  # type: List[Union[Tuple, ps.Series]]
             for key in by:
-                if isinstance(key, pp.DataFrame):
+                if isinstance(key, ps.DataFrame):
                     raise ValueError(
                         "Grouper for '{}' not 1-dimensional".format(type(key).__name__)
                     )
-                elif isinstance(key, pp.Series):
+                elif isinstance(key, ps.Series):
                     new_by.append(key)
                 elif is_name_like_tuple(key):
-                    if isinstance(self, pp.Series):
+                    if isinstance(self, ps.Series):
                         raise KeyError(key)
                     new_by.append(key)
                 elif is_name_like_value(key):
-                    if isinstance(self, pp.Series):
+                    if isinstance(self, ps.Series):
                         raise KeyError(key)
                     new_by.append((key,))
                 else:
@@ -2214,9 +2214,9 @@ class Frame(object, metaclass=ABCMeta):
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
 
-        if isinstance(self, pp.DataFrame):
+        if isinstance(self, ps.DataFrame):
             return DataFrameGroupBy._build(self, by, as_index=as_index, dropna=dropna)
-        elif isinstance(self, pp.Series):
+        elif isinstance(self, ps.Series):
             return SeriesGroupBy._build(self, by, as_index=as_index, dropna=dropna)
         else:
             raise TypeError(
@@ -2236,34 +2236,34 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> pp.DataFrame({'a': [True]}).bool()
+        >>> ps.DataFrame({'a': [True]}).bool()
         True
 
-        >>> pp.Series([False]).bool()
+        >>> ps.Series([False]).bool()
         False
 
         If there are non-boolean or multiple values exist, it raises an exception in all
         cases as below.
 
-        >>> pp.DataFrame({'a': ['a']}).bool()
+        >>> ps.DataFrame({'a': ['a']}).bool()
         Traceback (most recent call last):
           ...
         ValueError: bool cannot act on a non-boolean single element DataFrame
 
-        >>> pp.DataFrame({'a': [True], 'b': [False]}).bool()  # doctest: +NORMALIZE_WHITESPACE
+        >>> ps.DataFrame({'a': [True], 'b': [False]}).bool()  # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
           ...
         ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(),
         a.item(), a.any() or a.all().
 
-        >>> pp.Series([1]).bool()
+        >>> ps.Series([1]).bool()
         Traceback (most recent call last):
           ...
         ValueError: bool cannot act on a non-boolean single element DataFrame
         """
-        if isinstance(self, pp.DataFrame):
+        if isinstance(self, ps.DataFrame):
             df = self
-        elif isinstance(self, pp.Series):
+        elif isinstance(self, ps.Series):
             df = self.to_dataframe()
         else:
             raise TypeError("bool() expects DataFrame or Series; however, " "got [%s]" % (self,))
@@ -2282,7 +2282,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Support for DataFrame
 
-        >>> kdf = pp.DataFrame({'a': [None, 2, 3, 2],
+        >>> kdf = ps.DataFrame({'a': [None, 2, 3, 2],
         ...                     'b': [None, 2.0, 3.0, 1.0],
         ...                     'c': [None, 200, 400, 200]},
         ...                     index=['Q', 'W', 'E', 'R'])
@@ -2312,7 +2312,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Support for Series.
 
-        >>> s = pp.Series([None, None, 3, 4, 5], index=[100, 200, 300, 400, 500])
+        >>> s = ps.Series([None, None, 3, 4, 5], index=[100, 200, 300, 400, 500])
         >>> s
         100    NaN
         200    NaN
@@ -2330,7 +2330,7 @@ class Frame(object, metaclass=ABCMeta):
         ...                       ['speed', 'weight', 'length']],
         ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-        >>> s = pp.Series([None, None, None, None, 250, 1.5, 320, 1, 0.3], index=midx)
+        >>> s = ps.Series([None, None, None, None, 250, 1.5, 320, 1, 0.3], index=midx)
         >>> s
         lama    speed       NaN
                 weight      NaN
@@ -2389,7 +2389,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Support for DataFrame
 
-        >>> kdf = pp.DataFrame({'a': [1, 2, 3, None],
+        >>> kdf = ps.DataFrame({'a': [1, 2, 3, None],
         ...                     'b': [1.0, 2.0, 3.0, None],
         ...                     'c': [100, 200, 400, None]},
         ...                     index=['Q', 'W', 'E', 'R'])
@@ -2419,7 +2419,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Support for Series.
 
-        >>> s = pp.Series([1, 2, 3, None, None], index=[100, 200, 300, 400, 500])
+        >>> s = ps.Series([1, 2, 3, None, None], index=[100, 200, 300, 400, 500])
         >>> s
         100    1.0
         200    2.0
@@ -2437,7 +2437,7 @@ class Frame(object, metaclass=ABCMeta):
         ...                       ['speed', 'weight', 'length']],
         ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-        >>> s = pp.Series([250, 1.5, 320, 1, 0.3, None, None, None, None], index=midx)
+        >>> s = ps.Series([250, 1.5, 320, 1, 0.3, None, None, None, None], index=midx)
         >>> s
         lama    speed     250.0
                 weight      1.5
@@ -2545,7 +2545,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'x':range(3), 'y':['a','b','b'], 'z':['a','b','b']},
+        >>> df = ps.DataFrame({'x':range(3), 'y':['a','b','b'], 'z':['a','b','b']},
         ...                   columns=['x', 'y', 'z'], index=[10, 20, 20])
         >>> df
             x  y  z
@@ -2614,7 +2614,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> primes = pp.Series([2, 3, 5, 7])
+        >>> primes = ps.Series([2, 3, 5, 7])
 
         Slicing might produce a Series with a single value:
 
@@ -2643,7 +2643,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Squeezing is even more effective when used with DataFrames.
 
-        >>> df = pp.DataFrame([[1, 2], [3, 4]], columns=['a', 'b'])
+        >>> df = ps.DataFrame([[1, 2], [3, 4]], columns=['a', 'b'])
         >>> df
            a  b
         0  1  2
@@ -2688,7 +2688,7 @@ class Frame(object, metaclass=ABCMeta):
             axis = "index" if axis == "rows" else axis
             axis = validate_axis(axis)
 
-        if isinstance(self, pp.DataFrame):
+        if isinstance(self, ps.DataFrame):
             from pyspark.pandas.series import first_series
 
             is_squeezable = len(self.columns[:2]) == 1
@@ -2700,7 +2700,7 @@ class Frame(object, metaclass=ABCMeta):
             # If DataFrame has only a single value, use pandas API directly.
             if has_single_value:
                 result = self._to_internal_pandas().squeeze(axis)
-                return pp.Series(result) if isinstance(result, pd.Series) else result
+                return ps.Series(result) if isinstance(result, pd.Series) else result
             elif axis == 0:
                 return self
             else:
@@ -2711,7 +2711,7 @@ class Frame(object, metaclass=ABCMeta):
             # Otherwise, there is no change.
             self_top_two = self.head(2)
             has_single_value = len(self_top_two) == 1
-            return cast(Union[Scalar, pp.Series], self_top_two[0] if has_single_value else self)
+            return cast(Union[Scalar, ps.Series], self_top_two[0] if has_single_value else self)
 
     def truncate(
         self, before=None, after=None, axis=None, copy=True
@@ -2748,7 +2748,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': ['a', 'b', 'c', 'd', 'e'],
+        >>> df = ps.DataFrame({'A': ['a', 'b', 'c', 'd', 'e'],
         ...                    'B': ['f', 'g', 'h', 'i', 'j'],
         ...                    'C': ['k', 'l', 'm', 'n', 'o']},
         ...                   index=[1, 2, 3, 4, 5])
@@ -2786,7 +2786,7 @@ class Frame(object, metaclass=ABCMeta):
 
         A Series has index that sorted integers.
 
-        >>> s = pp.Series([10, 20, 30, 40, 50, 60, 70],
+        >>> s = ps.Series([10, 20, 30, 40, 50, 60, 70],
         ...               index=[1, 2, 3, 4, 5, 6, 7])
         >>> s
         1    10
@@ -2807,7 +2807,7 @@ class Frame(object, metaclass=ABCMeta):
 
         A Series has index that sorted strings.
 
-        >>> s = pp.Series([10, 20, 30, 40, 50, 60, 70],
+        >>> s = ps.Series([10, 20, 30, 40, 50, 60, 70],
         ...               index=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
         >>> s
         a    10
@@ -2834,16 +2834,16 @@ class Frame(object, metaclass=ABCMeta):
         if not indexes_increasing and not indexes.is_monotonic_decreasing:
             raise ValueError("truncate requires a sorted index")
         if (before is None) and (after is None):
-            return cast(Union[pp.DataFrame, pp.Series], self.copy() if copy else self)
+            return cast(Union[ps.DataFrame, ps.Series], self.copy() if copy else self)
         if (before is not None and after is not None) and before > after:
             raise ValueError("Truncate: %s must be after %s" % (after, before))
 
-        if isinstance(self, pp.Series):
+        if isinstance(self, ps.Series):
             if indexes_increasing:
                 result = first_series(self.to_frame().loc[before:after]).rename(self.name)
             else:
                 result = first_series(self.to_frame().loc[after:before]).rename(self.name)
-        elif isinstance(self, pp.DataFrame):
+        elif isinstance(self, ps.DataFrame):
             if axis == 0:
                 if indexes_increasing:
                     result = self.loc[before:after]
@@ -2852,7 +2852,7 @@ class Frame(object, metaclass=ABCMeta):
             elif axis == 1:
                 result = self.loc[:, before:after]
 
-        return cast(Union[pp.DataFrame, pp.Series], result.copy() if copy else result)
+        return cast(Union[ps.DataFrame, ps.Series], result.copy() if copy else result)
 
     def to_markdown(self, buf=None, mode=None) -> str:
         """
@@ -2879,7 +2879,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> kser = pp.Series(["elk", "pig", "dog", "quetzal"], name="animal")
+        >>> kser = ps.Series(["elk", "pig", "dog", "quetzal"], name="animal")
         >>> print(kser.to_markdown())  # doctest: +SKIP
         |    | animal   |
         |---:|:---------|
@@ -2888,7 +2888,7 @@ class Frame(object, metaclass=ABCMeta):
         |  2 | dog      |
         |  3 | quetzal  |
 
-        >>> kdf = pp.DataFrame(
+        >>> kdf = ps.DataFrame(
         ...     data={"animal_1": ["elk", "pig"], "animal_2": ["dog", "quetzal"]}
         ... )
         >>> print(kdf.to_markdown())  # doctest: +SKIP
@@ -2944,7 +2944,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({
+        >>> kdf = ps.DataFrame({
         ...     'A': [None, 3, None, None],
         ...     'B': [2, 4, None, 3],
         ...     'C': [None, None, None, 1],
@@ -2969,7 +2969,7 @@ class Frame(object, metaclass=ABCMeta):
 
         For Series
 
-        >>> kser = pp.Series([None, None, None, 1])
+        >>> kser = ps.Series([None, None, None, 1])
         >>> kser
         0    NaN
         1    NaN
@@ -3018,7 +3018,7 @@ class Frame(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({
+        >>> kdf = ps.DataFrame({
         ...     'A': [None, 3, None, None],
         ...     'B': [2, 4, None, 3],
         ...     'C': [None, None, None, 1],
@@ -3043,7 +3043,7 @@ class Frame(object, metaclass=ABCMeta):
 
         For Series
 
-        >>> kser = pp.Series([2, 4, None, 3])
+        >>> kser = ps.Series([2, 4, None, 3])
         >>> kser
         0    2.0
         1    4.0
@@ -3114,7 +3114,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.generic.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.generic tests")

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -43,7 +43,7 @@ from pyspark.sql.types import (
 )
 from pyspark.sql.functions import PandasUDFType, pandas_udf, Column
 
-from pyspark import pandas as pp  # For running doctests and reference resolution in PyCharm.
+from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.typedef import infer_return_type, DataFrameType, ScalarType, SeriesType
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.internal import (
@@ -148,7 +148,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 1, 2, 2],
+        >>> df = ps.DataFrame({'A': [1, 1, 2, 2],
         ...                    'B': [1, 2, 3, 4],
         ...                    'C': [0.362, 0.227, 1.267, -0.562]},
         ...                   columns=['A', 'B', 'C'])
@@ -196,7 +196,7 @@ class GroupBy(object, metaclass=ABCMeta):
         also supports 'named aggregation' or nested renaming in .agg. It can also be
         used when applying multiple aggregation functions to specific columns.
 
-        >>> aggregated = df.groupby('A').agg(b_max=pp.NamedAgg(column='B', aggfunc='max'))
+        >>> aggregated = df.groupby('A').agg(b_max=ps.NamedAgg(column='B', aggfunc='max'))
         >>> aggregated.sort_index()  # doctest: +NORMALIZE_WHITESPACE
              b_max
         A
@@ -344,7 +344,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 1, 2, 1, 2],
+        >>> df = ps.DataFrame({'A': [1, 1, 2, 1, 2],
         ...                    'B': [np.nan, 2, 3, 4, 5],
         ...                    'C': [1, 2, 1, 1, 2]}, columns=['A', 'B', 'C'])
         >>> df.groupby('A').count().sort_index()  # doctest: +NORMALIZE_WHITESPACE
@@ -407,7 +407,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 1, 2, 1, 2],
+        >>> df = ps.DataFrame({'A': [1, 1, 2, 1, 2],
         ...                    'B': [np.nan, 2, 3, 4, 5],
         ...                    'C': [1, 2, 1, 1, 2]}, columns=['A', 'B', 'C'])
 
@@ -501,7 +501,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+        >>> df = ps.DataFrame({'A': [1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
         ...                    'B': [True, True, True, False, False,
         ...                          False, None, True, None, False]},
         ...                   columns=['A', 'B'])
@@ -543,7 +543,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+        >>> df = ps.DataFrame({'A': [1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
         ...                    'B': [True, True, True, False, False,
         ...                          False, None, True, None, False]},
         ...                   columns=['A', 'B'])
@@ -585,7 +585,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 2, 2, 3, 3, 3],
+        >>> df = ps.DataFrame({'A': [1, 2, 2, 3, 3, 3],
         ...                    'B': [1, 1, 2, 3, 3, 3]},
         ...                   columns=['A', 'B'])
         >>> df
@@ -668,7 +668,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4, 5, 6],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4, 5, 6],
         ...                    'b': [1, 1, 2, 3, 5, 8],
         ...                    'c': [1, 4, 9, 16, 25, 36]}, columns=['a', 'b', 'c'])
         >>> df
@@ -727,7 +727,7 @@ class GroupBy(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame([['a'], ['a'], ['a'], ['b'], ['b'], ['a']],
+        >>> df = ps.DataFrame([['a'], ['a'], ['a'], ['b'], ['b'], ['a']],
         ...                   columns=['A'])
         >>> df
            A
@@ -779,7 +779,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame(
+        >>> df = ps.DataFrame(
         ...     [[1, None, 4], [1, 0.1, 3], [1, 20.0, 2], [4, 10.0, 1]],
         ...     columns=list('ABC'))
         >>> df
@@ -828,7 +828,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame(
+        >>> df = ps.DataFrame(
         ...     [[1, None, 4], [1, 0.1, 3], [1, 20.0, 2], [4, 10.0, 1]],
         ...     columns=list('ABC'))
         >>> df
@@ -877,7 +877,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame(
+        >>> df = ps.DataFrame(
         ...     [[1, None, 4], [1, 0.1, 3], [1, 20.0, 2], [4, 10.0, 1]],
         ...     columns=list('ABC'))
         >>> df
@@ -926,7 +926,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame(
+        >>> df = ps.DataFrame(
         ...     [[1, None, 4], [1, 0.1, 3], [1, 20.0, 2], [4, 10.0, 1]],
         ...     columns=list('ABC'))
         >>> df
@@ -982,7 +982,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
             To avoid this, specify return type in ``func``, for instance, as below:
 
-            >>> def pandas_div(x) -> pp.DataFrame[float, float]:
+            >>> def pandas_div(x) -> ps.DataFrame[float, float]:
             ...     return x[['B', 'C']] / x[['B', 'C']]
 
             If the return type is specified, the output column names become
@@ -991,11 +991,11 @@ class GroupBy(object, metaclass=ABCMeta):
 
             To specify the column names, you can assign them in a pandas friendly style as below:
 
-            >>> def pandas_div(x) -> pp.DataFrame["a": float, "b": float]:
+            >>> def pandas_div(x) -> ps.DataFrame["a": float, "b": float]:
             ...     return x[['B', 'C']] / x[['B', 'C']]
 
             >>> pdf = pd.DataFrame({'B': [1.], 'C': [3.]})
-            >>> def plus_one(x) -> pp.DataFrame[zip(pdf.columns, pdf.dtypes)]:
+            >>> def plus_one(x) -> ps.DataFrame[zip(pdf.columns, pdf.dtypes)]:
             ...     return x[['B', 'C']] / x[['B', 'C']]
 
             When the given function has the return type annotated, the original index of the
@@ -1028,7 +1028,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': 'a a b'.split(),
+        >>> df = ps.DataFrame({'A': 'a a b'.split(),
         ...                    'B': [1, 2, 3],
         ...                    'C': [4, 6, 5]}, columns=['A', 'B', 'C'])
         >>> g = df.groupby('A')
@@ -1062,7 +1062,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         You can specify the type hint and prevent schema inference for better performance.
 
-        >>> def pandas_div(x) -> pp.DataFrame[float, float]:
+        >>> def pandas_div(x) -> ps.DataFrame[float, float]:
         ...     return x[['B', 'C']] / x[['B', 'C']]
         >>> g.apply(pandas_div).sort_index()  # doctest: +NORMALIZE_WHITESPACE
             c0   c1
@@ -1072,7 +1072,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         In case of Series, it works as below.
 
-        >>> def plus_max(x) -> pp.Series[np.int]:
+        >>> def plus_max(x) -> ps.Series[np.int]:
         ...     return x + x.max()
         >>> df.B.groupby(df.A).apply(plus_max).sort_index()
         0    6
@@ -1155,10 +1155,10 @@ class GroupBy(object, metaclass=ABCMeta):
                 pser_or_pdf = pdf.groupby(groupkeys)[name].apply(pandas_apply, *args, **kwargs)
             else:
                 pser_or_pdf = pdf.groupby(groupkeys).apply(pandas_apply, *args, **kwargs)
-            kser_or_kdf = pp.from_pandas(pser_or_pdf)
+            kser_or_kdf = ps.from_pandas(pser_or_pdf)
 
             if len(pdf) <= limit:
-                if isinstance(kser_or_kdf, pp.Series) and is_series_groupby:
+                if isinstance(kser_or_kdf, ps.Series) and is_series_groupby:
                     kser_or_kdf = kser_or_kdf.rename(cast(SeriesGroupBy, self)._kser.name)
                 return cast(Union[Series, DataFrame], kser_or_kdf)
 
@@ -1276,7 +1276,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A' : ['foo', 'bar', 'foo', 'bar',
+        >>> df = ps.DataFrame({'A' : ['foo', 'bar', 'foo', 'bar',
         ...                           'foo', 'bar'],
         ...                    'B' : [1, 2, 3, 4, 5, 6],
         ...                    'C' : [2.0, 5., 8., 1., 2., 9.]}, columns=['A', 'B', 'C'])
@@ -1413,7 +1413,7 @@ class GroupBy(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
         ...     'b': [1, 2, 2, 2, 3, 3, 3, 4, 4]}, columns=['a', 'b'])
         >>> df
@@ -1478,7 +1478,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 1, 2, 2, 3],
+        >>> df = ps.DataFrame({'a': [1, 1, 2, 2, 3],
         ...                    'b': [1, 2, 3, 4, 5],
         ...                    'c': [5, 4, 3, 2, 1]}, columns=['a', 'b', 'c'])
 
@@ -1557,7 +1557,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 1, 2, 2, 3],
+        >>> df = ps.DataFrame({'a': [1, 1, 2, 2, 3],
         ...                    'b': [1, 2, 3, 4, 5],
         ...                    'c': [5, 4, 3, 2, 1]}, columns=['a', 'b', 'c'])
 
@@ -1648,7 +1648,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'A': [1, 1, 2, 2],
         ...     'B': [2, 4, None, 3],
         ...     'C': [None, None, None, 1],
@@ -1709,7 +1709,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'A': [1, 1, 2, 2],
         ...     'B': [2, 4, None, 3],
         ...     'C': [None, None, None, 1],
@@ -1760,7 +1760,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'A': [1, 1, 2, 2],
         ...     'B': [2, 4, None, 3],
         ...     'C': [None, None, None, 1],
@@ -1837,7 +1837,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 1, 1, 1, 2, 2, 2, 3, 3, 3],
+        >>> df = ps.DataFrame({'a': [1, 1, 1, 1, 2, 2, 2, 3, 3, 3],
         ...                    'b': [2, 3, 1, 4, 6, 9, 8, 10, 7, 5],
         ...                    'c': [3, 5, 2, 5, 1, 2, 6, 4, 3, 6]},
         ...                   columns=['a', 'b', 'c'],
@@ -1890,7 +1890,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 1, 1, 1, 2, 2, 2, 3, 3, 3],
+        >>> df = ps.DataFrame({'a': [1, 1, 1, 1, 2, 2, 2, 3, 3, 3],
         ...                    'b': [2, 3, 1, 4, 6, 9, 8, 10, 7, 5],
         ...                    'c': [3, 5, 2, 5, 1, 2, 6, 4, 3, 6]},
         ...                   columns=['a', 'b', 'c'],
@@ -1946,7 +1946,7 @@ class GroupBy(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({
+        >>> df = ps.DataFrame({
         ...     'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
         ...     'b': [1, 2, 2, 2, 3, 3, 3, 4, 4]}, columns=['a', 'b'])
         >>> df
@@ -2010,7 +2010,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
              To avoid this, specify return type in ``func``, for instance, as below:
 
-             >>> def convert_to_string(x) -> pp.Series[str]:
+             >>> def convert_to_string(x) -> ps.Series[str]:
              ...     return x.apply("a string {}".format)
 
             When the given function has the return type annotated, the original index of the
@@ -2044,7 +2044,7 @@ class GroupBy(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'A': [0, 0, 1],
+        >>> df = ps.DataFrame({'A': [0, 0, 1],
         ...                    'B': [1, 2, 3],
         ...                    'C': [4, 6, 5]}, columns=['A', 'B', 'C'])
 
@@ -2056,7 +2056,7 @@ class GroupBy(object, metaclass=ABCMeta):
         its argument and returns a Series. `transform` applies the function on each series
         in each grouped data, and combine them into a new DataFrame:
 
-        >>> def convert_to_string(x) -> pp.Series[str]:
+        >>> def convert_to_string(x) -> ps.Series[str]:
         ...     return x.apply("a string {}".format)
         >>> g.transform(convert_to_string)  # doctest: +NORMALIZE_WHITESPACE
                     B           C
@@ -2064,7 +2064,7 @@ class GroupBy(object, metaclass=ABCMeta):
         1  a string 2  a string 6
         2  a string 3  a string 5
 
-        >>> def plus_max(x) -> pp.Series[np.int]:
+        >>> def plus_max(x) -> ps.Series[np.int]:
         ...     return x + x.max()
         >>> g.transform(plus_max)  # doctest: +NORMALIZE_WHITESPACE
            B   C
@@ -2098,7 +2098,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         You can also specify extra arguments to pass to the function.
 
-        >>> def calculation(x, y, z) -> pp.Series[np.int]:
+        >>> def calculation(x, y, z) -> ps.Series[np.int]:
         ...     return x + x.min() + y + z
         >>> g.transform(calculation, 5, z=20)  # doctest: +NORMALIZE_WHITESPACE
             B   C
@@ -2192,7 +2192,7 @@ class GroupBy(object, metaclass=ABCMeta):
         Examples
         --------
 
-        >>> df = pp.DataFrame({'id': ['spam', 'egg', 'egg', 'spam',
+        >>> df = ps.DataFrame({'id': ['spam', 'egg', 'egg', 'spam',
         ...                           'ham', 'ham'],
         ...                    'value1': [1, 5, 5, 2, 5, 5],
         ...                    'value2': list('abbaxy')}, columns=['id', 'value1', 'value2'])
@@ -2293,7 +2293,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame([('falcon', 'bird', 389.0),
+        >>> kdf = ps.DataFrame([('falcon', 'bird', 389.0),
         ...                     ('parrot', 'bird', 24.0),
         ...                     ('lion', 'mammal', 80.5),
         ...                     ('monkey', 'mammal', np.nan)],
@@ -2380,7 +2380,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({'a': [1., 1., 1., 1., 2., 2., 2., 3., 3., 3.],
+        >>> kdf = ps.DataFrame({'a': [1., 1., 1., 1., 2., 2., 2., 3., 3., 3.],
         ...                     'b': [2., 3., 1., 4., 6., 9., 8., 10., 7., 5.],
         ...                     'c': [3., 5., 2., 5., 1., 2., 6., 4., 3., 6.]},
         ...                    columns=['a', 'b', 'c'],
@@ -2715,7 +2715,7 @@ class DataFrameGroupBy(GroupBy):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 1, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
+        >>> df = ps.DataFrame({'a': [1, 1, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
         >>> df
            a  b  c
         0  1  4  7
@@ -2885,7 +2885,7 @@ class SeriesGroupBy(GroupBy):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
+        >>> df = ps.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
         ...                    'b': [1, 2, 2, 2, 3, 3, 3, 4, 4]}, columns=['a', 'b'])
 
         >>> df.groupby(['a'])['b'].nsmallest(1).sort_index()  # doctest: +NORMALIZE_WHITESPACE
@@ -2962,7 +2962,7 @@ class SeriesGroupBy(GroupBy):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
+        >>> df = ps.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
         ...                    'b': [1, 2, 2, 2, 3, 3, 3, 4, 4]}, columns=['a', 'b'])
 
         >>> df.groupby(['a'])['b'].nlargest(1).sort_index()  # doctest: +NORMALIZE_WHITESPACE
@@ -3040,7 +3040,7 @@ class SeriesGroupBy(GroupBy):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'A': [1, 2, 2, 3, 3, 3],
+        >>> df = ps.DataFrame({'A': [1, 2, 2, 3, 3, 3],
         ...                    'B': [1, 1, 2, 3, 3, 3]},
         ...                   columns=['A', 'B'])
         >>> df
@@ -3097,7 +3097,7 @@ class SeriesGroupBy(GroupBy):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
+        >>> df = ps.DataFrame({'a': [1, 1, 1, 2, 2, 2, 3, 3, 3],
         ...                    'b': [1, 2, 2, 2, 3, 3, 3, 4, 4]}, columns=['a', 'b'])
 
         >>> df.groupby(['a'])['b'].unique().sort_index()  # doctest: +SKIP
@@ -3198,7 +3198,7 @@ def _test():
 
     globs = pyspark.pandas.groupby.__dict__.copy()
     globs["np"] = numpy
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.groupby tests")

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -40,7 +40,7 @@ from pyspark import sql as spark
 from pyspark.sql import functions as F
 from pyspark.sql.types import DataType, FractionalType, IntegralType, TimestampType
 
-from pyspark import pandas as pp  # For running doctests and reference resolution in PyCharm.
+from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.config import get_option, option_context
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.frame import DataFrame
@@ -94,28 +94,28 @@ class Index(IndexOpsMixin):
 
     Examples
     --------
-    >>> pp.DataFrame({'a': ['a', 'b', 'c']}, index=[1, 2, 3]).index
+    >>> ps.DataFrame({'a': ['a', 'b', 'c']}, index=[1, 2, 3]).index
     Int64Index([1, 2, 3], dtype='int64')
 
-    >>> pp.DataFrame({'a': [1, 2, 3]}, index=list('abc')).index
+    >>> ps.DataFrame({'a': [1, 2, 3]}, index=list('abc')).index
     Index(['a', 'b', 'c'], dtype='object')
 
-    >>> pp.Index([1, 2, 3])
+    >>> ps.Index([1, 2, 3])
     Int64Index([1, 2, 3], dtype='int64')
 
-    >>> pp.Index(list('abc'))
+    >>> ps.Index(list('abc'))
     Index(['a', 'b', 'c'], dtype='object')
 
     From a Series:
 
-    >>> s = pp.Series([1, 2, 3], index=[10, 20, 30])
-    >>> pp.Index(s)
+    >>> s = ps.Series([1, 2, 3], index=[10, 20, 30])
+    >>> ps.Index(s)
     Int64Index([1, 2, 3], dtype='int64')
 
     From an Index:
 
-    >>> idx = pp.Index([1, 2, 3])
-    >>> pp.Index(idx)
+    >>> idx = ps.Index([1, 2, 3])
+    >>> ps.Index(idx)
     Int64Index([1, 2, 3], dtype='int64')
     """
 
@@ -148,7 +148,7 @@ class Index(IndexOpsMixin):
                 data = data.rename(name)
             return data
 
-        return pp.from_pandas(
+        return ps.from_pandas(
             pd.Index(
                 data=data, dtype=dtype, copy=copy, name=name, tupleize_cols=tupleize_cols, **kwargs
             )
@@ -257,7 +257,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'],
         ...                   index=list('abcd'))
         >>> df.index.size
@@ -275,13 +275,13 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pp.Index(['a', 'b', 'c'])
+        >>> idx = ps.Index(['a', 'b', 'c'])
         >>> idx
         Index(['a', 'b', 'c'], dtype='object')
         >>> idx.shape
         (3,)
 
-        >>> midx = pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
+        >>> midx = ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
         >>> midx  # doctest: +SKIP
         MultiIndex([('a', 'x'),
                     ('b', 'y'),
@@ -307,18 +307,18 @@ class Index(IndexOpsMixin):
         --------
 
         >>> from pyspark.pandas.config import option_context
-        >>> idx = pp.Index(['a', 'b', 'c'])
-        >>> midx = pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
+        >>> idx = ps.Index(['a', 'b', 'c'])
+        >>> midx = ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
 
         For Index
 
         >>> idx.identical(idx)
         True
         >>> with option_context('compute.ops_on_diff_frames', True):
-        ...     idx.identical(pp.Index(['a', 'b', 'c']))
+        ...     idx.identical(ps.Index(['a', 'b', 'c']))
         True
         >>> with option_context('compute.ops_on_diff_frames', True):
-        ...     idx.identical(pp.Index(['b', 'b', 'a']))
+        ...     idx.identical(ps.Index(['b', 'b', 'a']))
         False
         >>> idx.identical(midx)
         False
@@ -328,10 +328,10 @@ class Index(IndexOpsMixin):
         >>> midx.identical(midx)
         True
         >>> with option_context('compute.ops_on_diff_frames', True):
-        ...     midx.identical(pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')]))
+        ...     midx.identical(ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')]))
         True
         >>> with option_context('compute.ops_on_diff_frames', True):
-        ...     midx.identical(pp.MultiIndex.from_tuples([('c', 'z'), ('b', 'y'), ('a', 'x')]))
+        ...     midx.identical(ps.MultiIndex.from_tuples([('c', 'z'), ('b', 'y'), ('a', 'x')]))
         False
         >>> midx.identical(idx)
         False
@@ -360,9 +360,9 @@ class Index(IndexOpsMixin):
         --------
 
         >>> from pyspark.pandas.config import option_context
-        >>> idx = pp.Index(['a', 'b', 'c'])
+        >>> idx = ps.Index(['a', 'b', 'c'])
         >>> idx.name = "name"
-        >>> midx = pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
+        >>> midx = ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
         >>> midx.names = ("nameA", "nameB")
 
         For Index
@@ -370,10 +370,10 @@ class Index(IndexOpsMixin):
         >>> idx.equals(idx)
         True
         >>> with option_context('compute.ops_on_diff_frames', True):
-        ...     idx.equals(pp.Index(['a', 'b', 'c']))
+        ...     idx.equals(ps.Index(['a', 'b', 'c']))
         True
         >>> with option_context('compute.ops_on_diff_frames', True):
-        ...     idx.equals(pp.Index(['b', 'b', 'a']))
+        ...     idx.equals(ps.Index(['b', 'b', 'a']))
         False
         >>> idx.equals(midx)
         False
@@ -383,10 +383,10 @@ class Index(IndexOpsMixin):
         >>> midx.equals(midx)
         True
         >>> with option_context('compute.ops_on_diff_frames', True):
-        ...     midx.equals(pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')]))
+        ...     midx.equals(ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')]))
         True
         >>> with option_context('compute.ops_on_diff_frames', True):
-        ...     midx.equals(pp.MultiIndex.from_tuples([('c', 'z'), ('b', 'y'), ('a', 'x')]))
+        ...     midx.equals(ps.MultiIndex.from_tuples([('c', 'z'), ('b', 'y'), ('a', 'x')]))
         False
         >>> midx.equals(idx)
         False
@@ -415,7 +415,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pp.Index(['a', 'b', 'c'])
+        >>> idx = ps.Index(['a', 'b', 'c'])
         >>> idx
         Index(['a', 'b', 'c'], dtype='object')
 
@@ -424,7 +424,7 @@ class Index(IndexOpsMixin):
 
         For MultiIndex
 
-        >>> midx = pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
+        >>> midx = ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
         >>> midx  # doctest: +SKIP
         MultiIndex([('a', 'x'),
                     ('b', 'y'),
@@ -458,7 +458,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'],
         ...                   index=list('abcd'))
         >>> df['dogs'].index.to_pandas()
@@ -498,9 +498,9 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.Series([1, 2, 3, 4]).index.to_numpy()
+        >>> ps.Series([1, 2, 3, 4]).index.to_numpy()
         array([0, 1, 2, 3])
-        >>> pp.DataFrame({'a': ['a', 'b', 'c']}, index=[[1, 2, 3], [4, 5, 6]]).index.to_numpy()
+        >>> ps.DataFrame({'a': ['a', 'b', 'c']}, index=[[1, 2, 3], [4, 5, 6]]).index.to_numpy()
         array([(1, 4), (2, 5), (3, 6)], dtype=object)
         """
         result = np.asarray(self._to_internal_pandas()._values, dtype=dtype)
@@ -524,9 +524,9 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.Series([1, 2, 3, 4]).index.values
+        >>> ps.Series([1, 2, 3, 4]).index.values
         array([0, 1, 2, 3])
-        >>> pp.DataFrame({'a': ['a', 'b', 'c']}, index=[[1, 2, 3], [4, 5, 6]]).index.values
+        >>> ps.DataFrame({'a': ['a', 'b', 'c']}, index=[[1, 2, 3], [4, 5, 6]]).index.values
         array([(1, 4), (2, 5), (3, 6)], dtype=object)
         """
         warnings.warn("We recommend using `{}.to_numpy()` instead.".format(type(self).__name__))
@@ -549,12 +549,12 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.Index([1, 2, 3]).asi8
+        >>> ps.Index([1, 2, 3]).asi8
         array([1, 2, 3])
 
         Returns None for non-int64 dtype
 
-        >>> pp.Index(['a', 'b', 'c']).asi8 is None
+        >>> ps.Index(['a', 'b', 'c']).asi8 is None
         True
         """
         warnings.warn("We recommend using `{}.to_numpy()` instead.".format(type(self).__name__))
@@ -582,20 +582,20 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pp.Index([1, 5, 7, 7])
+        >>> idx = ps.Index([1, 5, 7, 7])
         >>> idx.has_duplicates
         True
 
-        >>> idx = pp.Index([1, 5, 7])
+        >>> idx = ps.Index([1, 5, 7])
         >>> idx.has_duplicates
         False
 
-        >>> idx = pp.Index(["Watermelon", "Orange", "Apple",
+        >>> idx = ps.Index(["Watermelon", "Orange", "Apple",
         ...                 "Watermelon"])
         >>> idx.has_duplicates
         True
 
-        >>> idx = pp.Index(["Orange", "Apple",
+        >>> idx = ps.Index(["Orange", "Apple",
         ...                 "Watermelon"])
         >>> idx.has_duplicates
         False
@@ -612,20 +612,20 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pp.Index([1, 5, 7, 7])
+        >>> idx = ps.Index([1, 5, 7, 7])
         >>> idx.is_unique
         False
 
-        >>> idx = pp.Index([1, 5, 7])
+        >>> idx = ps.Index([1, 5, 7])
         >>> idx.is_unique
         True
 
-        >>> idx = pp.Index(["Watermelon", "Orange", "Apple",
+        >>> idx = ps.Index(["Watermelon", "Orange", "Apple",
         ...                 "Watermelon"])
         >>> idx.is_unique
         False
 
-        >>> idx = pp.Index(["Orange", "Apple",
+        >>> idx = ps.Index(["Orange", "Apple",
         ...                 "Watermelon"])
         >>> idx.is_unique
         True
@@ -671,11 +671,11 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({"a": [1, 2, 3]}, index=pd.Index(['a', 'b', 'c'], name="idx"))
+        >>> kdf = ps.DataFrame({"a": [1, 2, 3]}, index=pd.Index(['a', 'b', 'c'], name="idx"))
         >>> kdf.index.nlevels
         1
 
-        >>> kdf = pp.DataFrame({'a': [1, 2, 3]}, index=[list('abc'), list('def')])
+        >>> kdf = ps.DataFrame({'a': [1, 2, 3]}, index=[list('abc'), list('def')])
         >>> kdf.index.nlevels
         2
         """
@@ -702,7 +702,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': ['A', 'C'], 'b': ['A', 'B']}, columns=['a', 'b'])
+        >>> df = ps.DataFrame({'a': ['A', 'C'], 'b': ['A', 'B']}, columns=['a', 'b'])
         >>> df.index.rename("c")
         Int64Index([0, 1], dtype='int64', name='c')
 
@@ -724,7 +724,7 @@ class Index(IndexOpsMixin):
 
         Support for MultiIndex
 
-        >>> kidx = pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y')])
+        >>> kidx = ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y')])
         >>> kidx.names = ['hello', 'koalas']
         >>> kidx  # doctest: +SKIP
         MultiIndex([('a', 'x'),
@@ -771,7 +771,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> ki = pp.DataFrame({'a': ['a', 'b', 'c']}, index=[1, 2, None]).index
+        >>> ki = ps.DataFrame({'a': ['a', 'b', 'c']}, index=[1, 2, None]).index
         >>> ki
         Float64Index([1.0, 2.0, nan], dtype='float64')
 
@@ -802,7 +802,7 @@ class Index(IndexOpsMixin):
         --------
         Generate an pandas.Index with duplicate values.
 
-        >>> idx = pp.Index(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'])
+        >>> idx = ps.Index(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'])
 
         >>> idx.drop_duplicates().sort_values()
         Index(['beetle', 'cow', 'hippo', 'lama'], dtype='object')
@@ -837,7 +837,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'],
         ...                   index=list('abcd'))
         >>> df['dogs'].index.to_series()
@@ -886,7 +886,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pp.Index(['Ant', 'Bear', 'Cow'], name='animal')
+        >>> idx = ps.Index(['Ant', 'Bear', 'Cow'], name='animal')
         >>> idx.to_frame()  # doctest: +NORMALIZE_WHITESPACE
                animal
         animal
@@ -951,7 +951,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.DataFrame({'a': [1]}, index=[True]).index.is_boolean()
+        >>> ps.DataFrame({'a': [1]}, index=[True]).index.is_boolean()
         True
         """
         return is_bool_dtype(self.dtype)
@@ -962,7 +962,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.DataFrame({'a': [1]}, index=[1]).index.is_categorical()
+        >>> ps.DataFrame({'a': [1]}, index=[1]).index.is_categorical()
         False
         """
         return is_categorical_dtype(self.dtype)
@@ -973,7 +973,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.DataFrame({'a': [1]}, index=[1]).index.is_floating()
+        >>> ps.DataFrame({'a': [1]}, index=[1]).index.is_floating()
         False
         """
         return is_float_dtype(self.dtype)
@@ -984,7 +984,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.DataFrame({'a': [1]}, index=[1]).index.is_integer()
+        >>> ps.DataFrame({'a': [1]}, index=[1]).index.is_integer()
         True
         """
         return is_integer_dtype(self.dtype)
@@ -995,7 +995,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.DataFrame({'a': [1]}, index=[1]).index.is_interval()
+        >>> ps.DataFrame({'a': [1]}, index=[1]).index.is_interval()
         False
         """
         return is_interval_dtype(self.dtype)
@@ -1006,7 +1006,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.DataFrame({'a': [1]}, index=[1]).index.is_numeric()
+        >>> ps.DataFrame({'a': [1]}, index=[1]).index.is_numeric()
         True
         """
         return is_numeric_dtype(self.dtype)
@@ -1017,7 +1017,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.DataFrame({'a': [1]}, index=["a"]).index.is_object()
+        >>> ps.DataFrame({'a': [1]}, index=["a"]).index.is_object()
         True
         """
         return is_object_dtype(self.dtype)
@@ -1028,11 +1028,11 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> kidx = pp.Index([1, 2, 3])
+        >>> kidx = ps.Index([1, 2, 3])
         >>> kidx.is_type_compatible('integer')
         True
 
-        >>> kidx = pp.Index([1.0, 2.0, 3.0])
+        >>> kidx = ps.Index([1.0, 2.0, 3.0])
         >>> kidx.is_type_compatible('integer')
         False
         >>> kidx.is_type_compatible('floating')
@@ -1047,7 +1047,7 @@ class Index(IndexOpsMixin):
         Examples
         --------
 
-        >>> df = pp.DataFrame([[1, 2], [4, 5], [7, 8]],
+        >>> df = ps.DataFrame([[1, 2], [4, 5], [7, 8]],
         ...                   index=['cobra', 'viper', None],
         ...                   columns=['max_speed', 'shield'])
         >>> df
@@ -1065,7 +1065,7 @@ class Index(IndexOpsMixin):
         ...                       [None, 'weight', 'length']],
         ...                      [[0, 1, 1, 1, 1, 1, 2, 2, 2],
         ...                       [0, 1, 1, 0, 1, 2, 1, 1, 2]])
-        >>> s = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, None],
+        >>> s = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, None],
         ...               index=midx)
         >>> s
         lama    NaN        45.0
@@ -1121,15 +1121,15 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> pp.DataFrame({'a': ['a', 'b', 'c']}, index=[1, 1, 3]).index.unique().sort_values()
+        >>> ps.DataFrame({'a': ['a', 'b', 'c']}, index=[1, 1, 3]).index.unique().sort_values()
         Int64Index([1, 3], dtype='int64')
 
-        >>> pp.DataFrame({'a': ['a', 'b', 'c']}, index=['d', 'e', 'e']).index.unique().sort_values()
+        >>> ps.DataFrame({'a': ['a', 'b', 'c']}, index=['d', 'e', 'e']).index.unique().sort_values()
         Index(['d', 'e'], dtype='object')
 
         MultiIndex
 
-        >>> pp.MultiIndex.from_tuples([("A", "X"), ("A", "Y"), ("A", "X")]).unique()
+        >>> ps.MultiIndex.from_tuples([("A", "X"), ("A", "Y"), ("A", "X")]).unique()
         ... # doctest: +SKIP
         MultiIndex([('A', 'X'),
                     ('A', 'Y')],
@@ -1165,7 +1165,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> index = pp.Index([1, 2, 3])
+        >>> index = ps.Index([1, 2, 3])
         >>> index
         Int64Index([1, 2, 3], dtype='int64')
 
@@ -1213,7 +1213,7 @@ class Index(IndexOpsMixin):
 
         Examples:
         --------
-        >>> kidx = pp.Index(['a', 'b', 'c'], name='ks')
+        >>> kidx = ps.Index(['a', 'b', 'c'], name='ks')
         >>> kidx.get_level_values(0)
         Index(['a', 'b', 'c'], dtype='object', name='ks')
 
@@ -1236,7 +1236,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> df = pp.DataFrame([[1, 2], [4, 5], [7, 8]],
+        >>> df = ps.DataFrame([[1, 2], [4, 5], [7, 8]],
         ...                   index=['cobra', 'viper', 'sidewinder'],
         ...                   columns=['max_speed', 'shield'])
         >>> df
@@ -1280,7 +1280,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> midx = pp.DataFrame({'a': ['a', 'b']}, index=[['a', 'x'], ['b', 'y'], [1, 2]]).index
+        >>> midx = ps.DataFrame({'a': ['a', 'b']}, index=[['a', 'x'], ['b', 'y'], [1, 2]]).index
         >>> midx  # doctest: +SKIP
         MultiIndex([('a', 'b', 1),
                     ('x', 'y', 2)],
@@ -1379,8 +1379,8 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> s1 = pp.Series([1, 2, 3, 4], index=[1, 2, 3, 4])
-        >>> s2 = pp.Series([1, 2, 3, 4], index=[2, 3, 4, 5])
+        >>> s1 = ps.Series([1, 2, 3, 4], index=[1, 2, 3, 4])
+        >>> s2 = ps.Series([1, 2, 3, 4], index=[2, 3, 4, 5])
 
         >>> s1.index.symmetric_difference(s2.index)
         Int64Index([5, 1], dtype='int64')
@@ -1444,7 +1444,7 @@ class Index(IndexOpsMixin):
 
         Returns
         -------
-        sorted_index : pp.Index or pp.MultiIndex
+        sorted_index : ps.Index or ps.MultiIndex
             Sorted copy of the index.
 
         See Also
@@ -1454,7 +1454,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pp.Index([10, 100, 1, 1000])
+        >>> idx = ps.Index([10, 100, 1, 1000])
         >>> idx
         Int64Index([10, 100, 1, 1000], dtype='int64')
 
@@ -1470,7 +1470,7 @@ class Index(IndexOpsMixin):
 
         Support for MultiIndex.
 
-        >>> kidx = pp.MultiIndex.from_tuples([('a', 'x', 1), ('c', 'y', 2), ('b', 'z', 3)])
+        >>> kidx = ps.MultiIndex.from_tuples([('a', 'x', 1), ('c', 'y', 2), ('b', 'z', 3)])
         >>> kidx  # doctest: +SKIP
         MultiIndex([('a', 'x', 1),
                     ('c', 'y', 2),
@@ -1527,17 +1527,17 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pp.Index([3, 2, 1])
+        >>> idx = ps.Index([3, 2, 1])
         >>> idx.min()
         1
 
-        >>> idx = pp.Index(['c', 'b', 'a'])
+        >>> idx = ps.Index(['c', 'b', 'a'])
         >>> idx.min()
         'a'
 
         For a MultiIndex, the maximum is determined lexicographically.
 
-        >>> idx = pp.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2)])
+        >>> idx = ps.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2)])
         >>> idx.min()
         ('a', 'x', 1)
         """
@@ -1568,17 +1568,17 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pp.Index([3, 2, 1])
+        >>> idx = ps.Index([3, 2, 1])
         >>> idx.max()
         3
 
-        >>> idx = pp.Index(['c', 'b', 'a'])
+        >>> idx = ps.Index(['c', 'b', 'a'])
         >>> idx.max()
         'c'
 
         For a MultiIndex, the maximum is determined lexicographically.
 
-        >>> idx = pp.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2)])
+        >>> idx = ps.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2)])
         >>> idx.max()
         ('b', 'y', 2)
         """
@@ -1605,7 +1605,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> kidx = pp.Index([10, 10, 9, 8, 4, 2, 4, 4, 2, 2, 10, 10])
+        >>> kidx = ps.Index([10, 10, 9, 8, 4, 2, 4, 4, 2, 2, 10, 10])
         >>> kidx
         Int64Index([10, 10, 9, 8, 4, 2, 4, 4, 2, 2, 10, 10], dtype='int64')
 
@@ -1617,7 +1617,7 @@ class Index(IndexOpsMixin):
 
         MultiIndex
 
-        >>> kidx = pp.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
+        >>> kidx = ps.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
         >>> kidx  # doctest: +SKIP
         MultiIndex([('a', 'x', 1),
                     ('b', 'y', 2),
@@ -1720,7 +1720,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> kidx = pp.Index([10, 5, 0, 5, 10, 5, 0, 10])
+        >>> kidx = ps.Index([10, 5, 0, 5, 10, 5, 0, 10])
         >>> kidx
         Int64Index([10, 5, 0, 5, 10, 5, 0, 10], dtype='int64')
 
@@ -1729,7 +1729,7 @@ class Index(IndexOpsMixin):
 
         Support for MiltiIndex
 
-        >>> kidx = pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y')])
+        >>> kidx = ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y')])
         >>> kidx  # doctest: +SKIP
         MultiIndex([('a', 'x'),
                     ('b', 'y')],
@@ -1783,7 +1783,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> kidx = pp.Index([10, 9, 8, 7, 100, 5, 4, 3, 100, 3])
+        >>> kidx = ps.Index([10, 9, 8, 7, 100, 5, 4, 3, 100, 3])
         >>> kidx
         Int64Index([10, 9, 8, 7, 100, 5, 4, 3, 100, 3], dtype='int64')
 
@@ -1831,7 +1831,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> kidx = pp.Index([10, 9, 8, 7, 100, 5, 4, 3, 100, 3])
+        >>> kidx = ps.Index([10, 9, 8, 7, 100, 5, 4, 3, 100, 3])
         >>> kidx
         Int64Index([10, 9, 8, 7, 100, 5, 4, 3, 100, 3], dtype='int64')
 
@@ -1878,7 +1878,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pp.Index([1, 2, 3, 4])
+        >>> idx = ps.Index([1, 2, 3, 4])
         >>> idx
         Int64Index([1, 2, 3, 4], dtype='int64')
 
@@ -1887,7 +1887,7 @@ class Index(IndexOpsMixin):
 
         For MultiIndex
 
-        >>> idx = pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y')])
+        >>> idx = ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y')])
         >>> idx  # doctest: +SKIP
         MultiIndex([('a', 'x'),
                     ('b', 'y')],
@@ -1935,15 +1935,15 @@ class Index(IndexOpsMixin):
         Examples
         --------
 
-        >>> idx1 = pp.Index([2, 1, 3, 4])
-        >>> idx2 = pp.Index([3, 4, 5, 6])
+        >>> idx1 = ps.Index([2, 1, 3, 4])
+        >>> idx2 = ps.Index([3, 4, 5, 6])
         >>> idx1.difference(idx2, sort=True)
         Int64Index([1, 2], dtype='int64')
 
         MultiIndex
 
-        >>> midx1 = pp.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
-        >>> midx2 = pp.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'z', 2), ('k', 'z', 3)])
+        >>> midx1 = ps.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'y', 2), ('c', 'z', 3)])
+        >>> midx2 = ps.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'z', 2), ('k', 'z', 3)])
         >>> midx1.difference(midx2)  # doctest: +SKIP
         MultiIndex([('b', 'y', 2),
                     ('c', 'z', 3)],
@@ -2002,21 +2002,21 @@ class Index(IndexOpsMixin):
         --------
         >>> from datetime import datetime
 
-        >>> idx = pp.Index([datetime(2019, 1, 1, 0, 0, 0), datetime(2019, 2, 3, 0, 0, 0)])
+        >>> idx = ps.Index([datetime(2019, 1, 1, 0, 0, 0), datetime(2019, 2, 3, 0, 0, 0)])
         >>> idx
         DatetimeIndex(['2019-01-01', '2019-02-03'], dtype='datetime64[ns]', freq=None)
 
         >>> idx.is_all_dates
         True
 
-        >>> idx = pp.Index([datetime(2019, 1, 1, 0, 0, 0), None])
+        >>> idx = ps.Index([datetime(2019, 1, 1, 0, 0, 0), None])
         >>> idx
         DatetimeIndex(['2019-01-01', 'NaT'], dtype='datetime64[ns]', freq=None)
 
         >>> idx.is_all_dates
         True
 
-        >>> idx = pp.Index([0, 1, 2])
+        >>> idx = ps.Index([0, 1, 2])
         >>> idx
         Int64Index([0, 1, 2], dtype='int64')
 
@@ -2050,7 +2050,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx = pp.Index(['a', 'b', 'c'])
+        >>> idx = ps.Index(['a', 'b', 'c'])
         >>> idx
         Index(['a', 'b', 'c'], dtype='object')
         >>> idx.repeat(2)
@@ -2058,7 +2058,7 @@ class Index(IndexOpsMixin):
 
         For MultiIndex,
 
-        >>> midx = pp.MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'c')])
+        >>> midx = ps.MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'c')])
         >>> midx  # doctest: +SKIP
         MultiIndex([('x', 'a'),
                     ('x', 'b'),
@@ -2086,7 +2086,7 @@ class Index(IndexOpsMixin):
         if repeats == 0:
             return DataFrame(kdf._internal.with_filter(F.lit(False))).index
         else:
-            return pp.concat([kdf] * repeats).index
+            return ps.concat([kdf] * repeats).index
 
     def asof(self, label) -> Scalar:
         """
@@ -2115,7 +2115,7 @@ class Index(IndexOpsMixin):
         --------
         `Index.asof` returns the latest index label up to the passed label.
 
-        >>> idx = pp.Index(['2013-12-31', '2014-01-02', '2014-01-03'])
+        >>> idx = ps.Index(['2013-12-31', '2014-01-02', '2014-01-03'])
         >>> idx.asof('2014-01-01')
         '2013-12-31'
 
@@ -2164,15 +2164,15 @@ class Index(IndexOpsMixin):
 
         Index
 
-        >>> idx1 = pp.Index([1, 2, 3, 4])
-        >>> idx2 = pp.Index([3, 4, 5, 6])
+        >>> idx1 = ps.Index([1, 2, 3, 4])
+        >>> idx2 = ps.Index([3, 4, 5, 6])
         >>> idx1.union(idx2).sort_values()
         Int64Index([1, 2, 3, 4, 5, 6], dtype='int64')
 
         MultiIndex
 
-        >>> midx1 = pp.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")])
-        >>> midx2 = pp.MultiIndex.from_tuples([("x", "c"), ("x", "d"), ("x", "e"), ("x", "f")])
+        >>> midx1 = ps.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("x", "c"), ("x", "d")])
+        >>> midx2 = ps.MultiIndex.from_tuples([("x", "c"), ("x", "d"), ("x", "e"), ("x", "f")])
         >>> midx1.union(midx2).sort_values()  # doctest: +SKIP
         MultiIndex([('x', 'a'),
                     ('x', 'b'),
@@ -2233,24 +2233,24 @@ class Index(IndexOpsMixin):
         When Index contains null values the result can be different with pandas
         since Koalas cast integer to float when Index contains null values.
 
-        >>> pp.Index([1, 2, 3, None])
+        >>> ps.Index([1, 2, 3, None])
         Float64Index([1.0, 2.0, 3.0, nan], dtype='float64')
 
         Examples
         --------
-        >>> kidx = pp.Index([1, 2, 3, 4])
+        >>> kidx = ps.Index([1, 2, 3, 4])
         >>> kidx.holds_integer()
         True
 
         Returns False for string type.
 
-        >>> kidx = pp.Index(["A", "B", "C", "D"])
+        >>> kidx = ps.Index(["A", "B", "C", "D"])
         >>> kidx.holds_integer()
         False
 
         Returns False for float type.
 
-        >>> kidx = pp.Index([1.1, 2.2, 3.3, 4.4])
+        >>> kidx = ps.Index([1.1, 2.2, 3.3, 4.4])
         >>> kidx.holds_integer()
         False
         """
@@ -2272,8 +2272,8 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> idx1 = pp.Index([1, 2, 3, 4])
-        >>> idx2 = pp.Index([3, 4, 5, 6])
+        >>> idx1 = ps.Index([1, 2, 3, 4])
+        >>> idx2 = ps.Index([3, 4, 5, 6])
         >>> idx1.intersection(idx2).sort_values()
         Int64Index([3, 4], dtype='int64')
         """
@@ -2329,7 +2329,7 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> kidx = pp.Index([10])
+        >>> kidx = ps.Index([10])
         >>> kidx.item()
         10
         """
@@ -2352,13 +2352,13 @@ class Index(IndexOpsMixin):
 
         Examples
         --------
-        >>> kidx = pp.Index([1, 2, 3, 4, 5])
+        >>> kidx = ps.Index([1, 2, 3, 4, 5])
         >>> kidx.insert(3, 100)
         Int64Index([1, 2, 3, 100, 4, 5], dtype='int64')
 
         For negative values
 
-        >>> kidx = pp.Index([1, 2, 3, 4, 5])
+        >>> kidx = ps.Index([1, 2, 3, 4, 5])
         >>> kidx.insert(-3, 100)
         Int64Index([1, 2, 100, 3, 4, 5], dtype='int64')
         """
@@ -2397,14 +2397,14 @@ class Index(IndexOpsMixin):
         --------
         Index
 
-        >>> idx = pp.Index([1, 2, 3, 4, 5])
+        >>> idx = ps.Index([1, 2, 3, 4, 5])
         >>> idx.to_list()
         [1, 2, 3, 4, 5]
 
         MultiIndex
 
         >>> tuples = [(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'green')]
-        >>> midx = pp.MultiIndex.from_tuples(tuples)
+        >>> midx = ps.MultiIndex.from_tuples(tuples)
         >>> midx.to_list()
         [(1, 'red'), (1, 'blue'), (2, 'red'), (2, 'green')]
         """
@@ -2420,16 +2420,16 @@ class Index(IndexOpsMixin):
         Examples
         --------
         >>> from datetime import datetime
-        >>> pp.Index([1, 2, 3]).inferred_type
+        >>> ps.Index([1, 2, 3]).inferred_type
         'integer'
 
-        >>> pp.Index([1.0, 2.0, 3.0]).inferred_type
+        >>> ps.Index([1.0, 2.0, 3.0]).inferred_type
         'floating'
 
-        >>> pp.Index(['a', 'b', 'c']).inferred_type
+        >>> ps.Index(['a', 'b', 'c']).inferred_type
         'string'
 
-        >>> pp.Index([True, False, True, False]).inferred_type
+        >>> ps.Index([True, False, True, False]).inferred_type
         'boolean'
         """
         return lib.infer_dtype([self.to_series().head(1).item()])
@@ -2481,7 +2481,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.indexes.base.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.indexes.base tests")

--- a/python/pyspark/pandas/indexes/category.py
+++ b/python/pyspark/pandas/indexes/category.py
@@ -20,7 +20,7 @@ from typing import Any
 import pandas as pd
 from pandas.api.types import is_hashable
 
-from pyspark import pandas as pp
+from pyspark import pandas as ps
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.missing.indexes import MissingPandasLikeCategoricalIndex
 from pyspark.pandas.series import Series
@@ -62,20 +62,20 @@ class CategoricalIndex(Index):
 
     Examples
     --------
-    >>> pp.CategoricalIndex(["a", "b", "c", "a", "b", "c"])  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.CategoricalIndex(["a", "b", "c", "a", "b", "c"])  # doctest: +NORMALIZE_WHITESPACE
     CategoricalIndex(['a', 'b', 'c', 'a', 'b', 'c'],
                      categories=['a', 'b', 'c'], ordered=False, dtype='category')
 
     ``CategoricalIndex`` can also be instantiated from a ``Categorical``:
 
     >>> c = pd.Categorical(["a", "b", "c", "a", "b", "c"])
-    >>> pp.CategoricalIndex(c)  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.CategoricalIndex(c)  # doctest: +NORMALIZE_WHITESPACE
     CategoricalIndex(['a', 'b', 'c', 'a', 'b', 'c'],
                      categories=['a', 'b', 'c'], ordered=False, dtype='category')
 
     Ordered ``CategoricalIndex`` can have a min and max value.
 
-    >>> ci = pp.CategoricalIndex(
+    >>> ci = ps.CategoricalIndex(
     ...     ["a", "b", "c", "a", "b", "c"], ordered=True, categories=["c", "b", "a"]
     ... )
     >>> ci  # doctest: +NORMALIZE_WHITESPACE
@@ -84,15 +84,15 @@ class CategoricalIndex(Index):
 
     From a Series:
 
-    >>> s = pp.Series(["a", "b", "c", "a", "b", "c"], index=[10, 20, 30, 40, 50, 60])
-    >>> pp.CategoricalIndex(s)  # doctest: +NORMALIZE_WHITESPACE
+    >>> s = ps.Series(["a", "b", "c", "a", "b", "c"], index=[10, 20, 30, 40, 50, 60])
+    >>> ps.CategoricalIndex(s)  # doctest: +NORMALIZE_WHITESPACE
     CategoricalIndex(['a', 'b', 'c', 'a', 'b', 'c'],
                      categories=['a', 'b', 'c'], ordered=False, dtype='category')
 
     From an Index:
 
-    >>> idx = pp.Index(["a", "b", "c", "a", "b", "c"])
-    >>> pp.CategoricalIndex(idx)  # doctest: +NORMALIZE_WHITESPACE
+    >>> idx = ps.Index(["a", "b", "c", "a", "b", "c"])
+    >>> ps.CategoricalIndex(idx)  # doctest: +NORMALIZE_WHITESPACE
     CategoricalIndex(['a', 'b', 'c', 'a', 'b', 'c'],
                      categories=['a', 'b', 'c'], ordered=False, dtype='category')
     """
@@ -106,7 +106,7 @@ class CategoricalIndex(Index):
                 dtype = "category"
             return Index(data, dtype=dtype, copy=copy, name=name)
 
-        return pp.from_pandas(
+        return ps.from_pandas(
             pd.CategoricalIndex(
                 data=data, categories=categories, ordered=ordered, dtype=dtype, name=name
             )
@@ -130,7 +130,7 @@ class CategoricalIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.CategoricalIndex(list("abbccc"))
+        >>> idx = ps.CategoricalIndex(list("abbccc"))
         >>> idx  # doctest: +NORMALIZE_WHITESPACE
         CategoricalIndex(['a', 'b', 'b', 'c', 'c', 'c'],
                          categories=['a', 'b', 'c'], ordered=False, dtype='category')
@@ -147,7 +147,7 @@ class CategoricalIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.CategoricalIndex(list("abbccc"))
+        >>> idx = ps.CategoricalIndex(list("abbccc"))
         >>> idx  # doctest: +NORMALIZE_WHITESPACE
         CategoricalIndex(['a', 'b', 'b', 'c', 'c', 'c'],
                          categories=['a', 'b', 'c'], ordered=False, dtype='category')
@@ -168,7 +168,7 @@ class CategoricalIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.CategoricalIndex(list("abbccc"))
+        >>> idx = ps.CategoricalIndex(list("abbccc"))
         >>> idx  # doctest: +NORMALIZE_WHITESPACE
         CategoricalIndex(['a', 'b', 'b', 'c', 'c', 'c'],
                          categories=['a', 'b', 'c'], ordered=False, dtype='category')
@@ -198,7 +198,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.indexes.category.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.indexes.category tests")

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -22,7 +22,7 @@ import pandas as pd
 from pandas.api.types import is_hashable
 from pyspark._globals import _NoValue
 
-from pyspark import pandas as pp
+from pyspark import pandas as ps
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.missing.indexes import MissingPandasLikeDatetimeIndex
 from pyspark.pandas.series import Series, first_series
@@ -78,20 +78,20 @@ class DatetimeIndex(Index):
 
     Examples
     --------
-    >>> pp.DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'])
+    >>> ps.DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'])
     DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'], dtype='datetime64[ns]', freq=None)
 
     From a Series:
 
     >>> from datetime import datetime
-    >>> s = pp.Series([datetime(2021, 3, 1), datetime(2021, 3, 2)], index=[10, 20])
-    >>> pp.DatetimeIndex(s)
+    >>> s = ps.Series([datetime(2021, 3, 1), datetime(2021, 3, 2)], index=[10, 20])
+    >>> ps.DatetimeIndex(s)
     DatetimeIndex(['2021-03-01', '2021-03-02'], dtype='datetime64[ns]', freq=None)
 
     From an Index:
 
-    >>> idx = pp.DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'])
-    >>> pp.DatetimeIndex(idx)
+    >>> idx = ps.DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'])
+    >>> ps.DatetimeIndex(idx)
     DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'], dtype='datetime64[ns]', freq=None)
     """
 
@@ -129,7 +129,7 @@ class DatetimeIndex(Index):
         )
         if freq is not _NoValue:
             kwargs["freq"] = freq
-        return pp.from_pandas(pd.DatetimeIndex(**kwargs))
+        return ps.from_pandas(pd.DatetimeIndex(**kwargs))
 
     def __getattr__(self, item: str) -> Any:
         if hasattr(MissingPandasLikeDatetimeIndex, item):
@@ -225,7 +225,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range('2016-12-31', '2017-01-08', freq='D')
+        >>> idx = ps.date_range('2016-12-31', '2017-01-08', freq='D')
         >>> idx.dayofweek
         Int64Index([5, 6, 0, 1, 2, 3, 4, 5, 6], dtype='int64')
         """
@@ -280,7 +280,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range("2018-02-27", periods=3)
+        >>> idx = ps.date_range("2018-02-27", periods=3)
         >>> idx.is_month_start
         Index([False, False, True], dtype='object')
         """
@@ -303,7 +303,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range("2018-02-27", periods=3)
+        >>> idx = ps.date_range("2018-02-27", periods=3)
         >>> idx.is_month_end
         Index([False, True, False], dtype='object')
         """
@@ -326,7 +326,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range('2017-03-30', periods=4)
+        >>> idx = ps.date_range('2017-03-30', periods=4)
         >>> idx.is_quarter_start
         Index([False, False, True, False], dtype='object')
         """
@@ -349,7 +349,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range('2017-03-30', periods=4)
+        >>> idx = ps.date_range('2017-03-30', periods=4)
         >>> idx.is_quarter_end
         Index([False, True, False, False], dtype='object')
         """
@@ -371,7 +371,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range("2017-12-30", periods=3)
+        >>> idx = ps.date_range("2017-12-30", periods=3)
         >>> idx.is_year_start
         Index([False, False, True], dtype='object')
         """
@@ -393,7 +393,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range("2017-12-30", periods=3)
+        >>> idx = ps.date_range("2017-12-30", periods=3)
         >>> idx.is_year_end
         Index([False, True, False], dtype='object')
         """
@@ -416,7 +416,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range("2012-01-01", "2015-01-01", freq="Y")
+        >>> idx = ps.date_range("2012-01-01", "2015-01-01", freq="Y")
         >>> idx.is_leap_year
         Index([True, False, False], dtype='object')
         """
@@ -456,7 +456,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> rng = pp.date_range('1/1/2018 11:59:00', periods=3, freq='min')
+        >>> rng = ps.date_range('1/1/2018 11:59:00', periods=3, freq='min')
         >>> rng.ceil('H')  # doctest: +NORMALIZE_WHITESPACE
         DatetimeIndex(['2018-01-01 12:00:00', '2018-01-01 12:00:00',
                        '2018-01-01 13:00:00'],
@@ -486,7 +486,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> rng = pp.date_range('1/1/2018 11:59:00', periods=3, freq='min')
+        >>> rng = ps.date_range('1/1/2018 11:59:00', periods=3, freq='min')
         >>> rng.floor("H")  # doctest: +NORMALIZE_WHITESPACE
         DatetimeIndex(['2018-01-01 11:00:00', '2018-01-01 12:00:00',
                        '2018-01-01 12:00:00'],
@@ -516,7 +516,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> rng = pp.date_range('1/1/2018 11:59:00', periods=3, freq='min')
+        >>> rng = ps.date_range('1/1/2018 11:59:00', periods=3, freq='min')
         >>> rng.round("H")  # doctest: +NORMALIZE_WHITESPACE
         DatetimeIndex(['2018-01-01 12:00:00', '2018-01-01 12:00:00',
                        '2018-01-01 12:00:00'],
@@ -543,7 +543,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range(start='2018-01', freq='M', periods=3)
+        >>> idx = ps.date_range(start='2018-01', freq='M', periods=3)
         >>> idx.month_name()
         Index(['January', 'February', 'March'], dtype='object')
         """
@@ -566,7 +566,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range(start='2018-01-01', freq='D', periods=3)
+        >>> idx = ps.date_range(start='2018-01-01', freq='D', periods=3)
         >>> idx.day_name()
         Index(['Monday', 'Tuesday', 'Wednesday'], dtype='object')
         """
@@ -596,7 +596,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range(start='2014-08-01 10:00', freq='H', periods=3)
+        >>> idx = ps.date_range(start='2014-08-01 10:00', freq='H', periods=3)
         >>> idx.normalize()
         DatetimeIndex(['2014-08-01', '2014-08-01', '2014-08-01'], dtype='datetime64[ns]', freq=None)
         """
@@ -629,7 +629,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> idx = pp.date_range(pd.Timestamp("2018-03-10 09:00"), periods=3, freq='s')
+        >>> idx = ps.date_range(pd.Timestamp("2018-03-10 09:00"), periods=3, freq='s')
         >>> idx.strftime('%B %d, %Y, %r')  # doctest: +NORMALIZE_WHITESPACE
         Index(['March 10, 2018, 09:00:00 AM', 'March 10, 2018, 09:00:01 AM',
                'March 10, 2018, 09:00:02 AM'],
@@ -663,7 +663,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> kidx = pp.date_range("2000-01-01", periods=3, freq="T")
+        >>> kidx = ps.date_range("2000-01-01", periods=3, freq="T")
         >>> kidx  # doctest: +NORMALIZE_WHITESPACE
         DatetimeIndex(['2000-01-01 00:00:00', '2000-01-01 00:01:00',
                        '2000-01-01 00:02:00'],
@@ -679,17 +679,17 @@ class DatetimeIndex(Index):
         Int64Index([2], dtype='int64')
         """
 
-        def pandas_between_time(pdf) -> pp.DataFrame[int]:
+        def pandas_between_time(pdf) -> ps.DataFrame[int]:
             return pdf.between_time(start_time, end_time, include_start, include_end)
 
         kdf = self.to_frame()[[]]
         id_column_name = verify_temp_column_name(kdf, "__id_column__")
         kdf = kdf.koalas.attach_id_column("distributed-sequence", id_column_name)
-        with pp.option_context("compute.default_index_type", "distributed"):
+        with ps.option_context("compute.default_index_type", "distributed"):
             # The attached index in the statement below will be dropped soon,
             # so we enforce “distributed” default index type
             kdf = kdf.koalas.apply_batch(pandas_between_time)
-        return pp.Index(first_series(kdf).rename(self.name))
+        return ps.Index(first_series(kdf).rename(self.name))
 
     def indexer_at_time(self, time: Union[datetime.time, str], asof: bool = False) -> Index:
         """
@@ -709,7 +709,7 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> kidx = pp.date_range("2000-01-01", periods=3, freq="T")
+        >>> kidx = ps.date_range("2000-01-01", periods=3, freq="T")
         >>> kidx  # doctest: +NORMALIZE_WHITESPACE
         DatetimeIndex(['2000-01-01 00:00:00', '2000-01-01 00:01:00',
                        '2000-01-01 00:02:00'],
@@ -724,17 +724,17 @@ class DatetimeIndex(Index):
         if asof:
             raise NotImplementedError("'asof' argument is not supported")
 
-        def pandas_at_time(pdf) -> pp.DataFrame[int]:
+        def pandas_at_time(pdf) -> ps.DataFrame[int]:
             return pdf.at_time(time, asof)
 
         kdf = self.to_frame()[[]]
         id_column_name = verify_temp_column_name(kdf, "__id_column__")
         kdf = kdf.koalas.attach_id_column("distributed-sequence", id_column_name)
-        with pp.option_context("compute.default_index_type", "distributed"):
+        with ps.option_context("compute.default_index_type", "distributed"):
             # The attached index in the statement below will be dropped soon,
             # so we enforce “distributed” default index type
             kdf = kdf.koalas.apply_batch(pandas_at_time)
-        return pp.Index(first_series(kdf).rename(self.name))
+        return ps.Index(first_series(kdf).rename(self.name))
 
 
 def disallow_nanoseconds(freq):
@@ -752,7 +752,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.indexes.datetimes.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.indexes.datetimes tests")

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -29,7 +29,7 @@ from pyspark import sql as spark
 from pyspark.sql import functions as F, Window
 
 # For running doctests and reference resolution in PyCharm.
-from pyspark import pandas as pp  # noqa: F401
+from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.frame import DataFrame
@@ -84,13 +84,13 @@ class MultiIndex(Index):
 
     Examples
     --------
-    >>> pp.DataFrame({'a': ['a', 'b', 'c']}, index=[[1, 2, 3], [4, 5, 6]]).index  # doctest: +SKIP
+    >>> ps.DataFrame({'a': ['a', 'b', 'c']}, index=[[1, 2, 3], [4, 5, 6]]).index  # doctest: +SKIP
     MultiIndex([(1, 4),
                 (2, 5),
                 (3, 6)],
                )
 
-    >>> pp.DataFrame({'a': [1, 2, 3]}, index=[list('abc'), list('def')]).index  # doctest: +SKIP
+    >>> ps.DataFrame({'a': [1, 2, 3]}, index=[list('abc'), list('def')]).index  # doctest: +SKIP
     MultiIndex([('a', 'd'),
                 ('b', 'e'),
                 ('c', 'f')],
@@ -133,7 +133,7 @@ class MultiIndex(Index):
                 name=name,
                 verify_integrity=verify_integrity,
             )
-        return pp.from_pandas(pidx)
+        return ps.from_pandas(pidx)
 
     @property
     def _internal(self):
@@ -188,7 +188,7 @@ class MultiIndex(Index):
 
         >>> tuples = [(1, 'red'), (1, 'blue'),
         ...           (2, 'red'), (2, 'blue')]
-        >>> pp.MultiIndex.from_tuples(tuples, names=('number', 'color'))  # doctest: +SKIP
+        >>> ps.MultiIndex.from_tuples(tuples, names=('number', 'color'))  # doctest: +SKIP
         MultiIndex([(1,  'red'),
                     (1, 'blue'),
                     (2,  'red'),
@@ -197,7 +197,7 @@ class MultiIndex(Index):
         """
         return cast(
             MultiIndex,
-            pp.from_pandas(
+            ps.from_pandas(
                 pd.MultiIndex.from_tuples(tuples=tuples, sortorder=sortorder, names=names)
             ),
         )
@@ -225,7 +225,7 @@ class MultiIndex(Index):
         --------
 
         >>> arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
-        >>> pp.MultiIndex.from_arrays(arrays, names=('number', 'color'))  # doctest: +SKIP
+        >>> ps.MultiIndex.from_arrays(arrays, names=('number', 'color'))  # doctest: +SKIP
         MultiIndex([(1,  'red'),
                     (1, 'blue'),
                     (2,  'red'),
@@ -234,7 +234,7 @@ class MultiIndex(Index):
         """
         return cast(
             MultiIndex,
-            pp.from_pandas(
+            ps.from_pandas(
                 pd.MultiIndex.from_arrays(arrays=arrays, sortorder=sortorder, names=names)
             ),
         )
@@ -267,7 +267,7 @@ class MultiIndex(Index):
         --------
         >>> numbers = [0, 1, 2]
         >>> colors = ['green', 'purple']
-        >>> pp.MultiIndex.from_product([numbers, colors],
+        >>> ps.MultiIndex.from_product([numbers, colors],
         ...                            names=['number', 'color'])  # doctest: +SKIP
         MultiIndex([(0,  'green'),
                     (0, 'purple'),
@@ -279,7 +279,7 @@ class MultiIndex(Index):
         """
         return cast(
             MultiIndex,
-            pp.from_pandas(
+            ps.from_pandas(
                 pd.MultiIndex.from_product(iterables=iterables, sortorder=sortorder, names=names)
             ),
         )
@@ -312,7 +312,7 @@ class MultiIndex(Index):
 
         Examples
         --------
-        >>> df = pp.DataFrame([['HI', 'Temp'], ['HI', 'Precip'],
+        >>> df = ps.DataFrame([['HI', 'Temp'], ['HI', 'Precip'],
         ...                    ['NJ', 'Temp'], ['NJ', 'Precip']],
         ...                   columns=['a', 'b'])
         >>> df  # doctest: +SKIP
@@ -322,7 +322,7 @@ class MultiIndex(Index):
         2    NJ    Temp
         3    NJ  Precip
 
-        >>> pp.MultiIndex.from_frame(df)  # doctest: +SKIP
+        >>> ps.MultiIndex.from_frame(df)  # doctest: +SKIP
         MultiIndex([('HI',   'Temp'),
                     ('HI', 'Precip'),
                     ('NJ',   'Temp'),
@@ -331,7 +331,7 @@ class MultiIndex(Index):
 
         Using explicit names, instead of the column names
 
-        >>> pp.MultiIndex.from_frame(df, names=['state', 'observation'])  # doctest: +SKIP
+        >>> ps.MultiIndex.from_frame(df, names=['state', 'observation'])  # doctest: +SKIP
         MultiIndex([('HI',   'Temp'),
                     ('HI', 'Precip'),
                     ('NJ',   'Temp'),
@@ -399,7 +399,7 @@ class MultiIndex(Index):
 
         Examples
         --------
-        >>> midx = pp.MultiIndex.from_arrays([['a', 'b'], [1, 2]], names = ['word', 'number'])
+        >>> midx = ps.MultiIndex.from_arrays([['a', 'b'], [1, 2]], names = ['word', 'number'])
         >>> midx  # doctest: +SKIP
         MultiIndex([('a', 1),
                     ('b', 2)],
@@ -455,7 +455,7 @@ class MultiIndex(Index):
 
         Examples
         --------
-        >>> midx = pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
+        >>> midx = ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
         >>> midx  # doctest: +SKIP
         MultiIndex([('a', 'x'),
                     ('b', 'y'),
@@ -585,7 +585,7 @@ class MultiIndex(Index):
         --------
         >>> tuples = [(1, 'red'), (1, 'blue'),
         ...           (2, 'red'), (2, 'blue')]
-        >>> idx = pp.MultiIndex.from_tuples(tuples, names=('number', 'color'))
+        >>> idx = ps.MultiIndex.from_tuples(tuples, names=('number', 'color'))
         >>> idx  # doctest: +SKIP
         MultiIndex([(1,  'red'),
                     (1, 'blue'),
@@ -642,7 +642,7 @@ class MultiIndex(Index):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'],
         ...                   index=[list('abcd'), list('efgh')])
         >>> df['dogs'].index.to_pandas()  # doctest: +SKIP
@@ -682,7 +682,7 @@ class MultiIndex(Index):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'],
         ...                   index=[list('abcd'), list('efgh')])
         >>> df['dogs'].index  # doctest: +SKIP
@@ -737,9 +737,9 @@ class MultiIndex(Index):
         ...                        ['speed', 'weight', 'length']],
         ...                       [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                        [0, 0, 0, 0, 1, 2, 0, 1, 2]])
-        >>> s1 = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        >>> s1 = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
         ...                index=midx1)
-        >>> s2 = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        >>> s2 = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
         ...              index=midx2)
 
         >>> s1.index.symmetric_difference(s2.index)  # doctest: +SKIP
@@ -812,7 +812,7 @@ class MultiIndex(Index):
 
         Examples
         --------
-        >>> index = pp.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
+        >>> index = ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y'), ('c', 'z')])
         >>> index # doctest: +SKIP
         MultiIndex([('a', 'x'),
                     ('b', 'y'),
@@ -904,7 +904,7 @@ class MultiIndex(Index):
         --------
         >>> from datetime import datetime
 
-        >>> idx = pp.MultiIndex.from_tuples(
+        >>> idx = ps.MultiIndex.from_tuples(
         ...     [(datetime(2019, 1, 1, 0, 0, 0), datetime(2019, 1, 1, 0, 0, 0)),
         ...      (datetime(2019, 1, 1, 0, 0, 0), datetime(2019, 1, 1, 0, 0, 0))])
         >>> idx  # doctest: +SKIP
@@ -977,7 +977,7 @@ class MultiIndex(Index):
 
         Create a MultiIndex:
 
-        >>> mi = pp.MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'a')])
+        >>> mi = ps.MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'a')])
         >>> mi.names = ['level_1', 'level_2']
 
         Get level values by supplying level as either integer or name:
@@ -1019,7 +1019,7 @@ class MultiIndex(Index):
 
         Examples
         --------
-        >>> kmidx = pp.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        >>> kmidx = ps.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
         >>> kmidx.insert(3, ("h", "j"))  # doctest: +SKIP
         MultiIndex([('a', 'x'),
                     ('b', 'y'),
@@ -1082,7 +1082,7 @@ class MultiIndex(Index):
 
         Examples
         --------
-        >>> kmidx = pp.MultiIndex.from_tuples([('a', 'x')])
+        >>> kmidx = ps.MultiIndex.from_tuples([('a', 'x')])
         >>> kmidx.item()
         ('a', 'x')
         """
@@ -1104,8 +1104,8 @@ class MultiIndex(Index):
 
         Examples
         --------
-        >>> midx1 = pp.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        >>> midx2 = pp.MultiIndex.from_tuples([("c", "z"), ("d", "w")])
+        >>> midx1 = ps.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        >>> midx2 = ps.MultiIndex.from_tuples([("c", "z"), ("d", "w")])
         >>> midx1.intersection(midx2).sort_values()  # doctest: +SKIP
         MultiIndex([('c', 'z')],
                    )
@@ -1182,7 +1182,7 @@ def _test():
 
     globs = pyspark.pandas.indexes.multi.__dict__.copy()
     globs["np"] = numpy
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.indexes.multi tests")

--- a/python/pyspark/pandas/indexes/numeric.py
+++ b/python/pyspark/pandas/indexes/numeric.py
@@ -17,7 +17,7 @@
 import pandas as pd
 from pandas.api.types import is_hashable
 
-from pyspark import pandas as pp
+from pyspark import pandas as ps
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.series import Series
 
@@ -65,19 +65,19 @@ class Int64Index(IntegerIndex):
 
     Examples
     --------
-    >>> pp.Int64Index([1, 2, 3])
+    >>> ps.Int64Index([1, 2, 3])
     Int64Index([1, 2, 3], dtype='int64')
 
     From a Series:
 
-    >>> s = pp.Series([1, 2, 3], index=[10, 20, 30])
-    >>> pp.Int64Index(s)
+    >>> s = ps.Series([1, 2, 3], index=[10, 20, 30])
+    >>> ps.Int64Index(s)
     Int64Index([1, 2, 3], dtype='int64')
 
     From an Index:
 
-    >>> idx = pp.Index([1, 2, 3])
-    >>> pp.Int64Index(idx)
+    >>> idx = ps.Index([1, 2, 3])
+    >>> ps.Int64Index(idx)
     Int64Index([1, 2, 3], dtype='int64')
     """
 
@@ -90,7 +90,7 @@ class Int64Index(IntegerIndex):
                 dtype = "int64"
             return Index(data, dtype=dtype, copy=copy, name=name)
 
-        return pp.from_pandas(pd.Int64Index(data=data, dtype=dtype, copy=copy, name=name))
+        return ps.from_pandas(pd.Int64Index(data=data, dtype=dtype, copy=copy, name=name))
 
 
 class Float64Index(NumericIndex):
@@ -119,19 +119,19 @@ class Float64Index(NumericIndex):
 
     Examples
     --------
-    >>> pp.Float64Index([1.0, 2.0, 3.0])
+    >>> ps.Float64Index([1.0, 2.0, 3.0])
     Float64Index([1.0, 2.0, 3.0], dtype='float64')
 
     From a Series:
 
-    >>> s = pp.Series([1, 2, 3], index=[10, 20, 30])
-    >>> pp.Float64Index(s)
+    >>> s = ps.Series([1, 2, 3], index=[10, 20, 30])
+    >>> ps.Float64Index(s)
     Float64Index([1.0, 2.0, 3.0], dtype='float64')
 
     From an Index:
 
-    >>> idx = pp.Index([1, 2, 3])
-    >>> pp.Float64Index(idx)
+    >>> idx = ps.Index([1, 2, 3])
+    >>> ps.Float64Index(idx)
     Float64Index([1.0, 2.0, 3.0], dtype='float64')
     """
 
@@ -144,7 +144,7 @@ class Float64Index(NumericIndex):
                 dtype = "float64"
             return Index(data, dtype=dtype, copy=copy, name=name)
 
-        return pp.from_pandas(pd.Float64Index(data=data, dtype=dtype, copy=copy, name=name))
+        return ps.from_pandas(pd.Float64Index(data=data, dtype=dtype, copy=copy, name=name))
 
 
 def _test():
@@ -157,7 +157,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.indexes.numeric.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.indexes.numeric tests")

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -31,7 +31,7 @@ from pyspark.sql.types import BooleanType, LongType
 from pyspark.sql.utils import AnalysisException
 import numpy as np
 
-from pyspark import pandas as pp  # noqa: F401
+from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas.internal import (
     InternalFrame,
     NATURAL_ORDER_COLUMN_NAME,
@@ -113,7 +113,7 @@ class AtIndexer(IndexerLike):
 
     Examples
     --------
-    >>> kdf = pp.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]],
+    >>> kdf = ps.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]],
     ...                    index=[4, 5, 5], columns=['A', 'B', 'C'])
     >>> kdf
         A   B   C
@@ -193,7 +193,7 @@ class iAtIndexer(IndexerLike):
 
     Examples
     --------
-    >>> df = pp.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]],
+    >>> df = ps.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]],
     ...                   columns=['A', 'B', 'C'])
     >>> df
         A   B   C
@@ -208,7 +208,7 @@ class iAtIndexer(IndexerLike):
 
     Get value within a series
 
-    >>> kser = pp.Series([1, 2, 3], index=[10, 20, 30])
+    >>> kser = ps.Series([1, 2, 3], index=[10, 20, 30])
     >>> kser
     10    1
     20    2
@@ -789,7 +789,7 @@ class LocIndexer(LocIndexerLike):
     --------
     **Getting values**
 
-    >>> df = pp.DataFrame([[1, 2], [4, 5], [7, 8]],
+    >>> df = ps.DataFrame([[1, 2], [4, 5], [7, 8]],
     ...                   index=['cobra', 'viper', 'sidewinder'],
     ...                   columns=['max_speed', 'shield'])
     >>> df
@@ -928,7 +928,7 @@ class LocIndexer(LocIndexerLike):
 
     Another example using integers for the index
 
-    >>> df = pp.DataFrame([[1, 2], [4, 5], [7, 8]],
+    >>> df = ps.DataFrame([[1, 2], [4, 5], [7, 8]],
     ...                   index=[7, 8, 9],
     ...                   columns=['max_speed', 'shield'])
     >>> df
@@ -1349,7 +1349,7 @@ class iLocIndexer(LocIndexerLike):
     >>> mydict = [{'a': 1, 'b': 2, 'c': 3, 'd': 4},
     ...           {'a': 100, 'b': 200, 'c': 300, 'd': 400},
     ...           {'a': 1000, 'b': 2000, 'c': 3000, 'd': 4000 }]
-    >>> df = pp.DataFrame(mydict, columns=['a', 'b', 'c', 'd'])
+    >>> df = ps.DataFrame(mydict, columns=['a', 'b', 'c', 'd'])
     >>> df
           a     b     c     d
     0     1     2     3     4
@@ -1718,7 +1718,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.indexing.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.indexing tests")

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -40,7 +40,7 @@ except ImportError:
     from pyspark.sql.pandas.types import to_arrow_type  # noqa: F401
 
 # For running doctests and reference resolution in PyCharm.
-from pyspark import pandas as pp  # noqa: F401
+from pyspark import pandas as ps  # noqa: F401
 
 if TYPE_CHECKING:
     # This is required in old Python 3.5 to prevent circular reference.
@@ -91,7 +91,7 @@ class InternalFrame(object):
     For instance, if we have a Koalas DataFrame as below, pandas DataFrame does not store the index
     as columns.
 
-    >>> kdf = pp.DataFrame({
+    >>> kdf = ps.DataFrame({
     ...     'A': [1, 2, 3, 4],
     ...     'B': [5, 6, 7, 8],
     ...     'C': [9, 10, 11, 12],
@@ -304,7 +304,7 @@ class InternalFrame(object):
 
     >>> columns = pd.MultiIndex.from_tuples([('X', 'A'), ('X', 'B'),
     ...                                      ('Y', 'C'), ('Y', 'D')])
-    >>> kdf3 = pp.DataFrame([
+    >>> kdf3 = ps.DataFrame([
     ...     [1, 2, 3, 4],
     ...     [5, 6, 7, 8],
     ...     [9, 10, 11, 12],
@@ -424,7 +424,7 @@ class InternalFrame(object):
         >>> row_index = pd.MultiIndex.from_tuples(
         ...     [('foo', 'bar'), ('foo', 'bar'), ('zoo', 'bar')],
         ...     names=["row_index_a", "row_index_b"])
-        >>> kdf = pp.DataFrame(
+        >>> kdf = ps.DataFrame(
         ...     [[1, 2, 3], [4, 5, 6], [7, 8, 9]], index=row_index, columns=column_labels)
         >>> kdf.set_index(('a', 'x'), append=True, inplace=True)
         >>> kdf  # doctest: +NORMALIZE_WHITESPACE
@@ -635,7 +635,7 @@ class InternalFrame(object):
         notion so corresponding column should be generated.
         There are several types of default index can be configured by `compute.default_index_type`.
 
-        >>> spark_frame = pp.range(10).to_spark()
+        >>> spark_frame = ps.range(10).to_spark()
         >>> spark_frame
         DataFrame[id: bigint]
 
@@ -692,7 +692,7 @@ class InternalFrame(object):
         This method attaches a Spark column that has a sequence in a distributed manner.
         This is equivalent to the column assigned when default index type 'distributed-sequence'.
 
-        >>> sdf = pp.DataFrame(['a', 'b', 'c']).to_spark()
+        >>> sdf = ps.DataFrame(['a', 'b', 'c']).to_spark()
         >>> sdf = InternalFrame.attach_distributed_sequence_column(sdf, column_name="sequence")
         >>> sdf.show()  # doctest: +NORMALIZE_WHITESPACE
         +--------+---+
@@ -736,7 +736,7 @@ class InternalFrame(object):
     @staticmethod
     def _attach_distributed_sequence_column(sdf, column_name):
         """
-        >>> sdf = pp.DataFrame(['a', 'b', 'c']).to_spark()
+        >>> sdf = ps.DataFrame(['a', 'b', 'c']).to_spark()
         >>> sdf = InternalFrame._attach_distributed_sequence_column(sdf, column_name="sequence")
         >>> sdf.sort("sequence").show()  # doctest: +NORMALIZE_WHITESPACE
         +--------+---+
@@ -1448,7 +1448,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.internal.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.internal tests")

--- a/python/pyspark/pandas/ml.py
+++ b/python/pyspark/pandas/ml.py
@@ -27,13 +27,13 @@ from pyspark.ml.stat import Correlation
 from pyspark.pandas.utils import column_labels_level
 
 if TYPE_CHECKING:
-    import pyspark.pandas as pp  # noqa: F401 (SPARK-34943)
+    import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
 
 
 CORRELATION_OUTPUT_COLUMN = "__correlation_output__"
 
 
-def corr(kdf: "pp.DataFrame", method: str = "pearson") -> pd.DataFrame:
+def corr(kdf: "ps.DataFrame", method: str = "pearson") -> pd.DataFrame:
     """
     The correlation matrix of all the numerical columns of this dataframe.
 
@@ -45,7 +45,7 @@ def corr(kdf: "pp.DataFrame", method: str = "pearson") -> pd.DataFrame:
                    * spearman : Spearman rank correlation
     :return: :class:`pandas.DataFrame`
 
-    >>> pp.DataFrame({'A': [0, 1], 'B': [1, 0], 'C': ['x', 'y']}).corr()
+    >>> ps.DataFrame({'A': [0, 1], 'B': [1, 0], 'C': ['x', 'y']}).corr()
          A    B
     A  1.0 -1.0
     B -1.0  1.0
@@ -62,7 +62,7 @@ def corr(kdf: "pp.DataFrame", method: str = "pearson") -> pd.DataFrame:
     return pd.DataFrame(arr, columns=idx, index=idx)
 
 
-def to_numeric_df(kdf: "pp.DataFrame") -> Tuple[pyspark.sql.DataFrame, List[Tuple]]:
+def to_numeric_df(kdf: "ps.DataFrame") -> Tuple[pyspark.sql.DataFrame, List[Tuple]]:
     """
     Takes a dataframe and turns it into a dataframe containing a single numerical
     vector of doubles. This dataframe has a single field called '_1'.
@@ -72,7 +72,7 @@ def to_numeric_df(kdf: "pp.DataFrame") -> Tuple[pyspark.sql.DataFrame, List[Tupl
     :return: a pair of dataframe, list of strings (the name of the columns
              that were converted to numerical types)
 
-    >>> to_numeric_df(pp.DataFrame({'A': [0, 1], 'B': [1, 0], 'C': ['x', 'y']}))
+    >>> to_numeric_df(ps.DataFrame({'A': [0, 1], 'B': [1, 0], 'C': ['x', 'y']}))
     (DataFrame[__correlation_output__: vector], [('A',), ('B',)])
     """
     # TODO, it should be more robust.
@@ -101,7 +101,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.ml.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = SparkSession.builder.master("local[4]").appName("pyspark.pandas.ml tests").getOrCreate()
     (failure_count, test_count) = doctest.testmod(
         pyspark.pandas.ml, globs=globs, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE

--- a/python/pyspark/pandas/mlflow.py
+++ b/python/pyspark/pandas/mlflow.py
@@ -158,7 +158,7 @@ def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:
     >>> from pyspark.pandas.mlflow import load_model
     >>> run_info = client.list_run_infos(exp)[-1]
     >>> model = load_model("runs:/{run_id}/model".format(run_id=run_info.run_uuid))
-    >>> prediction_df = pp.DataFrame({"x1": [2.0], "x2": [4.0]})
+    >>> prediction_df = ps.DataFrame({"x1": [2.0], "x2": [4.0]})
     >>> prediction_df["prediction"] = model.predict(prediction_df)
     >>> prediction_df
         x1   x2  prediction
@@ -175,7 +175,7 @@ def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:
     Other columns have to be manually joined.
     For example, this code will not work:
 
-    >>> df = pp.DataFrame({"x1": [2.0], "x2": [3.0], "z": [-1]})
+    >>> df = ps.DataFrame({"x1": [2.0], "x2": [3.0], "z": [-1]})
     >>> features = df[["x1", "x2"]]
     >>> y = model.predict(features)
     >>> # Works:

--- a/python/pyspark/pandas/mlflow.py
+++ b/python/pyspark/pandas/mlflow.py
@@ -205,7 +205,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.mlflow.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.mlflow tests").getOrCreate()
     )

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -50,7 +50,7 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from pyspark import pandas as pp  # noqa: F401
+from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.utils import (
     align_diff_frames,
@@ -164,7 +164,7 @@ def range(
     --------
     When the first parameter is specified, we generate a range of values up till that number.
 
-    >>> pp.range(5)
+    >>> ps.range(5)
        id
     0   0
     1   1
@@ -174,7 +174,7 @@ def range(
 
     When start, end, and step are specified:
 
-    >>> pp.range(start = 100, end = 200, step = 20)
+    >>> ps.range(start = 100, end = 200, step = 20)
         id
     0  100
     1  120
@@ -266,7 +266,7 @@ def read_csv(
 
     Examples
     --------
-    >>> pp.read_csv('data.csv')  # doctest: +SKIP
+    >>> ps.read_csv('data.csv')  # doctest: +SKIP
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
         options = options.get("options")  # type: ignore
@@ -432,11 +432,11 @@ def read_json(
 
     Examples
     --------
-    >>> df = pp.DataFrame([['a', 'b'], ['c', 'd']],
+    >>> df = ps.DataFrame([['a', 'b'], ['c', 'd']],
     ...                   columns=['col 1', 'col 2'])
 
     >>> df.to_json(path=r'%s/read_json/foo.json' % path, num_files=1)
-    >>> pp.read_json(
+    >>> ps.read_json(
     ...     path=r'%s/read_json/foo.json' % path
     ... ).sort_values(by="col 1")
       col 1 col 2
@@ -444,7 +444,7 @@ def read_json(
     1     c     d
 
     >>> df.to_json(path=r'%s/read_json/foo.json' % path, num_files=1, lineSep='___')
-    >>> pp.read_json(
+    >>> ps.read_json(
     ...     path=r'%s/read_json/foo.json' % path, lineSep='___'
     ... ).sort_values(by="col 1")
       col 1 col 2
@@ -454,7 +454,7 @@ def read_json(
     You can preserve the index in the roundtrip as below.
 
     >>> df.to_json(path=r'%s/read_json/bar.json' % path, num_files=1, index_col="index")
-    >>> pp.read_json(
+    >>> ps.read_json(
     ...     path=r'%s/read_json/bar.json' % path, index_col="index"
     ... ).sort_values(by="col 1")  # doctest: +NORMALIZE_WHITESPACE
           col 1 col 2
@@ -512,14 +512,14 @@ def read_delta(
 
     Examples
     --------
-    >>> pp.range(1).to_delta('%s/read_delta/foo' % path)  # doctest: +SKIP
-    >>> pp.read_delta('%s/read_delta/foo' % path)  # doctest: +SKIP
+    >>> ps.range(1).to_delta('%s/read_delta/foo' % path)  # doctest: +SKIP
+    >>> ps.read_delta('%s/read_delta/foo' % path)  # doctest: +SKIP
        id
     0   0
 
-    >>> pp.range(10, 15, num_partitions=1).to_delta('%s/read_delta/foo' % path,
+    >>> ps.range(10, 15, num_partitions=1).to_delta('%s/read_delta/foo' % path,
     ...                                             mode='overwrite')  # doctest: +SKIP
-    >>> pp.read_delta('%s/read_delta/foo' % path)  # doctest: +SKIP
+    >>> ps.read_delta('%s/read_delta/foo' % path)  # doctest: +SKIP
        id
     0  10
     1  11
@@ -527,15 +527,15 @@ def read_delta(
     3  13
     4  14
 
-    >>> pp.read_delta('%s/read_delta/foo' % path, version=0)  # doctest: +SKIP
+    >>> ps.read_delta('%s/read_delta/foo' % path, version=0)  # doctest: +SKIP
        id
     0   0
 
     You can preserve the index in the roundtrip as below.
 
-    >>> pp.range(10, 15, num_partitions=1).to_delta(
+    >>> ps.range(10, 15, num_partitions=1).to_delta(
     ...     '%s/read_delta/bar' % path, index_col="index")  # doctest: +SKIP
-    >>> pp.read_delta('%s/read_delta/bar' % path, index_col="index")  # doctest: +SKIP
+    >>> ps.read_delta('%s/read_delta/bar' % path, index_col="index")  # doctest: +SKIP
            id
     index
     0      10
@@ -579,13 +579,13 @@ def read_table(name: str, index_col: Optional[Union[str, List[str]]] = None) -> 
 
     Examples
     --------
-    >>> pp.range(1).to_table('%s.my_table' % db)
-    >>> pp.read_table('%s.my_table' % db)
+    >>> ps.range(1).to_table('%s.my_table' % db)
+    >>> ps.read_table('%s.my_table' % db)
        id
     0   0
 
-    >>> pp.range(1).to_table('%s.my_table' % db, index_col="index")
-    >>> pp.read_table('%s.my_table' % db, index_col="index")  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.range(1).to_table('%s.my_table' % db, index_col="index")
+    >>> ps.read_table('%s.my_table' % db, index_col="index")  # doctest: +NORMALIZE_WHITESPACE
            id
     index
     0       0
@@ -639,15 +639,15 @@ def read_spark_io(
 
     Examples
     --------
-    >>> pp.range(1).to_spark_io('%s/read_spark_io/data.parquet' % path)
-    >>> pp.read_spark_io(
+    >>> ps.range(1).to_spark_io('%s/read_spark_io/data.parquet' % path)
+    >>> ps.read_spark_io(
     ...     '%s/read_spark_io/data.parquet' % path, format='parquet', schema='id long')
        id
     0   0
 
-    >>> pp.range(10, 15, num_partitions=1).to_spark_io('%s/read_spark_io/data.json' % path,
+    >>> ps.range(10, 15, num_partitions=1).to_spark_io('%s/read_spark_io/data.json' % path,
     ...                                                format='json', lineSep='__')
-    >>> pp.read_spark_io(
+    >>> ps.read_spark_io(
     ...     '%s/read_spark_io/data.json' % path, format='json', schema='id long', lineSep='__')
        id
     0  10
@@ -658,9 +658,9 @@ def read_spark_io(
 
     You can preserve the index in the roundtrip as below.
 
-    >>> pp.range(10, 15, num_partitions=1).to_spark_io('%s/read_spark_io/data.orc' % path,
+    >>> ps.range(10, 15, num_partitions=1).to_spark_io('%s/read_spark_io/data.orc' % path,
     ...                                                format='orc', index_col="index")
-    >>> pp.read_spark_io(
+    >>> ps.read_spark_io(
     ...     path=r'%s/read_spark_io/data.orc' % path, format="orc", index_col="index")
     ... # doctest: +NORMALIZE_WHITESPACE
            id
@@ -713,15 +713,15 @@ def read_parquet(path, columns=None, index_col=None, pandas_metadata=False, **op
 
     Examples
     --------
-    >>> pp.range(1).to_parquet('%s/read_spark_io/data.parquet' % path)
-    >>> pp.read_parquet('%s/read_spark_io/data.parquet' % path, columns=['id'])
+    >>> ps.range(1).to_parquet('%s/read_spark_io/data.parquet' % path)
+    >>> ps.read_parquet('%s/read_spark_io/data.parquet' % path, columns=['id'])
        id
     0   0
 
     You can preserve the index in the roundtrip as below.
 
-    >>> pp.range(1).to_parquet('%s/read_spark_io/data.parquet' % path, index_col="index")
-    >>> pp.read_parquet('%s/read_spark_io/data.parquet' % path, columns=['id'], index_col="index")
+    >>> ps.range(1).to_parquet('%s/read_spark_io/data.parquet' % path, index_col="index")
+    >>> ps.read_parquet('%s/read_spark_io/data.parquet' % path, columns=['id'], index_col="index")
     ... # doctest: +NORMALIZE_WHITESPACE
            id
     index
@@ -856,7 +856,7 @@ def read_excel(
 
         .. note::
             If the underlying Spark is below 3.0, the parameter as a string is not supported.
-            You can use `pp.from_pandas(pd.read_excel(...))` as a workaround.
+            You can use `ps.from_pandas(pd.read_excel(...))` as a workaround.
 
     sheet_name : str, int, list, or None, default 0
         Strings are used for sheet names. Integers are used in zero-indexed
@@ -992,13 +992,13 @@ def read_excel(
     --------
     The file can be read using the file name as string or an open file object:
 
-    >>> pp.read_excel('tmp.xlsx', index_col=0)  # doctest: +SKIP
+    >>> ps.read_excel('tmp.xlsx', index_col=0)  # doctest: +SKIP
            Name  Value
     0   string1      1
     1   string2      2
     2  #Comment      3
 
-    >>> pp.read_excel(open('tmp.xlsx', 'rb'),
+    >>> ps.read_excel(open('tmp.xlsx', 'rb'),
     ...               sheet_name='Sheet3')  # doctest: +SKIP
        Unnamed: 0      Name  Value
     0           0   string1      1
@@ -1007,7 +1007,7 @@ def read_excel(
 
     Index and header can be specified via the `index_col` and `header` arguments
 
-    >>> pp.read_excel('tmp.xlsx', index_col=None, header=None)  # doctest: +SKIP
+    >>> ps.read_excel('tmp.xlsx', index_col=None, header=None)  # doctest: +SKIP
          0         1      2
     0  NaN      Name  Value
     1  0.0   string1      1
@@ -1016,7 +1016,7 @@ def read_excel(
 
     Column types are inferred but can be explicitly specified
 
-    >>> pp.read_excel('tmp.xlsx', index_col=0,
+    >>> ps.read_excel('tmp.xlsx', index_col=0,
     ...               dtype={'Name': str, 'Value': float})  # doctest: +SKIP
            Name  Value
     0   string1    1.0
@@ -1027,7 +1027,7 @@ def read_excel(
     but can be explicitly specified, too. Supply the values you would like
     as strings or lists of strings!
 
-    >>> pp.read_excel('tmp.xlsx', index_col=0,
+    >>> ps.read_excel('tmp.xlsx', index_col=0,
     ...               na_values=['string1', 'string2'])  # doctest: +SKIP
            Name  Value
     0      None      1
@@ -1036,7 +1036,7 @@ def read_excel(
 
     Comment lines in the excel input file can be skipped using the `comment` kwarg
 
-    >>> pp.read_excel('tmp.xlsx', index_col=0, comment='#')  # doctest: +SKIP
+    >>> ps.read_excel('tmp.xlsx', index_col=0, comment='#')  # doctest: +SKIP
           Name  Value
     0  string1    1.0
     1  string2    2.0
@@ -1076,7 +1076,7 @@ def read_excel(
         if LooseVersion(pyspark.__version__) < LooseVersion("3.0.0"):
             raise ValueError(
                 "The `io` parameter as a string is not supported if the underlying Spark is "
-                "below 3.0. You can use `pp.from_pandas(pd.read_excel(...))` as a workaround"
+                "below 3.0. You can use `ps.from_pandas(pd.read_excel(...))` as a workaround"
             )
         # 'binaryFile' format is available since Spark 3.0.0.
         binaries = default_session().read.format("binaryFile").load(io).select("content").head(2)
@@ -1191,7 +1191,7 @@ def read_html(
         falls back on ``bs4`` + ``html5lib``.
 
     header : int or list-like or None, optional
-        The row (or list of rows for a :class:`~pp.MultiIndex`) to use to
+        The row (or list of rows for a :class:`~ps.MultiIndex`) to use to
         make the columns headers.
 
     index_col : int or list-like or None, optional
@@ -1226,7 +1226,7 @@ def read_html(
         latest information on table attributes for the modern web.
 
     parse_dates : bool, optional
-        See :func:`~pp.read_csv` for more details.
+        See :func:`~ps.read_csv` for more details.
 
     thousands : str, optional
         Separator to use to parse thousands. Defaults to ``','``.
@@ -1327,7 +1327,7 @@ def read_sql_table(
 
     Examples
     --------
-    >>> pp.read_sql_table('table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
+    >>> ps.read_sql_table('table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
         options = options.get("options")  # type: ignore
@@ -1387,7 +1387,7 @@ def read_sql_query(sql, con, index_col=None, **options) -> DataFrame:
 
     Examples
     --------
-    >>> pp.read_sql_query('SELECT * FROM table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
+    >>> ps.read_sql_query('SELECT * FROM table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
         options = options.get("options")  # type: ignore
@@ -1447,8 +1447,8 @@ def read_sql(sql, con, index_col=None, columns=None, **options) -> DataFrame:
 
     Examples
     --------
-    >>> pp.read_sql('table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
-    >>> pp.read_sql('SELECT * FROM table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
+    >>> ps.read_sql('table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
+    >>> ps.read_sql('SELECT * FROM table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
         options = options.get("options")  # type: ignore
@@ -1520,10 +1520,10 @@ def to_datetime(
     common abbreviations like ['year', 'month', 'day', 'minute', 'second',
     'ms', 'us', 'ns']) or plurals of the same
 
-    >>> df = pp.DataFrame({'year': [2015, 2016],
+    >>> df = ps.DataFrame({'year': [2015, 2016],
     ...                    'month': [2, 3],
     ...                    'day': [4, 5]})
-    >>> pp.to_datetime(df)
+    >>> ps.to_datetime(df)
     0   2015-02-04
     1   2016-03-05
     dtype: datetime64[ns]
@@ -1536,15 +1536,15 @@ def to_datetime(
     Passing errors='coerce' will force an out-of-bounds date to NaT,
     in addition to forcing non-dates (or non-parseable dates) to NaT.
 
-    >>> pp.to_datetime('13000101', format='%Y%m%d', errors='ignore')
+    >>> ps.to_datetime('13000101', format='%Y%m%d', errors='ignore')
     datetime.datetime(1300, 1, 1, 0, 0)
-    >>> pp.to_datetime('13000101', format='%Y%m%d', errors='coerce')
+    >>> ps.to_datetime('13000101', format='%Y%m%d', errors='coerce')
     NaT
 
     Passing infer_datetime_format=True can often-times speedup a parsing
     if its not an ISO8601 format exactly, but in a regular format.
 
-    >>> s = pp.Series(['3/11/2000', '3/12/2000', '3/13/2000'] * 1000)
+    >>> s = ps.Series(['3/11/2000', '3/12/2000', '3/13/2000'] * 1000)
     >>> s.head()
     0    3/11/2000
     1    3/12/2000
@@ -1555,25 +1555,25 @@ def to_datetime(
 
     >>> import timeit
     >>> timeit.timeit(
-    ...    lambda: repr(pp.to_datetime(s, infer_datetime_format=True)),
+    ...    lambda: repr(ps.to_datetime(s, infer_datetime_format=True)),
     ...    number = 1)  # doctest: +SKIP
     0.35832712500000063
 
     >>> timeit.timeit(
-    ...    lambda: repr(pp.to_datetime(s, infer_datetime_format=False)),
+    ...    lambda: repr(ps.to_datetime(s, infer_datetime_format=False)),
     ...    number = 1)  # doctest: +SKIP
     0.8895321660000004
 
     Using a unix epoch time
 
-    >>> pp.to_datetime(1490195805, unit='s')
+    >>> ps.to_datetime(1490195805, unit='s')
     Timestamp('2017-03-22 15:16:45')
-    >>> pp.to_datetime(1490195805433502912, unit='ns')
+    >>> ps.to_datetime(1490195805433502912, unit='ns')
     Timestamp('2017-03-22 15:16:45.433502912')
 
     Using a non-unix epoch origin
 
-    >>> pp.to_datetime([1, 2, 3], unit='D', origin=pd.Timestamp('1960-01-01'))
+    >>> ps.to_datetime([1, 2, 3], unit='D', origin=pd.Timestamp('1960-01-01'))
     DatetimeIndex(['1960-01-02', '1960-01-03', '1960-01-04'], dtype='datetime64[ns]', freq=None)
     """
 
@@ -1669,21 +1669,21 @@ def date_range(
 
     Specify `start` and `end`, with the default daily frequency.
 
-    >>> pp.date_range(start='1/1/2018', end='1/08/2018')  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.date_range(start='1/1/2018', end='1/08/2018')  # doctest: +NORMALIZE_WHITESPACE
     DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
                    '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08'],
                   dtype='datetime64[ns]', freq=None)
 
     Specify `start` and `periods`, the number of periods (days).
 
-    >>> pp.date_range(start='1/1/2018', periods=8)  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.date_range(start='1/1/2018', periods=8)  # doctest: +NORMALIZE_WHITESPACE
     DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
                    '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08'],
                   dtype='datetime64[ns]', freq=None)
 
     Specify `end` and `periods`, the number of periods (days).
 
-    >>> pp.date_range(end='1/1/2018', periods=8)  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.date_range(end='1/1/2018', periods=8)  # doctest: +NORMALIZE_WHITESPACE
     DatetimeIndex(['2017-12-25', '2017-12-26', '2017-12-27', '2017-12-28',
                    '2017-12-29', '2017-12-30', '2017-12-31', '2018-01-01'],
                   dtype='datetime64[ns]', freq=None)
@@ -1691,7 +1691,7 @@ def date_range(
     Specify `start`, `end`, and `periods`; the frequency is generated
     automatically (linearly spaced).
 
-    >>> pp.date_range(
+    >>> ps.date_range(
     ...     start='2018-04-24', end='2018-04-27', periods=3
     ... )  # doctest: +NORMALIZE_WHITESPACE
     DatetimeIndex(['2018-04-24 00:00:00', '2018-04-25 12:00:00',
@@ -1702,21 +1702,21 @@ def date_range(
 
     Changed the `freq` (frequency) to ``'M'`` (month end frequency).
 
-    >>> pp.date_range(start='1/1/2018', periods=5, freq='M')  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.date_range(start='1/1/2018', periods=5, freq='M')  # doctest: +NORMALIZE_WHITESPACE
     DatetimeIndex(['2018-01-31', '2018-02-28', '2018-03-31', '2018-04-30',
                    '2018-05-31'],
                   dtype='datetime64[ns]', freq=None)
 
     Multiples are allowed
 
-    >>> pp.date_range(start='1/1/2018', periods=5, freq='3M')  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.date_range(start='1/1/2018', periods=5, freq='3M')  # doctest: +NORMALIZE_WHITESPACE
     DatetimeIndex(['2018-01-31', '2018-04-30', '2018-07-31', '2018-10-31',
                    '2019-01-31'],
                   dtype='datetime64[ns]', freq=None)
 
     `freq` can also be specified as an Offset object.
 
-    >>> pp.date_range(
+    >>> ps.date_range(
     ...     start='1/1/2018', periods=5, freq=pd.offsets.MonthEnd(3)
     ... )  # doctest: +NORMALIZE_WHITESPACE
     DatetimeIndex(['2018-01-31', '2018-04-30', '2018-07-31', '2018-10-31',
@@ -1726,7 +1726,7 @@ def date_range(
     `closed` controls whether to include `start` and `end` that are on the
     boundary. The default includes boundary points on either end.
 
-    >>> pp.date_range(
+    >>> ps.date_range(
     ...     start='2017-01-01', end='2017-01-04', closed=None
     ... )  # doctest: +NORMALIZE_WHITESPACE
     DatetimeIndex(['2017-01-01', '2017-01-02', '2017-01-03', '2017-01-04'],
@@ -1734,14 +1734,14 @@ def date_range(
 
     Use ``closed='left'`` to exclude `end` if it falls on the boundary.
 
-    >>> pp.date_range(
+    >>> ps.date_range(
     ...     start='2017-01-01', end='2017-01-04', closed='left'
     ... )  # doctest: +NORMALIZE_WHITESPACE
     DatetimeIndex(['2017-01-01', '2017-01-02', '2017-01-03'], dtype='datetime64[ns]', freq=None)
 
     Use ``closed='right'`` to exclude `start` if it falls on the boundary.
 
-    >>> pp.date_range(
+    >>> ps.date_range(
     ...     start='2017-01-01', end='2017-01-04', closed='right'
     ... )  # doctest: +NORMALIZE_WHITESPACE
     DatetimeIndex(['2017-01-02', '2017-01-03', '2017-01-04'], dtype='datetime64[ns]', freq=None)
@@ -1751,7 +1751,7 @@ def date_range(
 
     return cast(
         DatetimeIndex,
-        pp.from_pandas(
+        ps.from_pandas(
             pd.date_range(
                 start=start,
                 end=end,
@@ -1818,26 +1818,26 @@ def get_dummies(
 
     Examples
     --------
-    >>> s = pp.Series(list('abca'))
+    >>> s = ps.Series(list('abca'))
 
-    >>> pp.get_dummies(s)
+    >>> ps.get_dummies(s)
        a  b  c
     0  1  0  0
     1  0  1  0
     2  0  0  1
     3  1  0  0
 
-    >>> df = pp.DataFrame({'A': ['a', 'b', 'a'], 'B': ['b', 'a', 'c'],
+    >>> df = ps.DataFrame({'A': ['a', 'b', 'a'], 'B': ['b', 'a', 'c'],
     ...                    'C': [1, 2, 3]},
     ...                   columns=['A', 'B', 'C'])
 
-    >>> pp.get_dummies(df, prefix=['col1', 'col2'])
+    >>> ps.get_dummies(df, prefix=['col1', 'col2'])
        C  col1_a  col1_b  col2_a  col2_b  col2_c
     0  1       1       0       0       1       0
     1  2       0       1       1       0       0
     2  3       1       0       0       0       1
 
-    >>> pp.get_dummies(pp.Series(list('abcaa')))
+    >>> ps.get_dummies(ps.Series(list('abcaa')))
        a  b  c
     0  1  0  0
     1  0  1  0
@@ -1845,7 +1845,7 @@ def get_dummies(
     3  1  0  0
     4  1  0  0
 
-    >>> pp.get_dummies(pp.Series(list('abcaa')), drop_first=True)
+    >>> ps.get_dummies(ps.Series(list('abcaa')), drop_first=True)
        b  c
     0  0  0
     1  1  0
@@ -1853,7 +1853,7 @@ def get_dummies(
     3  0  0
     4  0  0
 
-    >>> pp.get_dummies(pp.Series(list('abc')), dtype=float)
+    >>> ps.get_dummies(ps.Series(list('abc')), dtype=float)
          a    b    c
     0  1.0  0.0  0.0
     1  0.0  1.0  0.0
@@ -2035,9 +2035,9 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[
 
     Combine two ``Series``.
 
-    >>> s1 = pp.Series(['a', 'b'])
-    >>> s2 = pp.Series(['c', 'd'])
-    >>> pp.concat([s1, s2])
+    >>> s1 = ps.Series(['a', 'b'])
+    >>> s2 = ps.Series(['c', 'd'])
+    >>> ps.concat([s1, s2])
     0    a
     1    b
     0    c
@@ -2047,7 +2047,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[
     Clear the existing index and reset it in the result
     by setting the ``ignore_index`` option to ``True``.
 
-    >>> pp.concat([s1, s2], ignore_index=True)
+    >>> ps.concat([s1, s2], ignore_index=True)
     0    a
     1    b
     2    c
@@ -2056,20 +2056,20 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[
 
     Combine two ``DataFrame`` objects with identical columns.
 
-    >>> df1 = pp.DataFrame([['a', 1], ['b', 2]],
+    >>> df1 = ps.DataFrame([['a', 1], ['b', 2]],
     ...                    columns=['letter', 'number'])
     >>> df1
       letter  number
     0      a       1
     1      b       2
-    >>> df2 = pp.DataFrame([['c', 3], ['d', 4]],
+    >>> df2 = ps.DataFrame([['c', 3], ['d', 4]],
     ...                    columns=['letter', 'number'])
     >>> df2
       letter  number
     0      c       3
     1      d       4
 
-    >>> pp.concat([df1, df2])
+    >>> ps.concat([df1, df2])
       letter  number
     0      a       1
     1      b       2
@@ -2078,7 +2078,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[
 
     Combine ``DataFrame`` and ``Series`` objects with different columns.
 
-    >>> pp.concat([df2, s1])
+    >>> ps.concat([df2, s1])
       letter  number     0
     0      c     3.0  None
     1      d     4.0  None
@@ -2089,14 +2089,14 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[
     and return everything. Columns outside the intersection will
     be filled with ``None`` values.
 
-    >>> df3 = pp.DataFrame([['c', 3, 'cat'], ['d', 4, 'dog']],
+    >>> df3 = ps.DataFrame([['c', 3, 'cat'], ['d', 4, 'dog']],
     ...                    columns=['letter', 'number', 'animal'])
     >>> df3
       letter  number animal
     0      c       3    cat
     1      d       4    dog
 
-    >>> pp.concat([df1, df3])
+    >>> ps.concat([df1, df3])
       letter  number animal
     0      a       1   None
     1      b       2   None
@@ -2105,7 +2105,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[
 
     Sort the columns.
 
-    >>> pp.concat([df1, df3], sort=True)
+    >>> ps.concat([df1, df3], sort=True)
       animal letter  number
     0   None      a       1
     1   None      b       2
@@ -2116,19 +2116,19 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[
     and return only those that are shared by passing ``inner`` to
     the ``join`` keyword argument.
 
-    >>> pp.concat([df1, df3], join="inner")
+    >>> ps.concat([df1, df3], join="inner")
       letter  number
     0      a       1
     1      b       2
     0      c       3
     1      d       4
 
-    >>> df4 = pp.DataFrame([['bird', 'polly'], ['monkey', 'george']],
+    >>> df4 = ps.DataFrame([['bird', 'polly'], ['monkey', 'george']],
     ...                    columns=['animal', 'name'])
 
     Combine with column axis.
 
-    >>> pp.concat([df1, df4], axis=1)
+    >>> ps.concat([df1, df4], axis=1)
       letter  number  animal    name
     0      a       1    bird   polly
     1      b       2  monkey  george
@@ -2155,8 +2155,8 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[
             raise TypeError(
                 "cannot concatenate object of type "
                 "'{name}"
-                "; only pp.Series "
-                "and pp.DataFrame are valid".format(name=type(objs).__name__)
+                "; only ps.Series "
+                "and ps.DataFrame are valid".format(name=type(objs).__name__)
             )
 
     if join not in ["inner", "outer"]:
@@ -2416,10 +2416,10 @@ def isna(obj):
     --------
     Scalar arguments (including strings) result in a scalar boolean.
 
-    >>> pp.isna('dog')
+    >>> ps.isna('dog')
     False
 
-    >>> pp.isna(np.nan)
+    >>> ps.isna(np.nan)
     True
 
     ndarrays result in an ndarray of booleans.
@@ -2428,26 +2428,26 @@ def isna(obj):
     >>> array
     array([[ 1., nan,  3.],
            [ 4.,  5., nan]])
-    >>> pp.isna(array)
+    >>> ps.isna(array)
     array([[False,  True, False],
            [False, False,  True]])
 
     For Series and DataFrame, the same type is returned, containing booleans.
 
-    >>> df = pp.DataFrame({'a': ['ant', 'bee', 'cat'], 'b': ['dog', None, 'fly']})
+    >>> df = ps.DataFrame({'a': ['ant', 'bee', 'cat'], 'b': ['dog', None, 'fly']})
     >>> df
          a     b
     0  ant   dog
     1  bee  None
     2  cat   fly
 
-    >>> pp.isna(df)
+    >>> ps.isna(df)
            a      b
     0  False  False
     1  False   True
     2  False  False
 
-    >>> pp.isnull(df.b)
+    >>> ps.isnull(df.b)
     0    False
     1     True
     2    False
@@ -2491,7 +2491,7 @@ def notna(obj):
     --------
     Show which entries in a DataFrame are not NA.
 
-    >>> df = pp.DataFrame({'age': [5, 6, np.NaN],
+    >>> df = ps.DataFrame({'age': [5, 6, np.NaN],
     ...                    'born': [pd.NaT, pd.Timestamp('1939-05-27'),
     ...                             pd.Timestamp('1940-04-25')],
     ...                    'name': ['Alfred', 'Batman', ''],
@@ -2510,20 +2510,20 @@ def notna(obj):
 
     Show which entries in a Series are not NA.
 
-    >>> ser = pp.Series([5, 6, np.NaN])
+    >>> ser = ps.Series([5, 6, np.NaN])
     >>> ser
     0    5.0
     1    6.0
     2    NaN
     dtype: float64
 
-    >>> pp.notna(ser)
+    >>> ps.notna(ser)
     0     True
     1     True
     2    False
     dtype: bool
 
-    >>> pp.notna(ser.index)
+    >>> ps.notna(ser.index)
     True
     """
     # TODO: Add back:
@@ -2600,10 +2600,10 @@ def merge(
     Examples
     --------
 
-    >>> df1 = pp.DataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
+    >>> df1 = ps.DataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
     ...                     'value': [1, 2, 3, 5]},
     ...                    columns=['lkey', 'value'])
-    >>> df2 = pp.DataFrame({'rkey': ['foo', 'bar', 'baz', 'foo'],
+    >>> df2 = ps.DataFrame({'rkey': ['foo', 'bar', 'baz', 'foo'],
     ...                     'value': [5, 6, 7, 8]},
     ...                    columns=['rkey', 'value'])
     >>> df1
@@ -2622,7 +2622,7 @@ def merge(
     Merge df1 and df2 on the lkey and rkey columns. The value columns have
     the default suffixes, _x and _y, appended.
 
-    >>> merged = pp.merge(df1, df2, left_on='lkey', right_on='rkey')
+    >>> merged = ps.merge(df1, df2, left_on='lkey', right_on='rkey')
     >>> merged.sort_values(by=['lkey', 'value_x', 'rkey', 'value_y'])  # doctest: +ELLIPSIS
       lkey  value_x rkey  value_y
     ...bar        2  bar        6
@@ -2632,24 +2632,24 @@ def merge(
     ...foo        5  foo        5
     ...foo        5  foo        8
 
-    >>> left_kdf = pp.DataFrame({'A': [1, 2]})
-    >>> right_kdf = pp.DataFrame({'B': ['x', 'y']}, index=[1, 2])
+    >>> left_kdf = ps.DataFrame({'A': [1, 2]})
+    >>> right_kdf = ps.DataFrame({'B': ['x', 'y']}, index=[1, 2])
 
-    >>> pp.merge(left_kdf, right_kdf, left_index=True, right_index=True).sort_index()
+    >>> ps.merge(left_kdf, right_kdf, left_index=True, right_index=True).sort_index()
        A  B
     1  2  x
 
-    >>> pp.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='left').sort_index()
+    >>> ps.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='left').sort_index()
        A     B
     0  1  None
     1  2     x
 
-    >>> pp.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='right').sort_index()
+    >>> ps.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='right').sort_index()
          A  B
     1  2.0  x
     2  NaN  y
 
-    >>> pp.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='outer').sort_index()
+    >>> ps.merge(left_kdf, right_kdf, left_index=True, right_index=True, how='outer').sort_index()
          A     B
     0  1.0  None
     1  2.0     x
@@ -2694,14 +2694,14 @@ def to_numeric(arg):
     Examples
     --------
 
-    >>> kser = pp.Series(['1.0', '2', '-3'])
+    >>> kser = ps.Series(['1.0', '2', '-3'])
     >>> kser
     0    1.0
     1      2
     2     -3
     dtype: object
 
-    >>> pp.to_numeric(kser)
+    >>> ps.to_numeric(kser)
     0    1.0
     1    2.0
     2   -3.0
@@ -2709,7 +2709,7 @@ def to_numeric(arg):
 
     If given Series contains invalid value to cast float, just cast it to `np.nan`
 
-    >>> kser = pp.Series(['apple', '1.0', '2', '-3'])
+    >>> kser = ps.Series(['apple', '1.0', '2', '-3'])
     >>> kser
     0    apple
     1      1.0
@@ -2717,7 +2717,7 @@ def to_numeric(arg):
     3       -3
     dtype: object
 
-    >>> pp.to_numeric(kser)
+    >>> ps.to_numeric(kser)
     0    NaN
     1    1.0
     2    2.0
@@ -2726,16 +2726,16 @@ def to_numeric(arg):
 
     Also support for list, tuple, np.array, or a scalar
 
-    >>> pp.to_numeric(['1.0', '2', '-3'])
+    >>> ps.to_numeric(['1.0', '2', '-3'])
     array([ 1.,  2., -3.])
 
-    >>> pp.to_numeric(('1.0', '2', '-3'))
+    >>> ps.to_numeric(('1.0', '2', '-3'))
     array([ 1.,  2., -3.])
 
-    >>> pp.to_numeric(np.array(['1.0', '2', '-3']))
+    >>> ps.to_numeric(np.array(['1.0', '2', '-3']))
     array([ 1.,  2., -3.])
 
-    >>> pp.to_numeric('1.0')
+    >>> ps.to_numeric('1.0')
     1.0
     """
     if isinstance(arg, Series):
@@ -2765,13 +2765,13 @@ def broadcast(obj) -> DataFrame:
 
     Examples
     --------
-    >>> df1 = pp.DataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
+    >>> df1 = ps.DataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
     ...                     'value': [1, 2, 3, 5]},
     ...                    columns=['lkey', 'value']).set_index('lkey')
-    >>> df2 = pp.DataFrame({'rkey': ['foo', 'bar', 'baz', 'foo'],
+    >>> df2 = ps.DataFrame({'rkey': ['foo', 'bar', 'baz', 'foo'],
     ...                     'value': [5, 6, 7, 8]},
     ...                    columns=['rkey', 'value']).set_index('rkey')
-    >>> merged = df1.merge(pp.broadcast(df2), left_index=True, right_index=True)
+    >>> merged = df1.merge(ps.broadcast(df2), left_index=True, right_index=True)
     >>> merged.spark.explain()  # doctest: +ELLIPSIS
     == Physical Plan ==
     ...
@@ -2811,15 +2811,15 @@ def read_orc(
 
     Examples
     --------
-    >>> pp.range(1).to_orc('%s/read_spark_io/data.orc' % path)
-    >>> pp.read_orc('%s/read_spark_io/data.orc' % path, columns=['id'])
+    >>> ps.range(1).to_orc('%s/read_spark_io/data.orc' % path)
+    >>> ps.read_orc('%s/read_spark_io/data.orc' % path, columns=['id'])
        id
     0   0
 
     You can preserve the index in the roundtrip as below.
 
-    >>> pp.range(1).to_orc('%s/read_spark_io/data.orc' % path, index_col="index")
-    >>> pp.read_orc('%s/read_spark_io/data.orc' % path, columns=['id'], index_col="index")
+    >>> ps.range(1).to_orc('%s/read_spark_io/data.orc' % path, index_col="index")
+    >>> ps.read_orc('%s/read_spark_io/data.orc' % path, columns=['id'], index_col="index")
     ... # doctest: +NORMALIZE_WHITESPACE
            id
     index
@@ -2890,7 +2890,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.namespace.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.namespace tests")

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -220,7 +220,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.numpy_compat.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.numpy_compat tests")

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -545,7 +545,7 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> s = pp.Series([1, 3, 2])
+            >>> s = ps.Series([1, 3, 2])
             >>> s.plot.line()  # doctest: +SKIP
 
         For DataFrame:
@@ -555,7 +555,7 @@ class KoalasPlotAccessor(PandasObject):
             The following example shows the populations for some animals
             over the years.
 
-            >>> df = pp.DataFrame({'pig': [20, 18, 489, 675, 1776],
+            >>> df = ps.DataFrame({'pig': [20, 18, 489, 675, 1776],
             ...                    'horse': [4, 25, 281, 600, 1900]},
             ...                   index=[1990, 1997, 2003, 2009, 2014])
             >>> df.plot.line()  # doctest: +SKIP
@@ -565,7 +565,7 @@ class KoalasPlotAccessor(PandasObject):
             The following example shows the relationship between both
             populations.
 
-            >>> df = pp.DataFrame({'pig': [20, 18, 489, 675, 1776],
+            >>> df = ps.DataFrame({'pig': [20, 18, 489, 675, 1776],
             ...                    'horse': [4, 25, 281, 600, 1900]},
             ...                   index=[1990, 1997, 2003, 2009, 2014])
             >>> df.plot.line(x='pig', y='horse')  # doctest: +SKIP
@@ -602,14 +602,14 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> s = pp.Series([1, 3, 2])
+            >>> s = ps.Series([1, 3, 2])
             >>> s.plot.bar()  # doctest: +SKIP
 
         For DataFrame:
 
         .. plotly::
 
-            >>> df = pp.DataFrame({'lab': ['A', 'B', 'C'], 'val': [10, 30, 20]})
+            >>> df = ps.DataFrame({'lab': ['A', 'B', 'C'], 'val': [10, 30, 20]})
             >>> df.plot.bar(x='lab', y='val')  # doctest: +SKIP
 
         Plot a whole dataframe to a bar plot. Each column is stacked with a
@@ -621,7 +621,7 @@ class KoalasPlotAccessor(PandasObject):
             >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
             >>> index = ['snail', 'pig', 'elephant',
             ...          'rabbit', 'giraffe', 'coyote', 'horse']
-            >>> df = pp.DataFrame({'speed': speed,
+            >>> df = ps.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
             >>> df.plot.bar()  # doctest: +SKIP
 
@@ -635,7 +635,7 @@ class KoalasPlotAccessor(PandasObject):
             >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
             >>> index = ['snail', 'pig', 'elephant',
             ...          'rabbit', 'giraffe', 'coyote', 'horse']
-            >>> df = pp.DataFrame({'speed': speed,
+            >>> df = ps.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
             >>> fig = (make_subplots(rows=2, cols=1)
             ...        .add_trace(df.plot.bar(y='speed').data[0], row=1, col=1)
@@ -651,7 +651,7 @@ class KoalasPlotAccessor(PandasObject):
             >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
             >>> index = ['snail', 'pig', 'elephant',
             ...          'rabbit', 'giraffe', 'coyote', 'horse']
-            >>> df = pp.DataFrame({'speed': speed,
+            >>> df = ps.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
             >>> df.plot.bar(y='speed')  # doctest: +SKIP
 
@@ -663,7 +663,7 @@ class KoalasPlotAccessor(PandasObject):
             >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
             >>> index = ['snail', 'pig', 'elephant',
             ...          'rabbit', 'giraffe', 'coyote', 'horse']
-            >>> df = pp.DataFrame({'speed': speed,
+            >>> df = ps.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
             >>> df.plot.bar(x='lifespan')  # doctest: +SKIP
         """
@@ -711,14 +711,14 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> df = pp.DataFrame({'lab': ['A', 'B', 'C'], 'val': [10, 30, 20]})
+            >>> df = ps.DataFrame({'lab': ['A', 'B', 'C'], 'val': [10, 30, 20]})
             >>> df.val.plot.barh()  # doctest: +SKIP
 
         For DataFrame:
 
         .. plotly::
 
-            >>> df = pp.DataFrame({'lab': ['A', 'B', 'C'], 'val': [10, 30, 20]})
+            >>> df = ps.DataFrame({'lab': ['A', 'B', 'C'], 'val': [10, 30, 20]})
             >>> df.plot.barh(x='lab', y='val')  # doctest: +SKIP
 
         Plot a whole DataFrame to a horizontal bar plot
@@ -729,7 +729,7 @@ class KoalasPlotAccessor(PandasObject):
             >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
             >>> index = ['snail', 'pig', 'elephant',
             ...          'rabbit', 'giraffe', 'coyote', 'horse']
-            >>> df = pp.DataFrame({'speed': speed,
+            >>> df = ps.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
             >>> df.plot.barh()  # doctest: +SKIP
 
@@ -741,7 +741,7 @@ class KoalasPlotAccessor(PandasObject):
             >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
             >>> index = ['snail', 'pig', 'elephant',
             ...          'rabbit', 'giraffe', 'coyote', 'horse']
-            >>> df = pp.DataFrame({'speed': speed,
+            >>> df = ps.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
             >>> df.plot.barh(y='speed')  # doctest: +SKIP
 
@@ -753,7 +753,7 @@ class KoalasPlotAccessor(PandasObject):
             >>> lifespan = [2, 8, 70, 1.5, 25, 12, 28]
             >>> index = ['snail', 'pig', 'elephant',
             ...          'rabbit', 'giraffe', 'coyote', 'horse']
-            >>> df = pp.DataFrame({'speed': speed,
+            >>> df = ps.DataFrame({'speed': speed,
             ...                    'lifespan': lifespan}, index=index)
             >>> df.plot.barh(x='lifespan')  # doctest: +SKIP
         """
@@ -807,7 +807,7 @@ class KoalasPlotAccessor(PandasObject):
         .. plotly::
 
             >>> data = np.random.randn(25, 4)
-            >>> df = pp.DataFrame(data, columns=list('ABCD'))
+            >>> df = ps.DataFrame(data, columns=list('ABCD'))
             >>> df['A'].plot.box()  # doctest: +SKIP
 
         This is an unsupported function for DataFrame type
@@ -853,7 +853,7 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> s = pp.Series([1, 3, 2])
+            >>> s = ps.Series([1, 3, 2])
             >>> s.plot.hist()  # doctest: +SKIP
 
         For DataFrame:
@@ -864,7 +864,7 @@ class KoalasPlotAccessor(PandasObject):
             ...     np.random.randint(1, 7, 6000),
             ...     columns=['one'])
             >>> df['two'] = df['one'] + np.random.randint(1, 7, 6000)
-            >>> df = pp.from_pandas(df)
+            >>> df = ps.from_pandas(df)
             >>> df.plot.hist(bins=12, alpha=0.5)  # doctest: +SKIP
         """
         return self(kind="hist", bins=bins, **kwds)
@@ -900,12 +900,12 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> s = pp.Series([1, 2, 2.5, 3, 3.5, 4, 5])
+            >>> s = ps.Series([1, 2, 2.5, 3, 3.5, 4, 5])
             >>> s.plot.kde(bw_method=0.3)  # doctest: +SKIP
 
         .. plotly::
 
-            >>> s = pp.Series([1, 2, 2.5, 3, 3.5, 4, 5])
+            >>> s = ps.Series([1, 2, 2.5, 3, 3.5, 4, 5])
             >>> s.plot.kde(bw_method=3)  # doctest: +SKIP
 
         The `ind` parameter determines the evaluation points for the
@@ -913,14 +913,14 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> s = pp.Series([1, 2, 2.5, 3, 3.5, 4, 5])
+            >>> s = ps.Series([1, 2, 2.5, 3, 3.5, 4, 5])
             >>> s.plot.kde(ind=[1, 2, 3, 4, 5], bw_method=0.3)  # doctest: +SKIP
 
         For DataFrame, it works in the same way as Series:
 
         .. plotly::
 
-            >>> df = pp.DataFrame({
+            >>> df = ps.DataFrame({
             ...     'x': [1, 2, 2.5, 3, 3.5, 4, 5],
             ...     'y': [4, 4, 4.5, 5, 5.5, 6, 6],
             ... })
@@ -928,7 +928,7 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> df = pp.DataFrame({
+            >>> df = ps.DataFrame({
             ...     'x': [1, 2, 2.5, 3, 3.5, 4, 5],
             ...     'y': [4, 4, 4.5, 5, 5.5, 6, 6],
             ... })
@@ -936,7 +936,7 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> df = pp.DataFrame({
+            >>> df = ps.DataFrame({
             ...     'x': [1, 2, 2.5, 3, 3.5, 4, 5],
             ...     'y': [4, 4, 4.5, 5, 5.5, 6, 6],
             ... })
@@ -979,7 +979,7 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> df = pp.DataFrame({
+            >>> df = ps.DataFrame({
             ...     'sales': [3, 2, 3, 9, 10, 6],
             ...     'signups': [5, 5, 6, 12, 14, 13],
             ...     'visits': [20, 42, 28, 62, 81, 50],
@@ -991,7 +991,7 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> df = pp.DataFrame({
+            >>> df = ps.DataFrame({
             ...     'sales': [3, 2, 3, 9, 10, 6],
             ...     'signups': [5, 5, 6, 12, 14, 13],
             ...     'visits': [20, 42, 28, 62, 81, 50],
@@ -1035,7 +1035,7 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> df = pp.DataFrame({'mass': [0.330, 4.87, 5.97],
+            >>> df = ps.DataFrame({'mass': [0.330, 4.87, 5.97],
             ...                    'radius': [2439.7, 6051.8, 6378.1]},
             ...                   index=['Mercury', 'Venus', 'Earth'])
             >>> df.mass.plot.pie()  # doctest: +SKIP
@@ -1045,7 +1045,7 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> df = pp.DataFrame({'mass': [0.330, 4.87, 5.97],
+            >>> df = ps.DataFrame({'mass': [0.330, 4.87, 5.97],
             ...                    'radius': [2439.7, 6051.8, 6378.1]},
             ...                   index=['Mercury', 'Venus', 'Earth'])
             >>> df.plot.pie(y='mass')  # doctest: +SKIP
@@ -1113,7 +1113,7 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> df = pp.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1],
+            >>> df = ps.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1],
             ...                    [6.4, 3.2, 1], [5.9, 3.0, 2]],
             ...                   columns=['length', 'width', 'species'])
             >>> df.plot.scatter(x='length', y='width')  # doctest: +SKIP
@@ -1122,7 +1122,7 @@ class KoalasPlotAccessor(PandasObject):
 
         .. plotly::
 
-            >>> df = pp.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1],
+            >>> df = ps.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1],
             ...                    [6.4, 3.2, 1], [5.9, 3.0, 2]],
             ...                   columns=['length', 'width', 'species'])
             >>> fig = df.plot.scatter(x='length', y='width')

--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -27,10 +27,10 @@ from pyspark.pandas.plot import (
 )
 
 if TYPE_CHECKING:
-    import pyspark.pandas as pp  # noqa: F401 (SPARK-34943)
+    import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
 
 
-def plot_koalas(data: Union["pp.DataFrame", "pp.Series"], kind: str, **kwargs):
+def plot_koalas(data: Union["ps.DataFrame", "ps.Series"], kind: str, **kwargs):
     import plotly
 
     # Koalas specific plots
@@ -47,7 +47,7 @@ def plot_koalas(data: Union["pp.DataFrame", "pp.Series"], kind: str, **kwargs):
     return plotly.plot(KoalasPlotAccessor.pandas_plot_data_map[kind](data), kind, **kwargs)
 
 
-def plot_pie(data: Union["pp.DataFrame", "pp.Series"], **kwargs):
+def plot_pie(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
     from plotly import express
 
     data = KoalasPlotAccessor.pandas_plot_data_map["pie"](data)
@@ -71,7 +71,7 @@ def plot_pie(data: Union["pp.DataFrame", "pp.Series"], **kwargs):
         raise RuntimeError("Unexpected type: [%s]" % type(data))
 
 
-def plot_histogram(data: Union["pp.DataFrame", "pp.Series"], **kwargs):
+def plot_histogram(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
     import plotly.graph_objs as go
 
     bins = kwargs.get("bins", 10)
@@ -109,11 +109,11 @@ def plot_histogram(data: Union["pp.DataFrame", "pp.Series"], **kwargs):
     return fig
 
 
-def plot_box(data: Union["pp.DataFrame", "pp.Series"], **kwargs):
+def plot_box(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
     import plotly.graph_objs as go
-    import pyspark.pandas as pp
+    import pyspark.pandas as ps
 
-    if isinstance(data, pp.DataFrame):
+    if isinstance(data, ps.DataFrame):
         raise RuntimeError(
             "plotly does not support a box plot with Koalas DataFrame. Use Series instead."
         )
@@ -177,11 +177,11 @@ def plot_box(data: Union["pp.DataFrame", "pp.Series"], **kwargs):
     return fig
 
 
-def plot_kde(data: Union["pp.DataFrame", "pp.Series"], **kwargs):
+def plot_kde(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
     from plotly import express
-    import pyspark.pandas as pp
+    import pyspark.pandas as ps
 
-    if isinstance(data, pp.DataFrame) and "color" not in kwargs:
+    if isinstance(data, ps.DataFrame) and "color" not in kwargs:
         kwargs["color"] = "names"
 
     kdf = KdePlotBase.prepare_kde_data(data)

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -51,7 +51,7 @@ from pyspark.sql.types import (
 )
 from pyspark.sql.window import Window
 
-from pyspark import pandas as pp  # For running doctests and reference resolution in PyCharm.
+from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.accessors import KoalasSeriesMethods
 from pyspark.pandas.categorical import CategoricalAccessor
 from pyspark.pandas.config import get_option
@@ -125,7 +125,7 @@ Series.{reverse}
 _add_example_SERIES = """
 Examples
 --------
->>> df = pp.DataFrame({'a': [2, 2, 4, np.nan],
+>>> df = ps.DataFrame({'a': [2, 2, 4, np.nan],
 ...                    'b': [2, np.nan, 2, np.nan]},
 ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 >>> df
@@ -153,7 +153,7 @@ dtype: float64
 _sub_example_SERIES = """
 Examples
 --------
->>> df = pp.DataFrame({'a': [2, 2, 4, np.nan],
+>>> df = ps.DataFrame({'a': [2, 2, 4, np.nan],
 ...                    'b': [2, np.nan, 2, np.nan]},
 ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 >>> df
@@ -181,7 +181,7 @@ dtype: float64
 _mul_example_SERIES = """
 Examples
 --------
->>> df = pp.DataFrame({'a': [2, 2, 4, np.nan],
+>>> df = ps.DataFrame({'a': [2, 2, 4, np.nan],
 ...                    'b': [2, np.nan, 2, np.nan]},
 ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 >>> df
@@ -209,7 +209,7 @@ dtype: float64
 _div_example_SERIES = """
 Examples
 --------
->>> df = pp.DataFrame({'a': [2, 2, 4, np.nan],
+>>> df = ps.DataFrame({'a': [2, 2, 4, np.nan],
 ...                    'b': [2, np.nan, 2, np.nan]},
 ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 >>> df
@@ -237,7 +237,7 @@ dtype: float64
 _pow_example_SERIES = """
 Examples
 --------
->>> df = pp.DataFrame({'a': [2, 2, 4, np.nan],
+>>> df = ps.DataFrame({'a': [2, 2, 4, np.nan],
 ...                    'b': [2, np.nan, 2, np.nan]},
 ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 >>> df
@@ -265,7 +265,7 @@ dtype: float64
 _mod_example_SERIES = """
 Examples
 --------
->>> df = pp.DataFrame({'a': [2, 2, 4, np.nan],
+>>> df = ps.DataFrame({'a': [2, 2, 4, np.nan],
 ...                    'b': [2, np.nan, 2, np.nan]},
 ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 >>> df
@@ -293,7 +293,7 @@ dtype: float64
 _floordiv_example_SERIES = """
 Examples
 --------
->>> df = pp.DataFrame({'a': [2, 2, 4, np.nan],
+>>> df = ps.DataFrame({'a': [2, 2, 4, np.nan],
 ...                    'b': [2, np.nan, 2, np.nan]},
 ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 >>> df
@@ -358,7 +358,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     :ivar _internal: an internal immutable Frame to manage metadata.
     :type _internal: InternalFrame
     :ivar _kdf: Parent's Koalas DataFrame
-    :type _kdf: pp.DataFrame
+    :type _kdf: ps.DataFrame
 
     Parameters
     ----------
@@ -450,7 +450,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def dtypes(self) -> np.dtype:
         """Return the dtype object of the underlying data.
 
-        >>> s = pp.Series(list('abc'))
+        >>> s = ps.Series(list('abc'))
         >>> s.dtype == s.dtypes
         True
         """
@@ -464,7 +464,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
 
-        >>> kser = pp.Series([1, 2, 3])
+        >>> kser = ps.Series([1, 2, 3])
         >>> kser.axes
         [Int64Index([0, 1, 2], dtype='int64')]
         """
@@ -672,7 +672,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         Compare if the current value is equal to the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -698,7 +698,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         Compare if the current value is greater than the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -722,7 +722,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         Compare if the current value is greater than or equal to the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -746,7 +746,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         Compare if the current value is less than the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -770,7 +770,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         Compare if the current value is less than or equal to the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -794,7 +794,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         Compare if the current value is not equal to the other.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4],
         ...                    'b': [1, np.nan, 1, np.nan]},
         ...                   index=['a', 'b', 'c', 'd'], columns=['a', 'b'])
 
@@ -887,7 +887,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([2, 0, 4, 8, np.nan])
+        >>> s = ps.Series([2, 0, 4, 8, np.nan])
 
         Boundary values are included by default:
 
@@ -911,7 +911,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         `left` and `right` can be any scalar value:
 
-        >>> s = pp.Series(['Alice', 'Bob', 'Carol', 'Eve'])
+        >>> s = ps.Series(['Alice', 'Bob', 'Carol', 'Eve'])
         >>> s.between('Anna', 'Daniel')
         0    False
         1     True
@@ -967,7 +967,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series(['cat', 'dog', None, 'rabbit'])
+        >>> s = ps.Series(['cat', 'dog', None, 'rabbit'])
         >>> s
         0       cat
         1       dog
@@ -1069,7 +1069,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
 
-        >>> s = pp.Series([1, 2, 3])
+        >>> s = ps.Series([1, 2, 3])
         >>> s
         0    1
         1    2
@@ -1128,7 +1128,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series(["dog", "cat", "monkey"], name="animal")
+        >>> s = ps.Series(["dog", "cat", "monkey"], name="animal")
         >>> s  # doctest: +NORMALIZE_WHITESPACE
         0       dog
         1       cat
@@ -1146,7 +1146,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> index = pd.MultiIndex.from_product([['mammal'],
         ...                                        ['dog', 'cat', 'monkey']],
         ...                                       names=['type', 'name'])
-        >>> s = pp.Series([4, 4, 2], index=index, name='num_legs')
+        >>> s = ps.Series([4, 4, 2], index=index, name='num_legs')
         >>> s  # doctest: +NORMALIZE_WHITESPACE
         type    name
         mammal  dog       4
@@ -1174,7 +1174,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             return first_series(kdf)
 
     @property
-    def index(self) -> "pp.Index":
+    def index(self) -> "ps.Index":
         """The index (axis labels) Column of the Series.
 
         See Also
@@ -1192,11 +1192,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         -------
         is_unique : boolean
 
-        >>> pp.Series([1, 2, 3]).is_unique
+        >>> ps.Series([1, 2, 3]).is_unique
         True
-        >>> pp.Series([1, 2, 2]).is_unique
+        >>> ps.Series([1, 2, 2]).is_unique
         False
-        >>> pp.Series([1, 2, 3, None]).is_unique
+        >>> ps.Series([1, 2, 3, None]).is_unique
         True
         """
         scol = self.spark.column
@@ -1246,7 +1246,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'], name='idx'))
+        >>> s = ps.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'], name='idx'))
 
         Generate a DataFrame with default index.
 
@@ -1324,14 +1324,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series(["a", "b", "c"])
+        >>> s = ps.Series(["a", "b", "c"])
         >>> s.to_frame()
            0
         0  a
         1  b
         2  c
 
-        >>> s = pp.Series(["a", "b", "c"], name="vals")
+        >>> s = ps.Series(["a", "b", "c"], name="vals")
         >>> s.to_frame()
           vals
         0    a
@@ -1396,7 +1396,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)], columns=['dogs', 'cats'])
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)], columns=['dogs', 'cats'])
         >>> print(df['dogs'].to_string())
         0    0.2
         1    0.0
@@ -1451,7 +1451,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 3, 4])
+        >>> s = ps.Series([1, 2, 3, 4])
         >>> s_dict = s.to_dict()
         >>> sorted(s_dict.items())
         [(0, 1), (1, 2), (2, 3), (3, 4)]
@@ -1511,7 +1511,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)], columns=['dogs', 'cats'])
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)], columns=['dogs', 'cats'])
         >>> df['dogs'].to_pandas()
         0    0.2
         1    0.0
@@ -1570,7 +1570,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         --------
         Generate a Series with duplicated entries.
 
-        >>> s = pp.Series(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'],
+        >>> s = ps.Series(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'],
         ...               name='animal')
         >>> s.sort_index()
         0      lama
@@ -1651,7 +1651,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Create a series with some fictional data.
 
         >>> index = ['Firefox', 'Chrome', 'Safari', 'IE10', 'Konqueror']
-        >>> ser = pp.Series([200, 200, 404, 404, 301],
+        >>> ser = ps.Series([200, 200, 404, 404, 301],
         ...                 index=index, name='http_status')
         >>> ser
         Firefox      200
@@ -1692,7 +1692,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         of dates).
 
         >>> date_index = pd.date_range('1/1/2010', periods=6, freq='D')
-        >>> ser2 = pp.Series([100, 101, np.nan, 100, 89, 88],
+        >>> ser2 = ps.Series([100, 101, np.nan, 100, 89, 88],
         ...                  name='prices', index=date_index)
         >>> ser2.sort_index()
         2010-01-01    100.0
@@ -1757,7 +1757,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
 
-        >>> s1 = pp.Series([24.3, 31.0, 22.0, 35.0],
+        >>> s1 = ps.Series([24.3, 31.0, 22.0, 35.0],
         ...                index=pd.date_range(start='2014-02-12',
         ...                                    end='2014-02-15', freq='D'),
         ...                name="temp_celsius")
@@ -1768,7 +1768,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2014-02-15    35.0
         Name: temp_celsius, dtype: float64
 
-        >>> s2 = pp.Series(["low", "low", "medium"],
+        >>> s2 = ps.Series(["low", "low", "medium"],
         ...                index=pd.DatetimeIndex(['2014-02-12', '2014-02-13',
         ...                                        '2014-02-15']),
         ...                name="winspeed")
@@ -1828,7 +1828,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([np.nan, 2, 3, 4, np.nan, 6], name='x')
+        >>> s = ps.Series([np.nan, 2, 3, 4, np.nan, 6], name='x')
         >>> s
         0    NaN
         1    2.0
@@ -1860,7 +1860,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         5    6.0
         Name: x, dtype: float64
 
-        >>> s = pp.Series([np.nan, 'a', 'b', 'c', np.nan], name='x')
+        >>> s = ps.Series([np.nan, 'a', 'b', 'c', np.nan], name='x')
         >>> s.fillna(method='ffill')
         0    None
         1       a
@@ -1954,7 +1954,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> ser = pp.Series([1., 2., np.nan])
+        >>> ser = ps.Series([1., 2., np.nan])
         >>> ser
         0    1.0
         1    2.0
@@ -2005,7 +2005,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> pp.Series([0, 2, 4]).clip(1, 3)
+        >>> ps.Series([0, 2, 4]).clip(1, 3)
         0    1
         1    2
         2    3
@@ -2015,7 +2015,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         -----
         One difference between this implementation and pandas is that running
         `pd.Series(['a', 'b']).clip(0, 1)` will crash with "TypeError: '<=' not supported between
-        instances of 'str' and 'int'" while `pp.Series(['a', 'b']).clip(0, 1)` will output the
+        instances of 'str' and 'int'" while `ps.Series(['a', 'b']).clip(0, 1)` will output the
         original Series, simply ignoring the incompatible types.
         """
         if is_list_like(lower) or is_list_like(upper):
@@ -2065,7 +2065,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series(data=np.arange(3), index=['A', 'B', 'C'])
+        >>> s = ps.Series(data=np.arange(3), index=['A', 'B', 'C'])
         >>> s
         A    0
         B    1
@@ -2102,7 +2102,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ...                       ['speed', 'weight', 'length']],
         ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-        >>> s = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        >>> s = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
         ...               index=midx)
         >>> s
         lama    speed      45.0
@@ -2213,7 +2213,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'animal':['alligator', 'bee', 'falcon', 'lion']})
+        >>> df = ps.DataFrame({'animal':['alligator', 'bee', 'falcon', 'lion']})
         >>> df.animal.head(2)  # doctest: +NORMALIZE_WHITESPACE
         0     alligator
         1     bee
@@ -2247,7 +2247,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
         >>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
-        >>> kser = pp.Series([1, 2, 3, 4], index=index)
+        >>> kser = ps.Series([1, 2, 3, 4], index=index)
         >>> kser
         2018-04-09    1
         2018-04-11    2
@@ -2294,7 +2294,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
         >>> index = pd.date_range('2018-04-09', periods=4, freq='2D')
-        >>> kser = pp.Series([1, 2, 3, 4], index=index)
+        >>> kser = ps.Series([1, 2, 3, 4], index=index)
         >>> kser
         2018-04-09    1
         2018-04-11    2
@@ -2338,7 +2338,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> kser = pp.Series([2, 1, 3, 3], name='A')
+        >>> kser = ps.Series([2, 1, 3, 3], name='A')
         >>> kser.unique().sort_values()  # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
         <BLANKLINE>
         ...  1
@@ -2346,7 +2346,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ...  3
         Name: A, dtype: int64
 
-        >>> pp.Series([pd.Timestamp('2016-01-01') for _ in range(3)]).unique()
+        >>> ps.Series([pd.Timestamp('2016-01-01') for _ in range(3)]).unique()
         0   2016-01-01
         dtype: datetime64[ns]
 
@@ -2394,7 +2394,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([np.nan, 1, 3, 10, 5])
+        >>> s = ps.Series([np.nan, 1, 3, 10, 5])
         >>> s
         0     NaN
         1     1.0
@@ -2446,7 +2446,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Sort a series of strings
 
-        >>> s = pp.Series(['z', 'b', 'd', 'a', 'c'])
+        >>> s = ps.Series(['z', 'b', 'd', 'a', 'c'])
         >>> s
         0    z
         1    b
@@ -2507,7 +2507,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.Series([2, 1, np.nan], index=['b', 'a', np.nan])
+        >>> df = ps.Series([2, 1, np.nan], index=['b', 'a', np.nan])
 
         >>> df.sort_index()
         a      1.0
@@ -2534,7 +2534,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         NaN    NaN
         dtype: float64
 
-        >>> df = pp.Series(range(4), index=[['b', 'b', 'a', 'a'], [1, 0, 1, 0]], name='0')
+        >>> df = ps.Series(range(4), index=[['b', 'b', 'a', 'a'], [1, 0, 1, 0]], name='0')
 
         >>> df.sort_index()
         a  0    3
@@ -2592,7 +2592,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         MultiIndex([('a', 1),
                     ('b', 2)],
                    names=['word', 'number'])
-        >>> kser = pp.Series(['x', 'y'], index=midx)
+        >>> kser = ps.Series(['x', 'y'], index=midx)
         >>> kser
         word  number
         a     1         x
@@ -2634,7 +2634,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> kser = pp.Series([1, 2, 3], index=["x", "y", "z"])
+        >>> kser = ps.Series([1, 2, 3], index=["x", "y", "z"])
         >>> kser
         x    1
         y    2
@@ -2681,7 +2681,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 3, 4])
+        >>> s = ps.Series([1, 2, 3, 4])
         >>> s
         0    1
         1    2
@@ -2736,7 +2736,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 3, 4])
+        >>> s = ps.Series([1, 2, 3, 4])
         >>> s
         0    1
         1    2
@@ -2783,7 +2783,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'s1': [.2, .0, .6, .2],
+        >>> df = ps.DataFrame({'s1': [.2, .0, .6, .2],
         ...                    's2': [.3, .6, .0, .1]})
         >>> s1 = df.s1
         >>> s2 = df.s2
@@ -2841,7 +2841,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
         >>> data = [1, 2, 3, 4, np.nan ,6, 7, 8]
-        >>> s = pp.Series(data)
+        >>> s = ps.Series(data)
         >>> s
         0    1.0
         1    2.0
@@ -2901,7 +2901,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
         >>> data = [1, 2, 3, 4, np.nan ,6, 7, 8]
-        >>> s = pp.Series(data)
+        >>> s = ps.Series(data)
         >>> s
         0    1.0
         1    2.0
@@ -2953,9 +2953,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s1 = pp.Series([1, 2, 3])
-        >>> s2 = pp.Series([4, 5, 6])
-        >>> s3 = pp.Series([4, 5, 6], index=[3,4,5])
+        >>> s1 = ps.Series([1, 2, 3])
+        >>> s2 = ps.Series([4, 5, 6])
+        >>> s3 = ps.Series([4, 5, 6], index=[3,4,5])
 
         >>> s1.append(s2)
         0    1
@@ -3048,7 +3048,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         --------
         Create a Series with typical summer temperatures for each city.
 
-        >>> s = pp.Series([20, 21, 12],
+        >>> s = ps.Series([20, 21, 12],
         ...               index=['London', 'New York', 'Helsinki'])
         >>> s
         London      20
@@ -3170,7 +3170,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 3, 4])
+        >>> s = ps.Series([1, 2, 3, 4])
         >>> s.agg('min')
         1
 
@@ -3197,7 +3197,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         It returns the same object as the transpose of the given series object, which is by
         definition self.
 
-        >>> s = pp.Series([1, 2, 3])
+        >>> s = ps.Series([1, 2, 3])
         >>> s
         0    1
         1    2
@@ -3254,7 +3254,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
 
-        >>> s = pp.Series(range(3))
+        >>> s = ps.Series(range(3))
         >>> s
         0    0
         1    1
@@ -3302,7 +3302,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         else:
             return self.apply(func, args=args, **kwargs)
 
-    def transform_batch(self, func, *args, **kwargs) -> "pp.Series":
+    def transform_batch(self, func, *args, **kwargs) -> "ps.Series":
         warnings.warn(
             "Series.transform_batch is deprecated as of Series.koalas.transform_batch. "
             "Please use the API instead.",
@@ -3333,7 +3333,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.Series([0.028208, 0.038683, 0.877076], name='x')
+        >>> df = ps.Series([0.028208, 0.038683, 0.877076], name='x')
         >>> df
         0    0.028208
         1    0.038683
@@ -3379,7 +3379,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 3, 4, 5])
+        >>> s = ps.Series([1, 2, 3, 4, 5])
         >>> s.quantile(.5)
         3.0
 
@@ -3455,7 +3455,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 2, 3], name='A')
+        >>> s = ps.Series([1, 2, 2, 3], name='A')
         >>> s
         0    1
         1    2
@@ -3594,7 +3594,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': [1, 2, 3, 4, 5, 6],
+        >>> df = ps.DataFrame({'a': [1, 2, 3, 4, 5, 6],
         ...                    'b': [1, 1, 2, 3, 5, 8],
         ...                    'c': [1, 4, 9, 16, 25, 36]}, columns=['a', 'b', 'c'])
         >>> df
@@ -3680,7 +3680,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series(data=[1, None, 4, 3, 5],
+        >>> s = ps.Series(data=[1, None, 4, 3, 5],
         ...               index=['A', 'B', 'C', 'D', 'E'])
         >>> s
         A    1.0
@@ -3703,7 +3703,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> index = pd.MultiIndex.from_arrays([
         ...     ['a', 'a', 'b', 'b'], ['c', 'd', 'e', 'f']], names=('first', 'second'))
-        >>> s = pp.Series(data=[1, None, 4, 5], index=index)
+        >>> s = ps.Series(data=[1, None, 4, 5], index=index)
         >>> s
         first  second
         a      c         1.0
@@ -3718,7 +3718,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         If multiple values equal the maximum, the first row label with that
         value is returned.
 
-        >>> s = pp.Series([1, 100, 1, 100, 1, 100], index=[10, 3, 5, 2, 1, 8])
+        >>> s = ps.Series([1, 100, 1, 100, 1, 100], index=[10, 3, 5, 2, 1, 8])
         >>> s
         10      1
         3     100
@@ -3789,7 +3789,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series(data=[1, None, 4, 0],
+        >>> s = ps.Series(data=[1, None, 4, 0],
         ...               index=['A', 'B', 'C', 'D'])
         >>> s
         A    1.0
@@ -3811,7 +3811,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> index = pd.MultiIndex.from_arrays([
         ...     ['a', 'a', 'b', 'b'], ['c', 'd', 'e', 'f']], names=('first', 'second'))
-        >>> s = pp.Series(data=[1, None, 4, 0], index=index)
+        >>> s = ps.Series(data=[1, None, 4, 0], index=index)
         >>> s
         first  second
         a      c         1.0
@@ -3826,7 +3826,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         If multiple values equal the minimum, the first row label with that
         value is returned.
 
-        >>> s = pp.Series([1, 100, 1, 100, 1, 100], index=[10, 3, 5, 2, 1, 8])
+        >>> s = ps.Series([1, 100, 1, 100, 1, 100], index=[10, 3, 5, 2, 1, 8])
         >>> s
         10      1
         3     100
@@ -3876,7 +3876,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series(data=np.arange(3), index=['A', 'B', 'C'])
+        >>> s = ps.Series(data=np.arange(3), index=['A', 'B', 'C'])
         >>> s
         A    0
         B    1
@@ -3891,7 +3891,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         C    2
         dtype: int64
 
-        >>> s = pp.Series(data=np.arange(3), index=['A', 'A', 'C'])
+        >>> s = ps.Series(data=np.arange(3), index=['A', 'A', 'C'])
         >>> s
         A    0
         A    1
@@ -3913,7 +3913,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ...                       ['speed', 'weight', 'length']],
         ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-        >>> s = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        >>> s = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
         ...               index=midx)
         >>> s
         lama    speed      45.0
@@ -3951,7 +3951,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ...                       [0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [0, 1, 2, 0, 1, 2, 0, 0, 2]]
         ...  )
-        >>> s = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        >>> s = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
         ...              index=midx)
         >>> s
         a  lama    speed      45.0
@@ -4047,7 +4047,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2], index=["a", "b"])
+        >>> s = ps.Series([1, 2], index=["a", "b"])
         >>> s
         a    1
         b    2
@@ -4078,7 +4078,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([0, 0, 1, 1, 1, np.nan, np.nan, np.nan])
+        >>> s = ps.Series([0, 0, 1, 1, 1, np.nan, np.nan, np.nan])
         >>> s
         0    0.0
         1    0.0
@@ -4096,7 +4096,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         If there are several same modes, all items are shown
 
-        >>> s = pp.Series([0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3,
+        >>> s = ps.Series([0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3,
         ...                np.nan, np.nan, np.nan])
         >>> s
         0     0.0
@@ -4143,7 +4143,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         return first_series(DataFrame(internal))
 
-    def keys(self) -> "pp.Index":
+    def keys(self) -> "ps.Index":
         """
         Return alias for index.
 
@@ -4158,7 +4158,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ...                       ['speed', 'weight', 'length']],
         ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-        >>> kser = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
+        >>> kser = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
 
         >>> kser.keys()  # doctest: +SKIP
         MultiIndex([(  'lama',  'speed'),
@@ -4226,7 +4226,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Scalar `to_replace` and `value`
 
-        >>> s = pp.Series([0, 1, 2, 3, 4])
+        >>> s = ps.Series([0, 1, 2, 3, 4])
         >>> s
         0    0
         1    1
@@ -4277,7 +4277,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ...                       ['speed', 'weight', 'length']],
         ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-        >>> s = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        >>> s = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
         ...               index=midx)
         >>> s
         lama    speed      45.0
@@ -4381,45 +4381,45 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         --------
         >>> from pyspark.pandas.config import set_option, reset_option
         >>> set_option("compute.ops_on_diff_frames", True)
-        >>> s = pp.Series([1, 2, 3])
-        >>> s.update(pp.Series([4, 5, 6]))
+        >>> s = ps.Series([1, 2, 3])
+        >>> s.update(ps.Series([4, 5, 6]))
         >>> s.sort_index()
         0    4
         1    5
         2    6
         dtype: int64
 
-        >>> s = pp.Series(['a', 'b', 'c'])
-        >>> s.update(pp.Series(['d', 'e'], index=[0, 2]))
+        >>> s = ps.Series(['a', 'b', 'c'])
+        >>> s.update(ps.Series(['d', 'e'], index=[0, 2]))
         >>> s.sort_index()
         0    d
         1    b
         2    e
         dtype: object
 
-        >>> s = pp.Series([1, 2, 3])
-        >>> s.update(pp.Series([4, 5, 6, 7, 8]))
+        >>> s = ps.Series([1, 2, 3])
+        >>> s.update(ps.Series([4, 5, 6, 7, 8]))
         >>> s.sort_index()
         0    4
         1    5
         2    6
         dtype: int64
 
-        >>> s = pp.Series([1, 2, 3], index=[10, 11, 12])
+        >>> s = ps.Series([1, 2, 3], index=[10, 11, 12])
         >>> s
         10    1
         11    2
         12    3
         dtype: int64
 
-        >>> s.update(pp.Series([4, 5, 6]))
+        >>> s.update(ps.Series([4, 5, 6]))
         >>> s.sort_index()
         10    1
         11    2
         12    3
         dtype: int64
 
-        >>> s.update(pp.Series([4, 5, 6], index=[11, 12, 13]))
+        >>> s.update(ps.Series([4, 5, 6], index=[11, 12, 13]))
         >>> s.sort_index()
         10    1
         11    4
@@ -4429,8 +4429,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         If ``other`` contains NaNs the corresponding values are not updated
         in the original Series.
 
-        >>> s = pp.Series([1, 2, 3])
-        >>> s.update(pp.Series([4, np.nan, 6]))
+        >>> s = ps.Series([1, 2, 3])
+        >>> s.update(ps.Series([4, np.nan, 6]))
         >>> s.sort_index()
         0    4.0
         1    2.0
@@ -4480,8 +4480,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> from pyspark.pandas.config import set_option, reset_option
         >>> set_option("compute.ops_on_diff_frames", True)
-        >>> s1 = pp.Series([0, 1, 2, 3, 4])
-        >>> s2 = pp.Series([100, 200, 300, 400, 500])
+        >>> s1 = ps.Series([0, 1, 2, 3, 4])
+        >>> s2 = ps.Series([100, 200, 300, 400, 500])
         >>> s1.where(s1 > 0).sort_index()
         0    NaN
         1    1.0
@@ -4586,8 +4586,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> from pyspark.pandas.config import set_option, reset_option
         >>> set_option("compute.ops_on_diff_frames", True)
-        >>> s1 = pp.Series([0, 1, 2, 3, 4])
-        >>> s2 = pp.Series([100, 200, 300, 400, 500])
+        >>> s1 = ps.Series([0, 1, 2, 3, 4])
+        >>> s2 = ps.Series([100, 200, 300, 400, 500])
         >>> s1.mask(s1 > 0).sort_index()
         0    0.0
         1    NaN
@@ -4653,7 +4653,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ...                      [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                       [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-        >>> s = pp.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        >>> s = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
         ...               index=midx)
         >>> s
         a  lama    speed      45.0
@@ -4749,7 +4749,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
 
-        >>> kser = pp.Series([90, 91, 85], index=[2, 4, 1])
+        >>> kser = ps.Series([90, 91, 85], index=[2, 4, 1])
         >>> kser
         2    90
         4    91
@@ -4806,15 +4806,15 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s1 = pp.Series([1, np.nan])
-        >>> s2 = pp.Series([3, 4])
-        >>> with pp.option_context("compute.ops_on_diff_frames", True):
+        >>> s1 = ps.Series([1, np.nan])
+        >>> s2 = ps.Series([3, 4])
+        >>> with ps.option_context("compute.ops_on_diff_frames", True):
         ...     s1.combine_first(s2)
         0    1.0
         1    4.0
         dtype: float64
         """
-        if not isinstance(other, pp.Series):
+        if not isinstance(other, ps.Series):
             raise ValueError("`combine_first` only allows `Series` for parameter `other`")
         if same_anchor(self, other):
             this = self.spark.column
@@ -4856,8 +4856,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             ...
             ValueError: matrices are not aligned
 
-            >>> kdf1 = pp.Series([1, 2, 3], index=[0, 1, 2])
-            >>> kdf2 = pp.Series([1, 2, 3], index=[0, 1, 3])
+            >>> kdf1 = ps.Series([1, 2, 3], index=[0, 1, 2])
+            >>> kdf2 = ps.Series([1, 2, 3], index=[0, 1, 3])
             >>> kdf1.dot(kdf2)  # doctest: +SKIP
             5
 
@@ -4880,7 +4880,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([0, 1, 2, 3])
+        >>> s = ps.Series([0, 1, 2, 3])
 
         >>> s.dot(s)
         14
@@ -4888,7 +4888,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s @ s
         14
 
-        >>> kdf = pp.DataFrame({'x': [0, 1, 2, 3], 'y': [0, -1, -2, -3]})
+        >>> kdf = ps.DataFrame({'x': [0, 1, 2, 3], 'y': [0, -1, -2, -3]})
         >>> kdf
            x  y
         0  0  0
@@ -4896,7 +4896,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2  2 -2
         3  3 -3
 
-        >>> with pp.option_context("compute.ops_on_diff_frames", True):
+        >>> with ps.option_context("compute.ops_on_diff_frames", True):
         ...     s.dot(kdf)
         ...
         x    14
@@ -4961,7 +4961,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series(['a', 'b', 'c'])
+        >>> s = ps.Series(['a', 'b', 'c'])
         >>> s
         0    a
         1    b
@@ -4975,7 +4975,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1    b
         2    c
         dtype: object
-        >>> pp.Series([1, 2, 3]).repeat(0)
+        >>> ps.Series([1, 2, 3]).repeat(0)
         Series([], dtype: int64)
         """
         if not isinstance(repeats, (int, Series)):
@@ -5020,7 +5020,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             if repeats == 0:
                 return first_series(DataFrame(kdf._internal.with_filter(F.lit(False))))
             else:
-                return first_series(pp.concat([kdf] * repeats))
+                return first_series(ps.concat([kdf] * repeats))
 
     def asof(self, where) -> Union[Scalar, "Series"]:
         """
@@ -5055,7 +5055,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, np.nan, 4], index=[10, 20, 30, 40])
+        >>> s = ps.Series([1, 2, np.nan, 4], index=[10, 20, 30, 40])
         >>> s
         10    1.0
         20    2.0
@@ -5084,9 +5084,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2.0
         """
         should_return_series = True
-        if isinstance(self.index, pp.MultiIndex):
+        if isinstance(self.index, ps.MultiIndex):
             raise ValueError("asof is not supported for a MultiIndex")
-        if isinstance(where, (pp.Index, pp.Series, DataFrame)):
+        if isinstance(where, (ps.Index, ps.Series, DataFrame)):
             raise ValueError("where cannot be an Index, Series or a DataFrame")
         if not self.index.is_monotonic_increasing:
             raise ValueError("asof requires a sorted index")
@@ -5107,8 +5107,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             return result if result is not None else np.nan
 
         # The data is expected to be small so it's fine to transpose/use default index.
-        with pp.option_context("compute.default_index_type", "distributed", "compute.max_rows", 1):
-            kdf = pp.DataFrame(sdf)  # type: DataFrame
+        with ps.option_context("compute.default_index_type", "distributed", "compute.max_rows", 1):
+            kdf = ps.DataFrame(sdf)  # type: DataFrame
             kdf.columns = pd.Index(where)
             return first_series(kdf.transpose()).rename(self.name)
 
@@ -5118,7 +5118,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 3, 4])
+        >>> s = ps.Series([1, 2, 3, 4])
         >>> s
         0    1
         1    2
@@ -5160,7 +5160,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 3, 4],
+        >>> s = ps.Series([1, 2, 3, 4],
         ...               index=pd.MultiIndex.from_product([['one', 'two'],
         ...                                                 ['a', 'b']]))
         >>> s
@@ -5180,7 +5180,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         a    1    3
         b    2    4
         """
-        if not isinstance(self.index, pp.MultiIndex):
+        if not isinstance(self.index, ps.MultiIndex):
             raise ValueError("Series.unstack only support for a MultiIndex")
         index_nlevels = self.index.nlevels
         if level > 0 and (level > index_nlevels - 1):
@@ -5227,7 +5227,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> kser = pp.Series([10])
+        >>> kser = ps.Series([10])
         >>> kser.item()
         10
         """
@@ -5255,7 +5255,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> s = pp.Series(['A', 'B', 'C'])
+        >>> s = ps.Series(['A', 'B', 'C'])
         >>> for index, value in s.items():
         ...     print("Index : {}, Value : {}".format(index, value))
         Index : 0, Value : A
@@ -5301,7 +5301,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> kser = pp.Series(
+        >>> kser = ps.Series(
         ...     [1, 2, 3],
         ...     index=pd.MultiIndex.from_tuples(
         ...         [("x", "a"), ("x", "b"), ("y", "c")], names=["level_1", "level_2"]
@@ -5361,7 +5361,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> kser = pp.Series([1, 2, 3, 4, 5])
+        >>> kser = ps.Series([1, 2, 3, 4, 5])
         >>> kser
         0    1
         1    2
@@ -5398,7 +5398,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> kser = pp.Series([[1, 2, 3], [], [3, 4]])
+        >>> kser = ps.Series([[1, 2, 3], [], [3, 4]])
         >>> kser
         0    [1, 2, 3]
         1           []
@@ -5435,7 +5435,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> kser = pp.Series([3, 3, 4, 1, 6, 2, 3, 7, 8, 7, 10])
+        >>> kser = ps.Series([3, 3, 4, 1, 6, 2, 3, 7, 8, 7, 10])
         >>> kser
         0      3
         1      3
@@ -5525,7 +5525,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         kser = first_series(DataFrame(internal))
 
         return cast(
-            Series, pp.concat([kser, self.loc[self.isnull()].spark.transform(lambda _: F.lit(-1))])
+            Series, ps.concat([kser, self.loc[self.isnull()].spark.transform(lambda _: F.lit(-1))])
         )
 
     def argmax(self) -> int:
@@ -5544,7 +5544,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         --------
         Consider dataset containing cereal calories
 
-        >>> s = pp.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
+        >>> s = ps.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
         ...                'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
         >>> s  # doctest: +SKIP
         Corn Flakes              100.0
@@ -5591,7 +5591,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         --------
         Consider dataset containing cereal calories
 
-        >>> s = pp.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
+        >>> s = ps.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0,
         ...                'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
         >>> s  # doctest: +SKIP
         Corn Flakes              100.0
@@ -5652,8 +5652,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> from pyspark.pandas.config import set_option, reset_option
         >>> set_option("compute.ops_on_diff_frames", True)
-        >>> s1 = pp.Series(["a", "b", "c", "d", "e"])
-        >>> s2 = pp.Series(["a", "a", "c", "b", "e"])
+        >>> s1 = ps.Series(["a", "b", "c", "d", "e"])
+        >>> s2 = ps.Series(["a", "a", "c", "b", "e"])
 
         Align the differences on columns
 
@@ -5767,9 +5767,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Examples
         --------
-        >>> pp.set_option("compute.ops_on_diff_frames", True)
-        >>> s1 = pp.Series([7, 8, 9], index=[10, 11, 12])
-        >>> s2 = pp.Series(["g", "h", "i"], index=[10, 20, 30])
+        >>> ps.set_option("compute.ops_on_diff_frames", True)
+        >>> s1 = ps.Series([7, 8, 9], index=[10, 11, 12])
+        >>> s2 = ps.Series(["g", "h", "i"], index=[10, 20, 30])
 
         >>> aligned_l, aligned_r = s1.align(s2)
         >>> aligned_l.sort_index()
@@ -5799,7 +5799,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Align with a DataFrame:
 
-        >>> df = pp.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}, index=[10, 20, 30])
+        >>> df = ps.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}, index=[10, 20, 30])
         >>> aligned_l, aligned_r = s1.align(df)
         >>> aligned_l.sort_index()
         10    7.0
@@ -5816,7 +5816,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         20  2.0     b
         30  3.0     c
 
-        >>> pp.reset_option("compute.ops_on_diff_frames")
+        >>> ps.reset_option("compute.ops_on_diff_frames")
         """
         axis = validate_axis(axis)
         if axis == 1:
@@ -5879,7 +5879,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
         >>> idx = pd.date_range('2018-04-09', periods=4, freq='1D20min')
-        >>> kser = pp.Series([1, 2, 3, 4], index=idx)
+        >>> kser = ps.Series([1, 2, 3, 4], index=idx)
         >>> kser
         2018-04-09 00:00:00    1
         2018-04-10 00:20:00    2
@@ -5925,7 +5925,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Examples
         --------
         >>> idx = pd.date_range('2018-04-09', periods=4, freq='12H')
-        >>> kser = pp.Series([1, 2, 3, 4], index=idx)
+        >>> kser = ps.Series([1, 2, 3, 4], index=idx)
         >>> kser
         2018-04-09 00:00:00    1
         2018-04-09 12:00:00    2
@@ -6245,7 +6245,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.series.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.series tests").getOrCreate()
     )

--- a/python/pyspark/pandas/spark/accessors.py
+++ b/python/pyspark/pandas/spark/accessors.py
@@ -29,7 +29,7 @@ from pyspark.sql import Column, DataFrame as SparkDataFrame
 from pyspark.sql.types import DataType, StructType
 
 if TYPE_CHECKING:
-    import pyspark.pandas as pp  # noqa: F401 (SPARK-34943)
+    import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.base import IndexOpsMixin  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.frame import CachedDataFrame  # noqa: F401 (SPARK-34943)
 
@@ -61,7 +61,7 @@ class SparkIndexOpsMethods(object, metaclass=ABCMeta):
         """
         return self._data._internal.spark_column_for(self._data._column_label)
 
-    def transform(self, func) -> Union["pp.Series", "pp.Index"]:
+    def transform(self, func) -> Union["ps.Series", "ps.Index"]:
         """
         Applies a function that takes and returns a Spark column. It allows to natively
         apply a Spark function and column APIs with the Spark column internally used
@@ -86,7 +86,7 @@ class SparkIndexOpsMethods(object, metaclass=ABCMeta):
         Examples
         --------
         >>> from pyspark.sql.functions import log
-        >>> df = pp.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["a", "b"])
+        >>> df = ps.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["a", "b"])
         >>> df
            a  b
         0  1  4
@@ -127,17 +127,17 @@ class SparkIndexOpsMethods(object, metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def analyzed(self) -> Union["pp.Series", "pp.Index"]:
+    def analyzed(self) -> Union["ps.Series", "ps.Index"]:
         pass
 
 
 class SparkSeriesMethods(SparkIndexOpsMethods):
-    def transform(self, func) -> "pp.Series":
-        return cast("pp.Series", super().transform(func))
+    def transform(self, func) -> "ps.Series":
+        return cast("ps.Series", super().transform(func))
 
     transform.__doc__ = SparkIndexOpsMethods.transform.__doc__
 
-    def apply(self, func) -> "pp.Series":
+    def apply(self, func) -> "ps.Series":
         """
         Applies a function that takes and returns a Spark column. It allows to natively
         apply a Spark function and column APIs with the Spark column internally used
@@ -168,9 +168,9 @@ class SparkSeriesMethods(SparkIndexOpsMethods):
 
         Examples
         --------
-        >>> from pyspark import pandas as pp
+        >>> from pyspark import pandas as ps
         >>> from pyspark.sql.functions import count, lit
-        >>> df = pp.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["a", "b"])
+        >>> df = ps.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["a", "b"])
         >>> df
            a  b
         0  1  4
@@ -204,7 +204,7 @@ class SparkSeriesMethods(SparkIndexOpsMethods):
         return first_series(DataFrame(sdf)).rename(self._data.name)
 
     @property
-    def analyzed(self) -> "pp.Series":
+    def analyzed(self) -> "ps.Series":
         """
         Returns a new Series with the analyzed Spark DataFrame.
 
@@ -222,7 +222,7 @@ class SparkSeriesMethods(SparkIndexOpsMethods):
 
         Examples
         --------
-        >>> ser = pp.Series([1, 2, 3])
+        >>> ser = ps.Series([1, 2, 3])
         >>> ser
         0    1
         1    2
@@ -244,7 +244,7 @@ class SparkSeriesMethods(SparkIndexOpsMethods):
         ...
         ValueError: ... enable 'compute.ops_on_diff_frames' option.
 
-        >>> with pp.option_context('compute.ops_on_diff_frames', True):
+        >>> with ps.option_context('compute.ops_on_diff_frames', True):
         ...     (ser + ser.spark.analyzed).sort_index()
         0    2
         1    4
@@ -258,13 +258,13 @@ class SparkSeriesMethods(SparkIndexOpsMethods):
 
 
 class SparkIndexMethods(SparkIndexOpsMethods):
-    def transform(self, func) -> "pp.Index":
-        return cast("pp.Index", super().transform(func))
+    def transform(self, func) -> "ps.Index":
+        return cast("ps.Index", super().transform(func))
 
     transform.__doc__ = SparkIndexOpsMethods.transform.__doc__
 
     @property
-    def analyzed(self) -> "pp.Index":
+    def analyzed(self) -> "ps.Index":
         """
         Returns a new Index with the analyzed Spark DataFrame.
 
@@ -282,7 +282,7 @@ class SparkIndexMethods(SparkIndexOpsMethods):
 
         Examples
         --------
-        >>> idx = pp.Index([1, 2, 3])
+        >>> idx = ps.Index([1, 2, 3])
         >>> idx
         Int64Index([1, 2, 3], dtype='int64')
 
@@ -298,7 +298,7 @@ class SparkIndexMethods(SparkIndexOpsMethods):
         ...
         ValueError: ... enable 'compute.ops_on_diff_frames' option.
 
-        >>> with pp.option_context('compute.ops_on_diff_frames', True):
+        >>> with ps.option_context('compute.ops_on_diff_frames', True):
         ...     (idx + idx.spark.analyzed).sort_values()
         Int64Index([2, 4, 6], dtype='int64')
         """
@@ -311,7 +311,7 @@ class SparkFrameMethods(object):
     """Spark related features. Usually, the features here are missing in pandas
     but Spark has it."""
 
-    def __init__(self, frame: "pp.DataFrame"):
+    def __init__(self, frame: "ps.DataFrame"):
         self._kdf = frame
 
     def schema(self, index_col: Optional[Union[str, List[str]]] = None) -> StructType:
@@ -331,7 +331,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': list('abc'),
+        >>> df = ps.DataFrame({'a': list('abc'),
         ...                    'b': list(range(1, 4)),
         ...                    'c': np.arange(3, 6).astype('i1'),
         ...                    'd': np.arange(4.0, 7.0, dtype='float64'),
@@ -361,7 +361,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'a': list('abc'),
+        >>> df = ps.DataFrame({'a': list('abc'),
         ...                    'b': list(range(1, 4)),
         ...                    'c': np.arange(3, 6).astype('i1'),
         ...                    'd': np.arange(4.0, 7.0, dtype='float64'),
@@ -409,7 +409,7 @@ class SparkFrameMethods(object):
         --------
         By default, this method loses the index as below.
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
+        >>> df = ps.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
         >>> df.to_spark().show()  # doctest: +NORMALIZE_WHITESPACE
         +---+---+---+
         |  a|  b|  c|
@@ -419,7 +419,7 @@ class SparkFrameMethods(object):
         |  3|  6|  9|
         +---+---+---+
 
-        >>> df = pp.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
+        >>> df = ps.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
         >>> df.spark.frame().show()  # doctest: +NORMALIZE_WHITESPACE
         +---+---+---+
         |  a|  b|  c|
@@ -530,7 +530,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'])
         >>> df
            dogs  cats
@@ -582,7 +582,7 @@ class SparkFrameMethods(object):
         Examples
         --------
         >>> import pyspark
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'])
         >>> df
            dogs  cats
@@ -643,7 +643,7 @@ class SparkFrameMethods(object):
         )
         return CachedDataFrame(self._kdf._internal, storage_level=storage_level)
 
-    def hint(self, name: str, *parameters) -> "pp.DataFrame":
+    def hint(self, name: str, *parameters) -> "ps.DataFrame":
         """
         Specifies some hint on the current DataFrame.
 
@@ -662,10 +662,10 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> df1 = pp.DataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
+        >>> df1 = ps.DataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
         ...                     'value': [1, 2, 3, 5]},
         ...                    columns=['lkey', 'value']).set_index('lkey')
-        >>> df2 = pp.DataFrame({'rkey': ['foo', 'bar', 'baz', 'foo'],
+        >>> df2 = ps.DataFrame({'rkey': ['foo', 'bar', 'baz', 'foo'],
         ...                     'value': [5, 6, 7, 8]},
         ...                    columns=['rkey', 'value']).set_index('rkey')
         >>> merged = df1.merge(df2.spark.hint("broadcast"), left_index=True, right_index=True)
@@ -736,7 +736,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame(dict(
+        >>> df = ps.DataFrame(dict(
         ...    date=list(pd.date_range('2012-1-1 12:00:00', periods=3, freq='M')),
         ...    country=['KR', 'US', 'JP'],
         ...    code=[1, 2 ,3]), columns=['date', 'country', 'code'])
@@ -809,7 +809,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame(dict(
+        >>> df = ps.DataFrame(dict(
         ...    date=list(pd.date_range('2012-1-1 12:00:00', periods=3, freq='M')),
         ...    country=['KR', 'US', 'JP'],
         ...    code=[1, 2 ,3]), columns=['date', 'country', 'code'])
@@ -846,7 +846,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame({'id': range(10)})
+        >>> df = ps.DataFrame({'id': range(10)})
         >>> df.spark.explain()  # doctest: +ELLIPSIS
         == Physical Plan ==
         ...
@@ -904,7 +904,7 @@ class SparkFrameMethods(object):
         else:
             self._kdf._internal.to_internal_spark_frame.explain(extended, mode)
 
-    def apply(self, func, index_col: Optional[Union[str, List[str]]] = None) -> "pp.DataFrame":
+    def apply(self, func, index_col: Optional[Union[str, List[str]]] = None) -> "ps.DataFrame":
         """
         Applies a function that takes and returns a Spark DataFrame. It allows natively
         apply a Spark function and column APIs with the Spark column internally used
@@ -933,7 +933,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["a", "b"])
+        >>> kdf = ps.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["a", "b"])
         >>> kdf
            a  b
         0  1  4
@@ -966,7 +966,7 @@ class SparkFrameMethods(object):
             )
         return output.to_koalas(index_col)
 
-    def repartition(self, num_partitions: int) -> "pp.DataFrame":
+    def repartition(self, num_partitions: int) -> "ps.DataFrame":
         """
         Returns a new DataFrame partitioned by the given partitioning expressions. The
         resulting DataFrame is hash partitioned.
@@ -982,7 +982,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({"age": [5, 5, 2, 2],
+        >>> kdf = ps.DataFrame({"age": [5, 5, 2, 2],
         ...         "name": ["Bob", "Bob", "Alice", "Alice"]}).set_index("age")
         >>> kdf.sort_index()  # doctest: +NORMALIZE_WHITESPACE
               name
@@ -1008,7 +1008,7 @@ class SparkFrameMethods(object):
         repartitioned_sdf = internal.spark_frame.repartition(num_partitions)
         return DataFrame(internal.with_new_sdf(repartitioned_sdf))
 
-    def coalesce(self, num_partitions: int) -> "pp.DataFrame":
+    def coalesce(self, num_partitions: int) -> "ps.DataFrame":
         """
         Returns a new DataFrame that has exactly `num_partitions` partitions.
 
@@ -1033,7 +1033,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({"age": [5, 5, 2, 2],
+        >>> kdf = ps.DataFrame({"age": [5, 5, 2, 2],
         ...         "name": ["Bob", "Bob", "Alice", "Alice"]}).set_index("age")
         >>> kdf.sort_index()  # doctest: +NORMALIZE_WHITESPACE
               name
@@ -1059,7 +1059,7 @@ class SparkFrameMethods(object):
         coalesced_sdf = internal.spark_frame.coalesce(num_partitions)
         return DataFrame(internal.with_new_sdf(coalesced_sdf))
 
-    def checkpoint(self, eager: bool = True) -> "pp.DataFrame":
+    def checkpoint(self, eager: bool = True) -> "ps.DataFrame":
         """Returns a checkpointed version of this DataFrame.
 
         Checkpointing can be used to truncate the logical plan of this DataFrame, which is
@@ -1077,7 +1077,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({"a": ["a", "b", "c"]})
+        >>> kdf = ps.DataFrame({"a": ["a", "b", "c"]})
         >>> kdf
            a
         0  a
@@ -1096,7 +1096,7 @@ class SparkFrameMethods(object):
         checkpointed_sdf = internal.spark_frame.checkpoint(eager)
         return DataFrame(internal.with_new_sdf(checkpointed_sdf))
 
-    def local_checkpoint(self, eager: bool = True) -> "pp.DataFrame":
+    def local_checkpoint(self, eager: bool = True) -> "ps.DataFrame":
         """Returns a locally checkpointed version of this DataFrame.
 
         Checkpointing can be used to truncate the logical plan of this DataFrame, which is
@@ -1115,7 +1115,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> kdf = pp.DataFrame({"a": ["a", "b", "c"]})
+        >>> kdf = ps.DataFrame({"a": ["a", "b", "c"]})
         >>> kdf
            a
         0  a
@@ -1135,7 +1135,7 @@ class SparkFrameMethods(object):
         return DataFrame(internal.with_new_sdf(checkpointed_sdf))
 
     @property
-    def analyzed(self) -> "pp.DataFrame":
+    def analyzed(self) -> "ps.DataFrame":
         """
         Returns a new DataFrame with the analyzed Spark DataFrame.
 
@@ -1153,7 +1153,7 @@ class SparkFrameMethods(object):
 
         Examples
         --------
-        >>> df = pp.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["a", "b"])
+        >>> df = ps.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, columns=["a", "b"])
         >>> df
            a  b
         0  1  4
@@ -1175,7 +1175,7 @@ class SparkFrameMethods(object):
         ...
         ValueError: ... enable 'compute.ops_on_diff_frames' option.
 
-        >>> with pp.option_context('compute.ops_on_diff_frames', True):
+        >>> with ps.option_context('compute.ops_on_diff_frames', True):
         ...     (df + df.spark.analyzed).sort_index()
            a   b
         0  2   8
@@ -1201,9 +1201,9 @@ class CachedSparkFrameMethods(SparkFrameMethods):
 
         Examples
         --------
-        >>> import pyspark.pandas as pp
+        >>> import pyspark.pandas as ps
         >>> import pyspark
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'])
         >>> df
            dogs  cats
@@ -1237,7 +1237,7 @@ class CachedSparkFrameMethods(SparkFrameMethods):
 
         Examples
         --------
-        >>> df = pp.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
+        >>> df = ps.DataFrame([(.2, .3), (.0, .6), (.6, .0), (.2, .1)],
         ...                   columns=['dogs', 'cats'])
         >>> df = df.spark.cache()
 
@@ -1266,7 +1266,7 @@ def _test():
     globs = pyspark.pandas.spark.accessors.__dict__.copy()
     globs["np"] = numpy
     globs["pd"] = pandas
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.spark.accessors tests")

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -22,7 +22,7 @@ import pandas as pd
 
 from pyspark.sql import SparkSession, DataFrame as SDataFrame  # noqa: F401 (SPARK-34943)
 
-from pyspark import pandas as pp  # For running doctests and reference resolution in PyCharm.
+from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.utils import default_session
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.series import Series
@@ -76,7 +76,7 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
 
     Calling a built-in SQL function.
 
-    >>> pp.sql("select * from range(10) where id > 7")
+    >>> ps.sql("select * from range(10) where id > 7")
        id
     0   8
     1   9
@@ -84,16 +84,16 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
     A query can also reference a local variable or parameter by wrapping them in curly braces:
 
     >>> bound1 = 7
-    >>> pp.sql("select * from range(10) where id > {bound1} and id < {bound2}", bound2=9)
+    >>> ps.sql("select * from range(10) where id > {bound1} and id < {bound2}", bound2=9)
        id
     0   8
 
     You can also wrap a DataFrame with curly braces to query it directly. Note that when you do
     that, the indexes, if any, automatically become top level columns.
 
-    >>> mydf = pp.range(10)
+    >>> mydf = ps.range(10)
     >>> x = range(4)
-    >>> pp.sql("SELECT * from {mydf} WHERE id IN {x}")
+    >>> ps.sql("SELECT * from {mydf} WHERE id IN {x}")
        id
     0   0
     1   1
@@ -103,8 +103,8 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
     Queries can also be arbitrarily nested in functions:
 
     >>> def statement():
-    ...     mydf2 = pp.DataFrame({"x": range(2)})
-    ...     return pp.sql("SELECT * from {mydf2}")
+    ...     mydf2 = ps.DataFrame({"x": range(2)})
+    ...     return ps.sql("SELECT * from {mydf2}")
     >>> statement()
        x
     0  0
@@ -112,12 +112,12 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
 
     Mixing Koalas and pandas DataFrames in a join operation. Note that the index is dropped.
 
-    >>> pp.sql('''
+    >>> ps.sql('''
     ...   SELECT m1.a, m2.b
     ...   FROM {table1} m1 INNER JOIN {table2} m2
     ...   ON m1.key = m2.key
     ...   ORDER BY m1.a, m2.b''',
-    ...   table1=pp.DataFrame({"a": [1,2], "key": ["a", "b"]}),
+    ...   table1=ps.DataFrame({"a": [1,2], "key": ["a", "b"]}),
     ...   table2=pd.DataFrame({"b": [3,4,5], "key": ["a", "b", "b"]}))
        a  b
     0  1  3
@@ -126,8 +126,8 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
 
     Also, it is possible to query using Series.
 
-    >>> myser = pp.Series({'a': [1.0, 2.0, 3.0], 'b': [15.0, 30.0, 45.0]})
-    >>> pp.sql("SELECT * from {myser}")
+    >>> myser = ps.Series({'a': [1.0, 2.0, 3.0], 'b': [15.0, 30.0, 45.0]})
+    >>> ps.sql("SELECT * from {myser}")
                         0
     0     [1.0, 2.0, 3.0]
     1  [15.0, 30.0, 45.0]
@@ -226,18 +226,18 @@ class SQLProcessor(object):
         the underlying SQL engine.
 
         >>> str0 = 'abc'
-        >>> pp.sql("select {str0}")
+        >>> ps.sql("select {str0}")
            abc
         0  abc
 
         >>> str1 = 'abc"abc'
         >>> str2 = "abc'abc"
-        >>> pp.sql("select {str0}, {str1}, {str2}")
+        >>> ps.sql("select {str0}, {str1}, {str2}")
            abc  abc"abc  abc'abc
         0  abc  abc"abc  abc'abc
 
         >>> strs = ['a', 'b']
-        >>> pp.sql("select 'a' in {strs} as cond1, 'c' in {strs} as cond2")
+        >>> ps.sql("select 'a' in {strs} as cond1, 'c' in {strs} as cond2")
            cond1  cond2
         0   True  False
         """
@@ -285,7 +285,7 @@ class SQLProcessor(object):
         if isinstance(var, Series):
             return self._convert_var(var.to_dataframe())
         if isinstance(var, pd.DataFrame):
-            return self._convert_var(pp.DataFrame(var))
+            return self._convert_var(ps.DataFrame(var))
         if isinstance(var, DataFrame):
             df_id = "koalas_" + str(id(var))
             if df_id not in self._temp_views:
@@ -312,7 +312,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.sql_processor.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.sql_processor tests")

--- a/python/pyspark/pandas/strings.py
+++ b/python/pyspark/pandas/strings.py
@@ -29,25 +29,25 @@ from pyspark.sql.functions import pandas_udf, PandasUDFType
 from pyspark.pandas.spark import functions as SF
 
 if TYPE_CHECKING:
-    import pyspark.pandas as pp  # noqa: F401 (SPARK-34943)
+    import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
 
 
 class StringMethods(object):
     """String methods for Koalas Series"""
 
-    def __init__(self, series: "pp.Series"):
+    def __init__(self, series: "ps.Series"):
         if not isinstance(series.spark.data_type, (StringType, BinaryType, ArrayType)):
             raise ValueError("Cannot call StringMethods on type {}".format(series.spark.data_type))
         self._data = series
 
     # Methods
-    def capitalize(self) -> "pp.Series":
+    def capitalize(self) -> "ps.Series":
         """
         Convert Strings in the series to be capitalized.
 
         Examples
         --------
-        >>> s = pp.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
+        >>> s = ps.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
         >>> s
         0                 lower
         1              CAPITALS
@@ -63,18 +63,18 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_capitalize(s) -> "pp.Series[str]":
+        def pandas_capitalize(s) -> "ps.Series[str]":
             return s.str.capitalize()
 
         return self._data.koalas.transform_batch(pandas_capitalize)
 
-    def title(self) -> "pp.Series":
+    def title(self) -> "ps.Series":
         """
         Convert Strings in the series to be titlecase.
 
         Examples
         --------
-        >>> s = pp.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
+        >>> s = ps.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
         >>> s
         0                 lower
         1              CAPITALS
@@ -90,18 +90,18 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_title(s) -> "pp.Series[str]":
+        def pandas_title(s) -> "ps.Series[str]":
             return s.str.title()
 
         return self._data.koalas.transform_batch(pandas_title)
 
-    def lower(self) -> "pp.Series":
+    def lower(self) -> "ps.Series":
         """
         Convert strings in the Series/Index to all lowercase.
 
         Examples
         --------
-        >>> s = pp.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
+        >>> s = ps.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
         >>> s
         0                 lower
         1              CAPITALS
@@ -118,13 +118,13 @@ class StringMethods(object):
         """
         return self._data.spark.transform(F.lower)
 
-    def upper(self) -> "pp.Series":
+    def upper(self) -> "ps.Series":
         """
         Convert strings in the Series/Index to all uppercase.
 
         Examples
         --------
-        >>> s = pp.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
+        >>> s = ps.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
         >>> s
         0                 lower
         1              CAPITALS
@@ -141,13 +141,13 @@ class StringMethods(object):
         """
         return self._data.spark.transform(F.upper)
 
-    def swapcase(self) -> "pp.Series":
+    def swapcase(self) -> "ps.Series":
         """
         Convert strings in the Series/Index to be swapcased.
 
         Examples
         --------
-        >>> s = pp.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
+        >>> s = ps.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
         >>> s
         0                 lower
         1              CAPITALS
@@ -163,12 +163,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_swapcase(s) -> "pp.Series[str]":
+        def pandas_swapcase(s) -> "ps.Series[str]":
             return s.str.swapcase()
 
         return self._data.koalas.transform_batch(pandas_swapcase)
 
-    def startswith(self, pattern, na=None) -> "pp.Series":
+    def startswith(self, pattern, na=None) -> "ps.Series":
         """
         Test if the start of each string element matches a pattern.
 
@@ -189,7 +189,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['bat', 'Bear', 'cat', np.nan])
+        >>> s = ps.Series(['bat', 'Bear', 'cat', np.nan])
         >>> s
         0     bat
         1    Bear
@@ -214,12 +214,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_startswith(s) -> "pp.Series[bool]":
+        def pandas_startswith(s) -> "ps.Series[bool]":
             return s.str.startswith(pattern, na)
 
         return self._data.koalas.transform_batch(pandas_startswith)
 
-    def endswith(self, pattern, na=None) -> "pp.Series":
+    def endswith(self, pattern, na=None) -> "ps.Series":
         """
         Test if the end of each string element matches a pattern.
 
@@ -240,7 +240,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['bat', 'Bear', 'cat', np.nan])
+        >>> s = ps.Series(['bat', 'Bear', 'cat', np.nan])
         >>> s
         0     bat
         1    Bear
@@ -265,12 +265,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_endswith(s) -> "pp.Series[bool]":
+        def pandas_endswith(s) -> "ps.Series[bool]":
             return s.str.endswith(pattern, na)
 
         return self._data.koalas.transform_batch(pandas_endswith)
 
-    def strip(self, to_strip=None) -> "pp.Series":
+    def strip(self, to_strip=None) -> "ps.Series":
         """
         Remove leading and trailing characters.
 
@@ -291,7 +291,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['1. Ant.', '2. Bee!\\t', None])
+        >>> s = ps.Series(['1. Ant.', '2. Bee!\\t', None])
         >>> s
         0      1. Ant.
         1    2. Bee!\\t
@@ -317,12 +317,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_strip(s) -> "pp.Series[str]":
+        def pandas_strip(s) -> "ps.Series[str]":
             return s.str.strip(to_strip)
 
         return self._data.koalas.transform_batch(pandas_strip)
 
-    def lstrip(self, to_strip=None) -> "pp.Series":
+    def lstrip(self, to_strip=None) -> "ps.Series":
         """
         Remove leading characters.
 
@@ -343,7 +343,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['1. Ant.', '2. Bee!\\t', None])
+        >>> s = ps.Series(['1. Ant.', '2. Bee!\\t', None])
         >>> s
         0      1. Ant.
         1    2. Bee!\\t
@@ -357,12 +357,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_lstrip(s) -> "pp.Series[str]":
+        def pandas_lstrip(s) -> "ps.Series[str]":
             return s.str.lstrip(to_strip)
 
         return self._data.koalas.transform_batch(pandas_lstrip)
 
-    def rstrip(self, to_strip=None) -> "pp.Series":
+    def rstrip(self, to_strip=None) -> "ps.Series":
         """
         Remove trailing characters.
 
@@ -383,7 +383,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['1. Ant.', '2. Bee!\\t', None])
+        >>> s = ps.Series(['1. Ant.', '2. Bee!\\t', None])
         >>> s
         0      1. Ant.
         1    2. Bee!\\t
@@ -397,12 +397,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_rstrip(s) -> "pp.Series[str]":
+        def pandas_rstrip(s) -> "ps.Series[str]":
             return s.str.rstrip(to_strip)
 
         return self._data.koalas.transform_batch(pandas_rstrip)
 
-    def get(self, i) -> "pp.Series":
+    def get(self, i) -> "ps.Series":
         """
         Extract element from each string or string list/tuple in the Series
         at the specified position.
@@ -418,7 +418,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s1 = pp.Series(["String", "123"])
+        >>> s1 = ps.Series(["String", "123"])
         >>> s1
         0    String
         1       123
@@ -434,7 +434,7 @@ class StringMethods(object):
         1    3
         dtype: object
 
-        >>> s2 = pp.Series([["a", "b", "c"], ["x", "y"]])
+        >>> s2 = ps.Series([["a", "b", "c"], ["x", "y"]])
         >>> s2
         0    [a, b, c]
         1       [x, y]
@@ -451,12 +451,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_get(s) -> "pp.Series[str]":
+        def pandas_get(s) -> "ps.Series[str]":
             return s.str.get(i)
 
         return self._data.koalas.transform_batch(pandas_get)
 
-    def isalnum(self) -> "pp.Series":
+    def isalnum(self) -> "ps.Series":
         """
         Check whether all characters in each string are alphanumeric.
 
@@ -466,7 +466,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s1 = pp.Series(['one', 'one1', '1', ''])
+        >>> s1 = ps.Series(['one', 'one1', '1', ''])
 
         >>> s1.str.isalnum()
         0     True
@@ -479,7 +479,7 @@ class StringMethods(object):
         punctuation or whitespace will evaluate to false for an alphanumeric
         check.
 
-        >>> s2 = pp.Series(['A B', '1.5', '3,000'])
+        >>> s2 = ps.Series(['A B', '1.5', '3,000'])
         >>> s2.str.isalnum()
         0    False
         1    False
@@ -487,12 +487,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_isalnum(s) -> "pp.Series[bool]":
+        def pandas_isalnum(s) -> "ps.Series[bool]":
             return s.str.isalnum()
 
         return self._data.koalas.transform_batch(pandas_isalnum)
 
-    def isalpha(self) -> "pp.Series":
+    def isalpha(self) -> "ps.Series":
         """
         Check whether all characters in each string are alphabetic.
 
@@ -502,7 +502,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s1 = pp.Series(['one', 'one1', '1', ''])
+        >>> s1 = ps.Series(['one', 'one1', '1', ''])
 
         >>> s1.str.isalpha()
         0     True
@@ -512,12 +512,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_isalpha(s) -> "pp.Series[bool]":
+        def pandas_isalpha(s) -> "ps.Series[bool]":
             return s.str.isalpha()
 
         return self._data.koalas.transform_batch(pandas_isalpha)
 
-    def isdigit(self) -> "pp.Series":
+    def isdigit(self) -> "ps.Series":
         """
         Check whether all characters in each string are digits.
 
@@ -527,7 +527,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['23', '³', '⅕', ''])
+        >>> s = ps.Series(['23', '³', '⅕', ''])
 
         The s.str.isdecimal method checks for characters used to form numbers
         in base 10.
@@ -562,12 +562,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_isdigit(s) -> "pp.Series[bool]":
+        def pandas_isdigit(s) -> "ps.Series[bool]":
             return s.str.isdigit()
 
         return self._data.koalas.transform_batch(pandas_isdigit)
 
-    def isspace(self) -> "pp.Series":
+    def isspace(self) -> "ps.Series":
         """
         Check whether all characters in each string are whitespaces.
 
@@ -577,7 +577,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series([' ', '\\t\\r\\n ', ''])
+        >>> s = ps.Series([' ', '\\t\\r\\n ', ''])
         >>> s.str.isspace()
         0     True
         1     True
@@ -585,12 +585,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_isspace(s) -> "pp.Series[bool]":
+        def pandas_isspace(s) -> "ps.Series[bool]":
             return s.str.isspace()
 
         return self._data.koalas.transform_batch(pandas_isspace)
 
-    def islower(self) -> "pp.Series":
+    def islower(self) -> "ps.Series":
         """
         Check whether all characters in each string are lowercase.
 
@@ -600,7 +600,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['leopard', 'Golden Eagle', 'SNAKE', ''])
+        >>> s = ps.Series(['leopard', 'Golden Eagle', 'SNAKE', ''])
         >>> s.str.islower()
         0     True
         1    False
@@ -609,12 +609,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_isspace(s) -> "pp.Series[bool]":
+        def pandas_isspace(s) -> "ps.Series[bool]":
             return s.str.islower()
 
         return self._data.koalas.transform_batch(pandas_isspace)
 
-    def isupper(self) -> "pp.Series":
+    def isupper(self) -> "ps.Series":
         """
         Check whether all characters in each string are uppercase.
 
@@ -624,7 +624,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['leopard', 'Golden Eagle', 'SNAKE', ''])
+        >>> s = ps.Series(['leopard', 'Golden Eagle', 'SNAKE', ''])
         >>> s.str.isupper()
         0    False
         1    False
@@ -633,12 +633,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_isspace(s) -> "pp.Series[bool]":
+        def pandas_isspace(s) -> "ps.Series[bool]":
             return s.str.isupper()
 
         return self._data.koalas.transform_batch(pandas_isspace)
 
-    def istitle(self) -> "pp.Series":
+    def istitle(self) -> "ps.Series":
         """
         Check whether all characters in each string are titlecase.
 
@@ -648,7 +648,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['leopard', 'Golden Eagle', 'SNAKE', ''])
+        >>> s = ps.Series(['leopard', 'Golden Eagle', 'SNAKE', ''])
 
         The s.str.istitle method checks for whether all words are in title
         case (whether only the first letter of each word is capitalized).
@@ -663,12 +663,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_istitle(s) -> "pp.Series[bool]":
+        def pandas_istitle(s) -> "ps.Series[bool]":
             return s.str.istitle()
 
         return self._data.koalas.transform_batch(pandas_istitle)
 
-    def isnumeric(self) -> "pp.Series":
+    def isnumeric(self) -> "ps.Series":
         """
         Check whether all characters in each string are numeric.
 
@@ -678,7 +678,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s1 = pp.Series(['one', 'one1', '1', ''])
+        >>> s1 = ps.Series(['one', 'one1', '1', ''])
         >>> s1.str.isnumeric()
         0    False
         1    False
@@ -686,7 +686,7 @@ class StringMethods(object):
         3    False
         dtype: bool
 
-        >>> s2 = pp.Series(['23', '³', '⅕', ''])
+        >>> s2 = ps.Series(['23', '³', '⅕', ''])
 
         The s2.str.isdecimal method checks for characters used to form numbers
         in base 10.
@@ -721,12 +721,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_isnumeric(s) -> "pp.Series[bool]":
+        def pandas_isnumeric(s) -> "ps.Series[bool]":
             return s.str.isnumeric()
 
         return self._data.koalas.transform_batch(pandas_isnumeric)
 
-    def isdecimal(self) -> "pp.Series":
+    def isdecimal(self) -> "ps.Series":
         """
         Check whether all characters in each string are decimals.
 
@@ -736,7 +736,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['23', '³', '⅕', ''])
+        >>> s = ps.Series(['23', '³', '⅕', ''])
 
         The s.str.isdecimal method checks for characters used to form numbers
         in base 10.
@@ -771,18 +771,18 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_isdecimal(s) -> "pp.Series[bool]":
+        def pandas_isdecimal(s) -> "ps.Series[bool]":
             return s.str.isdecimal()
 
         return self._data.koalas.transform_batch(pandas_isdecimal)
 
-    def cat(self, others=None, sep=None, na_rep=None, join=None) -> "pp.Series":
+    def cat(self, others=None, sep=None, na_rep=None, join=None) -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def center(self, width, fillchar=" ") -> "pp.Series":
+    def center(self, width, fillchar=" ") -> "ps.Series":
         """
         Filling left and right side of strings in the Series/Index with an
         additional character. Equivalent to :func:`str.center`.
@@ -801,7 +801,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(["caribou", "tiger"])
+        >>> s = ps.Series(["caribou", "tiger"])
         >>> s
         0    caribou
         1      tiger
@@ -813,12 +813,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_center(s) -> "pp.Series[str]":
+        def pandas_center(s) -> "ps.Series[str]":
             return s.str.center(width, fillchar)
 
         return self._data.koalas.transform_batch(pandas_center)
 
-    def contains(self, pat, case=True, flags=0, na=None, regex=True) -> "pp.Series":
+    def contains(self, pat, case=True, flags=0, na=None, regex=True) -> "ps.Series":
         """
         Test if pattern or regex is contained within a string of a Series.
 
@@ -853,7 +853,7 @@ class StringMethods(object):
         --------
         Returning a Series of booleans using only a literal pattern.
 
-        >>> s1 = pp.Series(['Mouse', 'dog', 'house and parrot', '23', np.NaN])
+        >>> s1 = ps.Series(['Mouse', 'dog', 'house and parrot', '23', np.NaN])
         >>> s1.str.contains('og', regex=False)
         0    False
         1     True
@@ -920,7 +920,7 @@ class StringMethods(object):
         to return True. However, ‘.0’ as a regex matches any character followed
         by a 0.
 
-        >>> s2 = pp.Series(['40','40.0','41','41.0','35'])
+        >>> s2 = ps.Series(['40','40.0','41','41.0','35'])
         >>> s2.str.contains('.0', regex=True)
         0     True
         1     True
@@ -930,12 +930,12 @@ class StringMethods(object):
         dtype: bool
         """
 
-        def pandas_contains(s) -> "pp.Series[bool]":
+        def pandas_contains(s) -> "ps.Series[bool]":
             return s.str.contains(pat, case, flags, na, regex)
 
         return self._data.koalas.transform_batch(pandas_contains)
 
-    def count(self, pat, flags=0) -> "pp.Series":
+    def count(self, pat, flags=0) -> "ps.Series":
         """
         Count occurrences of pattern in each string of the Series.
 
@@ -956,7 +956,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['A', 'B', 'Aaba', 'Baca', np.NaN, 'CABA', 'cat'])
+        >>> s = ps.Series(['A', 'B', 'Aaba', 'Baca', np.NaN, 'CABA', 'cat'])
         >>> s.str.count('a')
         0    0.0
         1    0.0
@@ -969,7 +969,7 @@ class StringMethods(object):
 
         Escape '$' to find the literal dollar sign.
 
-        >>> s = pp.Series(['$', 'B', 'Aab$', '$$ca', 'C$B$', 'cat'])
+        >>> s = ps.Series(['$', 'B', 'Aab$', '$$ca', 'C$B$', 'cat'])
         >>> s.str.count('\\$')
         0    1
         1    0
@@ -980,36 +980,36 @@ class StringMethods(object):
         dtype: int64
         """
 
-        def pandas_count(s) -> "pp.Series[int]":
+        def pandas_count(s) -> "ps.Series[int]":
             return s.str.count(pat, flags)
 
         return self._data.koalas.transform_batch(pandas_count)
 
-    def decode(self, encoding, errors="strict") -> "pp.Series":
+    def decode(self, encoding, errors="strict") -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def encode(self, encoding, errors="strict") -> "pp.Series":
+    def encode(self, encoding, errors="strict") -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def extract(self, pat, flags=0, expand=True) -> "pp.Series":
+    def extract(self, pat, flags=0, expand=True) -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def extractall(self, pat, flags=0) -> "pp.Series":
+    def extractall(self, pat, flags=0) -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def find(self, sub, start=0, end=None) -> "pp.Series":
+    def find(self, sub, start=0, end=None) -> "ps.Series":
         """
         Return lowest indexes in each strings in the Series where the
         substring is fully contained between [start:end].
@@ -1032,7 +1032,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['apple', 'oranges', 'bananas'])
+        >>> s = ps.Series(['apple', 'oranges', 'bananas'])
 
         >>> s.str.find('a')
         0    0
@@ -1059,12 +1059,12 @@ class StringMethods(object):
         dtype: int64
         """
 
-        def pandas_find(s) -> "pp.Series[int]":
+        def pandas_find(s) -> "ps.Series[int]":
             return s.str.find(sub, start, end)
 
         return self._data.koalas.transform_batch(pandas_find)
 
-    def findall(self, pat, flags=0) -> "pp.Series":
+    def findall(self, pat, flags=0) -> "ps.Series":
         """
         Find all occurrences of pattern or regular expression in the Series.
 
@@ -1086,7 +1086,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['Lion', 'Monkey', 'Rabbit'])
+        >>> s = ps.Series(['Lion', 'Monkey', 'Rabbit'])
 
         The search for the pattern ‘Monkey’ returns one match:
 
@@ -1150,7 +1150,7 @@ class StringMethods(object):
         )
         return self._data._with_new_scol(scol=pudf(self._data.spark.column))
 
-    def index(self, sub, start=0, end=None) -> "pp.Series":
+    def index(self, sub, start=0, end=None) -> "ps.Series":
         """
         Return lowest indexes in each strings where the substring is fully
         contained between [start:end].
@@ -1175,7 +1175,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['apple', 'oranges', 'bananas'])
+        >>> s = ps.Series(['apple', 'oranges', 'bananas'])
 
         >>> s.str.index('a')
         0    0
@@ -1188,12 +1188,12 @@ class StringMethods(object):
         >>> s.str.index('a', start=2) # doctest: +SKIP
         """
 
-        def pandas_index(s) -> "pp.Series[np.int64]":
+        def pandas_index(s) -> "ps.Series[np.int64]":
             return s.str.index(sub, start, end)
 
         return self._data.koalas.transform_batch(pandas_index)
 
-    def join(self, sep) -> "pp.Series":
+    def join(self, sep) -> "ps.Series":
         """
         Join lists contained as elements in the Series with passed delimiter.
 
@@ -1222,7 +1222,7 @@ class StringMethods(object):
         --------
         Example with a list that contains a None element.
 
-        >>> s = pp.Series([['lion', 'elephant', 'zebra'],
+        >>> s = ps.Series([['lion', 'elephant', 'zebra'],
         ...                ['cat', None, 'dog']])
         >>> s
         0    [lion, elephant, zebra]
@@ -1237,12 +1237,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_join(s) -> "pp.Series[str]":
+        def pandas_join(s) -> "ps.Series[str]":
             return s.str.join(sep)
 
         return self._data.koalas.transform_batch(pandas_join)
 
-    def len(self) -> "pp.Series":
+    def len(self) -> "ps.Series":
         """
         Computes the length of each element in the Series.
 
@@ -1259,13 +1259,13 @@ class StringMethods(object):
         Returns the length (number of characters) in a string. Returns the
         number of entries for lists or tuples.
 
-        >>> s1 = pp.Series(['dog', 'monkey'])
+        >>> s1 = ps.Series(['dog', 'monkey'])
         >>> s1.str.len()
         0    3
         1    6
         dtype: int64
 
-        >>> s2 = pp.Series([["a", "b", "c"], []])
+        >>> s2 = ps.Series([["a", "b", "c"], []])
         >>> s2.str.len()
         0    3
         1    0
@@ -1276,7 +1276,7 @@ class StringMethods(object):
         else:
             return self._data.spark.transform(lambda c: F.length(c).cast(LongType()))
 
-    def ljust(self, width, fillchar=" ") -> "pp.Series":
+    def ljust(self, width, fillchar=" ") -> "ps.Series":
         """
         Filling right side of strings in the Series with an additional
         character. Equivalent to :func:`str.ljust`.
@@ -1295,7 +1295,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(["caribou", "tiger"])
+        >>> s = ps.Series(["caribou", "tiger"])
         >>> s
         0    caribou
         1      tiger
@@ -1307,12 +1307,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_ljust(s) -> "pp.Series[str]":
+        def pandas_ljust(s) -> "ps.Series[str]":
             return s.str.ljust(width, fillchar)
 
         return self._data.koalas.transform_batch(pandas_ljust)
 
-    def match(self, pat, case=True, flags=0, na=np.NaN) -> "pp.Series":
+    def match(self, pat, case=True, flags=0, na=np.NaN) -> "ps.Series":
         """
         Determine if each string matches a regular expression.
 
@@ -1338,7 +1338,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['Mouse', 'dog', 'house and parrot', '23', np.NaN])
+        >>> s = ps.Series(['Mouse', 'dog', 'house and parrot', '23', np.NaN])
         >>> s.str.match('dog')
         0    False
         1     True
@@ -1373,12 +1373,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_match(s) -> "pp.Series[bool]":
+        def pandas_match(s) -> "ps.Series[bool]":
             return s.str.match(pat, case, flags, na)
 
         return self._data.koalas.transform_batch(pandas_match)
 
-    def normalize(self, form) -> "pp.Series":
+    def normalize(self, form) -> "ps.Series":
         """
         Return the Unicode normal form for the strings in the Series.
 
@@ -1396,12 +1396,12 @@ class StringMethods(object):
             A Series of normalized strings.
         """
 
-        def pandas_normalize(s) -> "pp.Series[str]":
+        def pandas_normalize(s) -> "ps.Series[str]":
             return s.str.normalize(form)
 
         return self._data.koalas.transform_batch(pandas_normalize)
 
-    def pad(self, width, side="left", fillchar=" ") -> "pp.Series":
+    def pad(self, width, side="left", fillchar=" ") -> "ps.Series":
         """
         Pad strings in the Series up to width.
 
@@ -1422,7 +1422,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(["caribou", "tiger"])
+        >>> s = ps.Series(["caribou", "tiger"])
         >>> s
         0    caribou
         1      tiger
@@ -1444,18 +1444,18 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_pad(s) -> "pp.Series[str]":
+        def pandas_pad(s) -> "ps.Series[str]":
             return s.str.pad(width, side, fillchar)
 
         return self._data.koalas.transform_batch(pandas_pad)
 
-    def partition(self, sep=" ", expand=True) -> "pp.Series":
+    def partition(self, sep=" ", expand=True) -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def repeat(self, repeats) -> "pp.Series":
+    def repeat(self, repeats) -> "ps.Series":
         """
         Duplicate each string in the Series.
 
@@ -1473,7 +1473,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['a', 'b', 'c'])
+        >>> s = ps.Series(['a', 'b', 'c'])
         >>> s
         0    a
         1    b
@@ -1492,7 +1492,7 @@ class StringMethods(object):
             raise ValueError("repeats expects an int parameter")
         return self._data.spark.transform(lambda c: SF.repeat(col=c, n=repeats))
 
-    def replace(self, pat, repl, n=-1, case=None, flags=0, regex=True) -> "pp.Series":
+    def replace(self, pat, repl, n=-1, case=None, flags=0, regex=True) -> "ps.Series":
         """
         Replace occurrences of pattern/regex in the Series with some other
         string. Equivalent to :func:`str.replace` or :func:`re.sub`.
@@ -1533,7 +1533,7 @@ class StringMethods(object):
         patterns as with :func:`re.sub`. NaN value(s) in the Series are changed
         to None:
 
-        >>> pp.Series(['foo', 'fuz', np.nan]).str.replace('f.', 'ba', regex=True)
+        >>> ps.Series(['foo', 'fuz', np.nan]).str.replace('f.', 'ba', regex=True)
         0     bao
         1     baz
         2    None
@@ -1542,7 +1542,7 @@ class StringMethods(object):
         When pat is a string and regex is False, every pat is replaced with
         repl as with :func:`str.replace`:
 
-        >>> pp.Series(['f.o', 'fuz', np.nan]).str.replace('f.', 'ba', regex=False)
+        >>> ps.Series(['f.o', 'fuz', np.nan]).str.replace('f.', 'ba', regex=False)
         0     bao
         1     fuz
         2    None
@@ -1555,7 +1555,7 @@ class StringMethods(object):
         Reverse every lowercase alphabetic word:
 
         >>> repl = lambda m: m.group(0)[::-1]
-        >>> pp.Series(['foo 123', 'bar baz', np.nan]).str.replace(r'[a-z]+', repl)
+        >>> ps.Series(['foo 123', 'bar baz', np.nan]).str.replace(r'[a-z]+', repl)
         0    oof 123
         1    rab zab
         2       None
@@ -1565,7 +1565,7 @@ class StringMethods(object):
 
         >>> pat = r"(?P<one>\\w+) (?P<two>\\w+) (?P<three>\\w+)"
         >>> repl = lambda m: m.group('two').swapcase()
-        >>> pp.Series(['One Two Three', 'Foo Bar Baz']).str.replace(pat, repl)
+        >>> ps.Series(['One Two Three', 'Foo Bar Baz']).str.replace(pat, repl)
         0    tWO
         1    bAR
         dtype: object
@@ -1574,19 +1574,19 @@ class StringMethods(object):
 
         >>> import re
         >>> regex_pat = re.compile(r'FUZ', flags=re.IGNORECASE)
-        >>> pp.Series(['foo', 'fuz', np.nan]).str.replace(regex_pat, 'bar')
+        >>> ps.Series(['foo', 'fuz', np.nan]).str.replace(regex_pat, 'bar')
         0     foo
         1     bar
         2    None
         dtype: object
         """
 
-        def pandas_replace(s) -> "pp.Series[str]":
+        def pandas_replace(s) -> "ps.Series[str]":
             return s.str.replace(pat, repl, n=n, case=case, flags=flags, regex=regex)
 
         return self._data.koalas.transform_batch(pandas_replace)
 
-    def rfind(self, sub, start=0, end=None) -> "pp.Series":
+    def rfind(self, sub, start=0, end=None) -> "ps.Series":
         """
         Return highest indexes in each strings in the Series where the
         substring is fully contained between [start:end].
@@ -1609,7 +1609,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['apple', 'oranges', 'bananas'])
+        >>> s = ps.Series(['apple', 'oranges', 'bananas'])
 
         >>> s.str.rfind('a')
         0    0
@@ -1636,12 +1636,12 @@ class StringMethods(object):
         dtype: int64
         """
 
-        def pandas_rfind(s) -> "pp.Series[int]":
+        def pandas_rfind(s) -> "ps.Series[int]":
             return s.str.rfind(sub, start, end)
 
         return self._data.koalas.transform_batch(pandas_rfind)
 
-    def rindex(self, sub, start=0, end=None) -> "pp.Series":
+    def rindex(self, sub, start=0, end=None) -> "ps.Series":
         """
         Return highest indexes in each strings where the substring is fully
         contained between [start:end].
@@ -1666,7 +1666,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['apple', 'oranges', 'bananas'])
+        >>> s = ps.Series(['apple', 'oranges', 'bananas'])
 
         >>> s.str.rindex('a')
         0    0
@@ -1679,12 +1679,12 @@ class StringMethods(object):
         >>> s.str.rindex('a', start=2) # doctest: +SKIP
         """
 
-        def pandas_rindex(s) -> "pp.Series[np.int64]":
+        def pandas_rindex(s) -> "ps.Series[np.int64]":
             return s.str.rindex(sub, start, end)
 
         return self._data.koalas.transform_batch(pandas_rindex)
 
-    def rjust(self, width, fillchar=" ") -> "pp.Series":
+    def rjust(self, width, fillchar=" ") -> "ps.Series":
         """
         Filling left side of strings in the Series with an additional
         character. Equivalent to :func:`str.rjust`.
@@ -1703,7 +1703,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(["caribou", "tiger"])
+        >>> s = ps.Series(["caribou", "tiger"])
         >>> s
         0    caribou
         1      tiger
@@ -1720,18 +1720,18 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_rjust(s) -> "pp.Series[str]":
+        def pandas_rjust(s) -> "ps.Series[str]":
             return s.str.rjust(width, fillchar)
 
         return self._data.koalas.transform_batch(pandas_rjust)
 
-    def rpartition(self, sep=" ", expand=True) -> "pp.Series":
+    def rpartition(self, sep=" ", expand=True) -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def slice(self, start=None, stop=None, step=None) -> "pp.Series":
+    def slice(self, start=None, stop=None, step=None) -> "ps.Series":
         """
         Slice substrings from each element in the Series.
 
@@ -1751,7 +1751,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(["koala", "fox", "chameleon"])
+        >>> s = ps.Series(["koala", "fox", "chameleon"])
         >>> s
         0        koala
         1          fox
@@ -1783,12 +1783,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_slice(s) -> "pp.Series[str]":
+        def pandas_slice(s) -> "ps.Series[str]":
             return s.str.slice(start, stop, step)
 
         return self._data.koalas.transform_batch(pandas_slice)
 
-    def slice_replace(self, start=None, stop=None, repl=None) -> "pp.Series":
+    def slice_replace(self, start=None, stop=None, repl=None) -> "ps.Series":
         """
         Slice substrings from each element in the Series.
 
@@ -1813,7 +1813,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['a', 'ab', 'abc', 'abdc', 'abcde'])
+        >>> s = ps.Series(['a', 'ab', 'abc', 'abdc', 'abcde'])
         >>> s
         0        a
         1       ab
@@ -1857,12 +1857,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_slice_replace(s) -> "pp.Series[str]":
+        def pandas_slice_replace(s) -> "ps.Series[str]":
             return s.str.slice_replace(start, stop, repl)
 
         return self._data.koalas.transform_batch(pandas_slice_replace)
 
-    def split(self, pat=None, n=-1, expand=False) -> Union["pp.Series", "pp.DataFrame"]:
+    def split(self, pat=None, n=-1, expand=False) -> Union["ps.Series", "ps.DataFrame"]:
         """
         Split strings around given separator/delimiter.
 
@@ -1912,7 +1912,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(["this is a regular sentence",
+        >>> s = ps.Series(["this is a regular sentence",
         ...                "https://docs.python.org/3/tutorial/index.html",
         ...                np.nan])
 
@@ -1977,7 +1977,7 @@ class StringMethods(object):
         Remember to escape special characters when explicitly using regular
         expressions.
 
-        >>> s = pp.Series(["1+1=2"])
+        >>> s = ps.Series(["1+1=2"])
         >>> s.str.split(r"\\+|=", n=2, expand=True)
            0  1  2
         0  1  1  2
@@ -2009,7 +2009,7 @@ class StringMethods(object):
         else:
             return kser
 
-    def rsplit(self, pat=None, n=-1, expand=False) -> Union["pp.Series", "pp.DataFrame"]:
+    def rsplit(self, pat=None, n=-1, expand=False) -> Union["ps.Series", "ps.DataFrame"]:
         """
         Split strings around given separator/delimiter.
 
@@ -2058,7 +2058,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(["this is a regular sentence",
+        >>> s = ps.Series(["this is a regular sentence",
         ...                "https://docs.python.org/3/tutorial/index.html",
         ...                np.nan])
 
@@ -2115,7 +2115,7 @@ class StringMethods(object):
         Remember to escape special characters when explicitly using regular
         expressions.
 
-        >>> s = pp.Series(["1+1=2"])
+        >>> s = ps.Series(["1+1=2"])
         >>> s.str.split(r"\\+|=", n=2, expand=True)
            0  1  2
         0  1  1  2
@@ -2147,7 +2147,7 @@ class StringMethods(object):
         else:
             return kser
 
-    def translate(self, table) -> "pp.Series":
+    def translate(self, table) -> "ps.Series":
         """
         Map all characters in the string through the given mapping table.
         Equivalent to standard :func:`str.translate`.
@@ -2167,7 +2167,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(["dog", "cat", "bird"])
+        >>> s = ps.Series(["dog", "cat", "bird"])
         >>> m = str.maketrans({'a': 'X', 'i': 'Y', 'o': None})
         >>> s.str.translate(m)
         0      dg
@@ -2176,12 +2176,12 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_translate(s) -> "pp.Series[str]":
+        def pandas_translate(s) -> "ps.Series[str]":
             return s.str.translate(table)
 
         return self._data.koalas.transform_batch(pandas_translate)
 
-    def wrap(self, width, **kwargs) -> "pp.Series":
+    def wrap(self, width, **kwargs) -> "ps.Series":
         """
         Wrap long strings in the Series to be formatted in paragraphs with
         length less than a given width.
@@ -2220,19 +2220,19 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['line to be wrapped', 'another line to be wrapped'])
+        >>> s = ps.Series(['line to be wrapped', 'another line to be wrapped'])
         >>> s.str.wrap(12)
         0             line to be\\nwrapped
         1    another line\\nto be\\nwrapped
         dtype: object
         """
 
-        def pandas_wrap(s) -> "pp.Series[str]":
+        def pandas_wrap(s) -> "ps.Series[str]":
             return s.str.wrap(width, **kwargs)
 
         return self._data.koalas.transform_batch(pandas_wrap)
 
-    def zfill(self, width) -> "pp.Series":
+    def zfill(self, width) -> "ps.Series":
         """
         Pad strings in the Series by prepending ‘0’ characters.
 
@@ -2256,7 +2256,7 @@ class StringMethods(object):
 
         Examples
         --------
-        >>> s = pp.Series(['-1', '1', '1000', np.nan])
+        >>> s = ps.Series(['-1', '1', '1000', np.nan])
         >>> s
         0      -1
         1       1
@@ -2277,7 +2277,7 @@ class StringMethods(object):
         dtype: object
         """
 
-        def pandas_zfill(s) -> "pp.Series[str]":
+        def pandas_zfill(s) -> "ps.Series[str]":
             return s.str.zfill(width)
 
         return self._data.koalas.transform_batch(pandas_zfill)
@@ -2299,7 +2299,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.strings.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.pandas.strings tests")

--- a/python/pyspark/pandas/testing/utils.py
+++ b/python/pyspark/pandas/testing/utils.py
@@ -27,7 +27,7 @@ import pandas as pd
 from pandas.api.types import is_list_like
 from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 
-from pyspark import pandas as pp
+from pyspark import pandas as ps
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.indexes import Index
 from pyspark.pandas.series import Series
@@ -302,7 +302,7 @@ class TestUtils(object):
 class ComparisonTestBase(ReusedSQLTestCase):
     @property
     def kdf(self):
-        return pp.from_pandas(self.pdf)
+        return ps.from_pandas(self.pdf)
 
     @property
     def pdf(self):

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -30,7 +30,7 @@ from pyspark import StorageLevel
 from pyspark.ml.linalg import SparseVector
 from pyspark.sql import functions as F
 
-from pyspark import pandas as pp
+from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.pandas.frame import CachedDataFrame
@@ -60,12 +60,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     @property
     def kdf(self):
-        return pp.from_pandas(self.pdf)
+        return ps.from_pandas(self.pdf)
 
     @property
     def df_pair(self):
         pdf = self.pdf
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         return pdf, kdf
 
     def test_dataframe(self):
@@ -88,10 +88,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         self.assertEqual(kdf.a.notnull().rename("x").name, "x")
 
-        # check pp.DataFrame(pp.Series)
+        # check ps.DataFrame(ps.Series)
         pser = pd.Series([1, 2, 3], name="x", index=np.random.rand(3))
-        kser = pp.from_pandas(pser)
-        self.assert_eq(pd.DataFrame(pser), pp.DataFrame(kser))
+        kser = ps.from_pandas(pser)
+        self.assert_eq(pd.DataFrame(pser), ps.DataFrame(kser))
 
         # check kdf[pd.Index]
         pdf, kdf = self.df_pair
@@ -117,7 +117,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 "d": pd.Series([None, 2, None, 4], dtype="Int64"),
             }
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self._check_extension(kdf, pdf)
         self._check_extension(kdf + F.lit(1).cast("byte"), pdf + 1)
@@ -133,7 +133,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 "d": [None, 2, None, 4],
             }
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         astype = {"a": "Int8", "b": "Int16", "c": "Int32", "d": "Int64"}
 
@@ -149,7 +149,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 "b": pd.Series([True, None, False, True], dtype="boolean"),
             }
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self._check_extension(kdf, pdf)
 
@@ -158,7 +158,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     )
     def test_astype_extension_object_dtypes(self):
         pdf = pd.DataFrame({"a": ["a", "b", None, "c"], "b": [True, None, False, True]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         astype = {"a": "string", "b": "boolean"}
 
@@ -174,7 +174,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 "b": pd.Series([1.0, None, 3.0, 4.0], dtype="Float64"),
             }
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self._check_extension(kdf, pdf)
         self._check_extension(kdf + 1, pdf + 1)
@@ -185,7 +185,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     )
     def test_astype_extension_float_dtypes(self):
         pdf = pd.DataFrame({"a": [1.0, 2.0, None, 4.0], "b": [1.0, None, 3.0, 4.0]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         astype = {"a": "Float32", "b": "Float64"}
 
@@ -196,7 +196,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # Basic DataFrame
         #
         pdf = pd.DataFrame([1, 2, 3])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         kdf.insert(1, "b", 10)
         pdf.insert(1, "b", 10)
@@ -208,7 +208,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.insert(3, "d", pdf.b + 1)
         self.assert_eq(kdf.sort_index(), pdf.sort_index(), almost=True)
 
-        kser = pp.Series([4, 5, 6])
+        kser = ps.Series([4, 5, 6])
         self.assertRaises(ValueError, lambda: kdf.insert(0, "y", kser))
         self.assertRaisesRegex(
             ValueError, "cannot insert b, already exists", lambda: kdf.insert(1, "b", 10)
@@ -219,7 +219,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             lambda: kdf.insert(0, list("abc"), kser),
         )
         self.assertRaises(ValueError, lambda: kdf.insert(0, "e", [7, 8, 9, 10]))
-        self.assertRaises(ValueError, lambda: kdf.insert(0, "f", pp.Series([7, 8])))
+        self.assertRaises(ValueError, lambda: kdf.insert(0, "f", ps.Series([7, 8])))
         self.assertRaises(AssertionError, lambda: kdf.insert(100, "y", kser))
         self.assertRaises(AssertionError, lambda: kdf.insert(1, "y", kser, allow_duplicates=True))
 
@@ -227,7 +227,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # DataFrame with MultiIndex as columns
         #
         pdf = pd.DataFrame({("x", "a", "b"): [1, 2, 3]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         kdf.insert(1, "b", 10)
         pdf.insert(1, "b", 10)
@@ -285,7 +285,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(3),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf, pdf)
         self.assert_eq(kdf["x"], pdf["x"])
@@ -307,7 +307,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_dataframe_column_level_name(self):
         column = pd.Index(["A", "B", "C"], name="X")
         pdf = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=column, index=np.random.rand(2))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf, pdf)
         self.assert_eq(kdf.columns.names, pdf.columns.names)
@@ -323,16 +323,16 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=columns,
             index=np.random.rand(5),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.columns.names, pdf.columns.names)
         self.assert_eq(kdf.to_pandas().columns.names, pdf.columns.names)
 
-        kdf1 = pp.from_pandas(pdf)
+        kdf1 = ps.from_pandas(pdf)
         self.assert_eq(kdf1.columns.names, pdf.columns.names)
 
         self.assertRaises(
-            AssertionError, lambda: pp.DataFrame(kdf1._internal.copy(column_label_names=("level",)))
+            AssertionError, lambda: ps.DataFrame(kdf1._internal.copy(column_label_names=("level",)))
         )
 
         self.assert_eq(kdf["X"], pdf["X"])
@@ -348,7 +348,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_itertuples(self):
         pdf = pd.DataFrame({"num_legs": [4, 2], "num_wings": [0, 2]}, index=["dog", "hawk"])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         for ptuple, ktuple in zip(
             pdf.itertuples(index=False, name="Animal"), kdf.itertuples(index=False, name="Animal")
@@ -360,19 +360,19 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.index = pd.MultiIndex.from_arrays(
             [[1, 2], ["black", "brown"]], names=("count", "color")
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         for ptuple, ktuple in zip(pdf.itertuples(name="Animal"), kdf.itertuples(name="Animal")):
             self.assert_eq(ptuple, ktuple)
 
         pdf.columns = pd.MultiIndex.from_arrays(
             [["CA", "WA"], ["age", "children"]], names=("origin", "info")
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         for ptuple, ktuple in zip(pdf.itertuples(name="Animal"), kdf.itertuples(name="Animal")):
             self.assert_eq(ptuple, ktuple)
 
         pdf = pd.DataFrame([1, 2, 3])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         for ptuple, ktuple in zip(
             (pdf + 1).itertuples(name="num"), (kdf + 1).itertuples(name="num")
         ):
@@ -380,7 +380,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # DataFrames with a large number of columns (>254)
         pdf = pd.DataFrame(np.random.random((1, 255)))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         for ptuple, ktuple in zip(pdf.itertuples(name="num"), kdf.itertuples(name="num")):
             self.assert_eq(ptuple, ktuple)
 
@@ -394,7 +394,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(3),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         for (pdf_k, pdf_v), (kdf_k, kdf_v) in zip(pdf.iterrows(), kdf.iterrows()):
             self.assert_eq(pdf_k, kdf_k)
@@ -402,7 +402,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_reset_index(self):
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=np.random.rand(3))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.reset_index(), pdf.reset_index())
         self.assert_eq(kdf.reset_index().index, pdf.reset_index().index)
@@ -426,15 +426,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_reset_index_with_default_index_types(self):
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=np.random.rand(3))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
-        with pp.option_context("compute.default_index_type", "sequence"):
+        with ps.option_context("compute.default_index_type", "sequence"):
             self.assert_eq(kdf.reset_index(), pdf.reset_index())
 
-        with pp.option_context("compute.default_index_type", "distributed-sequence"):
+        with ps.option_context("compute.default_index_type", "distributed-sequence"):
             self.assert_eq(kdf.reset_index(), pdf.reset_index())
 
-        with pp.option_context("compute.default_index_type", "distributed"):
+        with ps.option_context("compute.default_index_type", "distributed"):
             # the index is different.
             self.assert_eq(kdf.reset_index().to_pandas().reset_index(drop=True), pdf.reset_index())
 
@@ -449,7 +449,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             index=index,
             columns=columns,
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf, pdf)
         self.assert_eq(kdf.reset_index(), pdf.reset_index())
@@ -523,7 +523,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=columns,
             index=np.random.rand(3),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf, pdf)
         self.assert_eq(kdf["a"], pdf["a"])
@@ -549,14 +549,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_repr_cache_invalidation(self):
         # If there is any cache, inplace operations should invalidate it.
-        df = pp.range(10)
+        df = ps.range(10)
         df.__repr__()
         df["a"] = df["id"]
         self.assertEqual(df.__repr__(), df.to_pandas().__repr__())
 
     def test_repr_html_cache_invalidation(self):
         # If there is any cache, inplace operations should invalidate it.
-        df = pp.range(10)
+        df = ps.range(10)
         df._repr_html_()
         df["a"] = df["id"]
         self.assertEqual(df._repr_html_(), df.to_pandas()._repr_html_())
@@ -564,7 +564,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_empty_dataframe(self):
         pdf = pd.DataFrame({"a": pd.Series([], dtype="i1"), "b": pd.Series([], dtype="str")})
 
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         if LooseVersion(pyspark.__version__) >= LooseVersion("2.4"):
             self.assert_eq(kdf, pdf)
         else:
@@ -572,7 +572,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 self.assert_eq(kdf, pdf)
 
         with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
-            kdf = pp.from_pandas(pdf)
+            kdf = ps.from_pandas(pdf)
             self.assert_eq(kdf, pdf)
 
     def test_all_null_dataframe(self):
@@ -586,7 +586,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 "f": [None, None, None] + list(pd.date_range("20130101", periods=1)),
             },
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.iloc[:-1], pdf.iloc[:-1])
 
@@ -600,7 +600,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
         )
 
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         if LooseVersion(pyspark.__version__) >= LooseVersion("2.4"):
             self.assert_eq(kdf, pdf)
         else:
@@ -608,7 +608,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 self.assert_eq(kdf, pdf)
 
         with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
-            kdf = pp.from_pandas(pdf)
+            kdf = ps.from_pandas(pdf)
             self.assert_eq(kdf, pdf)
 
     def test_nullable_object(self):
@@ -624,11 +624,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             index=np.random.rand(5),
         )
 
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(kdf, pdf)
 
         with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
-            kdf = pp.from_pandas(pdf)
+            kdf = ps.from_pandas(pdf)
             self.assert_eq(kdf, pdf)
 
     def test_assign(self):
@@ -690,9 +690,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertNotIn("foo", dir(kdf))
         self.assertRaises(AttributeError, lambda: kdf.foo)
 
-        kdf = pp.DataFrame({"a b c": [1, 2, 3]})
+        kdf = ps.DataFrame({"a b c": [1, 2, 3]})
         self.assertNotIn("a b c", dir(kdf))
-        kdf = pp.DataFrame({"a": [1, 2], 5: [1, 2]})
+        kdf = ps.DataFrame({"a": [1, 2], 5: [1, 2]})
         self.assertIn("a", dir(kdf))
         self.assertNotIn(5, dir(kdf))
 
@@ -716,7 +716,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"a": [1, 2, 3, 4, 5, 6, 7], "b": [7, 6, 5, 4, 3, 2, 1]}, index=np.random.rand(7)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         kdf.columns = ["x", "y"]
         pdf.columns = ["x", "y"]
@@ -741,7 +741,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {("A", "0"): [1, 2, 2, 3], ("B", "1"): [1, 2, 3, 4]}, index=np.random.rand(4)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         columns = pdf.columns
         self.assert_eq(kdf.columns, columns)
@@ -774,7 +774,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_rename_dataframe(self):
         pdf1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-        kdf1 = pp.from_pandas(pdf1)
+        kdf1 = ps.from_pandas(pdf1)
 
         self.assert_eq(
             kdf1.rename(columns={"A": "a", "B": "b"}), pdf1.rename(columns={"A": "a", "B": "b"})
@@ -811,7 +811,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         idx = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B"), ("Y", "C"), ("Y", "D")])
         pdf2 = pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=idx)
-        kdf2 = pp.from_pandas(pdf2)
+        kdf2 = ps.from_pandas(pdf2)
 
         self.assert_eq(kdf2.rename(columns=str_lower), pdf2.rename(columns=str_lower))
 
@@ -823,7 +823,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
         pdf3 = pd.DataFrame([[1, 2], [3, 4], [5, 6], [7, 8]], index=idx, columns=list("ab"))
-        kdf3 = pp.from_pandas(pdf3)
+        kdf3 = ps.from_pandas(pdf3)
 
         self.assert_eq(kdf3.rename(index=str_lower), pdf3.rename(index=str_lower))
         self.assert_eq(kdf3.rename(index=str_lower, level=0), pdf3.rename(index=str_lower, level=0))
@@ -841,7 +841,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         index = pd.Index(["A", "B", "C"], name="index")
         columns = pd.Index(["numbers", "values"], name="cols")
         pdf = pd.DataFrame([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], index=index, columns=columns)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         for axis in [0, "index"]:
             self.assert_eq(
@@ -921,7 +921,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             [("numbers", "first"), ("values", "second")], names=["cols1", "cols2"]
         )
         pdf = pd.DataFrame([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], index=index, columns=columns)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         for axis in [0, "index"]:
             self.assert_eq(
@@ -1006,15 +1006,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_dot_in_column_name(self):
         self.assert_eq(
-            pp.DataFrame(pp.range(1)._internal.spark_frame.selectExpr("1L as `a.b`"))["a.b"],
-            pp.Series([1], name="a.b"),
+            ps.DataFrame(ps.range(1)._internal.spark_frame.selectExpr("1L as `a.b`"))["a.b"],
+            ps.Series([1], name="a.b"),
         )
 
     def test_aggregate(self):
         pdf = pd.DataFrame(
             [[1, 2, 3], [4, 5, 6], [7, 8, 9], [np.nan, np.nan, np.nan]], columns=["A", "B", "C"]
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(
             kdf.agg(["sum", "min"])[["A", "B", "C"]].sort_index(),  # TODO?: fix column order
@@ -1051,7 +1051,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             [[1, 2, 3], [4, 5, 6], [7, 8, 9], [np.nan, np.nan, np.nan]], columns=[10, 20, 30]
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(
             kdf.agg(["sum", "min"])[[10, 20, 30]].sort_index(),
@@ -1083,7 +1083,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             [datetime(2019, 2, 2, 0, 0, 0, 0), datetime(2019, 2, 3, 0, 0, 0, 0)],
             columns=["timestamp"],
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.timestamp.min(), pdf.timestamp.min())
         self.assert_eq(kdf.timestamp.max(), pdf.timestamp.max())
@@ -1097,7 +1097,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.columns = pd.MultiIndex.from_tuples(
             [("c", "e"), ("d", "f")], names=["level_1", "level_2"]
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assertRaises(ValueError, lambda: kdf.droplevel(["a", "b"]))
         self.assertRaises(ValueError, lambda: kdf.droplevel([1, 1, 1, 1, 1]))
@@ -1155,7 +1155,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # Tupled names
         pdf.columns.names = [("level", 1), ("level", 2)]
         pdf.index.names = [("a", 10), ("x", 20)]
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assertRaises(KeyError, lambda: kdf.droplevel("a"))
         self.assertRaises(KeyError, lambda: kdf.droplevel(("a", 10)))
@@ -1184,7 +1184,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             .rename_axis([10.0, 20.0])
         )
         pdf.columns = pd.MultiIndex.from_tuples([("c", "e"), ("d", "f")], names=[100.0, 200.0])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # droplevel is new in pandas 0.24.0
         if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
@@ -1216,7 +1216,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_drop(self):
         pdf = pd.DataFrame({"x": [1, 2], "y": [3, 4], "z": [5, 6]}, index=np.random.rand(2))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # Assert 'labels' or 'columns' parameter is set
         expected_error_message = "Need to specify at least one of 'labels' or 'columns'"
@@ -1242,7 +1242,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         columns = pd.MultiIndex.from_tuples([(1, "x"), (1, "y"), (2, "z")])
         pdf.columns = columns
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.drop(columns=1), pdf.drop(columns=1))
         self.assert_eq(kdf.drop(columns=(1, "x")), pdf.drop(columns=(1, "x")))
@@ -1253,13 +1253,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # non-string names
         pdf = pd.DataFrame({10: [1, 2], 20: [3, 4], 30: [5, 6]}, index=np.random.rand(2))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.drop(10), pdf.drop(10, axis=1))
         self.assert_eq(kdf.drop([20, 30]), pdf.drop([20, 30], axis=1))
 
     def _test_dropna(self, pdf, axis):
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.dropna(axis=axis), pdf.dropna(axis=axis))
         self.assert_eq(kdf.dropna(axis=axis, how="all"), pdf.dropna(axis=axis, how="all"))
@@ -1294,7 +1294,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             pdf.columns = columns
         else:
             pdf.index = columns
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.dropna(axis=axis), pdf.dropna(axis=axis))
         self.assert_eq(kdf.dropna(axis=axis, how="all"), pdf.dropna(axis=axis, how="all"))
@@ -1328,13 +1328,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(6),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self._test_dropna(pdf, axis=0)
 
         # empty
         pdf = pd.DataFrame(index=np.random.rand(6))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.dropna(), pdf.dropna())
         self.assert_eq(kdf.dropna(how="all"), pdf.dropna(how="all"))
@@ -1364,7 +1364,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # empty
         pdf = pd.DataFrame({"x": [], "y": [], "z": []})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.dropna(axis=1), pdf.dropna(axis=1))
         self.assert_eq(kdf.dropna(axis=1, how="all"), pdf.dropna(axis=1, how="all"))
@@ -1383,7 +1383,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(3),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(kdf, pdf)
         self.assertTrue((kdf.dtypes == pdf.dtypes).all())
 
@@ -1402,7 +1402,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(6),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf, pdf)
         self.assert_eq(kdf.fillna(-1), pdf.fillna(-1))
@@ -1415,7 +1415,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(pdf.fillna(method="bfill", limit=2), kdf.fillna(method="bfill", limit=2))
 
         pdf = pdf.set_index(["x", "y"])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         # check multi index
         self.assert_eq(kdf.fillna(-1), pdf.fillna(-1))
         self.assert_eq(pdf.fillna(method="bfill"), kdf.fillna(method="bfill"))
@@ -1457,7 +1457,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(6),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.fillna(-1), pdf.fillna(-1))
         self.assert_eq(
@@ -1482,7 +1482,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # check multi index
         pdf = pdf.set_index([("x", "a"), ("x", "b")])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(kdf.fillna(-1), pdf.fillna(-1))
         self.assert_eq(
             kdf.fillna({("x", "a"): -1, ("x", "b"): -2, ("y", "c"): -5}),
@@ -1493,7 +1493,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"x": [1, 2, 3, 4, None, 6], "y": list("abdabd")}, index=np.random.rand(6)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.notnull(), pdf.notnull())
         self.assert_eq(kdf.isnull(), pdf.isnull())
@@ -1502,13 +1502,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"year": [2015, 2016], "month": [2, 3], "day": [4, 5]}, index=np.random.rand(2)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
-        self.assert_eq(pd.to_datetime(pdf), pp.to_datetime(kdf))
+        self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(kdf))
 
     def test_nunique(self):
         pdf = pd.DataFrame({"A": [1, 2, 3], "B": [np.nan, 3, np.nan]}, index=np.random.rand(3))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # Assert NaNs are dropped by default
         self.assert_eq(kdf.nunique(), pdf.nunique())
@@ -1518,10 +1518,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Assert approximate counts
         self.assert_eq(
-            pp.DataFrame({"A": range(100)}).nunique(approx=True), pd.Series([103], index=["A"]),
+            ps.DataFrame({"A": range(100)}).nunique(approx=True), pd.Series([103], index=["A"]),
         )
         self.assert_eq(
-            pp.DataFrame({"A": range(100)}).nunique(approx=True, rsd=0.01),
+            ps.DataFrame({"A": range(100)}).nunique(approx=True, rsd=0.01),
             pd.Series([100], index=["A"]),
         )
 
@@ -1542,7 +1542,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"a": [1, 2, 3, 4, 5, None, 7], "b": [7, 6, 5, 4, 3, 2, 1]}, index=np.random.rand(7)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(kdf.sort_values("b"), pdf.sort_values("b"))
         self.assert_eq(kdf.sort_values(["b", "a"]), pdf.sort_values(["b", "a"]))
         self.assert_eq(
@@ -1570,7 +1570,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             {("X", 10): [1, 2, 3, 4, 5, None, 7], ("X", 20): [7, 6, 5, 4, 3, 2, 1]},
             index=np.random.rand(7),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.sort_values(("X", 20)), pdf.sort_values(("X", 20)))
         self.assert_eq(
@@ -1587,7 +1587,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {10: [1, 2, 3, 4, 5, None, 7], 20: [7, 6, 5, 4, 3, 2, 1]}, index=np.random.rand(7)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.sort_values(20), pdf.sort_values(20))
         self.assert_eq(kdf.sort_values([20, 10]), pdf.sort_values([20, 10]))
@@ -1596,7 +1596,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"A": [2, 1, np.nan], "B": [np.nan, 0, np.nan]}, index=["b", "a", np.nan]
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # Assert invalid parameters
         self.assertRaises(NotImplementedError, lambda: kdf.sort_index(axis=1))
@@ -1621,7 +1621,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"A": range(4), "B": range(4)[::-1]}, index=[["b", "b", "a", "a"], [1, 0, 1, 0]]
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(kdf.sort_index(), pdf.sort_index())
         self.assert_eq(kdf.sort_index(level=[1, 0]), pdf.sort_index(level=[1, 0]))
         self.assert_eq(kdf.reset_index().sort_index(), pdf.reset_index().sort_index())
@@ -1638,7 +1638,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         arrays = [[1, 1, 2, 2], ["red", "blue", "red", "blue"]]
         pidx = pd.MultiIndex.from_arrays(arrays, names=("number", "color"))
         pdf = pd.DataFrame({"x1": ["a", "b", "c", "d"], "x2": ["a", "b", "c", "d"]}, index=pidx)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.swaplevel(), kdf.swaplevel())
         self.assert_eq(pdf.swaplevel(0, 1), kdf.swaplevel(0, 1))
         self.assert_eq(pdf.swaplevel(1, 1), kdf.swaplevel(1, 1))
@@ -1648,7 +1648,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         arrays = [[1, 1, 2, 2], ["red", "blue", "red", "blue"], ["l", "m", "s", "xs"]]
         pidx = pd.MultiIndex.from_arrays(arrays, names=("number", "color", "size"))
         pdf = pd.DataFrame({"x1": ["a", "b", "c", "d"], "x2": ["a", "b", "c", "d"]}, index=pidx)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.swaplevel(), kdf.swaplevel())
         self.assert_eq(pdf.swaplevel(0, 1), kdf.swaplevel(0, 1))
         self.assert_eq(pdf.swaplevel(0, 2), kdf.swaplevel(0, 2))
@@ -1676,7 +1676,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
         pidx = pd.MultiIndex.from_arrays(arrays, names=("number", "color", "size"))
         pdf.columns = pidx
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.swaplevel(axis=1), kdf.swaplevel(axis=1))
         self.assert_eq(pdf.swaplevel(0, 1, axis=1), kdf.swaplevel(0, 1, axis=1))
         self.assert_eq(pdf.swaplevel(0, 2, axis=1), kdf.swaplevel(0, 2, axis=1))
@@ -1698,7 +1698,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
         # Error conditions
-        self.assertRaises(AssertionError, lambda: pp.DataFrame([1, 2]).swaplevel())
+        self.assertRaises(AssertionError, lambda: ps.DataFrame([1, 2]).swaplevel())
         self.assertRaises(IndexError, lambda: kdf.swaplevel(0, 9, axis=1))
         self.assertRaises(KeyError, lambda: kdf.swaplevel("not_number", "color", axis=1))
         self.assertRaises(ValueError, lambda: kdf.swaplevel(axis=2))
@@ -1707,7 +1707,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             [[1, 2, 3], [4, 5, 6], [7, 8, 9]], index=["x", "y", "z"], columns=["a", "b", "c"]
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.swapaxes(0, 1), pdf.swapaxes(0, 1))
         self.assert_eq(kdf.swapaxes(1, 0), pdf.swapaxes(1, 0))
@@ -1722,7 +1722,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"a": [1, 2, 3, 4, 5, None, 7], "b": [7, 6, 5, 4, 3, 2, 1]}, index=np.random.rand(7)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(kdf.nlargest(n=5, columns="a"), pdf.nlargest(5, columns="a"))
         self.assert_eq(kdf.nlargest(n=5, columns=["a", "b"]), pdf.nlargest(5, columns=["a", "b"]))
 
@@ -1730,7 +1730,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"a": [1, 2, 3, 4, 5, None, 7], "b": [7, 6, 5, 4, 3, 2, 1]}, index=np.random.rand(7)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(kdf.nsmallest(n=5, columns="a"), pdf.nsmallest(5, columns="a"))
         self.assert_eq(kdf.nsmallest(n=5, columns=["a", "b"]), pdf.nsmallest(5, columns=["a", "b"]))
 
@@ -1744,13 +1744,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         }
         pdf = pd.DataFrame(data=d)
         pdf = pdf.set_index(["class", "animal", "locomotion"])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.xs("mammal"), pdf.xs("mammal"))
         self.assert_eq(kdf.xs(("mammal",)), pdf.xs(("mammal",)))
         self.assert_eq(kdf.xs(("mammal", "dog", "walks")), pdf.xs(("mammal", "dog", "walks")))
         self.assert_eq(
-            pp.concat([kdf, kdf]).xs(("mammal", "dog", "walks")),
+            ps.concat([kdf, kdf]).xs(("mammal", "dog", "walks")),
             pd.concat([pdf, pdf]).xs(("mammal", "dog", "walks")),
         )
         self.assert_eq(kdf.xs("cat", level=1), pdf.xs("cat", level=1))
@@ -1774,7 +1774,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         # non-string names
         pdf = pd.DataFrame(data=d)
         pdf = pdf.set_index(["class", "animal", "num_legs", "num_wings"])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.xs(("mammal", "dog", 4)), pdf.xs(("mammal", "dog", 4)))
         self.assert_eq(kdf.xs(2, level=2), pdf.xs(2, level=2))
@@ -1840,7 +1840,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             index=np.random.rand(6),
         )
 
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.to_numpy(), pdf.values)
 
@@ -1858,7 +1858,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(6),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.isin([4, "six"]), pdf.isin([4, "six"]))
         # Seems like pandas has a bug when passing `np.array` as parameter
@@ -1903,9 +1903,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
         right_ps = pd.Series(list("defghi"), name="x", index=[5, 6, 7, 8, 9, 10])
 
-        left_kdf = pp.from_pandas(left_pdf)
-        right_kdf = pp.from_pandas(right_pdf)
-        right_kser = pp.from_pandas(right_ps)
+        left_kdf = ps.from_pandas(left_pdf)
+        right_kdf = ps.from_pandas(right_pdf)
+        right_kser = ps.from_pandas(right_ps)
 
         def check(op, right_kdf=right_kdf, right_pdf=right_pdf):
             k_res = op(left_kdf, right_kdf)
@@ -2060,7 +2060,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             columns=["lkey", "rkey", "value", "x", "y"],
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         left_pdf = pdf[["lkey", "value", "x"]]
         right_pdf = pdf[["rkey", "value", "y"]]
@@ -2100,8 +2100,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_merge_retains_indices(self):
         left_pdf = pd.DataFrame({"A": [0, 1]})
         right_pdf = pd.DataFrame({"B": [1, 2]}, index=[1, 2])
-        left_kdf = pp.from_pandas(left_pdf)
-        right_kdf = pp.from_pandas(right_pdf)
+        left_kdf = ps.from_pandas(left_pdf)
+        right_kdf = ps.from_pandas(right_pdf)
 
         self.assert_eq(
             left_kdf.merge(right_kdf, left_index=True, right_index=True),
@@ -2123,8 +2123,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_merge_how_parameter(self):
         left_pdf = pd.DataFrame({"A": [1, 2]})
         right_pdf = pd.DataFrame({"B": ["x", "y"]}, index=[1, 2])
-        left_kdf = pp.from_pandas(left_pdf)
-        right_kdf = pp.from_pandas(right_pdf)
+        left_kdf = ps.from_pandas(left_pdf)
+        right_kdf = ps.from_pandas(right_pdf)
 
         kdf = left_kdf.merge(right_kdf, left_index=True, right_index=True)
         pdf = left_pdf.merge(right_pdf, left_index=True, right_index=True)
@@ -2155,12 +2155,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
     def test_merge_raises(self):
-        left = pp.DataFrame(
+        left = ps.DataFrame(
             {"value": [1, 2, 3, 5, 6], "x": list("abcde")},
             columns=["value", "x"],
             index=["foo", "bar", "baz", "foo", "bar"],
         )
-        right = pp.DataFrame(
+        right = ps.DataFrame(
             {"value": [4, 5, 6, 7, 8], "y": list("fghij")},
             columns=["value", "y"],
             index=["baz", "foo", "bar", "baz", "foo"],
@@ -2202,9 +2202,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_append(self):
         pdf = pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         other_pdf = pd.DataFrame([[3, 4], [5, 6]], columns=list("BC"), index=[2, 3])
-        other_kdf = pp.from_pandas(other_pdf)
+        other_kdf = ps.from_pandas(other_pdf)
 
         self.assert_eq(kdf.append(kdf), pdf.append(pdf))
         self.assert_eq(kdf.append(kdf, ignore_index=True), pdf.append(pdf, ignore_index=True))
@@ -2239,11 +2239,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Assert appending multi-index DataFrames
         multi_index_pdf = pd.DataFrame([[1, 2], [3, 4]], columns=list("AB"), index=[[2, 3], [4, 5]])
-        multi_index_kdf = pp.from_pandas(multi_index_pdf)
+        multi_index_kdf = ps.from_pandas(multi_index_pdf)
         other_multi_index_pdf = pd.DataFrame(
             [[5, 6], [7, 8]], columns=list("AB"), index=[[2, 3], [6, 7]]
         )
-        other_multi_index_kdf = pp.from_pandas(other_multi_index_pdf)
+        other_multi_index_kdf = ps.from_pandas(other_multi_index_pdf)
 
         self.assert_eq(
             multi_index_kdf.append(multi_index_kdf), multi_index_pdf.append(multi_index_pdf)
@@ -2290,7 +2290,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"A": [0, 2, 4], "B": [4, 2, 0], "X": [-1, 10, 0]}, index=np.random.rand(3)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # Assert list-like values are not accepted for 'lower' and 'upper'
         msg = "List-like value are not supported for 'lower' and 'upper' at the moment"
@@ -2313,33 +2313,33 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf, pdf)
 
         # Assert behavior on string values
-        str_kdf = pp.DataFrame({"A": ["a", "b", "c"]}, index=np.random.rand(3))
+        str_kdf = ps.DataFrame({"A": ["a", "b", "c"]}, index=np.random.rand(3))
         self.assert_eq(str_kdf.clip(1, 3), str_kdf)
 
     def test_binary_operators(self):
         pdf = pd.DataFrame(
             {"A": [0, 2, 4], "B": [4, 2, 0], "X": [-1, 10, 0]}, index=np.random.rand(3)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf + kdf.copy(), pdf + pdf.copy())
 
         self.assertRaisesRegex(
             ValueError,
             "it comes from a different dataframe",
-            lambda: pp.range(10).add(pp.range(10)),
+            lambda: ps.range(10).add(ps.range(10)),
         )
 
         self.assertRaisesRegex(
             ValueError,
             "add with a sequence is currently not supported",
-            lambda: pp.range(10).add(pp.range(10).id),
+            lambda: ps.range(10).add(ps.range(10).id),
         )
 
     def test_binary_operator_add(self):
         # Positive
         pdf = pd.DataFrame({"a": ["x"], "b": ["y"], "c": [1], "d": [2]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf["a"] + kdf["b"], pdf["a"] + pdf["b"])
         self.assert_eq(kdf["c"] + kdf["d"], pdf["c"] + pdf["d"])
@@ -2357,12 +2357,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_binary_operator_sub(self):
         # Positive
         pdf = pd.DataFrame({"a": [2], "b": [1]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf["a"] - kdf["b"], pdf["a"] - pdf["b"])
 
         # Negative
-        kdf = pp.DataFrame({"a": ["x"], "b": [1]})
+        kdf = ps.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = "substraction can not be applied to string series or literals"
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - kdf["b"])
@@ -2372,18 +2372,18 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 - kdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - 1)
 
-        kdf = pp.DataFrame({"a": ["x"], "b": ["y"]})
+        kdf = ps.DataFrame({"a": ["x"], "b": ["y"]})
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] - kdf["b"])
 
     def test_binary_operator_truediv(self):
         # Positive
         pdf = pd.DataFrame({"a": [3], "b": [2]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf["a"] / kdf["b"], pdf["a"] / pdf["b"])
 
         # Negative
-        kdf = pp.DataFrame({"a": ["x"], "b": [1]})
+        kdf = ps.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = "division can not be applied on string series or literals"
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] / kdf["b"])
@@ -2393,7 +2393,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 / kdf["a"])
 
     def test_binary_operator_floordiv(self):
-        kdf = pp.DataFrame({"a": ["x"], "b": [1]})
+        kdf = ps.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = "division can not be applied on string series or literals"
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] // kdf["b"])
@@ -2405,12 +2405,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_binary_operator_mod(self):
         # Positive
         pdf = pd.DataFrame({"a": [3], "b": [2]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf["a"] % kdf["b"], pdf["a"] % pdf["b"])
 
         # Negative
-        kdf = pp.DataFrame({"a": ["x"], "b": [1]})
+        kdf = ps.DataFrame({"a": ["x"], "b": [1]})
         ks_err_msg = "modulo can not be applied on string series or literals"
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["a"] % kdf["b"])
@@ -2421,7 +2421,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_binary_operator_multiply(self):
         # Positive
         pdf = pd.DataFrame({"a": ["x", "y"], "b": [1, 2], "c": [3, 4]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf["b"] * kdf["c"], pdf["b"] * pdf["c"])
         self.assert_eq(kdf["c"] * kdf["b"], pdf["c"] * pdf["b"])
@@ -2433,7 +2433,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(2 * kdf["b"], 2 * pdf["b"])
 
         # Negative
-        kdf = pp.DataFrame({"a": ["x"], "b": [2]})
+        kdf = ps.DataFrame({"a": ["x"], "b": [2]})
         ks_err_msg = "multiplication can not be applied to a string literal"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: kdf["b"] * "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * kdf["b"])
@@ -2447,7 +2447,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_sample(self):
         pdf = pd.DataFrame({"A": [0, 2, 4]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # Make sure the tests run, but we can't check the result because they are non-deterministic.
         kdf.sample(frac=0.1)
@@ -2464,7 +2464,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_add_prefix(self):
         pdf = pd.DataFrame({"A": [1, 2, 3, 4], "B": [3, 4, 5, 6]}, index=np.random.rand(4))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.add_prefix("col_"), kdf.add_prefix("col_"))
 
         columns = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B")])
@@ -2474,7 +2474,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_add_suffix(self):
         pdf = pd.DataFrame({"A": [1, 2, 3, 4], "B": [3, 4, 5, 6]}, index=np.random.rand(4))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.add_suffix("first_series"), kdf.add_suffix("first_series"))
 
         columns = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B")])
@@ -2490,8 +2490,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf2 = pd.DataFrame(
             {"key": ["K0", "K1", "K2"], "B": ["B0", "B1", "B2"]}, columns=["key", "B"]
         )
-        kdf1 = pp.from_pandas(pdf1)
-        kdf2 = pp.from_pandas(pdf2)
+        kdf1 = ps.from_pandas(pdf1)
+        kdf2 = ps.from_pandas(pdf2)
 
         join_pdf = pdf1.join(pdf2, lsuffix="_left", rsuffix="_right")
         join_pdf.sort_values(by=list(join_pdf.columns), inplace=True)
@@ -2503,7 +2503,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # join with duplicated columns in Series
         with self.assertRaisesRegex(ValueError, "columns overlap but no suffix specified"):
-            ks1 = pp.Series(["A1", "A5"], index=[1, 2], name="A")
+            ks1 = ps.Series(["A1", "A5"], index=[1, 2], name="A")
             kdf1.join(ks1, how="outer")
         # join with duplicated columns in DataFrame
         with self.assertRaisesRegex(ValueError, "columns overlap but no suffix specified"):
@@ -2578,8 +2578,8 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
         pdf1.index = midx1
         pdf2.index = midx2
-        kdf1 = pp.from_pandas(pdf1)
-        kdf2 = pp.from_pandas(pdf2)
+        kdf1 = ps.from_pandas(pdf1)
+        kdf2 = ps.from_pandas(pdf2)
 
         join_pdf = pdf1.join(pdf2, on=["index1", "index2"], rsuffix="_right")
         join_pdf.sort_values(by=list(join_pdf.columns), inplace=True)
@@ -2602,7 +2602,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(4),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         with self.assertRaisesRegex(
             NotImplementedError, "replace currently works only for method='pad"
@@ -2642,7 +2642,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             {"A": [0, 1, 2, 3, np.nan], "B": [5, 6, 7, 8, np.nan], "C": ["a", "b", "c", "d", None]},
             index=np.random.rand(5),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.replace([0, 1, 2, 3, 5, 6], 4), pdf.replace([0, 1, 2, 3, 5, 6], 4))
 
@@ -2712,10 +2712,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 columns=["B", "C"],
             )
 
-            left_kdf = pp.DataFrame(
+            left_kdf = ps.DataFrame(
                 {"A": ["1", "2", "3", "4"], "B": ["100", "200", None, None]}, columns=["A", "B"]
             )
-            right_kdf = pp.DataFrame(
+            right_kdf = ps.DataFrame(
                 {"B": ["x", None, "y", None], "C": ["100", "200", "300", "400"]}, columns=["B", "C"]
             )
             if left_columns is not None:
@@ -2787,7 +2787,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(6),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # Skip columns comparison by reset_index
         res_df = kdf.pivot_table(
@@ -2824,7 +2824,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(6),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # Checking if both DataFrames have the same results
         self.assert_eq(
@@ -2977,7 +2977,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=["A", "B", "C", "D", "E"],
             index=np.random.rand(9),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         ptable = pdf.pivot_table(
             values="D", index=["A", "B"], columns="C", aggfunc="sum", fill_value=0
@@ -2998,7 +2998,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf_single_level_cols = pd.DataFrame(
             [[0, 1], [2, 3]], index=["cat", "dog"], columns=["weight", "height"]
         )
-        kdf_single_level_cols = pp.from_pandas(pdf_single_level_cols)
+        kdf_single_level_cols = ps.from_pandas(pdf_single_level_cols)
 
         self.assert_eq(
             kdf_single_level_cols.stack().sort_index(), pdf_single_level_cols.stack().sort_index()
@@ -3010,7 +3010,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf_multi_level_cols1 = pd.DataFrame(
             [[1, 2], [2, 4]], index=["cat", "dog"], columns=multicol1
         )
-        kdf_multi_level_cols1 = pp.from_pandas(pdf_multi_level_cols1)
+        kdf_multi_level_cols1 = ps.from_pandas(pdf_multi_level_cols1)
 
         self.assert_eq(
             kdf_multi_level_cols1.stack().sort_index(), pdf_multi_level_cols1.stack().sort_index()
@@ -3020,7 +3020,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf_multi_level_cols2 = pd.DataFrame(
             [[1.0, 2.0], [3.0, 4.0]], index=["cat", "dog"], columns=multicol2
         )
-        kdf_multi_level_cols2 = pp.from_pandas(pdf_multi_level_cols2)
+        kdf_multi_level_cols2 = ps.from_pandas(pdf_multi_level_cols2)
 
         self.assert_eq(
             kdf_multi_level_cols2.stack().sort_index(), pdf_multi_level_cols2.stack().sort_index()
@@ -3034,7 +3034,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 ("y", "a"): [False, True],
             }
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.stack().sort_index(), pdf.stack().sort_index())
         self.assert_eq(kdf[[]].stack().sort_index(), pdf[[]].stack().sort_index(), almost=True)
@@ -3044,12 +3044,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             np.random.randn(3, 3),
             index=pd.MultiIndex.from_tuples([("rg1", "x"), ("rg1", "y"), ("rg2", "z")]),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.unstack().sort_index(), pdf.unstack().sort_index(), almost=True)
 
     def test_pivot_errors(self):
-        kdf = pp.range(10)
+        kdf = ps.range(10)
 
         with self.assertRaisesRegex(ValueError, "columns should be set"):
             kdf.pivot(index="id")
@@ -3067,7 +3067,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(6),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assertRaises(KeyError, lambda: kdf.pivot_table(index=["c"], columns="a", values=5))
 
@@ -3099,7 +3099,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 index=["c"], columns="A", values=["b", "e"], aggfunc={"b": "mean", "e": "sum"}
             )
 
-        kdf = pp.DataFrame(
+        kdf = ps.DataFrame(
             {
                 "A": ["foo", "foo", "foo", "foo", "foo", "bar", "bar", "bar", "bar"],
                 "B": ["one", "one", "one", "two", "two", "one", "one", "two", "two"],
@@ -3134,13 +3134,13 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_transpose(self):
         # TODO: what if with random index?
         pdf1 = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]}, columns=["col1", "col2"])
-        kdf1 = pp.from_pandas(pdf1)
+        kdf1 = ps.from_pandas(pdf1)
 
         pdf2 = pd.DataFrame(
             data={"score": [9, 8], "kids": [0, 0], "age": [12, 22]},
             columns=["score", "kids", "age"],
         )
-        kdf2 = pp.from_pandas(pdf2)
+        kdf2 = ps.from_pandas(pdf2)
 
         self.assert_eq(pdf1.transpose().sort_index(), kdf1.transpose().sort_index())
         self.assert_eq(pdf2.transpose().sort_index(), kdf2.transpose().sort_index())
@@ -3159,7 +3159,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=pd.MultiIndex.from_tuples([("rg1", "x"), ("rg1", "y"), ("rg2", "z")]),
         )
-        kdf3 = pp.from_pandas(pdf3)
+        kdf3 = ps.from_pandas(pdf3)
 
         self.assert_eq(pdf3.transpose().sort_index(), kdf3.transpose().sort_index())
 
@@ -3177,14 +3177,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=list("AB"),
             index=np.random.rand(5),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self._test_cummin(pdf, kdf)
 
     def test_cummin_multiindex_columns(self):
         arrays = [np.array(["A", "A", "B", "B"]), np.array(["one", "two", "one", "two"])]
         pdf = pd.DataFrame(np.random.randn(3, 4), index=["A", "C", "B"], columns=arrays)
         pdf.at["C", ("A", "two")] = None
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self._test_cummin(pdf, kdf)
 
     def _test_cummax(self, pdf, kdf):
@@ -3198,14 +3198,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=list("AB"),
             index=np.random.rand(5),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self._test_cummax(pdf, kdf)
 
     def test_cummax_multiindex_columns(self):
         arrays = [np.array(["A", "A", "B", "B"]), np.array(["one", "two", "one", "two"])]
         pdf = pd.DataFrame(np.random.randn(3, 4), index=["A", "C", "B"], columns=arrays)
         pdf.at["C", ("A", "two")] = None
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self._test_cummax(pdf, kdf)
 
     def _test_cumsum(self, pdf, kdf):
@@ -3219,14 +3219,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=list("AB"),
             index=np.random.rand(5),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self._test_cumsum(pdf, kdf)
 
     def test_cumsum_multiindex_columns(self):
         arrays = [np.array(["A", "A", "B", "B"]), np.array(["one", "two", "one", "two"])]
         pdf = pd.DataFrame(np.random.randn(3, 4), index=["A", "C", "B"], columns=arrays)
         pdf.at["C", ("A", "two")] = None
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self._test_cumsum(pdf, kdf)
 
     def _test_cumprod(self, pdf, kdf):
@@ -3241,7 +3241,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 columns=list("ABC"),
                 index=np.random.rand(5),
             )
-            kdf = pp.from_pandas(pdf)
+            kdf = ps.from_pandas(pdf)
             self._test_cumprod(pdf, kdf)
         else:
             pdf = pd.DataFrame(
@@ -3249,21 +3249,21 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 columns=list("ABC"),
                 index=np.random.rand(5),
             )
-            kdf = pp.from_pandas(pdf)
+            kdf = ps.from_pandas(pdf)
             self._test_cumprod(pdf, kdf)
 
     def test_cumprod_multiindex_columns(self):
         arrays = [np.array(["A", "A", "B", "B"]), np.array(["one", "two", "one", "two"])]
         pdf = pd.DataFrame(np.random.rand(3, 4), index=["A", "C", "B"], columns=arrays)
         pdf.at["C", ("A", "two")] = None
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self._test_cumprod(pdf, kdf)
 
     def test_drop_duplicates(self):
         pdf = pd.DataFrame(
             {"a": [1, 2, 2, 2, 3], "b": ["a", "a", "a", "c", "d"]}, index=np.random.rand(5)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # inplace is False
         for keep in ["first", "last", False]:
@@ -3315,7 +3315,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             pdf = pd.DataFrame(
                 {"a": [1, 2, 2, 2, 3], "b": ["a", "a", "a", "c", "d"]}, index=np.random.rand(5)
             )
-            kdf = pp.from_pandas(pdf)
+            kdf = ps.from_pandas(pdf)
             pser = pdf.a
             kser = kdf.a
             pdf.drop_duplicates(subset=subset, inplace=True)
@@ -3329,7 +3329,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             pdf = pd.DataFrame(
                 {"a": [1, 2, 2, 2, 3], "b": ["a", "a", "a", "c", "d"]}, index=np.random.rand(5)
             )
-            kdf = pp.from_pandas(pdf)
+            kdf = ps.from_pandas(pdf)
             columns = pd.MultiIndex.from_tuples([("x", "a"), ("y", "b")])
             pdf.columns = columns
             kdf.columns = columns
@@ -3344,7 +3344,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {10: [1, 2, 2, 2, 3], 20: ["a", "a", "a", "c", "d"]}, index=np.random.rand(5)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(
             pdf.drop_duplicates(10, keep=keep).sort_index(),
@@ -3359,7 +3359,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         index = pd.Index(["A", "B", "C", "D", "E"])
         columns = pd.Index(["numbers"])
         pdf = pd.DataFrame([1.0, 2.0, 3.0, 4.0, None], index=index, columns=columns)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         columns2 = pd.Index(["numbers", "2", "3"], name="cols2")
         self.assert_eq(
@@ -3417,7 +3417,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Reindexing single Index on single Index
         pindex2 = pd.Index(["A", "C", "D", "E", "0"], name="index2")
-        kindex2 = pp.from_pandas(pindex2)
+        kindex2 = ps.from_pandas(pindex2)
 
         for fill_value in [None, 0]:
             self.assert_eq(
@@ -3426,7 +3426,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             )
 
         pindex2 = pd.DataFrame({"index2": ["A", "C", "D", "E", "0"]}).set_index("index2").index
-        kindex2 = pp.from_pandas(pindex2)
+        kindex2 = ps.from_pandas(pindex2)
 
         for fill_value in [None, 0]:
             self.assert_eq(
@@ -3438,7 +3438,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pindex = pd.MultiIndex.from_tuples(
             [("A", "B"), ("C", "D"), ("F", "G")], names=["name1", "name2"]
         )
-        kindex = pp.from_pandas(pindex)
+        kindex = ps.from_pandas(pindex)
 
         self.assert_eq(
             pdf.reindex(index=pindex, fill_value=0.0).sort_index(),
@@ -3452,11 +3452,11 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Reindexing MultiIndex on MultiIndex
         pdf = pd.DataFrame({"numbers": [1.0, 2.0, None]}, index=pindex)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         pindex2 = pd.MultiIndex.from_tuples(
             [("A", "G"), ("C", "D"), ("I", "J")], names=["name1", "name2"]
         )
-        kindex2 = pp.from_pandas(pindex2)
+        kindex2 = ps.from_pandas(pindex2)
 
         for fill_value in [None, 0.0]:
             self.assert_eq(
@@ -3469,7 +3469,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             .set_index(["index_level_1", "index_level_2"])
             .index
         )
-        kindex2 = pp.from_pandas(pindex2)
+        kindex2 = ps.from_pandas(pindex2)
 
         for fill_value in [None, 0.0]:
             self.assert_eq(
@@ -3490,9 +3490,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         index = pd.Index(["A", "B", "C", "D", "E"])
         pdf = pd.DataFrame(data=[1.0, 2.0, 3.0, 4.0, None], index=index, columns=columns)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         pindex2 = pd.Index(["A", "C", "D", "E", "0"], name="index2")
-        kindex2 = pp.from_pandas(pindex2)
+        kindex2 = ps.from_pandas(pindex2)
 
         # Reindexing single Index on MultiIndex columns and single Index
         for fill_value in [None, 0.0]:
@@ -3526,21 +3526,21 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         index = pd.Index(["A", "B", "C"], name="index")
         columns = pd.Index(["numbers", "values"], name="cols")
         pdf = pd.DataFrame(data=data, index=index, columns=columns)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # Reindexing single Index on single Index
         data2 = [[5.0, None], [6.0, 7.0], [8.0, None]]
         index2 = pd.Index(["A", "C", "D"], name="index2")
         columns2 = pd.Index(["numbers", "F"], name="cols2")
         pdf2 = pd.DataFrame(data=data2, index=index2, columns=columns2)
-        kdf2 = pp.from_pandas(pdf2)
+        kdf2 = ps.from_pandas(pdf2)
 
         self.assert_eq(
             pdf.reindex_like(pdf2).sort_index(), kdf.reindex_like(kdf2).sort_index(),
         )
 
         pdf2 = pd.DataFrame({"index_level_1": ["A", "C", "I"]})
-        kdf2 = pp.from_pandas(pdf2)
+        kdf2 = ps.from_pandas(pdf2)
 
         self.assert_eq(
             pdf.reindex_like(pdf2.set_index(["index_level_1"])).sort_index(),
@@ -3552,7 +3552,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             [("A", "G"), ("C", "D"), ("I", "J")], names=["name3", "name4"]
         )
         pdf2 = pd.DataFrame(data=data2, index=index2)
-        kdf2 = pp.from_pandas(pdf2)
+        kdf2 = ps.from_pandas(pdf2)
 
         self.assert_eq(
             pdf.reindex_like(pdf2).sort_index(), kdf.reindex_like(kdf2).sort_index(),
@@ -3575,7 +3575,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             [("A", "B"), ("C", "D"), ("E", "F")], names=["name1", "name2"]
         )
         pdf = pd.DataFrame(data=data, index=index, columns=columns)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(
             pdf.reindex_like(pdf2).sort_index(), kdf.reindex_like(kdf2).sort_index(),
@@ -3585,7 +3585,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"A": [1, 3, 5], "B": [2, 4, 6], "C": [7, 8, 9]}, index=np.random.rand(3)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(
             kdf.melt().sort_values(["variable", "value"]).reset_index(drop=True),
@@ -3745,7 +3745,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(3),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.all(), pdf.all())
 
@@ -3787,7 +3787,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(3),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.any(), pdf.any())
 
@@ -3823,7 +3823,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=["col1", "col2"],
             index=np.random.rand(4),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(pdf.rank().sort_index(), kdf.rank().sort_index())
         self.assert_eq(pdf.rank().sum(), kdf.rank().sum())
@@ -3855,10 +3855,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=["A", "B", "C"],
             index=np.random.rand(3),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         pser = pd.Series([1, 0, 2], index=["A", "B", "C"])
-        kser = pp.Series([1, 0, 2], index=["A", "B", "C"])
+        kser = ps.Series([1, 0, 2], index=["A", "B", "C"])
         self.assert_eq(pdf.round(2), kdf.round(2))
         self.assert_eq(pdf.round({"A": 1, "C": 2}), kdf.round({"A": 1, "C": 2}))
         self.assert_eq(pdf.round({"A": 1, "D": 2}), kdf.round({"A": 1, "D": 2}))
@@ -3872,7 +3872,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf.columns = columns
         kdf.columns = columns
         pser = pd.Series([1, 0, 2], index=columns)
-        kser = pp.Series([1, 0, 2], index=columns)
+        kser = ps.Series([1, 0, 2], index=columns)
         self.assert_eq(pdf.round(2), kdf.round(2))
         self.assert_eq(
             pdf.round({("X", "A"): 1, ("Y", "C"): 2}), kdf.round({("X", "A"): 1, ("Y", "C"): 2})
@@ -3889,7 +3889,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(3),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(pdf.round({10: 1, 30: 2}), kdf.round({10: 1, 30: 2}))
 
@@ -3902,7 +3902,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(5),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(pdf.shift(3), kdf.shift(3))
         self.assert_eq(pdf.shift().shift(-1), kdf.shift().shift(-1))
@@ -3930,7 +3930,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},
             index=np.random.rand(6),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(pdf.diff(), kdf.diff())
         self.assert_eq(pdf.diff().diff(-1), kdf.diff().diff(-1))
@@ -3954,7 +3954,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"a": [1, 1, 2, 3], "b": [1, 1, 1, 4], "c": [1, 1, 1, 5]}, index=np.random.rand(4)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(pdf.duplicated().sort_index(), kdf.duplicated().sort_index())
         self.assert_eq(
@@ -4010,7 +4010,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {10: [1, 1, 2, 3], 20: [1, 1, 1, 4], 30: [1, 1, 1, 5]}, index=np.random.rand(4)
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(pdf.duplicated().sort_index(), kdf.duplicated().sort_index())
         self.assert_eq(
@@ -4027,7 +4027,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=idx,
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.ffill(), pdf.ffill())
         self.assert_eq(kdf.ffill(limit=1), pdf.ffill(limit=1))
@@ -4052,7 +4052,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=idx,
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.bfill(), pdf.bfill())
         self.assert_eq(kdf.bfill(limit=1), pdf.bfill(limit=1))
@@ -4077,7 +4077,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             }
         )
         pdf = pdf.set_index("aa")
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(
             kdf.filter(items=["ab", "aa"], axis=0).sort_index(),
@@ -4097,7 +4097,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
         pdf = pdf.set_index("ba", append=True)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(
             kdf.filter(items=[("aa", 1), ("bd", 2)], axis=0).sort_index(),
@@ -4136,7 +4136,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             }
         )
         pdf = pdf.set_index(("x", "aa"))
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(
             kdf.filter(items=["ab", "aa"], axis=0).sort_index(),
@@ -4156,7 +4156,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
     def test_pipe(self):
-        kdf = pp.DataFrame(
+        kdf = ps.DataFrame(
             {"category": ["A", "A", "B"], "col1": [1, 2, 3], "col2": [4, 5, 6]},
             columns=["category", "col1", "col2"],
         )
@@ -4177,7 +4177,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=["a", "b", "c"],
             index=np.random.rand(600),
         )
-        kdf = pp.DataFrame(pdf)
+        kdf = ps.DataFrame(pdf)
         self.assert_eq(
             kdf.transform(lambda x: x + 1).sort_index(), pdf.transform(lambda x: x + 1).sort_index()
         )
@@ -4222,7 +4222,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=["a", "b", "c"],
             index=np.random.rand(600),
         )
-        kdf = pp.DataFrame(pdf)
+        kdf = ps.DataFrame(pdf)
 
         self.assert_eq(
             kdf.apply(lambda x: x + 1).sort_index(), pdf.apply(lambda x: x + 1).sort_index()
@@ -4273,14 +4273,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(TypeError, "The given function.*1 or 'column'; however"):
 
-            def f1(_) -> pp.DataFrame[int]:
+            def f1(_) -> ps.DataFrame[int]:
                 pass
 
             kdf.apply(f1, axis=0)
 
         with self.assertRaisesRegex(TypeError, "The given function.*0 or 'index'; however"):
 
-            def f2(_) -> pp.Series[int]:
+            def f2(_) -> ps.Series[int]:
                 pass
 
             kdf.apply(f2, axis=1)
@@ -4319,7 +4319,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=["a", "b", "c"],
             index=np.random.rand(600),
         )
-        kdf = pp.DataFrame(pdf)
+        kdf = ps.DataFrame(pdf)
 
         # One to test alias.
         self.assert_eq(kdf.apply_batch(lambda pdf: pdf + 1).sort_index(), (pdf + 1).sort_index())
@@ -4341,7 +4341,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         with self.assertRaisesRegex(TypeError, "The given function.*frame as its type hints"):
 
-            def f2(_) -> pp.Series[int]:
+            def f2(_) -> ps.Series[int]:
                 pass
 
             kdf.koalas.apply_batch(f2)
@@ -4370,7 +4370,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             columns=["a", "b", "c"],
             index=np.random.rand(600),
         )
-        kdf = pp.DataFrame(pdf)
+        kdf = ps.DataFrame(pdf)
 
         # One to test alias.
         self.assert_eq(
@@ -4430,22 +4430,22 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             )
 
     def test_transform_batch_same_anchor(self):
-        kdf = pp.range(10)
+        kdf = ps.range(10)
         kdf["d"] = kdf.koalas.transform_batch(lambda pdf: pdf.id + 1)
         self.assert_eq(
             kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}, columns=["id", "d"])
         )
 
-        kdf = pp.range(10)
+        kdf = ps.range(10)
         # One to test alias.
         kdf["d"] = kdf.id.transform_batch(lambda ser: ser + 1)
         self.assert_eq(
             kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}, columns=["id", "d"])
         )
 
-        kdf = pp.range(10)
+        kdf = ps.range(10)
 
-        def plus_one(pdf) -> pp.Series[np.int64]:
+        def plus_one(pdf) -> ps.Series[np.int64]:
             return pdf.id + 1
 
         kdf["d"] = kdf.koalas.transform_batch(plus_one)
@@ -4453,9 +4453,9 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf, pd.DataFrame({"id": list(range(10)), "d": list(range(1, 11))}, columns=["id", "d"])
         )
 
-        kdf = pp.range(10)
+        kdf = ps.range(10)
 
-        def plus_one(ser) -> pp.Series[np.int64]:
+        def plus_one(ser) -> ps.Series[np.int64]:
             return ser + 1
 
         kdf["d"] = kdf.id.koalas.transform_batch(plus_one)
@@ -4474,12 +4474,12 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=np.random.rand(3),
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(kdf[kdf["t"] != kdf["t"]], pdf[pdf["t"] != pdf["t"]])
         self.assert_eq(kdf[kdf["t"] != kdf["t"]].dtypes, pdf[pdf["t"] != pdf["t"]].dtypes)
 
     def test_to_spark(self):
-        kdf = pp.from_pandas(self.pdf)
+        kdf = ps.from_pandas(self.pdf)
 
         with self.assertRaisesRegex(ValueError, "'index_col' cannot be overlapped"):
             kdf.to_spark(index_col="a")
@@ -4493,7 +4493,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             index=["cobra", "viper", "sidewinder"],
             columns=["max_speed", "shield"],
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.keys(), pdf.keys())
 
@@ -4534,7 +4534,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.quantile([0.25, 0.5, 0.75]), pdf.quantile([0.25, 0.5, 0.75]))
 
         pdf = pd.DataFrame({"x": ["a", "b", "c"]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.0.0"):
             self.assert_eq(kdf.quantile(0.5), pdf.quantile(0.5))
@@ -4554,26 +4554,26 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             index=np.random.rand(4),
         )
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.pct_change(2), pdf.pct_change(2), check_exact=False)
         self.assert_eq(kdf.pct_change().sum(), pdf.pct_change().sum(), check_exact=False)
 
     def test_where(self):
-        kdf = pp.from_pandas(self.pdf)
+        kdf = ps.from_pandas(self.pdf)
 
         with self.assertRaisesRegex(ValueError, "type of cond must be a DataFrame or Series"):
             kdf.where(1)
 
     def test_mask(self):
-        kdf = pp.from_pandas(self.pdf)
+        kdf = ps.from_pandas(self.pdf)
 
         with self.assertRaisesRegex(ValueError, "type of cond must be a DataFrame or Series"):
             kdf.mask(1)
 
     def test_query(self):
         pdf = pd.DataFrame({"A": range(1, 6), "B": range(10, 0, -2), "C": range(10, 5, -1)})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         exprs = ("A > B", "A < C", "C == B")
         for expr in exprs:
@@ -4622,7 +4622,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             {"A": range(0, 50000), "B": range(100000, 0, -2), "C": range(100000, 50000, -1)}
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # axis=0 (default)
         self.assert_eq(kdf.take([1, 2]).sort_index(), pdf.take([1, 2]).sort_index())
@@ -4711,7 +4711,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_axes(self):
         pdf = self.pdf
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.axes, kdf.axes)
 
         # multi-index columns
@@ -4727,15 +4727,15 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
             with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
-                kdf = pp.from_pandas(pdf)
+                kdf = ps.from_pandas(pdf)
                 self.assert_eq(kdf, pdf)
         else:
-            kdf = pp.from_pandas(pdf)
+            kdf = ps.from_pandas(pdf)
             self.assert_eq(kdf, pdf)
 
     def test_eval(self):
         pdf = pd.DataFrame({"A": range(1, 6), "B": range(10, 0, -2)})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # operation between columns (returns Series)
         self.assert_eq(pdf.eval("A + B"), kdf.eval("A + B"))
@@ -4770,7 +4770,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     @unittest.skipIf(not have_tabulate, "tabulate not installed")
     def test_to_markdown(self):
         pdf = pd.DataFrame(data={"animal_1": ["elk", "pig"], "animal_2": ["dog", "quetzal"]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         # `to_markdown()` is supported in pandas >= 1.0.0 since it's newly added in pandas 1.0.0.
         if LooseVersion(pd.__version__) < LooseVersion("1.0.0"):
@@ -4782,7 +4782,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             [(0.2, 0.3), (0.0, 0.6), (0.6, 0.0), (0.2, 0.1)], columns=["dogs", "cats"]
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         with kdf.cache() as cached_df:
             self.assert_eq(isinstance(cached_df, CachedDataFrame), True)
@@ -4794,7 +4794,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame(
             [(0.2, 0.3), (0.0, 0.6), (0.6, 0.0), (0.2, 0.1)], columns=["dogs", "cats"]
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         storage_levels = [
             StorageLevel.DISK_ONLY,
             StorageLevel.MEMORY_AND_DISK,
@@ -4814,7 +4814,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Multiple columns
         pdf = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"], index=["x", "y"])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         for axis in axises:
             self.assert_eq(pdf.squeeze(axis), kdf.squeeze(axis))
         # Multiple columns with MultiIndex columns
@@ -4826,7 +4826,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Single column with single value
         pdf = pd.DataFrame([[1]], columns=["a"], index=["x"])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         for axis in axises:
             self.assert_eq(pdf.squeeze(axis), kdf.squeeze(axis))
         # Single column with single value with MultiIndex column
@@ -4838,7 +4838,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Single column with multiple values
         pdf = pd.DataFrame([1, 2, 3, 4], columns=["a"])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         for axis in axises:
             self.assert_eq(pdf.squeeze(axis), kdf.squeeze(axis))
         # Single column with multiple values with MultiIndex column
@@ -4853,7 +4853,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             index=["circle", "triangle", "rectangle"],
             columns=["angles", "degrees"],
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         if LooseVersion(pd.__version__) < LooseVersion("1.0.0") and LooseVersion(
             pd.__version__
@@ -4877,7 +4877,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=[-500, -20, -1, 0, 400, 550, 1000],
         )
-        kdf1 = pp.from_pandas(pdf1)
+        kdf1 = ps.from_pandas(pdf1)
         pdf2 = pd.DataFrame(
             {
                 "A": ["a", "b", "c", "d", "e", "f", "g"],
@@ -4886,7 +4886,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             index=[1000, 550, 400, 0, -1, -20, -500],
         )
-        kdf2 = pp.from_pandas(pdf2)
+        kdf2 = ps.from_pandas(pdf2)
 
         self.assert_eq(kdf1.truncate(), pdf1.truncate())
         self.assert_eq(kdf1.truncate(before=-20), pdf1.truncate(before=-20))
@@ -4898,7 +4898,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             self.assert_eq(kdf2.truncate(0, 550), pdf2.truncate(0, 550))
             self.assert_eq(kdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
         else:
-            expected_kdf = pp.DataFrame(
+            expected_kdf = ps.DataFrame(
                 {"A": ["b", "c", "d"], "B": ["i", "j", "k"], "C": ["p", "q", "r"]},
                 index=[550, 400, 0],
             )
@@ -4948,7 +4948,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         )
 
         # Exceptions
-        kdf = pp.DataFrame(
+        kdf = ps.DataFrame(
             {
                 "A": ["a", "b", "c", "d", "e", "f", "g"],
                 "B": ["h", "i", "j", "k", "l", "m", "n"],
@@ -4960,7 +4960,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(ValueError, msg):
             kdf.truncate()
 
-        kdf = pp.DataFrame(
+        kdf = ps.DataFrame(
             {
                 "A": ["a", "b", "c", "d", "e", "f", "g"],
                 "B": ["h", "i", "j", "k", "l", "m", "n"],
@@ -4979,7 +4979,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         pdf = pd.DataFrame({"A": [[-1.0, np.nan], [0.0, np.inf], [1.0, -np.inf]], "B": 1})
         pdf.index.name = "index"
         pdf.columns.name = "columns"
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         if LooseVersion(pd.__version__) >= LooseVersion("0.25.0"):
             expected_result1 = pdf.explode("A")
@@ -5005,7 +5005,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             [("x", "a"), ("x", "b"), ("y", "c")], names=["index1", "index2"]
         )
         pdf.index = midx
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         if LooseVersion(pd.__version__) >= LooseVersion("0.25.0"):
             expected_result1 = pdf.explode("A")
@@ -5052,7 +5052,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaises(ValueError, lambda: kdf.explode("A"))
 
     def test_spark_schema(self):
-        kdf = pp.DataFrame(
+        kdf = ps.DataFrame(
             {
                 "a": list("abc"),
                 "b": list(range(1, 4)),
@@ -5067,7 +5067,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertEqual(kdf.spark_schema("index"), kdf.spark.schema("index"))
 
     def test_print_schema(self):
-        kdf = pp.DataFrame(
+        kdf = ps.DataFrame(
             {"a": list("abc"), "b": list(range(1, 4)), "c": np.arange(3, 6).astype("i1")},
             columns=["a", "b", "c"],
         )
@@ -5089,10 +5089,10 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             sys.stdout = prev
 
     def test_explain_hint(self):
-        kdf1 = pp.DataFrame(
+        kdf1 = ps.DataFrame(
             {"lkey": ["foo", "bar", "baz", "foo"], "value": [1, 2, 3, 5]}, columns=["lkey", "value"]
         )
-        kdf2 = pp.DataFrame(
+        kdf2 = ps.DataFrame(
             {"rkey": ["foo", "bar", "baz", "foo"], "value": [5, 6, 7, 8]}, columns=["rkey", "value"]
         )
         merged = kdf1.merge(kdf2.hint("broadcast"), left_on="lkey", right_on="rkey")
@@ -5120,7 +5120,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 "C": ["a", "b", "c", "d", "e"],
             }
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.mad(), pdf.mad())
         self.assert_eq(kdf.mad(axis=1), pdf.mad(axis=1))
@@ -5137,14 +5137,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assert_eq(kdf.mad(axis=1), pdf.mad(axis=1))
 
         pdf = pd.DataFrame({"A": [True, True, False, False], "B": [True, False, False, True]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(kdf.mad(), pdf.mad())
         self.assert_eq(kdf.mad(axis=1), pdf.mad(axis=1))
 
     def test_abs(self):
         pdf = pd.DataFrame({"a": [-2, -1, 0, 1]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(abs(kdf), abs(pdf))
         self.assert_eq(np.abs(kdf), np.abs(pdf))
@@ -5155,7 +5155,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             index=["panda", "polar", "koala"],
             columns=["species", "population"],
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         for (p_name, p_items), (k_name, k_items) in zip(pdf.iteritems(), kdf.iteritems()):
             self.assert_eq(p_name, k_name)
@@ -5167,7 +5167,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     )
     def test_tail(self):
         pdf = pd.DataFrame({"x": range(1000)})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         self.assert_eq(pdf.tail(), kdf.tail())
         self.assert_eq(pdf.tail(10), kdf.tail(10))
@@ -5193,55 +5193,55 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             {"a": [1, 2, 3, None], "b": [1.0, 2.0, 3.0, None], "c": [100, 200, 400, None]},
             index=["Q", "W", "E", "R"],
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
         self.assert_eq(pdf[[]].last_valid_index(), kdf[[]].last_valid_index())
 
         # MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
 
         # Empty DataFrame
         pdf = pd.Series([]).to_frame()
-        kdf = pp.Series([]).to_frame()
+        kdf = ps.Series([]).to_frame()
         self.assert_eq(pdf.last_valid_index(), kdf.last_valid_index())
 
     def test_last(self):
         index = pd.date_range("2018-04-09", periods=4, freq="2D")
         pdf = pd.DataFrame([1, 2, 3, 4], index=index)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.last("1D"), kdf.last("1D"))
         self.assert_eq(pdf.last(DateOffset(days=1)), kdf.last(DateOffset(days=1)))
         with self.assertRaisesRegex(TypeError, "'last' only supports a DatetimeIndex"):
-            pp.DataFrame([1, 2, 3, 4]).last("1D")
+            ps.DataFrame([1, 2, 3, 4]).last("1D")
 
     def test_first(self):
         index = pd.date_range("2018-04-09", periods=4, freq="2D")
         pdf = pd.DataFrame([1, 2, 3, 4], index=index)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.first("1D"), kdf.first("1D"))
         self.assert_eq(pdf.first(DateOffset(days=1)), kdf.first(DateOffset(days=1)))
         with self.assertRaisesRegex(TypeError, "'first' only supports a DatetimeIndex"):
-            pp.DataFrame([1, 2, 3, 4]).first("1D")
+            ps.DataFrame([1, 2, 3, 4]).first("1D")
 
     def test_first_valid_index(self):
         pdf = pd.DataFrame(
             {"a": [None, 2, 3, 2], "b": [None, 2.0, 3.0, 1.0], "c": [None, 200, 400, 200]},
             index=["Q", "W", "E", "R"],
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.first_valid_index(), kdf.first_valid_index())
         self.assert_eq(pdf[[]].first_valid_index(), kdf[[]].first_valid_index())
 
         # MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.first_valid_index(), kdf.first_valid_index())
 
         # Empty DataFrame
         pdf = pd.Series([]).to_frame()
-        kdf = pp.Series([]).to_frame()
+        kdf = ps.Series([]).to_frame()
         self.assert_eq(pdf.first_valid_index(), kdf.first_valid_index())
 
         pdf = pd.DataFrame(
@@ -5253,49 +5253,49 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 datetime(2021, 4, 1),
             ],
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.first_valid_index(), kdf.first_valid_index())
 
     def test_product(self):
         pdf = pd.DataFrame(
             {"A": [1, 2, 3, 4, 5], "B": [10, 20, 30, 40, 50], "C": ["a", "b", "c", "d", "e"]}
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # Named columns
         pdf.columns.name = "Koalas"
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # Named MultiIndex columns
         pdf.columns.names = ["Hello", "Koalas"]
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # No numeric columns
         pdf = pd.DataFrame({"key": ["a", "b", "c"], "val": ["x", "y", "z"]})
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index())
 
         # No numeric named columns
         pdf.columns.name = "Koalas"
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # No numeric MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y")])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # No numeric named MultiIndex columns
         pdf.columns.names = ["Hello", "Koalas"]
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index(), almost=True)
 
         # All NaN columns
@@ -5306,36 +5306,36 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
                 "C": ["a", "b", "c", "d", "e"],
             }
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index(), check_exact=False)
 
         # All NaN named columns
         pdf.columns.name = "Koalas"
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index(), check_exact=False)
 
         # All NaN MultiIndex columns
         pdf.columns = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index(), check_exact=False)
 
         # All NaN named MultiIndex columns
         pdf.columns.names = ["Hello", "Koalas"]
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.prod(), kdf.prod().sort_index(), check_exact=False)
 
     def test_from_dict(self):
         data = {"row_1": [3, 2, 1, 0], "row_2": [10, 20, 30, 40]}
         pdf = pd.DataFrame.from_dict(data)
-        kdf = pp.DataFrame.from_dict(data)
+        kdf = ps.DataFrame.from_dict(data)
         self.assert_eq(pdf, kdf)
 
         pdf = pd.DataFrame.from_dict(data, dtype="int8")
-        kdf = pp.DataFrame.from_dict(data, dtype="int8")
+        kdf = ps.DataFrame.from_dict(data, dtype="int8")
         self.assert_eq(pdf, kdf)
 
         pdf = pd.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
-        kdf = pp.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
+        kdf = ps.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
         self.assert_eq(pdf, kdf)
 
     def test_pad(self):
@@ -5348,7 +5348,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             columns=["A", "B", "C", "D"],
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
             self.assert_eq(pdf.pad(), kdf.pad())
@@ -5358,7 +5358,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.pad(inplace=True)
             self.assert_eq(pdf, kdf)
         else:
-            expected = pp.DataFrame(
+            expected = ps.DataFrame(
                 {
                     "A": [None, 3, 3, 3],
                     "B": [2.0, 4.0, 4.0, 3.0],
@@ -5383,7 +5383,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             },
             columns=["A", "B", "C", "D"],
         )
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
             self.assert_eq(pdf.backfill(), kdf.backfill())
@@ -5393,7 +5393,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
             kdf.backfill(inplace=True)
             self.assert_eq(pdf, kdf)
         else:
-            expected = pp.DataFrame(
+            expected = ps.DataFrame(
                 {
                     "A": [3.0, 3.0, None, None],
                     "B": [2.0, 4.0, 3.0, 3.0],
@@ -5410,7 +5410,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_align(self):
         pdf1 = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}, index=[10, 20, 30])
-        kdf1 = pp.from_pandas(pdf1)
+        kdf1 = ps.from_pandas(pdf1)
 
         for join in ["outer", "inner", "left", "right"]:
             for axis in [None, 0, 1]:
@@ -5444,7 +5444,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         self.assertRaises(NotImplementedError, lambda: kdf1.align(kdf1["b"], axis=1))
 
         pdf2 = pd.DataFrame({"a": [4, 5, 6], "d": ["d", "e", "f"]}, index=[10, 11, 12])
-        kdf2 = pp.from_pandas(pdf2)
+        kdf2 = ps.from_pandas(pdf2)
 
         for join in ["outer", "inner", "left", "right"]:
             kdf_l, kdf_r = kdf1.align(kdf2, join=join, axis=1)
@@ -5455,14 +5455,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
     def test_between_time(self):
         idx = pd.date_range("2018-04-09", periods=4, freq="1D20min")
         pdf = pd.DataFrame({"A": [1, 2, 3, 4]}, index=idx)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(
             pdf.between_time("0:15", "0:45").sort_index(),
             kdf.between_time("0:15", "0:45").sort_index(),
         )
 
         pdf.index.name = "ts"
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(
             pdf.between_time("0:15", "0:45").sort_index(),
             kdf.between_time("0:15", "0:45").sort_index(),
@@ -5470,7 +5470,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Column label is 'index'
         pdf.columns = pd.Index(["index"])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(
             pdf.between_time("0:15", "0:45").sort_index(),
             kdf.between_time("0:15", "0:45").sort_index(),
@@ -5478,7 +5478,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Both index name and column label are 'index'
         pdf.index.name = "index"
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(
             pdf.between_time("0:15", "0:45").sort_index(),
             kdf.between_time("0:15", "0:45").sort_index(),
@@ -5486,7 +5486,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Index name is 'index', column label is ('X', 'A')
         pdf.columns = pd.MultiIndex.from_arrays([["X"], ["A"]])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(
             pdf.between_time("0:15", "0:45").sort_index(),
             kdf.between_time("0:15", "0:45").sort_index(),
@@ -5497,14 +5497,14 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         ):
             kdf.between_time("0:15", "0:45", axis=1)
 
-        kdf = pp.DataFrame({"A": [1, 2, 3, 4]})
+        kdf = ps.DataFrame({"A": [1, 2, 3, 4]})
         with self.assertRaisesRegex(TypeError, "Index must be DatetimeIndex"):
             kdf.between_time("0:15", "0:45")
 
     def test_at_time(self):
         idx = pd.date_range("2018-04-09", periods=4, freq="1D20min")
         pdf = pd.DataFrame({"A": [1, 2, 3, 4]}, index=idx)
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         kdf.at_time("0:20")
         self.assert_eq(
             pdf.at_time("0:20").sort_index(), kdf.at_time("0:20").sort_index(),
@@ -5512,28 +5512,28 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
 
         # Index name is 'ts'
         pdf.index.name = "ts"
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(
             pdf.at_time("0:20").sort_index(), kdf.at_time("0:20").sort_index(),
         )
 
         # Index name is 'ts', column label is 'index'
         pdf.columns = pd.Index(["index"])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(
             pdf.at_time("0:40").sort_index(), kdf.at_time("0:40").sort_index(),
         )
 
         # Both index name and column label are 'index'
         pdf.index.name = "index"
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(
             pdf.at_time("0:40").sort_index(), kdf.at_time("0:40").sort_index(),
         )
 
         # Index name is 'index', column label is ('X', 'A')
         pdf.columns = pd.MultiIndex.from_arrays([["X"], ["A"]])
-        kdf = pp.from_pandas(pdf)
+        kdf = ps.from_pandas(pdf)
         self.assert_eq(
             pdf.at_time("0:40").sort_index(), kdf.at_time("0:40").sort_index(),
         )
@@ -5544,7 +5544,7 @@ class DataFrameTest(ReusedSQLTestCase, SQLTestUtils):
         with self.assertRaisesRegex(NotImplementedError, "at_time currently only works for axis=0"):
             kdf.at_time("0:15", axis=1)
 
-        kdf = pp.DataFrame({"A": [1, 2, 3, 4]})
+        kdf = ps.DataFrame({"A": [1, 2, 3, 4]})
         with self.assertRaisesRegex(TypeError, "Index must be DatetimeIndex"):
             kdf.at_time("0:15")
 

--- a/python/pyspark/pandas/typedef/string_typehints.py
+++ b/python/pyspark/pandas/typedef/string_typehints.py
@@ -23,12 +23,12 @@ from inspect import getfullargspec  # noqa: F401
 
 
 def resolve_string_type_hint(tpe):
-    import pyspark.pandas as pp
+    import pyspark.pandas as ps
     from pyspark.pandas import DataFrame, Series
 
     locs = {
-        "pp": pp,
-        "koalas": pp,
+        "ps": ps,
+        "koalas": ps,
         "DataFrame": DataFrame,
         "Series": Series,
     }

--- a/python/pyspark/pandas/typedef/string_typehints.py
+++ b/python/pyspark/pandas/typedef/string_typehints.py
@@ -28,7 +28,7 @@ def resolve_string_type_hint(tpe):
 
     locs = {
         "ps": ps,
-        "koalas": ps,
+        "pyspark.pandas": ps,
         "DataFrame": DataFrame,
         "Series": Series,
     }

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -64,7 +64,7 @@ try:
 except ImportError:
     from pyspark.sql.pandas.types import to_arrow_type, from_arrow_type
 
-from pyspark import pandas as pp  # For running doctests and reference resolution in PyCharm.
+from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.typedef.string_typehints import resolve_string_type_hint
 
 T = TypeVar("T")
@@ -341,7 +341,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     >>> inferred.spark_type
     LongType
 
-    >>> def func() -> pp.Series[int]:
+    >>> def func() -> ps.Series[int]:
     ...    pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtype
@@ -349,7 +349,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     >>> inferred.spark_type
     LongType
 
-    >>> def func() -> pp.DataFrame[np.float, str]:
+    >>> def func() -> ps.DataFrame[np.float, str]:
     ...    pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -357,7 +357,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     >>> inferred.spark_type
     StructType(List(StructField(c0,DoubleType,true),StructField(c1,StringType,true)))
 
-    >>> def func() -> pp.DataFrame[np.float]:
+    >>> def func() -> ps.DataFrame[np.float]:
     ...    pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -373,7 +373,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     >>> inferred.spark_type
     LongType
 
-    >>> def func() -> 'pp.Series[int]':
+    >>> def func() -> 'ps.Series[int]':
     ...    pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtype
@@ -381,7 +381,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     >>> inferred.spark_type
     LongType
 
-    >>> def func() -> 'pp.DataFrame[np.float, str]':
+    >>> def func() -> 'ps.DataFrame[np.float, str]':
     ...    pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -389,7 +389,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     >>> inferred.spark_type
     StructType(List(StructField(c0,DoubleType,true),StructField(c1,StringType,true)))
 
-    >>> def func() -> 'pp.DataFrame[np.float]':
+    >>> def func() -> 'ps.DataFrame[np.float]':
     ...    pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -397,7 +397,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     >>> inferred.spark_type
     StructType(List(StructField(c0,DoubleType,true)))
 
-    >>> def func() -> pp.DataFrame['a': np.float, 'b': int]:
+    >>> def func() -> ps.DataFrame['a': np.float, 'b': int]:
     ...     pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -405,7 +405,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     >>> inferred.spark_type
     StructType(List(StructField(a,DoubleType,true),StructField(b,LongType,true)))
 
-    >>> def func() -> "pp.DataFrame['a': np.float, 'b': int]":
+    >>> def func() -> "ps.DataFrame['a': np.float, 'b': int]":
     ...     pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -414,7 +414,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     StructType(List(StructField(a,DoubleType,true),StructField(b,LongType,true)))
 
     >>> pdf = pd.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
-    >>> def func() -> pp.DataFrame[pdf.dtypes]:
+    >>> def func() -> ps.DataFrame[pdf.dtypes]:
     ...     pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -423,7 +423,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     StructType(List(StructField(c0,LongType,true),StructField(c1,LongType,true)))
 
     >>> pdf = pd.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
-    >>> def func() -> pp.DataFrame[zip(pdf.columns, pdf.dtypes)]:
+    >>> def func() -> ps.DataFrame[zip(pdf.columns, pdf.dtypes)]:
     ...     pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -432,7 +432,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     StructType(List(StructField(a,LongType,true),StructField(b,LongType,true)))
 
     >>> pdf = pd.DataFrame({("x", "a"): [1, 2, 3], ("y", "b"): [3, 4, 5]})
-    >>> def func() -> pp.DataFrame[zip(pdf.columns, pdf.dtypes)]:
+    >>> def func() -> ps.DataFrame[zip(pdf.columns, pdf.dtypes)]:
     ...     pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -441,7 +441,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     StructType(List(StructField((x, a),LongType,true),StructField((y, b),LongType,true)))
 
     >>> pdf = pd.DataFrame({"a": [1, 2, 3], "b": pd.Categorical([3, 4, 5])})
-    >>> def func() -> pp.DataFrame[pdf.dtypes]:
+    >>> def func() -> ps.DataFrame[pdf.dtypes]:
     ...     pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -449,7 +449,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     >>> inferred.spark_type
     StructType(List(StructField(c0,LongType,true),StructField(c1,LongType,true)))
 
-    >>> def func() -> pp.DataFrame[zip(pdf.columns, pdf.dtypes)]:
+    >>> def func() -> ps.DataFrame[zip(pdf.columns, pdf.dtypes)]:
     ...     pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtypes
@@ -457,7 +457,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
     >>> inferred.spark_type
     StructType(List(StructField(a,LongType,true),StructField(b,LongType,true)))
 
-    >>> def func() -> pp.Series[pdf.b.dtype]:
+    >>> def func() -> ps.Series[pdf.b.dtype]:
     ...     pass
     >>> inferred = infer_return_type(func)
     >>> inferred.dtype
@@ -477,7 +477,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
         tpe = resolve_string_type_hint(tpe)
 
     if hasattr(tpe, "__origin__") and (
-        tpe.__origin__ == pp.DataFrame or tpe.__origin__ == pp.Series
+        tpe.__origin__ == ps.DataFrame or tpe.__origin__ == ps.Series
     ):
         # When Python version is lower then 3.7. Unwrap it to a Tuple/SeriesType type hints.
         tpe = tpe.__args__[0]

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -35,7 +35,7 @@ import pandas as pd
 from pandas.api.types import is_list_like
 
 # For running doctests and reference resolution in PyCharm.
-from pyspark import pandas as pp  # noqa: F401
+from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas.typedef.typehints import (
     as_spark_type,
     extension_dtypes,
@@ -300,8 +300,8 @@ def align_diff_frames(
         >>>
         >>> set_option("compute.ops_on_diff_frames", True)
         >>>
-        >>> kdf1 = pp.DataFrame({'a': [9, 8, 7, 6, 5, 4, 3, 2, 1]})
-        >>> kdf2 = pp.DataFrame({'a': [9, 8, 7, 6, 5, 4, 3, 2, 1]})
+        >>> kdf1 = ps.DataFrame({'a': [9, 8, 7, 6, 5, 4, 3, 2, 1]})
+        >>> kdf2 = ps.DataFrame({'a': [9, 8, 7, 6, 5, 4, 3, 2, 1]})
         >>>
         >>> def func(kdf, this_column_labels, that_column_labels):
         ...    kdf  # conceptually this is A + B.
@@ -759,7 +759,7 @@ def verify_temp_column_name(
     The temporary column names should start and end with `__`. In addition, `column_name_or_label`
     expects a single string, or column labels when `df` is a Koalas DataFrame.
 
-    >>> kdf = pp.DataFrame({("x", "a"): ['a', 'b', 'c']})
+    >>> kdf = ps.DataFrame({("x", "a"): ['a', 'b', 'c']})
     >>> kdf["__dummy__"] = 0
     >>> kdf[("", "__dummy__")] = 1
     >>> kdf  # doctest: +NORMALIZE_WHITESPACE
@@ -888,7 +888,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.utils.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.utils tests").getOrCreate()
     )

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -27,7 +27,7 @@ from pyspark.pandas.missing.window import (
 )
 
 # For running doctests and reference resolution in PyCharm.
-from pyspark import pandas as pp  # noqa: F401
+from pyspark import pandas as ps  # noqa: F401
 
 from pyspark.pandas.internal import NATURAL_ORDER_COLUMN_NAME, SPARK_INDEX_NAME_FORMAT
 from pyspark.pandas.utils import scol_for
@@ -176,7 +176,7 @@ class Rolling(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([2, 3, float("nan"), 10])
+        >>> s = ps.Series([2, 3, float("nan"), 10])
         >>> s.rolling(1).count()
         0    1.0
         1    1.0
@@ -231,7 +231,7 @@ class Rolling(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([4, 3, 5, 2, 6])
+        >>> s = ps.Series([4, 3, 5, 2, 6])
         >>> s
         0    4
         1    3
@@ -258,7 +258,7 @@ class Rolling(RollingAndExpanding):
 
         For DataFrame, each rolling summation is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df
            A   B
         0  4  16
@@ -309,7 +309,7 @@ class Rolling(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([4, 3, 5, 2, 6])
+        >>> s = ps.Series([4, 3, 5, 2, 6])
         >>> s
         0    4
         1    3
@@ -336,7 +336,7 @@ class Rolling(RollingAndExpanding):
 
         For DataFrame, each rolling minimum is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df
            A   B
         0  4  16
@@ -386,7 +386,7 @@ class Rolling(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([4, 3, 5, 2, 6])
+        >>> s = ps.Series([4, 3, 5, 2, 6])
         >>> s
         0    4
         1    3
@@ -413,7 +413,7 @@ class Rolling(RollingAndExpanding):
 
         For DataFrame, each rolling maximum is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df
            A   B
         0  4  16
@@ -464,7 +464,7 @@ class Rolling(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([4, 3, 5, 2, 6])
+        >>> s = ps.Series([4, 3, 5, 2, 6])
         >>> s
         0    4
         1    3
@@ -491,7 +491,7 @@ class Rolling(RollingAndExpanding):
 
         For DataFrame, each rolling mean is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df
            A   B
         0  4  16
@@ -542,7 +542,7 @@ class Rolling(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([5, 5, 6, 7, 5, 5, 5])
+        >>> s = ps.Series([5, 5, 6, 7, 5, 5, 5])
         >>> s.rolling(3).std()
         0         NaN
         1         NaN
@@ -555,7 +555,7 @@ class Rolling(RollingAndExpanding):
 
         For DataFrame, each rolling standard deviation is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.rolling(2).std()
                   A          B
         0       NaN        NaN
@@ -592,7 +592,7 @@ class Rolling(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([5, 5, 6, 7, 5, 5, 5])
+        >>> s = ps.Series([5, 5, 6, 7, 5, 5, 5])
         >>> s.rolling(3).var()
         0         NaN
         1         NaN
@@ -605,7 +605,7 @@ class Rolling(RollingAndExpanding):
 
         For DataFrame, each unbiased rolling variance is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.rolling(2).var()
              A      B
         0  NaN    NaN
@@ -745,7 +745,7 @@ class RollingGroupby(Rolling):
 
         Examples
         --------
-        >>> s = pp.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
         >>> s.groupby(s).rolling(3).count().sort_index()
         2  0     1.0
            1     2.0
@@ -762,7 +762,7 @@ class RollingGroupby(Rolling):
 
         For DataFrame, each rolling count is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).rolling(2).count().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                 A    B
         A
@@ -799,7 +799,7 @@ class RollingGroupby(Rolling):
 
         Examples
         --------
-        >>> s = pp.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
         >>> s.groupby(s).rolling(3).sum().sort_index()
         2  0      NaN
            1      NaN
@@ -816,7 +816,7 @@ class RollingGroupby(Rolling):
 
         For DataFrame, each rolling summation is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).rolling(2).sum().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                  A     B
         A
@@ -853,7 +853,7 @@ class RollingGroupby(Rolling):
 
         Examples
         --------
-        >>> s = pp.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
         >>> s.groupby(s).rolling(3).min().sort_index()
         2  0     NaN
            1     NaN
@@ -870,7 +870,7 @@ class RollingGroupby(Rolling):
 
         For DataFrame, each rolling minimum is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).rolling(2).min().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                 A     B
         A
@@ -907,7 +907,7 @@ class RollingGroupby(Rolling):
 
         Examples
         --------
-        >>> s = pp.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
         >>> s.groupby(s).rolling(3).max().sort_index()
         2  0     NaN
            1     NaN
@@ -924,7 +924,7 @@ class RollingGroupby(Rolling):
 
         For DataFrame, each rolling maximum is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).rolling(2).max().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                 A     B
         A
@@ -961,7 +961,7 @@ class RollingGroupby(Rolling):
 
         Examples
         --------
-        >>> s = pp.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
         >>> s.groupby(s).rolling(3).mean().sort_index()
         2  0     NaN
            1     NaN
@@ -978,7 +978,7 @@ class RollingGroupby(Rolling):
 
         For DataFrame, each rolling mean is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).rolling(2).mean().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                 A     B
         A
@@ -1092,7 +1092,7 @@ class Expanding(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([2, 3, float("nan"), 10])
+        >>> s = ps.Series([2, 3, float("nan"), 10])
         >>> s.expanding().count()
         0    1.0
         1    2.0
@@ -1140,7 +1140,7 @@ class Expanding(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([1, 2, 3, 4, 5])
+        >>> s = ps.Series([1, 2, 3, 4, 5])
         >>> s
         0    1
         1    2
@@ -1159,7 +1159,7 @@ class Expanding(RollingAndExpanding):
 
         For DataFrame, each expanding summation is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df
            A   B
         0  1   1
@@ -1204,7 +1204,7 @@ class Expanding(RollingAndExpanding):
         --------
         Performing a expanding minimum with a window size of 3.
 
-        >>> s = pp.Series([4, 3, 5, 2, 6])
+        >>> s = ps.Series([4, 3, 5, 2, 6])
         >>> s.expanding(3).min()
         0    NaN
         1    NaN
@@ -1240,7 +1240,7 @@ class Expanding(RollingAndExpanding):
         --------
         Performing a expanding minimum with a window size of 3.
 
-        >>> s = pp.Series([4, 3, 5, 2, 6])
+        >>> s = ps.Series([4, 3, 5, 2, 6])
         >>> s.expanding(3).max()
         0    NaN
         1    NaN
@@ -1278,7 +1278,7 @@ class Expanding(RollingAndExpanding):
         The below examples will show expanding mean calculations with window sizes of
         two and three, respectively.
 
-        >>> s = pp.Series([1, 2, 3, 4])
+        >>> s = ps.Series([1, 2, 3, 4])
         >>> s.expanding(2).mean()
         0    NaN
         1    1.5
@@ -1319,7 +1319,7 @@ class Expanding(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([5, 5, 6, 7, 5, 5, 5])
+        >>> s = ps.Series([5, 5, 6, 7, 5, 5, 5])
         >>> s.expanding(3).std()
         0         NaN
         1         NaN
@@ -1332,7 +1332,7 @@ class Expanding(RollingAndExpanding):
 
         For DataFrame, each expanding standard deviation variance is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.expanding(2).std()
                   A          B
         0       NaN        NaN
@@ -1369,7 +1369,7 @@ class Expanding(RollingAndExpanding):
 
         Examples
         --------
-        >>> s = pp.Series([5, 5, 6, 7, 5, 5, 5])
+        >>> s = ps.Series([5, 5, 6, 7, 5, 5, 5])
         >>> s.expanding(3).var()
         0         NaN
         1         NaN
@@ -1382,7 +1382,7 @@ class Expanding(RollingAndExpanding):
 
         For DataFrame, each unbiased expanding variance is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.expanding(2).var()
                   A           B
         0       NaN         NaN
@@ -1449,7 +1449,7 @@ class ExpandingGroupby(Expanding):
 
         Examples
         --------
-        >>> s = pp.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
         >>> s.groupby(s).expanding(3).count().sort_index()
         2  0     NaN
            1     NaN
@@ -1466,7 +1466,7 @@ class ExpandingGroupby(Expanding):
 
         For DataFrame, each expanding count is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).expanding(2).count().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                 A    B
         A
@@ -1503,7 +1503,7 @@ class ExpandingGroupby(Expanding):
 
         Examples
         --------
-        >>> s = pp.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
         >>> s.groupby(s).expanding(3).sum().sort_index()
         2  0      NaN
            1      NaN
@@ -1520,7 +1520,7 @@ class ExpandingGroupby(Expanding):
 
         For DataFrame, each expanding summation is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).expanding(2).sum().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                  A     B
         A
@@ -1557,7 +1557,7 @@ class ExpandingGroupby(Expanding):
 
         Examples
         --------
-        >>> s = pp.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
         >>> s.groupby(s).expanding(3).min().sort_index()
         2  0     NaN
            1     NaN
@@ -1574,7 +1574,7 @@ class ExpandingGroupby(Expanding):
 
         For DataFrame, each expanding minimum is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).expanding(2).min().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                 A     B
         A
@@ -1610,7 +1610,7 @@ class ExpandingGroupby(Expanding):
 
         Examples
         --------
-        >>> s = pp.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
         >>> s.groupby(s).expanding(3).max().sort_index()
         2  0     NaN
            1     NaN
@@ -1627,7 +1627,7 @@ class ExpandingGroupby(Expanding):
 
         For DataFrame, each expanding maximum is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).expanding(2).max().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                 A     B
         A
@@ -1664,7 +1664,7 @@ class ExpandingGroupby(Expanding):
 
         Examples
         --------
-        >>> s = pp.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
+        >>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
         >>> s.groupby(s).expanding(3).mean().sort_index()
         2  0     NaN
            1     NaN
@@ -1681,7 +1681,7 @@ class ExpandingGroupby(Expanding):
 
         For DataFrame, each expanding mean is computed column-wise.
 
-        >>> df = pp.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
+        >>> df = ps.DataFrame({"A": s.to_numpy(), "B": s.to_numpy() ** 2})
         >>> df.groupby(df.A).expanding(2).mean().sort_index()  # doctest: +NORMALIZE_WHITESPACE
                 A     B
         A
@@ -1749,7 +1749,7 @@ def _test():
     os.chdir(os.environ["SPARK_HOME"])
 
     globs = pyspark.pandas.window.__dict__.copy()
-    globs["pp"] = pyspark.pandas
+    globs["ps"] = pyspark.pandas
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.window tests").getOrCreate()
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix:

```python
import pyspark.pandas as pp
```

to

```python
import pyspark.pandas as ps
```

### Why are the changes needed?

`pp` might sound offensive in some contexts.

### Does this PR introduce _any_ user-facing change?

The change is in master only. We'll use `ps` as the short name instead of `pp`.

### How was this patch tested?

The CI in this PR will test it out.