### PR TITLE
[SPARK-35039][PYTHON] Remove PySpark version dependent codes.

### DIFF
--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -54,55 +54,9 @@ def assert_python_version():
         )
 
 
-def assert_pyspark_version():
-    import logging
-
-    try:
-        import pyspark
-    except ImportError:
-        raise ImportError(
-            "Unable to import pyspark - consider doing a pip install with [spark] "
-            "extra to install pyspark with pip"
-        )
-    else:
-        pyspark_ver = getattr(pyspark, "__version__")
-        if pyspark_ver is None or LooseVersion(pyspark_ver) < LooseVersion("2.4"):
-            logging.warning(
-                'Found pyspark version "{}" installed. pyspark>=2.4.0 is recommended.'.format(
-                    pyspark_ver if pyspark_ver is not None else "<unknown version>"
-                )
-            )
-
-
 assert_python_version()
-assert_pyspark_version()
 
-import pyspark
 import pyarrow
-
-if LooseVersion(pyspark.__version__) < LooseVersion("3.0"):
-    if (
-        LooseVersion(pyarrow.__version__) >= LooseVersion("0.15")
-        and "ARROW_PRE_0_15_IPC_FORMAT" not in os.environ
-    ):
-        import logging
-
-        logging.warning(
-            "'ARROW_PRE_0_15_IPC_FORMAT' environment variable was not set. It is required to "
-            "set this environment variable to '1' in both driver and executor sides if you use "
-            "pyarrow>=0.15 and pyspark<3.0. "
-            "Koalas will set it for you but it does not work if there is a Spark context already "
-            "launched."
-        )
-        # This is required to support PyArrow 0.15 in PySpark versions lower than 3.0.
-        # See SPARK-29367.
-        os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
-elif "ARROW_PRE_0_15_IPC_FORMAT" in os.environ:
-    raise RuntimeError(
-        "Please explicitly unset 'ARROW_PRE_0_15_IPC_FORMAT' environment variable in both "
-        "driver and executor sides. It is required to set this environment variable only "
-        "when you use pyarrow>=0.15 and pyspark<3.0."
-    )
 
 if (
     LooseVersion(pyarrow.__version__) >= LooseVersion("2.0.0")

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -80,7 +80,6 @@ from pyspark.sql.window import Window
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.accessors import KoalasFrameMethods
 from pyspark.pandas.config import option_context, get_option
-from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.spark.accessors import SparkFrameMethods, CachedSparkFrameMethods
 from pyspark.pandas.utils import (
     align_diff_frames,
@@ -10740,7 +10739,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         def quantile(spark_column, spark_type):
             if isinstance(spark_type, (BooleanType, NumericType)):
-                return SF.percentile_approx(spark_column.cast(DoubleType()), q, accuracy)
+                return F.percentile_approx(spark_column.cast(DoubleType()), q, accuracy)
             else:
                 raise TypeError(
                     "Could not convert {} ({}) to numeric".format(

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -43,7 +43,6 @@ from pyspark.sql.types import (
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from pyspark.pandas.internal import InternalFrame
-from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import Scalar, spark_type_to_pandas_dtype
 from pyspark.pandas.utils import (
     is_name_like_tuple,
@@ -1902,7 +1901,7 @@ class Frame(object, metaclass=ABCMeta):
 
         def median(spark_column, spark_type):
             if isinstance(spark_type, (BooleanType, NumericType)):
-                return SF.percentile_approx(spark_column.cast(DoubleType()), 0.5, accuracy)
+                return F.percentile_approx(spark_column.cast(DoubleType()), 0.5, accuracy)
             else:
                 raise TypeError(
                     "Could not convert {} ({}) to numeric".format(

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -30,7 +30,6 @@ import numpy as np  # noqa: F401
 import pandas as pd
 from pandas.api.types import is_list_like
 
-import pyspark
 from pyspark.sql import functions as F
 from pyspark.sql.types import (
     BooleanType,
@@ -2453,9 +2452,6 @@ class Frame(object, metaclass=ABCMeta):
         >>> s.last_valid_index()  # doctest: +SKIP
         ('cow', 'weight')
         """
-        if LooseVersion(pyspark.__version__) < LooseVersion("3.0"):
-            raise RuntimeError("last_valid_index can be used in PySpark >= 3.0")
-
         data_spark_columns = self._internal.data_spark_columns
 
         if len(data_spark_columns) == 0:

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -71,7 +71,6 @@ from pyspark.pandas.utils import (
 from pyspark.pandas.spark.utils import as_nullable_spark_type, force_decimal_precision_scale
 from pyspark.pandas.window import RollingGroupby, ExpandingGroupby
 from pyspark.pandas.exceptions import DataError
-from pyspark.pandas.spark import functions as SF
 
 # to keep it the same as pandas
 NamedAgg = namedtuple("NamedAgg", ["column", "aggfunc"])
@@ -2421,7 +2420,7 @@ class GroupBy(object, metaclass=ABCMeta):
                 "accuracy must be an integer; however, got [%s]" % type(accuracy).__name__
             )
 
-        stat_function = lambda col: SF.percentile_approx(col, 0.5, accuracy)
+        stat_function = lambda col: F.percentile_approx(col, 0.5, accuracy)
         return self._reduce_for_stat_function(stat_function, only_numeric=numeric_only)
 
     def _reduce_for_stat_function(self, sfun, only_numeric):

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -24,7 +24,6 @@ import pandas as pd
 from pandas.api.types import is_list_like
 from pandas.api.types import is_hashable
 
-import pyspark
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Window
 
@@ -38,7 +37,6 @@ from pyspark.pandas.missing.indexes import MissingPandasLikeMultiIndex
 from pyspark.pandas.series import Series, first_series
 from pyspark.pandas.utils import (
     compare_disallow_null,
-    default_session,
     is_name_like_tuple,
     name_like_string,
     scol_for,
@@ -864,25 +862,6 @@ class MultiIndex(Index):
             data_dtypes=[],
         )
         return cast(MultiIndex, DataFrame(internal).index)
-
-    def value_counts(
-        self, normalize=False, sort=True, ascending=False, bins=None, dropna=True
-    ) -> Series:
-        if (
-            LooseVersion(pyspark.__version__) < LooseVersion("2.4")
-            and default_session().conf.get("spark.sql.execution.arrow.enabled") == "true"
-            and isinstance(self, MultiIndex)
-        ):
-            raise RuntimeError(
-                "if you're using pyspark < 2.4, set conf "
-                "'spark.sql.execution.arrow.enabled' to 'false' "
-                "for using this function with MultiIndex"
-            )
-        return super().value_counts(
-            normalize=normalize, sort=sort, ascending=ascending, bins=bins, dropna=dropna
-        )
-
-    value_counts.__doc__ = IndexOpsMixin.value_counts.__doc__
 
     def argmax(self) -> None:
         raise TypeError("reduction operation 'argmax' not allowed for this dtype")

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -30,7 +30,6 @@ from pyspark.sql import functions as F, Window
 # For running doctests and reference resolution in PyCharm.
 from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas.exceptions import PandasNotImplementedError
-from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.missing.indexes import MissingPandasLikeMultiIndex

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -30,7 +30,7 @@ from pyspark import sql as spark
 from pyspark._globals import _NoValue, _NoValueType
 from pyspark.sql import functions as F, Window
 from pyspark.sql.functions import PandasUDFType, pandas_udf
-from pyspark.sql.types import BooleanType, DataType, IntegralType, StructField, StructType, LongType
+from pyspark.sql.types import BooleanType, DataType, StructField, StructType, LongType
 
 try:
     from pyspark.sql.types import to_arrow_type

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -18,7 +18,6 @@
 """
 An internal immutable DataFrame with some metadata to manage indexes.
 """
-from distutils.version import LooseVersion
 import re
 from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from itertools import accumulate
@@ -27,7 +26,6 @@ import py4j
 import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype, is_datetime64_dtype, is_datetime64tz_dtype
-import pyspark
 from pyspark import sql as spark
 from pyspark._globals import _NoValue, _NoValueType
 from pyspark.sql import functions as F, Window
@@ -936,17 +934,6 @@ class InternalFrame(object):
             pdf = pdf.astype(
                 {field.name: spark_type_to_pandas_dtype(field.dataType) for field in sdf.schema}
             )
-        elif LooseVersion(pyspark.__version__) < LooseVersion("3.0"):
-            for field in sdf.schema:
-                if field.nullable and pdf[field.name].isnull().all():
-                    if isinstance(field.dataType, BooleanType):
-                        pdf[field.name] = pdf[field.name].astype(np.object)
-                    elif isinstance(field.dataType, IntegralType):
-                        pdf[field.name] = pdf[field.name].astype(np.float64)
-                    else:
-                        pdf[field.name] = pdf[field.name].astype(
-                            spark_type_to_pandas_dtype(field.dataType)
-                        )
 
         return InternalFrame.restore_index(pdf, **self.arguments_for_restore_index)
 

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -31,7 +31,6 @@ import pandas as pd
 from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype, is_list_like
 import pyarrow as pa
 import pyarrow.parquet as pq
-import pyspark
 from pyspark import sql as spark
 from pyspark.sql import functions as F
 from pyspark.sql.functions import pandas_udf, PandasUDFType
@@ -736,9 +735,6 @@ def read_parquet(path, columns=None, index_col=None, pandas_metadata=False, **op
     index_names = None
 
     if index_col is None and pandas_metadata:
-        if LooseVersion(pyspark.__version__) < LooseVersion("3.0.0"):
-            raise ValueError("pandas_metadata is not supported with Spark < 3.0.")
-
         # Try to read pandas metadata
 
         @pandas_udf("index_col array<string>, index_names array<string>", PandasUDFType.SCALAR)
@@ -1073,11 +1069,6 @@ def read_excel(
         )
 
     if isinstance(io, str):
-        if LooseVersion(pyspark.__version__) < LooseVersion("3.0.0"):
-            raise ValueError(
-                "The `io` parameter as a string is not supported if the underlying Spark is "
-                "below 3.0. You can use `ps.from_pandas(pd.read_excel(...))` as a workaround"
-            )
         # 'binaryFile' format is available since Spark 3.0.0.
         binaries = default_session().read.format("binaryFile").load(io).select("content").head(2)
         io_or_bin = binaries[0][0]

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4984,12 +4984,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             )
 
         if isinstance(repeats, Series):
-            if LooseVersion(pyspark.__version__) < LooseVersion("2.4"):
-                raise ValueError(
-                    "`repeats` argument must be integer with Spark<2.4, but got {}".format(
-                        type(repeats)
-                    )
-                )
             if not same_anchor(self, repeats):
                 kdf = self.to_frame()
                 temp_repeats = verify_temp_column_name(kdf, "__temp_repeats__")

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -82,7 +82,6 @@ from pyspark.pandas.utils import (
     SPARK_CONF_ARROW_ENABLED,
 )
 from pyspark.pandas.datetimes import DatetimeMethods
-from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.spark.accessors import SparkSeriesMethods
 from pyspark.pandas.strings import StringMethods
 from pyspark.pandas.typedef import (
@@ -3415,7 +3414,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
             def quantile(spark_column, spark_type):
                 if isinstance(spark_type, (BooleanType, NumericType)):
-                    return SF.percentile_approx(spark_column.cast(DoubleType()), q, accuracy)
+                    return F.percentile_approx(spark_column.cast(DoubleType()), q, accuracy)
                 else:
                     raise TypeError(
                         "Could not convert {} ({}) to numeric".format(
@@ -4993,7 +4992,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 )
             else:
                 scol = F.explode(
-                    SF.array_repeat(self.spark.column, repeats.astype("int32").spark.column)
+                    F.array_repeat(self.spark.column, repeats.astype("int32").spark.column)
                 ).alias(name_like_string(self.name))
                 sdf = self._internal.spark_frame.select(self._internal.index_spark_columns + [scol])
                 internal = self._internal.copy(

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -24,7 +24,6 @@ import inspect
 import sys
 import warnings
 from collections.abc import Mapping
-from distutils.version import LooseVersion
 from functools import partial, wraps, reduce
 from typing import Any, Generic, Iterable, List, Optional, Tuple, TypeVar, Union, cast
 
@@ -35,7 +34,6 @@ from pandas.io.formats.printing import pprint_thing
 from pandas.api.types import is_list_like, is_hashable
 from pandas.api.extensions import ExtensionDtype
 from pandas.tseries.frequencies import DateOffset
-import pyspark
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
 from pyspark.sql.types import (

--- a/python/pyspark/pandas/spark/accessors.py
+++ b/python/pyspark/pandas/spark/accessors.py
@@ -20,10 +20,8 @@ Spark related features. Usually, the features here are missing in pandas
 but Spark has it.
 """
 from abc import ABCMeta, abstractmethod
-from distutils.version import LooseVersion
 from typing import TYPE_CHECKING, Optional, Union, List, cast
 
-import pyspark
 from pyspark import StorageLevel
 from pyspark.sql import Column, DataFrame as SparkDataFrame
 from pyspark.sql.types import DataType, StructType
@@ -881,28 +879,7 @@ class SparkFrameMethods(object):
         == Physical Plan ==
         ...
         """
-        if LooseVersion(pyspark.__version__) < LooseVersion("3.0"):
-            if mode is not None and extended is not None:
-                raise Exception("extended and mode should not be set together.")
-
-            if extended is not None and isinstance(extended, str):
-                mode = extended
-
-            if mode is not None:
-                if mode == "simple":
-                    extended = False
-                elif mode == "extended":
-                    extended = True
-                else:
-                    raise ValueError(
-                        "Unknown spark.explain mode: {}. Accepted spark.explain modes are "
-                        "'simple', 'extended'.".format(mode)
-                    )
-            if extended is None:
-                extended = False
-            self._kdf._internal.to_internal_spark_frame.explain(extended)
-        else:
-            self._kdf._internal.to_internal_spark_frame.explain(extended, mode)
+        self._kdf._internal.to_internal_spark_frame.explain(extended, mode)
 
     def apply(self, func, index_col: Optional[Union[str, List[str]]] = None) -> "ps.DataFrame":
         """

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -19,63 +19,7 @@ Additional Spark functions used in Koalas.
 """
 
 from pyspark import SparkContext
-from pyspark.sql.column import Column, _to_java_column, _to_seq, _create_column_from_literal
-
-
-__all__ = ["percentile_approx"]
-
-
-def percentile_approx(col, percentage, accuracy=10000):
-    """
-    Returns the approximate percentile value of numeric column col at the given percentage.
-    The value of percentage must be between 0.0 and 1.0.
-
-    The accuracy parameter (default: 10000)
-    is a positive numeric literal which controls approximation accuracy at the cost of memory.
-    Higher value of accuracy yields better accuracy, 1.0/accuracy is the relative error
-    of the approximation.
-
-    When percentage is an array, each value of the percentage array must be between 0.0 and 1.0.
-    In this case, returns the approximate percentile array of column col
-    at the given percentage array.
-
-    Ported from Spark 3.1.
-    """
-    sc = SparkContext._active_spark_context
-
-    if isinstance(percentage, (list, tuple)):
-        # A local list
-        percentage = sc._jvm.functions.array(
-            _to_seq(sc, [_create_column_from_literal(x) for x in percentage])
-        )
-    elif isinstance(percentage, Column):
-        # Already a Column
-        percentage = _to_java_column(percentage)
-    else:
-        # Probably scalar
-        percentage = _create_column_from_literal(percentage)
-
-    accuracy = (
-        _to_java_column(accuracy)
-        if isinstance(accuracy, Column)
-        else _create_column_from_literal(accuracy)
-    )
-
-    return _call_udf(sc, "percentile_approx", _to_java_column(col), percentage, accuracy)
-
-
-def array_repeat(col, count):
-    """
-    Collection function: creates an array containing a column repeated count times.
-
-    Ported from Spark 3.0.
-    """
-    sc = SparkContext._active_spark_context
-    return Column(
-        sc._jvm.functions.array_repeat(
-            _to_java_column(col), _to_java_column(count) if isinstance(count, Column) else count
-        )
-    )
+from pyspark.sql.column import Column, _to_java_column, _create_column_from_literal
 
 
 def repeat(col, n):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes PySpark version dependent codes from `pyspark.pandas` main codes.

### Why are the changes needed?

There are several places to check the PySpark version and switch the logic, but now those are not necessary.
We should remove them.

We will do the same thing after we finish porting tests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
