### PR TITLE
[SPARK-35033][PYTHON] Port Koalas plot unit tests into PySpark

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -621,10 +621,10 @@ pyspark_pandas = Module(
         "pyspark.pandas.tests.test_series_datetime",
         "pyspark.pandas.tests.test_series_string",
         "pyspark.pandas.tests.test_frame_plot",
-        "pyspark.pandas.tests.test_series_plot",
         "pyspark.pandas.tests.test_frame_plot_matplotlib",
-        "pyspark.pandas.tests.test_series_plot_matplotlib",
         "pyspark.pandas.tests.test_frame_plot_plotly",
+        "pyspark.pandas.tests.test_series_plot",
+        "pyspark.pandas.tests.test_series_plot_matplotlib",
         "pyspark.pandas.tests.test_series_plot_plotly",
     ],
     excluded_python_implementations=[

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -620,12 +620,12 @@ pyspark_pandas = Module(
         "pyspark.pandas.tests.test_series_conversion",
         "pyspark.pandas.tests.test_series_datetime",
         "pyspark.pandas.tests.test_series_string",
-        "pyspark.pandas.tests.test_frame_plot",
-        "pyspark.pandas.tests.test_frame_plot_matplotlib",
-        "pyspark.pandas.tests.test_frame_plot_plotly",
-        "pyspark.pandas.tests.test_series_plot",
-        "pyspark.pandas.tests.test_series_plot_matplotlib",
-        "pyspark.pandas.tests.test_series_plot_plotly",
+        "pyspark.pandas.tests.plot.test_frame_plot",
+        "pyspark.pandas.tests.plot.test_frame_plot_matplotlib",
+        "pyspark.pandas.tests.plot.test_frame_plot_plotly",
+        "pyspark.pandas.tests.plot.test_series_plot",
+        "pyspark.pandas.tests.plot.test_series_plot_matplotlib",
+        "pyspark.pandas.tests.plot.test_series_plot_plotly",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -620,6 +620,12 @@ pyspark_pandas = Module(
         "pyspark.pandas.tests.test_series_conversion",
         "pyspark.pandas.tests.test_series_datetime",
         "pyspark.pandas.tests.test_series_string",
+        "pyspark.pandas.tests.test_frame_plot",
+        "pyspark.pandas.tests.test_series_plot",
+        "pyspark.pandas.tests.test_frame_plot_matplotlib",
+        "pyspark.pandas.tests.test_series_plot_matplotlib",
+        "pyspark.pandas.tests.test_frame_plot_plotly",
+        "pyspark.pandas.tests.test_series_plot_plotly",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and

--- a/python/pyspark/pandas/testing/utils.py
+++ b/python/pyspark/pandas/testing/utils.py
@@ -42,6 +42,22 @@ except ImportError as e:
     tabulate_requirement_message = str(e)
 have_tabulate = tabulate_requirement_message is None
 
+matplotlib_requirement_message = None
+try:
+    import matplotlib  # noqa: F401
+except ImportError as e:
+    # If matplotlib requirement is not satisfied, skip related tests.
+    matplotlib_requirement_message = str(e)
+have_matplotlib = matplotlib_requirement_message is None
+
+plotly_requirement_message = None
+try:
+    import plotly  # noqa: F401
+except ImportError as e:
+    # If plotly requirement is not satisfied, skip related tests.
+    plotly_requirement_message = str(e)
+have_plotly = plotly_requirement_message is None
+
 
 class SQLTestUtils(object):
     """

--- a/python/pyspark/pandas/tests/plot/__init__.py
+++ b/python/pyspark/pandas/tests/plot/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/pyspark/pandas/tests/plot/test_frame_plot.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot.py
@@ -1,0 +1,123 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pandas as pd
+import numpy as np
+
+from pyspark import pandas as ps
+from pyspark.pandas.config import set_option, reset_option, option_context
+from pyspark.pandas.plot import TopNPlotBase, SampledPlotBase, HistogramPlotBase
+from pyspark.pandas.exceptions import PandasNotImplementedError
+from pyspark.pandas.testing.utils import ReusedSQLTestCase
+
+
+class DataFramePlotTest(ReusedSQLTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        set_option("plotting.max_rows", 2000)
+        set_option("plotting.sample_ratio", None)
+
+    @classmethod
+    def tearDownClass(cls):
+        reset_option("plotting.max_rows")
+        reset_option("plotting.sample_ratio")
+        super().tearDownClass()
+
+    def test_missing(self):
+        kdf = ps.DataFrame(np.random.rand(2500, 4), columns=["a", "b", "c", "d"])
+
+        unsupported_functions = ["box", "hexbin"]
+
+        for name in unsupported_functions:
+            with self.assertRaisesRegex(
+                PandasNotImplementedError, "method.*DataFrame.*{}.*not implemented".format(name)
+            ):
+                getattr(kdf.plot, name)()
+
+    def test_topn_max_rows(self):
+
+        pdf = pd.DataFrame(np.random.rand(2500, 4), columns=["a", "b", "c", "d"])
+        kdf = ps.from_pandas(pdf)
+
+        data = TopNPlotBase().get_top_n(kdf)
+        self.assertEqual(len(data), 2000)
+
+    def test_sampled_plot_with_ratio(self):
+        with option_context("plotting.sample_ratio", 0.5):
+            pdf = pd.DataFrame(np.random.rand(2500, 4), columns=["a", "b", "c", "d"])
+            kdf = ps.from_pandas(pdf)
+            data = SampledPlotBase().get_sampled(kdf)
+            self.assertEqual(round(len(data) / 2500, 1), 0.5)
+
+    def test_sampled_plot_with_max_rows(self):
+        # 'plotting.max_rows' is 2000
+        pdf = pd.DataFrame(np.random.rand(2000, 4), columns=["a", "b", "c", "d"])
+        kdf = ps.from_pandas(pdf)
+        data = SampledPlotBase().get_sampled(kdf)
+        self.assertEqual(round(len(data) / 2000, 1), 1)
+
+    def test_compute_hist_single_column(self):
+        kdf = ps.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50]}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10]
+        )
+
+        expected_bins = np.linspace(1, 50, 11)
+        bins = HistogramPlotBase.get_bins(kdf[["a"]].to_spark(), 10)
+
+        expected_histogram = np.array([5, 4, 1, 0, 0, 0, 0, 0, 0, 1])
+        histogram = HistogramPlotBase.compute_hist(kdf[["a"]], bins)[0]
+        self.assert_eq(pd.Series(expected_bins), pd.Series(bins))
+        self.assert_eq(pd.Series(expected_histogram, name="a"), histogram, almost=True)
+
+    def test_compute_hist_multi_columns(self):
+        expected_bins = np.linspace(1, 50, 11)
+        kdf = ps.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],
+                "b": [50, 50, 30, 30, 30, 24, 10, 5, 4, 3, 1],
+            }
+        )
+
+        bins = HistogramPlotBase.get_bins(kdf.to_spark(), 10)
+        self.assert_eq(pd.Series(expected_bins), pd.Series(bins))
+
+        expected_histograms = [
+            np.array([5, 4, 1, 0, 0, 0, 0, 0, 0, 1]),
+            np.array([4, 1, 0, 0, 1, 3, 0, 0, 0, 2]),
+        ]
+        histograms = HistogramPlotBase.compute_hist(kdf, bins)
+        expected_names = ["a", "b"]
+
+        for histogram, expected_histogram, expected_name in zip(
+            histograms, expected_histograms, expected_names
+        ):
+            self.assert_eq(
+                pd.Series(expected_histogram, name=expected_name), histogram, almost=True
+            )
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.pandas.tests.plot.test_frame_plot import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/plot/test_frame_plot_matplotlib.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot_matplotlib.py
@@ -1,0 +1,467 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import base64
+from distutils.version import LooseVersion
+from io import BytesIO
+
+import matplotlib
+from matplotlib import pyplot as plt
+import pandas as pd
+import numpy as np
+
+from pyspark import pandas as ps
+from pyspark.pandas.config import set_option, reset_option
+from pyspark.pandas.testing.utils import ReusedSQLTestCase, TestUtils
+
+
+matplotlib.use("agg")
+
+
+class DataFramePlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
+    sample_ratio_default = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if LooseVersion(pd.__version__) >= LooseVersion("0.25"):
+            pd.set_option("plotting.backend", "matplotlib")
+        set_option("plotting.backend", "matplotlib")
+        set_option("plotting.max_rows", 2000)
+        set_option("plotting.sample_ratio", None)
+
+    @classmethod
+    def tearDownClass(cls):
+        if LooseVersion(pd.__version__) >= LooseVersion("0.25"):
+            pd.reset_option("plotting.backend")
+        reset_option("plotting.backend")
+        reset_option("plotting.max_rows")
+        reset_option("plotting.sample_ratio")
+        super().tearDownClass()
+
+    @property
+    def pdf1(self):
+        return pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50], "b": [2, 3, 4, 5, 7, 9, 10, 15, 34, 45, 49]},
+            index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10],
+        )
+
+    @property
+    def kdf1(self):
+        return ps.from_pandas(self.pdf1)
+
+    @staticmethod
+    def plot_to_base64(ax):
+        bytes_data = BytesIO()
+        ax.figure.savefig(bytes_data, format="png")
+        bytes_data.seek(0)
+        b64_data = base64.b64encode(bytes_data.read())
+        plt.close(ax.figure)
+        return b64_data
+
+    def test_line_plot(self):
+        def check_line_plot(pdf, kdf):
+            ax1 = pdf.plot(kind="line", colormap="Paired")
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot(kind="line", colormap="Paired")
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax3 = pdf.plot.line(colormap="Paired")
+            bin3 = self.plot_to_base64(ax3)
+            ax4 = kdf.plot.line(colormap="Paired")
+            bin4 = self.plot_to_base64(ax4)
+            self.assertEqual(bin3, bin4)
+
+        pdf1 = self.pdf1
+        kdf1 = self.kdf1
+        check_line_plot(pdf1, kdf1)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "a"), ("y", "b")])
+        pdf1.columns = columns
+        kdf1.columns = columns
+        check_line_plot(pdf1, kdf1)
+
+    def test_area_plot(self):
+        def check_area_plot(pdf, kdf):
+            ax1 = pdf.plot(kind="area", colormap="Paired")
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot(kind="area", colormap="Paired")
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax3 = pdf.plot.area(colormap="Paired")
+            bin3 = self.plot_to_base64(ax3)
+            ax4 = kdf.plot.area(colormap="Paired")
+            bin4 = self.plot_to_base64(ax4)
+            self.assertEqual(bin3, bin4)
+
+        pdf = self.pdf1
+        kdf = self.kdf1
+        check_area_plot(pdf, kdf)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "a"), ("y", "b")])
+        pdf.columns = columns
+        kdf.columns = columns
+        check_area_plot(pdf, kdf)
+
+    def test_area_plot_stacked_false(self):
+        def check_area_plot_stacked_false(pdf, kdf):
+            ax1 = pdf.plot.area(stacked=False)
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot.area(stacked=False)
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            # test if frame area plot is correct when stacked=False because default is True
+
+        pdf = pd.DataFrame(
+            {
+                "sales": [3, 2, 3, 9, 10, 6],
+                "signups": [5, 5, 6, 12, 14, 13],
+                "visits": [20, 42, 28, 62, 81, 50],
+            },
+            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="M"),
+        )
+        kdf = ps.from_pandas(pdf)
+        check_area_plot_stacked_false(pdf, kdf)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "sales"), ("x", "signups"), ("y", "visits")])
+        pdf.columns = columns
+        kdf.columns = columns
+        check_area_plot_stacked_false(pdf, kdf)
+
+    def test_area_plot_y(self):
+        def check_area_plot_y(pdf, kdf, y):
+            ax1 = pdf.plot.area(y=y)
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot.area(y=y)
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+        # test if frame area plot is correct when y is specified
+        pdf = pd.DataFrame(
+            {
+                "sales": [3, 2, 3, 9, 10, 6],
+                "signups": [5, 5, 6, 12, 14, 13],
+                "visits": [20, 42, 28, 62, 81, 50],
+            },
+            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="M"),
+        )
+        kdf = ps.from_pandas(pdf)
+        check_area_plot_y(pdf, kdf, y="sales")
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "sales"), ("x", "signups"), ("y", "visits")])
+        pdf.columns = columns
+        kdf.columns = columns
+        check_area_plot_y(pdf, kdf, y=("x", "sales"))
+
+    def test_barh_plot_with_x_y(self):
+        def check_barh_plot_with_x_y(pdf, kdf, x, y):
+            ax1 = pdf.plot(kind="barh", x=x, y=y, colormap="Paired")
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot(kind="barh", x=x, y=y, colormap="Paired")
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax3 = pdf.plot.barh(x=x, y=y, colormap="Paired")
+            bin3 = self.plot_to_base64(ax3)
+            ax4 = kdf.plot.barh(x=x, y=y, colormap="Paired")
+            bin4 = self.plot_to_base64(ax4)
+            self.assertEqual(bin3, bin4)
+
+        # this is testing plot with specified x and y
+        pdf1 = pd.DataFrame({"lab": ["A", "B", "C"], "val": [10, 30, 20]})
+        kdf1 = ps.from_pandas(pdf1)
+        check_barh_plot_with_x_y(pdf1, kdf1, x="lab", y="val")
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "lab"), ("y", "val")])
+        pdf1.columns = columns
+        kdf1.columns = columns
+        check_barh_plot_with_x_y(pdf1, kdf1, x=("x", "lab"), y=("y", "val"))
+
+    def test_barh_plot(self):
+        def check_barh_plot(pdf, kdf):
+            ax1 = pdf.plot(kind="barh", colormap="Paired")
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot(kind="barh", colormap="Paired")
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax3 = pdf.plot.barh(colormap="Paired")
+            bin3 = self.plot_to_base64(ax3)
+            ax4 = kdf.plot.barh(colormap="Paired")
+            bin4 = self.plot_to_base64(ax4)
+            self.assertEqual(bin3, bin4)
+
+        # this is testing when x or y is not assigned
+        pdf1 = pd.DataFrame({"lab": ["A", "B", "C"], "val": [10, 30, 20]})
+        kdf1 = ps.from_pandas(pdf1)
+        check_barh_plot(pdf1, kdf1)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "lab"), ("y", "val")])
+        pdf1.columns = columns
+        kdf1.columns = columns
+        check_barh_plot(pdf1, kdf1)
+
+    def test_bar_plot(self):
+        def check_bar_plot(pdf, kdf):
+            ax1 = pdf.plot(kind="bar", colormap="Paired")
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot(kind="bar", colormap="Paired")
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax3 = pdf.plot.bar(colormap="Paired")
+            bin3 = self.plot_to_base64(ax3)
+            ax4 = kdf.plot.bar(colormap="Paired")
+            bin4 = self.plot_to_base64(ax4)
+            self.assertEqual(bin3, bin4)
+
+        pdf1 = self.pdf1
+        kdf1 = self.kdf1
+        check_bar_plot(pdf1, kdf1)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "lab"), ("y", "val")])
+        pdf1.columns = columns
+        kdf1.columns = columns
+        check_bar_plot(pdf1, kdf1)
+
+    def test_bar_with_x_y(self):
+        # this is testing plot with specified x and y
+        pdf = pd.DataFrame({"lab": ["A", "B", "C"], "val": [10, 30, 20]})
+        kdf = ps.from_pandas(pdf)
+
+        ax1 = pdf.plot(kind="bar", x="lab", y="val", colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf.plot(kind="bar", x="lab", y="val", colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+        ax3 = pdf.plot.bar(x="lab", y="val", colormap="Paired")
+        bin3 = self.plot_to_base64(ax3)
+        ax4 = kdf.plot.bar(x="lab", y="val", colormap="Paired")
+        bin4 = self.plot_to_base64(ax4)
+        self.assertEqual(bin3, bin4)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "lab"), ("y", "val")])
+        pdf.columns = columns
+        kdf.columns = columns
+
+        ax5 = pdf.plot(kind="bar", x=("x", "lab"), y=("y", "val"), colormap="Paired")
+        bin5 = self.plot_to_base64(ax5)
+        ax6 = kdf.plot(kind="bar", x=("x", "lab"), y=("y", "val"), colormap="Paired")
+        bin6 = self.plot_to_base64(ax6)
+        self.assertEqual(bin5, bin6)
+
+        ax7 = pdf.plot.bar(x=("x", "lab"), y=("y", "val"), colormap="Paired")
+        bin7 = self.plot_to_base64(ax7)
+        ax8 = kdf.plot.bar(x=("x", "lab"), y=("y", "val"), colormap="Paired")
+        bin8 = self.plot_to_base64(ax8)
+        self.assertEqual(bin7, bin8)
+
+    def test_pie_plot(self):
+        def check_pie_plot(pdf, kdf, y):
+            ax1 = pdf.plot.pie(y=y, figsize=(5, 5), colormap="Paired")
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot.pie(y=y, figsize=(5, 5), colormap="Paired")
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax1 = pdf.plot(kind="pie", y=y, figsize=(5, 5), colormap="Paired")
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot(kind="pie", y=y, figsize=(5, 5), colormap="Paired")
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax11, ax12 = pdf.plot.pie(figsize=(5, 5), subplots=True, colormap="Paired")
+            bin11 = self.plot_to_base64(ax11)
+            bin12 = self.plot_to_base64(ax12)
+            self.assertEqual(bin11, bin12)
+
+            ax21, ax22 = kdf.plot.pie(figsize=(5, 5), subplots=True, colormap="Paired")
+            bin21 = self.plot_to_base64(ax21)
+            bin22 = self.plot_to_base64(ax22)
+            self.assertEqual(bin21, bin22)
+
+            ax11, ax12 = pdf.plot(kind="pie", figsize=(5, 5), subplots=True, colormap="Paired")
+            bin11 = self.plot_to_base64(ax11)
+            bin12 = self.plot_to_base64(ax12)
+            self.assertEqual(bin11, bin12)
+
+            ax21, ax22 = kdf.plot(kind="pie", figsize=(5, 5), subplots=True, colormap="Paired")
+            bin21 = self.plot_to_base64(ax21)
+            bin22 = self.plot_to_base64(ax22)
+            self.assertEqual(bin21, bin22)
+
+        pdf1 = pd.DataFrame(
+            {"mass": [0.330, 4.87, 5.97], "radius": [2439.7, 6051.8, 6378.1]},
+            index=["Mercury", "Venus", "Earth"],
+        )
+        kdf1 = ps.from_pandas(pdf1)
+        check_pie_plot(pdf1, kdf1, y="mass")
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "mass"), ("y", "radius")])
+        pdf1.columns = columns
+        kdf1.columns = columns
+        check_pie_plot(pdf1, kdf1, y=("x", "mass"))
+
+    def test_pie_plot_error_message(self):
+        # this is to test if error is correctly raising when y is not specified
+        # and subplots is not set to True
+        pdf = pd.DataFrame(
+            {"mass": [0.330, 4.87, 5.97], "radius": [2439.7, 6051.8, 6378.1]},
+            index=["Mercury", "Venus", "Earth"],
+        )
+        kdf = ps.from_pandas(pdf)
+
+        with self.assertRaises(ValueError) as context:
+            kdf.plot.pie(figsize=(5, 5), colormap="Paired")
+        error_message = "pie requires either y column or 'subplots=True'"
+        self.assertTrue(error_message in str(context.exception))
+
+    def test_scatter_plot(self):
+        def check_scatter_plot(pdf, kdf, x, y, c):
+            ax1 = pdf.plot.scatter(x=x, y=y)
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot.scatter(x=x, y=y)
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax1 = pdf.plot(kind="scatter", x=x, y=y)
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot(kind="scatter", x=x, y=y)
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            # check when keyword c is given as name of a column
+            ax1 = pdf.plot.scatter(x=x, y=y, c=c, s=50)
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot.scatter(x=x, y=y, c=c, s=50)
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+        # Use pandas scatter plot example
+        pdf1 = pd.DataFrame(np.random.rand(50, 4), columns=["a", "b", "c", "d"])
+        kdf1 = ps.from_pandas(pdf1)
+        check_scatter_plot(pdf1, kdf1, x="a", y="b", c="c")
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c"), ("z", "d")])
+        pdf1.columns = columns
+        kdf1.columns = columns
+        check_scatter_plot(pdf1, kdf1, x=("x", "a"), y=("x", "b"), c=("y", "c"))
+
+    def test_hist_plot(self):
+        def check_hist_plot(pdf, kdf):
+            _, ax1 = plt.subplots(1, 1)
+            ax1 = pdf.plot.hist()
+            bin1 = self.plot_to_base64(ax1)
+            _, ax2 = plt.subplots(1, 1)
+            ax2 = kdf.plot.hist()
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax1 = pdf.plot.hist(bins=15)
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot.hist(bins=15)
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax1 = pdf.plot(kind="hist", bins=15)
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot(kind="hist", bins=15)
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+            ax1 = pdf.plot.hist(bins=3, bottom=[2, 1, 3])
+            bin1 = self.plot_to_base64(ax1)
+            ax2 = kdf.plot.hist(bins=3, bottom=[2, 1, 3])
+            bin2 = self.plot_to_base64(ax2)
+            self.assertEqual(bin1, bin2)
+
+        pdf1 = self.pdf1
+        kdf1 = self.kdf1
+        check_hist_plot(pdf1, kdf1)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "a"), ("y", "b")])
+        pdf1.columns = columns
+        kdf1.columns = columns
+        check_hist_plot(pdf1, kdf1)
+
+    def test_kde_plot(self):
+        def moving_average(a, n=10):
+            ret = np.cumsum(a, dtype=float)
+            ret[n:] = ret[n:] - ret[:-n]
+            return ret[n - 1:] / n
+
+        def check_kde_plot(pdf, kdf, *args, **kwargs):
+            _, ax1 = plt.subplots(1, 1)
+            ax1 = pdf.plot.kde(*args, **kwargs)
+            _, ax2 = plt.subplots(1, 1)
+            ax2 = kdf.plot.kde(*args, **kwargs)
+
+            try:
+                for i, (line1, line2) in enumerate(zip(ax1.get_lines(), ax2.get_lines())):
+                    expected = line1.get_xydata().ravel()
+                    actual = line2.get_xydata().ravel()
+                    # TODO: Due to implementation difference, the output is different comparing
+                    # to pandas'. We should identify the root cause of difference, and reduce
+                    # the diff.
+
+                    # Note: Data is from 1 to 50. So, it smooths them by moving average and compares
+                    # both.
+                    self.assertTrue(
+                        np.allclose(moving_average(actual), moving_average(expected), rtol=3.0)
+                    )
+            finally:
+                ax1.cla()
+                ax2.cla()
+
+        pdf1 = self.pdf1
+        kdf1 = self.kdf1
+        check_kde_plot(pdf1, kdf1, bw_method=0.3)
+        check_kde_plot(pdf1, kdf1, ind=[1, 2, 3], bw_method=3.0)
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples([("x", "a"), ("y", "b")])
+        pdf1.columns = columns
+        pdf1.columns = columns
+        check_kde_plot(pdf1, kdf1, bw_method=0.3)
+        check_kde_plot(pdf1, kdf1, ind=[1, 2, 3], bw_method=3.0)
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.pandas.tests.plot.test_frame_plot_matplotlib import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/plot/test_frame_plot_matplotlib.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot_matplotlib.py
@@ -18,20 +18,23 @@
 import base64
 from distutils.version import LooseVersion
 from io import BytesIO
+import unittest
 
-import matplotlib
-from matplotlib import pyplot as plt
 import pandas as pd
 import numpy as np
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
-from pyspark.pandas.testing.utils import ReusedSQLTestCase, TestUtils
+from pyspark.pandas.testing.utils import have_matplotlib, ReusedSQLTestCase, TestUtils
+
+if have_matplotlib:
+    import matplotlib
+    from matplotlib import pyplot as plt
+
+    matplotlib.use("agg")
 
 
-matplotlib.use("agg")
-
-
+@unittest.skipIf(not have_matplotlib, "matplotlib is not installed.")
 class DataFramePlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
     sample_ratio_default = None
 
@@ -456,7 +459,6 @@ class DataFramePlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.plot.test_frame_plot_matplotlib import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
@@ -21,18 +21,21 @@ import pprint
 
 import pandas as pd
 import numpy as np
-from plotly import express
-import plotly.graph_objs as go
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
-from pyspark.pandas.testing.utils import ReusedSQLTestCase, TestUtils
+from pyspark.pandas.testing.utils import ReusedSQLTestCase, TestUtils, have_plotly
 from pyspark.pandas.utils import name_like_string
+
+if have_plotly:
+    from plotly import express
+    import plotly.graph_objs as go
 
 
 @unittest.skipIf(
-    LooseVersion(pd.__version__) < "1.0.0",
-    "pandas<1.0 does not support latest plotly and/or 'plotting.backend' option.",
+    not have_plotly or LooseVersion(pd.__version__) < "1.0.0",
+    "plotly is not installed or pandas<1.0. pandas<1.0 does not support latest plotly "
+    "and/or 'plotting.backend' option.",
 )
 class DataFramePlotPlotlyTest(ReusedSQLTestCase, TestUtils):
     @classmethod

--- a/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
@@ -1,0 +1,267 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from distutils.version import LooseVersion
+import pprint
+
+import pandas as pd
+import numpy as np
+from plotly import express
+import plotly.graph_objs as go
+
+from pyspark import pandas as ps
+from pyspark.pandas.config import set_option, reset_option
+from pyspark.pandas.testing.utils import ReusedSQLTestCase, TestUtils
+from pyspark.pandas.utils import name_like_string
+
+
+@unittest.skipIf(
+    LooseVersion(pd.__version__) < "1.0.0",
+    "pandas<1.0 does not support latest plotly and/or 'plotting.backend' option.",
+)
+class DataFramePlotPlotlyTest(ReusedSQLTestCase, TestUtils):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        pd.set_option("plotting.backend", "plotly")
+        set_option("plotting.backend", "plotly")
+        set_option("plotting.max_rows", 2000)
+        set_option("plotting.sample_ratio", None)
+
+    @classmethod
+    def tearDownClass(cls):
+        pd.reset_option("plotting.backend")
+        reset_option("plotting.backend")
+        reset_option("plotting.max_rows")
+        reset_option("plotting.sample_ratio")
+        super().tearDownClass()
+
+    @property
+    def pdf1(self):
+        return pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50], "b": [2, 3, 4, 5, 7, 9, 10, 15, 34, 45, 49]},
+            index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10],
+        )
+
+    @property
+    def kdf1(self):
+        return ps.from_pandas(self.pdf1)
+
+    def test_line_plot(self):
+        def check_line_plot(pdf, kdf):
+            self.assertEqual(pdf.plot(kind="line"), kdf.plot(kind="line"))
+            self.assertEqual(pdf.plot.line(), kdf.plot.line())
+
+        pdf1 = self.pdf1
+        kdf1 = self.kdf1
+        check_line_plot(pdf1, kdf1)
+
+    def test_area_plot(self):
+        def check_area_plot(pdf, kdf):
+            self.assertEqual(pdf.plot(kind="area"), kdf.plot(kind="area"))
+            self.assertEqual(pdf.plot.area(), kdf.plot.area())
+
+        pdf = self.pdf1
+        kdf = self.kdf1
+        check_area_plot(pdf, kdf)
+
+    def test_area_plot_y(self):
+        def check_area_plot_y(pdf, kdf, y):
+            self.assertEqual(pdf.plot.area(y=y), kdf.plot.area(y=y))
+
+        # test if frame area plot is correct when y is specified
+        pdf = pd.DataFrame(
+            {
+                "sales": [3, 2, 3, 9, 10, 6],
+                "signups": [5, 5, 6, 12, 14, 13],
+                "visits": [20, 42, 28, 62, 81, 50],
+            },
+            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="M"),
+        )
+        kdf = ps.from_pandas(pdf)
+        check_area_plot_y(pdf, kdf, y="sales")
+
+    def test_barh_plot_with_x_y(self):
+        def check_barh_plot_with_x_y(pdf, kdf, x, y):
+            self.assertEqual(pdf.plot(kind="barh", x=x, y=y), kdf.plot(kind="barh", x=x, y=y))
+            self.assertEqual(pdf.plot.barh(x=x, y=y), kdf.plot.barh(x=x, y=y))
+
+        # this is testing plot with specified x and y
+        pdf1 = pd.DataFrame({"lab": ["A", "B", "C"], "val": [10, 30, 20]})
+        kdf1 = ps.from_pandas(pdf1)
+        check_barh_plot_with_x_y(pdf1, kdf1, x="lab", y="val")
+
+    def test_barh_plot(self):
+        def check_barh_plot(pdf, kdf):
+            self.assertEqual(pdf.plot(kind="barh"), kdf.plot(kind="barh"))
+            self.assertEqual(pdf.plot.barh(), kdf.plot.barh())
+
+        # this is testing when x or y is not assigned
+        pdf1 = pd.DataFrame({"lab": [20.1, 40.5, 60.6], "val": [10, 30, 20]})
+        kdf1 = ps.from_pandas(pdf1)
+        check_barh_plot(pdf1, kdf1)
+
+    def test_bar_plot(self):
+        def check_bar_plot(pdf, kdf):
+            self.assertEqual(pdf.plot(kind="bar"), kdf.plot(kind="bar"))
+            self.assertEqual(pdf.plot.bar(), kdf.plot.bar())
+
+        pdf1 = self.pdf1
+        kdf1 = self.kdf1
+        check_bar_plot(pdf1, kdf1)
+
+    def test_bar_with_x_y(self):
+        # this is testing plot with specified x and y
+        pdf = pd.DataFrame({"lab": ["A", "B", "C"], "val": [10, 30, 20]})
+        kdf = ps.from_pandas(pdf)
+
+        self.assertEqual(
+            pdf.plot(kind="bar", x="lab", y="val"), kdf.plot(kind="bar", x="lab", y="val")
+        )
+        self.assertEqual(pdf.plot.bar(x="lab", y="val"), kdf.plot.bar(x="lab", y="val"))
+
+    def test_scatter_plot(self):
+        def check_scatter_plot(pdf, kdf, x, y, c):
+            self.assertEqual(pdf.plot.scatter(x=x, y=y), kdf.plot.scatter(x=x, y=y))
+            self.assertEqual(pdf.plot(kind="scatter", x=x, y=y), kdf.plot(kind="scatter", x=x, y=y))
+
+            # check when keyword c is given as name of a column
+            self.assertEqual(
+                pdf.plot.scatter(x=x, y=y, c=c, s=50), kdf.plot.scatter(x=x, y=y, c=c, s=50)
+            )
+
+        # Use pandas scatter plot example
+        pdf1 = pd.DataFrame(np.random.rand(50, 4), columns=["a", "b", "c", "d"])
+        kdf1 = ps.from_pandas(pdf1)
+        check_scatter_plot(pdf1, kdf1, x="a", y="b", c="c")
+
+    def test_pie_plot(self):
+        def check_pie_plot(kdf):
+            pdf = kdf.to_pandas()
+            self.assertEqual(
+                kdf.plot(kind="pie", y=kdf.columns[0]),
+                express.pie(pdf, values="a", names=pdf.index),
+            )
+
+            self.assertEqual(
+                kdf.plot(kind="pie", values="a"), express.pie(pdf, values="a"),
+            )
+
+        kdf1 = self.kdf1
+        check_pie_plot(kdf1)
+
+        # TODO: support multi-index columns
+        # columns = pd.MultiIndex.from_tuples([("x", "y"), ("y", "z")])
+        # kdf1.columns = columns
+        # check_pie_plot(kdf1)
+
+        # TODO: support multi-index
+        # kdf1 = ps.DataFrame(
+        #     {
+        #         "a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],
+        #         "b": [2, 3, 4, 5, 7, 9, 10, 15, 34, 45, 49]
+        #     },
+        #     index=pd.MultiIndex.from_tuples([("x", "y")] * 11),
+        # )
+        # check_pie_plot(kdf1)
+
+    def test_hist_plot(self):
+        def check_hist_plot(kdf):
+            bins = np.array([1.0, 5.9, 10.8, 15.7, 20.6, 25.5, 30.4, 35.3, 40.2, 45.1, 50.0])
+            data = [
+                np.array([5.0, 4.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
+                np.array([4.0, 3.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0]),
+            ]
+            prev = bins[0]
+            text_bins = []
+            for b in bins[1:]:
+                text_bins.append("[%s, %s)" % (prev, b))
+                prev = b
+            text_bins[-1] = text_bins[-1][:-1] + "]"
+            bins = 0.5 * (bins[:-1] + bins[1:])
+            name_a = name_like_string(kdf.columns[0])
+            name_b = name_like_string(kdf.columns[1])
+            bars = [
+                go.Bar(
+                    x=bins,
+                    y=data[0],
+                    name=name_a,
+                    text=text_bins,
+                    hovertemplate=("variable=" + name_a + "<br>value=%{text}<br>count=%{y}"),
+                ),
+                go.Bar(
+                    x=bins,
+                    y=data[1],
+                    name=name_b,
+                    text=text_bins,
+                    hovertemplate=("variable=" + name_b + "<br>value=%{text}<br>count=%{y}"),
+                ),
+            ]
+            fig = go.Figure(data=bars, layout=go.Layout(barmode="stack"))
+            fig["layout"]["xaxis"]["title"] = "value"
+            fig["layout"]["yaxis"]["title"] = "count"
+
+            self.assertEqual(
+                pprint.pformat(kdf.plot(kind="hist").to_dict()), pprint.pformat(fig.to_dict())
+            )
+
+        kdf1 = self.kdf1
+        check_hist_plot(kdf1)
+
+        columns = pd.MultiIndex.from_tuples([("x", "y"), ("y", "z")])
+        kdf1.columns = columns
+        check_hist_plot(kdf1)
+
+    def test_kde_plot(self):
+        kdf = ps.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 3, 5, 7, 9], "c": [2, 4, 6, 8, 10]})
+
+        pdf = pd.DataFrame(
+            {
+                "Density": [
+                    0.03515491,
+                    0.06834979,
+                    0.00663503,
+                    0.02372059,
+                    0.06834979,
+                    0.01806934,
+                    0.01806934,
+                    0.06834979,
+                    0.02372059,
+                ],
+                "names": ["a", "a", "a", "b", "b", "b", "c", "c", "c"],
+                "index": [-3.5, 5.5, 14.5, -3.5, 5.5, 14.5, -3.5, 5.5, 14.5],
+            }
+        )
+
+        actual = kdf.plot.kde(bw_method=5, ind=3)
+
+        expected = express.line(pdf, x="index", y="Density", color="names")
+        expected["layout"]["xaxis"]["title"] = None
+
+        self.assertEqual(pprint.pformat(actual.to_dict()), pprint.pformat(expected.to_dict()))
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.plot.test_frame_plot_plotly import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/plot/test_series_plot.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot.py
@@ -1,0 +1,99 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+import pandas as pd
+import numpy as np
+
+from databricks import koalas as ks
+from databricks.koalas.plot import KoalasPlotAccessor, BoxPlotBase
+
+
+class SeriesPlotTest(unittest.TestCase):
+    @property
+    def pdf1(self):
+        return pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50]}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10]
+        )
+
+    @property
+    def kdf1(self):
+        return ks.from_pandas(self.pdf1)
+
+    def test_plot_backends(self):
+        plot_backend = "plotly"
+
+        with ks.option_context("plotting.backend", plot_backend):
+            self.assertEqual(ks.options.plotting.backend, plot_backend)
+
+            module = KoalasPlotAccessor._get_plot_backend(plot_backend)
+            self.assertEqual(module.__name__, "databricks.koalas.plot.plotly")
+
+    def test_plot_backends_incorrect(self):
+        fake_plot_backend = "none_plotting_module"
+
+        with ks.option_context("plotting.backend", fake_plot_backend):
+            self.assertEqual(ks.options.plotting.backend, fake_plot_backend)
+
+            with self.assertRaises(ValueError):
+                KoalasPlotAccessor._get_plot_backend(fake_plot_backend)
+
+    def test_box_summary(self):
+        def check_box_summary(kdf, pdf):
+            k = 1.5
+            stats, fences = BoxPlotBase.compute_stats(kdf["a"], "a", whis=k, precision=0.01)
+            outliers = BoxPlotBase.outliers(kdf["a"], "a", *fences)
+            whiskers = BoxPlotBase.calc_whiskers("a", outliers)
+            fliers = BoxPlotBase.get_fliers("a", outliers, whiskers[0])
+
+            expected_mean = pdf["a"].mean()
+            expected_median = pdf["a"].median()
+            expected_q1 = np.percentile(pdf["a"], 25)
+            expected_q3 = np.percentile(pdf["a"], 75)
+            iqr = expected_q3 - expected_q1
+            expected_fences = (expected_q1 - k * iqr, expected_q3 + k * iqr)
+            pdf["outlier"] = ~pdf["a"].between(fences[0], fences[1])
+            expected_whiskers = (
+                pdf.query("not outlier")["a"].min(),
+                pdf.query("not outlier")["a"].max(),
+            )
+            expected_fliers = pdf.query("outlier")["a"].values
+
+            self.assertEqual(expected_mean, stats["mean"])
+            self.assertEqual(expected_median, stats["med"])
+            self.assertEqual(expected_q1, stats["q1"] + 0.5)
+            self.assertEqual(expected_q3, stats["q3"] - 0.5)
+            self.assertEqual(expected_fences[0], fences[0] + 2.0)
+            self.assertEqual(expected_fences[1], fences[1] - 2.0)
+            self.assertEqual(expected_whiskers[0], whiskers[0])
+            self.assertEqual(expected_whiskers[1], whiskers[1])
+            self.assertEqual(expected_fliers, fliers)
+
+        check_box_summary(self.kdf1, self.pdf1)
+        check_box_summary(-self.kdf1, -self.pdf1)
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.plot.test_series_plot import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/plot/test_series_plot.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot.py
@@ -20,8 +20,9 @@ import unittest
 import pandas as pd
 import numpy as np
 
-from databricks import koalas as ks
-from databricks.koalas.plot import KoalasPlotAccessor, BoxPlotBase
+from pyspark import pandas as ps
+from pyspark.pandas.plot import KoalasPlotAccessor, BoxPlotBase
+from pyspark.pandas.testing.utils import have_plotly
 
 
 class SeriesPlotTest(unittest.TestCase):
@@ -33,22 +34,23 @@ class SeriesPlotTest(unittest.TestCase):
 
     @property
     def kdf1(self):
-        return ks.from_pandas(self.pdf1)
+        return ps.from_pandas(self.pdf1)
 
+    @unittest.skipIf(not have_plotly, "plotly is not installed")
     def test_plot_backends(self):
         plot_backend = "plotly"
 
-        with ks.option_context("plotting.backend", plot_backend):
-            self.assertEqual(ks.options.plotting.backend, plot_backend)
+        with ps.option_context("plotting.backend", plot_backend):
+            self.assertEqual(ps.options.plotting.backend, plot_backend)
 
             module = KoalasPlotAccessor._get_plot_backend(plot_backend)
-            self.assertEqual(module.__name__, "databricks.koalas.plot.plotly")
+            self.assertEqual(module.__name__, "pyspark.pandas.plot.plotly")
 
     def test_plot_backends_incorrect(self):
         fake_plot_backend = "none_plotting_module"
 
-        with ks.option_context("plotting.backend", fake_plot_backend):
-            self.assertEqual(ks.options.plotting.backend, fake_plot_backend)
+        with ps.option_context("plotting.backend", fake_plot_backend):
+            self.assertEqual(ps.options.plotting.backend, fake_plot_backend)
 
             with self.assertRaises(ValueError):
                 KoalasPlotAccessor._get_plot_backend(fake_plot_backend)

--- a/python/pyspark/pandas/tests/plot/test_series_plot_matplotlib.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot_matplotlib.py
@@ -1,0 +1,399 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import base64
+from distutils.version import LooseVersion
+from io import BytesIO
+
+import matplotlib
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+
+from pyspark import pandas as ps
+from pyspark.pandas.config import set_option, reset_option
+from pyspark.pandas.testing.utils import ReusedSQLTestCase, TestUtils
+
+matplotlib.use("agg")
+
+
+class SeriesPlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if LooseVersion(pd.__version__) >= LooseVersion("0.25"):
+            pd.set_option("plotting.backend", "matplotlib")
+        set_option("plotting.backend", "matplotlib")
+        set_option("plotting.max_rows", 1000)
+
+    @classmethod
+    def tearDownClass(cls):
+        if LooseVersion(pd.__version__) >= LooseVersion("0.25"):
+            pd.reset_option("plotting.backend")
+        reset_option("plotting.backend")
+        reset_option("plotting.max_rows")
+        super().tearDownClass()
+
+    @property
+    def pdf1(self):
+        return pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50]}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10]
+        )
+
+    @property
+    def kdf1(self):
+        return ps.from_pandas(self.pdf1)
+
+    @property
+    def kdf2(self):
+        return ps.range(1002)
+
+    @property
+    def pdf2(self):
+        return self.kdf2.to_pandas()
+
+    @staticmethod
+    def plot_to_base64(ax):
+        bytes_data = BytesIO()
+        ax.figure.savefig(bytes_data, format="png")
+        bytes_data.seek(0)
+        b64_data = base64.b64encode(bytes_data.read())
+        plt.close(ax.figure)
+        return b64_data
+
+    def test_bar_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        ax1 = pdf["a"].plot(kind="bar", colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["a"].plot(kind="bar", colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+        ax1 = pdf["a"].plot(kind="bar", colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["a"].plot(kind="bar", colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+    def test_bar_plot_limited(self):
+        pdf = self.pdf2
+        kdf = self.kdf2
+
+        _, ax1 = plt.subplots(1, 1)
+        ax1 = pdf["id"][:1000].plot.bar(colormap="Paired")
+        ax1.text(
+            1,
+            1,
+            "showing top 1000 elements only",
+            size=6,
+            ha="right",
+            va="bottom",
+            transform=ax1.transAxes,
+        )
+        bin1 = self.plot_to_base64(ax1)
+
+        _, ax2 = plt.subplots(1, 1)
+        ax2 = kdf["id"].plot.bar(colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+
+        self.assertEqual(bin1, bin2)
+
+    def test_pie_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        ax1 = pdf["a"].plot.pie(colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["a"].plot.pie(colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+        ax1 = pdf["a"].plot(kind="pie", colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["a"].plot(kind="pie", colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+    def test_pie_plot_limited(self):
+        pdf = self.pdf2
+        kdf = self.kdf2
+
+        _, ax1 = plt.subplots(1, 1)
+        ax1 = pdf["id"][:1000].plot.pie(colormap="Paired")
+        ax1.text(
+            1,
+            1,
+            "showing top 1000 elements only",
+            size=6,
+            ha="right",
+            va="bottom",
+            transform=ax1.transAxes,
+        )
+        bin1 = self.plot_to_base64(ax1)
+
+        _, ax2 = plt.subplots(1, 1)
+        ax2 = kdf["id"].plot.pie(colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+
+        self.assertEqual(bin1, bin2)
+
+    def test_line_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        ax1 = pdf["a"].plot(kind="line", colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["a"].plot(kind="line", colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+        ax1 = pdf["a"].plot.line(colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["a"].plot.line(colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+    def test_barh_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        ax1 = pdf["a"].plot(kind="barh", colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["a"].plot(kind="barh", colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+    def test_barh_plot_limited(self):
+        pdf = self.pdf2
+        kdf = self.kdf2
+
+        _, ax1 = plt.subplots(1, 1)
+        ax1 = pdf["id"][:1000].plot.barh(colormap="Paired")
+        ax1.text(
+            1,
+            1,
+            "showing top 1000 elements only",
+            size=6,
+            ha="right",
+            va="bottom",
+            transform=ax1.transAxes,
+        )
+        bin1 = self.plot_to_base64(ax1)
+
+        _, ax2 = plt.subplots(1, 1)
+        ax2 = kdf["id"].plot.barh(colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+
+        self.assertEqual(bin1, bin2)
+
+    def test_hist(self):
+        pdf = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50]}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10]
+        )
+
+        kdf = ps.from_pandas(pdf)
+
+        def plot_to_base64(ax):
+            bytes_data = BytesIO()
+            ax.figure.savefig(bytes_data, format="png")
+            bytes_data.seek(0)
+            b64_data = base64.b64encode(bytes_data.read())
+            plt.close(ax.figure)
+            return b64_data
+
+        _, ax1 = plt.subplots(1, 1)
+        # Using plot.hist() because pandas changes ticks props when called hist()
+        ax1 = pdf["a"].plot.hist()
+        _, ax2 = plt.subplots(1, 1)
+        ax2 = kdf["a"].hist()
+        self.assert_eq(plot_to_base64(ax1), plot_to_base64(ax2))
+
+    def test_hist_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        _, ax1 = plt.subplots(1, 1)
+        ax1 = pdf["a"].plot.hist()
+        bin1 = self.plot_to_base64(ax1)
+        _, ax2 = plt.subplots(1, 1)
+        ax2 = kdf["a"].plot.hist()
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+        ax1 = pdf["a"].plot.hist(bins=15)
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["a"].plot.hist(bins=15)
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+        ax1 = pdf["a"].plot(kind="hist", bins=15)
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["a"].plot(kind="hist", bins=15)
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+        ax1 = pdf["a"].plot.hist(bins=3, bottom=[2, 1, 3])
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["a"].plot.hist(bins=3, bottom=[2, 1, 3])
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+    def test_area_plot(self):
+        pdf = pd.DataFrame(
+            {
+                "sales": [3, 2, 3, 9, 10, 6],
+                "signups": [5, 5, 6, 12, 14, 13],
+                "visits": [20, 42, 28, 62, 81, 50],
+            },
+            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="M"),
+        )
+        kdf = ps.from_pandas(pdf)
+
+        ax1 = pdf["sales"].plot(kind="area", colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["sales"].plot(kind="area", colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+        ax1 = pdf["sales"].plot.area(colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf["sales"].plot.area(colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+        # just a sanity check for df.col type
+        ax1 = pdf.sales.plot(kind="area", colormap="Paired")
+        bin1 = self.plot_to_base64(ax1)
+        ax2 = kdf.sales.plot(kind="area", colormap="Paired")
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+    def test_box_plot(self):
+        def check_box_plot(pser, kser, *args, **kwargs):
+            _, ax1 = plt.subplots(1, 1)
+            ax1 = pser.plot.box(*args, **kwargs)
+            _, ax2 = plt.subplots(1, 1)
+            ax2 = kser.plot.box(*args, **kwargs)
+
+            diffs = [
+                np.array([0, 0.5, 0, 0.5, 0, -0.5, 0, -0.5, 0, 0.5]),
+                np.array([0, 0.5, 0, 0]),
+                np.array([0, -0.5, 0, 0]),
+            ]
+
+            try:
+                for i, (line1, line2) in enumerate(zip(ax1.get_lines(), ax2.get_lines())):
+                    expected = line1.get_xydata().ravel()
+                    actual = line2.get_xydata().ravel()
+                    if i < 3:
+                        actual += diffs[i]
+                    self.assert_eq(pd.Series(expected), pd.Series(actual))
+            finally:
+                ax1.cla()
+                ax2.cla()
+
+        # Non-named Series
+        pser = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50], [0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10])
+        kser = ps.from_pandas(pser)
+
+        spec = [(self.pdf1.a, self.kdf1.a), (pser, kser)]
+
+        for p, k in spec:
+            check_box_plot(p, k)
+            check_box_plot(p, k, showfliers=True)
+            check_box_plot(p, k, sym="")
+            check_box_plot(p, k, sym=".", color="r")
+            check_box_plot(p, k, use_index=False, labels=["Test"])
+            check_box_plot(p, k, usermedians=[2.0])
+            check_box_plot(p, k, conf_intervals=[(1.0, 3.0)])
+
+        val = (1, 3)
+        self.assertRaises(
+            ValueError, lambda: check_box_plot(self.pdf1, self.kdf1, usermedians=[2.0, 3.0])
+        )
+        self.assertRaises(
+            ValueError, lambda: check_box_plot(self.pdf1, self.kdf1, conf_intervals=[val, val])
+        )
+        self.assertRaises(
+            ValueError, lambda: check_box_plot(self.pdf1, self.kdf1, conf_intervals=[(1,)])
+        )
+
+    def test_kde_plot(self):
+        def moving_average(a, n=10):
+            ret = np.cumsum(a, dtype=float)
+            ret[n:] = ret[n:] - ret[:-n]
+            return ret[n - 1:] / n
+
+        def check_kde_plot(pdf, kdf, *args, **kwargs):
+            _, ax1 = plt.subplots(1, 1)
+            ax1 = pdf["a"].plot.kde(*args, **kwargs)
+            _, ax2 = plt.subplots(1, 1)
+            ax2 = kdf["a"].plot.kde(*args, **kwargs)
+
+            try:
+                for i, (line1, line2) in enumerate(zip(ax1.get_lines(), ax2.get_lines())):
+                    expected = line1.get_xydata().ravel()
+                    actual = line2.get_xydata().ravel()
+                    # TODO: Due to implementation difference, the output is different comparing
+                    # to pandas'. We should identify the root cause of difference, and reduce
+                    # the diff.
+
+                    # Note: Data is from 1 to 50. So, it smooths them by moving average and compares
+                    # both.
+                    self.assertTrue(
+                        np.allclose(moving_average(actual), moving_average(expected), rtol=3)
+                    )
+            finally:
+                ax1.cla()
+                ax2.cla()
+
+        check_kde_plot(self.pdf1, self.kdf1, bw_method=0.3)
+        check_kde_plot(self.pdf1, self.kdf1, ind=[1, 2, 3, 4, 5], bw_method=3.0)
+
+    def test_empty_hist(self):
+        pdf = self.pdf1.assign(categorical="A")
+        kdf = ps.from_pandas(pdf)
+        kser = kdf["categorical"]
+
+        with self.assertRaisesRegex(TypeError, "Empty 'DataFrame': no numeric data to plot"):
+            kser.plot.hist()
+
+    def test_single_value_hist(self):
+        pdf = self.pdf1.assign(single=2)
+        kdf = ps.from_pandas(pdf)
+
+        _, ax1 = plt.subplots(1, 1)
+        ax1 = pdf["single"].plot.hist()
+        bin1 = self.plot_to_base64(ax1)
+        _, ax2 = plt.subplots(1, 1)
+        ax2 = kdf["single"].plot.hist()
+        bin2 = self.plot_to_base64(ax2)
+        self.assertEqual(bin1, bin2)
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.pandas.tests.plot.test_series_plot_matplotlib import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/plot/test_series_plot_matplotlib.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot_matplotlib.py
@@ -18,19 +18,23 @@
 import base64
 from distutils.version import LooseVersion
 from io import BytesIO
+import unittest
 
-import matplotlib
-from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
-from pyspark.pandas.testing.utils import ReusedSQLTestCase, TestUtils
+from pyspark.pandas.testing.utils import have_matplotlib, ReusedSQLTestCase, TestUtils
 
-matplotlib.use("agg")
+if have_matplotlib:
+    import matplotlib
+    from matplotlib import pyplot as plt
+
+    matplotlib.use("agg")
 
 
+@unittest.skipIf(not have_matplotlib, "matplotlib is not installed.")
 class SeriesPlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
     @classmethod
     def setUpClass(cls):
@@ -388,7 +392,6 @@ class SeriesPlotMatplotlibTest(ReusedSQLTestCase, TestUtils):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.plot.test_series_plot_matplotlib import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
@@ -1,0 +1,238 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from distutils.version import LooseVersion
+import pprint
+
+import pandas as pd
+import numpy as np
+from plotly import express
+import plotly.graph_objs as go
+
+from pyspark import pandas as ps
+from pyspark.pandas.config import set_option, reset_option
+from pyspark.pandas.testing.utils import ReusedSQLTestCase, TestUtils
+from pyspark.pandas.utils import name_like_string
+
+
+@unittest.skipIf(
+    LooseVersion(pd.__version__) < "1.0.0",
+    "pandas<1.0 does not support latest plotly and/or 'plotting.backend' option.",
+)
+class SeriesPlotPlotlyTest(ReusedSQLTestCase, TestUtils):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        pd.set_option("plotting.backend", "plotly")
+        set_option("plotting.backend", "plotly")
+        set_option("plotting.max_rows", 1000)
+        set_option("plotting.sample_ratio", None)
+
+    @classmethod
+    def tearDownClass(cls):
+        pd.reset_option("plotting.backend")
+        reset_option("plotting.backend")
+        reset_option("plotting.max_rows")
+        reset_option("plotting.sample_ratio")
+        super().tearDownClass()
+
+    @property
+    def pdf1(self):
+        return pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50]}, index=[0, 1, 3, 5, 6, 8, 9, 9, 9, 10, 10]
+        )
+
+    @property
+    def kdf1(self):
+        return ps.from_pandas(self.pdf1)
+
+    @property
+    def kdf2(self):
+        return ps.range(1002)
+
+    @property
+    def pdf2(self):
+        return self.kdf2.to_pandas()
+
+    def test_bar_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        self.assertEqual(pdf["a"].plot(kind="bar"), kdf["a"].plot(kind="bar"))
+        self.assertEqual(pdf["a"].plot.bar(), kdf["a"].plot.bar())
+
+    def test_line_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        self.assertEqual(pdf["a"].plot(kind="line"), kdf["a"].plot(kind="line"))
+        self.assertEqual(pdf["a"].plot.line(), kdf["a"].plot.line())
+
+    def test_barh_plot(self):
+        pdf = self.pdf1
+        kdf = self.kdf1
+
+        self.assertEqual(pdf["a"].plot(kind="barh"), kdf["a"].plot(kind="barh"))
+
+    def test_area_plot(self):
+        pdf = pd.DataFrame(
+            {
+                "sales": [3, 2, 3, 9, 10, 6],
+                "signups": [5, 5, 6, 12, 14, 13],
+                "visits": [20, 42, 28, 62, 81, 50],
+            },
+            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="M"),
+        )
+        kdf = ps.from_pandas(pdf)
+
+        self.assertEqual(pdf["sales"].plot(kind="area"), kdf["sales"].plot(kind="area"))
+        self.assertEqual(pdf["sales"].plot.area(), kdf["sales"].plot.area())
+
+        # just a sanity check for df.col type
+        self.assertEqual(pdf.sales.plot(kind="area"), kdf.sales.plot(kind="area"))
+
+    def test_pie_plot(self):
+        kdf = self.kdf1
+        pdf = kdf.to_pandas()
+        self.assertEqual(
+            kdf["a"].plot(kind="pie"), express.pie(pdf, values=pdf.columns[0], names=pdf.index),
+        )
+
+        # TODO: support multi-index columns
+        # columns = pd.MultiIndex.from_tuples([("x", "y")])
+        # kdf.columns = columns
+        # pdf.columns = columns
+        # self.assertEqual(
+        #     kdf[("x", "y")].plot(kind="pie"),
+        #     express.pie(pdf, values=pdf.iloc[:, 0].to_numpy(), names=pdf.index.to_numpy()),
+        # )
+
+        # TODO: support multi-index
+        # kdf = ps.DataFrame(
+        #     {
+        #         "a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 50],
+        #         "b": [2, 3, 4, 5, 7, 9, 10, 15, 34, 45, 49]
+        #     },
+        #     index=pd.MultiIndex.from_tuples([("x", "y")] * 11),
+        # )
+        # pdf = kdf.to_pandas()
+        # self.assertEqual(
+        #     kdf["a"].plot(kind="pie"), express.pie(pdf, values=pdf.columns[0], names=pdf.index),
+        # )
+
+    def test_hist_plot(self):
+        def check_hist_plot(kser):
+            bins = np.array([1.0, 5.9, 10.8, 15.7, 20.6, 25.5, 30.4, 35.3, 40.2, 45.1, 50.0])
+            data = np.array([5.0, 4.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+            prev = bins[0]
+            text_bins = []
+            for b in bins[1:]:
+                text_bins.append("[%s, %s)" % (prev, b))
+                prev = b
+            text_bins[-1] = text_bins[-1][:-1] + "]"
+            bins = 0.5 * (bins[:-1] + bins[1:])
+            name_a = name_like_string(kser.name)
+            bars = [
+                go.Bar(
+                    x=bins,
+                    y=data,
+                    name=name_a,
+                    text=text_bins,
+                    hovertemplate=("variable=" + name_a + "<br>value=%{text}<br>count=%{y}"),
+                ),
+            ]
+            fig = go.Figure(data=bars, layout=go.Layout(barmode="stack"))
+            fig["layout"]["xaxis"]["title"] = "value"
+            fig["layout"]["yaxis"]["title"] = "count"
+
+            self.assertEqual(
+                pprint.pformat(kser.plot(kind="hist").to_dict()), pprint.pformat(fig.to_dict())
+            )
+
+        kdf1 = self.kdf1
+        check_hist_plot(kdf1["a"])
+
+        columns = pd.MultiIndex.from_tuples([("x", "y")])
+        kdf1.columns = columns
+        check_hist_plot(kdf1[("x", "y")])
+
+    def test_pox_plot(self):
+        def check_pox_plot(kser):
+            fig = go.Figure()
+            fig.add_trace(
+                go.Box(
+                    name=name_like_string(kser.name),
+                    q1=[3],
+                    median=[6],
+                    q3=[9],
+                    mean=[10.0],
+                    lowerfence=[1],
+                    upperfence=[15],
+                    y=[[50]],
+                    boxpoints="suspectedoutliers",
+                    notched=False,
+                )
+            )
+            fig["layout"]["xaxis"]["title"] = name_like_string(kser.name)
+            fig["layout"]["yaxis"]["title"] = "value"
+
+            self.assertEqual(
+                pprint.pformat(kser.plot(kind="box").to_dict()), pprint.pformat(fig.to_dict())
+            )
+
+        kdf1 = self.kdf1
+        check_pox_plot(kdf1["a"])
+
+        columns = pd.MultiIndex.from_tuples([("x", "y")])
+        kdf1.columns = columns
+        check_pox_plot(kdf1[("x", "y")])
+
+    def test_pox_plot_arguments(self):
+        with self.assertRaisesRegex(ValueError, "does not support"):
+            self.kdf1.a.plot.box(boxpoints="all")
+        with self.assertRaisesRegex(ValueError, "does not support"):
+            self.kdf1.a.plot.box(notched=True)
+        self.kdf1.a.plot.box(hovertext="abc")  # other arguments should not throw an exception
+
+    def test_kde_plot(self):
+        kdf = ps.DataFrame({"a": [1, 2, 3, 4, 5]})
+        pdf = pd.DataFrame(
+            {
+                "Density": [0.05709372, 0.07670272, 0.05709372],
+                "names": ["a", "a", "a"],
+                "index": [-1.0, 3.0, 7.0],
+            }
+        )
+
+        actual = kdf.a.plot.kde(bw_method=5, ind=3)
+
+        expected = express.line(pdf, x="index", y="Density")
+        expected["layout"]["xaxis"]["title"] = None
+
+        self.assertEqual(pprint.pformat(actual.to_dict()), pprint.pformat(expected.to_dict()))
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.plot.test_series_plot_plotly import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
@@ -21,18 +21,21 @@ import pprint
 
 import pandas as pd
 import numpy as np
-from plotly import express
-import plotly.graph_objs as go
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
-from pyspark.pandas.testing.utils import ReusedSQLTestCase, TestUtils
+from pyspark.pandas.testing.utils import have_plotly, ReusedSQLTestCase, TestUtils
 from pyspark.pandas.utils import name_like_string
+
+if have_plotly:
+    from plotly import express
+    import plotly.graph_objs as go
 
 
 @unittest.skipIf(
-    LooseVersion(pd.__version__) < "1.0.0",
-    "pandas<1.0 does not support latest plotly and/or 'plotting.backend' option.",
+    not have_plotly or LooseVersion(pd.__version__) < "1.0.0",
+    "plotly is not installed or pandas<1.0. pandas<1.0 does not support latest plotly "
+    "and/or 'plotting.backend' option.",
 )
 class SeriesPlotPlotlyTest(ReusedSQLTestCase, TestUtils):
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?
Now that we merged the Koalas main code into the PySpark code base (#32036), we should port the Koalas plot unit tests to PySpark.

### Why are the changes needed?
Currently, the pandas-on-Spark modules are not tested fully. We should enable the plot unit tests.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Enable plot unit tests.