### PR TITLE
[MINOR][PYTHON][DOCS] Fix docstring for pyspark.sql.DataFrameWriter.json lineSep param

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -1223,7 +1223,8 @@ class DataFrameWriter(OptionUtils):
         encoding : str, optional
             specifies encoding (charset) of saved json files. If None is set,
             the default UTF-8 charset will be used.
-        lineSep : str, optional defines the line separator that should be used for writing. If None is
+        lineSep : str, optional
+            defines the line separator that should be used for writing. If None is
             set, it uses the default value, ``\\n``.
         ignoreNullFields : str or bool, optional
             Whether to ignore null fields when generating JSON objects.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new line to the `lineSep` parameter so that the doc renders correctly.

### Why are the changes needed?

> <img width="608" alt="image" src="https://user-images.githubusercontent.com/8269566/114631408-5c608900-9c71-11eb-8ded-ae1e21ae48b2.png">

The first line of the description is part of the signature and is **bolded**.

### Does this PR introduce _any_ user-facing change?

Yes, it changes how the docs for `pyspark.sql.DataFrameWriter.json` are rendered.

### How was this patch tested?

I didn't test it; I don't have the doc rendering tool chain on my machine, but the change is obvious.
