### PR TITLE
[SPARK-35086][SQL][CORE] --verbose should be passed to Spark SQL CLI too

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -852,6 +852,9 @@ private[spark] class SparkSubmit extends Logging {
     }
     sparkConf.set(SUBMIT_PYTHON_FILES, formattedPyFiles.split(",").toSeq)
 
+    if (args.verbose) {
+      childArgs ++= Seq("--verbose")
+    }
     (childArgs.toSeq, childClasspath.toSeq, sparkConf, childMainClass)
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -147,8 +147,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
       }
 
       // If we haven't found all expected answers and another expected answer comes up...
-      if (next < expectedAnswers.size && !line.contains("spark-sql>") &&
-        line.contains(expectedAnswers(next))) {
+      if (next < expectedAnswers.size && line.contains(expectedAnswers(next))) {
         log.info(s"$source> found expected output line $next: '${expectedAnswers(next)}'")
         next += 1
         // If all expected answers have been found...

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -136,6 +136,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     val lock = new Object
 
     def captureOutput(source: String)(line: String): Unit = lock.synchronized {
+      println(line)
       // This test suite sometimes gets extremely slow out of unknown reason on Jenkins.  Here we
       // add a timestamp to provide more diagnosis information.
       val newLine = s"${new Timestamp(new Date().getTime)} - $source> $line"
@@ -147,7 +148,9 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
       }
 
       // If we haven't found all expected answers and another expected answer comes up...
-      if (next < expectedAnswers.size && line.contains(expectedAnswers(next))) {
+      if
+      (next < expectedAnswers.size && !line.contains("spark-sql>") &&
+        line.contains(expectedAnswers(next))) {
         log.info(s"$source> found expected output line $next: '${expectedAnswers(next)}'")
         next += 1
         // If all expected answers have been found...

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -136,7 +136,6 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     val lock = new Object
 
     def captureOutput(source: String)(line: String): Unit = lock.synchronized {
-      println(line)
       // This test suite sometimes gets extremely slow out of unknown reason on Jenkins.  Here we
       // add a timestamp to provide more diagnosis information.
       val newLine = s"${new Timestamp(new Date().getTime)} - $source> $line"
@@ -148,8 +147,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
       }
 
       // If we haven't found all expected answers and another expected answer comes up...
-      if
-      (next < expectedAnswers.size && !line.contains("spark-sql>") &&
+      if (next < expectedAnswers.size && !line.contains("spark-sql>") &&
         line.contains(expectedAnswers(next))) {
         log.info(s"$source> found expected output line $next: '${expectedAnswers(next)}'")
         next += 1

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -596,9 +596,9 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
   }
 
   test("SPARK-35086: --verbose should be passed to Spark SQL CLI") {
-    runCliWithin(2.minute,
-      Seq("--verbose"))(
-      "SELECT 1;" -> "SELECT 1"
+    runCliWithin(2.minute, Seq("--verbose"))(
+      "SELECT 'SPARK-35086' AS c1, '--verbose' AS c2;" ->
+        "SELECT 'SPARK-35086' AS c1, '--verbose' AS c2"
     )
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -594,4 +594,11 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
         -> "BroadcastHashJoin"
     )
   }
+
+  test("SPARK-35086: --verbose should be passed to Spark SQL CLI") {
+    runCliWithin(2.minute,
+      Seq("--verbose"))(
+      "SELECT 1;" -> "SELECT 1"
+    )
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In current code, if we run spark sql with 
```
./bin/spark-sql --verbose
```
It won't be passed to end SparkSQLCliDriver, then the SessionState won't call `setIsVerbose`

In the CLI option, it shows
```
CLI options:
 -v,--verbose                     Verbose mode (echo executed SQL to the
                                  console)
```

It's not consistent. This pr fix this issue
### Why are the changes needed?
Fix bug


### Does this PR introduce _any_ user-facing change?
when user call `-v` when run spark sql, sql will be echoed to console.


### How was this patch tested?
Added UT
