### PR TITLE
[SPARK-35071][PYTHON] Rename Koalas to pandas-on-Spark in main codes

### DIFF
--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -42,11 +42,12 @@ def assert_python_version():
 
     if sys.version_info[:2] <= deprecated_version:
         warnings.warn(
-            "Koalas support for Python {dep_ver} is deprecated and will be dropped in "
+            "pandas-on-Spark support for Python {dep_ver} is deprecated and will be dropped in "
             "the future release. At that point, existing Python {dep_ver} workflows "
-            "that use Koalas will continue to work without modification, but Python {dep_ver} "
-            "users will no longer get access to the latest Koalas features and bugfixes. "
-            "We recommend that you upgrade to Python {min_ver} or newer.".format(
+            "that use pandas-on-Spark will continue to work without modification, but "
+            "Python {dep_ver} users will no longer get access to the latest pandas-on-Spark "
+            "features and bugfixes. We recommend that you upgrade to Python {min_ver} or "
+            "newer.".format(
                 dep_ver=".".join(map(str, deprecated_version)),
                 min_ver=".".join(map(str, min_supported_version)),
             ),
@@ -68,8 +69,8 @@ if (
         "'PYARROW_IGNORE_TIMEZONE' environment variable was not set. It is required to "
         "set this environment variable to '1' in both driver and executor sides if you use "
         "pyarrow>=2.0.0. "
-        "Koalas will set it for you but it does not work if there is a Spark context already "
-        "launched."
+        "pandas-on-Spark will set it for you but it does not work if there is a Spark context "
+        "already launched."
     )
     os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
 

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 """
-Koalas specific features.
+pandas-on-Spark specific features.
 """
 import inspect
 from typing import Any, Optional, Tuple, Union, TYPE_CHECKING, cast
@@ -47,8 +47,8 @@ if TYPE_CHECKING:
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
-class KoalasFrameMethods(object):
-    """ Koalas specific features for DataFrame. """
+class PandasOnSparkFrameMethods(object):
+    """ pandas-on-Spark specific features for DataFrame. """
 
     def __init__(self, frame: "DataFrame"):
         self._kdf = frame
@@ -194,10 +194,10 @@ class KoalasFrameMethods(object):
         See also `Transform and apply a function
         <https://koalas.readthedocs.io/en/latest/user_guide/transform_apply.html>`_.
 
-        .. note:: the `func` is unable to access to the whole input frame. Koalas internally
-            splits the input series into multiple batches and calls `func` with each batch multiple
-            times. Therefore, operations such as global aggregations are impossible. See the example
-            below.
+        .. note:: the `func` is unable to access to the whole input frame. pandas-on-Spark
+            internally splits the input series into multiple batches and calls `func` with each
+            batch multiple times. Therefore, operations such as global aggregations are impossible.
+            See the example below.
 
             >>> # This case does not return the length of whole frame but of the batch internally
             ... # used.
@@ -286,7 +286,7 @@ class KoalasFrameMethods(object):
            A  B
         0  1  2
 
-        You can also omit the type hints so Koalas infers the return schema as below:
+        You can also omit the type hints so pandas-on-Spark infers the return schema as below:
 
         >>> df.koalas.apply_batch(lambda pdf: pdf.query('A == 1'))
            A  B
@@ -400,10 +400,10 @@ class KoalasFrameMethods(object):
         See also `Transform and apply a function
         <https://koalas.readthedocs.io/en/latest/user_guide/transform_apply.html>`_.
 
-        .. note:: the `func` is unable to access to the whole input frame. Koalas internally
-            splits the input series into multiple batches and calls `func` with each batch multiple
-            times. Therefore, operations such as global aggregations are impossible. See the example
-            below.
+        .. note:: the `func` is unable to access to the whole input frame. pandas-on-Spark
+            internally splits the input series into multiple batches and calls `func` with each
+            batch multiple times. Therefore, operations such as global aggregations are impossible.
+            See the example below.
 
             >>> # This case does not return the length of whole frame but of the batch internally
             ... # used.
@@ -497,7 +497,7 @@ class KoalasFrameMethods(object):
         2    7
         dtype: int64
 
-        You can also omit the type hints so Koalas infers the return schema as below:
+        You can also omit the type hints so pandas-on-Spark infers the return schema as below:
 
         >>> df.koalas.transform_batch(lambda pdf: pdf + 1)
            A  B
@@ -699,8 +699,8 @@ class KoalasFrameMethods(object):
                 return DataFrame(internal)
 
 
-class KoalasSeriesMethods(object):
-    """ Koalas specific features for Series. """
+class PandasOnSparkSeriesMethods(object):
+    """ pandas-on-Spark specific features for Series. """
 
     def __init__(self, series: "Series"):
         self._kser = series
@@ -713,10 +713,10 @@ class KoalasSeriesMethods(object):
         See also `Transform and apply a function
         <https://koalas.readthedocs.io/en/latest/user_guide/transform_apply.html>`_.
 
-        .. note:: the `func` is unable to access to the whole input series. Koalas internally
-            splits the input series into multiple batches and calls `func` with each batch multiple
-            times. Therefore, operations such as global aggregations are impossible. See the example
-            below.
+        .. note:: the `func` is unable to access to the whole input series. pandas-on-Spark
+            internally splits the input series into multiple batches and calls `func` with each
+            batch multiple times. Therefore, operations such as global aggregations are impossible.
+            See the example below.
 
             >>> # This case does not return the length of whole frame but of the batch internally
             ... # used.
@@ -774,7 +774,7 @@ class KoalasSeriesMethods(object):
         2    6
         Name: A, dtype: int64
 
-        You can also omit the type hints so Koalas infers the return schema as below:
+        You can also omit the type hints so pandas-on-Spark infers the return schema as below:
 
         >>> df.A.koalas.transform_batch(lambda pser: pser + 1)
         0    2

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -56,7 +56,7 @@ from pyspark.pandas.typedef import (
     Dtype,
     as_spark_type,
     extension_dtypes,
-    koalas_dtype,
+    pandas_on_spark_type,
     spark_type_to_pandas_dtype,
 )
 from pyspark.pandas.utils import (
@@ -213,8 +213,8 @@ def column_op(f):
     """
     A decorator that wraps APIs taking/returning Spark Column so that pandas-on-Spark Series can be
     supported too. If this decorator is used for the `f` function that takes Spark Column and
-    returns Spark Column, decorated `f` takes pandas-on-Spark Series as well and returns Koalas
-    Series.
+    returns Spark Column, decorated `f` takes pandas-on-Spark Series as well and returns
+    pandas-on-Spark Series.
 
     :param f: a function that takes Spark Column and returns Spark Column.
     :param self: pandas-on-Spark Series
@@ -1086,7 +1086,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         >>> ser.rename("a").to_frame().set_index("a").index.astype('int64')
         Int64Index([1, 2], dtype='int64', name='a')
         """
-        dtype, spark_type = koalas_dtype(dtype)
+        dtype, spark_type = pandas_on_spark_type(dtype)
         if not spark_type:
             raise ValueError("Type {} not understood".format(dtype))
 
@@ -1653,13 +1653,13 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         If Index has name, keep the name up.
 
-        >>> idx = ps.Index([0, 0, 0, 1, 1, 2, 3], name='koalas')
+        >>> idx = ps.Index([0, 0, 0, 1, 1, 2, 3], name='pandas-on-Spark')
         >>> idx.value_counts().sort_index()
         0    3
         1    2
         2    1
         3    1
-        Name: koalas, dtype: int64
+        Name: pandas-on-Spark, dtype: int64
         """
         from pyspark.pandas.series import first_series
 

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -16,7 +16,7 @@
 #
 
 """
-Base and utility classes for Koalas objects.
+Base and utility classes for pandas-on-Spark objects.
 """
 from abc import ABCMeta, abstractmethod
 import datetime
@@ -211,13 +211,13 @@ def booleanize_null(scol, f) -> Column:
 
 def column_op(f):
     """
-    A decorator that wraps APIs taking/returning Spark Column so that Koalas Series can be
+    A decorator that wraps APIs taking/returning Spark Column so that pandas-on-Spark Series can be
     supported too. If this decorator is used for the `f` function that takes Spark Column and
-    returns Spark Column, decorated `f` takes Koalas Series as well and returns Koalas
+    returns Spark Column, decorated `f` takes pandas-on-Spark Series as well and returns Koalas
     Series.
 
     :param f: a function that takes Spark Column and returns Spark Column.
-    :param self: Koalas Series
+    :param self: pandas-on-Spark Series
     :param args: arguments that the function `f` takes.
     """
 
@@ -226,7 +226,7 @@ def column_op(f):
         from pyspark.pandas.series import Series
 
         # It is possible for the function `f` takes other arguments than Spark Column.
-        # To cover this case, explicitly check if the argument is Koalas Series and
+        # To cover this case, explicitly check if the argument is pandas-on-Spark Series and
         # extract Spark Column. For other arguments, they are used as are.
         cols = [arg for arg in args if isinstance(arg, IndexOpsMixin)]
 
@@ -719,7 +719,8 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             return result
         else:
             # TODO: support more APIs?
-            raise NotImplementedError("Koalas objects currently do not support %s." % ufunc)
+            raise NotImplementedError(
+                "pandas-on-Spark objects currently do not support %s." % ufunc)
 
     @property
     def dtype(self) -> Dtype:
@@ -802,7 +803,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             transferred to single node which can easily cause out-of-memory error currently.
 
         .. note:: Disable the Spark config `spark.sql.optimizer.nestedSchemaPruning.enabled`
-            for multi-index if you're using Koalas < 1.7.0 with PySpark 3.1.1.
+            for multi-index if you're using pandas-on-Spark < 1.7.0 with PySpark 3.1.1.
 
         Returns
         -------
@@ -880,7 +881,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             to single node which can easily cause out-of-memory error currently.
 
         .. note:: Disable the Spark config `spark.sql.optimizer.nestedSchemaPruning.enabled`
-            for multi-index if you're using Koalas < 1.7.0 with PySpark 3.1.1.
+            for multi-index if you're using pandas-on-Spark < 1.7.0 with PySpark 3.1.1.
 
         Returns
         -------
@@ -1053,7 +1054,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     def astype(self, dtype: Union[str, type, Dtype]) -> Union["Index", "Series"]:
         """
-        Cast a Koalas object to a specified dtype ``dtype``.
+        Cast a pandas-on-Spark object to a specified dtype ``dtype``.
 
         Parameters
         ----------
@@ -1705,10 +1706,10 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             If False, will use the exact algorithm and return the exact number of unique.
             If True, it uses the HyperLogLog approximate algorithm, which is significantly faster
             for large amount of data.
-            Note: This parameter is specific to Koalas and is not found in pandas.
+            Note: This parameter is specific to pandas-on-Spark and is not found in pandas.
         rsd: float, default 0.05
             Maximum estimation error allowed in the HyperLogLog algorithm.
-            Note: Just like ``approx`` this parameter is specific to Koalas.
+            Note: Just like ``approx`` this parameter is specific to pandas-on-Spark.
 
         Returns
         -------

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -16,7 +16,7 @@
 #
 
 """
-Infrastructure of options for Koalas.
+Infrastructure of options for pandas-on-Spark.
 """
 from contextlib import contextmanager
 import json
@@ -120,7 +120,7 @@ _options = [
     Option(
         key="display.max_rows",
         doc=(
-            "This sets the maximum number of rows Koalas should output when printing out "
+            "This sets the maximum number of rows pandas-on-Spark should output when printing out "
             "various output. For example, this value determines the number of rows to be "
             "shown at the repr() in a dataframe. Set `None` to unlimit the input length. "
             "Default is 1000."
@@ -135,10 +135,10 @@ _options = [
     Option(
         key="compute.max_rows",
         doc=(
-            "'compute.max_rows' sets the limit of the current Koalas DataFrame. Set `None` to "
-            "unlimit the input length. When the limit is set, it is executed by the shortcut by "
-            "collecting the data into the driver, and then using the pandas API. If the limit is "
-            "unset, the operation is executed by PySpark. Default is 1000."
+            "'compute.max_rows' sets the limit of the current pandas-on-Spark DataFrame. "
+            "Set `None` to unlimit the input length. When the limit is set, it is executed "
+            "by the shortcut by collecting the data into the driver, and then using the pandas "
+            "API. If the limit is unset, the operation is executed by PySpark. Default is 1000."
         ),
         default=1000,
         types=(int, type(None)),
@@ -152,7 +152,7 @@ _options = [
         doc=(
             "'compute.shortcut_limit' sets the limit for a shortcut. "
             "It computes specified number of rows and use its schema. When the dataframe "
-            "length is larger than this limit, Koalas uses PySpark to compute."
+            "length is larger than this limit, pandas-on-Spark uses PySpark to compute."
         ),
         default=1000,
         types=int,
@@ -186,9 +186,10 @@ _options = [
         key="compute.ordered_head",
         doc=(
             "'compute.ordered_head' sets whether or not to operate head with natural ordering. "
-            "Koalas does not guarantee the row ordering so `head` could return some rows from "
-            "distributed partitions. If 'compute.ordered_head' is set to True, Koalas performs "
-            "natural ordering beforehand, but it will cause a performance overhead."
+            "pandas-on-Spark does not guarantee the row ordering so `head` could return some "
+            "rows from distributed partitions. If 'compute.ordered_head' is set to True, "
+            "pandas-on-Spark performs natural ordering beforehand, but it will cause a "
+            "performance overhead."
         ),
         default=False,
         types=bool,

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -236,7 +236,7 @@ _options = [
 
 _options_dict = dict(zip((option.key for option in _options), _options))  # type: Dict[str, Option]
 
-_key_format = "koalas.{}".format
+_key_format = "pandas_on_Spark.{}".format
 
 
 class OptionError(AttributeError, KeyError):

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -16,7 +16,7 @@
 #
 
 """
-Date/Time related functions on Koalas Series
+Date/Time related functions on pandas-on-Spark Series
 """
 from typing import TYPE_CHECKING
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 
 class DatetimeMethods(object):
-    """Date/Time methods for Koalas Series"""
+    """Date/Time methods for pandas-on-Spark Series"""
 
     def __init__(self, series: "ps.Series"):
         if not isinstance(series.spark.data_type, (DateType, TimestampType)):

--- a/python/pyspark/pandas/exceptions.py
+++ b/python/pyspark/pandas/exceptions.py
@@ -16,7 +16,7 @@
 #
 
 """
-Exceptions/Errors used in Koalas.
+Exceptions/Errors used in pandas-on-Spark.
 """
 
 
@@ -79,7 +79,7 @@ class PandasNotImplementedError(NotImplementedError):
                 if deprecated:
                     msg = (
                         "The method `{0}.{1}()` is deprecated in pandas and will therefore "
-                        + "not be supported in Koalas. {2}"
+                        + "not be supported in pandas-on-Spark. {2}"
                     ).format(class_name, method_name, reason)
                 else:
                     if reason == "":
@@ -93,7 +93,7 @@ class PandasNotImplementedError(NotImplementedError):
             if deprecated:
                 msg = (
                     "The property `{0}.{1}()` is deprecated in pandas and will therefore "
-                    + "not be supported in Koalas. {2}"
+                    + "not be supported in pandas-on-Spark. {2}"
                 ).format(class_name, property_name, reason)
             else:
                 if reason == "":

--- a/python/pyspark/pandas/extensions.py
+++ b/python/pyspark/pandas/extensions.py
@@ -39,7 +39,7 @@ class CachedAccessor:
     This object is not meant to be instantiated directly. Instead, use register_dataframe_accessor,
     register_series_accessor, or register_index_accessor.
 
-    The Koalas accessor is modified based on pandas.core.accessor.
+    The pandas-on-Spark accessor is modified based on pandas.core.accessor.
     """
 
     def __init__(self, name, accessor):
@@ -77,8 +77,8 @@ def _register_accessor(name, cls):
 
     Notes
     -----
-    When accessed, your accessor will be initialiazed with the Koalas object the user is interacting
-    with. The code signature must be:
+    When accessed, your accessor will be initialiazed with the pandas-on-Spark object the user
+    is interacting with. The code signature must be:
 
     .. code-block:: python
 
@@ -87,11 +87,11 @@ def _register_accessor(name, cls):
         ...
 
     In the pandas API, if data passed to your accessor has an incorrect dtype, it's recommended to
-    raise an ``AttributeError`` for consistency purposes. In Koalas, ``ValueError`` is more
+    raise an ``AttributeError`` for consistency purposes. In pandas-on-Spark, ``ValueError`` is more
     frequently used to annotate when a value's datatype is unexpected for a given method/function.
 
-    Ultimately, you can structure this however you like, but Koalas would likely do something like
-    this:
+    Ultimately, you can structure this however you like, but pandas-on-Spark would likely do
+    something like this:
 
     >>> ps.Series(['a', 'b']).dt
     ...
@@ -140,16 +140,16 @@ def register_dataframe_accessor(name):
 
     Notes
     -----
-    When accessed, your accessor will be initialiazed with the Koalas object the user is interacting
-    with. The accessor's init method should always ingest the object being accessed. See the
-    examples for the init signature.
+    When accessed, your accessor will be initialiazed with the pandas-on-Spark object the user
+    is interacting with. The accessor's init method should always ingest the object being accessed.
+    See the examples for the init signature.
 
     In the pandas API, if data passed to your accessor has an incorrect dtype, it's recommended to
-    raise an ``AttributeError`` for consistency purposes. In Koalas, ``ValueError`` is more
+    raise an ``AttributeError`` for consistency purposes. In pandas-on-Spark, ``ValueError`` is more
     frequently used to annotate when a value's datatype is unexpected for a given method/function.
 
-    Ultimately, you can structure this however you like, but Koalas would likely do something like
-    this:
+    Ultimately, you can structure this however you like, but pandas-on-Spark would likely do
+    something like this:
 
     >>> ps.Series(['a', 'b']).dt
     ...
@@ -218,19 +218,19 @@ def register_series_accessor(name):
 
     Notes
     -----
-    When accessed, your accessor will be initialiazed with the Koalas object the user is interacting
-    with. The code signature must be::
+    When accessed, your accessor will be initialiazed with the pandas-on-Spark object the user is
+    interacting with. The code signature must be::
 
         def __init__(self, koalas_obj):
             # constructor logic
         ...
 
     In the pandas API, if data passed to your accessor has an incorrect dtype, it's recommended to
-    raise an ``AttributeError`` for consistency purposes. In Koalas, ``ValueError`` is more
+    raise an ``AttributeError`` for consistency purposes. In pandas-on-Spark, ``ValueError`` is more
     frequently used to annotate when a value's datatype is unexpected for a given method/function.
 
-    Ultimately, you can structure this however you like, but Koalas would likely do something like
-    this:
+    Ultimately, you can structure this however you like, but pandas-on-Spark would likely do
+    something like this:
 
     >>> ps.Series(['a', 'b']).dt
     ...
@@ -290,19 +290,19 @@ def register_index_accessor(name):
 
     Notes
     -----
-    When accessed, your accessor will be initialiazed with the Koalas object the user is interacting
-    with. The code signature must be::
+    When accessed, your accessor will be initialiazed with the pandas-on-Spark object the user is
+    interacting with. The code signature must be::
 
         def __init__(self, koalas_obj):
             # constructor logic
         ...
 
     In the pandas API, if data passed to your accessor has an incorrect dtype, it's recommended to
-    raise an ``AttributeError`` for consistency purposes. In Koalas, ``ValueError`` is more
+    raise an ``AttributeError`` for consistency purposes. In pandas-on-Spark, ``ValueError`` is more
     frequently used to annotate when a value's datatype is unexpected for a given method/function.
 
-    Ultimately, you can structure this however you like, but Koalas would likely do something like
-    this:
+    Ultimately, you can structure this however you like, but pandas-on-Spark would likely do
+    something like this:
 
     >>> ps.Series(['a', 'b']).dt
     ...

--- a/python/pyspark/pandas/extensions.py
+++ b/python/pyspark/pandas/extensions.py
@@ -82,7 +82,7 @@ def _register_accessor(name, cls):
 
     .. code-block:: python
 
-        def __init__(self, koalas_obj):
+        def __init__(self, pandas_on_spark_obj):
             # constructor logic
         ...
 
@@ -166,8 +166,8 @@ def register_dataframe_accessor(name):
         @register_dataframe_accessor("geo")
         class GeoAccessor:
 
-            def __init__(self, koalas_obj):
-                self._obj = koalas_obj
+            def __init__(self, pandas_on_spark_obj):
+                self._obj = pandas_on_spark_obj
                 # other constructor logic
 
             @property
@@ -221,7 +221,7 @@ def register_series_accessor(name):
     When accessed, your accessor will be initialiazed with the pandas-on-Spark object the user is
     interacting with. The code signature must be::
 
-        def __init__(self, koalas_obj):
+        def __init__(self, pandas_on_spark_obj):
             # constructor logic
         ...
 
@@ -247,8 +247,8 @@ def register_series_accessor(name):
         @register_series_accessor("geo")
         class GeoAccessor:
 
-            def __init__(self, koalas_obj):
-                self._obj = koalas_obj
+            def __init__(self, pandas_on_spark_obj):
+                self._obj = pandas_on_spark_obj
 
             @property
             def is_valid(self):
@@ -293,7 +293,7 @@ def register_index_accessor(name):
     When accessed, your accessor will be initialiazed with the pandas-on-Spark object the user is
     interacting with. The code signature must be::
 
-        def __init__(self, koalas_obj):
+        def __init__(self, pandas_on_spark_obj):
             # constructor logic
         ...
 
@@ -319,8 +319,8 @@ def register_index_accessor(name):
         @register_index_accessor("foo")
         class CustomAccessor:
 
-            def __init__(self, koalas_obj):
-                self._obj = koalas_obj
+            def __init__(self, pandas_on_spark_obj):
+                self._obj = pandas_on_spark_obj
                 self.item = "baz"
 
             @property

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -4941,7 +4941,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Assigning multiple columns within the same ``assign`` is possible
         but you cannot refer to newly created or modified columns. This
         feature is supported in pandas for Python 3.6 and later but not in
-        pandas-on-Spark. In Koalas, all items are computed first, and then assigned.
+        pandas-on-Spark. In pandas-on-Spark, all items are computed first,
+        and then assigned.
         """
         return self._assign(kwargs)
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -78,7 +78,7 @@ from pyspark.sql.types import (
 from pyspark.sql.window import Window
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas.accessors import KoalasFrameMethods
+from pyspark.pandas.accessors import PandasOnSparkFrameMethods
 from pyspark.pandas.config import option_context, get_option
 from pyspark.pandas.spark.accessors import SparkFrameMethods, CachedSparkFrameMethods
 from pyspark.pandas.utils import (
@@ -119,7 +119,7 @@ from pyspark.pandas.typedef import (
     Scalar,
     ScalarType,
 )
-from pyspark.pandas.plot import KoalasPlotAccessor
+from pyspark.pandas.plot import PandasOnSparkPlotAccessor
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -404,8 +404,8 @@ if (3, 5) <= sys.version_info < (3, 7) and __name__ != "__main__":
 
 class DataFrame(Frame, Generic[T]):
     """
-    Koalas DataFrame that corresponds to pandas DataFrame logically. This holds Spark DataFrame
-    internally.
+    pandas-on-Spark DataFrame that corresponds to pandas DataFrame logically. This holds Spark
+    DataFrame internally.
 
     :ivar _internal: an internal immutable Frame to manage metadata.
     :type _internal: InternalFrame
@@ -413,11 +413,11 @@ class DataFrame(Frame, Generic[T]):
     Parameters
     ----------
     data : numpy ndarray (structured or homogeneous), dict, pandas DataFrame, Spark DataFrame \
-        or Koalas Series
+        or pandas-on-Spark Series
         Dict can contain Series, arrays, constants, or list-like objects
         If data is a dict, argument order is maintained for Python 3.6
         and later.
-        Note that if `data` is a pandas DataFrame, a Spark DataFrame, and a Koalas Series,
+        Note that if `data` is a pandas DataFrame, a Spark DataFrame, and a pandas-on-Spark Series,
         other arguments should not be used.
     index : Index or array-like
         Index to use for resulting frame. Will default to RangeIndex if
@@ -876,23 +876,23 @@ class DataFrame(Frame, Generic[T]):
         return self + other
 
     # create accessor for plot
-    plot = CachedAccessor("plot", KoalasPlotAccessor)
+    plot = CachedAccessor("plot", PandasOnSparkPlotAccessor)
 
     # create accessor for Spark related methods.
     spark = CachedAccessor("spark", SparkFrameMethods)
 
-    # create accessor for Koalas specific methods.
-    koalas = CachedAccessor("koalas", KoalasFrameMethods)
+    # create accessor for pandas-on-Spark specific methods.
+    koalas = CachedAccessor("koalas", PandasOnSparkFrameMethods)
 
     def hist(self, bins=10, **kwds):
         return self.plot.hist(bins, **kwds)
 
-    hist.__doc__ = KoalasPlotAccessor.hist.__doc__
+    hist.__doc__ = PandasOnSparkPlotAccessor.hist.__doc__
 
     def kde(self, bw_method=None, ind=None, **kwds):
         return self.plot.kde(bw_method, ind, **kwds)
 
-    kde.__doc__ = KoalasPlotAccessor.kde.__doc__
+    kde.__doc__ = PandasOnSparkPlotAccessor.kde.__doc__
 
     add.__doc__ = _flex_doc_FRAME.format(
         desc="Addition", op_name="+", equiv="dataframe + other", reverse="radd"
@@ -1148,7 +1148,7 @@ class DataFrame(Frame, Generic[T]):
              >>> def square(x) -> np.int32:
              ...     return x ** 2
 
-             Koalas uses return type hint and does not try to infer the type.
+             pandas-on-Spark uses return type hint and does not try to infer the type.
 
         Parameters
         ----------
@@ -1182,7 +1182,7 @@ class DataFrame(Frame, Generic[T]):
         0   1.000000   4.494400
         1  11.262736  20.857489
 
-        You can omit the type hint and let Koalas infer its type.
+        You can omit the type hint and let pandas-on-Spark infer its type.
 
         >>> df.applymap(lambda x: x ** 2)
                    0          1
@@ -1349,11 +1349,11 @@ class DataFrame(Frame, Generic[T]):
 
         Notes
         -----
-        There are behavior differences between Koalas and pandas.
+        There are behavior differences between pandas-on-Spark and pandas.
 
         * the `method` argument only accepts 'pearson', 'spearman'
-        * the data should not contain NaNs. Koalas will return an error.
-        * Koalas doesn't support the following argument(s).
+        * the data should not contain NaNs. pandas-on-Spark will return an error.
+        * pandas-on-Spark doesn't support the following argument(s).
 
           * `min_periods` argument is not supported
         """
@@ -1464,7 +1464,7 @@ class DataFrame(Frame, Generic[T]):
             s = pd.Series(v, index=columns, name=k)
             yield k, s
 
-    def itertuples(self, index: bool = True, name: Optional[str] = "Koalas") -> Iterator:
+    def itertuples(self, index: bool = True, name: Optional[str] = "PandasOnSpark") -> Iterator:
         """
         Iterate over DataFrame rows as namedtuples.
 
@@ -1472,7 +1472,7 @@ class DataFrame(Frame, Generic[T]):
         ----------
         index : bool, default True
             If True, return the index as the first element of the tuple.
-        name : str or None, default "Koalas"
+        name : str or None, default "PandasOnSpark"
             The name of the returned namedtuples or None to return regular
             tuples.
 
@@ -1508,8 +1508,8 @@ class DataFrame(Frame, Generic[T]):
         >>> for row in df.itertuples():
         ...     print(row)
         ...
-        Koalas(Index='dog', num_legs=4, num_wings=0)
-        Koalas(Index='hawk', num_legs=2, num_wings=2)
+        PandasOnSpark(Index='dog', num_legs=4, num_wings=0)
+        PandasOnSpark(Index='hawk', num_legs=2, num_wings=2)
 
         By setting the `index` parameter to False we can remove the index
         as the first element of the tuple:
@@ -1517,8 +1517,8 @@ class DataFrame(Frame, Generic[T]):
         >>> for row in df.itertuples(index=False):
         ...     print(row)
         ...
-        Koalas(num_legs=4, num_wings=0)
-        Koalas(num_legs=2, num_wings=2)
+        PandasOnSpark(num_legs=4, num_wings=0)
+        PandasOnSpark(num_legs=2, num_wings=2)
 
         With the `name` parameter set we set a custom name for the yielded
         namedtuples:
@@ -2306,9 +2306,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
         return self.koalas.apply_batch(func, args=args, **kwds)
 
-    apply_batch.__doc__ = KoalasFrameMethods.apply_batch.__doc__
+    apply_batch.__doc__ = PandasOnSparkFrameMethods.apply_batch.__doc__
 
-    # TODO: Remove this API when Koalas 2.0.0.
+    # TODO: Remove this API.
     def map_in_pandas(self, func) -> "DataFrame":
         warnings.warn(
             "DataFrame.map_in_pandas is deprecated as of DataFrame.koalas.apply_batch. "
@@ -2317,7 +2317,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
         return self.koalas.apply_batch(func)
 
-    map_in_pandas.__doc__ = KoalasFrameMethods.apply_batch.__doc__
+    map_in_pandas.__doc__ = PandasOnSparkFrameMethods.apply_batch.__doc__
 
     def apply(self, func, axis=0, args=(), **kwds) -> Union["Series", "DataFrame", "Index"]:
         """
@@ -2331,8 +2331,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         <https://koalas.readthedocs.io/en/latest/user_guide/transform_apply.html>`_.
 
         .. note:: when `axis` is 0 or 'index', the `func` is unable to access
-            to the whole input series. Koalas internally splits the input series into multiple
-            batches and calls `func` with each batch multiple times. Therefore, operations
+            to the whole input series. pandas-on-Spark internally splits the input series into
+            multiple batches and calls `func` with each batch multiple times. Therefore, operations
             such as global aggregations are impossible. See the example below.
 
             >>> # This case does not return the length of whole series but of the batch internally
@@ -2360,7 +2360,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             >>> def square(s) -> ps.Series[np.int32]:
             ...     return s ** 2
 
-            Koalas uses return type hint and does not try to infer the type.
+            pandas-on-Spark uses return type hint and does not try to infer the type.
 
             In case when axis is 1, it requires to specify `DataFrame` or scalar value
             with type hints as below:
@@ -2440,7 +2440,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1  2.0  3.0
         2  2.0  3.0
 
-        You can omit the type hint and let Koalas infer its type.
+        You can omit the type hint and let pandas-on-Spark infer its type.
 
         >>> df.apply(np.sqrt, axis=0)
              A    B
@@ -2459,7 +2459,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2    13
         dtype: int64
 
-        Likewise, you can omit the type hint and let Koalas infer its type.
+        Likewise, you can omit the type hint and let pandas-on-Spark infer its type.
 
         >>> df.apply(np.sum, axis=1)
         0    13
@@ -2629,10 +2629,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
              >>> def square(x) -> ps.Series[np.int32]:
              ...     return x ** 2
 
-             Koalas uses return type hint and does not try to infer the type.
+             pandas-on-Spark uses return type hint and does not try to infer the type.
 
         .. note:: the series within ``func`` is actually multiple pandas series as the
-            segments of the whole Koalas series; therefore, the length of each series
+            segments of the whole pandas-on-Spark series; therefore, the length of each series
             is not guaranteed. As an example, an aggregation against each series
             does work as a global aggregation but an aggregation of each segment. See
             below:
@@ -2684,7 +2684,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1  1  4
         2  4  9
 
-        You can omit the type hint and let Koalas infer its type.
+        You can omit the type hint and let pandas-on-Spark infer its type.
 
         >>> df.transform(lambda x: x ** 2)
            A  B
@@ -2776,7 +2776,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
         return self.koalas.transform_batch(func, *args, **kwargs)
 
-    transform_batch.__doc__ = KoalasFrameMethods.transform_batch.__doc__
+    transform_batch.__doc__ = PandasOnSparkFrameMethods.transform_batch.__doc__
 
     def pop(self, item) -> "DataFrame":
         """
@@ -3069,8 +3069,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         def pandas_between_time(pdf) -> ps.DataFrame[return_types]:  # type: ignore
             return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
-        # apply_batch will remove the index of the Koalas DataFrame and attach a default index,
-        # which will never be used. So use "distributed" index as a dummy to avoid overhead.
+        # apply_batch will remove the index of the pandas-on-Spark DataFrame and attach a
+        # default index, which will never be used. So use "distributed" index as a dummy to
+        # avoid overhead.
         with option_context("compute.default_index_type", "distributed"):
             kdf = kdf.koalas.apply_batch(pandas_between_time)
 
@@ -3150,8 +3151,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             def pandas_at_time(pdf) -> ps.DataFrame[return_types]:  # type: ignore
                 return pdf.at_time(time, asof, axis).reset_index()
 
-        # apply_batch will remove the index of the Koalas DataFrame and attach a default index,
-        # which will never be used. So use "distributed" index as a dummy to avoid overhead.
+        # apply_batch will remove the index of the pandas-on-Spark DataFrame and attach
+        # a default index, which will never be used. So use "distributed" index as a dummy
+        # to avoid overhead.
         with option_context("compute.default_index_type", "distributed"):
             kdf = kdf.koalas.apply_batch(pandas_at_time)
 
@@ -3648,7 +3650,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         lion    mammal       80.5
         monkey  mammal        NaN
 
-        When we reset the index, the old index is added as a column. Unlike pandas, Koalas
+        When we reset the index, the old index is added as a column. Unlike pandas, pandas-on-Spark
         does not automatically add a sequential index. The following 0, 1, 2, 3 are only
         there when we display the DataFrame.
 
@@ -4161,14 +4163,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             If False, will use the exact algorithm and return the exact number of unique.
             If True, it uses the HyperLogLog approximate algorithm, which is significantly faster
             for large amount of data.
-            Note: This parameter is specific to Koalas and is not found in pandas.
+            Note: This parameter is specific to pandas-on-Spark and is not found in pandas.
         rsd: float, default 0.05
             Maximum estimation error allowed in the HyperLogLog algorithm.
-            Note: Just like ``approx`` this parameter is specific to Koalas.
+            Note: Just like ``approx`` this parameter is specific to pandas-on-Spark.
 
         Returns
         -------
-        The number of unique values per column as a Koalas Series.
+        The number of unique values per column as a pandas-on-Spark Series.
 
         Examples
         --------
@@ -4506,14 +4508,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     def to_koalas(self, index_col: Optional[Union[str, List[str]]] = None) -> "DataFrame":
         """
-        Converts the existing DataFrame into a Koalas DataFrame.
+        Converts the existing DataFrame into a pandas-on-Spark DataFrame.
 
         This method is monkey-patched into Spark's DataFrame and can be used
-        to convert a Spark DataFrame into a Koalas DataFrame. If running on
-        an existing Koalas DataFrame, the method returns itself.
+        to convert a Spark DataFrame into a pandas-on-Spark DataFrame. If running on
+        an existing pandas-on-Spark DataFrame, the method returns itself.
 
-        If a Koalas DataFrame is converted to a Spark DataFrame and then back
-        to Koalas, it will lose the index information and the original index
+        If a pandas-on-Spark DataFrame is converted to a Spark DataFrame and then back
+        to pandas-on-Spark, it will lose the index information and the original index
         will be turned into a normal column.
 
         Parameters
@@ -4552,7 +4554,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         1        3
         2        4
 
-        Calling to_koalas on a Koalas DataFrame simply returns itself.
+        Calling to_koalas on a pandas-on-Spark DataFrame simply returns itself.
 
         >>> df.to_koalas()
            col1  col2
@@ -4641,8 +4643,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         partition_cols : str or list of str, optional, default None
             Names of partitioning columns
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. The index name
-            in Koalas is ignored. By default, the index is always lost.
+            Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+            in pandas-on-Spark is ignored. By default, the index is always lost.
         options : dict
             All other options passed directly into Delta Lake.
 
@@ -4723,8 +4725,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             Compression codec to use when saving to file. If None is set, it uses the
             value specified in `spark.sql.parquet.compression.codec`.
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. The index name
-            in Koalas is ignored. By default, the index is always lost.
+            Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+            in pandas-on-Spark is ignored. By default, the index is always lost.
         options : dict
             All other options passed directly into Spark's data source.
 
@@ -4790,8 +4792,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         partition_cols : str or list of str, optional, default None
             Names of partitioning columns
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. The index name
-            in Koalas is ignored. By default, the index is always lost.
+            Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+            in pandas-on-Spark is ignored. By default, the index is always lost.
         options : dict
             All other options passed directly into Spark's data source.
 
@@ -4896,7 +4898,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             The column names are keywords. If the values are
             callable, they are computed on the DataFrame and
             assigned to the new columns. The callable must not
-            change input DataFrame (though Koalas doesn't check it).
+            change input DataFrame (though pandas-on-Spark doesn't check it).
             If the values are not callable, (e.g. a Series or a literal),
             they are simply assigned.
 
@@ -4939,7 +4941,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Assigning multiple columns within the same ``assign`` is possible
         but you cannot refer to newly created or modified columns. This
         feature is supported in pandas for Python 3.6 and later but not in
-        Koalas. In Koalas, all items are computed first, and then assigned.
+        pandas-on-Spark. In Koalas, all items are computed first, and then assigned.
         """
         return self._assign(kwargs)
 
@@ -6188,9 +6190,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         5  NaN  NaN  6.0
 
         Notice that, unlike pandas raises an ValueError when duplicated values are found,
-        Koalas' pivot still works with its first value it meets during operation because pivot
-        is an expensive operation and it is preferred to permissively execute over failing fast
-        when processing large data.
+        pandas-on-Spark's pivot still works with its first value it meets during operation because
+        pivot is an expensive operation and it is preferred to permissively execute over failing
+        fast when processing large data.
 
         >>> df = ps.DataFrame({"foo": ['one', 'one', 'two', 'two'],
         ...                    "bar": ['A', 'A', 'B', 'C'],
@@ -6893,7 +6895,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         inplace : bool, default False
             if True, perform operation in-place
         kind : str, default None
-            Koalas does not allow specifying the sorting algorithm at the moment, default None
+            pandas-on-Spark does not allow specifying the sorting algorithm at the moment,
+            default None
         na_position : {‘first’, ‘last’}, default ‘last’
             first puts NaNs at the beginning, last puts NaNs at the end. Not implemented for
             MultiIndex.
@@ -7205,7 +7208,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         This method is equivalent to
         ``df.sort_values(columns, ascending=False).head(n)``, but more
         performant in pandas.
-        In Koalas, thanks to Spark's lazy execution and query optimizer,
+        In pandas-on-Spark, thanks to Spark's lazy execution and query optimizer,
         the two would have same performance.
 
         Parameters
@@ -7277,8 +7280,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         well, but not used for ordering.
 
         This method is equivalent to ``df.sort_values(columns, ascending=True).head(n)``,
-        but more performant. In Koalas, thanks to Spark's lazy execution and query optimizer,
-        the two would have same performance.
+        but more performant. In pandas-on-Spark, thanks to Spark's lazy execution and query
+        optimizer, the two would have same performance.
 
         Parameters
         ----------
@@ -8082,10 +8085,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Please call this function using named argument by specifying the ``frac`` argument.
 
         You can use `random_state` for reproducibility. However, note that different from pandas,
-        specifying a seed in Koalas/Spark does not guarantee the sampled rows will be fixed. The
-        result set depends on not only the seed, but also how the data is distributed across
-        machines and to some extent network randomness when shuffle operations are involved. Even
-        in the simplest case, the result set will depend on the system's CPU core count.
+        specifying a seed in pandas-on-Spark/Spark does not guarantee the sampled rows will
+        be fixed. The result set depends on not only the seed, but also how the data is distributed
+        across machines and to some extent network randomness when shuffle operations are involved.
+        Even in the simplest case, the result set will depend on the system's CPU core count.
 
         Parameters
         ----------
@@ -8160,12 +8163,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     def astype(self, dtype) -> "DataFrame":
         """
-        Cast a Koalas object to a specified dtype ``dtype``.
+        Cast a pandas-on-Spark object to a specified dtype ``dtype``.
 
         Parameters
         ----------
         dtype : data type, or dict of column name -> data type
-            Use a numpy.dtype or Python type to cast entire Koalas object to
+            Use a numpy.dtype or Python type to cast entire pandas-on-Spark object to
             the same type. Alternatively, use {col: dtype, ...}, where col is a
             column label and dtype is a numpy.dtype or Python type to cast one
             or more of the DataFrame's columns to column-specific types.
@@ -8773,7 +8776,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         nlevels = self._internal.index_level
         assert nlevels <= 1 or (
             isinstance(index, ps.MultiIndex) and nlevels == index.nlevels
-        ), "MultiIndex DataFrame can only be reindexed with a similar Koalas MultiIndex."
+        ), "MultiIndex DataFrame can only be reindexed with a similar pandas-on-Spark MultiIndex."
 
         index_columns = self._internal.index_spark_column_names
         frame = self._internal.resolved_copy.spark_frame.drop(NATURAL_ORDER_COLUMN_NAME)
@@ -8961,7 +8964,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if isinstance(other, DataFrame):
             return self.reindex(index=other.index, columns=other.columns, copy=copy)
         else:
-            raise TypeError("other must be a Koalas DataFrame")
+            raise TypeError("other must be a pandas-on-Spark DataFrame")
 
     def melt(self, id_vars=None, value_vars=None, var_name=None, value_name="value") -> "DataFrame":
         """
@@ -10637,8 +10640,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ' 2   float_col  5 non-null      float64\\n',
         'dtypes: float64(1), int64(1), object(1)']
         """
-        # To avoid pandas' existing config affects Koalas.
-        # TODO: should we have corresponding Koalas configs?
+        # To avoid pandas' existing config affects pandas-on-Spark.
+        # TODO: should we have corresponding pandas-on-Spark configs?
         with pd.option_context(
             "display.max_info_columns", sys.maxsize, "display.max_info_rows", sys.maxsize
         ):
@@ -10670,9 +10673,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         """
         Return value at the given quantile.
 
-        .. note:: Unlike pandas', the quantile in Koalas is an approximated quantile based upon
-            approximate percentile computation because computing quantile across a large dataset
-            is extremely expensive.
+        .. note:: Unlike pandas', the quantile in pandas-on-Spark is an approximated quantile
+            based upon approximate percentile computation because computing quantile across a
+            large dataset is extremely expensive.
 
         Parameters
         ----------
@@ -11814,7 +11817,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if (key,) in self._internal.column_labels:
             self[key] = value
         else:
-            msg = "Koalas doesn't allow columns to be created via a new attribute name"
+            msg = "pandas-on-Spark doesn't allow columns to be created via a new attribute name"
             if is_testing():
                 raise AssertionError(msg)
             else:
@@ -11883,7 +11886,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     elif (3, 5) <= sys.version_info < (3, 7):
         # This is a workaround to support variadic generic in DataFrame in Python 3.5+
         # The implementation is in its metaclass so this flag is needed to distinguish
-        # Koalas DataFrame.
+        # pandas-on-Spark DataFrame.
         is_dataframe = None
 
 
@@ -11903,8 +11906,8 @@ def _reduce_spark_multi(sdf, aggs):
 
 class CachedDataFrame(DataFrame):
     """
-    Cached Koalas DataFrame, which corresponds to pandas DataFrame logically, but internally
-    it caches the corresponding Spark DataFrame.
+    Cached pandas-on-Spark DataFrame, which corresponds to pandas DataFrame logically, but
+    internally it caches the corresponding Spark DataFrame.
     """
 
     def __init__(self, internal, storage_level=None):

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -621,8 +621,8 @@ class Frame(object, metaclass=ABCMeta):
         r"""
         Write object to a comma-separated values (csv) file.
 
-        .. note:: pandas-on-Spark `to_csv` writes files to a path or URI. Unlike pandas', Koalas
-            respects HDFS's property such as 'fs.default.name'.
+        .. note:: pandas-on-Spark `to_csv` writes files to a path or URI. Unlike pandas',
+            pandas-on-Spark respects HDFS's property such as 'fs.default.name'.
 
         .. note:: pandas-on-Spark writes CSV files into the directory, `path`, and writes
             multiple `part-...` files in the directory when `path` is specified.
@@ -852,8 +852,8 @@ class Frame(object, metaclass=ABCMeta):
         """
         Convert the object to a JSON string.
 
-        .. note:: pandas-on-Spark `to_json` writes files to a path or URI. Unlike pandas', Koalas
-            respects HDFS's property such as 'fs.default.name'.
+        .. note:: pandas-on-Spark `to_json` writes files to a path or URI. Unlike pandas',
+            pandas-on-Spark respects HDFS's property such as 'fs.default.name'.
 
         .. note:: pandas-on-Spark writes JSON files into the directory, `path`, and writes
             multiple `part-...` files in the directory when `path` is specified.

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -306,8 +306,8 @@ class Frame(object, metaclass=ABCMeta):
             single partition in single machine and could cause serious
             performance degradation. Avoid this method against very large dataset.
 
-        .. note:: unlike pandas', Koalas' emulates cumulative product by ``exp(sum(log(...)))``
-            trick. Therefore, it only works for positive numbers.
+        .. note:: unlike pandas', pandas-on-Spark's emulates cumulative product by
+            ``exp(sum(log(...)))`` trick. Therefore, it only works for positive numbers.
 
         Parameters
         ----------
@@ -621,10 +621,10 @@ class Frame(object, metaclass=ABCMeta):
         r"""
         Write object to a comma-separated values (csv) file.
 
-        .. note:: Koalas `to_csv` writes files to a path or URI. Unlike pandas', Koalas
+        .. note:: pandas-on-Spark `to_csv` writes files to a path or URI. Unlike pandas', Koalas
             respects HDFS's property such as 'fs.default.name'.
 
-        .. note:: Koalas writes CSV files into the directory, `path`, and writes
+        .. note:: pandas-on-Spark writes CSV files into the directory, `path`, and writes
             multiple `part-...` files in the directory when `path` is specified.
             This behaviour was inherited from Apache Spark. The number of files can
             be controlled by `num_files`.
@@ -663,8 +663,8 @@ class Frame(object, metaclass=ABCMeta):
         partition_cols : str or list of str, optional, default None
             Names of partitioning columns
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. The index name
-            in Koalas is ignored. By default, the index is always lost.
+            Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+            in pandas-on-Spark is ignored. By default, the index is always lost.
         options: keyword arguments for additional options specific to PySpark.
             This kwargs are specific to PySpark's CSV options to pass. Check
             the options in PySpark's API documentation for spark.write.csv(...).
@@ -852,10 +852,10 @@ class Frame(object, metaclass=ABCMeta):
         """
         Convert the object to a JSON string.
 
-        .. note:: Koalas `to_json` writes files to a path or URI. Unlike pandas', Koalas
+        .. note:: pandas-on-Spark `to_json` writes files to a path or URI. Unlike pandas', Koalas
             respects HDFS's property such as 'fs.default.name'.
 
-        .. note:: Koalas writes JSON files into the directory, `path`, and writes
+        .. note:: pandas-on-Spark writes JSON files into the directory, `path`, and writes
             multiple `part-...` files in the directory when `path` is specified.
             This behaviour was inherited from Apache Spark. The number of files can
             be controlled by `num_files`.
@@ -895,8 +895,8 @@ class Frame(object, metaclass=ABCMeta):
         partition_cols : str or list of str, optional, default None
             Names of partitioning columns
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. The index name
-            in Koalas is ignored. By default, the index is always lost.
+            Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+            in pandas-on-Spark is ignored. By default, the index is always lost.
         options: keyword arguments for additional options specific to PySpark.
             It is specific to PySpark's JSON options to pass. Check
             the options in PySpark's API documentation for `spark.write.json(...)`.
@@ -1254,7 +1254,7 @@ class Frame(object, metaclass=ABCMeta):
         """
         Return the product of the values.
 
-        .. note:: unlike pandas', Koalas' emulates product by ``exp(sum(log(...)))``
+        .. note:: unlike pandas', pandas-on-Spark's emulates product by ``exp(sum(log(...)))``
             trick. Therefore, it only works for positive numbers.
 
         Parameters
@@ -1810,7 +1810,7 @@ class Frame(object, metaclass=ABCMeta):
         """
         Return the median of the values for the requested axis.
 
-        .. note:: Unlike pandas', the median in Koalas is an approximated median based upon
+        .. note:: Unlike pandas', the median in pandas-on-Spark is an approximated median based upon
             approximate percentile computation because computing median across a large dataset
             is extremely expensive.
 
@@ -2480,7 +2480,7 @@ class Frame(object, metaclass=ABCMeta):
         """
         Provide rolling transformations.
 
-        .. note:: 'min_periods' in Koalas works as a fixed window size unlike pandas.
+        .. note:: 'min_periods' in pandas-on-Spark works as a fixed window size unlike pandas.
             Unlike pandas, NA is also counted as the period. This might be changed
             in the near future.
 
@@ -2509,7 +2509,7 @@ class Frame(object, metaclass=ABCMeta):
         """
         Provide expanding transformations.
 
-        .. note:: 'min_periods' in Koalas works as a fixed window size unlike pandas.
+        .. note:: 'min_periods' in pandas-on-Spark works as a fixed window size unlike pandas.
             Unlike pandas, NA is also counted as the period. This might be changed
             in the near future.
 
@@ -2895,7 +2895,7 @@ class Frame(object, metaclass=ABCMeta):
         # `to_markdown` is supported in pandas >= 1.0.0 since it's newly added in pandas 1.0.0.
         if LooseVersion(pd.__version__) < LooseVersion("1.0.0"):
             raise NotImplementedError(
-                "`to_markdown()` only supported in Koalas with pandas >= 1.0.0"
+                "`to_markdown()` only supported in pandas-on-Spark with pandas >= 1.0.0"
             )
         # Make sure locals() call is at the top of the function so we don't capture local variables.
         args = locals()

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -3161,7 +3161,7 @@ def normalize_keyword_aggregation(kwargs):
     >>> normalize_keyword_aggregation({'output': ('input', 'sum')})
     (OrderedDict([('input', ['sum'])]), ('output',), [('input', 'sum')])
     """
-    # this is due to python version issue, not sure the impact on koalas
+    # this is due to python version issue, not sure the impact on pandas-on-Spark
     PY36 = sys.version_info >= (3, 6)
     if not PY36:
         kwargs = OrderedDict(sorted(kwargs.items()))

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -191,7 +191,7 @@ class GroupBy(object, metaclass=ABCMeta):
         1    1    2  0.227  0.362
         2    3    4 -0.562  1.267
 
-        To control the output names with different aggregations per column, Koalas
+        To control the output names with different aggregations per column, pandas-on-Spark
         also supports 'named aggregation' or nested renaming in .agg. It can also be
         used when applying multiple aggregation functions to specific columns.
 
@@ -216,8 +216,8 @@ class GroupBy(object, metaclass=ABCMeta):
         1        2   0.227
         2        4  -0.562
         """
-        # I think current implementation of func and arguments in Koalas for aggregate is different
-        # than pandas, later once arguments are added, this could be removed.
+        # I think current implementation of func and arguments in pandas-on-Spark for aggregate
+        # is different than pandas, later once arguments are added, this could be removed.
         if func_or_funcs is None and kwargs is None:
             raise ValueError("No aggregation argument or function specified.")
 
@@ -971,7 +971,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         While `apply` is a very flexible method, its downside is that
         using it can be quite a bit slower than using more specific methods
-        like `agg` or `transform`. Koalas offers a wide range of method that will
+        like `agg` or `transform`. pandas-on-Spark offers a wide range of method that will
         be much faster than using `apply` for their specific purposes, so try to
         use them before reaching for `apply`.
 
@@ -1366,7 +1366,7 @@ class GroupBy(object, metaclass=ABCMeta):
     def _make_pandas_df_builder_func(kdf, func, return_schema, retain_index):
         """
         Creates a function that can be used inside the pandas UDF. This function can construct
-        the same pandas DataFrame as if the Koalas DataFrame is collected to driver side.
+        the same pandas DataFrame as if the pandas-on-Spark DataFrame is collected to driver side.
         The index, column labels, etc. are re-constructed within the function.
         """
         arguments_for_restore_index = kdf._internal.arguments_for_restore_index
@@ -1999,7 +1999,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         While `transform` is a very flexible method, its downside is that
         using it can be quite a bit slower than using more specific methods
-        like `agg` or `transform`. Koalas offers a wide range of method that will
+        like `agg` or `transform`. pandas-on-Spark offers a wide range of method that will
         be much faster than using `transform` for their specific purposes, so try to
         use them before reaching for `transform`.
 
@@ -2071,7 +2071,7 @@ class GroupBy(object, metaclass=ABCMeta):
         1  4  12
         2  6  10
 
-        You can omit the type hint and let Koalas infer its type.
+        You can omit the type hint and let pandas-on-Spark infer its type.
 
         >>> def plus_min(x):
         ...     return x + x.min()
@@ -2233,7 +2233,7 @@ class GroupBy(object, metaclass=ABCMeta):
         Return an rolling grouper, providing rolling
         functionality per group.
 
-        .. note:: 'min_periods' in Koalas works as a fixed window size unlike pandas.
+        .. note:: 'min_periods' in pandas-on-Spark works as a fixed window size unlike pandas.
         Unlike pandas, NA is also counted as the period. This might be changed
         in the near future.
 
@@ -2260,7 +2260,7 @@ class GroupBy(object, metaclass=ABCMeta):
         Return an expanding grouper, providing expanding
         functionality per group.
 
-        .. note:: 'min_periods' in Koalas works as a fixed window size unlike pandas.
+        .. note:: 'min_periods' in pandas-on-Spark works as a fixed window size unlike pandas.
         Unlike pandas, NA is also counted as the period. This might be changed
         in the near future.
 
@@ -2362,7 +2362,7 @@ class GroupBy(object, metaclass=ABCMeta):
 
         For multiple groupings, the result index will be a MultiIndex
 
-        .. note:: Unlike pandas', the median in Koalas is an approximated median based upon
+        .. note:: Unlike pandas', the median in pandas-on-Spark is an approximated median based upon
             approximate percentile computation because computing median across a large dataset
             is extremely expensive.
 
@@ -2695,7 +2695,7 @@ class DataFrameGroupBy(GroupBy):
         will vary depending on what is provided. Refer to the notes
         below for more detail.
 
-        .. note:: Unlike pandas, the percentiles in Koalas are based upon
+        .. note:: Unlike pandas, the percentiles in pandas-on-Spark are based upon
             approximate percentile computation because computing percentiles
             across a large dataset is extremely expensive.
 

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -725,11 +725,11 @@ class Index(IndexOpsMixin):
         Support for MultiIndex
 
         >>> kidx = ps.MultiIndex.from_tuples([('a', 'x'), ('b', 'y')])
-        >>> kidx.names = ['hello', 'koalas']
+        >>> kidx.names = ['hello', 'pandas-on-Spark']
         >>> kidx  # doctest: +SKIP
         MultiIndex([('a', 'x'),
                     ('b', 'y')],
-                   names=['hello', 'koalas'])
+                   names=['hello', 'pandas-on-Spark'])
 
         >>> kidx.rename(['aloha', 'databricks'])  # doctest: +SKIP
         MultiIndex([('a', 'x'),
@@ -1387,8 +1387,8 @@ class Index(IndexOpsMixin):
 
         You can set name of result Index.
 
-        >>> s1.index.symmetric_difference(s2.index, result_name='koalas')  # doctest: +SKIP
-        Int64Index([5, 1], dtype='int64', name='koalas')
+        >>> s1.index.symmetric_difference(s2.index, result_name='pandas-on-Spark')  # doctest: +SKIP
+        Int64Index([5, 1], dtype='int64', name='pandas-on-Spark')
 
         You can set sort to `True`, if you want to sort the resulting index.
 

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -68,7 +68,7 @@ from pyspark.pandas.typedef import Scalar
 
 class Index(IndexOpsMixin):
     """
-    Koalas Index that corresponds to pandas Index logically. This might hold Spark Column
+    pandas-on-Spark Index that corresponds to pandas Index logically. This might hold Spark Column
     internally.
 
     Parameters
@@ -203,7 +203,7 @@ class Index(IndexOpsMixin):
 
     def _with_new_scol(self, scol: spark.Column, *, dtype=None) -> "Index":
         """
-        Copy Koalas Index with the new Spark Column.
+        Copy pandas-on-Spark Index with the new Spark Column.
 
         :param scol: the new Spark Column
         :return: the copied Index
@@ -1995,7 +1995,7 @@ class Index(IndexOpsMixin):
     def is_all_dates(self) -> bool:
         """
         Return if all data types of the index are datetime.
-        remember that since Koalas does not support multiple data types in an index,
+        remember that since pandas-on-Spark does not support multiple data types in an index,
         so it returns True if any type of data is datetime.
 
         Examples
@@ -2231,7 +2231,7 @@ class Index(IndexOpsMixin):
         Notes
         -----
         When Index contains null values the result can be different with pandas
-        since Koalas cast integer to float when Index contains null values.
+        since pandas-on-Spark cast integer to float when Index contains null values.
 
         >>> ps.Index([1, 2, 3, None])
         Float64Index([1.0, 2.0, 3.0, nan], dtype='float64')

--- a/python/pyspark/pandas/indexes/category.py
+++ b/python/pyspark/pandas/indexes/category.py
@@ -58,7 +58,7 @@ class CategoricalIndex(Index):
 
     See Also
     --------
-    Index : The base Koalas Index type.
+    Index : The base pandas-on-Spark Index type.
 
     Examples
     --------

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -51,8 +51,8 @@ from pyspark.pandas.typedef import Scalar
 
 class MultiIndex(Index):
     """
-    Koalas MultiIndex that corresponds to pandas MultiIndex logically. This might hold Spark Column
-    internally.
+    pandas-on-Spark MultiIndex that corresponds to pandas MultiIndex logically. This might hold
+    Spark Column internally.
 
     Parameters
     ----------

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -730,7 +730,7 @@ class MultiIndex(Index):
         ...                        ['speed', 'weight', 'length']],
         ...                       [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                        [0, 0, 0, 0, 1, 2, 0, 1, 2]])
-        >>> midx2 = pd.MultiIndex([['koalas', 'cow', 'falcon'],
+        >>> midx2 = pd.MultiIndex([['pandas-on-Spark', 'cow', 'falcon'],
         ...                        ['speed', 'weight', 'length']],
         ...                       [[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                        [0, 0, 0, 0, 1, 2, 0, 1, 2]])
@@ -740,28 +740,28 @@ class MultiIndex(Index):
         ...              index=midx2)
 
         >>> s1.index.symmetric_difference(s2.index)  # doctest: +SKIP
-        MultiIndex([('koalas', 'speed'),
+        MultiIndex([('pandas-on-Spark', 'speed'),
                     (  'lama', 'speed')],
                    )
 
         You can set names of result Index.
 
         >>> s1.index.symmetric_difference(s2.index, result_name=['a', 'b'])  # doctest: +SKIP
-        MultiIndex([('koalas', 'speed'),
+        MultiIndex([('pandas-on-Spark', 'speed'),
                     (  'lama', 'speed')],
                    names=['a', 'b'])
 
         You can set sort to `True`, if you want to sort the resulting index.
 
         >>> s1.index.symmetric_difference(s2.index, sort=True)  # doctest: +SKIP
-        MultiIndex([('koalas', 'speed'),
+        MultiIndex([('pandas-on-Spark', 'speed'),
                     (  'lama', 'speed')],
                    )
 
         You can also use the ``^`` operator:
 
         >>> s1.index ^ s2.index  # doctest: +SKIP
-        MultiIndex([('koalas', 'speed'),
+        MultiIndex([('pandas-on-Spark', 'speed'),
                     (  'lama', 'speed')],
                    )
         """

--- a/python/pyspark/pandas/indexes/numeric.py
+++ b/python/pyspark/pandas/indexes/numeric.py
@@ -56,7 +56,7 @@ class Int64Index(IntegerIndex):
 
     See Also
     --------
-    Index : The base Koalas Index type.
+    Index : The base pandas-on-Spark Index type.
     Float64Index : A special case of :class:`Index` with purely float labels.
 
     Notes
@@ -110,7 +110,7 @@ class Float64Index(NumericIndex):
 
     See Also
     --------
-    Index : The base Koalas Index type.
+    Index : The base pandas-on-Spark Index type.
     Int64Index : A special case of :class:`Index` with purely integer labels.
 
     Notes

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -16,7 +16,7 @@
 #
 
 """
-A loc indexer for Koalas DataFrame/Series.
+A loc indexer for pandas-on-Spark DataFrame/Series.
 """
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
@@ -101,7 +101,8 @@ class AtIndexer(IndexerLike):
     Similar to ``loc``, in that both provide label-based lookups. Use ``at`` if you only need to
     get a single value in a DataFrame or Series.
 
-    .. note:: Unlike pandas, Koalas only allows using ``at`` to get values but not to set them.
+    .. note:: Unlike pandas, pandas-on-Spark only allows using ``at`` to get values but not to
+        set them.
 
     .. note:: Warning: If ``row_index`` matches a lot of rows, large amounts of data will be
         fetched, potentially causing your machine to run out of memory.
@@ -779,7 +780,7 @@ class LocIndexer(LocIndexerLike):
         start and the stop are included, and the step of the slice is not allowed.
 
     .. note:: With a list or array of labels for row selection,
-        Koalas behaves as a filter without reordering by the labels.
+        pandas-on-Spark behaves as a filter without reordering by the labels.
 
     See Also
     --------
@@ -806,7 +807,7 @@ class LocIndexer(LocIndexerLike):
     Name: viper, dtype: int64
 
     List of labels. Note using ``[[]]`` returns a DataFrame.
-    Also note that Koalas behaves just a filter without reordering by the labels.
+    Also note that pandas-on-Spark behaves just a filter without reordering by the labels.
 
     >>> df.loc[['viper', 'sidewinder']]
                 max_speed  shield

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -63,10 +63,10 @@ from pyspark.pandas.utils import (
 )
 
 
-# A function to turn given numbers to Spark columns that represent Koalas index.
+# A function to turn given numbers to Spark columns that represent pandas-on-Spark index.
 SPARK_INDEX_NAME_FORMAT = "__index_level_{}__".format
 SPARK_DEFAULT_INDEX_NAME = SPARK_INDEX_NAME_FORMAT(0)
-# A pattern to check if the name of a Spark column is a Koalas index name or not.
+# A pattern to check if the name of a Spark column is a pandas-on-Spark index name or not.
 SPARK_INDEX_NAME_PATTERN = re.compile(r"__index_level_[0-9]+__")
 
 NATURAL_ORDER_COLUMN_NAME = "__natural_order__"
@@ -86,8 +86,8 @@ class InternalFrame(object):
         should not directly access to it.
 
     The internal immutable DataFrame represents the index information for a DataFrame it belongs to.
-    For instance, if we have a Koalas DataFrame as below, pandas DataFrame does not store the index
-    as columns.
+    For instance, if we have a pandas-on-Spark DataFrame as below, pandas DataFrame does not
+    store the index as columns.
 
     >>> kdf = ps.DataFrame({
     ...     'A': [1, 2, 3, 4],
@@ -116,7 +116,7 @@ class InternalFrame(object):
     +-----------------+---+---+---+---+---+
 
     In order to fill this gap, the current metadata is used by mapping Spark's internal column
-    to Koalas' index. See the method below:
+    to pandas-on-Spark's index. See the method below:
 
     * `spark_frame` represents the internal Spark DataFrame
 
@@ -467,7 +467,7 @@ class InternalFrame(object):
         """
 
         assert isinstance(spark_frame, spark.DataFrame)
-        assert not spark_frame.isStreaming, "Koalas does not support Structured Streaming."
+        assert not spark_frame.isStreaming, "pandas-on-Spark does not support Structured Streaming."
 
         if not index_spark_columns:
             if data_spark_columns is not None:

--- a/python/pyspark/pandas/missing/common.py
+++ b/python/pyspark/pandas/missing/common.py
@@ -19,7 +19,7 @@
 memory_usage = lambda f: f(
     "memory_usage",
     reason="Unlike pandas, most DataFrames are not materialized in memory in Spark "
-    "(and Koalas), and as a result memory_usage() does not do what you intend it "
+    "(and pandas-on-Spark), and as a result memory_usage() does not do what you intend it "
     "to do. Use Spark's web UI to monitor disk and memory usage of your application.",
 )
 

--- a/python/pyspark/pandas/missing/indexes.py
+++ b/python/pyspark/pandas/missing/indexes.py
@@ -191,13 +191,13 @@ class MissingPandasLikeMultiIndex(object):
     codes = _unsupported_property(
         "codes",
         reason="'codes' requires to collect all data into the driver which is against the "
-        "design principle of Koalas. Alternatively, you could call 'to_pandas()' and"
+        "design principle of pandas-on-Spark. Alternatively, you could call 'to_pandas()' and"
         " use 'codes' property in pandas.",
     )
     levels = _unsupported_property(
         "levels",
         reason="'levels' requires to collect all data into the driver which is against the "
-        "design principle of Koalas. Alternatively, you could call 'to_pandas()' and"
+        "design principle of pandas-on-Spark. Alternatively, you could call 'to_pandas()' and"
         " use 'levels' property in pandas.",
     )
     __iter__ = common.__iter__(_unsupported_function)

--- a/python/pyspark/pandas/ml.py
+++ b/python/pyspark/pandas/ml.py
@@ -39,7 +39,7 @@ def corr(kdf: "ps.DataFrame", method: str = "pearson") -> pd.DataFrame:
 
     Only accepts scalar numerical values for now.
 
-    :param kdf: the Koalas dataframe.
+    :param kdf: the pandas-on-Spark dataframe.
     :param method: {'pearson', 'spearman'}
                    * pearson : standard correlation coefficient
                    * spearman : Spearman rank correlation
@@ -68,7 +68,7 @@ def to_numeric_df(kdf: "ps.DataFrame") -> Tuple[pyspark.sql.DataFrame, List[Tupl
     vector of doubles. This dataframe has a single field called '_1'.
 
     TODO: index is not preserved currently
-    :param kdf: the Koalas dataframe.
+    :param kdf: the pandas-on-Spark dataframe.
     :return: a pair of dataframe, list of strings (the name of the columns
              that were converted to numerical types)
 

--- a/python/pyspark/pandas/mlflow.py
+++ b/python/pyspark/pandas/mlflow.py
@@ -35,7 +35,7 @@ class PythonModelWrapper(object):
     """
     A wrapper around MLflow's Python object model.
 
-    This wrapper acts as a predictor on koalas
+    This wrapper acts as a predictor on pandas-on-Spark
 
     """
 
@@ -82,7 +82,7 @@ class PythonModelWrapper(object):
         """
         Returns a prediction on the data.
 
-        If the data is a koalas DataFrame, the return is a pandas-on-Spark Series.
+        If the data is a pandas-on-Spark DataFrame, the return is a pandas-on-Spark Series.
 
         If the data is a pandas Dataframe, the return is the expected output of the underlying
         pyfunc object (typically a pandas Series or a numpy array).
@@ -135,7 +135,7 @@ def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:
     >>> from mlflow.tracking import MlflowClient, set_tracking_uri
     >>> import mlflow.sklearn
     >>> from tempfile import mkdtemp
-    >>> d = mkdtemp("koalas_mlflow")
+    >>> d = mkdtemp("pandas_on_spark_mlflow")
     >>> set_tracking_uri("file:%s"%d)
     >>> client = MlflowClient()
     >>> exp = mlflow.create_experiment("my_experiment")

--- a/python/pyspark/pandas/mlflow.py
+++ b/python/pyspark/pandas/mlflow.py
@@ -16,7 +16,7 @@
 #
 
 """
-MLflow-related functions to load models and apply them to Koalas dataframes.
+MLflow-related functions to load models and apply them to pandas-on-Spark dataframes.
 """
 from pyspark.sql.types import DataType
 import pandas as pd
@@ -82,7 +82,7 @@ class PythonModelWrapper(object):
         """
         Returns a prediction on the data.
 
-        If the data is a koalas DataFrame, the return is a Koalas Series.
+        If the data is a koalas DataFrame, the return is a pandas-on-Spark Series.
 
         If the data is a pandas Dataframe, the return is the expected output of the underlying
         pyfunc object (typically a pandas Series or a numpy array).
@@ -106,7 +106,8 @@ class PythonModelWrapper(object):
 
 def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:
     """
-    Loads an MLflow model into an wrapper that can be used both for pandas and Koalas DataFrame.
+    Loads an MLflow model into an wrapper that can be used both for pandas and pandas-on-Spark
+    DataFrame.
 
     Parameters
     ----------
@@ -126,7 +127,7 @@ def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:
     Examples
     --------
     Here is a full example that creates a model with scikit-learn and saves the model with
-     MLflow. The model is then loaded as a predictor that can be applied on a Koalas
+     MLflow. The model is then loaded as a predictor that can be applied on a pandas-on-Spark
      Dataframe.
 
     We first initialize our MLflow environment:
@@ -153,7 +154,8 @@ def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:
     ...     mlflow.sklearn.log_model(lr, "model")
     LinearRegression(...)
 
-    Now that our model is logged using MLflow, we load it back and apply it on a Koalas dataframe:
+    Now that our model is logged using MLflow, we load it back and apply it on a pandas-on-Spark
+    dataframe:
 
     >>> from pyspark.pandas.mlflow import load_model
     >>> run_info = client.list_run_infos(exp)[-1]

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -103,7 +103,7 @@ __all__ = [
 
 
 def from_pandas(pobj: Union[pd.DataFrame, pd.Series, pd.Index]) -> Union[Series, DataFrame, Index]:
-    """Create a Koalas DataFrame, Series or Index from a pandas DataFrame, Series or Index.
+    """Create a pandas-on-Spark DataFrame, Series or Index from a pandas DataFrame, Series or Index.
 
     This is similar to Spark's `SparkSession.createDataFrame()` with pandas DataFrame,
     but this also works with pandas Series and picks the index.
@@ -116,8 +116,8 @@ def from_pandas(pobj: Union[pd.DataFrame, pd.Series, pd.Index]) -> Union[Series,
     Returns
     -------
     Series or DataFrame
-        If a pandas Series is passed in, this function returns a Koalas Series.
-        If a pandas DataFrame is passed in, this function returns a Koalas DataFrame.
+        If a pandas Series is passed in, this function returns a pandas-on-Spark Series.
+        If a pandas DataFrame is passed in, this function returns a pandas-on-Spark DataFrame.
     """
     if isinstance(pobj, pd.Series):
         return Series(pobj)
@@ -840,7 +840,7 @@ def read_excel(
     **kwds
 ) -> Union[DataFrame, Series, OrderedDict]:
     """
-    Read an Excel file into a Koalas DataFrame or Series.
+    Read an Excel file into a pandas-on-Spark DataFrame or Series.
 
     Support both `xls` and `xlsx` file extensions from a local filesystem or URL.
     Support an option to read a single sheet or a list of sheets.
@@ -943,7 +943,7 @@ def read_excel(
     date_parser : function, optional
         Function to use for converting a sequence of string columns to an array of
         datetime instances. The default uses ``dateutil.parser.parser`` to do the
-        conversion. Koalas will try to call `date_parser` in three different ways,
+        conversion. pandas-on-Spark will try to call `date_parser` in three different ways,
         advancing to the next if an exception occurs: 1) Pass one or more arrays
         (as defined by `parse_dates`) as arguments; 2) concatenate (row-wise) the
         string values from the columns defined by `parse_dates` into a single array
@@ -1792,7 +1792,7 @@ def get_dummies(
     sparse : bool, default False
         Whether the dummy-encoded columns should be be backed by
         a :class:`SparseArray` (True) or a regular NumPy array (False).
-        In Koalas, this value must be "False".
+        In pandas-on-Spark, this value must be "False".
     drop_first : bool, default False
         Whether to get k-1 dummies out of k categorical levels by removing the
         first level.
@@ -1984,7 +1984,7 @@ def get_dummies(
 # TODO: there are many parameters to implement and support. See pandas's pd.concat.
 def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[Series, DataFrame]:
     """
-    Concatenate Koalas objects along a particular axis with optional set logic
+    Concatenate pandas-on-Spark objects along a particular axis with optional set logic
     along the other axes.
 
     Parameters
@@ -2130,7 +2130,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=False) -> Union[
         objs, Iterable
     ):  # TODO: support dict
         raise TypeError(
-            "first argument must be an iterable of Koalas "
+            "first argument must be an iterable of pandas-on-Spark "
             "objects, you passed an object of type "
             '"{name}"'.format(name=type(objs).__name__)
         )

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -35,7 +35,7 @@ unary_np_spark_mappings = OrderedDict(
         "bitwise_not": F.bitwiseNOT,
         "cbrt": F.cbrt,
         "ceil": F.ceil,
-        # It requires complex type which Koalas does not support yet
+        # It requires complex type which pandas-on-Spark does not support yet
         "conj": lambda _: NotImplemented,
         "conjugate": lambda _: NotImplemented,  # It requires complex type
         "cos": F.cos,
@@ -53,7 +53,7 @@ unary_np_spark_mappings = OrderedDict(
         "isfinite": lambda c: c != float("inf"),
         "isinf": lambda c: c == float("inf"),
         "isnan": F.isnan,
-        "isnat": lambda c: NotImplemented,  # Koalas and PySpark does not have Nat concept.
+        "isnat": lambda c: NotImplemented,  # pandas-on-Spark and PySpark does not have Nat concept.
         "log": F.log,
         "log10": F.log10,
         "log1p": F.log1p,

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -399,7 +399,7 @@ class KdePlotBase:
         return kd.estimate(list(map(float, ind)))
 
 
-class KoalasPlotAccessor(PandasObject):
+class PandasOnSparkPlotAccessor(PandasObject):
     """
     Series/Frames plotting accessor and method.
 
@@ -427,10 +427,10 @@ class KoalasPlotAccessor(PandasObject):
     @staticmethod
     def _find_backend(backend):
         """
-        Find a Koalas plotting backend
+        Find a pandas-on-Spark plotting backend
         """
         try:
-            return KoalasPlotAccessor._backends[backend]
+            return PandasOnSparkPlotAccessor._backends[backend]
         except KeyError:
             try:
                 module = importlib.import_module(backend)
@@ -441,7 +441,7 @@ class KoalasPlotAccessor(PandasObject):
                 if hasattr(module, "plot") or hasattr(module, "plot_koalas"):
                     # Validate that the interface is implemented when the option
                     # is set, rather than at plot time.
-                    KoalasPlotAccessor._backends[backend] = module
+                    PandasOnSparkPlotAccessor._backends[backend] = module
                     return module
 
         raise ValueError(
@@ -454,8 +454,8 @@ class KoalasPlotAccessor(PandasObject):
     def _get_plot_backend(backend=None):
         backend = backend or get_option("plotting.backend")
         # Shortcut
-        if backend in KoalasPlotAccessor._backends:
-            return KoalasPlotAccessor._backends[backend]
+        if backend in PandasOnSparkPlotAccessor._backends:
+            return PandasOnSparkPlotAccessor._backends[backend]
 
         if backend == "matplotlib":
             # Because matplotlib is an optional dependency,
@@ -470,7 +470,7 @@ class KoalasPlotAccessor(PandasObject):
                     "default backend 'matplotlib' is selected."
                 ) from None
 
-            KoalasPlotAccessor._backends["matplotlib"] = module
+            PandasOnSparkPlotAccessor._backends["matplotlib"] = module
         elif backend == "plotly":
             try:
                 # test if plotly can be imported
@@ -482,14 +482,14 @@ class KoalasPlotAccessor(PandasObject):
                     "default backend 'plotly' is selected."
                 ) from None
 
-            KoalasPlotAccessor._backends["plotly"] = module
+            PandasOnSparkPlotAccessor._backends["plotly"] = module
         else:
-            module = KoalasPlotAccessor._find_backend(backend)
-            KoalasPlotAccessor._backends[backend] = module
+            module = PandasOnSparkPlotAccessor._find_backend(backend)
+            PandasOnSparkPlotAccessor._backends[backend] = module
         return module
 
     def __call__(self, kind="line", backend=None, **kwargs):
-        plot_backend = KoalasPlotAccessor._get_plot_backend(backend)
+        plot_backend = PandasOnSparkPlotAccessor._get_plot_backend(backend)
         plot_data = self.data
 
         kind = {"density": "kde"}.get(kind, kind)
@@ -498,12 +498,12 @@ class KoalasPlotAccessor(PandasObject):
             return plot_backend.plot_koalas(plot_data, kind=kind, **kwargs)
         else:
             # fallback to use pandas'
-            if not KoalasPlotAccessor.pandas_plot_data_map[kind]:
+            if not PandasOnSparkPlotAccessor.pandas_plot_data_map[kind]:
                 raise NotImplementedError(
                     "'%s' plot is not supported with '%s' plot "
                     "backend yet." % (kind, plot_backend.__name__)
                 )
-            plot_data = KoalasPlotAccessor.pandas_plot_data_map[kind](plot_data)
+            plot_data = PandasOnSparkPlotAccessor.pandas_plot_data_map[kind](plot_data)
             return plot_backend.plot(plot_data, kind=kind, **kwargs)
 
     def line(self, x=None, y=None, **kwargs):
@@ -775,7 +775,7 @@ class KoalasPlotAccessor(PandasObject):
             :meth:`Koalas.Series.plot`.
 
         precision: scalar, default = 0.01
-            This argument is used by Koalas to compute approximate statistics
+            This argument is used by pandas-on-Spark to compute approximate statistics
             for building a boxplot. Use *smaller* values to get more precise
             statistics (matplotlib-only).
 
@@ -787,12 +787,12 @@ class KoalasPlotAccessor(PandasObject):
 
         Notes
         -----
-        There are behavior differences between Koalas and pandas.
+        There are behavior differences between pandas-on-Spark and pandas.
 
-        * Koalas computes approximate statistics - expect differences between
-          pandas and Koalas boxplots, especially regarding 1st and 3rd quartiles.
+        * pandas-on-Spark computes approximate statistics - expect differences between
+          pandas and pandas-on-Spark boxplots, especially regarding 1st and 3rd quartiles.
         * The `whis` argument is only supported as a single number.
-        * Koalas doesn't support the following argument(s) (matplotlib-only).
+        * pandas-on-Spark doesn't support the following argument(s) (matplotlib-only).
 
           * `bootstrap` argument is not supported
           * `autorange` argument is not supported
@@ -884,7 +884,7 @@ class KoalasPlotAccessor(PandasObject):
             KDE is evaluated at the points passed. If `ind` is an integer,
             `ind` number of equally spaced points are used.
         **kwargs : optional
-            Keyword arguments to pass on to :meth:`Koalas.Series.plot`.
+            Keyword arguments to pass on to :meth:`pandas-on-Spark.Series.plot`.
 
         Returns
         -------
@@ -1020,7 +1020,7 @@ class KoalasPlotAccessor(PandasObject):
             Label or position of the column to plot.
             If not provided, ``subplots=True`` argument must be passed (matplotlib-only).
         **kwds
-            Keyword arguments to pass on to :meth:`Koalas.Series.plot`.
+            Keyword arguments to pass on to :meth:`pandas-on-Spark.Series.plot`.
 
         Returns
         -------

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -438,7 +438,7 @@ class PandasOnSparkPlotAccessor(PandasObject):
                 # We re-raise later on.
                 pass
             else:
-                if hasattr(module, "plot") or hasattr(module, "plot_koalas"):
+                if hasattr(module, "plot") or hasattr(module, "plot_pandas_on_spark"):
                     # Validate that the interface is implemented when the option
                     # is set, rather than at plot time.
                     PandasOnSparkPlotAccessor._backends[backend] = module
@@ -493,9 +493,9 @@ class PandasOnSparkPlotAccessor(PandasObject):
         plot_data = self.data
 
         kind = {"density": "kde"}.get(kind, kind)
-        if hasattr(plot_backend, "plot_koalas"):
-            # use if there's koalas specific method.
-            return plot_backend.plot_koalas(plot_data, kind=kind, **kwargs)
+        if hasattr(plot_backend, "plot_pandas_on_spark"):
+            # use if there's pandas-on-Spark specific method.
+            return plot_backend.plot_pandas_on_spark(plot_data, kind=kind, **kwargs)
         else:
             # fallback to use pandas'
             if not PandasOnSparkPlotAccessor.pandas_plot_data_map[kind]:
@@ -586,7 +586,8 @@ class PandasOnSparkPlotAccessor(PandasObject):
             If not specified, all numerical columns are used.
         **kwds : optional
             Additional keyword arguments are documented in
-            :meth:`Koalas.Series.plot` or :meth:`Koalas.DataFrame.plot`.
+            :meth:`pyspark.pandas.Series.plot` or
+            :meth:`pyspark.pandas.DataFrame.plot`.
 
         Returns
         -------
@@ -772,7 +773,7 @@ class PandasOnSparkPlotAccessor(PandasObject):
         ----------
         **kwds : optional
             Additional keyword arguments are documented in
-            :meth:`Koalas.Series.plot`.
+            :meth:`pyspark.pandas.Series.plot`.
 
         precision: scalar, default = 0.01
             This argument is used by pandas-on-Spark to compute approximate statistics

--- a/python/pyspark/pandas/plot/matplotlib.py
+++ b/python/pyspark/pandas/plot/matplotlib.py
@@ -66,7 +66,7 @@ else:
     _all_kinds = PlotAccessor._all_kinds
 
 
-class KoalasBarPlot(PandasBarPlot, TopNPlotBase):
+class PandasOnSparkBarPlot(PandasBarPlot, TopNPlotBase):
     def __init__(self, data, **kwargs):
         super().__init__(self.get_top_n(data), **kwargs)
 
@@ -75,7 +75,7 @@ class KoalasBarPlot(PandasBarPlot, TopNPlotBase):
         return ax.bar(x, y, w, bottom=start, log=log, **kwds)
 
 
-class KoalasBoxPlot(PandasBoxPlot, BoxPlotBase):
+class PandasOnSparkBoxPlot(PandasBoxPlot, BoxPlotBase):
     def boxplot(
         self,
         ax,
@@ -251,14 +251,14 @@ class KoalasBoxPlot(PandasBoxPlot, BoxPlotBase):
         data = self.data
 
         # Updates all props with the rc defaults from matplotlib
-        self.kwds.update(KoalasBoxPlot.rc_defaults(**self.kwds))
+        self.kwds.update(PandasOnSparkBoxPlot.rc_defaults(**self.kwds))
 
         # Gets some important kwds
         showfliers = self.kwds.get("showfliers", False)
         whis = self.kwds.get("whis", 1.5)
         labels = self.kwds.get("labels", [colname])
 
-        # This one is Koalas specific to control precision for approx_percentile
+        # This one is pandas-on-Spark specific to control precision for approx_percentile
         precision = self.kwds.get("precision", 0.01)
 
         # # Computes mean, median, Q1 and Q3 with approx_percentile and precision
@@ -370,7 +370,7 @@ class KoalasBoxPlot(PandasBoxPlot, BoxPlotBase):
         )
 
 
-class KoalasHistPlot(PandasHistPlot, HistogramPlotBase):
+class PandasOnSparkHistPlot(PandasHistPlot, HistogramPlotBase):
     def _args_adjust(self):
         if is_list_like(self.bottom):
             self.bottom = np.array(self.bottom)
@@ -418,7 +418,7 @@ class KoalasHistPlot(PandasHistPlot, HistogramPlotBase):
         return patches
 
 
-class KoalasPiePlot(PandasPiePlot, TopNPlotBase):
+class PandasOnSparkPiePlot(PandasPiePlot, TopNPlotBase):
     def __init__(self, data, **kwargs):
         super().__init__(self.get_top_n(data), **kwargs)
 
@@ -427,7 +427,7 @@ class KoalasPiePlot(PandasPiePlot, TopNPlotBase):
         super()._make_plot()
 
 
-class KoalasAreaPlot(PandasAreaPlot, SampledPlotBase):
+class PandasOnSparkAreaPlot(PandasAreaPlot, SampledPlotBase):
     def __init__(self, data, **kwargs):
         super().__init__(self.get_sampled(data), **kwargs)
 
@@ -436,7 +436,7 @@ class KoalasAreaPlot(PandasAreaPlot, SampledPlotBase):
         super()._make_plot()
 
 
-class KoalasLinePlot(PandasLinePlot, SampledPlotBase):
+class PandasOnSparkLinePlot(PandasLinePlot, SampledPlotBase):
     def __init__(self, data, **kwargs):
         super().__init__(self.get_sampled(data), **kwargs)
 
@@ -445,7 +445,7 @@ class KoalasLinePlot(PandasLinePlot, SampledPlotBase):
         super()._make_plot()
 
 
-class KoalasBarhPlot(PandasBarhPlot, TopNPlotBase):
+class PandasOnSparkBarhPlot(PandasBarhPlot, TopNPlotBase):
     def __init__(self, data, **kwargs):
         super().__init__(self.get_top_n(data), **kwargs)
 
@@ -454,7 +454,7 @@ class KoalasBarhPlot(PandasBarhPlot, TopNPlotBase):
         super()._make_plot()
 
 
-class KoalasScatterPlot(PandasScatterPlot, TopNPlotBase):
+class PandasOnSparkScatterPlot(PandasScatterPlot, TopNPlotBase):
     def __init__(self, data, x, y, **kwargs):
         super().__init__(self.get_top_n(data), x, y, **kwargs)
 
@@ -463,7 +463,7 @@ class KoalasScatterPlot(PandasScatterPlot, TopNPlotBase):
         super()._make_plot()
 
 
-class KoalasKdePlot(PandasKdePlot, KdePlotBase):
+class PandasOnSparkKdePlot(PandasKdePlot, KdePlotBase):
     def _compute_plot_data(self):
         self.data = KdePlotBase.prepare_kde_data(self.data)
 
@@ -506,15 +506,15 @@ class KoalasKdePlot(PandasKdePlot, KdePlotBase):
 
 
 _klasses = [
-    KoalasHistPlot,
-    KoalasBarPlot,
-    KoalasBoxPlot,
-    KoalasPiePlot,
-    KoalasAreaPlot,
-    KoalasLinePlot,
-    KoalasBarhPlot,
-    KoalasScatterPlot,
-    KoalasKdePlot,
+    PandasOnSparkHistPlot,
+    PandasOnSparkBarPlot,
+    PandasOnSparkBoxPlot,
+    PandasOnSparkPiePlot,
+    PandasOnSparkAreaPlot,
+    PandasOnSparkLinePlot,
+    PandasOnSparkBarhPlot,
+    PandasOnSparkScatterPlot,
+    PandasOnSparkKdePlot,
 ]
 _plot_klass = {getattr(klass, "_kind"): klass for klass in _klasses}
 _common_kinds = {"area", "bar", "barh", "box", "hist", "kde", "line", "pie"}
@@ -869,7 +869,7 @@ def _plot(data, x=None, y=None, subplots=False, ax=None, kind="line", **kwds):
     from pyspark.pandas import DataFrame
 
     # function copied from pandas.plotting._core
-    # and adapted to handle Koalas DataFrame and Series
+    # and adapted to handle pandas-on-Spark DataFrame and Series
 
     kind = kind.lower().strip()
     kind = {"density": "kde"}.get(kind, kind)

--- a/python/pyspark/pandas/plot/matplotlib.py
+++ b/python/pyspark/pandas/plot/matplotlib.py
@@ -520,11 +520,11 @@ _plot_klass = {getattr(klass, "_kind"): klass for klass in _klasses}
 _common_kinds = {"area", "bar", "barh", "box", "hist", "kde", "line", "pie"}
 _series_kinds = _common_kinds.union(set())
 _dataframe_kinds = _common_kinds.union({"scatter", "hexbin"})
-_koalas_all_kinds = _common_kinds.union(_series_kinds).union(_dataframe_kinds)
+_pandas_on_spark_all_kinds = _common_kinds.union(_series_kinds).union(_dataframe_kinds)
 
 
-def plot_koalas(data, kind, **kwargs):
-    if kind not in _koalas_all_kinds:
+def plot_pandas_on_spark(data, kind, **kwargs):
+    if kind not in _pandas_on_spark_all_kinds:
         raise ValueError("{} is not a valid plot kind".format(kind))
 
     from pyspark.pandas import DataFrame, Series

--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -21,7 +21,7 @@ import pandas as pd
 from pyspark.pandas.plot import (
     HistogramPlotBase,
     name_like_string,
-    KoalasPlotAccessor,
+    PandasOnSparkPlotAccessor,
     BoxPlotBase,
     KdePlotBase,
 )
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 def plot_koalas(data: Union["ps.DataFrame", "ps.Series"], kind: str, **kwargs):
     import plotly
 
-    # Koalas specific plots
+    # pandas-on-Spark specific plots
     if kind == "pie":
         return plot_pie(data, **kwargs)
     if kind == "hist":
@@ -44,13 +44,13 @@ def plot_koalas(data: Union["ps.DataFrame", "ps.Series"], kind: str, **kwargs):
         return plot_kde(data, **kwargs)
 
     # Other plots.
-    return plotly.plot(KoalasPlotAccessor.pandas_plot_data_map[kind](data), kind, **kwargs)
+    return plotly.plot(PandasOnSparkPlotAccessor.pandas_plot_data_map[kind](data), kind, **kwargs)
 
 
 def plot_pie(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
     from plotly import express
 
-    data = KoalasPlotAccessor.pandas_plot_data_map["pie"](data)
+    data = PandasOnSparkPlotAccessor.pandas_plot_data_map["pie"](data)
 
     if isinstance(data, pd.Series):
         pdf = data.to_frame()
@@ -115,14 +115,14 @@ def plot_box(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
 
     if isinstance(data, ps.DataFrame):
         raise RuntimeError(
-            "plotly does not support a box plot with Koalas DataFrame. Use Series instead."
+            "plotly does not support a box plot with pandas-on-Spark DataFrame. Use Series instead."
         )
 
     # 'whis' isn't actually an argument in plotly (but in matplotlib). But seems like
     # plotly doesn't expose the reach of the whiskers to the beyond the first and
     # third quartiles (?). Looks they use default 1.5.
     whis = kwargs.pop("whis", 1.5)
-    # 'precision' is Koalas specific to control precision for approx_percentile
+    # 'precision' is pandas-on-Spark specific to control precision for approx_percentile
     precision = kwargs.pop("precision", 0.01)
 
     # Plotly options

--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -30,7 +30,8 @@ if TYPE_CHECKING:
     import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
 
 
-def plot_koalas(data: Union["ps.DataFrame", "ps.Series"], kind: str, **kwargs):
+def plot_pandas_on_spark(
+        data: Union["ps.DataFrame", "ps.Series"], kind: str, **kwargs):
     import plotly
 
     # pandas-on-Spark specific plots

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -50,7 +50,7 @@ from pyspark.sql.types import (
 from pyspark.sql.window import Window
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas.accessors import KoalasSeriesMethods
+from pyspark.pandas.accessors import PandasOnSparkSeriesMethods
 from pyspark.pandas.categorical import CategoricalAccessor
 from pyspark.pandas.config import get_option
 from pyspark.pandas.base import IndexOpsMixin
@@ -65,7 +65,7 @@ from pyspark.pandas.internal import (
     SPARK_DEFAULT_SERIES_NAME,
 )
 from pyspark.pandas.missing.series import MissingPandasLikeSeries
-from pyspark.pandas.plot import KoalasPlotAccessor
+from pyspark.pandas.plot import PandasOnSparkPlotAccessor
 from pyspark.pandas.ml import corr
 from pyspark.pandas.utils import (
     combine_frames,
@@ -349,12 +349,12 @@ if (3, 5) <= sys.version_info < (3, 7) and __name__ != "__main__":
 
 class Series(Frame, IndexOpsMixin, Generic[T]):
     """
-    Koalas Series that corresponds to pandas Series logically. This holds Spark Column
+    pandas-on-Spark Series that corresponds to pandas Series logically. This holds Spark Column
     internally.
 
     :ivar _internal: an internal immutable Frame to manage metadata.
     :type _internal: InternalFrame
-    :ivar _kdf: Parent's Koalas DataFrame
+    :ivar _kdf: Parent's pandas-on-Spark DataFrame
     :type _kdf: ps.DataFrame
 
     Parameters
@@ -430,7 +430,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def _with_new_scol(self, scol: spark.Column, *, dtype=None) -> "Series":
         """
-        Copy Koalas Series with the new Spark Column.
+        Copy pandas-on-Spark Series with the new Spark Column.
 
         :param scol: the new Spark Column
         :return: the copied Series
@@ -661,8 +661,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         series_examples=_floordiv_example_SERIES,
     )
 
-    # create accessor for Koalas specific methods.
-    koalas = CachedAccessor("koalas", KoalasSeriesMethods)
+    # create accessor for pandas-on-Spark specific methods.
+    koalas = CachedAccessor("koalas", PandasOnSparkSeriesMethods)
 
     # Comparison Operators
     def eq(self, other) -> bool:
@@ -1785,7 +1785,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if isinstance(other, (Series, DataFrame)):
             return self.reindex(index=other.index)
         else:
-            raise TypeError("other must be a Koalas Series or DataFrame")
+            raise TypeError("other must be a pandas-on-Spark Series or DataFrame")
 
     def fillna(
         self, value=None, method=None, axis=None, inplace=False, limit=None
@@ -2493,7 +2493,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         inplace : bool, default False
             if True, perform operation in-place
         kind : str, default None
-            Koalas does not allow specifying the sorting algorithm at the moment, default None
+            pandas-on-Spark does not allow specifying the sorting algorithm at the moment,
+            default None
         na_position : {‘first’, ‘last’}, default ‘last’
             first puts NaNs at the beginning, last puts NaNs at the end. Not implemented for
             MultiIndex.
@@ -2792,11 +2793,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Notes
         -----
-        There are behavior differences between Koalas and pandas.
+        There are behavior differences between pandas-on-Spark and pandas.
 
         * the `method` argument only accepts 'pearson', 'spearman'
-        * the data should not contain NaNs. Koalas will return an error.
-        * Koalas doesn't support the following argument(s).
+        * the data should not contain NaNs. pandas-on-Spark will return an error.
+        * pandas-on-Spark doesn't support the following argument(s).
 
           * `min_periods` argument is not supported
         """
@@ -2832,7 +2833,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         -----
         Faster than ``.sort_values().head(n)`` for small `n` relative to
         the size of the ``Series`` object.
-        In Koalas, thanks to Spark's lazy execution and query optimizer,
+        In pandas-on-Spark, thanks to Spark's lazy execution and query optimizer,
         the two would have same performance.
 
         Examples
@@ -2892,7 +2893,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Faster than ``.sort_values(ascending=False).head(n)`` for small `n`
         relative to the size of the ``Series`` object.
 
-        In Koalas, thanks to Spark's lazy execution and query optimizer,
+        In pandas-on-Spark, thanks to Spark's lazy execution and query optimizer,
         the two would have same performance.
 
         Examples
@@ -3003,7 +3004,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def hist(self, bins=10, **kwds):
         return self.plot.hist(bins, **kwds)
 
-    hist.__doc__ = KoalasPlotAccessor.hist.__doc__
+    hist.__doc__ = PandasOnSparkPlotAccessor.hist.__doc__
 
     def apply(self, func, args=(), **kwds) -> "Series":
         """
@@ -3020,7 +3021,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
              >>> def square(x) -> np.int32:
              ...     return x ** 2
 
-             Koalas uses return type hint and does not try to infer the type.
+             pandas-on-Spark uses return type hint and does not try to infer the type.
 
         Parameters
         ----------
@@ -3106,7 +3107,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         dtype: float64
 
 
-        You can omit the type hint and let Koalas infer its type.
+        You can omit the type hint and let pandas-on-Spark infer its type.
 
         >>> s.apply(np.log)
         London      2.995732
@@ -3225,7 +3226,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
              >>> def square(x) -> np.int32:
              ...     return x ** 2
 
-             Koalas uses return type hint and does not try to infer the type.
+             pandas-on-Spark uses return type hint and does not try to infer the type.
 
         Parameters
         ----------
@@ -3277,7 +3278,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1  1.000000  2.718282
         2  1.414214  7.389056
 
-        You can omit the type hint and let Koalas infer its type.
+        You can omit the type hint and let pandas-on-Spark infer its type.
 
         >>> s.transform([np.sqrt, np.exp])
                sqrt       exp
@@ -3307,7 +3308,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         )
         return self.koalas.transform_batch(func, *args, **kwargs)
 
-    transform_batch.__doc__ = KoalasSeriesMethods.transform_batch.__doc__
+    transform_batch.__doc__ = PandasOnSparkSeriesMethods.transform_batch.__doc__
 
     def round(self, decimals=0) -> "Series":
         """
@@ -3355,9 +3356,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         Return value at the given quantile.
 
-        .. note:: Unlike pandas', the quantile in Koalas is an approximated quantile based upon
-            approximate percentile computation because computing quantile across a large dataset
-            is extremely expensive.
+        .. note:: Unlike pandas', the quantile in pandas-on-Spark is an approximated quantile
+            based upon approximate percentile computation because computing quantile across
+            a large dataset is extremely expensive.
 
         Parameters
         ----------
@@ -4844,8 +4845,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         .. note:: This API is slightly different from pandas when indexes from both Series
             are not aligned. To match with pandas', it requires to read the whole data for,
-            for example, counting. pandas raises an exception; however, Koalas just proceeds
-            and performs by ignoring mismatches with NaN permissively.
+            for example, counting. pandas raises an exception; however, pandas-on-Spark
+            just proceeds and performs by ignoring mismatches with NaN permissively.
 
             >>> pdf1 = pd.Series([1, 2, 3], index=[0, 1, 2])
             >>> pdf2 = pd.Series([1, 2, 3], index=[0, 1, 3])
@@ -5135,7 +5136,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Notes
         -----
-        Unlike pandas, Koalas doesn't check whether an index is duplicated or not
+        Unlike pandas, pandas-on-Spark doesn't check whether an index is duplicated or not
         because the checking of duplicated index requires scanning whole data which
         can be quite expensive.
 
@@ -5231,7 +5232,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         This method returns an iterable tuple (index, value). This is
         convenient if you want to create a lazy iterator.
 
-        .. note:: Unlike pandas', the iteritems in Koalas returns generator rather zip object
+        .. note:: Unlike pandas', the iteritems in pandas-on-Spark returns generator rather
+            zip object
 
         Returns
         -------
@@ -6069,7 +6071,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     dt = CachedAccessor("dt", DatetimeMethods)
     str = CachedAccessor("str", StringMethods)
     cat = CachedAccessor("cat", CategoricalAccessor)
-    plot = CachedAccessor("plot", KoalasPlotAccessor)
+    plot = CachedAccessor("plot", PandasOnSparkPlotAccessor)
 
     # ----------------------------------------------------------------------
 
@@ -6198,7 +6200,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     elif (3, 5) <= sys.version_info < (3, 7):
         # The implementation is in its metaclass so this flag is needed to distinguish
-        # Koalas Series.
+        # pandas-on-Spark Series.
         is_series = None
 
 

--- a/python/pyspark/pandas/spark/accessors.py
+++ b/python/pyspark/pandas/spark/accessors.py
@@ -324,8 +324,8 @@ class SparkFrameMethods(object):
         Parameters
         ----------
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. The index name
-            in Koalas is ignored. By default, the index is always lost.
+            Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+            in pandas-on-Spark is ignored. By default, the index is always lost.
 
         Examples
         --------
@@ -350,8 +350,8 @@ class SparkFrameMethods(object):
         Parameters
         ----------
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. The index name
-            in Koalas is ignored. By default, the index is always lost.
+            Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+            in pandas-on-Spark is ignored. By default, the index is always lost.
 
         Returns
         -------
@@ -394,8 +394,8 @@ class SparkFrameMethods(object):
         Parameters
         ----------
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. The index name
-            in Koalas is ignored. By default, the index is always lost.
+            Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+            in pandas-on-Spark is ignored. By default, the index is always lost.
 
         See Also
         --------
@@ -439,7 +439,7 @@ class SparkFrameMethods(object):
         +-----+---+---+---+
 
         Keeping index column is useful when you want to call some Spark APIs and
-        convert it back to Koalas DataFrame without creating a default index, which
+        convert it back to pandas-on-Spark DataFrame without creating a default index, which
         can affect performance.
 
         >>> spark_df = df.to_spark(index_col="index")
@@ -462,7 +462,7 @@ class SparkFrameMethods(object):
         |      2|      3|  6|  9|
         +-------+-------+---+---+
 
-        Likewise, can be converted to back to Koalas DataFrame.
+        Likewise, can be converted to back to pandas-on-Spark DataFrame.
 
         >>> new_spark_df.to_koalas(
         ...     index_col=["index_1", "index_2"])  # doctest: +NORMALIZE_WHITESPACE
@@ -517,7 +517,7 @@ class SparkFrameMethods(object):
         """
         Yields and caches the current DataFrame.
 
-        The Koalas DataFrame is yielded as a protected resource and its corresponding
+        The pandas-on-Spark DataFrame is yielded as a protected resource and its corresponding
         data is cached which gets uncached after execution goes of the context.
 
         If you want to specify the StorageLevel manually, use :meth:`DataFrame.spark.persist`
@@ -570,7 +570,7 @@ class SparkFrameMethods(object):
         Yields and caches the current DataFrame with a specific StorageLevel.
         If a StogeLevel is not given, the `MEMORY_AND_DISK` level is used by default like PySpark.
 
-        The Koalas DataFrame is yielded as a protected resource and its corresponding
+        The pandas-on-Spark DataFrame is yielded as a protected resource and its corresponding
         data is cached which gets uncached after execution goes of the context.
 
         See Also
@@ -716,8 +716,8 @@ class SparkFrameMethods(object):
         partition_cols : str or list of str, optional, default None
             Names of partitioning columns
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. The index name
-            in Koalas is ignored. By default, the index is always lost.
+            Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+            in pandas-on-Spark is ignored. By default, the index is always lost.
         options
             Additional options passed directly to Spark.
 
@@ -787,8 +787,8 @@ class SparkFrameMethods(object):
         partition_cols : str or list of str, optional
             Names of partitioning columns
         index_col: str or list of str, optional, default: None
-            Column names to be used in Spark to represent Koalas' index. The index name
-            in Koalas is ignored. By default, the index is always lost.
+            Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+            in pandas-on-Spark is ignored. By default, the index is always lost.
         options : dict
             All other options passed directly into Spark's data source.
 
@@ -1205,7 +1205,7 @@ class CachedSparkFrameMethods(SparkFrameMethods):
 
     def unpersist(self) -> None:
         """
-        The `unpersist` function is used to uncache the Koalas DataFrame when it
+        The `unpersist` function is used to uncache the pandas-on-Spark DataFrame when it
         is not used with `with` statement.
 
         Returns

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 """
-Additional Spark functions used in Koalas.
+Additional Spark functions used in pandas-on-Spark.
 """
 
 from pyspark import SparkContext

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -36,7 +36,7 @@ from builtins import locals as builtin_locals
 
 def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
     """
-    Execute a SQL query and return the result as a Koalas DataFrame.
+    Execute a SQL query and return the result as a pandas-on-Spark DataFrame.
 
     This function also supports embedding Python variables (locals, globals, and parameters)
     in the SQL statement by wrapping them in curly braces. See examples section for details.
@@ -52,8 +52,8 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
         * int
         * float
         * list, tuple, range of above types
-        * Koalas DataFrame
-        * Koalas Series
+        * pandas-on-Spark DataFrame
+        * pandas-on-Spark Series
         * pandas DataFrame
 
     Parameters
@@ -69,7 +69,7 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
 
     Returns
     -------
-    Koalas DataFrame
+    pandas-on-Spark DataFrame
 
     Examples
     --------
@@ -110,7 +110,8 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
     0  0
     1  1
 
-    Mixing Koalas and pandas DataFrames in a join operation. Note that the index is dropped.
+    Mixing pandas-on-Spark and pandas DataFrames in a join operation. Note that the index is
+    dropped.
 
     >>> ps.sql('''
     ...   SELECT m1.a, m2.b

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -288,7 +288,7 @@ class SQLProcessor(object):
         if isinstance(var, pd.DataFrame):
             return self._convert_var(ps.DataFrame(var))
         if isinstance(var, DataFrame):
-            df_id = "koalas_" + str(id(var))
+            df_id = "pandas_on_spark_" + str(id(var))
             if df_id not in self._temp_views:
                 sdf = var.to_spark()
                 sdf.createOrReplaceTempView(df_id)

--- a/python/pyspark/pandas/strings.py
+++ b/python/pyspark/pandas/strings.py
@@ -16,7 +16,7 @@
 #
 
 """
-String functions on Koalas Series
+String functions on pandas-on-Spark Series
 """
 from typing import Union, TYPE_CHECKING, cast, Optional, List
 
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 
 class StringMethods(object):
-    """String methods for Koalas Series"""
+    """String methods for pandas-on-Spark Series"""
 
     def __init__(self, series: "ps.Series"):
         if not isinstance(series.spark.data_type, (StringType, BinaryType, ArrayType)):
@@ -184,7 +184,7 @@ class StringMethods(object):
         Returns
         -------
         Series of bool or object
-            Koalas Series of booleans indicating whether the given pattern
+            pandas-on-Spark Series of booleans indicating whether the given pattern
             matches the start of each string element.
 
         Examples
@@ -235,7 +235,7 @@ class StringMethods(object):
         Returns
         -------
         Series of bool or object
-            Koalas Series of booleans indicating whether the given pattern
+            pandas-on-Spark Series of booleans indicating whether the given pattern
             matches the end of each string element.
 
         Examples

--- a/python/pyspark/pandas/tests/plot/test_series_plot.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot.py
@@ -21,7 +21,7 @@ import pandas as pd
 import numpy as np
 
 from pyspark import pandas as ps
-from pyspark.pandas.plot import KoalasPlotAccessor, BoxPlotBase
+from pyspark.pandas.plot import PandasOnSparkPlotAccessor, BoxPlotBase
 from pyspark.pandas.testing.utils import have_plotly
 
 
@@ -43,7 +43,7 @@ class SeriesPlotTest(unittest.TestCase):
         with ps.option_context("plotting.backend", plot_backend):
             self.assertEqual(ps.options.plotting.backend, plot_backend)
 
-            module = KoalasPlotAccessor._get_plot_backend(plot_backend)
+            module = PandasOnSparkPlotAccessor._get_plot_backend(plot_backend)
             self.assertEqual(module.__name__, "pyspark.pandas.plot.plotly")
 
     def test_plot_backends_incorrect(self):
@@ -53,7 +53,7 @@ class SeriesPlotTest(unittest.TestCase):
             self.assertEqual(ps.options.plotting.backend, fake_plot_backend)
 
             with self.assertRaises(ValueError):
-                KoalasPlotAccessor._get_plot_backend(fake_plot_backend)
+                PandasOnSparkPlotAccessor._get_plot_backend(fake_plot_backend)
 
     def test_box_summary(self):
         def check_box_summary(kdf, pdf):

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -80,12 +80,12 @@ class NumPyCompatTest(ReusedSQLTestCase, SQLTestUtils):
 
     def test_np_unsupported_series(self):
         kdf = self.kdf
-        with self.assertRaisesRegex(NotImplementedError, "Koalas.*not.*support.*sqrt.*"):
+        with self.assertRaisesRegex(NotImplementedError, "pandas.*not.*support.*sqrt.*"):
             np.sqrt(kdf.a, kdf.b)
 
     def test_np_unsupported_frame(self):
         kdf = self.kdf
-        with self.assertRaisesRegex(NotImplementedError, "Koalas.*not.*support.*sqrt.*"):
+        with self.assertRaisesRegex(NotImplementedError, "on-Spark.*not.*support.*sqrt.*"):
             np.sqrt(kdf, kdf)
 
     def test_np_spark_compat_series(self):

--- a/python/pyspark/pandas/tests/test_typedef.py
+++ b/python/pyspark/pandas/tests/test_typedef.py
@@ -49,7 +49,7 @@ from pyspark.pandas.typedef import (
     extension_float_dtypes_available,
     extension_object_dtypes_available,
     infer_return_type,
-    koalas_dtype,
+    pandas_on_spark_type,
 )
 from pyspark import pandas as ps
 
@@ -366,7 +366,7 @@ class TypeHintTests(unittest.TestCase):
 
         for numpy_or_python_type, (dtype, spark_type) in type_mapper.items():
             self.assertEqual(as_spark_type(numpy_or_python_type), spark_type)
-            self.assertEqual(koalas_dtype(numpy_or_python_type), (dtype, spark_type))
+            self.assertEqual(pandas_on_spark_type(numpy_or_python_type), (dtype, spark_type))
 
         with self.assertRaisesRegex(TypeError, "Type uint64 was not understood."):
             as_spark_type(np.dtype("uint64"))
@@ -375,10 +375,10 @@ class TypeHintTests(unittest.TestCase):
             as_spark_type(np.dtype("object"))
 
         with self.assertRaisesRegex(TypeError, "Type uint64 was not understood."):
-            koalas_dtype(np.dtype("uint64"))
+            pandas_on_spark_type(np.dtype("uint64"))
 
         with self.assertRaisesRegex(TypeError, "Type object was not understood."):
-            koalas_dtype(np.dtype("object"))
+            pandas_on_spark_type(np.dtype("object"))
 
     @unittest.skipIf(not extension_dtypes_available, "The pandas extension types are not available")
     def test_as_spark_type_extension_dtypes(self):
@@ -393,7 +393,7 @@ class TypeHintTests(unittest.TestCase):
 
         for extension_dtype, spark_type in type_mapper.items():
             self.assertEqual(as_spark_type(extension_dtype), spark_type)
-            self.assertEqual(koalas_dtype(extension_dtype), (extension_dtype, spark_type))
+            self.assertEqual(pandas_on_spark_type(extension_dtype), (extension_dtype, spark_type))
 
     @unittest.skipIf(
         not extension_object_dtypes_available, "The pandas extension object types are not available"
@@ -408,7 +408,7 @@ class TypeHintTests(unittest.TestCase):
 
         for extension_dtype, spark_type in type_mapper.items():
             self.assertEqual(as_spark_type(extension_dtype), spark_type)
-            self.assertEqual(koalas_dtype(extension_dtype), (extension_dtype, spark_type))
+            self.assertEqual(pandas_on_spark_type(extension_dtype), (extension_dtype, spark_type))
 
     @unittest.skipIf(
         not extension_float_dtypes_available, "The pandas extension float types are not available"
@@ -423,7 +423,7 @@ class TypeHintTests(unittest.TestCase):
 
         for extension_dtype, spark_type in type_mapper.items():
             self.assertEqual(as_spark_type(extension_dtype), spark_type)
-            self.assertEqual(koalas_dtype(extension_dtype), (extension_dtype, spark_type))
+            self.assertEqual(pandas_on_spark_type(extension_dtype), (extension_dtype, spark_type))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/usage_logging/__init__.py
+++ b/python/pyspark/pandas/usage_logging/__init__.py
@@ -26,7 +26,7 @@ from typing import Union
 import pandas as pd
 
 from pyspark.pandas import config, namespace, sql_processor
-from pyspark.pandas.accessors import KoalasFrameMethods
+from pyspark.pandas.accessors import PandasOnSparkFrameMethods
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.datetimes import DatetimeMethods
 from pyspark.pandas.groupby import DataFrameGroupBy, SeriesGroupBy
@@ -103,7 +103,7 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
         CachedSparkFrameMethods,
         SparkFrameMethods,
         SparkIndexOpsMethods,
-        KoalasFrameMethods,
+        PandasOnSparkFrameMethods,
     ]
 
     try:

--- a/python/pyspark/pandas/usage_logging/usage_logger.py
+++ b/python/pyspark/pandas/usage_logging/usage_logger.py
@@ -26,7 +26,7 @@ from typing import Any, Optional
 
 def get_logger() -> Any:
     """ An entry point of the plug-in and return the usage logger. """
-    return KoalasUsageLogger()
+    return PandasOnSparkUsageLogger()
 
 
 def _format_signature(signature):
@@ -37,7 +37,7 @@ def _format_signature(signature):
     )
 
 
-class KoalasUsageLogger(object):
+class PandasOnSparkUsageLogger(object):
     """
     The reference implementation of usage logger.
 

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 """
-Commonly used utils in Koalas.
+Commonly used utils in pandas-on-Spark.
 """
 
 import functools
@@ -429,10 +429,10 @@ def default_session(conf=None):
     if conf is None:
         conf = dict()
 
-    builder = spark.SparkSession.builder.appName("Koalas")
+    builder = spark.SparkSession.builder.appName("pandas-on-Spark")
     for key, value in conf.items():
         builder = builder.config(key, value)
-    # Currently, Koalas is dependent on such join due to 'compute.ops_on_diff_frames'
+    # Currently, pandas-on-Spark is dependent on such join due to 'compute.ops_on_diff_frames'
     # configuration. This is needed with Spark 3.0+.
     builder.config("spark.sql.analyzer.failAmbiguousSelfJoin", False)
 
@@ -489,7 +489,7 @@ def validate_arguments_and_invoke_function(
     For example usage, look at DataFrame.to_html().
 
     :param pobj: the pandas DataFrame or Series to operate on
-    :param koalas_func: Koalas function, used to get default parameter values
+    :param koalas_func: pandas-on-Spark function, used to get default parameter values
     :param pandas_func: pandas function, used to check whether pandas supports all the arguments
     :param input_args: arguments to pass to the pandas function, often created by using locals().
                        Make sure locals() call is at the top of the function so it captures only
@@ -700,7 +700,7 @@ def validate_how(how: str) -> str:
     """ Check the given how for join is valid. """
     if how == "full":
         warnings.warn(
-            "Warning: While Koalas will accept 'full', you should use 'outer' "
+            "Warning: While pandas-on-Spark will accept 'full', you should use 'outer' "
             + "instead to be compatible with the pandas merge API",
             UserWarning,
         )
@@ -719,10 +719,11 @@ def verify_temp_column_name(
     df: Union["DataFrame", spark.DataFrame], column_name_or_label: Union[Any, Tuple]
 ) -> Union[Any, Tuple]:
     """
-    Verify that the given column name does not exist in the given Koalas or Spark DataFrame.
+    Verify that the given column name does not exist in the given pandas-on-Spark or
+    Spark DataFrame.
 
     The temporary column names should start and end with `__`. In addition, `column_name_or_label`
-    expects a single string, or column labels when `df` is a Koalas DataFrame.
+    expects a single string, or column labels when `df` is a pandas-on-Spark DataFrame.
 
     >>> kdf = ps.DataFrame({("x", "a"): ['a', 'b', 'c']})
     >>> kdf["__dummy__"] = 0
@@ -800,7 +801,7 @@ def verify_temp_column_name(
         )
         assert all(
             column_name_or_label != label for label in df._internal.column_labels
-        ), "The given column name `{}` already exists in the Koalas DataFrame: {}".format(
+        ), "The given column name `{}` already exists in the pandas-on-Spark DataFrame: {}".format(
             name_like_string(column_name_or_label), df.columns
         )
         df = df._internal.resolved_copy.spark_frame

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -470,7 +470,7 @@ def sql_conf(pairs, *, spark=None):
 
 def validate_arguments_and_invoke_function(
     pobj: Union[pd.DataFrame, pd.Series],
-    koalas_func: Callable,
+    pandas_on_spark_func: Callable,
     pandas_func: Callable,
     input_args: Dict,
 ):
@@ -489,7 +489,7 @@ def validate_arguments_and_invoke_function(
     For example usage, look at DataFrame.to_html().
 
     :param pobj: the pandas DataFrame or Series to operate on
-    :param koalas_func: pandas-on-Spark function, used to get default parameter values
+    :param pandas_on_spark_func: pandas-on-Spark function, used to get default parameter values
     :param pandas_func: pandas function, used to check whether pandas supports all the arguments
     :param input_args: arguments to pass to the pandas function, often created by using locals().
                        Make sure locals() call is at the top of the function so it captures only
@@ -509,10 +509,10 @@ def validate_arguments_and_invoke_function(
         del args["kwargs"]
         args = {**args, **kwargs}
 
-    koalas_params = inspect.signature(koalas_func).parameters
+    pandas_on_spark_params = inspect.signature(pandas_on_spark_func).parameters
     pandas_params = inspect.signature(pandas_func).parameters
 
-    for param in koalas_params.values():
+    for param in pandas_on_spark_params.values():
         if param.name not in pandas_params:
             if args[param.name] == param.default:
                 del args[param.name]

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -50,7 +50,7 @@ class RollingAndExpanding(object):
     def _apply_as_series_or_frame(self, func):
         """
         Wraps a function that handles Spark column in order
-        to support it in both Koalas Series and DataFrame.
+        to support it in both pandas-on-Spark Series and DataFrame.
         Note that the given `func` name should be same as the API's method name.
         """
         raise NotImplementedError(
@@ -654,7 +654,7 @@ class RollingGroupby(Rolling):
     def _apply_as_series_or_frame(self, func):
         """
         Wraps a function that handles Spark column in order
-        to support it in both Koalas Series and DataFrame.
+        to support it in both pandas-on-Spark Series and DataFrame.
         Note that the given `func` name should be same as the API's method name.
         """
         from pyspark.pandas import DataFrame


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename Koalas to pandas-on-Spark in main codes

### Why are the changes needed?

To have the correct name in PySpark. NOTE that the official name in the main documentation will be pandas APIs on Spark to be extra clear. pandas-on-Spark is not the official term.

### Does this PR introduce _any_ user-facing change?

No, it's master-only change. It changes the docstring and class names.

### How was this patch tested?

Manually tested via:

```bash
./python/run-tests --python-executable=python3 --modules pyspark-pandas
```