### PR TITLE
[SPARK-35002][INFRA][FOLLOW-UP] Add current ip address, long hostname and short hostname to /etc/hosts

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -1,0 +1,13 @@
+name: Tune Runner VM
+description: tunes the GitHub Runner VM operation system
+runs:
+  using: composite
+  steps:
+    - run: |
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            # workaround for https://github.com/actions/virtual-environments/issues/3185
+            # Ensure that reverse lookups for current hostname are handled properly
+            # Add the current IP address, long hostname and short hostname record to /etc/hosts file
+            echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+        fi
+      shell: bash

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,6 +54,8 @@ jobs:
       # In order to get diff files
       with:
         fetch-depth: 0
+    - name: Tune Runner VM
+      uses: ./.github/actions/tune-runner-vm        
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -84,6 +84,8 @@ jobs:
         fetch-depth: 0
         repository: apache/spark
         ref: master
+    - name: Tune Runner VM
+      uses: ./.github/actions/tune-runner-vm        
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       id: sync-branch
@@ -387,6 +389,8 @@ jobs:
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2
+    - name: Tune Runner VM
+      uses: ./.github/actions/tune-runner-vm        
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:
@@ -423,6 +427,8 @@ jobs:
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2
+    - name: Tune Runner VM
+      uses: ./.github/actions/tune-runner-vm        
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:
@@ -456,6 +462,8 @@ jobs:
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2
+    - name: Tune Runner VM
+      uses: ./.github/actions/tune-runner-vm        
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:
@@ -490,6 +498,8 @@ jobs:
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2
+    - name: Tune Runner VM
+      uses: ./.github/actions/tune-runner-vm        
     - name: Cache TPC-DS generated data
       id: cache-tpcds-sf-1
       uses: actions/cache@v2


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Fixes reverse DNS lookup for current hostname in GitHub Actions

### Why are the changes needed?

Reverse DNS lookups are broken for GitHub Actions VMs currently. 
The problem has been reported as https://github.com/actions/virtual-environments/issues/3185 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not tested.