### PR TITLE
[SPARK-35048][INFRA] Only trigger the notify test workflow in upstream

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: "Notify test workflow"
         uses: actions/github-script@v3
-        if: ${{ github.base_ref == 'master' }}
+        if: github.base_ref == 'master' && github.repository == 'apache/spark'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
Only trigger the notify test workflow in upstream


### Why are the changes needed?
We should only trigger the notify test workflow in upstream apache/spark job, otherwise we will trigger the same workflow twice in fork repos.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
See local test in https://github.com/Yikun/spark/pull/13,
The notify test is skiped in fork repo.
https://github.com/Yikun/spark/pull/13/checks?check_run_id=2345776215

Note that current [notify_test_workflow with pull_request_target event](https://github.com/apache/spark/blob/f32114d17e1c022817a16c83f33138a1b8faa7c6/.github/workflows/notify_test_workflow.yml#L3) doesn't use something like `action/checkout` to checkout code. So this skip will only effect when this patch is merged, I just use change the `pull_request_target` the `pull request` to do local test.