### PR TITLE
[SPARK-35082][INFRA] Use permissive and squshed merge when syncing to the latest branch in GitHub Actions testing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -90,7 +90,7 @@ jobs:
       run: |
         apache_spark_ref=`git rev-parse HEAD`
         git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF##*/}
-        git merge --progress --ff-only FETCH_HEAD
+        git merge --progress --squash FETCH_HEAD
         echo "::set-output name=APACHE_SPARK_REF::$apache_spark_ref"
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
@@ -186,7 +186,7 @@ jobs:
       run: |
         apache_spark_ref=`git rev-parse HEAD`
         git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF##*/}
-        git merge --progress --ff-only FETCH_HEAD
+        git merge --progress --squash FETCH_HEAD
         echo "::set-output name=APACHE_SPARK_REF::$apache_spark_ref"
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
@@ -261,7 +261,7 @@ jobs:
       run: |
         apache_spark_ref=`git rev-parse HEAD`
         git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF##*/}
-        git merge --progress --ff-only FETCH_HEAD
+        git merge --progress --squash FETCH_HEAD
         echo "::set-output name=APACHE_SPARK_REF::$apache_spark_ref"
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven


### PR DESCRIPTION
### What changes were proposed in this pull request?

There is an issue when syncing to the Apache master branch, see also https://github.com/apache/spark/pull/32168:

```
From https://github.com/yaooqinn/spark
 * branch                  SPARK-35044 -> FETCH_HEAD
fatal: Not possible to fast-forward, aborting.
Error: Process completed with exit code 128.
```

This is because we use `--ff-only` option so it assumes that the fork is always based on the latest master branch.
We should make it less strict.

This PR proposes to use the same command when we merge PRs: 

https://github.com/apache/spark/blob/c8f56eb7bb49d7aafd7b83bad241a0b1b50a0e33/dev/merge_spark_pr.py#L127

### Why are the changes needed?

To unblock PR testing broken.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Locally tested

Co-authored-by: Kent Yao <yaooqinn@hotmail.com>
Co-authored-by: Yikun Jiang <yikunkero@gmail.com>

Closes #32168 