### PR TITLE
[SPARK-35087] Some columns  in table ` Aggregated Metrics by Executor` of stage-detail page shows incorrectly.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -576,8 +576,8 @@ $(document).ready(function () {
                         }
                     ],
                     "columnDefs": [
-                        // to ensure that strings like '12345678 / 123456', '9999 / 1234' in tables
-                        // can be sorted as numerical-order instead of lexicographical-order.
+                        // String with structures like : 'bytes / bytes', 'bytes / bytes'
+                        // they should be sorted as numerical-order instead of lexicographical-order.
                         { "type": "size", "targets": 9 },
                         { "type": "size", "targets": 10 },
                         { "type": "size", "targets": 11 },

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -562,10 +562,14 @@ $(document).ready(function () {
                         }
                     ],
                     "columnDefs": [
-                        { "visible": false, "targets": 15 },
-                        { "visible": false, "targets": 16 },
-                        { "visible": false, "targets": 17 },
-                        { "visible": false, "targets": 18 }
+                        { "type": "duration", "targets": 9 },
+                        { "type": "duration", "targets": 10 },
+                        { "type": "duration", "targets": 11 },
+                        { "type": "duration", "targets": 12 },
+                        { "type": "duration", "visible": false, "targets": 15 },
+                        { "type": "duration", "visible": false, "targets": 16 },
+                        { "type": "duration", "visible": false, "targets": 17 },
+                        { "type": "duration", "visible": false, "targets": 18 }
                     ],
                     "deferRender": true,
                     "order": [[0, "asc"]],

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -43,6 +43,20 @@ $.extend( $.fn.dataTable.ext.type.order, {
         a = ConvertDurationString( a );
         b = ConvertDurationString( b );
         return ((a < b) ? 1 : ((a > b) ? -1 : 0));
+    },
+
+    "size-pre": parseFloat,
+
+    "size-asc": function ( a, b ) {
+        a = parseFloat( a );
+        b = parseFloat( b );
+        return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+    },
+
+    "size-desc": function ( a, b ) {
+        a = parseFloat( a );
+        b = parseFloat( b );
+        return ((a < b) ? 1 : ((a > b) ? -1 : 0));
     }
 } );
 
@@ -562,17 +576,16 @@ $(document).ready(function () {
                         }
                     ],
                     "columnDefs": [
-                        // Reuse the duration-related sorting methods defined in [stagapage.js#33]
                         // to ensure that strings like '12345678 / 123456', '9999 / 1234' in tables
                         // can be sorted as numerical-order instead of lexicographical-order.
-                        { "type": "duration", "targets": 9 },
-                        { "type": "duration", "targets": 10 },
-                        { "type": "duration", "targets": 11 },
-                        { "type": "duration", "targets": 12 },
-                        { "type": "duration", "visible": false, "targets": 15 },
-                        { "type": "duration", "visible": false, "targets": 16 },
-                        { "type": "duration", "visible": false, "targets": 17 },
-                        { "type": "duration", "visible": false, "targets": 18 }
+                        { "type": "size", "targets": 9 },
+                        { "type": "size", "targets": 10 },
+                        { "type": "size", "targets": 11 },
+                        { "type": "size", "targets": 12 },
+                        { "type": "size", "visible": false, "targets": 15 },
+                        { "type": "size", "visible": false, "targets": 16 },
+                        { "type": "size", "visible": false, "targets": 17 },
+                        { "type": "size", "visible": false, "targets": 18 }
                     ],
                     "deferRender": true,
                     "order": [[0, "asc"]],

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -562,6 +562,9 @@ $(document).ready(function () {
                         }
                     ],
                     "columnDefs": [
+                        // Reuse the duration-related sorting methods defined in [stagapage.js#33]
+                        // to ensure that strings like '12345678 / 123456', '9999 / 1234' in tables
+                        // can be sorted as numerical-order instead of lexicographical-order.
                         { "type": "duration", "targets": 9 },
                         { "type": "duration", "targets": 10 },
                         { "type": "duration", "targets": 11 },


### PR DESCRIPTION
### What changes were proposed in this pull request?

 columns like 'Shuffle Read Size / Records', 'Output Size/ Records' etc  in table ` Aggregated Metrics by Executor` of stage-detail page should be sorted as numerical-order instead of lexicographical-order.

### Why are the changes needed?
buf fix,the sorting style should be consistentbetween different columns

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Only JS was modified, and the manual test result works well.

**before modified:**
![sort-result-incorrent](https://user-images.githubusercontent.com/52202080/114865055-565ed980-9e24-11eb-97ff-bd1769d3848b.png)

**after modified:**

![sort-result-corrent](https://user-images.githubusercontent.com/52202080/114865187-7c847980-9e24-11eb-9fbc-39ee224726d6.png)

