### PR TITLE
[SPARK-35087][UI] Some columns in table Aggregated Metrics by Executor of stage-detail page shows incorrectly. 

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -45,18 +45,20 @@ $.extend( $.fn.dataTable.ext.type.order, {
         return ((a < b) ? 1 : ((a > b) ? -1 : 0));
     },
 
-    
-    "size-pre": parseFloat,
+    "size-pre": function (data) {
+        var floatValue = parseFloat(data)
+        return isNaN(floatValue) ? 0 : floatValue;
+    },
 
-    "size-asc": function ( a, b ) {
-        a = parseFloat( a );
-        b = parseFloat( b );
+    "size-asc": function (a, b) {
+        a = parseFloat(a);
+        b = parseFloat(b);
         return ((a < b) ? -1 : ((a > b) ? 1 : 0));
     },
 
-    "size-desc": function ( a, b ) {
-        a = parseFloat( a );
-        b = parseFloat( b );
+    "size-desc": function (a, b) {
+        a = parseFloat(a);
+        b = parseFloat(b);
         return ((a < b) ? 1 : ((a > b) ? -1 : 0));
     }
 } );
@@ -577,16 +579,27 @@ $(document).ready(function () {
                         }
                     ],
                     "columnDefs": [
-                        // String with structures like : 'bytes / bytes', 'bytes / bytes'
-                        // they should be sorted as numerical-order instead of lexicographical-order.
-                        { "type": "size", "targets": 9 },
-                        { "type": "size", "targets": 10 },
-                        { "type": "size", "targets": 11 },
-                        { "type": "size", "targets": 12 },
-                        { "type": "size", "visible": false, "targets": 15 },
-                        { "type": "size", "visible": false, "targets": 16 },
-                        { "type": "size", "visible": false, "targets": 17 },
-                        { "type": "size", "visible": false, "targets": 18 }
+                        // SPARK-35087 [type:size] means String with structures like : 'bytes / bytes', 'bytes / bytes',
+                        // they should be sorted as numerical-order instead of lexicographical-order by default.
+                        // The targets: $id represents column id which comes from stagespage-template.html#summary-executor-table.
+                        // If the relative position of the columns in the table #summary-executor-table has changed,
+                        // please be careful to adjust the column index here.
+                        // Input Size / Records
+                        {"type": "size", "targets": 9},
+                        // Output Size / Records
+                        {"type": "size", "targets": 10},
+                        // Shuffle Read Size / Records
+                        {"type": "size", "targets": 11},
+                        // Shuffle Write Size / Records
+                        {"type": "size", "targets": 12},
+                        // Peak JVM Memory OnHeap / OffHeap
+                        {"type": "size", "visible": false, "targets": 15},
+                        // Peak Execution Memory OnHeap / OffHeap
+                        {"type": "size", "visible": false, "targets": 16},
+                        // Peak Storage Memory OnHeap / OffHeap
+                        {"type": "size", "visible": false, "targets": 17},
+                        // Peak Pool Memory Direct / Mapped
+                        {"type": "size", "visible": false, "targets": 18}
                     ],
                     "deferRender": true,
                     "order": [[0, "asc"]],

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -592,9 +592,13 @@ $(document).ready(function () {
                         {"type": "size", "targets": 11},
                         // Shuffle Write Size / Records
                         {"type": "size", "targets": 12},
+                        // Peak JVM Memory OnHeap / OffHeap
                         {"visible": false, "targets": 15},
+                        // Peak Execution Memory OnHeap / OffHeap
                         {"visible": false, "targets": 16},
+                        // Peak Storage Memory OnHeap / OffHeap
                         {"visible": false, "targets": 17},
+                        // Peak Pool Memory Direct / Mapped
                         {"visible": false, "targets": 18}
                     ],
                     "deferRender": true,

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -43,6 +43,20 @@ $.extend( $.fn.dataTable.ext.type.order, {
         a = ConvertDurationString( a );
         b = ConvertDurationString( b );
         return ((a < b) ? 1 : ((a > b) ? -1 : 0));
+    },
+
+    "size-pre": parseFloat,
+
+    "size-asc": function ( a, b ) {
+        a = parseFloat( a );
+        b = parseFloat( b );
+        return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+    },
+
+    "size-desc": function ( a, b ) {
+        a = parseFloat( a );
+        b = parseFloat( b );
+        return ((a < b) ? 1 : ((a > b) ? -1 : 0));
     }
 } );
 
@@ -562,10 +576,16 @@ $(document).ready(function () {
                         }
                     ],
                     "columnDefs": [
-                        { "visible": false, "targets": 15 },
-                        { "visible": false, "targets": 16 },
-                        { "visible": false, "targets": 17 },
-                        { "visible": false, "targets": 18 }
+                        // String with structures like : 'bytes / bytes', 'bytes / bytes'
+                        // they should be sorted as numerical-order instead of lexicographical-order.
+                        { "type": "size", "targets": 9 },
+                        { "type": "size", "targets": 10 },
+                        { "type": "size", "targets": 11 },
+                        { "type": "size", "targets": 12 },
+                        { "type": "size", "visible": false, "targets": 15 },
+                        { "type": "size", "visible": false, "targets": 16 },
+                        { "type": "size", "visible": false, "targets": 17 },
+                        { "type": "size", "visible": false, "targets": 18 }
                     ],
                     "deferRender": true,
                     "order": [[0, "asc"]],

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -579,11 +579,11 @@ $(document).ready(function () {
                         }
                     ],
                     "columnDefs": [
-                        // SPARK-35087 [type:size] means String with structures like : 'bytes / bytes', 'bytes / bytes',
+                        // SPARK-35087 [type:size] means String with structures like : 'size / records',
                         // they should be sorted as numerical-order instead of lexicographical-order by default.
-                        // The targets: $id represents column id which comes from stagespage-template.html#summary-executor-table.
-                        // If the relative position of the columns in the table #summary-executor-table has changed,
-                        // please be careful to adjust the column index here.
+                        // The targets: $id represents column id which comes from stagespage-template.html
+                        // #summary-executor-table.If the relative position of the columns in the table
+                        // #summary-executor-table has changed,please be careful to adjust the column index here
                         // Input Size / Records
                         {"type": "size", "targets": 9},
                         // Output Size / Records
@@ -592,14 +592,10 @@ $(document).ready(function () {
                         {"type": "size", "targets": 11},
                         // Shuffle Write Size / Records
                         {"type": "size", "targets": 12},
-                        // Peak JVM Memory OnHeap / OffHeap
-                        {"type": "size", "visible": false, "targets": 15},
-                        // Peak Execution Memory OnHeap / OffHeap
-                        {"type": "size", "visible": false, "targets": 16},
-                        // Peak Storage Memory OnHeap / OffHeap
-                        {"type": "size", "visible": false, "targets": 17},
-                        // Peak Pool Memory Direct / Mapped
-                        {"type": "size", "visible": false, "targets": 18}
+                        {"visible": false, "targets": 15},
+                        {"visible": false, "targets": 16},
+                        {"visible": false, "targets": 17},
+                        {"visible": false, "targets": 18}
                     ],
                     "deferRender": true,
                     "order": [[0, "asc"]],

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -45,6 +45,7 @@ $.extend( $.fn.dataTable.ext.type.order, {
         return ((a < b) ? 1 : ((a > b) ? -1 : 0));
     },
 
+    
     "size-pre": parseFloat,
 
     "size-asc": function ( a, b ) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

 columns like 'Shuffle Read Size / Records', 'Output Size/ Records' etc  in table ` Aggregated Metrics by Executor` of stage-detail page should be sorted as numerical-order instead of lexicographical-order.

### Why are the changes needed?
buf fix,the sorting style should be consistent between different columns.

The correspondence between the table and the index is shown below(it is defined in stagespage-template.html)：
| index | column name                            |
| ----- | -------------------------------------- |
| 0     | Executor ID                            |
| 1     | Logs                                   |
| 2     | Address                                |
| 3     | Task Time                              |
| 4     | Total Tasks                            |
| 5     | Failed Tasks                           |
| 6     | Killed Tasks                           |
| 7     | Succeeded Tasks                        |
| 8     | Excluded                               |
| 9     | Input Size / Records                   |
| 10    | Output Size / Records                  |
| 11    | Shuffle Read Size / Records            |
| 12    | Shuffle Write Size / Records           |
| 13    | Spill (Memory)                         |
| 14    | Spill (Disk)                           |
| 15    | Peak JVM Memory OnHeap / OffHeap       |
| 16    | Peak Execution Memory OnHeap / OffHeap |
| 17    | Peak Storage Memory OnHeap / OffHeap   |
| 18    | Peak Pool Memory Direct / Mapped       |

I constructed some data to simulate the sorting results of the index columns from 9 to 18. 
As shown below,it can be seen that the sorting results of columns 9-12 are wrong:

![simulate-result](https://user-images.githubusercontent.com/52202080/115120775-c9fa1580-9fe1-11eb-8514-71f29db3a5eb.png)

The reason is that the real data corresponding to columns 9-12 (note that it is not the data displayed on the page) are **all strings similar to`94685/131`(bytes/records),while the real data corresponding to columns 13-18 are all numbers,** 
so the sorting corresponding to columns 13-18 loos well, but the results of columns 9-12 are incorrect because the strings are sorted according to lexicographical order. 




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Only JS was modified, and the manual test result works well.

**before modified:**
![looks-illegal](https://user-images.githubusercontent.com/52202080/115120812-06c60c80-9fe2-11eb-9ada-fa520fe43c4e.png)

**after modified:**
![sort-result-corrent](https://user-images.githubusercontent.com/52202080/114865187-7c847980-9e24-11eb-9fbc-39ee224726d6.png)

