### PR TITLE
[SPARK-35092][UI] the auto-generated rdd's name in the storage tab should be truncated if it is too long.

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -326,7 +326,7 @@ private[spark] object UIUtils extends Logging {
           <div class="row">
             <div class="col-12">
               <h3 style="vertical-align: bottom; white-space: nowrap; overflow: hidden;
-               text-overflow: ellipsis;">
+                text-overflow: ellipsis;">
                 {title}
                 {helpButton}
               </h3>

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -325,7 +325,7 @@ private[spark] object UIUtils extends Logging {
         <div class="container-fluid">
           <div class="row">
             <div class="col-12">
-              <h3 style="vertical-align: bottom; display: inline-block;">
+              <h3 style="vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
                 {title}
                 {helpButton}
               </h3>

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -325,7 +325,7 @@ private[spark] object UIUtils extends Logging {
         <div class="container-fluid">
           <div class="row">
             <div class="col-12">
-              <h3 style="vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+              <h3 style="vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow:ellipsis;">
                 {title}
                 {helpButton}
               </h3>

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -325,7 +325,8 @@ private[spark] object UIUtils extends Logging {
         <div class="container-fluid">
           <div class="row">
             <div class="col-12">
-              <h3 style="vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+              <h3 style="vertical-align: bottom; white-space: nowrap; overflow: hidden;
+               text-overflow: ellipsis;">
                 {title}
                 {helpButton}
               </h3>

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -325,7 +325,7 @@ private[spark] object UIUtils extends Logging {
         <div class="container-fluid">
           <div class="row">
             <div class="col-12">
-              <h3 style="vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow:ellipsis;">
+              <h3 style="vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
                 {title}
                 {helpButton}
               </h3>


### PR DESCRIPTION
### What changes were proposed in this pull request?
the auto-generated rdd's name in the storage tab should be truncated  as a single line if it is too long.

### Why are the changes needed?
to make the ui shows more friendly.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
just a simple modifition in css, manual test works well like below:

before modified:
![the rdd title in storage page shows too long](https://user-images.githubusercontent.com/52202080/115009655-17da2500-9edf-11eb-86a7-088bed7ef8f7.png)


after modified：
Tht titile  needs just one line:

![storage标题过长修改后](https://user-images.githubusercontent.com/52202080/114872091-8c07c080-9e2c-11eb-81a8-0c097b1a77bf.png)



