### PR TITLE
[SPARK-35096][SQL] SchemaPruning should adhere spark.sql.caseSensitive config

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
@@ -67,7 +67,7 @@ object SchemaPruning extends SQLConfHelper {
         val filteredRightFieldNames = rightStruct.fieldNames
           .filter(name => leftStruct.fieldNames.exists(resolver(_, name)))
         val sortedLeftFields = filteredRightFieldNames.map { fieldName =>
-          val resolvedLeftStruct = leftStruct.filter(p => resolver(p.name, fieldName)).head
+          val resolvedLeftStruct = leftStruct.find(p => resolver(p.name, fieldName)).get
           val leftFieldType = resolvedLeftStruct.dataType
           val rightFieldType = rightStruct(fieldName).dataType
           val sortedLeftFieldType = sortLeftFieldsByRight(leftFieldType, rightFieldType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
@@ -38,8 +38,7 @@ object SchemaPruning extends SQLConfHelper {
       .reduceLeft(_ merge _)
     val dataSchemaFieldNames = dataSchema.fieldNames.toSet
     val mergedDataSchema =
-      StructType(mergedSchema.filter(f => dataSchemaFieldNames.exists(resolver(_, f.name))
-      ))
+      StructType(mergedSchema.filter(f => dataSchemaFieldNames.exists(resolver(_, f.name))))
     // Sort the fields of mergedDataSchema according to their order in dataSchema,
     // recursively. This makes mergedDataSchema a pruned schema of dataSchema
     sortLeftFieldsByRight(mergedDataSchema, dataSchema).asInstanceOf[StructType]
@@ -70,8 +69,7 @@ object SchemaPruning extends SQLConfHelper {
         val sortedLeftFields = filteredRightFieldNames.map { fieldName =>
           val resolvedLeftStruct = leftStruct.filter(p => resolver(p.name, fieldName)).head
           val leftFieldType = resolvedLeftStruct.dataType
-          val resolvedRightStruct = rightStruct.filter(p => resolver(p.name, fieldName)).head
-          val rightFieldType = resolvedRightStruct.dataType
+          val rightFieldType = rightStruct(fieldName).dataType
           val sortedLeftFieldType = sortLeftFieldsByRight(leftFieldType, rightFieldType)
           StructField(fieldName, sortedLeftFieldType, nullable = resolvedLeftStruct.nullable)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
@@ -17,9 +17,10 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.types._
 
-object SchemaPruning {
+object SchemaPruning extends SQLConfHelper {
   /**
    * Filters the schema by the requested fields. For example, if the schema is struct<a:int, b:int>,
    * and given requested field are "a", the field "b" is pruned in the returned schema.
@@ -28,6 +29,7 @@ object SchemaPruning {
   def pruneDataSchema(
       dataSchema: StructType,
       requestedRootFields: Seq[RootField]): StructType = {
+    val resolver = conf.resolver
     // Merge the requested root fields into a single schema. Note the ordering of the fields
     // in the resulting schema may differ from their ordering in the logical relation's
     // original schema
@@ -36,7 +38,8 @@ object SchemaPruning {
       .reduceLeft(_ merge _)
     val dataSchemaFieldNames = dataSchema.fieldNames.toSet
     val mergedDataSchema =
-      StructType(mergedSchema.filter(f => dataSchemaFieldNames.contains(f.name)))
+      StructType(mergedSchema.filter(f => dataSchemaFieldNames.exists(resolver(_, f.name))
+      ))
     // Sort the fields of mergedDataSchema according to their order in dataSchema,
     // recursively. This makes mergedDataSchema a pruned schema of dataSchema
     sortLeftFieldsByRight(mergedDataSchema, dataSchema).asInstanceOf[StructType]
@@ -61,12 +64,16 @@ object SchemaPruning {
           sortLeftFieldsByRight(leftValueType, rightValueType),
           containsNull)
       case (leftStruct: StructType, rightStruct: StructType) =>
-        val filteredRightFieldNames = rightStruct.fieldNames.filter(leftStruct.fieldNames.contains)
+        val resolver = conf.resolver
+        val filteredRightFieldNames = rightStruct.fieldNames
+          .filter(name => leftStruct.fieldNames.exists(resolver(_, name)))
         val sortedLeftFields = filteredRightFieldNames.map { fieldName =>
-          val leftFieldType = leftStruct(fieldName).dataType
-          val rightFieldType = rightStruct(fieldName).dataType
+          val resolvedLeftStruct = leftStruct.filter(p => resolver(p.name, fieldName)).head
+          val leftFieldType = resolvedLeftStruct.dataType
+          val resolvedRightStruct = rightStruct.filter(p => resolver(p.name, fieldName)).head
+          val rightFieldType = resolvedRightStruct.dataType
           val sortedLeftFieldType = sortLeftFieldsByRight(leftFieldType, rightFieldType)
-          StructField(fieldName, sortedLeftFieldType, nullable = leftStruct(fieldName).nullable)
+          StructField(fieldName, sortedLeftFieldType, nullable = resolvedLeftStruct.nullable)
         }
         StructType(sortedLeftFields)
       case _ => left

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruningSuite.scala
@@ -18,9 +18,20 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.SchemaPruning.RootField
+import org.apache.spark.sql.catalyst.plans.SQLHelper
+import org.apache.spark.sql.internal.SQLConf.CASE_SENSITIVE
 import org.apache.spark.sql.types._
 
-class SchemaPruningSuite extends SparkFunSuite {
+class SchemaPruningSuite extends SparkFunSuite with SQLHelper {
+
+  def getRootFields(requestedFields: StructField*): Seq[RootField] = {
+    requestedFields.map { f =>
+      // `derivedFromAtt` doesn't affect the result of pruned schema.
+      SchemaPruning.RootField(field = f, derivedFromAtt = true)
+    }
+  }
+
   test("prune schema by the requested fields") {
     def testPrunedSchema(
         schema: StructType,
@@ -32,7 +43,6 @@ class SchemaPruningSuite extends SparkFunSuite {
       val expectedSchema = SchemaPruning.pruneDataSchema(schema, requestedRootFields)
       assert(expectedSchema == StructType(requestedFields))
     }
-
     testPrunedSchema(StructType.fromDDL("a int, b int"), StructField("a", IntegerType))
     testPrunedSchema(StructType.fromDDL("a int, b int"), StructField("b", IntegerType))
 
@@ -58,5 +68,29 @@ class SchemaPruningSuite extends SparkFunSuite {
     val selectFieldInMap = StructField("d", MapType(StructType.fromDDL("a int, b int"),
       StructType.fromDDL("e int, f string")))
     testPrunedSchema(complexStruct, StructField("c", IntegerType), selectFieldInMap)
+  }
+
+  test("SPARK-35096: test case insensitivity of pruned schema  ") {
+    Seq(true, false).foreach(isCaseSensitive => {
+      withSQLConf(CASE_SENSITIVE.key -> isCaseSensitive.toString) {
+        if (isCaseSensitive) {
+          val requestedFields = getRootFields(StructField("id", IntegerType))
+          val prunedSchema = SchemaPruning.pruneDataSchema(
+            StructType.fromDDL("ID int, name String"), requestedFields)
+          assert(prunedSchema == StructType(Seq.empty))
+        } else {
+          // Schema is case insensitive
+          val prunedSchema = SchemaPruning.pruneDataSchema(
+            StructType.fromDDL("ID int, name String"),
+            getRootFields(StructField("id", IntegerType)))
+          assert(prunedSchema == StructType(StructField("ID", IntegerType) :: Nil))
+          // Root fields are insensitive
+          val prunedSchema_1 = SchemaPruning.pruneDataSchema(
+            StructType.fromDDL("id int, name String"),
+            getRootFields(StructField("ID", IntegerType)))
+          assert(prunedSchema_1 == StructType(StructField("id", IntegerType) :: Nil))
+        }
+      }
+    })
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruningSuite.scala
@@ -75,12 +75,18 @@ class SchemaPruningSuite extends SparkFunSuite with SQLHelper {
     Seq(true, false).foreach(isCaseSensitive => {
       withSQLConf(CASE_SENSITIVE.key -> isCaseSensitive.toString) {
         if (isCaseSensitive) {
+          // Schema is case-sensitive
           val requestedFields = getRootFields(StructField("id", IntegerType))
           val prunedSchema = SchemaPruning.pruneDataSchema(
             StructType.fromDDL("ID int, name String"), requestedFields)
           assert(prunedSchema == StructType(Seq.empty))
+          // Root fields are case-sensitive
+          val rootFieldsSchema = SchemaPruning.pruneDataSchema(
+            StructType.fromDDL("id int, name String"),
+            getRootFields(StructField("ID", IntegerType)))
+          assert(rootFieldsSchema == StructType(StructType(Seq.empty)))
         } else {
-          // Schema is case insensitive
+          // Schema is case-insensitive
           val prunedSchema = SchemaPruning.pruneDataSchema(
             StructType.fromDDL("ID int, name String"),
             getRootFields(StructField("id", IntegerType)))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruningSuite.scala
@@ -43,6 +43,7 @@ class SchemaPruningSuite extends SparkFunSuite with SQLHelper {
       val expectedSchema = SchemaPruning.pruneDataSchema(schema, requestedRootFields)
       assert(expectedSchema == StructType(requestedFields))
     }
+
     testPrunedSchema(StructType.fromDDL("a int, b int"), StructField("a", IntegerType))
     testPrunedSchema(StructType.fromDDL("a int, b int"), StructField("b", IntegerType))
 
@@ -70,7 +71,7 @@ class SchemaPruningSuite extends SparkFunSuite with SQLHelper {
     testPrunedSchema(complexStruct, StructField("c", IntegerType), selectFieldInMap)
   }
 
-  test("SPARK-35096: test case insensitivity of pruned schema  ") {
+  test("SPARK-35096: test case insensitivity of pruned schema") {
     Seq(true, false).foreach(isCaseSensitive => {
       withSQLConf(CASE_SENSITIVE.key -> isCaseSensitive.toString) {
         if (isCaseSensitive) {
@@ -84,11 +85,11 @@ class SchemaPruningSuite extends SparkFunSuite with SQLHelper {
             StructType.fromDDL("ID int, name String"),
             getRootFields(StructField("id", IntegerType)))
           assert(prunedSchema == StructType(StructField("ID", IntegerType) :: Nil))
-          // Root fields are insensitive
-          val prunedSchema_1 = SchemaPruning.pruneDataSchema(
+          // Root fields are case-insensitive
+          val rootFieldsSchema = SchemaPruning.pruneDataSchema(
             StructType.fromDDL("id int, name String"),
             getRootFields(StructField("ID", IntegerType)))
-          assert(prunedSchema_1 == StructType(StructField("id", IntegerType) :: Nil))
+          assert(rootFieldsSchema == StructType(StructField("id", IntegerType) :: Nil))
         }
       }
     })


### PR DESCRIPTION

### What changes were proposed in this pull request?

As a part of the SPARK-26837 pruning of nested fields from object serializers are supported. But it is missed to handle case insensitivity nature of spark

In this PR I have resolved the column names to be pruned based on `spark.sql.caseSensitive ` config
**Exception Before Fix**

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
  at org.apache.spark.sql.types.StructType.apply(StructType.scala:414)
  at org.apache.spark.sql.catalyst.optimizer.ObjectSerializerPruning$$anonfun$apply$4.$anonfun$applyOrElse$3(objects.scala:216)
  at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238)
  at scala.collection.immutable.List.foreach(List.scala:392)
  at scala.collection.TraversableLike.map(TraversableLike.scala:238)
  at scala.collection.TraversableLike.map$(TraversableLike.scala:231)
  at scala.collection.immutable.List.map(List.scala:298)
  at org.apache.spark.sql.catalyst.optimizer.ObjectSerializerPruning$$anonfun$apply$4.applyOrElse(objects.scala:215)
  at org.apache.spark.sql.catalyst.optimizer.ObjectSerializerPruning$$anonfun$apply$4.applyOrElse(objects.scala:203)
  at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDown$1(TreeNode.scala:309)
  at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:72)
  at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:309)
  at 
```

### Why are the changes needed?
After Upgrade to Spark 3 `foreachBatch` API throws` java.lang.ArrayIndexOutOfBoundsException`. This issue will be fixed using this PR


### Does this PR introduce _any_ user-facing change?
No, Infact fixes the regression


### How was this patch tested?
Added tests and also tested verified manually
