### PR TITLE
[SPARK-32634][SQL] Introduce sort-based fallback for shuffled hash join (non-code-gen path)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -385,6 +385,16 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val SHUFFLEDHASHJOIN_FALLBACK_ENABLED =
+    buildConf("spark.sql.join.enableShuffledHashJoinFallback")
+      .internal()
+      .doc("When true, enable sort-based fallback for shuffled hash join. " +
+        "The sort-based fallback is to use sort merge join when there is no enough memory " +
+        "to build hash table for shuffled hash join. This can help avoid task OOM automatically.")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val RADIX_SORT_ENABLED = buildConf("spark.sql.sort.enableRadixSort")
     .internal()
     .doc("When true, enable use of radix sort when possible. Radix sort is much faster but " +
@@ -3536,6 +3546,8 @@ class SQLConf extends Serializable with Logging {
     getConf(ADVANCED_PARTITION_PREDICATE_PUSHDOWN)
 
   def preferSortMergeJoin: Boolean = getConf(PREFER_SORTMERGEJOIN)
+
+  def enableShuffledHashJoinFallback: Boolean = getConf(SHUFFLEDHASHJOIN_FALLBACK_ENABLED)
 
   def enableRadixSort: Boolean = getConf(RADIX_SORT_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -107,202 +107,241 @@ case class SortMergeJoinExec(
   override def requiredChildOrdering: Seq[Seq[SortOrder]] =
     requiredOrders(leftKeys) :: requiredOrders(rightKeys) :: Nil
 
-  private def requiredOrders(keys: Seq[Expression]): Seq[SortOrder] = {
-    // This must be ascending in order to agree with the `keyOrdering` defined in `doExecute()`.
-    keys.map(SortOrder(_, Ascending))
-  }
-
   private def createLeftKeyGenerator(): Projection =
     UnsafeProjection.create(leftKeys, left.output)
 
   private def createRightKeyGenerator(): Projection =
     UnsafeProjection.create(rightKeys, right.output)
 
-  private def getSpillThreshold: Int = {
-    sqlContext.conf.sortMergeJoinExecBufferSpillThreshold
-  }
-
-  private def getInMemoryThreshold: Int = {
-    sqlContext.conf.sortMergeJoinExecBufferInMemoryThreshold
-  }
-
   protected override def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
     val spillThreshold = getSpillThreshold
     val inMemoryThreshold = getInMemoryThreshold
     left.execute().zipPartitions(right.execute()) { (leftIter, rightIter) =>
-      val boundCondition: (InternalRow) => Boolean = {
-        condition.map { cond =>
-          Predicate.create(cond, left.output ++ right.output).eval _
-        }.getOrElse {
-          (r: InternalRow) => true
-        }
+      executeJoinWithIterators(
+        leftIter, rightIter, numOutputRows, spillThreshold, inMemoryThreshold)
+    }
+  }
+
+  def executeJoinWithIterators(
+      leftIter: Iterator[InternalRow],
+      rightIter: Iterator[InternalRow],
+      numOutputRows: SQLMetric,
+      spillThreshold: Int,
+      inMemoryThreshold: Int): Iterator[InternalRow] = {
+    val boundCondition: (InternalRow) => Boolean = {
+      condition.map { cond =>
+        Predicate.create(cond, left.output ++ right.output).eval _
+      }.getOrElse {
+        (r: InternalRow) => true
       }
+    }
 
-      // An ordering that can be used to compare keys from both sides.
-      val keyOrdering = RowOrdering.createNaturalAscendingOrdering(leftKeys.map(_.dataType))
-      val resultProj: InternalRow => InternalRow = UnsafeProjection.create(output, output)
+    // An ordering that can be used to compare keys from both sides.
+    val keyOrdering = RowOrdering.createNaturalAscendingOrdering(leftKeys.map(_.dataType))
+    val resultProj: InternalRow => InternalRow = UnsafeProjection.create(output, output)
 
-      joinType match {
-        case _: InnerLike =>
-          new RowIterator {
-            private[this] var currentLeftRow: InternalRow = _
-            private[this] var currentRightMatches: ExternalAppendOnlyUnsafeRowArray = _
-            private[this] var rightMatchesIterator: Iterator[UnsafeRow] = null
-            private[this] val smjScanner = new SortMergeJoinScanner(
-              createLeftKeyGenerator(),
-              createRightKeyGenerator(),
-              keyOrdering,
-              RowIterator.fromScala(leftIter),
-              RowIterator.fromScala(rightIter),
-              inMemoryThreshold,
-              spillThreshold,
-              cleanupResources
-            )
-            private[this] val joinRow = new JoinedRow
+    joinType match {
+      case _: InnerLike =>
+        new RowIterator {
+          private[this] var currentLeftRow: InternalRow = _
+          private[this] var currentRightMatches: ExternalAppendOnlyUnsafeRowArray = _
+          private[this] var rightMatchesIterator: Iterator[UnsafeRow] = null
+          private[this] val smjScanner = new SortMergeJoinScanner(
+            createLeftKeyGenerator(),
+            createRightKeyGenerator(),
+            keyOrdering,
+            RowIterator.fromScala(leftIter),
+            RowIterator.fromScala(rightIter),
+            inMemoryThreshold,
+            spillThreshold,
+            cleanupResources
+          )
+          private[this] val joinRow = new JoinedRow
 
-            if (smjScanner.findNextInnerJoinRows()) {
-              currentRightMatches = smjScanner.getBufferedMatches
-              currentLeftRow = smjScanner.getStreamedRow
-              rightMatchesIterator = currentRightMatches.generateIterator()
+          if (smjScanner.findNextInnerJoinRows()) {
+            currentRightMatches = smjScanner.getBufferedMatches
+            currentLeftRow = smjScanner.getStreamedRow
+            rightMatchesIterator = currentRightMatches.generateIterator()
+          }
+
+          override def advanceNext(): Boolean = {
+            while (rightMatchesIterator != null) {
+              if (!rightMatchesIterator.hasNext) {
+                if (smjScanner.findNextInnerJoinRows()) {
+                  currentRightMatches = smjScanner.getBufferedMatches
+                  currentLeftRow = smjScanner.getStreamedRow
+                  rightMatchesIterator = currentRightMatches.generateIterator()
+                } else {
+                  currentRightMatches = null
+                  currentLeftRow = null
+                  rightMatchesIterator = null
+                  return false
+                }
+              }
+              joinRow(currentLeftRow, rightMatchesIterator.next())
+              if (boundCondition(joinRow)) {
+                numOutputRows += 1
+                return true
+              }
             }
+            false
+          }
 
-            override def advanceNext(): Boolean = {
-              while (rightMatchesIterator != null) {
-                if (!rightMatchesIterator.hasNext) {
-                  if (smjScanner.findNextInnerJoinRows()) {
-                    currentRightMatches = smjScanner.getBufferedMatches
-                    currentLeftRow = smjScanner.getStreamedRow
-                    rightMatchesIterator = currentRightMatches.generateIterator()
-                  } else {
-                    currentRightMatches = null
-                    currentLeftRow = null
-                    rightMatchesIterator = null
-                    return false
+          override def getRow: InternalRow = resultProj(joinRow)
+        }.toScala
+
+      case LeftOuter =>
+        val smjScanner = new SortMergeJoinScanner(
+          streamedKeyGenerator = createLeftKeyGenerator(),
+          bufferedKeyGenerator = createRightKeyGenerator(),
+          keyOrdering,
+          streamedIter = RowIterator.fromScala(leftIter),
+          bufferedIter = RowIterator.fromScala(rightIter),
+          inMemoryThreshold,
+          spillThreshold,
+          cleanupResources
+        )
+        val rightNullRow = new GenericInternalRow(right.output.length)
+        new LeftOuterIterator(
+          smjScanner, rightNullRow, boundCondition, resultProj, numOutputRows).toScala
+
+      case RightOuter =>
+        val smjScanner = new SortMergeJoinScanner(
+          streamedKeyGenerator = createRightKeyGenerator(),
+          bufferedKeyGenerator = createLeftKeyGenerator(),
+          keyOrdering,
+          streamedIter = RowIterator.fromScala(rightIter),
+          bufferedIter = RowIterator.fromScala(leftIter),
+          inMemoryThreshold,
+          spillThreshold,
+          cleanupResources
+        )
+        val leftNullRow = new GenericInternalRow(left.output.length)
+        new RightOuterIterator(
+          smjScanner, leftNullRow, boundCondition, resultProj, numOutputRows).toScala
+
+      case FullOuter =>
+        val leftNullRow = new GenericInternalRow(left.output.length)
+        val rightNullRow = new GenericInternalRow(right.output.length)
+        val smjScanner = new SortMergeFullOuterJoinScanner(
+          leftKeyGenerator = createLeftKeyGenerator(),
+          rightKeyGenerator = createRightKeyGenerator(),
+          keyOrdering,
+          leftIter = RowIterator.fromScala(leftIter),
+          rightIter = RowIterator.fromScala(rightIter),
+          boundCondition,
+          leftNullRow,
+          rightNullRow)
+
+        new FullOuterIterator(
+          smjScanner,
+          resultProj,
+          numOutputRows).toScala
+
+      case LeftSemi =>
+        new RowIterator {
+          private[this] var currentLeftRow: InternalRow = _
+          private[this] val smjScanner = new SortMergeJoinScanner(
+            createLeftKeyGenerator(),
+            createRightKeyGenerator(),
+            keyOrdering,
+            RowIterator.fromScala(leftIter),
+            RowIterator.fromScala(rightIter),
+            inMemoryThreshold,
+            spillThreshold,
+            cleanupResources,
+            condition.isEmpty
+          )
+          private[this] val joinRow = new JoinedRow
+
+          override def advanceNext(): Boolean = {
+            while (smjScanner.findNextInnerJoinRows()) {
+              val currentRightMatches = smjScanner.getBufferedMatches
+              currentLeftRow = smjScanner.getStreamedRow
+              if (currentRightMatches != null && currentRightMatches.length > 0) {
+                val rightMatchesIterator = currentRightMatches.generateIterator()
+                while (rightMatchesIterator.hasNext) {
+                  joinRow(currentLeftRow, rightMatchesIterator.next())
+                  if (boundCondition(joinRow)) {
+                    numOutputRows += 1
+                    return true
                   }
                 }
+              }
+            }
+            false
+          }
+
+          override def getRow: InternalRow = currentLeftRow
+        }.toScala
+
+      case LeftAnti =>
+        new RowIterator {
+          private[this] var currentLeftRow: InternalRow = _
+          private[this] val smjScanner = new SortMergeJoinScanner(
+            createLeftKeyGenerator(),
+            createRightKeyGenerator(),
+            keyOrdering,
+            RowIterator.fromScala(leftIter),
+            RowIterator.fromScala(rightIter),
+            inMemoryThreshold,
+            spillThreshold,
+            cleanupResources,
+            condition.isEmpty
+          )
+          private[this] val joinRow = new JoinedRow
+
+          override def advanceNext(): Boolean = {
+            while (smjScanner.findNextOuterJoinRows()) {
+              currentLeftRow = smjScanner.getStreamedRow
+              val currentRightMatches = smjScanner.getBufferedMatches
+              if (currentRightMatches == null || currentRightMatches.length == 0) {
+                numOutputRows += 1
+                return true
+              }
+              var found = false
+              val rightMatchesIterator = currentRightMatches.generateIterator()
+              while (!found && rightMatchesIterator.hasNext) {
                 joinRow(currentLeftRow, rightMatchesIterator.next())
                 if (boundCondition(joinRow)) {
-                  numOutputRows += 1
-                  return true
+                  found = true
                 }
               }
-              false
-            }
-
-            override def getRow: InternalRow = resultProj(joinRow)
-          }.toScala
-
-        case LeftOuter =>
-          val smjScanner = new SortMergeJoinScanner(
-            streamedKeyGenerator = createLeftKeyGenerator(),
-            bufferedKeyGenerator = createRightKeyGenerator(),
-            keyOrdering,
-            streamedIter = RowIterator.fromScala(leftIter),
-            bufferedIter = RowIterator.fromScala(rightIter),
-            inMemoryThreshold,
-            spillThreshold,
-            cleanupResources
-          )
-          val rightNullRow = new GenericInternalRow(right.output.length)
-          new LeftOuterIterator(
-            smjScanner, rightNullRow, boundCondition, resultProj, numOutputRows).toScala
-
-        case RightOuter =>
-          val smjScanner = new SortMergeJoinScanner(
-            streamedKeyGenerator = createRightKeyGenerator(),
-            bufferedKeyGenerator = createLeftKeyGenerator(),
-            keyOrdering,
-            streamedIter = RowIterator.fromScala(rightIter),
-            bufferedIter = RowIterator.fromScala(leftIter),
-            inMemoryThreshold,
-            spillThreshold,
-            cleanupResources
-          )
-          val leftNullRow = new GenericInternalRow(left.output.length)
-          new RightOuterIterator(
-            smjScanner, leftNullRow, boundCondition, resultProj, numOutputRows).toScala
-
-        case FullOuter =>
-          val leftNullRow = new GenericInternalRow(left.output.length)
-          val rightNullRow = new GenericInternalRow(right.output.length)
-          val smjScanner = new SortMergeFullOuterJoinScanner(
-            leftKeyGenerator = createLeftKeyGenerator(),
-            rightKeyGenerator = createRightKeyGenerator(),
-            keyOrdering,
-            leftIter = RowIterator.fromScala(leftIter),
-            rightIter = RowIterator.fromScala(rightIter),
-            boundCondition,
-            leftNullRow,
-            rightNullRow)
-
-          new FullOuterIterator(
-            smjScanner,
-            resultProj,
-            numOutputRows).toScala
-
-        case LeftSemi =>
-          new RowIterator {
-            private[this] var currentLeftRow: InternalRow = _
-            private[this] val smjScanner = new SortMergeJoinScanner(
-              createLeftKeyGenerator(),
-              createRightKeyGenerator(),
-              keyOrdering,
-              RowIterator.fromScala(leftIter),
-              RowIterator.fromScala(rightIter),
-              inMemoryThreshold,
-              spillThreshold,
-              cleanupResources,
-              condition.isEmpty
-            )
-            private[this] val joinRow = new JoinedRow
-
-            override def advanceNext(): Boolean = {
-              while (smjScanner.findNextInnerJoinRows()) {
-                val currentRightMatches = smjScanner.getBufferedMatches
-                currentLeftRow = smjScanner.getStreamedRow
-                if (currentRightMatches != null && currentRightMatches.length > 0) {
-                  val rightMatchesIterator = currentRightMatches.generateIterator()
-                  while (rightMatchesIterator.hasNext) {
-                    joinRow(currentLeftRow, rightMatchesIterator.next())
-                    if (boundCondition(joinRow)) {
-                      numOutputRows += 1
-                      return true
-                    }
-                  }
-                }
+              if (!found) {
+                numOutputRows += 1
+                return true
               }
-              false
             }
+            false
+          }
 
-            override def getRow: InternalRow = currentLeftRow
-          }.toScala
+          override def getRow: InternalRow = currentLeftRow
+        }.toScala
 
-        case LeftAnti =>
-          new RowIterator {
-            private[this] var currentLeftRow: InternalRow = _
-            private[this] val smjScanner = new SortMergeJoinScanner(
-              createLeftKeyGenerator(),
-              createRightKeyGenerator(),
-              keyOrdering,
-              RowIterator.fromScala(leftIter),
-              RowIterator.fromScala(rightIter),
-              inMemoryThreshold,
-              spillThreshold,
-              cleanupResources,
-              condition.isEmpty
-            )
-            private[this] val joinRow = new JoinedRow
+      case j: ExistenceJoin =>
+        new RowIterator {
+          private[this] var currentLeftRow: InternalRow = _
+          private[this] val result: InternalRow = new GenericInternalRow(Array[Any](null))
+          private[this] val smjScanner = new SortMergeJoinScanner(
+            createLeftKeyGenerator(),
+            createRightKeyGenerator(),
+            keyOrdering,
+            RowIterator.fromScala(leftIter),
+            RowIterator.fromScala(rightIter),
+            inMemoryThreshold,
+            spillThreshold,
+            cleanupResources,
+            condition.isEmpty
+          )
+          private[this] val joinRow = new JoinedRow
 
-            override def advanceNext(): Boolean = {
-              while (smjScanner.findNextOuterJoinRows()) {
-                currentLeftRow = smjScanner.getStreamedRow
-                val currentRightMatches = smjScanner.getBufferedMatches
-                if (currentRightMatches == null || currentRightMatches.length == 0) {
-                  numOutputRows += 1
-                  return true
-                }
-                var found = false
+          override def advanceNext(): Boolean = {
+            while (smjScanner.findNextOuterJoinRows()) {
+              currentLeftRow = smjScanner.getStreamedRow
+              val currentRightMatches = smjScanner.getBufferedMatches
+              var found = false
+              if (currentRightMatches != null && currentRightMatches.length > 0) {
                 val rightMatchesIterator = currentRightMatches.generateIterator()
                 while (!found && rightMatchesIterator.hasNext) {
                   joinRow(currentLeftRow, rightMatchesIterator.next())
@@ -310,63 +349,20 @@ case class SortMergeJoinExec(
                     found = true
                   }
                 }
-                if (!found) {
-                  numOutputRows += 1
-                  return true
-                }
               }
-              false
+              result.setBoolean(0, found)
+              numOutputRows += 1
+              return true
             }
+            false
+          }
 
-            override def getRow: InternalRow = currentLeftRow
-          }.toScala
+          override def getRow: InternalRow = resultProj(joinRow(currentLeftRow, result))
+        }.toScala
 
-        case j: ExistenceJoin =>
-          new RowIterator {
-            private[this] var currentLeftRow: InternalRow = _
-            private[this] val result: InternalRow = new GenericInternalRow(Array[Any](null))
-            private[this] val smjScanner = new SortMergeJoinScanner(
-              createLeftKeyGenerator(),
-              createRightKeyGenerator(),
-              keyOrdering,
-              RowIterator.fromScala(leftIter),
-              RowIterator.fromScala(rightIter),
-              inMemoryThreshold,
-              spillThreshold,
-              cleanupResources,
-              condition.isEmpty
-            )
-            private[this] val joinRow = new JoinedRow
-
-            override def advanceNext(): Boolean = {
-              while (smjScanner.findNextOuterJoinRows()) {
-                currentLeftRow = smjScanner.getStreamedRow
-                val currentRightMatches = smjScanner.getBufferedMatches
-                var found = false
-                if (currentRightMatches != null && currentRightMatches.length > 0) {
-                  val rightMatchesIterator = currentRightMatches.generateIterator()
-                  while (!found && rightMatchesIterator.hasNext) {
-                    joinRow(currentLeftRow, rightMatchesIterator.next())
-                    if (boundCondition(joinRow)) {
-                      found = true
-                    }
-                  }
-                }
-                result.setBoolean(0, found)
-                numOutputRows += 1
-                return true
-              }
-              false
-            }
-
-            override def getRow: InternalRow = resultProj(joinRow(currentLeftRow, result))
-          }.toScala
-
-        case x =>
-          throw new IllegalArgumentException(
-            s"SortMergeJoin should not take $x as the JoinType")
-      }
-
+      case x =>
+        throw new IllegalArgumentException(
+          s"SortMergeJoin should not take $x as the JoinType")
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
A major pain point for spark users to stay away from using shuffled hash join is out of memory issue. Shuffled hash join tends to have OOM issue because it allocates in-memory hashed relation (`UnsafeHashedRelation` or `LongHashedRelation`) for build side, and there's no recovery (e.g. fallback/spill) once the size of hashed relation grows and cannot fit in memory. On the other hand, shuffled hash join is more CPU and IO efficient than sort merge join when joining one large table and a small table (but small table is too large to be broadcasted), as SHJ does not sort the large table, but SMJ needs to do that. See historical discussion in https://github.com/apache/spark/pull/11788 for evidence.

To improve the reliability of shuffled hash join, a fallback mechanism can be introduced to avoid shuffled hash join OOM issue automatically. Similarly we already have a fallback to sort-based aggregation for hash aggregate. The idea is:

* Build hashed relation as current, but stop adding rows to hashed relation if there's no enough memory. Do not throw exception, and do not fail the task/query.
* Sort stream side and build side on join keys if necessary. Note here we need to read all build rows in hashed relation back and destruct the hashed relation on the fly to free memory.
* Execute sort merge join on sorted stream & build side.

Note:

(1).the fallback is automatic and happened per task, which means task 0 can incur the fallback e.g. if it has a big build side, but task 1,2 don't need to incur the fallback depending on the size of hashed relation.

(2).there's no major code change for SHJ and SMJ. Major change is around `HashedRelation` to introduce some new methods, e.g. `HashedRelation.destructiveValues()` to return an Iterator of build side rows in hashed relation and destruct hashed relation on the fly.

(3).Per this PR, a new config `spark.sql.join.enableShuffledHashJoinFallback` is introduced to enable/disable this feature (disable by default). This PR only supports fallback for non-code-gen execution path. Fallback for code-gen will be added in followup PRs, as it will depend on sort merge join code-gen work (SPARK-34705).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Shuffled hash join OOM is a huge pain point for users and developers. This is the major reason why people stay away from shuffled hash join. This can improve reliability for shuffled hash join quite a bit.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit test in `JoinSuite.scala`.