### PR TITLE
[SPARK-35118][SQL] Propagate empty relation through Join if join condition is empty

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/join-empty-relation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-empty-relation.sql.out
@@ -71,7 +71,7 @@ SELECT * FROM t1 LEFT SEMI JOIN empty_table
 -- !query schema
 struct<a:int>
 -- !query output
-
+1
 
 
 -- !query
@@ -79,7 +79,7 @@ SELECT * FROM t1 LEFT ANTI JOIN empty_table
 -- !query schema
 struct<a:int>
 -- !query output
-1
+
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/join-empty-relation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-empty-relation.sql.out
@@ -71,7 +71,7 @@ SELECT * FROM t1 LEFT SEMI JOIN empty_table
 -- !query schema
 struct<a:int>
 -- !query output
-1
+
 
 
 -- !query
@@ -79,7 +79,7 @@ SELECT * FROM t1 LEFT ANTI JOIN empty_table
 -- !query schema
 struct<a:int>
 -- !query output
-
+1
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr makes propagate empty relation through Join if join condition is empty. For example:
```scala
spark.sql("create table t1 using parquet as select id as a, id as b from range(10)")
spark.sql("create table t2 using parquet as select id as a, id as b from range(20)")
spark.sql("select t1.a from t1 left anti join t2").explain(true)
```

Before this pr:
```
== Optimized Logical Plan ==
Join LeftAnti
:- Project [a#6L]
:  +- Relation default.t1[a#6L,b#7L] parquet
+- Project
   +- Relation default.t2[a#8L,b#9L] parquet
```

After this pr:
```
== Optimized Logical Plan ==
LocalRelation <empty>, [a#6L]
```



### Why are the changes needed?

Improve query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.
