### PR TITLE
[SPARK-35126][SQL] Execute jdbc cancellation method when jdbc load job is interrupted

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.jdbc
 
 import java.sql.{Connection, PreparedStatement, ResultSet, SQLException}
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.util.control.NonFatal
 
@@ -29,8 +30,6 @@ import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.CompletionIterator
-
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Data corresponding to one partition of a JDBCRDD.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -17,8 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources.jdbc
 
-import java.sql.{Connection, PreparedStatement, ResultSet, SQLException}
+import java.sql.{Connection, PreparedStatement, ResultSet}
+
 import scala.util.control.NonFatal
+
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
@@ -337,7 +339,7 @@ private[jdbc] class JDBCRDD(
         try {
           stmt.cancel()
         } catch {
-          case e: SQLException => logWarning("SQLException cancel statement", e)
+          case e: Exception => logWarning("Exception cancel statement", e)
         }
       }
     })

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.jdbc
 
-import java.sql.{Connection, PreparedStatement, ResultSet}
+import java.sql.{Connection, PreparedStatement, ResultSet, SQLException}
 
 import scala.util.control.NonFatal
 
@@ -339,7 +339,7 @@ private[jdbc] class JDBCRDD(
         try {
           stmt.cancel()
         } catch {
-          case e: Exception => logWarning("Exception cancel statement", e)
+          case e: SQLException => logWarning("SQLException cancel statement", e)
         }
       }
     })

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -184,7 +184,7 @@ private[jdbc] class JDBCRDD(
     partitions: Array[Partition],
     url: String,
     options: JDBCOptions)
-  extends RDD[InternalRow](sc, Nil) {
+    extends RDD[InternalRow](sc, Nil) {
 
   /**
    * Retrieve the list of partitions corresponding to this RDD.
@@ -324,8 +324,10 @@ private[jdbc] class JDBCRDD(
    * Start the job interruption listener thread, if the job is interrupted and
    * stmt.executeQuery() is not completed, initiate a stmt.cancel() request.
    */
-  private def startTheJobInterruptListenerThread(context: TaskContext, stmt: PreparedStatement
-                                                 , isFinished: AtomicBoolean): Unit = {
+  private def startTheJobInterruptListenerThread(
+      context: TaskContext,
+      stmt: PreparedStatement,
+      isFinished: AtomicBoolean): Unit = {
     val thread = new Thread(() => {
       val waitInterval = 100
       // Always wait for job interruption or stmt.executeQuery() execution to complete

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -17,10 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.jdbc
 
-import java.sql.{Connection, PreparedStatement, ResultSet}
-
+import java.sql.{Connection, PreparedStatement, ResultSet, SQLException}
 import scala.util.control.NonFatal
-
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
@@ -339,7 +337,7 @@ private[jdbc] class JDBCRDD(
         try {
           stmt.cancel()
         } catch {
-          case e: Exception => logWarning("Exception cancel statement", e)
+          case e: SQLException => logWarning("SQLException cancel statement", e)
         }
       }
     })

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDDSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDDSuite.scala
@@ -17,11 +17,12 @@
 
 package org.apache.spark.sql.execution.datasources.jdbc
 
-import org.apache.spark.SparkFunSuite
-import org.mockito.Mockito
-
 import java.sql.{Connection, PreparedStatement, ResultSet}
 import java.util.concurrent.atomic.AtomicBoolean
+
+import org.mockito.Mockito
+
+import org.apache.spark.SparkFunSuite
 
 class JDBCRDDSuite extends SparkFunSuite {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDDSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDDSuite.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.jdbc
+
+import org.apache.spark.SparkFunSuite
+import org.mockito.Mockito
+
+import java.sql.{Connection, PreparedStatement, ResultSet}
+import java.util.concurrent.atomic.AtomicBoolean
+
+class JDBCRDDSuite extends SparkFunSuite {
+
+  test("SPARK-35126: Execute jdbc cancellation method when jdbc load job is interrupted") {
+    val query = "select * from test"
+
+    val conn = Mockito.mock(classOf[Connection])
+    val stmt = Mockito.mock(classOf[PreparedStatement])
+    Mockito.when(conn.prepareStatement(query)).thenReturn(stmt)
+    var rs: ResultSet = null
+
+    val isFinished = new AtomicBoolean(false)
+    rs = stmt.executeQuery()
+    isFinished.set(true)
+
+    assert(isFinished.get())
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

I have a long-running spark service that continuously receives and runs spark programs submitted by the client. There is a program that can load the jdbc table, and one is passed in the query option
Very complicated sql. Each execution of this SQL requires a lot of time and resources. When the client submits such a request, the client can interrupt work at any time. I found that after the job was interrupted, the query process in the database was still executing and had not been killed yet.


### Why are the changes needed?

If the query process in the database cannot be killed after the job is cancelled, the spark task will be in a blocked state at this time, waiting for the stmt.executeQuery() method to complete.
If the client frequently executes such complex SQL and cannot cancel the execution, this will cause the database to be particularly stressful.

Interrupt the listener thread by starting the job. When the job is cancelled, execute the `stmt.cancel()` method to kill the database query process, which is not only friendly to the database, but also releases the task.

### Does this PR introduce _any_ user-facing change?
No



### How was this patch tested?

By running the affected test suite:
`$ build/mvn test -DwildcardSuites=none -Dtest=org.apache.spark.sql.execution.datasources.jdbc.JDBCRDDSuite test`

Other test reference codes:
```
import org.apache.spark.SparkConf;
import org.apache.spark.SparkContext;
import org.apache.spark.sql.Dataset;
import org.apache.spark.sql.Row;
import org.apache.spark.sql.SparkSession;

import java.util.concurrent.TimeUnit;

/**
 * jdbc load cancel test
 *
 * @author gavin
 * @create 2021/4/18 10:58
 */
public class JdbcLoadCancelTest {

    public static void main(String[] args) throws Exception {
        final SparkConf sparkConf = new SparkConf();
        sparkConf.setAppName("jdbc load test");
        sparkConf.setMaster("local[*]");
        final SparkContext sparkContext = new SparkContext(sparkConf);
        final SparkSession sparkSession = new SparkSession(sparkContext);

        // This is a sql that takes about a minute to execute
        String querySql = "select t1.aa\n" +
                "from SPARK_TEST1  t1 \n" +
                "left join SPARK_TEST1 t2\n" +
                "on t1.aa= t2.aa\n" +
                "group by t1.aa\n" +
                "limit 10";

        // Specify job information
        final String jobGroup = "test";
        sparkContext.clearJobGroup();
        sparkContext.setJobGroup(jobGroup, "test", true);

        // Start the independent thread to start the jdbc load test logic
        new Thread(() -> {
            final Dataset<Row> table = sparkSession.read()
                    .format("org.apache.spark.sql.execution.datasources.jdbc3")
                    .option("url", "jdbc:mysql://192.168.10.226:32320/test?useUnicode=true&characterEncoding=utf-8&useSSL=false&useCursorFetch=true")
                    .option("user", "xx")
                    .option("password", "xxx")
                    .option("query", querySql)
                    .load();

            // Print the first data
            System.out.println(table.limit(1).first());
        }).start();

        // Wait for the jdbc load job to start
        TimeUnit.SECONDS.sleep(10);

        // Cancel the job just now
        sparkContext.cancelJobGroup(jobGroup);
    }
}

```