### PR TITLE
[SPARK-35120][INFRA] Guide users to sync branch and enable GitHub Actions in their forked repository

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -57,34 +57,63 @@ jobs:
             await new Promise(r => setTimeout(r, 3000))
 
             const runs = await github.request(endpoint, params)
-            const runID = runs.data.workflow_runs[0].id
-            // TODO: If no workflows were found, it's likely GitHub Actions was not enabled
-
-            if (runs.data.workflow_runs[0].head_sha != context.payload.pull_request.head.sha) {
-              throw new Error('There was a new unsynced commit pushed. Please retrigger the workflow.');
-            }
-
-            const runUrl = 'https://github.com/'
-              + context.payload.pull_request.head.repo.full_name
-              + '/actions/runs/'
-              + runID
 
             const name = 'Build and test'
             const head_sha = context.payload.pull_request.head.sha
-            const status = 'queued'
+            let status = 'queued'
 
-            github.checks.create({
-              ...context.repo,
-              name,
-              head_sha,
-              status,
-              output: {
-                title: 'Test results',
-                summary: runUrl,
-                text: JSON.stringify({
-                  owner: context.payload.pull_request.head.repo.owner.login,
-                  repo: context.payload.pull_request.head.repo.name,
-                  run_id: runID
-                })
+            if (runs.data.workflow_runs.length === 0) {
+              status = 'completed'
+              const conclusion = 'action_required'
+
+              github.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: name,
+                head_sha: head_sha,
+                status: status,
+                conclusion: conclusion,
+                output: {
+                  title: 'Workflow run detection failed',
+                  summary: `
+            Unable to detect the workflow run for testing the changes in your PR.
+
+            1. If you did not enable GitHub Actions in your forked repository, please enable it. See also [Disabling or limiting GitHub Actions for a repository](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository) for more details.
+            2. It is possible your branch is based on the old \`master\` branch in Apache Spark, please sync your branch to the latest master branch. For example as below:
+                \`\`\`bash
+                git fetch upstream
+                git rebase upstream/master
+                git push origin YOUR_BRANCH --force
+                \`\`\``
+                }
+              })
+            } else {
+              const runID = runs.data.workflow_runs[0].id
+
+              if (runs.data.workflow_runs[0].head_sha != context.payload.pull_request.head.sha) {
+                throw new Error('There was a new unsynced commit pushed. Please retrigger the workflow.');
               }
-            })
+
+              const runUrl = 'https://github.com/'
+                + context.payload.pull_request.head.repo.full_name
+                + '/actions/runs/'
+                + runID
+
+              github.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: name,
+                head_sha: head_sha,
+                status: status,
+                output: {
+                  title: 'Test results',
+                  summary: '[See test results](' + runUrl + ')',
+                  text: JSON.stringify({
+                    owner: context.payload.pull_request.head.repo.owner.login,
+                    repo: context.payload.pull_request.head.repo.name,
+                    run_id: runID
+                  })
+                },
+                details_url: runUrl,
+              })
+            }

--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -58,7 +58,7 @@ jobs:
 
                   // Iterator GitHub Checks in the PR
                   for await (const cr of checkRuns.data.check_runs) {
-                    if (cr.name == 'Build and test') {
+                    if (cr.name == 'Build and test' && cr.conclusion != "action_required") {
                       // text contains parameters to make request in JSON.
                       const params = JSON.parse(cr.output.text)
 
@@ -74,7 +74,8 @@ jobs:
                           check_run_id: cr.id,
                           output: cr.output,
                           status: run.data.status,
-                          conclusion: run.data.conclusion
+                          conclusion: run.data.conclusion,
+                          details_url: run.data.details_url
                         })
                       } else {
                         console.log('    Run ' + cr.id + ': set status (' + run.data.status + ')')
@@ -84,6 +85,7 @@ jobs:
                           check_run_id: cr.id,
                           output: cr.output,
                           status: run.data.status,
+                          details_url: run.data.details_url
                         })
                       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add messages when the workflow fails to find the workflow run in a forked repository, for example as below:

**Before**

![Screen Shot 2021-04-19 at 9 41 52 PM](https://user-images.githubusercontent.com/6477701/115238011-28e19b00-a158-11eb-8c5c-6374ca1e9790.png)

![Screen Shot 2021-04-19 at 9 42 00 PM](https://user-images.githubusercontent.com/6477701/115237984-22ebba00-a158-11eb-9b0f-11fe11072830.png)


**After**

![Screen Shot 2021-04-19 at 9 25 32 PM](https://user-images.githubusercontent.com/6477701/115237507-9c36dd00-a157-11eb-8ba7-f5f88caa1058.png)

![Screen Shot 2021-04-19 at 9 23 13 PM](https://user-images.githubusercontent.com/6477701/115236793-c2a84880-a156-11eb-98fc-1bb7d4bc31dd.png)
(typo `foce` in the image was fixed)

See this example: https://github.com/HyukjinKwon/spark/runs/2380644793

### Why are the changes needed?

To guide users to enable Github Actions in their forked repositories (and sync their branch to the latest `master` in Apache Spark).

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested in:
- https://github.com/HyukjinKwon/spark/pull/47
- https://github.com/HyukjinKwon/spark/pull/46
