### PR TITLE
[SPARK-35018][SQL][TESTS] Check transferring of year-month intervals via Hive Thrift server

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.hive.thriftserver
 import java.sql.{Date, Timestamp}
 import java.util.{List => JList, Properties}
 
-import org.apache.hadoop.hive.common.`type`.HiveIntervalDayTime
+import org.apache.hadoop.hive.common.`type`.{HiveIntervalDayTime, HiveIntervalYearMonth}
 import org.apache.hive.jdbc.{HiveConnection, HiveQueryResultSet}
 import org.apache.hive.service.auth.PlainSaslHelper
 import org.apache.hive.service.cli.GetInfoType
@@ -468,6 +468,18 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2TestBase {
         val metaData = rs.getMetaData
         assert(metaData.getColumnName(1) === "dt")
         assert(metaData.getColumnTypeName(1) === "interval_day_time")
+        assert(metaData.getColumnType(1) === java.sql.Types.OTHER)
+      }
+    }
+
+    test(s"SPARK-35018: $version get year-month interval type") {
+      testExecuteStatementWithProtocolVersion(
+        version, "SELECT INTERVAL '1-1' YEAR TO MONTH AS ym") { rs =>
+        assert(rs.next())
+        assert(rs.getObject(1) === new HiveIntervalYearMonth(1, 1))
+        val metaData = rs.getMetaData
+        assert(metaData.getColumnName(1) === "ym")
+        assert(metaData.getColumnTypeName(1) === "interval_year_month")
         assert(metaData.getColumnType(1) === java.sql.Types.OTHER)
       }
     }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkThriftServerProtocolVersionsSuite.scala
@@ -462,9 +462,9 @@ class SparkThriftServerProtocolVersionsSuite extends HiveThriftServer2TestBase {
 
     test(s"SPARK-35017: $version get day-time interval type") {
       testExecuteStatementWithProtocolVersion(
-        version, "SELECT date'2021-01-01' - date'2020-12-31' AS dt") { rs =>
+        version, "SELECT INTERVAL '1 10:11:12' DAY TO SECOND AS dt") { rs =>
         assert(rs.next())
-        assert(rs.getObject(1) === new HiveIntervalDayTime(1, 0, 0, 0, 0))
+        assert(rs.getObject(1) === new HiveIntervalDayTime(1, 10, 11, 12, 0))
         val metaData = rs.getMetaData
         assert(metaData.getColumnName(1) === "dt")
         assert(metaData.getColumnTypeName(1) === "interval_day_time")


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add a test to check that Thrift server is able to collect year-month intervals and transfer them via thrift protocol.
2. Improve similar test for day-time intervals. After the changes, the test doesn't depend on the result of date subtractions. In the future, the type of date subtract can be changed. So, current PR should make the test tolerant to the changes. 

### Why are the changes needed?
To improve test coverage.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running the modified test suite:
```
$ ./build/sbt -Phive -Phive-thriftserver "test:testOnly *SparkThriftServerProtocolVersionsSuite"
```
