### PR TITLE
[SPARK-35140][INFRA] Add error message guidelines to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -8,6 +8,8 @@ Thanks for sending a pull request!  Here are some tips for you:
   6. If possible, provide a concise example to reproduce the issue for a faster review.
   7. If you want to add a new configuration, please read the guideline first for naming configurations in
      'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
+  8. If you want to add or modify an error message, please read the guideline first:
+     https://spark.apache.org/error-message-guidelines.html
 -->
 
 ### What changes were proposed in this pull request?
@@ -34,7 +36,6 @@ Please clarify why the changes are needed. For instance,
 Note that it means *any* user-facing change including all aspects such as the documentation fix.
 If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
 If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
-If this change involves adding or modifying an error message, please read the guideline first: https://spark.apache.org/error-message-guidelines.html
 If no, write 'No'.
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -34,6 +34,7 @@ Please clarify why the changes are needed. For instance,
 Note that it means *any* user-facing change including all aspects such as the documentation fix.
 If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
 If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
+If this change involves adding or modifying an error message, please read the guideline first: https://spark.apache.org/error-message-guidelines.html
 If no, write 'No'.
 -->
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a link to the [error message guidelines](https://spark.apache.org/error-message-guidelines.html) to the PR template to increase visibility.

### Why are the changes needed?

Increases visibility of the error message guidelines, which are otherwise hidden in the [Contributing guidelines](https://spark.apache.org/contributing.html).

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Not needed.