### PR TITLE
[SPARK-35094][SQL]Spark from_json(JsonToStruct) function return wrong value in permissive mode

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -48,12 +48,12 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
 
   val tuples: Seq[(String, String)] =
     ("1", """{"f1": "value1", "f2": "value2", "f3": 3, "f5": 5.23}""") ::
-    ("2", """{"f1": "value12", "f3": "value3", "f2": 2, "f4": 4.01}""") ::
-    ("3", """{"f1": "value13", "f4": "value44", "f3": "value33", "f2": 2, "f5": 5.01}""") ::
-    ("4", null) ::
-    ("5", """{"f1": "", "f5": null}""") ::
-    ("6", "[invalid JSON string]") ::
-    Nil
+      ("2", """{"f1": "value12", "f3": "value3", "f2": 2, "f4": 4.01}""") ::
+      ("3", """{"f1": "value13", "f4": "value44", "f3": "value33", "f2": 2, "f5": 5.01}""") ::
+      ("4", null) ::
+      ("5", """{"f1": "", "f5": null}""") ::
+      ("6", "[invalid JSON string]") ::
+      Nil
 
   test("function get_json_object - null") {
     val df: DataFrame = tuples.toDF("key", "jstring")
@@ -67,7 +67,9 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
         Nil
 
     checkAnswer(
-      df.select($"key", functions.get_json_object($"jstring", "$.f1"),
+      df.select(
+        $"key",
+        functions.get_json_object($"jstring", "$.f1"),
         functions.get_json_object($"jstring", "$.f2"),
         functions.get_json_object($"jstring", "$.f3"),
         functions.get_json_object($"jstring", "$.f4"),
@@ -79,12 +81,12 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     val df: DataFrame = tuples.toDF("key", "jstring")
     val expected =
       Row("1", "value1", "value2", "3", null, "5.23") ::
-      Row("2", "value12", "2", "value3", "4.01", null) ::
-      Row("3", "value13", "2", "value33", "value44", "5.01") ::
-      Row("4", null, null, null, null, null) ::
-      Row("5", "", null, null, null, null) ::
-      Row("6", null, null, null, null, null) ::
-      Nil
+        Row("2", "value12", "2", "value3", "4.01", null) ::
+        Row("3", "value13", "2", "value33", "value44", "5.01") ::
+        Row("4", null, null, null, null, null) ::
+        Row("5", "", null, null, null, null) ::
+        Row("6", null, null, null, null, null) ::
+        Nil
 
     checkAnswer(
       df.select($"key", functions.json_tuple($"jstring", "f1", "f2", "f3", "f4", "f5")),
@@ -115,9 +117,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     val df = Seq("""{"a": 1}""").toDS()
     val schema = new StructType().add("a", IntegerType)
 
-    checkAnswer(
-      df.select(from_json($"value", schema)),
-      Row(Row(1)) :: Nil)
+    checkAnswer(df.select(from_json($"value", schema)), Row(Row(1)) :: Nil)
   }
 
   test("from_json with option") {
@@ -134,18 +134,14 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     val df = Seq("""{"a": 1}""").toDS()
     val schema = new StructType().add("b", IntegerType)
 
-    checkAnswer(
-      df.select(from_json($"value", schema)),
-      Row(Row(null)) :: Nil)
+    checkAnswer(df.select(from_json($"value", schema)), Row(Row(null)) :: Nil)
   }
 
   test("from_json invalid json") {
     val df = Seq("""{"a" 1}""").toDS()
     val schema = new StructType().add("a", IntegerType)
 
-    checkAnswer(
-      df.select(from_json($"value", schema)),
-      Row(Row(null)) :: Nil)
+    checkAnswer(df.select(from_json($"value", schema)), Row(Row(null)) :: Nil)
   }
 
   test("from_json - json doesn't conform to the array type") {
@@ -158,8 +154,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
   test("from_json array support") {
     val df = Seq("""[{"a": 1, "b": "a"}, {"a": 2}, { }]""").toDS()
     val schema = ArrayType(
-      StructType(
-        StructField("a", IntegerType) ::
+      StructType(StructField("a", IntegerType) ::
         StructField("b", StringType) :: Nil))
 
     checkAnswer(
@@ -184,74 +179,58 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
   test("to_json - struct") {
     val df = Seq(Tuple1(Tuple1(1))).toDF("a")
 
-    checkAnswer(
-      df.select(to_json($"a")),
-      Row("""{"_1":1}""") :: Nil)
+    checkAnswer(df.select(to_json($"a")), Row("""{"_1":1}""") :: Nil)
   }
 
   test("to_json - array") {
     val df = Seq(Tuple1(Tuple1(1) :: Nil)).toDF("a")
     val df2 = Seq(Tuple1(Map("a" -> 1) :: Nil)).toDF("a")
 
-    checkAnswer(
-      df.select(to_json($"a")),
-      Row("""[{"_1":1}]""") :: Nil)
-    checkAnswer(
-      df2.select(to_json($"a")),
-      Row("""[{"a":1}]""") :: Nil)
+    checkAnswer(df.select(to_json($"a")), Row("""[{"_1":1}]""") :: Nil)
+    checkAnswer(df2.select(to_json($"a")), Row("""[{"a":1}]""") :: Nil)
   }
 
   test("to_json - map") {
     val df1 = Seq(Map("a" -> Tuple1(1))).toDF("a")
     val df2 = Seq(Map("a" -> 1)).toDF("a")
 
-    checkAnswer(
-      df1.select(to_json($"a")),
-      Row("""{"a":{"_1":1}}""") :: Nil)
-    checkAnswer(
-      df2.select(to_json($"a")),
-      Row("""{"a":1}""") :: Nil)
+    checkAnswer(df1.select(to_json($"a")), Row("""{"a":{"_1":1}}""") :: Nil)
+    checkAnswer(df2.select(to_json($"a")), Row("""{"a":1}""") :: Nil)
   }
 
   test("to_json with option") {
     val df = Seq(Tuple1(Tuple1(java.sql.Timestamp.valueOf("2015-08-26 18:00:00.0")))).toDF("a")
     val options = Map("timestampFormat" -> "dd/MM/yyyy HH:mm")
 
-    checkAnswer(
-      df.select(to_json($"a", options)),
-      Row("""{"_1":"26/08/2015 18:00"}""") :: Nil)
+    checkAnswer(df.select(to_json($"a", options)), Row("""{"_1":"26/08/2015 18:00"}""") :: Nil)
   }
 
   test("to_json - interval support") {
     val baseDf = Seq(Tuple1(Tuple1("-3 month 7 hours"))).toDF("a")
     val df = baseDf.select(struct($"a._1".cast(CalendarIntervalType).as("a")).as("c"))
-    checkAnswer(
-      df.select(to_json($"c")),
-      Row("""{"a":"-3 months 7 hours"}""") :: Nil)
+    checkAnswer(df.select(to_json($"c")), Row("""{"a":"-3 months 7 hours"}""") :: Nil)
 
     val df1 = baseDf
       .select(struct(map($"a._1".cast(CalendarIntervalType), lit("a")).as("col1")).as("c"))
-    checkAnswer(
-      df1.select(to_json($"c")),
-      Row("""{"col1":{"-3 months 7 hours":"a"}}""") :: Nil)
+    checkAnswer(df1.select(to_json($"c")), Row("""{"col1":{"-3 months 7 hours":"a"}}""") :: Nil)
 
     val df2 = baseDf
       .select(struct(map(lit("a"), $"a._1".cast(CalendarIntervalType)).as("col1")).as("c"))
-    checkAnswer(
-      df2.select(to_json($"c")),
-      Row("""{"col1":{"a":"-3 months 7 hours"}}""") :: Nil)
+    checkAnswer(df2.select(to_json($"c")), Row("""{"col1":{"a":"-3 months 7 hours"}}""") :: Nil)
   }
 
   test("roundtrip in to_json and from_json - struct") {
     val dfOne = Seq(Tuple1(Tuple1(1)), Tuple1(null)).toDF("struct")
     val schemaOne = dfOne.schema(0).dataType.asInstanceOf[StructType]
-    val readBackOne = dfOne.select(to_json($"struct").as("json"))
+    val readBackOne = dfOne
+      .select(to_json($"struct").as("json"))
       .select(from_json($"json", schemaOne).as("struct"))
     checkAnswer(dfOne, readBackOne)
 
     val dfTwo = Seq(Some("""{"a":1}"""), None).toDF("json")
     val schemaTwo = new StructType().add("a", IntegerType)
-    val readBackTwo = dfTwo.select(from_json($"json", schemaTwo).as("struct"))
+    val readBackTwo = dfTwo
+      .select(from_json($"json", schemaTwo).as("struct"))
       .select(to_json($"struct").as("json"))
     checkAnswer(dfTwo, readBackTwo)
   }
@@ -259,22 +238,22 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
   test("roundtrip in to_json and from_json - array") {
     val dfOne = Seq(Tuple1(Tuple1(1) :: Nil), Tuple1(null :: Nil)).toDF("array")
     val schemaOne = dfOne.schema(0).dataType
-    val readBackOne = dfOne.select(to_json($"array").as("json"))
+    val readBackOne = dfOne
+      .select(to_json($"array").as("json"))
       .select(from_json($"json", schemaOne).as("array"))
     checkAnswer(dfOne, readBackOne)
 
     val dfTwo = Seq(Some("""[{"a":1}]"""), None).toDF("json")
     val schemaTwo = ArrayType(StructType(StructField("a", IntegerType) :: Nil))
-    val readBackTwo = dfTwo.select(from_json($"json", schemaTwo).as("array"))
+    val readBackTwo = dfTwo
+      .select(from_json($"json", schemaTwo).as("array"))
       .select(to_json($"array").as("json"))
     checkAnswer(dfTwo, readBackTwo)
   }
 
   test("SPARK-19637 Support to_json in SQL") {
     val df1 = Seq(Tuple1(Tuple1(1))).toDF("a")
-    checkAnswer(
-      df1.selectExpr("to_json(a)"),
-      Row("""{"_1":1}""") :: Nil)
+    checkAnswer(df1.selectExpr("to_json(a)"), Row("""{"_1":1}""") :: Nil)
 
     val df2 = Seq(Tuple1(Tuple1(java.sql.Timestamp.valueOf("2015-08-26 18:00:00.0")))).toDF("a")
     checkAnswer(
@@ -289,15 +268,13 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     val errMsg2 = intercept[AnalysisException] {
       df2.selectExpr("to_json(a, map('a', 1))")
     }
-    assert(errMsg2.getMessage.startsWith(
-      "A type of keys and values in map() must be string, but got"))
+    assert(
+      errMsg2.getMessage.startsWith("A type of keys and values in map() must be string, but got"))
   }
 
   test("SPARK-19967 Support from_json in SQL") {
     val df1 = Seq("""{"a": 1}""").toDS()
-    checkAnswer(
-      df1.selectExpr("from_json(value, 'a INT')"),
-      Row(Row(1)) :: Nil)
+    checkAnswer(df1.selectExpr("from_json(value, 'a INT')"), Row(Row(1)) :: Nil)
 
     val df2 = Seq("""{"c0": "a", "c1": 1, "c2": {"c20": 3.8, "c21": 8}}""").toDS()
     checkAnswer(
@@ -325,8 +302,8 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     val errMsg4 = intercept[AnalysisException] {
       df3.selectExpr("from_json(value, 'time Timestamp', map('a', 1))")
     }
-    assert(errMsg4.getMessage.startsWith(
-      "A type of keys and values in map() must be string, but got"))
+    assert(
+      errMsg4.getMessage.startsWith("A type of keys and values in map() must be string, but got"))
   }
 
   test("SPARK-24027: from_json - map<string, int>") {
@@ -389,27 +366,27 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
   test("SPARK-24027: from_json of a map with unsupported key type") {
     val schema = MapType(StructType(StructField("f", IntegerType) :: Nil), StringType)
 
-    checkAnswer(Seq("""{{"f": 1}: "a"}""").toDS().select(from_json($"value", schema)),
-      Row(null))
-    checkAnswer(Seq("""{"{"f": 1}": "a"}""").toDS().select(from_json($"value", schema)),
+    checkAnswer(Seq("""{{"f": 1}: "a"}""").toDS().select(from_json($"value", schema)), Row(null))
+    checkAnswer(
+      Seq("""{"{"f": 1}": "a"}""").toDS().select(from_json($"value", schema)),
       Row(null))
   }
 
   test("SPARK-24709: infers schemas of json strings and pass them to from_json") {
     val in = Seq("""{"a": [1, 2, 3]}""").toDS()
     val out = in.select(from_json('value, schema_of_json("""{"a": [1]}""")) as "parsed")
-    val expected = StructType(StructField(
-      "parsed",
-      StructType(StructField(
-        "a",
-        ArrayType(LongType, true), true) :: Nil),
-      true) :: Nil)
+    val expected = StructType(
+      StructField(
+        "parsed",
+        StructType(StructField("a", ArrayType(LongType, true), true) :: Nil),
+        true) :: Nil)
 
     assert(out.schema == expected)
   }
 
   test("infers schemas using options") {
-    val df = spark.range(1)
+    val df = spark
+      .range(1)
       .select(schema_of_json(lit("{a:1}"), Map("allowUnquotedFieldNames" -> "true").asJava))
     checkAnswer(df, Seq(Row("STRUCT<`a`: BIGINT>")))
   }
@@ -518,9 +495,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     val jsonDF = Seq(json).toDF("a")
     val schema = new ArrayType(ArrayType(IntegerType, false), false)
 
-    checkAnswer(
-      jsonDF.select(to_json(from_json($"a", schema))),
-      Seq(Row(json)))
+    checkAnswer(jsonDF.select(to_json(from_json($"a", schema))), Seq(Row(json)))
   }
 
   test("roundtrip from_json -> to_json - array of maps") {
@@ -528,9 +503,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     val jsonDF = Seq(json).toDF("a")
     val schema = new ArrayType(MapType(StringType, IntegerType, false), false)
 
-    checkAnswer(
-      jsonDF.select(to_json(from_json($"a", schema))),
-      Seq(Row(json)))
+    checkAnswer(jsonDF.select(to_json(from_json($"a", schema))), Seq(Row(json)))
   }
 
   test("roundtrip from_json -> to_json - array of structs") {
@@ -538,9 +511,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     val jsonDF = Seq(json).toDF("a")
     val schema = new ArrayType(new StructType().add("a", IntegerType), false)
 
-    checkAnswer(
-      jsonDF.select(to_json(from_json($"a", schema))),
-      Seq(Row(json)))
+    checkAnswer(jsonDF.select(to_json(from_json($"a", schema))), Seq(Row(json)))
   }
 
   test("pretty print - roundtrip from_json -> to_json") {
@@ -558,9 +529,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
 
     checkAnswer(
       jsonDF.select(
-        to_json(
-          from_json($"root", schema_of_json(lit(json))),
-          Map("pretty" -> "true"))),
+        to_json(from_json($"root", schema_of_json(lit(json))), Map("pretty" -> "true"))),
       Seq(Row(expected)))
   }
 
@@ -580,15 +549,16 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       val exception1 = intercept[SparkException] {
         df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
       }.getMessage
-      assert(exception1.contains(
-        "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
+      assert(
+        exception1.contains(
+          "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
 
       val exception2 = intercept[SparkException] {
         df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED")))
           .collect()
       }.getMessage
-      assert(exception2.contains(
-        "from_json() doesn't support the DROPMALFORMED mode. " +
+      assert(
+        exception2.contains("from_json() doesn't support the DROPMALFORMED mode. " +
           "Acceptable modes are PERMISSIVE and FAILFAST."))
     }
   }
@@ -623,8 +593,9 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
   test("special timestamp values") {
     Seq("now", "today", "epoch", "tomorrow", "yesterday").foreach { specialValue =>
       val input = Seq(s"""{"t": "$specialValue"}""").toDS()
-      val readback = input.select(from_json($"value", lit("t timestamp"),
-        Map.empty[String, String].asJava)).collect()
+      val readback = input
+        .select(from_json($"value", lit("t timestamp"), Map.empty[String, String].asJava))
+        .collect()
       assert(readback(0).getAs[Row](0).getAs[Timestamp](0).getTime >= 0)
     }
   }
@@ -632,8 +603,9 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
   test("special date values") {
     Seq("now", "today", "epoch", "tomorrow", "yesterday").foreach { specialValue =>
       val input = Seq(s"""{"d": "$specialValue"}""").toDS()
-      val readback = input.select(from_json($"value", lit("d date"),
-        Map.empty[String, String].asJava)).collect()
+      val readback = input
+        .select(from_json($"value", lit("d date"), Map.empty[String, String].asJava))
+        .collect()
       assert(readback(0).getAs[Row](0).getAs[Date](0).getTime >= 0)
     }
   }
@@ -650,18 +622,22 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
 
   test("to_json - timestamp in micros") {
     val s = "2019-11-18 11:56:00.123456"
-    val df = Seq(java.sql.Timestamp.valueOf(s)).toDF("t").select(
-      to_json(struct($"t"), Map("timestampFormat" -> "yyyy-MM-dd HH:mm:ss.SSSSSS")))
+    val df = Seq(java.sql.Timestamp.valueOf(s))
+      .toDF("t")
+      .select(to_json(struct($"t"), Map("timestampFormat" -> "yyyy-MM-dd HH:mm:ss.SSSSSS")))
     checkAnswer(df, Row(s"""{"t":"$s"}"""))
   }
 
   test("json_tuple - do not truncate results") {
     Seq(2000, 2800, 8000 - 1, 8000, 8000 + 1, 65535).foreach { len =>
       val str = Array.tabulate(len)(_ => "a").mkString
-      val json_tuple_result = Seq(s"""{"test":"$str"}""").toDF("json")
+      val json_tuple_result = Seq(s"""{"test":"$str"}""")
+        .toDF("json")
         .withColumn("result", json_tuple('json, "test"))
         .select('result)
-        .as[String].head.length
+        .as[String]
+        .head
+        .length
       assert(json_tuple_result === len)
     }
   }
@@ -674,8 +650,10 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       Row(Row(1, "Moscow")))
 
     val errMsg = intercept[AnalysisException] {
-      Seq(("""{"i":1}""", "i int")).toDF("json", "schema")
-        .select(from_json($"json", $"schema", options)).collect()
+      Seq(("""{"i":1}""", "i int"))
+        .toDF("json", "schema")
+        .select(from_json($"json", $"schema", options))
+        .collect()
     }.getMessage
     assert(errMsg.contains("Schema should be specified in DDL format as a string literal"))
   }
@@ -689,9 +667,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-31065: schema_of_json - null and empty strings as strings") {
     Seq("""{"id": null}""", """{"id": ""}""").foreach { input =>
-      checkAnswer(
-        spark.range(1).select(schema_of_json(input)),
-        Seq(Row("STRUCT<`id`: STRING>")))
+      checkAnswer(spark.range(1).select(schema_of_json(input)), Seq(Row("STRUCT<`id`: STRING>")))
     }
   }
 
@@ -699,33 +675,27 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     val options = Map("dropFieldIfAllNull" -> "true")
     // Structs
     checkAnswer(
-      spark.range(1).select(
-        schema_of_json(
-          lit("""{"id": "a", "drop": {"drop": null}}"""),
-          options.asJava)),
+      spark
+        .range(1)
+        .select(schema_of_json(lit("""{"id": "a", "drop": {"drop": null}}"""), options.asJava)),
       Seq(Row("STRUCT<`id`: STRING>")))
 
     // Array of structs
     checkAnswer(
-      spark.range(1).select(
-        schema_of_json(
-          lit("""[{"id": "a", "drop": {"drop": null}}]"""),
-          options.asJava)),
+      spark
+        .range(1)
+        .select(schema_of_json(lit("""[{"id": "a", "drop": {"drop": null}}]"""), options.asJava)),
       Seq(Row("ARRAY<STRUCT<`id`: STRING>>")))
 
     // Other types are not affected.
     checkAnswer(
-      spark.range(1).select(
-        schema_of_json(
-          lit("""null"""),
-          options.asJava)),
+      spark.range(1).select(schema_of_json(lit("""null"""), options.asJava)),
       Seq(Row("STRING")))
   }
 
   test("optional datetime parser does not affect json time formatting") {
     val s = "2015-08-26 12:34:46"
-    def toDF(p: String): DataFrame = sql(
-      s"""
+    def toDF(p: String): DataFrame = sql(s"""
          |SELECT
          | to_json(
          |   named_struct('time', timestamp'$s'), map('timestampFormat', "$p")
@@ -741,9 +711,11 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     val df1 = Seq("""{"c2": [19], "c1": 123456}""").toDF("c0")
     checkAnswer(df1.select(from_json($"c0", st)), Row(Row(123456, null)))
     val df2 = Seq("""{"data": {"c2": [19], "c1": 123456}}""").toDF("c0")
-    checkAnswer(df2.select(from_json($"c0", new StructType().add("data", st))), Row(Row(null)))
+    checkAnswer(
+      df2.select(from_json($"c0", new StructType().add("data", st))),
+      Row(Row(Row(123456, null))))
     val df3 = Seq("""[{"c2": [19], "c1": 123456}]""").toDF("c0")
-    checkAnswer(df3.select(from_json($"c0", ArrayType(st))), Row(null))
+    checkAnswer(df3.select(from_json($"c0", ArrayType(st))), Row(Seq(Row(123456, null))))
     val df4 = Seq("""{"c2": [19]}""").toDF("c0")
     checkAnswer(df4.select(from_json($"c0", MapType(StringType, st))), Row(null))
   }
@@ -788,14 +760,16 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
         val exception1 = intercept[SparkException] {
           df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("b")).collect()
         }.getMessage
-        assert(exception1.contains(
-          "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
+        assert(
+          exception1.contains(
+            "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
 
         val exception2 = intercept[SparkException] {
           df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("a")).collect()
         }.getMessage
-        assert(exception2.contains(
-          "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
+        assert(
+          exception2.contains(
+            "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
       }
     }
   }
@@ -803,23 +777,26 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
   test("SPARK-33907: bad json input with json pruning optimization: GetArrayStructFields") {
     Seq("true", "false").foreach { enabled =>
       withSQLConf(SQLConf.JSON_EXPRESSION_OPTIMIZATION.key -> enabled) {
-        val schema = ArrayType(new StructType()
-          .add("a", IntegerType)
-          .add("b", IntegerType))
+        val schema = ArrayType(
+          new StructType()
+            .add("a", IntegerType)
+            .add("b", IntegerType))
         val badRec = """{"a" 1, "b": 11}"""
         val df = Seq(s"""[$badRec, {"a": 2, "b": 12}]""").toDS()
 
         val exception1 = intercept[SparkException] {
           df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("b")).collect()
         }.getMessage
-        assert(exception1.contains(
-          "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
+        assert(
+          exception1.contains(
+            "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
 
         val exception2 = intercept[SparkException] {
           df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("a")).collect()
         }.getMessage
-        assert(exception2.contains(
-          "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
+        assert(
+          exception2.contains(
+            "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
       }
     }
   }
@@ -832,7 +809,8 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
           .add("b", IntegerType)
         val badRec = """{"a" 1, "b": 11}"""
 
-        val df = Seq(badRec, """{"a": 2, "b": 12}""").toDS()
+        val df = Seq(badRec, """{"a": 2, "b": 12}""")
+          .toDS()
           .selectExpr("from_json(value, 'a int, b int, _corrupt_record string') as parsed")
           .selectExpr("parsed._corrupt_record")
 
@@ -840,4 +818,29 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       }
     }
   }
+
+  test(
+    "SPARK-35094: Spark from_json(JsonToStruct) function return wrong value in permissive mode in case best effort") {
+    val s1 = StructField("name", StringType, nullable = true)
+    val s2_1 =
+      StructField(
+        "badNestedField",
+        StructType(
+          Seq(StructField("SomethingWhichNotInJsonMessage", IntegerType, nullable = true))))
+    val s2 =
+      StructField("nestedField", StructType(Seq(s2_1, s1)))
+    val customSchema = StructType(Seq(s1, s2))
+
+    val jsonStringToTest =
+      """{"name":"v1","nestedField":{"badNestedField":"14","name":"v2"}}"""
+    val df = List(jsonStringToTest)
+      .toDF("json")
+      .select(from_json($"json", customSchema).as("toBeFlatten"))
+      .select("toBeFlatten.*")
+
+    assert(
+      df.select("name").as[String].first() == "v1",
+      "wrong value in root schema, parser take value from column with same name but in another nested elvel")
+  }
+
 }


### PR DESCRIPTION
### Why are the changes needed?
In https://issues.apache.org/jira/browse/SPARK-35094, When use spark from_json(JsonToStruct) function in permissive mode to handle the case of contains incorrect nested json fields. It will return wrong value.


### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
unit test
