### PR TITLE
[SPARK-35094][SQL]Spark from_json(JsonToStruct) function return wrong value in permissive mode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -398,8 +398,10 @@ class JacksonParser(
             skipRow = structFilters.skipRow(row, index)
           } catch {
             case e: SparkUpgradeException => throw e
-            case NonFatal(e) if isRoot =>
-              badRecordException = badRecordException.orElse(Some(e))
+            case NonFatal(e) =>
+              if (isRoot) {
+                badRecordException = badRecordException.orElse(Some(e))
+              }
               parser.skipChildren()
           }
         case None =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In https://issues.apache.org/jira/browse/SPARK-35094, When use spark from_json(JsonToStruct) function in permissive mode to handle the case of contains incorrect nested json fields. It will return wrong value.


### Why are the changes needed?
It is necessary to ensure that the data is correct.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
unit test
