### PR TITLE
[SPARK-35120][INFRA][FOLLOW-UP] Try catch an error to show the correct guidance

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -56,13 +56,19 @@ jobs:
             // Wait 3 seconds to make sure the fork repository triggered a workflow.
             await new Promise(r => setTimeout(r, 3000))
 
-            const runs = await github.request(endpoint, params)
+            let runs
+            try {
+              runs = await github.request(endpoint, params)
+            } catch (error) {
+              console.error(error)
+              // Assume that runs were not found.
+            }
 
             const name = 'Build and test'
             const head_sha = context.payload.pull_request.head.sha
             let status = 'queued'
 
-            if (runs.data.workflow_runs.length === 0) {
+            if (!runs || runs.data.workflow_runs.length === 0) {
               status = 'completed'
               const conclusion = 'action_required'
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to handle 404 not found, see https://github.com/apache/spark/pull/32255/checks?check_run_id=2390446579 as an example.

If a fork does not have any previous workflow runs, it seems throwing 404 error instead of empty runs.

### Why are the changes needed?

To show the correct guidance to contributors.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested at https://github.com/HyukjinKwon/spark/pull/48. See https://github.com/HyukjinKwon/spark/runs/2391469416 as an example.
