### PR TITLE
[SPARK-35178][BUILD][FOLLOWUP][3.1] Update Zinc argument

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -106,7 +106,7 @@ install_zinc() {
     local TYPESAFE_MIRROR=${TYPESAFE_MIRROR:-https://downloads.lightbend.com}
 
     install_app \
-      "${TYPESAFE_MIRROR}/zinc/${ZINC_VERSION}" \
+      "${TYPESAFE_MIRROR}/zinc/${ZINC_VERSION}/zinc-${ZINC_VERSION}.tgz" \
       "zinc-${ZINC_VERSION}.tgz" \
       "${zinc_path}"
     ZINC_BIN="${_DIR}/${zinc_path}"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to adjust zinc installation with the new parameter.

### Why are the changes needed?

Currently, zinc is ignored.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually.

**BEFORE**
```
$ build/mvn clean
exec: curl --silent --show-error -L https://downloads.lightbend.com/zinc/0.3.15
tar: Error opening archive: Unrecognized archive format
exec: curl --silent --show-error -L https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.tgz
exec: curl --silent --show-error -L https://www.apache.org/dyn/closer.lua/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz?action=download
build/mvn: line 149: /Users/dongjoon/APACHE/spark-merge/build/zinc-0.3.15/bin/zinc: No such file or directory
build/mvn: line 151: /Users/dongjoon/APACHE/spark-merge/build/zinc-0.3.15/bin/zinc: No such file or directory
Using `mvn` from path: /Users/dongjoon/APACHE/spark-merge/build/apache-maven-3.6.3/bin/mvn
[INFO] Scanning for projects...
```

**AFTER**
```
$ build/mvn clean
exec: curl --silent --show-error -L https://downloads.lightbend.com/zinc/0.3.15/zinc-0.3.15.tgz
exec: curl --silent --show-error -L https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.tgz
exec: curl --silent --show-error -L https://www.apache.org/dyn/closer.lua/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz?action=download
Using `mvn` from path: /Users/dongjoon/PRS/SPARK-PR-32282/build/apache-maven-3.6.3/bin/mvn
[INFO] Scanning for projects...
```