### PR TITLE
[SPARK-33357][K8S] Support Spark application managing with SparkAppHandle on Kubernetes

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -32,6 +32,7 @@ import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.KubernetesUtils.addOwnerReference
 import org.apache.spark.internal.Logging
+import org.apache.spark.launcher.LauncherBackend
 import org.apache.spark.util.Utils
 
 /**
@@ -98,7 +99,10 @@ private[spark] class Client(
     conf: KubernetesDriverConf,
     builder: KubernetesDriverBuilder,
     kubernetesClient: KubernetesClient,
-    watcher: LoggingPodStatusWatcher) extends Logging {
+    watcher: PodStatusWatcher) extends Logging {
+
+  private val launcherBackend = new KubernetesLauncherBackend(conf.sparkConf, client = this)
+  private var driverPodName: String = _
 
   def run(): Unit = {
     val resolvedDriverSpec = builder.buildFromFeatures(conf, kubernetesClient)
@@ -131,7 +135,12 @@ private[spark] class Client(
           .endVolume()
         .endSpec()
       .build()
-    val driverPodName = resolvedDriverPod.getMetadata.getName
+    driverPodName = resolvedDriverPod.getMetadata.getName
+
+    launcherBackend.setAppId(driverPodName)
+    launcherBackend.connect()
+
+    watcher.registerLauncherBackend(launcherBackend)
 
     var watch: Watch = null
     var createdDriverPod: Pod = null
@@ -172,6 +181,34 @@ private[spark] class Client(
       }
     }
   }
+
+  def stop(): Unit = {
+    Option(driverPodName)
+      .map(podName => {
+        val driverPod = kubernetesClient
+          .pods()
+          .inNamespace(conf.namespace)
+          .withName(podName)
+
+        conf.sparkConf.get(KUBERNETES_SUBMIT_GRACE_PERIOD) match {
+          case Some(period) => driverPod.withGracePeriod(period).delete()
+          case _ => driverPod.delete()
+        }
+      })
+    launcherBackend.close()
+  }
+
+}
+
+private[spark] class KubernetesLauncherBackend(
+  private val k8sConf: SparkConf,
+  private val client: Client
+) extends LauncherBackend {
+
+  override protected def conf: SparkConf = k8sConf
+
+  override protected def onStopRequest(): Unit = client.stop()
+
 }
 
 /**
@@ -200,7 +237,7 @@ private[spark] class KubernetesClientApplication extends SparkApplication {
     // The master URL has been checked for validity already in SparkSubmit.
     // We just need to get rid of the "k8s://" prefix here.
     val master = KubernetesUtils.parseMasterUrl(sparkConf.get("spark.master"))
-    val watcher = new LoggingPodStatusWatcherImpl(kubernetesConf)
+    val watcher = new PodStatusWatcherImpl(kubernetesConf)
 
     Utils.tryWithResource(SparkKubernetesClientFactory.createKubernetesClient(
       master,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/PodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/PodStatusWatcher.scala
@@ -24,10 +24,12 @@ import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.KubernetesDriverConf
 import org.apache.spark.deploy.k8s.KubernetesUtils._
 import org.apache.spark.internal.Logging
+import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
 
-private[k8s] trait LoggingPodStatusWatcher extends Watcher[Pod] {
+private[k8s] trait PodStatusWatcher extends Watcher[Pod] {
   def watchOrStop(submissionId: String): Boolean
   def reset(): Unit
+  def registerLauncherBackend(launcherBackend: LauncherBackend): Unit
 }
 
 /**
@@ -36,8 +38,8 @@ private[k8s] trait LoggingPodStatusWatcher extends Watcher[Pod] {
  *
  * @param conf kubernetes driver conf.
  */
-private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
-  extends LoggingPodStatusWatcher with Logging {
+private[k8s] class PodStatusWatcherImpl(conf: KubernetesDriverConf)
+  extends PodStatusWatcher with Logging {
 
   private val appId = conf.appId
 
@@ -47,21 +49,31 @@ private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
 
   private var pod = Option.empty[Pod]
 
+  private var launcherBackend = Option.empty[LauncherBackend]
+
+  private var latestPhase: String = _
+
   private def phase: String = pod.map(_.getStatus.getPhase).getOrElse("unknown")
 
   override def reset(): Unit = {
     resourceTooOldReceived = false
   }
 
+  override def registerLauncherBackend(launcherBackend: LauncherBackend): Unit = {
+    this.launcherBackend = Option(launcherBackend)
+  }
+
   override def eventReceived(action: Action, pod: Pod): Unit = {
     this.pod = Option(pod)
     action match {
       case Action.DELETED | Action.ERROR =>
+        notifyStatusChanged()
         closeWatch()
 
       case _ =>
         logLongStatus()
-        if (hasCompleted()) {
+        notifyStatusChanged()
+        if (hasCompleted) {
           closeWatch()
         }
     }
@@ -82,11 +94,29 @@ private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
     closeWatch()
   }
 
+  private def notifyStatusChanged(): Unit = {
+    if (phase != latestPhase) {
+      latestPhase = phase
+      latestPhase match {
+        case "Pending" => reportStatusChanged(SparkAppHandle.State.SUBMITTED)
+        case "Running" => reportStatusChanged(SparkAppHandle.State.RUNNING)
+        case "Succeeded" => reportStatusChanged(SparkAppHandle.State.FINISHED)
+        case "Failed" => reportStatusChanged(SparkAppHandle.State.FAILED)
+        case "Unknown" => reportStatusChanged(SparkAppHandle.State.LOST)
+        case _ => reportStatusChanged(SparkAppHandle.State.UNKNOWN)
+      }
+    }
+  }
+
+  def reportStatusChanged(state: SparkAppHandle.State): Unit = {
+    launcherBackend.foreach(_.setState(state))
+  }
+
   private def logLongStatus(): Unit = {
     logInfo("State changed, new state: " + pod.map(formatPodState).getOrElse("unknown"))
   }
 
-  private def hasCompleted(): Boolean = {
+  private def hasCompleted: Boolean = {
     phase == "Succeeded" || phase == "Failed"
   }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/PodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/PodStatusWatcher.scala
@@ -65,14 +65,13 @@ private[k8s] class PodStatusWatcherImpl(conf: KubernetesDriverConf)
 
   override def eventReceived(action: Action, pod: Pod): Unit = {
     this.pod = Option(pod)
+    notifyStatusChanged()
     action match {
       case Action.DELETED | Action.ERROR =>
-        notifyStatusChanged()
         closeWatch()
 
       case _ =>
         logLongStatus()
-        notifyStatusChanged()
         if (hasCompleted) {
           closeWatch()
         }
@@ -102,7 +101,7 @@ private[k8s] class PodStatusWatcherImpl(conf: KubernetesDriverConf)
         case "Running" => reportStatusChanged(SparkAppHandle.State.RUNNING)
         case "Succeeded" => reportStatusChanged(SparkAppHandle.State.FINISHED)
         case "Failed" => reportStatusChanged(SparkAppHandle.State.FAILED)
-        case "Unknown" => reportStatusChanged(SparkAppHandle.State.LOST)
+        case "Unknown" => reportStatusChanged(SparkAppHandle.State.UNKNOWN)
         case _ => reportStatusChanged(SparkAppHandle.State.UNKNOWN)
       }
     }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -128,7 +128,7 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
   private var namedPods: PodResource[Pod] = _
 
   @Mock
-  private var loggingPodStatusWatcher: LoggingPodStatusWatcher = _
+  private var podStatusWatcher: PodStatusWatcher = _
 
   @Mock
   private var driverBuilder: KubernetesDriverBuilder = _
@@ -146,13 +146,14 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
       resourceNamePrefix = Some(KUBERNETES_RESOURCE_PREFIX))
     when(driverBuilder.buildFromFeatures(kconf, kubernetesClient)).thenReturn(BUILT_KUBERNETES_SPEC)
     when(kubernetesClient.pods()).thenReturn(podOperations)
+    when(podOperations.inNamespace(kconf.namespace)).thenReturn(podOperations)
     when(podOperations.withName(POD_NAME)).thenReturn(namedPods)
 
     createdPodArgumentCaptor = ArgumentCaptor.forClass(classOf[Pod])
     createdResourcesArgumentCaptor = ArgumentCaptor.forClass(classOf[HasMetadata])
     when(podOperations.create(fullExpectedPod())).thenReturn(podWithOwnerReference())
-    when(namedPods.watch(loggingPodStatusWatcher)).thenReturn(mock[Watch])
-    when(loggingPodStatusWatcher.watchOrStop(kconf.namespace + ":" + POD_NAME)).thenReturn(true)
+    when(namedPods.watch(podStatusWatcher)).thenReturn(mock[Watch])
+    when(podStatusWatcher.watchOrStop(kconf.namespace + ":" + POD_NAME)).thenReturn(true)
     doReturn(resourceList)
       .when(kubernetesClient)
       .resourceList(createdResourcesArgumentCaptor.capture())
@@ -163,7 +164,7 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
       kconf,
       driverBuilder,
       kubernetesClient,
-      loggingPodStatusWatcher)
+      podStatusWatcher)
     submissionClient.run()
     verify(podOperations).create(fullExpectedPod())
   }
@@ -173,7 +174,7 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
       kconf,
       driverBuilder,
       kubernetesClient,
-      loggingPodStatusWatcher)
+      podStatusWatcher)
     submissionClient.run()
     val otherCreatedResources = createdResourcesArgumentCaptor.getAllValues
     assert(otherCreatedResources.size === 2)
@@ -241,7 +242,7 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
       kconf,
       driverBuilder,
       kubernetesClient,
-      loggingPodStatusWatcher)
+      podStatusWatcher)
     submissionClient.run()
     val otherCreatedResources = createdResourcesArgumentCaptor.getAllValues
 
@@ -263,8 +264,20 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
       kconf,
       driverBuilder,
       kubernetesClient,
-      loggingPodStatusWatcher)
+      podStatusWatcher)
     submissionClient.run()
-    verify(loggingPodStatusWatcher).watchOrStop(kconf.namespace + ":driver")
+    verify(podStatusWatcher).watchOrStop(kconf.namespace + ":driver")
+  }
+
+  test("The client should stop current spark application.") {
+    val submissionClient = new Client(
+      kconf,
+      driverBuilder,
+      kubernetesClient,
+      podStatusWatcher)
+    submissionClient.run()
+    verify(podOperations).create(fullExpectedPod())
+    submissionClient.stop()
+    verify(namedPods).delete()
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/PodStatusWatcherSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/PodStatusWatcherSuite.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.submit
+
+import java.util
+
+import io.fabric8.kubernetes.api.model.{ObjectMeta, Pod, PodSpec, PodStatus}
+import io.fabric8.kubernetes.client.Watcher.Action.{ADDED, MODIFIED}
+import org.mockito.Mock
+import org.mockito.Mockito.{times, verify}
+import org.mockito.MockitoAnnotations
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.deploy.k8s.KubernetesTestConf
+import org.apache.spark.launcher.SparkAppHandle
+
+class PodStatusWatcherSuite extends SparkFunSuite with BeforeAndAfter {
+
+  @Mock
+  private var launcherBackend: KubernetesLauncherBackend = _
+
+  private val podStatusWatcher = new PodStatusWatcherImpl(k8sDriverConf)
+
+  before {
+    MockitoAnnotations.openMocks(this).close()
+    podStatusWatcher.registerLauncherBackend(launcherBackend)
+  }
+
+  test("The pod status watcher should notify launcher backend about status change.") {
+    podStatusWatcher.eventReceived(ADDED, podWithPhase("Running"))
+    verify(launcherBackend).setState(SparkAppHandle.State.RUNNING)
+  }
+
+  test("The pod status watcher should not notify launcher backend if status is not changed.") {
+    podStatusWatcher.eventReceived(MODIFIED, podWithPhase("Succeeded"))
+    podStatusWatcher.eventReceived(MODIFIED, podWithPhase("Succeeded"))
+    verify(launcherBackend, times(1)).setState(SparkAppHandle.State.FINISHED)
+  }
+
+  test("The pod status watcher should notify launcher backend " +
+    "with unknown state if pod status is not known.") {
+    podStatusWatcher.eventReceived(ADDED, podWithPhase("SomeUnknownPodStatus"))
+    verify(launcherBackend).setState(SparkAppHandle.State.UNKNOWN)
+  }
+
+  private def k8sDriverConf = KubernetesTestConf.createDriverConf(
+    resourceNamePrefix = Some("resource-example")
+  )
+
+  private def podWithPhase(phase: String): Pod = {
+    new Pod() {
+      setMetadata(new ObjectMeta() {
+        setName("pod")
+        setNamespace("namespace")
+        setLabels(new util.HashMap())
+        setUid("uid")
+        setCreationTimestamp("now")
+      })
+      setSpec(new PodSpec() {
+        setServiceAccountName("sa")
+        setNodeName("nodeName")
+      })
+      setStatus(new PodStatus() {
+        setPhase(phase)
+        setStartTime("now")
+      })
+    }
+  }
+
+}


### PR DESCRIPTION
Co-authored-by: hongdd <hongdongdong@cmss.chinamobile.com>

### What changes were proposed in this pull request?
Supporting SparkAppHandle object to be able to manage a running Spark application on Kubernetes. It can be used to monitor the application changes and to stop the application by pod deletion.

This Pull Request has been raised due to a inactivity of a previous one - #30520


### Why are the changes needed?
There is an inconsistency in the Spark application managing with SparkAppHandle object between Kubernetes and other resource managers such as Yarn/Mesos.

Currently, this feature is not properly implemented on Kubernetes which may cause some issues.


### Does this PR introduce _any_ user-facing change?
Yes, it changes the behavior of `SparkAppHandle` object which the user may use to communicate with the launched Spark application. Its interface is remained as it is. Some missing functionalities have been implemented.


### How was this patch tested?
Few unit tests has been added. May be found in org.apache.spark.deploy.k8s.submit package:

- `PodStatusWatcherSuite` - new ones
- `ClientSuite` - added some
