### PR TITLE
[SPARK-35183][SQL] Use transformAllExpressions in CombineConcats

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -986,7 +986,7 @@ object CombineConcats extends Rule[LogicalPlan] {
     case _ => false
   }
 
-  def apply(plan: LogicalPlan): LogicalPlan = plan.transformExpressionsDown {
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformAllExpressions {
     case concat: Concat if hasNestedConcats(concat) =>
       flattenConcats(concat)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineConcatsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombineConcatsSuite.scala
@@ -31,8 +31,10 @@ class CombineConcatsSuite extends PlanTest {
   }
 
   protected def assertEquivalent(e1: Expression, e2: Expression): Unit = {
-    val correctAnswer = Project(Alias(e2, "out")() :: Nil, OneRowRelation()).analyze
-    val actual = Optimize.execute(Project(Alias(e1, "out")() :: Nil, OneRowRelation()).analyze)
+    val correctAnswer = Limit(Literal(1), Project(Alias(e2, "out")() :: Nil, OneRowRelation()))
+      .analyze
+    val actual = Optimize.execute(Limit(Literal(1), Project(Alias(e1, "out")() :: Nil,
+      OneRowRelation())).analyze)
     comparePlans(actual, correctAnswer)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -60,7 +60,7 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
    * Runs the plan and makes sure the plans contains all of the keywords.
    */
   protected def checkKeywordsExistsInExplain(
-      df: DataFrame, mode: ExplainMode, keywords: String*): Unit = {
+    df: DataFrame, mode: ExplainMode, keywords: String*): Unit = {
     withNormalizedExplain(df, mode) { normalizedOutput =>
       for (key <- keywords) {
         assert(normalizedOutput.contains(key))
@@ -76,7 +76,7 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
    * Runs the plan and makes sure the plans does not contain any of the keywords.
    */
   protected def checkKeywordsNotExistsInExplain(
-      df: DataFrame, mode: ExplainMode, keywords: String*): Unit = {
+    df: DataFrame, mode: ExplainMode, keywords: String*): Unit = {
     withNormalizedExplain(df, mode) { normalizedOutput =>
       for (key <- keywords) {
         assert(!normalizedOutput.contains(key))
@@ -86,7 +86,6 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
 }
 
 class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite {
-
   import testImplicits._
 
   test("SPARK-23034 show rdd names in RDD scan nodes (Dataset)") {
@@ -402,12 +401,10 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
 
   test("Dataset.toExplainString has mode as string") {
     val df = spark.range(10).toDF
-
     def assertExplainOutput(mode: ExplainMode): Unit = {
       assert(df.queryExecution.explainString(mode).replaceAll("#\\d+", "#x").trim ===
         getNormalizedExplain(df, mode).trim)
     }
-
     assertExplainOutput(SimpleMode)
     assertExplainOutput(ExtendedMode)
     assertExplainOutput(CodegenMode)
@@ -451,7 +448,7 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     withTempDir { dir =>
       Seq("parquet", "orc", "csv", "json").foreach { fmt =>
         val basePath = dir.getCanonicalPath + "/" + fmt
-        val pushFilterMaps = Map(
+        val pushFilterMaps = Map (
           "parquet" ->
             "|PushedFilters: \\[IsNotNull\\(value\\), GreaterThan\\(value,2\\)\\]",
           "orc" ->

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -506,18 +506,6 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
       checkKeywordsExistsInExplain(df2, keywords = "[key1=value1, KEY2=VALUE2]")
     }
   }
-
-  test("SPARK-35183: CombineConcats should call transformAllExpressions") {
-    val df_concat = sql(
-      """
-        |SELECT (col1 || col2 || col3 || col4) col
-        |  FROM (SELECT id col1, id col2, id col3, id col4 FROM range(10))
-        |  LIMIT 5
-      """.stripMargin)
-    checkKeywordsExistsInExplain(df_concat,
-      "Project [concat(cast(id#xL as string), cast(id#xL as string), cast(id#xL as string)" +
-        ", cast(id#xL as string)) AS col#x]")
-  }
 }
 
 class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -60,7 +60,7 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
    * Runs the plan and makes sure the plans contains all of the keywords.
    */
   protected def checkKeywordsExistsInExplain(
-    df: DataFrame, mode: ExplainMode, keywords: String*): Unit = {
+      df: DataFrame, mode: ExplainMode, keywords: String*): Unit = {
     withNormalizedExplain(df, mode) { normalizedOutput =>
       for (key <- keywords) {
         assert(normalizedOutput.contains(key))
@@ -76,7 +76,7 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
    * Runs the plan and makes sure the plans does not contain any of the keywords.
    */
   protected def checkKeywordsNotExistsInExplain(
-    df: DataFrame, mode: ExplainMode, keywords: String*): Unit = {
+      df: DataFrame, mode: ExplainMode, keywords: String*): Unit = {
     withNormalizedExplain(df, mode) { normalizedOutput =>
       for (key <- keywords) {
         assert(!normalizedOutput.contains(key))
@@ -262,45 +262,45 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
       withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
         SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
         SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
-        spark.range(1000).select(col("id"), col("id").as("k"))
-          .write
-          .partitionBy("k")
-          .format("parquet")
-          .mode("overwrite")
-          .saveAsTable("df1")
+          spark.range(1000).select(col("id"), col("id").as("k"))
+            .write
+            .partitionBy("k")
+            .format("parquet")
+            .mode("overwrite")
+            .saveAsTable("df1")
 
-        spark.range(100)
-          .select(col("id"), col("id").as("k"))
-          .write
-          .partitionBy("k")
-          .format("parquet")
-          .mode("overwrite")
-          .saveAsTable("df2")
+          spark.range(100)
+            .select(col("id"), col("id").as("k"))
+            .write
+            .partitionBy("k")
+            .format("parquet")
+            .mode("overwrite")
+            .saveAsTable("df2")
 
-        val sqlText =
-          """
-            |EXPLAIN FORMATTED SELECT df1.id, df2.k
-            |FROM df1 JOIN df2 ON df1.k = df2.k AND df2.id < 2
-            |""".stripMargin
+          val sqlText =
+            """
+              |EXPLAIN FORMATTED SELECT df1.id, df2.k
+              |FROM df1 JOIN df2 ON df1.k = df2.k AND df2.id < 2
+              |""".stripMargin
 
-        val expected_pattern1 =
-          "Subquery:1 Hosting operator id = 1 Hosting Expression = k#xL IN subquery#x"
-        val expected_pattern2 =
-          "PartitionFilters: \\[isnotnull\\(k#xL\\), dynamicpruningexpression\\(k#xL " +
-            "IN subquery#x\\)\\]"
-        val expected_pattern3 =
-          "Location: InMemoryFileIndex \\[\\S*org.apache.spark.sql.ExplainSuite" +
-            "/df2/\\S*, ... 99 entries\\]"
-        val expected_pattern4 =
-          "Location: InMemoryFileIndex \\[\\S*org.apache.spark.sql.ExplainSuite" +
-            "/df1/\\S*, ... 999 entries\\]"
-        withNormalizedExplain(sqlText) { normalizedOutput =>
-          assert(expected_pattern1.r.findAllMatchIn(normalizedOutput).length == 1)
-          assert(expected_pattern2.r.findAllMatchIn(normalizedOutput).length == 1)
-          assert(expected_pattern3.r.findAllMatchIn(normalizedOutput).length == 2)
-          assert(expected_pattern4.r.findAllMatchIn(normalizedOutput).length == 1)
+          val expected_pattern1 =
+            "Subquery:1 Hosting operator id = 1 Hosting Expression = k#xL IN subquery#x"
+          val expected_pattern2 =
+            "PartitionFilters: \\[isnotnull\\(k#xL\\), dynamicpruningexpression\\(k#xL " +
+              "IN subquery#x\\)\\]"
+          val expected_pattern3 =
+            "Location: InMemoryFileIndex \\[\\S*org.apache.spark.sql.ExplainSuite" +
+              "/df2/\\S*, ... 99 entries\\]"
+          val expected_pattern4 =
+            "Location: InMemoryFileIndex \\[\\S*org.apache.spark.sql.ExplainSuite" +
+              "/df1/\\S*, ... 999 entries\\]"
+          withNormalizedExplain(sqlText) { normalizedOutput =>
+            assert(expected_pattern1.r.findAllMatchIn(normalizedOutput).length == 1)
+            assert(expected_pattern2.r.findAllMatchIn(normalizedOutput).length == 1)
+            assert(expected_pattern3.r.findAllMatchIn(normalizedOutput).length == 2)
+            assert(expected_pattern4.r.findAllMatchIn(normalizedOutput).length == 1)
+          }
         }
-      }
     }
   }
 
@@ -329,8 +329,8 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     val simpleExplainOutput = getNormalizedExplain(testDf, SimpleMode)
     assert(simpleExplainOutput.startsWith("== Physical Plan =="))
     Seq("== Parsed Logical Plan ==",
-      "== Analyzed Logical Plan ==",
-      "== Optimized Logical Plan ==").foreach { planType =>
+        "== Analyzed Logical Plan ==",
+        "== Optimized Logical Plan ==").foreach { planType =>
       assert(!simpleExplainOutput.contains(planType))
     }
     checkKeywordsExistsInExplain(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use transformAllExpressions instead of transformExpressionsDown in CombineConcats. The latter only transforms the root plan node.

### Why are the changes needed?

It allows CombineConcats to cover more cases where `concat` are not in the root plan node.

### How was this patch tested?

Unit test. The updated tests would fail without the code change.
