### PR TITLE
Allow custom JsonGenerator in JacksonGenerator

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
@@ -45,7 +45,7 @@ private[sql] class JacksonGenerator(
            options: JSONOptions) {
     this(
       dataType,
-      options.buildJsonFactory().createGenerator(writer).setRootValueSeparator(null),
+      new JsonFactory().createGenerator(writer).setRootValueSeparator(null),
       options)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
@@ -37,8 +37,18 @@ import org.apache.spark.sql.types._
  */
 private[sql] class JacksonGenerator(
     dataType: DataType,
-    writer: Writer,
+    generator: JsonGenerator,
     options: JSONOptions) {
+
+  def this(dataType: DataType,
+           writer: Writer,
+           options: JSONOptions) {
+    this(
+      dataType,
+      options.buildJsonFactory().createGenerator(writer).setRootValueSeparator(null),
+      options)
+  }
+
   // A `ValueWriter` is responsible for writing a field of an `InternalRow` to appropriate
   // JSON data. Here we are using `SpecializedGetters` rather than `InternalRow` so that
   // we can directly access data in `ArrayData` without the help of `SpecificMutableRow`.
@@ -73,7 +83,6 @@ private[sql] class JacksonGenerator(
   }
 
   private val gen = {
-    val generator = new JsonFactory().createGenerator(writer).setRootValueSeparator(null)
     if (options.pretty) generator.setPrettyPrinter(new DefaultPrettyPrinter("")) else generator
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JacksonGeneratorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JacksonGeneratorSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.json
 
-import java.io.CharArrayWriter
+import java.io.{ByteArrayOutputStream, CharArrayWriter}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
@@ -137,4 +137,14 @@ class JacksonGeneratorSuite extends SparkFunSuite {
     }
   }
 
+  test("using JsonGenerator writing to OutputStream") {
+    val dataType = StructType(StructField("a", IntegerType) :: Nil)
+    val input = InternalRow(1)
+    val writer = new ByteArrayOutputStream()
+    val gen = new JacksonGenerator(
+      dataType, option.buildJsonFactory().createGenerator(writer), option)
+    gen.write(input)
+    gen.flush()
+    assert(writer.toString === """{"a":1}""")
+  }
 }


### PR DESCRIPTION
This PR provides an overloaded version of `JacksonGenerator` constructor that accepts a custom `JsonGenerator` instead of `java.io.Writer`. This would enable the use of `JacksonGenerator` with any [Jackson binary dataformat](https://github.com/FasterXML/jackson-dataformats-binary).
Those Jackson implementations mostly do not have support for `com.fasterxml.jackson.core.JsonFactory#createGenerator(java.io.Writer)`, but only for `com.fasterxml.jackson.core.JsonFactory#createGenerator(java.io.OutputStream)`.

### Why are the changes needed?

This would be beneficial for datasources implementations, which need to convert data to any Jackson binary dataformat, since they could reuse `JacksonGenerator` type mappings.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
I added a positive unit test.