### PR TITLE
[SPARK-35197][Web UI] Accumulators Explore Page on Spark UI on History Server

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -26,6 +26,7 @@ import org.apache.spark.scheduler._
 import org.apache.spark.status.AppStatusStore
 import org.apache.spark.status.api.v1._
 import org.apache.spark.ui.JettyUtils._
+import org.apache.spark.ui.accm.AccumulatorsTab
 import org.apache.spark.ui.env.EnvironmentTab
 import org.apache.spark.ui.exec.ExecutorsTab
 import org.apache.spark.ui.jobs.{JobsTab, StagesTab}
@@ -63,6 +64,7 @@ private[spark] class SparkUI private (
     attachTab(new StorageTab(this, store))
     attachTab(new EnvironmentTab(this, store))
     attachTab(new ExecutorsTab(this))
+    attachTab(new AccumulatorsTab(this, store))
     addStaticHandler(SparkUI.STATIC_RESOURCE_DIR)
     attachHandler(createRedirectHandler("/", "/jobs/", basePath = basePath))
     attachHandler(ApiRootResource.getServletHandler(this))

--- a/core/src/main/scala/org/apache/spark/ui/accm/AccumulatorPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/accm/AccumulatorPage.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui.accm
+
+import javax.servlet.http.HttpServletRequest
+
+import scala.collection.immutable.SortedMap
+import scala.xml.Node
+
+import org.apache.spark.status._
+import org.apache.spark.ui._
+
+
+/** Page showing table with single accumulator across all stages and tasks* */
+private[ui] class AccumulatorPage (parent: AccumulatorsTab, store: AppStatusStore)
+  extends WebUIPage(prefix = "accumulator") {
+
+  def render(request: HttpServletRequest): Seq[Node] = {
+    val parameterAccumulatorName = UIUtils.stripXSS(request.getParameter("accumulator_name"))
+    require(parameterAccumulatorName != null && parameterAccumulatorName.nonEmpty,
+      "Missing accumulator name parameter")
+    val parameterAttempt = UIUtils.stripXSS(request.getParameter("attempt"))
+    require(parameterAttempt != null && parameterAttempt.nonEmpty, "Missing attempt parameter")
+    val accumulatorName = parameterAccumulatorName
+    val attemptId = parameterAttempt.toInt
+
+    val accumulatorHeader = s"Details for all Stages (Attempt ${attemptId})"
+
+    val allStages = parent.store.stageList(null)
+    val basePathUri = UIUtils.prependBaseUri(request, parent.basePath)
+
+    def createSingleAccumulatorTable(tempMap: SortedMap[Long, NamedAccumulatorInfo]):
+    Seq[Node] = {
+      if (tempMap.nonEmpty) {
+        val accumulableHeaders: Seq[String] = Seq("Stage", "Task Id", "Task Index", "Value")
+
+        def accumulableRow(acc: (Long, NamedAccumulatorInfo)): Seq[Node] = {
+          <tr>
+            <td>{acc._2.stage}</td>
+            <td>{acc._2.taskId}</td>
+            <td>{acc._2.taskIndex}</td>
+            <td>{acc._2.value}</td>
+          </tr>
+        }
+
+        val singleAccTable = UIUtils.listingTable(
+          accumulableHeaders,
+          accumulableRow,
+          tempMap
+        )
+
+        singleAccTable
+      } else {
+         Nil
+      }
+    }
+
+    def createStagesAccumulatorTable(tempStageMap: SortedMap[Int, String]): Seq[Node] = {
+      val accumulableStageHeaders: Seq[String] = Seq("Stage", "Value")
+
+      def accumulableStagesRow(acc: (Int, String)): Seq[Node] = {
+          <tr>
+            <td>{acc._1}</td>
+            <td>{acc._2}</td>
+          </tr>
+      }
+
+      val singleAccTable = UIUtils.listingTable(
+        accumulableStageHeaders,
+        accumulableStagesRow,
+        tempStageMap
+      )
+
+      val maybeTable : Seq[Node] = if (tempStageMap.nonEmpty) singleAccTable else Nil
+      maybeTable
+    }
+
+    var tempStageMap = SortedMap[Int, String]()// SortedMap[StageId -> accumulator.update]
+    var tempMapStagesAndTasks = SortedMap[Long, NamedAccumulatorInfo]()
+    // SortedMap[TaskId ->
+    // NamedAccumulatorInfoDetails(stage, task.id, task.index, accumulator.update)]
+
+    allStages.foreach(stage => {
+      val taskD = store.taskList(stage.stageId, stage.attemptId, Int.MaxValue)
+      taskD.foreach(task => {
+        task.accumulatorUpdates.filter(_.name == accumulatorName).foreach(ac => {
+          val stageLinkUri =
+            s"$basePathUri/accumulators/stage/?id=${stage.stageId}&attempt=${stage.attemptId}"
+          tempMapStagesAndTasks+=(
+            task.taskId ->
+              NamedAccumulatorInfo(
+                stage.stageId,
+                task.taskId,
+                task.index,
+                ac.update.get))
+        })
+      })
+      val stageData = parent.store.asOption(
+        parent.store.stageAttempt(stage.stageId, stage.attemptId, details = false)).get
+      val targetAcc = stageData.accumulatorUpdates.filter(_.name == accumulatorName)
+      if (targetAcc.nonEmpty) tempStageMap+=(stage.stageId -> targetAcc.head.value)
+    })
+
+    val accummulatorsTableAllTasks = createSingleAccumulatorTable(tempMapStagesAndTasks)
+    val AccStageTable = createStagesAccumulatorTable(tempStageMap)
+
+    val content = {
+      <h4>Accumulator {accumulatorName}</h4>
+        <span>
+          <h4>Per Stage ({tempStageMap.size})</h4>
+          {AccStageTable}
+        </span>
+        <span>
+          <h4>Per Task ({tempMapStagesAndTasks.size})</h4>
+          {accummulatorsTableAllTasks}
+        </span>
+    }
+    UIUtils.headerSparkPage(request, accumulatorHeader, content, parent)
+  }
+
+  case class NamedAccumulatorInfo(
+        stage: Int,
+        taskId: Long,
+        taskIndex: Long,
+        value: String)
+}

--- a/core/src/main/scala/org/apache/spark/ui/accm/AccumulatorStagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/accm/AccumulatorStagePage.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui.accm
+
+import javax.servlet.http.HttpServletRequest
+
+import scala.collection.immutable.SortedMap
+import scala.xml.Node
+
+import org.apache.spark.status._
+import org.apache.spark.ui._
+
+/** Page showing table with a list of tasks from a single accumulator across a single stage* */
+private[ui] class AccumulatorStagePage(parent: AccumulatorsTab, store: AppStatusStore)
+  extends WebUIPage(prefix = "stage") {
+
+  def render(request: HttpServletRequest): Seq[Node] = {
+    val parameterAccumulatorName = UIUtils.stripXSS(request.getParameter("accumulator_name"))
+    require(parameterAccumulatorName != null && parameterAccumulatorName.nonEmpty,
+      "Missing accumulator name parameter")
+    val parameterAttempt = UIUtils.stripXSS(request.getParameter("attempt"))
+    require(parameterAttempt != null && parameterAttempt.nonEmpty, "Missing attempt parameter")
+    val parameterId = UIUtils.stripXSS(request.getParameter("id"))
+    val accumulatorName = parameterAccumulatorName
+    val attemptId = parameterAttempt.toInt
+    val stageId = parameterId.toInt
+
+    val accumulatorHeader =
+      s"Details for Stage ${stageId} (Attempt ${attemptId})"
+
+    def createAccumulatorTaskTable(tempMap: SortedMap[Long, AccumulatorTaskInfo] ): Seq[Node] = {
+      if (tempMap.nonEmpty) {
+        val accumulableHeaders: Seq[String] = Seq("Task Id", "Task Index", "Update")
+
+        def accumulableRow(acc: (Long, AccumulatorTaskInfo)): Seq[Node] = {
+          <tr>
+            <td>{acc._2.taskId}</td>
+            <td>{acc._2.taskIndex}</td>
+            <td>{acc._2.update}</td>
+          </tr>
+        }
+
+        val singleAccTable = UIUtils.listingTable(
+          accumulableHeaders,
+          accumulableRow,
+          tempMap
+        )
+
+        singleAccTable
+      } else {
+        Nil
+      }
+    }
+
+    val taskD = store.taskList(stageId, attemptId, Int.MaxValue)
+    var tempMap = SortedMap[Long, AccumulatorTaskInfo]()
+    // SortedMap[TaskId ->
+    // NamedAccumulatorInfoDetails(task.id, task.index, accumulator.update)]
+
+    taskD.foreach(task => {
+      task.accumulatorUpdates.filter(_.name == accumulatorName).map(ac => {
+          tempMap+=(task.taskId ->
+            AccumulatorTaskInfo(
+              task.taskId,
+              task.index,
+              ac.update.get))
+      })
+    })
+
+    val singleAccumulatorSingleStageTable = createAccumulatorTaskTable(tempMap)
+
+    val content = {
+      <h4> Accumulator {accumulatorName} all tasks</h4> ++
+        singleAccumulatorSingleStageTable
+    }
+    UIUtils.headerSparkPage(request, accumulatorHeader, content, parent)
+  }
+
+  case class AccumulatorTaskInfo(taskId: Long, taskIndex: Long, update: String)
+}

--- a/core/src/main/scala/org/apache/spark/ui/accm/AccumulatorStagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/accm/AccumulatorStagePage.scala
@@ -30,12 +30,12 @@ private[ui] class AccumulatorStagePage(parent: AccumulatorsTab, store: AppStatus
   extends WebUIPage(prefix = "stage") {
 
   def render(request: HttpServletRequest): Seq[Node] = {
-    val parameterAccumulatorName = UIUtils.stripXSS(request.getParameter("accumulator_name"))
+    val parameterAccumulatorName = request.getParameter("accumulator_name")
     require(parameterAccumulatorName != null && parameterAccumulatorName.nonEmpty,
       "Missing accumulator name parameter")
-    val parameterAttempt = UIUtils.stripXSS(request.getParameter("attempt"))
+    val parameterAttempt = request.getParameter("attempt")
     require(parameterAttempt != null && parameterAttempt.nonEmpty, "Missing attempt parameter")
-    val parameterId = UIUtils.stripXSS(request.getParameter("id"))
+    val parameterId = request.getParameter("id")
     val accumulatorName = parameterAccumulatorName
     val attemptId = parameterAttempt.toInt
     val stageId = parameterId.toInt
@@ -54,13 +54,11 @@ private[ui] class AccumulatorStagePage(parent: AccumulatorsTab, store: AppStatus
             <td>{acc._2.update}</td>
           </tr>
         }
-
         val singleAccTable = UIUtils.listingTable(
           accumulableHeaders,
           accumulableRow,
           tempMap
         )
-
         singleAccTable
       } else {
         Nil
@@ -74,11 +72,8 @@ private[ui] class AccumulatorStagePage(parent: AccumulatorsTab, store: AppStatus
 
     taskD.foreach(task => {
       task.accumulatorUpdates.filter(_.name == accumulatorName).map(ac => {
-          tempMap+=(task.taskId ->
-            AccumulatorTaskInfo(
-              task.taskId,
-              task.index,
-              ac.update.get))
+        tempMap+=(task.taskId ->
+          AccumulatorTaskInfo(task.taskId, task.index, ac.update.get))
       })
     })
 

--- a/core/src/main/scala/org/apache/spark/ui/accm/AccumulatorsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/accm/AccumulatorsTab.scala
@@ -27,4 +27,3 @@ private[ui] class AccumulatorsTab(val parent: SparkUI, val store: AppStatusStore
   attachPage(new AccumulatorPage(this, store))
   attachPage(new AccumulatorStagePage(this, store))
 }
-

--- a/core/src/main/scala/org/apache/spark/ui/accm/AccumulatorsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/accm/AccumulatorsTab.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui.accm
+
+import org.apache.spark.status.AppStatusStore
+import org.apache.spark.ui.{SparkUI, SparkUITab}
+
+private[ui] class AccumulatorsTab(val parent: SparkUI, val store: AppStatusStore)
+  extends SparkUITab(parent, "accumulators") {
+
+  attachPage(new AllAccumulatorsPage(this, store))
+  attachPage(new AccumulatorPage(this, store))
+  attachPage(new AccumulatorStagePage(this, store))
+}
+

--- a/core/src/main/scala/org/apache/spark/ui/accm/AllAccumulatorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/accm/AllAccumulatorsPage.scala
@@ -24,19 +24,54 @@ import scala.collection.mutable.ListBuffer
 import scala.xml.Node
 
 import org.apache.spark.status._
+import org.apache.spark.status.api.v1.AccumulableInfo
 import org.apache.spark.ui._
 
 /** Page showing table with a list of all accumulators across all finished stages* */
 private[ui] class AllAccumulatorsPage(parent: AccumulatorsTab, store: AppStatusStore)
   extends WebUIPage("") {
 
+  private var tempMap = SortedMap[String, ListBuffer[AccumulatorInfo]]()
+  // SortedMap[accumulator.name ->
+  // ListBuffer[
+  // AccumulatorInfoDetails(
+  // stageId,
+  // accumulator.name,
+  // accumulator.value,
+  // stageLink,
+  // accumulatorNameLink)]]
+
+  private[ui] def displayMap(): SortedMap[String, ListBuffer[AccumulatorInfo]] = tempMap
+
+  private[ui] def addStageAcc(acc: AccumulableInfo,
+                              basePathUri: String,
+                              stageId: Int,
+                              attemptId: Int): Unit = {
+    val accNameLinkUri =
+      s"$basePathUri/accumulators/accumulator/?accumulator_name=" +
+        s"${acc.name}&attempt=${attemptId}"
+
+    val stageLinkUri =
+      s"$basePathUri/accumulators/stage/?accumulator_name=" +
+        s"${acc.name}&id=${stageId}&attempt=${attemptId}"
+
+    def addAccToMap(): ListBuffer[AccumulatorInfo] = {
+      tempMap += (acc.name -> new ListBuffer[AccumulatorInfo]())
+      tempMap(acc.name)
+    }
+    val newList = tempMap.getOrElse(acc.name, addAccToMap()):+
+      AccumulatorInfo(stageId, acc.name, acc.value, stageLinkUri, accNameLinkUri)
+    tempMap+=(acc.name -> newList)
+  }
+
   def render(request: HttpServletRequest): Seq[Node] = {
     val allStages = parent.store.stageList(null)
     val basePathUri = UIUtils.prependBaseUri(request, parent.basePath)
     val accumulatorHeader = s"Accumulators across all Stages"
+    if (tempMap.size > 0) tempMap = tempMap.empty
 
-    def generateAccumulatorsTable(
-      tempMap: SortedMap[String, ListBuffer[AccumulatorInfo]]): Seq[Node] = {
+    def generateAccumulatorsTable(tempMap: SortedMap[String, ListBuffer[AccumulatorInfo]]):
+    Seq[Node] = {
       if (tempMap.nonEmpty) {
         val accumulableHeaders: Seq[String] = Seq("Accumulable", "Stage", "Value")
         def accumulableRow(acc: (String, ListBuffer[AccumulatorInfo])): Seq[Node] = {
@@ -57,25 +92,14 @@ private[ui] class AllAccumulatorsPage(parent: AccumulatorsTab, store: AppStatusS
           accumulableRow,
           tempMap
         )
-
         accumulableTable.toSeq
       } else {
         Nil
       }
     }
 
-    var tempMap = SortedMap[String, ListBuffer[AccumulatorInfo]]()
-      // SortedMap[accumulator.name ->
-      // ListBuffer[
-      // AccumulatorInfoDetails(
-       // stage,
-       // accumulator.name,
-       // accumulator.value,
-       // stageLink,
-       // accumulatorNameLink)]]
-
-    allStages.map( stage => {
-      val stageData = parent.store
+    allStages.foreach(stage => {
+      parent.store
         .asOption(parent.store.stageAttempt(stage.stageId, stage.attemptId, details = false))
         .getOrElse {
           val content =
@@ -83,28 +107,12 @@ private[ui] class AllAccumulatorsPage(parent: AccumulatorsTab, store: AppStatusS
             </div>
           return UIUtils.headerSparkPage(request, "", content, parent)
         }
-      val sd = stageData.accumulatorUpdates.toSeq
+      val sd = stage.accumulatorUpdates.toSeq
 
-      sd.map(acc => {
-        val accNameLinkUri =
-          s"$basePathUri/accumulators/accumulator/?accumulator_name=" +
-            s"${acc.name}&attempt=${stage.attemptId}"
-
-        val stageLinkUri =
-          s"$basePathUri/accumulators/stage/?accumulator_name=" +
-            s"${acc.name}&id=${stageData.stageId}&attempt=${stageData.attemptId}"
-
-        def addAccToMap(): ListBuffer[AccumulatorInfo] = {
-          tempMap += (acc.name -> new ListBuffer[AccumulatorInfo]())
-          tempMap(acc.name)
-        }
-
-        val newList = tempMap.getOrElse(acc.name, addAccToMap()):+
-          AccumulatorInfo(stage.stageId, acc.name, acc.value, stageLinkUri, accNameLinkUri)
-        tempMap+=(acc.name -> newList)
+      sd.foreach(acc => {
+        addStageAcc(acc, basePathUri, stage.stageId, stage.attemptId)
       })
     })
-
     val accumulatorsTable = generateAccumulatorsTable(tempMap)
 
     val content =
@@ -112,14 +120,14 @@ private[ui] class AllAccumulatorsPage(parent: AccumulatorsTab, store: AppStatusS
         <h4>Accumulators</h4>
         {accumulatorsTable}
       </div>
-
     UIUtils.headerSparkPage(request, accumulatorHeader, content, parent, showVisualization = true)
   }
 
-  case class AccumulatorInfo(
-     stageId: Int,
-     name: String,
-     value: String,
-     stageLink: String,
-     accNameLink: String)
+
 }
+case class AccumulatorInfo(
+      stageId: Int,
+      name: String,
+      value: String,
+      stageLink: String,
+      accNameLink: String)

--- a/core/src/main/scala/org/apache/spark/ui/accm/AllAccumulatorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/accm/AllAccumulatorsPage.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui.accm
+
+import javax.servlet.http.HttpServletRequest
+
+import scala.collection.immutable.SortedMap
+import scala.collection.mutable.ListBuffer
+import scala.xml.Node
+
+import org.apache.spark.status._
+import org.apache.spark.ui._
+
+/** Page showing table with a list of all accumulators across all finished stages* */
+private[ui] class AllAccumulatorsPage(parent: AccumulatorsTab, store: AppStatusStore)
+  extends WebUIPage("") {
+
+  def render(request: HttpServletRequest): Seq[Node] = {
+    val allStages = parent.store.stageList(null)
+    val basePathUri = UIUtils.prependBaseUri(request, parent.basePath)
+    val accumulatorHeader = s"Accumulators across all Stages"
+
+    def generateAccumulatorsTable(
+      tempMap: SortedMap[String, ListBuffer[AccumulatorInfo]]): Seq[Node] = {
+      if (tempMap.nonEmpty) {
+        val accumulableHeaders: Seq[String] = Seq("Accumulable", "Stage", "Value")
+        def accumulableRow(acc: (String, ListBuffer[AccumulatorInfo])): Seq[Node] = {
+          acc._2.map(accDetails => {
+            <tr>
+              <td>
+                <a href={accDetails.accNameLink} class="name-link">{accDetails.name}</a>
+              </td>
+              <td>
+                <a href={accDetails.stageLink} class="name-link">{accDetails.stageId}</a>
+              </td>
+              <td>{accDetails.value}</td>
+            </tr>
+          })
+        }
+        val accumulableTable = UIUtils.listingTable(
+          accumulableHeaders,
+          accumulableRow,
+          tempMap
+        )
+
+        accumulableTable.toSeq
+      } else {
+        Nil
+      }
+    }
+
+    var tempMap = SortedMap[String, ListBuffer[AccumulatorInfo]]()
+      // SortedMap[accumulator.name ->
+      // ListBuffer[
+      // AccumulatorInfoDetails(
+       // stage,
+       // accumulator.name,
+       // accumulator.value,
+       // stageLink,
+       // accumulatorNameLink)]]
+
+    allStages.map( stage => {
+      val stageData = parent.store
+        .asOption(parent.store.stageAttempt(stage.stageId, stage.attemptId, details = false))
+        .getOrElse {
+          val content =
+            <div id="no-info">
+            </div>
+          return UIUtils.headerSparkPage(request, "", content, parent)
+        }
+      val sd = stageData.accumulatorUpdates.toSeq
+
+      sd.map(acc => {
+        val accNameLinkUri =
+          s"$basePathUri/accumulators/accumulator/?accumulator_name=" +
+            s"${acc.name}&attempt=${stage.attemptId}"
+
+        val stageLinkUri =
+          s"$basePathUri/accumulators/stage/?accumulator_name=" +
+            s"${acc.name}&id=${stageData.stageId}&attempt=${stageData.attemptId}"
+
+        def addAccToMap(): ListBuffer[AccumulatorInfo] = {
+          tempMap += (acc.name -> new ListBuffer[AccumulatorInfo]())
+          tempMap(acc.name)
+        }
+
+        val newList = tempMap.getOrElse(acc.name, addAccToMap()):+
+          AccumulatorInfo(stage.stageId, acc.name, acc.value, stageLinkUri, accNameLinkUri)
+        tempMap+=(acc.name -> newList)
+      })
+    })
+
+    val accumulatorsTable = generateAccumulatorsTable(tempMap)
+
+    val content =
+      <div id="tables-info-acc">
+        <h4>Accumulators</h4>
+        {accumulatorsTable}
+      </div>
+
+    UIUtils.headerSparkPage(request, accumulatorHeader, content, parent, showVisualization = true)
+  }
+
+  case class AccumulatorInfo(
+     stageId: Int,
+     name: String,
+     value: String,
+     stageLink: String,
+     accNameLink: String)
+}

--- a/core/src/test/scala/org/apache/spark/ui/AllAccumulatorsPageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/AllAccumulatorsPageSuite.scala
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui
+
+import scala.collection.immutable.SortedMap
+import scala.collection.mutable.ListBuffer
+
+import org.mockito.Mockito.{mock, RETURNS_SMART_NULLS}
+
+import org.apache.spark._
+import org.apache.spark.internal.config.Status._
+import org.apache.spark.resource.ResourceProfile
+import org.apache.spark.status.AppStatusStore
+import org.apache.spark.status.api.v1.{ AccumulableInfo => UIAccumulableInfo, StageData, StageStatus}
+import org.apache.spark.ui.accm._
+
+class AllAccumulatorsPageSuite extends SparkFunSuite with LocalSparkContext {
+
+  val conf = new SparkConf(false).set(LIVE_ENTITY_UPDATE_PERIOD, 0L)
+  val statusStore = AppStatusStore.createLiveStore(conf)
+
+  test("check contents of tempMap") {
+    val mockStageData1 = new StageData(
+      status = StageStatus.COMPLETE,
+      stageId = 1,
+      attemptId = 1,
+      numTasks = 1,
+      numActiveTasks = 1,
+      numCompleteTasks = 1,
+      numFailedTasks = 1,
+      numKilledTasks = 1,
+      numCompletedIndices = 1,
+
+      submissionTime = None,
+      firstTaskLaunchedTime = None,
+      completionTime = None,
+      failureReason = None,
+
+      executorDeserializeTime = 1L,
+      executorDeserializeCpuTime = 1L,
+      executorRunTime = 1L,
+      executorCpuTime = 1L,
+      resultSize = 1L,
+      jvmGcTime = 1L,
+      resultSerializationTime = 1L,
+      memoryBytesSpilled = 1L,
+      diskBytesSpilled = 1L,
+      peakExecutionMemory = 1L,
+      inputBytes = 1L,
+      inputRecords = 1L,
+      outputBytes = 1L,
+      outputRecords = 1L,
+      shuffleRemoteBlocksFetched = 1L,
+      shuffleLocalBlocksFetched = 1L,
+      shuffleFetchWaitTime = 1L,
+      shuffleRemoteBytesRead = 1L,
+      shuffleRemoteBytesReadToDisk = 1L,
+      shuffleLocalBytesRead = 1L,
+      shuffleReadBytes = 1L,
+      shuffleReadRecords = 1L,
+      shuffleWriteBytes = 1L,
+      shuffleWriteTime = 1L,
+      shuffleWriteRecords = 1L,
+
+      name = "stage1",
+      description = Some("description"),
+      details = "detail",
+      schedulingPool = "pool1",
+
+      rddIds = Seq(1),
+      accumulatorUpdates = Seq(new UIAccumulableInfo(0L, "test_acc1", None, "000100"),
+        new UIAccumulableInfo(1L, "test_acc2", None, "000200")),
+      tasks = None,
+      executorSummary = None,
+      killedTasksSummary = Map.empty,
+      ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID,
+      peakExecutorMetrics = None,
+      taskMetricsDistributions = None,
+      executorMetricsDistributions = None
+    )
+    val mockStageData2 = new StageData(
+      status = StageStatus.COMPLETE,
+      stageId = 2,
+      attemptId = 1,
+      numTasks = 1,
+      numActiveTasks = 1,
+      numCompleteTasks = 1,
+      numFailedTasks = 1,
+      numKilledTasks = 1,
+      numCompletedIndices = 1,
+
+      submissionTime = None,
+      firstTaskLaunchedTime = None,
+      completionTime = None,
+      failureReason = None,
+
+      executorDeserializeTime = 1L,
+      executorDeserializeCpuTime = 1L,
+      executorRunTime = 1L,
+      executorCpuTime = 1L,
+      resultSize = 1L,
+      jvmGcTime = 1L,
+      resultSerializationTime = 1L,
+      memoryBytesSpilled = 1L,
+      diskBytesSpilled = 1L,
+      peakExecutionMemory = 1L,
+      inputBytes = 1L,
+      inputRecords = 1L,
+      outputBytes = 1L,
+      outputRecords = 1L,
+      shuffleRemoteBlocksFetched = 1L,
+      shuffleLocalBlocksFetched = 1L,
+      shuffleFetchWaitTime = 1L,
+      shuffleRemoteBytesRead = 1L,
+      shuffleRemoteBytesReadToDisk = 1L,
+      shuffleLocalBytesRead = 1L,
+      shuffleReadBytes = 1L,
+      shuffleReadRecords = 1L,
+      shuffleWriteBytes = 1L,
+      shuffleWriteTime = 1L,
+      shuffleWriteRecords = 1L,
+
+      name = "stage1",
+      description = Some("description"),
+      details = "detail",
+      schedulingPool = "pool1",
+
+      rddIds = Seq(1),
+      accumulatorUpdates = Seq(new UIAccumulableInfo(0L, "test_acc1", None, "000300"),
+        new UIAccumulableInfo(1L, "test_acc2", None, "000300")),
+      tasks = None,
+      executorSummary = None,
+      killedTasksSummary = Map.empty,
+      ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID,
+      peakExecutorMetrics = None,
+      taskMetricsDistributions = None,
+      executorMetricsDistributions = None
+    )
+    val mockStageData3 = new StageData(
+      status = StageStatus.COMPLETE,
+      stageId = 2,
+      attemptId = 1,
+      numTasks = 1,
+      numActiveTasks = 1,
+      numCompleteTasks = 1,
+      numFailedTasks = 1,
+      numKilledTasks = 1,
+      numCompletedIndices = 1,
+
+      submissionTime = None,
+      firstTaskLaunchedTime = None,
+      completionTime = None,
+      failureReason = None,
+
+      executorDeserializeTime = 1L,
+      executorDeserializeCpuTime = 1L,
+      executorRunTime = 1L,
+      executorCpuTime = 1L,
+      resultSize = 1L,
+      jvmGcTime = 1L,
+      resultSerializationTime = 1L,
+      memoryBytesSpilled = 1L,
+      diskBytesSpilled = 1L,
+      peakExecutionMemory = 1L,
+      inputBytes = 1L,
+      inputRecords = 1L,
+      outputBytes = 1L,
+      outputRecords = 1L,
+      shuffleRemoteBlocksFetched = 1L,
+      shuffleLocalBlocksFetched = 1L,
+      shuffleFetchWaitTime = 1L,
+      shuffleRemoteBytesRead = 1L,
+      shuffleRemoteBytesReadToDisk = 1L,
+      shuffleLocalBytesRead = 1L,
+      shuffleReadBytes = 1L,
+      shuffleReadRecords = 1L,
+      shuffleWriteBytes = 1L,
+      shuffleWriteTime = 1L,
+      shuffleWriteRecords = 1L,
+
+      name = "stage1",
+      description = Some("description"),
+      details = "detail",
+      schedulingPool = "pool1",
+
+      rddIds = Seq(1),
+      accumulatorUpdates = Seq(new UIAccumulableInfo(1L, "test_acc2", None, "000600")),
+      tasks = None,
+      executorSummary = None,
+      killedTasksSummary = Map.empty,
+      ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID,
+      peakExecutorMetrics = None,
+      taskMetricsDistributions = None,
+      executorMetricsDistributions = None
+    )
+
+    val basePath = ""
+    val tab = mock(classOf[AccumulatorsTab], RETURNS_SMART_NULLS)
+    val page = new AllAccumulatorsPage(tab, statusStore)
+
+    val stages = Array(mockStageData1, mockStageData2, mockStageData3)
+
+    stages.foreach(stage => {
+      stage.accumulatorUpdates.foreach(acc => {
+        page.addStageAcc(acc, basePath, stage.stageId, stage.attemptId)
+      })
+    })
+
+    var tempMapMock = SortedMap[String, ListBuffer[AccumulatorInfo]]()
+
+    stages.foreach(stage => {
+      stage.accumulatorUpdates.foreach(acc => {
+        val accNameLinkUri =
+          s"$basePath/accumulators/accumulator/?accumulator_name=" +
+            s"${acc.name}&attempt=${stage.attemptId}"
+
+        val stageLinkUri =
+          s"$basePath/accumulators/stage/?accumulator_name=" +
+            s"${acc.name}&id=${stage.stageId}&attempt=${stage.attemptId}"
+
+        def addAccToMap(): ListBuffer[AccumulatorInfo] = {
+          tempMapMock += (acc.name -> new ListBuffer[AccumulatorInfo]())
+          tempMapMock(acc.name)
+        }
+        val newList = tempMapMock.getOrElse(acc.name, addAccToMap()):+
+          AccumulatorInfo(stage.stageId, acc.name, acc.value, stageLinkUri, accNameLinkUri)
+        tempMapMock+=(acc.name -> newList)
+      })
+    })
+    assert(tempMapMock == page.displayMap())
+  }
+}


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The original Spark UI on SHS does not have a specific way to explore accumulators information, this data is scattered across stages which makes it difficult to access it.
 The accumulators information is located on the Stage Page, but this column is hard to read since it groups all the accumulators names and values for a specific task. This is one of the reasons why understanding the changes of counters from a job can become a difficult task.
The proposed change creates an explore page for Accumulators on the SparkUI. The information will be located under a new tab that has an overview page with links to check for more details about the accumulators information by a particular name or stage.
[Community discussion on accumulators page](http://apache-spark-developers-list.1001551.n3.nabble.com/accumulators-td8814.html)

**Why are the changes needed?**
A page that allows users to explore accumulators information is a helpful feature for users because currently the information is scattered across stages and the display on the Stages Page is difficult to read. This page offers easy access to accumulators information in detail which translates into a better user experience and an increased velocity to solve problems and track accumulator changes.

**Does this PR introduce user-facing change?**
Yes. A new tab will be added to the Spark UI and three new pages will dependent on it.

<img width="889" alt="Screen Shot 2021-04-09 at 3 05 39 PM" src="https://user-images.githubusercontent.com/45573418/115795081-15b31300-a384-11eb-88c2-56d7454faee5.png">

 **How was this patch tested?**
This patch was tested manually by using real spark event logs from a Spark History Server on a production cluster. I also used unit testing to check for contents inside the new data structure used for the Accumulators Overview page.
