### PR TITLE
[SPARK-35203][SQL] Improve Repartition statistics estimation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
@@ -81,9 +81,9 @@ object BasicStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
     ProjectEstimation.estimate(p).getOrElse(fallback(p))
   }
 
-  override def visitRepartition(p: Repartition): Statistics = default(p)
+  override def visitRepartition(p: Repartition): Statistics = fallback(p)
 
-  override def visitRepartitionByExpr(p: RepartitionByExpression): Statistics = default(p)
+  override def visitRepartitionByExpr(p: RepartitionByExpression): Statistics = fallback(p)
 
   override def visitSample(p: Sample): Statistics = fallback(p)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
@@ -128,9 +128,9 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
 
   override def visitProject(p: Project): Statistics = visitUnaryNode(p)
 
-  override def visitRepartition(p: Repartition): Statistics = default(p)
+  override def visitRepartition(p: Repartition): Statistics = p.child.stats
 
-  override def visitRepartitionByExpr(p: RepartitionByExpression): Statistics = default(p)
+  override def visitRepartitionByExpr(p: RepartitionByExpression): Statistics = p.child.stats
 
   override def visitSample(p: Sample): Statistics = {
     val ratio = p.upperBound - p.lowerBound

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
@@ -328,6 +328,16 @@ class BasicStatsEstimationSuite extends PlanTest with StatsEstimationTestBase {
       expectedStatsCboOff = Statistics(sizeInBytes = expectedSize))
   }
 
+  test("SPARK-35203: Improve Repartition statistics estimation") {
+    Seq(RepartitionByExpression(plan.output, plan, 10), plan.repartition(2)).foreach { rep =>
+      val expectedStats = Statistics(plan.size.get, Some(plan.rowCount), plan.attributeStats)
+      checkStats(
+        rep,
+        expectedStatsCboOn = expectedStats,
+        expectedStatsCboOff = expectedStats)
+    }
+  }
+
   /** Check estimated stats when cbo is turned on/off. */
   private def checkStats(
       plan: LogicalPlan,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
@@ -259,11 +259,14 @@ class BasicStatsEstimationSuite extends PlanTest with StatsEstimationTestBase {
       expectedStatsCboOff = Statistics.DUMMY)
   }
 
-  test("SPARK-33954: Some operator missing rowCount when enable CBO") {
-    checkStats(
-      plan.repartition(10),
-      expectedStatsCboOn = Statistics(sizeInBytes = 120, rowCount = Some(10)),
-      expectedStatsCboOff = Statistics(sizeInBytes = 120))
+  test("SPARK-35203: Improve Repartition statistics estimation") {
+    Seq(RepartitionByExpression(plan.output, plan, 10), plan.repartition(2)).foreach { rep =>
+      val expectedStats = Statistics(plan.size.get, Some(plan.rowCount), plan.attributeStats)
+      checkStats(
+        rep,
+        expectedStatsCboOn = expectedStats,
+        expectedStatsCboOff = expectedStats)
+    }
   }
 
   test("SPARK-34031: Union operator missing rowCount when enable CBO") {
@@ -326,16 +329,6 @@ class BasicStatsEstimationSuite extends PlanTest with StatsEstimationTestBase {
       sort,
       expectedStatsCboOn = expectedSortStats,
       expectedStatsCboOff = Statistics(sizeInBytes = expectedSize))
-  }
-
-  test("SPARK-35203: Improve Repartition statistics estimation") {
-    Seq(RepartitionByExpression(plan.output, plan, 10), plan.repartition(2)).foreach { rep =>
-      val expectedStats = Statistics(plan.size.get, Some(plan.rowCount), plan.attributeStats)
-      checkStats(
-        rep,
-        expectedStatsCboOn = expectedStats,
-        expectedStatsCboOff = expectedStats)
-    }
   }
 
   /** Check estimated stats when cbo is turned on/off. */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
@@ -260,7 +260,11 @@ class BasicStatsEstimationSuite extends PlanTest with StatsEstimationTestBase {
   }
 
   test("SPARK-35203: Improve Repartition statistics estimation") {
-    Seq(RepartitionByExpression(plan.output, plan, 10), plan.repartition(2)).foreach { rep =>
+    Seq(
+      RepartitionByExpression(plan.output, plan, 10),
+      RepartitionByExpression(Nil, plan, None),
+      plan.repartition(2),
+      plan.coalesce(3)).foreach { rep =>
       val expectedStats = Statistics(plan.size.get, Some(plan.rowCount), plan.attributeStats)
       checkStats(
         rep,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves `Repartition` and `RepartitionByExpr` statistics estimation using child statistics.


### Why are the changes needed?

The current implementation will missing column stat. For example:
```sql
CREATE TABLE t1 USING parquet AS SELECT id % 10 AS key FROM range(100);
ANALYZE TABLE t1 COMPUTE STATISTICS FOR ALL COLUMNS;
set spark.sql.cbo.enabled=true;
EXPLAIN COST SELECT key FROM (SELECT key FROM t1 DISTRIBUTE BY key) t GROUP BY key;
```
Before this PR:
```
== Optimized Logical Plan ==
Aggregate [key#2950L], [key#2950L], Statistics(sizeInBytes=1600.0 B)
+- RepartitionByExpression [key#2950L], Statistics(sizeInBytes=1600.0 B, rowCount=100)
   +- Relation default.t1[key#2950L] parquet, Statistics(sizeInBytes=1600.0 B, rowCount=100)
```
After this PR:
```
== Optimized Logical Plan ==
Aggregate [key#2950L], [key#2950L], Statistics(sizeInBytes=160.0 B, rowCount=10)
+- RepartitionByExpression [key#2950L], Statistics(sizeInBytes=1600.0 B, rowCount=100)
   +- Relation default.t1[key#2950L] parquet, Statistics(sizeInBytes=1600.0 B, rowCount=100)
```


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
