### PR TITLE
[SPARK-34771][PYTHON] Support UDT for Pandas/Spark conversion with Arrow support Enabled

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -22,9 +22,8 @@ from pyspark.rdd import _load_from_socket
 from pyspark.sql.pandas.serializers import ArrowCollectSerializer
 from pyspark.sql.types import ByteType, ShortType, IntegerType, LongType, FloatType, \
     DoubleType, BooleanType, MapType, TimestampType, StructType, DataType, \
-    IntegralType, UserDefinedType, _is_datatype_with_udt
-from pyspark.sql.pandas.types import _serialize_pandas_with_udt, \
-    _deserialize_pandas_with_udt
+    IntegralType, _is_datatype_with_udt
+from pyspark.sql.pandas.types import _deserialize_pandas_with_udt
 from pyspark.traceback_utils import SCCallSiteSync
 
 
@@ -466,8 +465,8 @@ class SparkConversionMixin(object):
         else:
             # Any timestamps must be coerced to be compatible with Spark
             data_types = [to_arrow_type(TimestampType())
-                           if is_datetime64_dtype(t) or is_datetime64tz_dtype(t) else None
-                           for t in pdf.dtypes]
+                          if is_datetime64_dtype(t) or is_datetime64tz_dtype(t) else None
+                          for t in pdf.dtypes]
 
         # Slice the DataFrame to be batched
         step = -(-len(pdf) // self.sparkContext.defaultParallelism)  # round int up

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -22,7 +22,7 @@ from pyspark.rdd import _load_from_socket
 from pyspark.sql.pandas.serializers import ArrowCollectSerializer
 from pyspark.sql.types import ByteType, ShortType, IntegerType, LongType, FloatType, \
     DoubleType, BooleanType, MapType, TimestampType, StructType, DataType, \
-    IntegralType, _is_datatype_with_udt
+    IntegralType, _has_udt
 from pyspark.sql.pandas.types import _deserialize_pandas_with_udt
 from pyspark.traceback_utils import SCCallSiteSync
 
@@ -140,7 +140,7 @@ class PandasConversionMixin(object):
                             elif isinstance(dt, MapType):
                                 pdf[name] = \
                                     _convert_map_items_to_dict(pdf[name])
-                            elif _is_datatype_with_udt(dt):
+                            elif _has_udt(dt):
                                 pdf[name] = _deserialize_pandas_with_udt(pdf[name], dt)
                         return pdf
                     else:

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -21,7 +21,7 @@ Serializers for PyArrow and pandas conversions. See `pyspark.serializers` for mo
 
 from pyspark.serializers import Serializer, read_int, write_int, UTF8Deserializer
 from pyspark.sql.types import DataType, UserDefinedType, StructType, \
-    _is_datatype_with_udt
+    _has_udt
 from pyspark.sql.pandas.types import to_arrow_type, _serialize_pandas_with_udt
 
 
@@ -221,7 +221,7 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         def preprocess_series(s):
             if not isinstance(s, (list, tuple)):
                 return (s, None)
-            elif _is_datatype_with_udt(s[1]):
+            elif _has_udt(s[1]):
                 return (_serialize_pandas_with_udt(s[0], s[1]), s[1])
             else:
                 return s

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -165,6 +165,9 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
                 elif isinstance(dt, ArrayType) and isinstance(dt.elementType, UserDefinedType):
                     udt = dt.elementType
                     s = s.apply(lambda x: [udt.serialize(f) for f in x])
+                else:
+                    # For DataType without UDT, serialization can be skipped
+                    pass
 
             # Ensure timestamp series are in expected form for Spark internal representation
             if pdt is not None and pa.types.is_timestamp(pdt):

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -236,15 +236,16 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         series = ((s, None) if not isinstance(s, (list, tuple)) else s for s in series)
 
         arrs = []
-        for s, dt in series:
-            pdt = to_arrow_type(dt) if isinstance(dt, DataType) else dt
+        for s, t in series:
+            dt = t if isinstance(t, DataType) else None
+            pdt = to_arrow_type(t) if isinstance(t, DataType) else t
             if pdt is not None and pa.types.is_struct(pdt) and not isinstance(dt, UserDefinedType):
                 if not isinstance(s, pd.DataFrame):
                     raise ValueError("A field of type StructType expects a pandas.DataFrame, "
                                      "but got: %s" % str(type(s)))
                 if isinstance(dt, DataType):
-                    type_not_match = "dt must be instance of StructType when pdt is pyarrow struct"
-                    assert isinstance(dt, StructType), type_not_match
+                    not_match_msg = "dt must be instance of StructType when pdt is pyarrow struct"
+                    assert isinstance(dt, StructType), not_match_msg
                     arrs_names = create_arrs_names(s, pdt, dt)
                 else:
                     arrs_names = create_arrs_names(s, pdt)

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -170,7 +170,8 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             try:
                 mask = s.isnull()
                 if padt is not None and pa.types.is_list(padt):
-                    array = pa.StructArray.from_pandas(s, mask=mask, type=padt, safe=self._safecheck)
+                    array = pa.StructArray.from_pandas(s, mask=mask, type=padt,
+                                                       safe=self._safecheck)
                 else:
                     array = pa.Array.from_pandas(s, mask=mask, type=padt, safe=self._safecheck)
             except ValueError as e:
@@ -237,7 +238,8 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         for s, t in series:
             dt = t if isinstance(t, DataType) else None
             padt = to_arrow_type(t) if isinstance(t, DataType) else t
-            if padt is not None and pa.types.is_struct(padt) and not isinstance(dt, UserDefinedType):
+            if padt is not None and pa.types.is_struct(padt) and \
+                    not isinstance(dt, UserDefinedType):
                 if not isinstance(s, pd.DataFrame):
                     raise ValueError("A field of type StructType expects a pandas.DataFrame, "
                                      "but got: %s" % str(type(s)))

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -19,10 +19,8 @@
 Serializers for PyArrow and pandas conversions. See `pyspark.serializers` for more details.
 """
 
-from typing import Optional
-
 from pyspark.serializers import Serializer, read_int, write_int, UTF8Deserializer
-from pyspark.sql.types import ArrayType, DataType, UserDefinedType, StructType, \
+from pyspark.sql.types import DataType, UserDefinedType, StructType, \
     _is_datatype_with_udt
 from pyspark.sql.pandas.types import to_arrow_type, _serialize_pandas_with_udt
 
@@ -159,7 +157,7 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             _convert_dict_to_map_items
         from pandas.api.types import is_categorical_dtype
 
-        def create_array(s, pdt, dt = None):
+        def create_array(s, pdt, dt=None):
             # Ensure timestamp series are in expected form for Spark internal representation
             if pdt is not None and pa.types.is_timestamp(pdt):
                 s = _check_series_convert_timestamps_internal(s, self._timezone)
@@ -187,7 +185,7 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
                     raise e
             return array
 
-        def create_arrs_names(s, pdt, dt = None):
+        def create_arrs_names(s, pdt, dt=None):
             # If input s is empty with zero columns, return empty Arrays with struct
             if len(s) == 0 and len(s.columns) == 0:
                 return [(pa.array([], type=field.type), field.name) for field in pdt]

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -351,6 +351,12 @@ def _convert_dict_to_map_items(s):
 
 
 def _serialize_pandas_with_udt(s, dt):
+    """
+    Assuming s is pandas Series with UDT, serialize the UDT part and return
+    :param s: pandas.Series
+    :param dt: DataType
+    :return: pandas.Series with UDT serialized
+    """
     if isinstance(dt, UserDefinedType):
         return s.apply(dt.serialize)
     elif isinstance(dt, ArrayType) and isinstance(dt.elementType, UserDefinedType):
@@ -364,6 +370,12 @@ def _serialize_pandas_with_udt(s, dt):
 
 
 def _deserialize_pandas_with_udt(s, dt):
+    """
+    Assuming s is pandas Series with UDT, deserialize the UDT part and return
+    :param s: pandas.Series
+    :param dt: DataType
+    :return: pandas.Series with UDT deserialized
+    """
     if isinstance(dt, UserDefinedType):
         return s.apply(dt.deserialize)
     elif isinstance(dt, ArrayType) and isinstance(dt.elementType, UserDefinedType):
@@ -372,5 +384,5 @@ def _deserialize_pandas_with_udt(s, dt):
     elif isinstance(dt, StructType):
         raise ValueError("Nested UDT in StructType has not been supported yet")
     else:
-        # For DataType without UDT, serialization can be skipped
+        # For DataType without UDT, deserialization can be skipped
         return s

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -22,7 +22,7 @@ pandas instances during the type conversion.
 
 from pyspark.sql.types import BooleanType, ByteType, ShortType, IntegerType, LongType, \
     FloatType, DoubleType, DecimalType, StringType, BinaryType, DateType, TimestampType, \
-    ArrayType, MapType, StructType, StructField, NullType
+    ArrayType, MapType, StructType, StructField, NullType, UserDefinedType
 
 
 def to_arrow_type(dt):
@@ -74,6 +74,8 @@ def to_arrow_type(dt):
         arrow_type = pa.struct(fields)
     elif type(dt) == NullType:
         arrow_type = pa.null()
+    elif isinstance(dt, UserDefinedType):
+        arrow_type = to_arrow_type(dt.sqlType())
     else:
         raise TypeError("Unsupported type in conversion to Arrow: " + str(dt))
     return arrow_type

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -362,6 +362,7 @@ def _serialize_pandas_with_udt(s, dt):
         # For DataType without UDT, serialization can be skipped
         return s
 
+
 def _deserialize_pandas_with_udt(s, dt):
     if isinstance(dt, UserDefinedType):
         return s.apply(dt.deserialize)

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -348,3 +348,28 @@ def _convert_dict_to_map_items(s):
     :return: pandas.Series of lists of (key, value) pairs
     """
     return s.apply(lambda d: list(d.items()) if d is not None else None)
+
+
+def _serialize_pandas_with_udt(s, dt):
+    if isinstance(dt, UserDefinedType):
+        return s.apply(dt.serialize)
+    elif isinstance(dt, ArrayType) and isinstance(dt.elementType, UserDefinedType):
+        udt = dt.elementType
+        return s.apply(lambda x: [udt.serialize(f) for f in x])
+    elif isinstance(dt, StructType):
+        raise ValueError("Nested UDT in StructType has not been supported yet")
+    else:
+        # For DataType without UDT, serialization can be skipped
+        return s
+
+def _deserialize_pandas_with_udt(s, dt):
+    if isinstance(dt, UserDefinedType):
+        return s.apply(dt.deserialize)
+    elif isinstance(dt, ArrayType) and isinstance(dt.elementType, UserDefinedType):
+        udt = dt.elementType
+        return s.apply(lambda x: [udt.deserialize(f) for f in x])
+    elif isinstance(dt, StructType):
+        raise ValueError("Nested UDT in StructType has not been supported yet")
+    else:
+        # For DataType without UDT, serialization can be skipped
+        return s

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -764,17 +764,22 @@ class UserDefinedType(DataType):
         return type(self) == type(other)
 
 
-def _is_datatype_with_udt(dt):
-    if dt is None:
+def _has_udt(dt):
+    '''
+    Test if dt has UDT
+    '''
+    if dt is None and (not isinstance(dt, DataType)):
+        # This is the most hitted cases
         return False
-    elif isinstance(dt, UserDefinedType):
+
+    if isinstance(dt, UserDefinedType):
         return True
     elif isinstance(dt, ArrayType):
-        # SPARK-34771: TODO elementType is ArrayType/StructType
-        return isinstance(dt.elementType, UserDefinedType)
+        return _has_udt(dt.elementType)
     elif isinstance(dt, StructType):
-        # SPARK-34771: TODO field.dataType is ArrayType/StructType
-        return any(isinstance(field.dataType, UserDefinedType) for field in dt.fields)
+        return any(_has_udt(field.dataType) for field in dt.fields)
+    elif isinstance(dt, MapType):
+        return _has_udt(dt.keyType) or _has_udt(dt.valueType)
     else:
         return False
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -764,6 +764,21 @@ class UserDefinedType(DataType):
         return type(self) == type(other)
 
 
+def _is_datatype_with_udt(dt):
+    if dt is None:
+        return False
+    elif isinstance(dt, UserDefinedType):
+        return True
+    elif isinstance(dt, ArrayType):
+        # SPARK-34771: TODO elementType is ArrayType/StructType
+        return isinstance(dt.elementType, UserDefinedType)
+    elif isinstance(dt, StructType):
+        # SPARK-34771: TODO field.dataType is ArrayType/StructType
+        return any(isinstance(field.dataType, UserDefinedType) for field in dt.fields)
+    else:
+        return False
+
+
 _atomic_types = [StringType, BinaryType, BooleanType, DecimalType, FloatType, DoubleType,
                  ByteType, ShortType, IntegerType, LongType, DateType, TimestampType, NullType]
 _all_atomic_types = dict((t.typeName(), t) for t in _atomic_types)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1095,7 +1095,7 @@ def _has_nulltype(dt):
 
 def _has_udt(dt):
     """ Return whether there is a UserDefinedType in `dt` or not """
-    if dt is None and (not isinstance(dt, DataType)):
+    if (dt is None) or (not isinstance(dt, DataType)):
         # This is the most hitted cases
         return False
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -764,26 +764,6 @@ class UserDefinedType(DataType):
         return type(self) == type(other)
 
 
-def _has_udt(dt):
-    '''
-    Test if dt has UDT
-    '''
-    if dt is None and (not isinstance(dt, DataType)):
-        # This is the most hitted cases
-        return False
-
-    if isinstance(dt, UserDefinedType):
-        return True
-    elif isinstance(dt, ArrayType):
-        return _has_udt(dt.elementType)
-    elif isinstance(dt, StructType):
-        return any(_has_udt(field.dataType) for field in dt.fields)
-    elif isinstance(dt, MapType):
-        return _has_udt(dt.keyType) or _has_udt(dt.valueType)
-    else:
-        return False
-
-
 _atomic_types = [StringType, BinaryType, BooleanType, DecimalType, FloatType, DoubleType,
                  ByteType, ShortType, IntegerType, LongType, DateType, TimestampType, NullType]
 _all_atomic_types = dict((t.typeName(), t) for t in _atomic_types)
@@ -1111,6 +1091,24 @@ def _has_nulltype(dt):
         return _has_nulltype(dt.keyType) or _has_nulltype(dt.valueType)
     else:
         return isinstance(dt, NullType)
+
+
+def _has_udt(dt):
+    """ Return whether there is a UserDefinedType in `dt` or not """
+    if dt is None and (not isinstance(dt, DataType)):
+        # This is the most hitted cases
+        return False
+
+    if isinstance(dt, UserDefinedType):
+        return True
+    elif isinstance(dt, ArrayType):
+        return _has_udt(dt.elementType)
+    elif isinstance(dt, StructType):
+        return any(_has_udt(field.dataType) for field in dt.fields)
+    elif isinstance(dt, MapType):
+        return _has_udt(dt.keyType) or _has_udt(dt.valueType)
+    else:
+        return False
 
 
 def _merge_type(a, b, name=None):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -44,6 +44,7 @@ from pyspark.serializers import write_with_length, write_int, read_long, read_bo
     write_long, read_int, SpecialLengths, UTF8Deserializer, PickleSerializer, \
     BatchedSerializer
 from pyspark.sql.pandas.serializers import ArrowStreamPandasUDFSerializer, CogroupUDFSerializer
+from pyspark.sql.pandas.types import to_arrow_type
 from pyspark.sql.types import StructType
 from pyspark.util import fail_on_stopiteration, try_simplify_traceback  # type: ignore
 from pyspark import shuffle
@@ -87,6 +88,8 @@ def wrap_udf(f, return_type):
 
 
 def wrap_scalar_pandas_udf(f, return_type):
+    arrow_return_type = to_arrow_type(return_type)
+
     def verify_result_type(result):
         if not hasattr(result, "__len__"):
             pd_type = "Pandas.DataFrame" if type(return_type) == StructType else "Pandas.Series"
@@ -101,10 +104,12 @@ def wrap_scalar_pandas_udf(f, return_type):
         return result
 
     return lambda *a: (verify_result_length(
-        verify_result_type(f(*a)), len(a[0])), return_type)
+        verify_result_type(f(*a)), len(a[0])), arrow_return_type)
 
 
 def wrap_pandas_iter_udf(f, return_type):
+    arrow_return_type = to_arrow_type(return_type)
+
     def verify_result_type(result):
         if not hasattr(result, "__len__"):
             pd_type = "Pandas.DataFrame" if type(return_type) == StructType else "Pandas.Series"
@@ -112,7 +117,7 @@ def wrap_pandas_iter_udf(f, return_type):
                             "{}, but is {}".format(pd_type, type(result)))
         return result
 
-    return lambda *iterator: map(lambda res: (res, return_type),
+    return lambda *iterator: map(lambda res: (res, arrow_return_type),
                                  map(verify_result_type, f(*iterator)))
 
 
@@ -140,7 +145,7 @@ def wrap_cogrouped_map_pandas_udf(f, return_type, argspec):
                 "Expected: {} Actual: {}".format(len(return_type), len(result.columns)))
         return result
 
-    return lambda kl, vl, kr, vr: [(wrapped(kl, vl, kr, vr), return_type)]
+    return lambda kl, vl, kr, vr: [(wrapped(kl, vl, kr, vr), to_arrow_type(return_type))]
 
 
 def wrap_grouped_map_pandas_udf(f, return_type, argspec):
@@ -164,16 +169,18 @@ def wrap_grouped_map_pandas_udf(f, return_type, argspec):
                 "Expected: {} Actual: {}".format(len(return_type), len(result.columns)))
         return result
 
-    return lambda k, v: [(wrapped(k, v), return_type)]
+    return lambda k, v: [(wrapped(k, v), to_arrow_type(return_type))]
 
 
 def wrap_grouped_agg_pandas_udf(f, return_type):
+    arrow_return_type = to_arrow_type(return_type)
+
     def wrapped(*series):
         import pandas as pd
         result = f(*series)
         return pd.Series([result])
 
-    return lambda *a: (wrapped(*a), return_type)
+    return lambda *a: (wrapped(*a), arrow_return_type)
 
 
 def wrap_window_agg_pandas_udf(f, return_type, runner_conf, udf_index):
@@ -192,15 +199,19 @@ def wrap_unbounded_window_agg_pandas_udf(f, return_type):
     # is that window_agg_pandas_udf needs to repeat the return value
     # to match window length, where grouped_agg_pandas_udf just returns
     # the scalar value.
+    arrow_return_type = to_arrow_type(return_type)
+
     def wrapped(*series):
         import pandas as pd
         result = f(*series)
         return pd.Series([result]).repeat(len(series[0]))
 
-    return lambda *a: (wrapped(*a), return_type)
+    return lambda *a: (wrapped(*a), arrow_return_type)
 
 
 def wrap_bounded_window_agg_pandas_udf(f, return_type):
+    arrow_return_type = to_arrow_type(return_type)
+
     def wrapped(begin_index, end_index, *series):
         import pandas as pd
         result = []
@@ -229,7 +240,7 @@ def wrap_bounded_window_agg_pandas_udf(f, return_type):
             result.append(f(*series_slices))
         return pd.Series(result)
 
-    return lambda *a: (wrapped(*a), return_type)
+    return lambda *a: (wrapped(*a), arrow_return_type)
 
 
 def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -44,7 +44,6 @@ from pyspark.serializers import write_with_length, write_int, read_long, read_bo
     write_long, read_int, SpecialLengths, UTF8Deserializer, PickleSerializer, \
     BatchedSerializer
 from pyspark.sql.pandas.serializers import ArrowStreamPandasUDFSerializer, CogroupUDFSerializer
-from pyspark.sql.pandas.types import to_arrow_type
 from pyspark.sql.types import StructType
 from pyspark.util import fail_on_stopiteration, try_simplify_traceback  # type: ignore
 from pyspark import shuffle
@@ -88,8 +87,6 @@ def wrap_udf(f, return_type):
 
 
 def wrap_scalar_pandas_udf(f, return_type):
-    arrow_return_type = to_arrow_type(return_type)
-
     def verify_result_type(result):
         if not hasattr(result, "__len__"):
             pd_type = "Pandas.DataFrame" if type(return_type) == StructType else "Pandas.Series"
@@ -104,12 +101,10 @@ def wrap_scalar_pandas_udf(f, return_type):
         return result
 
     return lambda *a: (verify_result_length(
-        verify_result_type(f(*a)), len(a[0])), arrow_return_type)
+        verify_result_type(f(*a)), len(a[0])), return_type)
 
 
 def wrap_pandas_iter_udf(f, return_type):
-    arrow_return_type = to_arrow_type(return_type)
-
     def verify_result_type(result):
         if not hasattr(result, "__len__"):
             pd_type = "Pandas.DataFrame" if type(return_type) == StructType else "Pandas.Series"
@@ -117,7 +112,7 @@ def wrap_pandas_iter_udf(f, return_type):
                             "{}, but is {}".format(pd_type, type(result)))
         return result
 
-    return lambda *iterator: map(lambda res: (res, arrow_return_type),
+    return lambda *iterator: map(lambda res: (res, return_type),
                                  map(verify_result_type, f(*iterator)))
 
 
@@ -145,7 +140,7 @@ def wrap_cogrouped_map_pandas_udf(f, return_type, argspec):
                 "Expected: {} Actual: {}".format(len(return_type), len(result.columns)))
         return result
 
-    return lambda kl, vl, kr, vr: [(wrapped(kl, vl, kr, vr), to_arrow_type(return_type))]
+    return lambda kl, vl, kr, vr: [(wrapped(kl, vl, kr, vr), return_type)]
 
 
 def wrap_grouped_map_pandas_udf(f, return_type, argspec):
@@ -169,18 +164,16 @@ def wrap_grouped_map_pandas_udf(f, return_type, argspec):
                 "Expected: {} Actual: {}".format(len(return_type), len(result.columns)))
         return result
 
-    return lambda k, v: [(wrapped(k, v), to_arrow_type(return_type))]
+    return lambda k, v: [(wrapped(k, v), return_type)]
 
 
 def wrap_grouped_agg_pandas_udf(f, return_type):
-    arrow_return_type = to_arrow_type(return_type)
-
     def wrapped(*series):
         import pandas as pd
         result = f(*series)
         return pd.Series([result])
 
-    return lambda *a: (wrapped(*a), arrow_return_type)
+    return lambda *a: (wrapped(*a), return_type)
 
 
 def wrap_window_agg_pandas_udf(f, return_type, runner_conf, udf_index):
@@ -199,19 +192,15 @@ def wrap_unbounded_window_agg_pandas_udf(f, return_type):
     # is that window_agg_pandas_udf needs to repeat the return value
     # to match window length, where grouped_agg_pandas_udf just returns
     # the scalar value.
-    arrow_return_type = to_arrow_type(return_type)
-
     def wrapped(*series):
         import pandas as pd
         result = f(*series)
         return pd.Series([result]).repeat(len(series[0]))
 
-    return lambda *a: (wrapped(*a), arrow_return_type)
+    return lambda *a: (wrapped(*a), return_type)
 
 
 def wrap_bounded_window_agg_pandas_udf(f, return_type):
-    arrow_return_type = to_arrow_type(return_type)
-
     def wrapped(begin_index, end_index, *series):
         import pandas as pd
         result = []
@@ -240,7 +229,7 @@ def wrap_bounded_window_agg_pandas_udf(f, return_type):
             result.append(f(*series_slices))
         return pd.Series(result)
 
-    return lambda *a: (wrapped(*a), arrow_return_type)
+    return lambda *a: (wrapped(*a), return_type)
 
 
 def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -105,6 +105,8 @@ private[sql] object ArrowUtils {
               .add(MapVector.VALUE_NAME, valueType, nullable = valueContainsNull),
             nullable = false,
             timeZoneId)).asJava)
+      case udt: UserDefinedType[_] =>
+        toArrowField(name, udt.sqlType, nullable, timeZoneId)
       case dataType =>
         val fieldType = new FieldType(nullable, toArrowType(dataType, timeZoneId), null)
         new Field(name, fieldType, Seq.empty[Field].asJava)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -112,6 +112,7 @@ private[sql] object ArrowEvalPythonExec {
    * UserDefinedType:
    * - will be erased as UserDefinedType.sqlType
    * - recursively rewrite internal ArrayType with `containsNull=true`
+   *   why: see pyspark.sql.pandas.types.to_arrow_type
    * ArrayType: containsNull will always be true when returned by PyArrow
    * - useArrowContainsNull(true): always mark containsNull as true
    * - useArrowContainsNull(false): reserve the original nullability

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -110,7 +110,7 @@ private[sql] object ArrowEvalPythonExec {
    * Erase User-Defined Types and returns the plain Spark StructType instead.
    *
    * UserDefinedType:
-   * - will be erased as dt.sqlType
+   * - will be erased as UserDefinedType.sqlType
    * - recursively rewrite internal ArrayType with `containsNull=true`
    * ArrayType: containsNull will always be true when returned by PyArrow
    * - useArrowContainsNull(true): always mark containsNull as true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -24,7 +24,7 @@ import org.apache.spark.api.python.ChainedPythonFunctions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType, UserDefinedType}
 import org.apache.spark.sql.util.ArrowUtils
 
 /**
@@ -89,12 +89,60 @@ case class ArrowEvalPythonExec(udfs: Seq[PythonUDF], resultAttrs: Seq[Attribute]
 
     columnarBatchIter.flatMap { batch =>
       val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-      assert(outputTypes == actualDataTypes, "Invalid schema from pandas_udf: " +
-        s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
+      assert(plainSchemaSeq(outputTypes) == actualDataTypes,
+        "Incompatible schema from pandas_udf: " +
+          s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
       batch.rowIterator.asScala
     }
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
     copy(child = newChild)
+
+  private def plainSchemaSeq(schema: Seq[DataType]): Seq[DataType] = {
+    schema.map(v => ArrowEvalPythonExec.plainSchema(v)).toList
+  }
+
+}
+
+private[sql] object ArrowEvalPythonExec {
+  /**
+   * Erase User-Defined Types and returns the plain Spark StructType instead.
+   *
+   * UserDefinedType:
+   * - will be erased as dt.sqlType
+   * - recursively rewrite internal ArrayType with `containsNull=true`
+   * ArrayType: containsNull will always be true when returned by PyArrow
+   * - useArrowContainsNull(true): always mark containsNull as true
+   * - useArrowContainsNull(false): reserve the original nullability
+   * Non-primitive DataType: recursively rewrite the internal ArrayType
+   * Primitive DataType: reserve the original nullability
+   */
+  def plainSchema(schema: DataType, useArrowContainsNull: Boolean = false): DataType = {
+    schema match {
+      case dt: UserDefinedType[_] =>
+        plainSchema(dt.sqlType, useArrowContainsNull = true)
+      case ArrayType(elementType, containsNull) =>
+        ArrayType(
+          plainSchema(elementType, useArrowContainsNull),
+          containsNull = (useArrowContainsNull || containsNull)
+        )
+      case StructType(fields) =>
+        StructType(fields.map(field =>
+          StructField(
+            field.name,
+            plainSchema(field.dataType, useArrowContainsNull),
+            field.nullable,
+            field.metadata
+          ))
+        )
+      case MapType(keyType, valueType, valueContainsNull) =>
+        MapType(
+          plainSchema(keyType, useArrowContainsNull),
+          plainSchema(valueType, useArrowContainsNull),
+          valueContainsNull
+        )
+      case _ => schema
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecSuite.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.ExampleBoxUDT
+import org.apache.spark.sql.test.ExamplePointUDT
+import org.apache.spark.sql.types._
+
+class ArrowEvalPythonExecSuite extends SparkFunSuite {
+  import ArrowEvalPythonExec.plainSchema
+
+  test("plainSchema: fixed point data type") {
+    Seq(
+      BinaryType, BooleanType, ByteType, NullType,
+      StringType, VarcharType(10), CharType(10),
+      DoubleType, FloatType, ShortType, IntegerType, LongType,
+      DataTypes.DateType, DataTypes.TimestampType,
+      DataTypes.CalendarIntervalType,
+      DataTypes.DayTimeIntervalType,
+      DataTypes.YearMonthIntervalType,
+      DataTypes.createDecimalType()
+    ).foreach { tpe =>
+      assert(plainSchema(tpe) === tpe)
+    }
+  }
+
+  test("plainSchema: UDT") {
+    assert (plainSchema(new ExamplePointUDT()) === ArrayType(DoubleType, true))
+
+    val exampleBoxUDT = new ExampleBoxUDT()
+    assert (plainSchema(exampleBoxUDT) === exampleBoxUDT.sqlType)
+  }
+
+  test("plainSchema: complex data type") {
+    val plainStructType = StructType(Array(StructField(name = "id", LongType)))
+    assert(plainSchema(plainStructType) === plainStructType)
+    val arrStructType = StructType(Array(StructField(name = "id_arr", ArrayType(LongType, false))))
+    assert(plainSchema(arrStructType) === arrStructType)
+    val udtStructType = StructType(Array(StructField(name = "udt", new ExamplePointUDT())))
+    val udtStructType2 = StructType(Array(StructField(name = "udt", ArrayType(DoubleType, true))))
+    assert(plainSchema(udtStructType) === udtStructType2)
+
+    val plainArrayType = ArrayType(LongType, false)
+    assert(plainSchema(plainArrayType) === plainArrayType)
+    val udtArrayType = ArrayType(new ExamplePointUDT(), false)
+    assert(plainSchema(udtArrayType) === ArrayType(ArrayType(DoubleType, true), false))
+
+    val plainMapType = MapType(LongType, LongType, true)
+    assert(plainSchema(plainMapType) === plainMapType)
+    val udtMapType = MapType(LongType, new ExamplePointUDT(), false)
+    assert(plainSchema(udtMapType) === MapType(LongType, ArrayType(DoubleType, true), false))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.python
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.test.ExampleBoxUDT
 import org.apache.spark.sql.test.ExamplePointUDT
 import org.apache.spark.sql.types._
 
@@ -38,13 +37,6 @@ class ArrowEvalPythonExecSuite extends SparkFunSuite {
     ).foreach { tpe =>
       assert(plainSchema(tpe) === tpe)
     }
-  }
-
-  test("plainSchema: UDT") {
-    assert (plainSchema(new ExamplePointUDT()) === ArrayType(DoubleType, true))
-
-    val exampleBoxUDT = new ExampleBoxUDT()
-    assert (plainSchema(exampleBoxUDT) === exampleBoxUDT.sqlType)
   }
 
   test("plainSchema: complex data type") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecSuite.scala
@@ -31,8 +31,6 @@ class ArrowEvalPythonExecSuite extends SparkFunSuite {
       DoubleType, FloatType, ShortType, IntegerType, LongType,
       DataTypes.DateType, DataTypes.TimestampType,
       DataTypes.CalendarIntervalType,
-      DataTypes.DayTimeIntervalType,
-      DataTypes.YearMonthIntervalType,
       DataTypes.createDecimalType()
     ).foreach { tpe =>
       assert(plainSchema(tpe) === tpe)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix a bug of Pandas/Spark conversion with Arrow support enabled.

Support DataType with UDT:
+ [x] UDT
+ [x] ArrayType(UDT)
+ [x] <del>StructType(..., UDT, ...)</del>, postponed


``` python
spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", True)
from pyspark.testing.sqlutils  import ExamplePoint, ExamplePointUDT
from pyspark.sql.types import StructType, StructField
import pandas as pd
schema = StructType([StructField('point', ExamplePointUDT(), False)])
pdf = pd.DataFrame({'point': pd.Series([ExamplePoint(1, 1), ExamplePoint(2, 2)])})
df = spark.createDataFrame(pdf, schema)
print(df.toPandas())
```

before (because it fallbacks to arrow disabled):
```
       point
0  (0.0,0.0)
1  (0.0,0.0)
```

after:
```
       point
0  (1.0,1.0)
1  (2.0,2.0)
```


### Why are the changes needed?
Fix a bug.

For UDT without Arrow support, I will create another PR.


### Does this PR introduce _any_ user-facing change?
Support Python UDT in PySpark now. No user-facing changes.


### How was this patch tested?
``` bash
python/run-tests --testnames pyspark.sql.tests.test_arrow
```
