### PR TITLE
[SPARK-35212][Spark Core][DStreams] Added PreferRandom for the scenario that topic partitions need to be randomly distributed across all executors

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1816,7 +1816,8 @@ class SparkContext(config: SparkConf) extends Logging {
    * Return an array of executors' host name from the block manager.
    */
   def getExecutorHosts: Array[String] = {
-    getExecutorMemoryStatus.map(_._1).toArray
+    // need only host name, not port
+    getExecutorMemoryStatus.map(_._1.split(":")(0)).toArray
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1813,6 +1813,13 @@ class SparkContext(config: SparkConf) extends Logging {
   def version: String = SPARK_VERSION
 
   /**
+   * Return an array of executors' host name from the block manager.
+   */
+  def getExecutorHosts: Array[String] = {
+    getExecutorMemoryStatus.map(_._1).toArray
+  }
+
+  /**
    * Return a map from the block manager to the max memory available for caching and the remaining
    * memory available for caching.
    */

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1813,14 +1813,6 @@ class SparkContext(config: SparkConf) extends Logging {
   def version: String = SPARK_VERSION
 
   /**
-   * Return an array of executors' host name from the block manager.
-   */
-  def getExecutorHosts: Array[String] = {
-    // need only host name, not port
-    getExecutorMemoryStatus.map(_._1.split(":")(0)).toArray
-  }
-
-  /**
    * Return a map from the block manager to the max memory available for caching and the remaining
    * memory available for caching.
    */

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -17,20 +17,22 @@
 
 package org.apache.spark.streaming.kafka010
 
-import org.apache.kafka.clients.consumer._
-import org.apache.kafka.common.TopicPartition
-import org.apache.spark.internal.Logging
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.streaming.dstream._
-import org.apache.spark.streaming.scheduler.rate.RateEstimator
-import org.apache.spark.streaming.scheduler.{RateController, StreamInputInfo}
-import org.apache.spark.streaming.{StreamingContext, Time}
-
+import java.{ util => ju }
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicReference
-import java.{util => ju}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+
+import org.apache.kafka.clients.consumer._
+import org.apache.kafka.common.TopicPartition
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.{StreamingContext, Time}
+import org.apache.spark.streaming.dstream._
+import org.apache.spark.streaming.scheduler.{RateController, StreamInputInfo}
+import org.apache.spark.streaming.scheduler.rate.RateEstimator
 
 /**
  *  A DStream where

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -105,6 +105,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
     locationStrategy match {
       case PreferBrokers => getBrokers
       case PreferConsistent => ju.Collections.emptyMap[TopicPartition, String]()
+      case PreferRandom => PreferRandom.random(_ssc.sparkContext.getExecutorHosts)
       case PreferFixed(hostMap) => hostMap
     }
   }

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -17,22 +17,20 @@
 
 package org.apache.spark.streaming.kafka010
 
-import java.{ util => ju }
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.atomic.AtomicReference
-
-import scala.collection.JavaConverters._
-import scala.collection.mutable
-
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.streaming.{StreamingContext, Time}
 import org.apache.spark.streaming.dstream._
-import org.apache.spark.streaming.scheduler.{RateController, StreamInputInfo}
 import org.apache.spark.streaming.scheduler.rate.RateEstimator
+import org.apache.spark.streaming.scheduler.{RateController, StreamInputInfo}
+import org.apache.spark.streaming.{StreamingContext, Time}
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicReference
+import java.{util => ju}
+import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 /**
  *  A DStream where
@@ -105,7 +103,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
     locationStrategy match {
       case PreferBrokers => getBrokers
       case PreferConsistent => ju.Collections.emptyMap[TopicPartition, String]()
-      case PreferRandom => PreferRandom.random(_ssc.sparkContext.getExecutorHosts)
+      case r: PreferRandom => r.random
       case PreferFixed(hostMap) => hostMap
     }
   }

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
@@ -17,18 +17,17 @@
 
 package org.apache.spark.streaming.kafka010
 
-import java.{ util => ju }
-
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
-
 import org.apache.spark.SparkContext
-import org.apache.spark.api.java.{ JavaRDD, JavaSparkContext }
+import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.StreamingContext
-import org.apache.spark.streaming.api.java.{ JavaInputDStream, JavaStreamingContext }
+import org.apache.spark.streaming.api.java.{JavaInputDStream, JavaStreamingContext}
 import org.apache.spark.streaming.dstream._
+
+import java.{util => ju}
 
 /**
  * object for constructing Kafka streams and RDDs
@@ -60,7 +59,7 @@ object KafkaUtils extends Logging {
           "If you want to prefer brokers, you must provide a mapping using PreferFixed " +
           "A single KafkaRDD does not have a driver consumer and cannot look up brokers for you.")
       case PreferConsistent => ju.Collections.emptyMap[TopicPartition, String]()
-      case PreferRandom => PreferRandom.random(sc.getExecutorHosts)
+      case r: PreferRandom => r.random
       case PreferFixed(hostMap) => hostMap
     }
     val kp = new ju.HashMap[String, Object](kafkaParams)

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
@@ -60,6 +60,7 @@ object KafkaUtils extends Logging {
           "If you want to prefer brokers, you must provide a mapping using PreferFixed " +
           "A single KafkaRDD does not have a driver consumer and cannot look up brokers for you.")
       case PreferConsistent => ju.Collections.emptyMap[TopicPartition, String]()
+      case PreferRandom => PreferRandom.random(sc.getExecutorHosts)
       case PreferFixed(hostMap) => hostMap
     }
     val kp = new ju.HashMap[String, Object](kafkaParams)

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
@@ -17,17 +17,18 @@
 
 package org.apache.spark.streaming.kafka010
 
+import java.{ util => ju }
+
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
+
 import org.apache.spark.SparkContext
-import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
+import org.apache.spark.api.java.{ JavaRDD, JavaSparkContext }
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.StreamingContext
-import org.apache.spark.streaming.api.java.{JavaInputDStream, JavaStreamingContext}
+import org.apache.spark.streaming.api.java.{ JavaInputDStream, JavaStreamingContext }
 import org.apache.spark.streaming.dstream._
-
-import java.{util => ju}
 
 /**
  * object for constructing Kafka streams and RDDs

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/LocationStrategy.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/LocationStrategy.scala
@@ -37,7 +37,7 @@ private case object PreferBrokers extends LocationStrategy
 
 private case object PreferConsistent extends LocationStrategy
 
-private case object PreferRandom extends LocationStrategy {
+private case class PreferRandom(hosts: Array[String]) extends LocationStrategy {
   class RandomLocationStrategyMap(hosts: Array[String])
     extends ju.HashMap[TopicPartition, String] {
     override def get(key: Object): String = {
@@ -45,7 +45,7 @@ private case object PreferRandom extends LocationStrategy {
     }
   }
 
-  def random(hosts: Array[String]): RandomLocationStrategyMap = {
+  def random: RandomLocationStrategyMap = {
     new RandomLocationStrategyMap(hosts)
   }
 }
@@ -68,12 +68,11 @@ object LocationStrategies {
   def PreferConsistent: LocationStrategy =
     org.apache.spark.streaming.kafka010.PreferConsistent
 
-
   /**
    * Use this in some cases, it will randomly distribute partitions across all executors.
    */
-  def PreferRandom: LocationStrategy =
-    org.apache.spark.streaming.kafka010.PreferRandom
+  def PreferRandom(hosts: Array[String]): LocationStrategy =
+    org.apache.spark.streaming.kafka010.PreferRandom(hosts)
 
   /**
    * Use this to place particular TopicPartitions on particular hosts if your load is uneven.

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/LocationStrategy.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/LocationStrategy.scala
@@ -37,6 +37,19 @@ private case object PreferBrokers extends LocationStrategy
 
 private case object PreferConsistent extends LocationStrategy
 
+private case object PreferRandom extends LocationStrategy {
+  class RandomLocationStrategyMap(hosts: Array[String])
+    extends ju.HashMap[TopicPartition, String] {
+    override def get(key: Object): String = {
+      hosts(new ju.Random().nextInt(hosts.length))
+    }
+  }
+
+  def random(hosts: Array[String]): RandomLocationStrategyMap = {
+    new RandomLocationStrategyMap(hosts)
+  }
+}
+
 private case class PreferFixed(hostMap: ju.Map[TopicPartition, String]) extends LocationStrategy
 
 /**
@@ -54,6 +67,13 @@ object LocationStrategies {
    */
   def PreferConsistent: LocationStrategy =
     org.apache.spark.streaming.kafka010.PreferConsistent
+
+
+  /**
+   * Use this in some cases, it will randomly distribute partitions across all executors.
+   */
+  def PreferRandom: LocationStrategy =
+    org.apache.spark.streaming.kafka010.PreferRandom
 
   /**
    * Use this to place particular TopicPartitions on particular hosts if your load is uneven.

--- a/external/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaLocationStrategySuite.java
+++ b/external/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaLocationStrategySuite.java
@@ -54,6 +54,10 @@ public class JavaLocationStrategySuite implements Serializable {
     final LocationStrategy c5 = LocationStrategies.PreferFixed(hosts);
     final LocationStrategy c6 = LocationStrategies.PreferFixed(sHosts);
     Assert.assertEquals(c5, c6);
+
+    final LocationStrategy c7 = LocationStrategies.PreferRandom();
+    final LocationStrategy c8 = LocationStrategies.PreferRandom();
+    Assert.assertSame(c7, c8);
   }
 
 }

--- a/external/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaLocationStrategySuite.java
+++ b/external/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaLocationStrategySuite.java
@@ -55,9 +55,10 @@ public class JavaLocationStrategySuite implements Serializable {
     final LocationStrategy c6 = LocationStrategies.PreferFixed(sHosts);
     Assert.assertEquals(c5, c6);
 
-    final LocationStrategy c7 = LocationStrategies.PreferRandom();
-    final LocationStrategy c8 = LocationStrategies.PreferRandom();
-    Assert.assertSame(c7, c8);
+    String[] hostArray = new String[] {"host1", "host2"};
+    final LocationStrategy c7 = LocationStrategies.PreferRandom(hostArray);
+    final LocationStrategy c8 = LocationStrategies.PreferRandom(hostArray);
+    Assert.assertNotSame(c7, c8);
   }
 
 }


### PR DESCRIPTION
There are three LocationStrategy: PreferBrokers, PreferConsistent, PreferFixed. I got a scenario that I need a random one. There are plenty of topic partitions that are varies from each other with different records inside. And I have a lot of executors. PreferBrokers does not help here. PreferConsistent will make things worse that some executor will always get heavy tasks. PreferFixed does not help too, because it is fixed, neither to say I have to create a mapping manually.

A random LocationStrategy should dispatch a topic partition to different executors in different window. This would balance the load among spark executors.

### What changes were proposed in this pull request?
I added a new method getExecutorHosts in SparkContext which provides host name list. And a PreferRandom case object, which has a random method that returns a "faked" map. That map's get method randomly return a host name.

### Does this PR introduce _any_ user-facing change?
User will have another option that may be helpful.


### How was this patch tested?
I constructed PreferFixed with RandomLocationStrategyMap inside, and verified with 1000+ topic partitions across against 2000+ executors. It worked.