### PR TITLE
[SPARK-35216][SQL] a general auto merge output files feature for datasource api

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2622,6 +2622,18 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val MERGE_ENABLE_DATASOURCE =
+    buildConf("spark.sql.merge.output2ds.enabled").doc("whether enable auto merge small files for datasource api")
+    .booleanConf.createWithDefault(false)
+
+  val MERGE_AVG_CONDSIZE =
+    buildConf("spark.sql.merge.output.avgcond").doc("trigger merge when avg-file-size of output less than the threshold")
+    .longConf.createWithDefault(128000000)
+
+  val MERGE_AVG_OUTSIZE =
+    buildConf("spark.sql.merge.output.avgoutput").doc("the target avg-file-size after merge end")
+    .longConf.createWithDefault(256000000)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -18,22 +18,31 @@
 package org.apache.spark.sql.execution.datasources
 
 import java.io.IOException
+import java.nio.file.Paths
 
 import org.apache.hadoop.fs.{FileSystem, Path}
-
+import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.mapreduce.lib.output.{FileOutputCommitter, FileOutputFormat}
 import org.apache.spark.internal.io.FileCommitProtocol
+import org.apache.spark.rdd.{RDD, UnionPartition, UnionRDD}
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTablePartition}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils._
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{FileSourceScanExec, QueryExecution, SparkPlan}
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.PartitionOverwriteMode
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.SchemaUtils
+import org.apache.spark.util.SerializableConfiguration
+
+import scala.collection.mutable
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 /**
  * A command for writing data to a [[HadoopFsRelation]].  Supports both overwriting and appending.
@@ -76,7 +85,15 @@ case class InsertIntoHadoopFsRelationCommand(
       staticPartitions.size < partitionColumns.length
   }
 
+  var avgConditionSize = 0l
+  var avgOutputSize = 0l
+  var mergeEnabled = false
+
   override def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] = {
+    mergeEnabled = SQLConf.get.getConf(SQLConf.MERGE_ENABLE_DATASOURCE)
+    avgConditionSize = SQLConf.get.getConf(SQLConf.MERGE_AVG_CONDSIZE)
+    avgOutputSize = SQLConf.get.getConf(SQLConf.MERGE_AVG_OUTSIZE)
+
     // Most formats don't do well with duplicate columns, so lets not allow that
     SchemaUtils.checkColumnNameDuplication(
       outputColumnNames,
@@ -85,7 +102,8 @@ case class InsertIntoHadoopFsRelationCommand(
 
     val hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(options)
     val fs = outputPath.getFileSystem(hadoopConf)
-    val qualifiedOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
+    val finalOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
+    var qualifiedOutputPath = outputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
 
     val partitionsTrackedByCatalog = sparkSession.sessionState.conf.manageFilesourcePartitions &&
       catalogTable.isDefined &&
@@ -106,19 +124,27 @@ case class InsertIntoHadoopFsRelationCommand(
         fs, catalogTable.get, qualifiedOutputPath, matchingPartitions)
     }
 
+    val canMerge = mergeEnabled && bucketSpec.isEmpty && customPartitionLocations.isEmpty
+
+    val mergedir = ".merge-temp-" + java.util.UUID.randomUUID().toString
+    if(canMerge){
+      qualifiedOutputPath = new Path(qualifiedOutputPath, mergedir)
+    }
+    logInfo("output path " + qualifiedOutputPath)
+
     val committer = FileCommitProtocol.instantiate(
       sparkSession.sessionState.conf.fileCommitProtocolClass,
       jobId = java.util.UUID.randomUUID().toString,
-      outputPath = outputPath.toString,
+      outputPath = qualifiedOutputPath.toString,
       dynamicPartitionOverwrite = dynamicPartitionOverwrite)
 
     val doInsertion = if (mode == SaveMode.Append) {
       true
     } else {
-      val pathExists = fs.exists(qualifiedOutputPath)
+      val pathExists = fs.exists(finalOutputPath)
       (mode, pathExists) match {
         case (SaveMode.ErrorIfExists, true) =>
-          throw new AnalysisException(s"path $qualifiedOutputPath already exists.")
+          throw new AnalysisException(s"path $finalOutputPath already exists.")
         case (SaveMode.Overwrite, true) =>
           if (ifPartitionNotExists && matchingPartitions.nonEmpty) {
             false
@@ -126,7 +152,7 @@ case class InsertIntoHadoopFsRelationCommand(
             // For dynamic partition overwrite, do not delete partition directories ahead.
             true
           } else {
-            deleteMatchingPartitions(fs, qualifiedOutputPath, customPartitionLocations, committer)
+            deleteMatchingPartitions(fs, finalOutputPath, customPartitionLocations, committer)
             true
           }
         case (SaveMode.Overwrite, _) | (SaveMode.ErrorIfExists, false) =>
@@ -163,7 +189,7 @@ case class InsertIntoHadoopFsRelationCommand(
         }
       }
 
-      val updatedPartitionPaths =
+      var updatedPartitionPaths =
         FileFormatWriter.write(
           sparkSession = sparkSession,
           plan = child,
@@ -177,6 +203,115 @@ case class InsertIntoHadoopFsRelationCommand(
           statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
           options = options)
 
+      logInfo("updated partition paths " + updatedPartitionPaths.mkString(","))
+      logInfo("updated partition total " + updatedPartitionPaths.size)
+      updatedPartitionPaths = updatedPartitionPaths.map(p=>p.replace("/"+ mergedir,""))
+
+      if(canMerge) {
+        try{
+          logInfo("enable merge files for " + qualifiedOutputPath)
+          val directRenamePathList = new ListBuffer[Path]
+          val dataAttr = outputColumns.filterNot(AttributeSet(partitionColumns).contains)
+          if (partitionColumns.isEmpty) {
+            logInfo("non partition insert, merge single dir " + qualifiedOutputPath)
+            val (reParitionNum, avgsize) = MergeUtils.getRePartitionNum(qualifiedOutputPath, hadoopConf, avgConditionSize, avgOutputSize)
+            logInfo(s"[mergeFile] static $qualifiedOutputPath rePartionNum is: " + reParitionNum)
+            if (reParitionNum > 0) {
+                val committer2 = FileCommitProtocol.instantiate(
+                  sparkSession.sessionState.conf.fileCommitProtocolClass,
+                  jobId = java.util.UUID.randomUUID().toString,
+                  outputPath = finalOutputPath.toString)
+                val sourceRdd = getRdd(sparkSession, qualifiedOutputPath, dataAttr).coalesce(reParitionNum)
+                FileFormatWriter.writeRdd(sparkSession, sourceRdd, fileFormat, committer2,
+                  FileFormatWriter.OutputSpec(
+                    finalOutputPath.toString, Map.empty, dataAttr), hadoopConf, Seq.empty, None,
+                  statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)), options)
+              logInfo("[mergeFile] merge static dir finished")
+            } else {
+              logInfo(s"direct rename $qualifiedOutputPath's files")
+              val files = fs.listStatus(qualifiedOutputPath)
+              files.foreach(directRenamePathList += _.getPath)
+            }
+          } else {
+            logInfo("has partition insert, merge multi dir " + qualifiedOutputPath)
+            val tmpDynamicPartInfos = MergeUtils.getTmpDynamicPartPathInfo(qualifiedOutputPath, hadoopConf)
+            if (dynamicPartitionOverwrite) {
+              deleteExistingPartition(fs, tmpDynamicPartInfos.keys.toSeq, mergedir)
+            }
+            val mergeRule = generateDynamicMergeRule(tmpDynamicPartInfos, directRenamePathList)
+            logInfo(s"[mergeFile] merge candidate " + mergeRule.plist.size)
+            if (mergeRule.plist.nonEmpty) {
+                val committerJobPair = new ArrayBuffer[(FileCommitProtocol, Job)]()
+                val rdds = mergeRule.plist.map { case (path, repartnum) =>
+                  val finalPartPath = path.toString.replace("/"+mergedir, "")
+                  logInfo(s"[makeMergedRDDForPartitionedTable] create rdd for $path to $finalPartPath coalesce $repartnum")
+                  val committer = FileCommitProtocol.instantiate(
+                    sparkSession.sessionState.conf.fileCommitProtocolClass,
+                    jobId = java.util.UUID.randomUUID().toString,
+                    outputPath = finalPartPath)
+                  val job = Job.getInstance(hadoopConf)
+                  job.setOutputKeyClass(classOf[Void])
+                  job.setOutputValueClass(classOf[InternalRow])
+                  FileOutputFormat.setOutputPath(job, new Path(finalPartPath))
+                  committerJobPair += ((committer, job))
+                  getRdd(sparkSession, path, dataAttr).coalesce(repartnum)
+                }
+
+                for (i <- 0 until rdds.size) {
+                  val outputdir = committerJobPair(i)._2.getConfiguration.get(FileOutputFormat.OUTDIR)
+                  logInfo(s"rdd $i correspond with " + outputdir)
+                }
+
+                // index partition id of unionrdd with repsective committer
+                val union = new UnionRDD(rdds(0).context, rdds)
+                val rddIndex2Commiter = union.rdds.zipWithIndex.map(_._2).zip(committerJobPair.map(_._1)).toMap
+                val map4Committer = union.getPartitions.map { p =>
+                  val up = p.asInstanceOf[UnionPartition[RDD[InternalRow]]]
+                  val withCommiter = rddIndex2Commiter(up.parentRddIndex)
+                  logInfo(s"partition index ${up.index} correspond with rdd ${up.parentRddIndex}")
+                  (up.index, withCommiter)
+                }.toMap
+                FileFormatWriter.writeRdd2(sparkSession, union, fileFormat, map4Committer, committerJobPair,
+                  FileFormatWriter.OutputSpec(
+                    "", Map.empty, dataAttr), hadoopConf, Seq.empty, Seq(basicWriteJobStatsTracker(hadoopConf)), options)
+              logInfo("[mergeFile] merge dynamic partition finished")
+            }
+          }
+          if (directRenamePathList.nonEmpty) {
+            directRenamePathList.foreach { path =>
+              if (fs.isDirectory(path)) {
+                val (destPath, existed) = checkPartitionDirExists(fs, path, qualifiedOutputPath, finalOutputPath)
+                if (existed) {
+                  val files = fs.listStatus(path)
+                  files.foreach { f =>
+                    if(f.getPath.getName == FileOutputCommitter.SUCCEEDED_FILE_NAME){
+                      if(!fs.rename(f.getPath, destPath))
+                        logInfo("skip rename marked success file, maybe already exists")
+                    } else {
+                      if (!fs.rename(f.getPath, destPath)) throw new IOException(s"direct rename fail from ${f.getPath} to $destPath")
+                      logInfo("direct rename file [" + f.getPath + " to " + destPath + "]")
+                    }
+                  }
+                } else {
+                  if (!fs.rename(path, destPath)) throw new IOException(s"direct rename fail from $path to $destPath")
+                  logInfo("direct rename dir [" + path + " to " + destPath + "]")
+                }
+              } else {
+                if(path.getName == FileOutputCommitter.SUCCEEDED_FILE_NAME){
+                  if(!fs.rename(path, finalOutputPath))
+                    logInfo("skip rename marked success file, maybe already exists")
+                } else {
+                  if (!fs.rename(path, finalOutputPath)) throw new IOException(s"direct rename fail from $path to $finalOutputPath")
+                  logInfo("direct rename file [" + path + " to " + finalOutputPath + "]")
+                }
+              }
+            }
+          }
+        }finally {
+          fs.delete(qualifiedOutputPath, true)
+          logInfo("delete temp path " + qualifiedOutputPath)
+        }
+      }
 
       // update metastore partition metadata
       if (updatedPartitionPaths.isEmpty && staticPartitions.nonEmpty
@@ -263,5 +398,65 @@ case class InsertIntoHadoopFsRelationCommand(
         None
       }
     }.toMap
+  }
+
+  // replay output data to filescan rdd, use prepared execution rule to columnar format
+  private def getRdd(sparkSession:SparkSession, input:Path, dataAttr:Seq[Attribute]): RDD[InternalRow]={
+    val fi = new InMemoryFileIndex(sparkSession, Seq(input), Map.empty, None)
+    val relation = HadoopFsRelation(fi,new StructType(),dataAttr.toStructType,None,fileFormat,options)(sparkSession)
+    val fsScanExec = FileSourceScanExec(relation,dataAttr,dataAttr.toStructType,Seq.empty,None,Seq.empty,None)
+    QueryExecution.prepareExecutedPlan(sparkSession,fsScanExec).execute()
+  }
+
+  def generateDynamicMergeRule(tmpDynamicPartInfos:mutable.Map[Path,MergeUtils.AverageSize], directRenamePathList: ListBuffer[Path]): DynamicPartMergeRule = {
+    logInfo("generate DynamicMergeRule tmp partInfo size: " + tmpDynamicPartInfos.size)
+    val mergeRule = DynamicPartMergeRule(new ArrayBuffer[(Path, Int)]())
+    for (part <- tmpDynamicPartInfos) {
+      if (part._2.numFiles <= 1 || part._2.getAverageSize > avgConditionSize) {
+        logInfo("direct rename " + part._1 + " number of files " + part._2.numFiles)
+        directRenamePathList += part._1
+      } else {
+        val targetPart = MergeUtils.computeMergePartitionNum(part._2,avgConditionSize,avgOutputSize)
+        mergeRule.plist += ((part._1, targetPart.toInt))
+        logInfo(s"add merge path " + part._1 + s" and target partition $targetPart")
+      }
+    }
+    mergeRule
+  }
+
+  //compatible with insert into/overwrite case that the dest dir handle
+  def checkPartitionDirExists(fs: FileSystem, tempPath:Path, qualifiedPath:Path, finalOutputPath:Path):(Path,Boolean)={
+    val tempJavaPath = Paths.get(tempPath.toUri.getPath)
+    val qualifiedJavaPath = Paths.get(qualifiedPath.toUri.getPath)
+    val relativeJavaPath = qualifiedJavaPath.relativize(tempJavaPath)
+    val finalDestPath = new Path(finalOutputPath,relativeJavaPath.toString)
+    val finalDestParent = finalDestPath.getParent
+    if(!fs.exists(finalDestParent)){
+      fs.mkdirs(finalDestParent)
+      logInfo("mkdir direct parent " + finalDestParent)
+    }
+    if(fs.exists(finalDestPath)){
+      logInfo(s"existing dest dir $finalDestPath")
+      (finalDestPath, true)
+    }else{
+      logInfo(s"non existing dest dir $finalDestPath")
+      (finalDestPath, false)
+    }
+  }
+
+  def deleteExistingPartition(fs:FileSystem, paths:Seq[Path], mergedir:String): Unit ={
+    paths.foreach{ p=>
+      val finalPartPath = new Path(p.toString.replace("/"+ mergedir,""))
+      if(fs.exists(finalPartPath)){
+        fs.delete(finalPartPath,true)
+        logInfo("delete overwrite dir " + finalPartPath)
+      }
+    }
+  }
+
+  case class DynamicPartMergeRule(plist: ArrayBuffer[(Path, Int)]) {
+    override def toString: String = {
+      plist.map { case (path, repartition) => s"$path: $repartition" }.mkString("\n")
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/MergeUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/MergeUtils.scala
@@ -1,0 +1,129 @@
+package org.apache.spark.sql.execution.datasources
+
+import java.io.IOException
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.internal.Logging
+
+import scala.collection.mutable.{Map => MutableMap}
+
+object MergeUtils extends Logging{
+
+  class AverageSize(var totalSize: Long, var numFiles: Int) {
+    def getAverageSize: Long = {
+      if (numFiles != 0) {
+        totalSize / numFiles
+      } else {
+        0
+      }
+    }
+
+    override def toString: String = "{totalSize: " + totalSize + ", numFiles: " + numFiles + "}"
+  }
+
+  def hasFile(path: Path, conf: Configuration): Boolean = {
+    val fs = path.getFileSystem(conf)
+    val fStatus = fs.listStatus(path)
+    for (fStat <- fStatus) {
+      if (fStat.isFile) {
+        return true
+      }
+    }
+    false
+  }
+
+  def getPathSize(inpFs: FileSystem, dirPath: Path): AverageSize = {
+    val error = new AverageSize(-1, -1)
+    try {
+      val fStats = inpFs.listStatus(dirPath)
+      var totalSz: Long = 0L
+      var numFiles: Int = 0
+
+      for (fStat <- fStats) {
+        if (fStat.isDirectory()) {
+          val avgSzDir = getPathSize(inpFs, fStat.getPath)
+          if (avgSzDir.totalSize < 0) {
+            return error
+          }
+          totalSz += avgSzDir.totalSize
+          numFiles += avgSzDir.numFiles
+        } else {
+          if (!fStat.getPath.toString.endsWith("_SUCCESS")) {
+            totalSz += fStat.getLen
+            numFiles += 1
+          }
+        }
+      }
+      new AverageSize(totalSz, numFiles)
+    } catch {
+      case _: IOException => error
+    }
+  }
+
+  // get all the dynamic partition path and it's file size
+  def getTmpDynamicPartPathInfo(tmpPath: Path,
+                                conf: Configuration): MutableMap[Path, AverageSize] = {
+    val fs = tmpPath.getFileSystem(conf)
+    val fStatus = fs.listStatus(tmpPath)
+    val partPathInfo = MutableMap[Path, AverageSize]()
+
+    for (fStat <- fStatus) {
+      if (fStat.isDirectory) {
+        logInfo("temp dynamic part path: " + fStat.getPath.toString)
+        if (!hasFile(fStat.getPath, conf)) {
+          partPathInfo ++= getTmpDynamicPartPathInfo(fStat.getPath, conf)
+        } else {
+          val avgSize = getPathSize(fs, fStat.getPath)
+          logInfo("path2size (" + fStat.getPath.toString + " -> " + avgSize.totalSize + ")")
+          partPathInfo += (fStat.getPath -> avgSize)
+        }
+      }
+    }
+    partPathInfo
+  }
+
+  def getExternalMergeTmpPath(tempPath: Path, hadoopConf: Configuration): Path = {
+    val fs = tempPath.getFileSystem(hadoopConf)
+    val dir = fs.makeQualified(tempPath)
+    logInfo("Created temp merging dir = " + dir + " for path = " + tempPath)
+    fs.delete(dir,true)
+    try {
+      if (!fs.mkdirs(dir)) {
+        throw new IllegalStateException("Cannot create staging directory  '" + dir.toString + "'")
+      }
+      fs.deleteOnExit(dir)
+    }
+    catch {
+      case e: IOException =>
+        throw new RuntimeException(
+          "Cannot create temp merging directory '" + dir.toString + "': " + e.getMessage, e)
+    }
+    return dir
+  }
+
+  def getRePartitionNum(path: Path, conf: Configuration, avgConditionSize:Long, avgOutputSize:Long): (Int,Long) = {
+    var rePartitionNum = -1
+    val inpFs = path.getFileSystem(conf)
+    val totSize = getPathSize(inpFs, path)
+    logInfo("static partition totalsize of path: " + path.toString + " is: "
+      + totSize + "; numFiles is: " + totSize.numFiles)
+    rePartitionNum = computeMergePartitionNum(totSize,avgConditionSize,avgOutputSize)
+    (rePartitionNum, totSize.getAverageSize)
+  }
+
+  def computeMergePartitionNum(totSize: AverageSize, avgConditionSize:Long, avgOutputSize:Long): Int = {
+    var partitionNum = -1
+    if (totSize.numFiles <= 1) {
+      partitionNum = -1
+    } else {
+      if (totSize.getAverageSize > avgConditionSize) {
+        partitionNum = -1
+      } else {
+        partitionNum = Math.ceil(totSize.totalSize.toDouble / avgOutputSize).toInt
+      }
+    }
+    partitionNum
+  }
+
+}


### PR DESCRIPTION
in most case, users write data to hive table or hdfs dir with spark sql, since as spark3.0 released, offical didn't encourge to use hive module to read/write hive table, preferred  switching to datasoruce api from hive strategy rule, so as to centralize io operation with one module.

so given a general auto merge output files ability for datasource api would resolve many users's small files problem in production, and it can bind with datasource write framwork tightly, so that the auto merge course is transparent to users, and it is capable to handle all kinds of writing method, such as writing hdfs dir/non-partitioned hive table/dynamic partition hive table

this is my individual implemetation for the functionality, and it's stable in production environment of my company
