### PR TITLE
[SPARK-35220][SQL] DayTimeIntervalType/YearMonthIntervalType show different between Hive SerDe and row format delimited

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
@@ -603,7 +603,7 @@ abstract class BaseScriptTransformationSuite extends SparkPlanTest with SQLTestU
     }
   }
 
-  test("SPARK-35220: DayTimeIntervalType/YearMonthIntervalString show different " +
+  test("SPARK-35220: DayTimeIntervalType/YearMonthIntervalType show different " +
     "between hive serde and row format delimited\t") {
     assume(TestUtils.testCommandAvailable("/bin/bash"))
     withTempView("v") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution
 
 import java.sql.{Date, Timestamp}
+import java.time.{Duration, Period}
 
 import org.json4s.DefaultFormats
 import org.json4s.JsonDSL._
@@ -42,6 +43,8 @@ abstract class BaseScriptTransformationSuite extends SparkPlanTest with SQLTestU
   with BeforeAndAfterEach {
   import testImplicits._
   import ScriptTransformationIOSchema._
+
+  protected def defaultSerDe(): String
 
   protected val uncaughtExceptionHandler = new TestUncaughtExceptionHandler
 
@@ -597,6 +600,37 @@ abstract class BaseScriptTransformationSuite extends SparkPlanTest with SQLTestU
           'c.cast("string"),
           'd.cast("string"),
           'e.cast("string")).collect())
+    }
+  }
+
+  test("SPARK-35220: DayTimeIntervalType/YearMonthIntervalString show different " +
+    "between hive serde and row format delimited\t") {
+    assume(TestUtils.testCommandAvailable("/bin/bash"))
+    withTempView("v") {
+      val df = Seq(
+        (Duration.ofDays(1), Period.ofMonths(10))
+      ).toDF("a", "b")
+      df.createTempView("v")
+
+      if (defaultSerDe == "hive-serde") {
+        checkAnswer(sql(
+          """
+            |SELECT TRANSFORM(a, b)
+            |  USING 'cat' AS (a, b)
+            |FROM v
+            |""".stripMargin),
+          identity,
+          Row("1 00:00:00.000000000", "0-10") :: Nil)
+      } else {
+        checkAnswer(sql(
+          """
+            |SELECT TRANSFORM(a, b)
+            |  USING 'cat' AS (a, b)
+            |FROM v
+            |""".stripMargin),
+          identity,
+          Row("INTERVAL '1 00:00:00' DAY TO SECOND", "INTERVAL '0-10' YEAR TO MONTH") :: Nil)
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkScriptTransformationSuite.scala
@@ -25,6 +25,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 class SparkScriptTransformationSuite extends BaseScriptTransformationSuite with SharedSparkSession {
   import testImplicits._
 
+  override protected def defaultSerDe(): String = "row-format-delimited"
+
   override def createScriptTransformationExec(
       script: String,
       output: Seq[Attribute],

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
@@ -39,6 +39,8 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
 
   import ScriptTransformationIOSchema._
 
+  override protected def defaultSerDe(): String = "hive-serde"
+
   override def createScriptTransformationExec(
       script: String,
       output: Seq[Attribute],


### PR DESCRIPTION
### What changes were proposed in this pull request?
DayTimeIntervalType/YearMonthIntervalString show different between Hive SerDe and row format delimited.
Create this pr to add a test and  have disscuss.

For this problem I think we have two direction:

1. leave it as current and add a item t explain this  in migration guide docs.
2. Since we should not change hive serde's behavior, so we can cast spark row format delimited's behavior to use cast  DayTimeIntervalType/YearMonthIntervalType as HIVE_STYLE

### Why are the changes needed?
Add UT


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
added ut
