### PR TITLE
[SPARK-35222] In YARN mode, the tracking URL is  printed to allow users to better track Spark Job

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -207,7 +207,7 @@ private[spark] class Client(
       yarnClient.submitApplication(appContext)
       launcherBackend.setAppId(appId.toString)
       reportLauncherState(SparkAppHandle.State.SUBMITTED)
-
+      printTrackingInfo(appId)
       appId
     } catch {
       case e: Throwable =>
@@ -343,6 +343,12 @@ private[spark] class Client(
   /** Get the application report from the ResourceManager for an application we have submitted. */
   def getApplicationReport(appId: ApplicationId): ApplicationReport =
     yarnClient.getApplicationReport(appId)
+
+  /**  Get the application Tracking url for an application we have submitted. */
+  private def printTrackingInfo(appId: ApplicationId): Unit = {
+    val trackingUrl = getApplicationReport(appId).getTrackingUrl
+    print(s"Application Id: ${appId}, Tracking URL: ${trackingUrl}")
+  }
 
   /**
    * Return the security token used by this client to communicate with the ApplicationMaster.


### PR DESCRIPTION

### What changes were proposed in this pull request?
In YARN mode, for better user experience, when Spark is started, not only the AppID is printed, but the Tracking URL is also printed to allow users to better track Spark Job

![clipboard_image_1619343476789](https://user-images.githubusercontent.com/40849158/115990609-c1fc3000-a5f6-11eb-8ce5-2e3a66348c09.png)


### Why are the changes needed?
In practice, the user needs to track the Spark task through the YARN Trackting URL. At the moment, it is just printing the appId, which is a bit of a nuisance for the user to use. You need to look up YARN and find the corresponding app. If the trackting URL information is available, the user can open the URL connection directly，This improves the user experience

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
This just prints the tracking URL, so they won't cause behaviour change. So passing the existing tests should be enough.
