### PR TITLE
[SPARK-35212][Spark Core][DStreams] Another way to added PreferRandom for the scenario that topic partitions need to be randomly distributed across all executors.

### DIFF
--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/DirectKafkaInputDStream.scala
@@ -105,6 +105,7 @@ private[spark] class DirectKafkaInputDStream[K, V](
     locationStrategy match {
       case PreferBrokers => getBrokers
       case PreferConsistent => ju.Collections.emptyMap[TopicPartition, String]()
+      case PreferRandom => null
       case PreferFixed(hostMap) => hostMap
     }
   }

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaRDD.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaRDD.scala
@@ -21,6 +21,7 @@ import java.{ util => ju }
 
 import org.apache.kafka.clients.consumer.{ ConsumerConfig, ConsumerRecord }
 import org.apache.kafka.common.TopicPartition
+
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.Network._

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaUtils.scala
@@ -60,6 +60,7 @@ object KafkaUtils extends Logging {
           "If you want to prefer brokers, you must provide a mapping using PreferFixed " +
           "A single KafkaRDD does not have a driver consumer and cannot look up brokers for you.")
       case PreferConsistent => ju.Collections.emptyMap[TopicPartition, String]()
+      case PreferRandom => null
       case PreferFixed(hostMap) => hostMap
     }
     val kp = new ju.HashMap[String, Object](kafkaParams)

--- a/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/LocationStrategy.scala
+++ b/external/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/LocationStrategy.scala
@@ -37,6 +37,8 @@ private case object PreferBrokers extends LocationStrategy
 
 private case object PreferConsistent extends LocationStrategy
 
+private case object PreferRandom extends LocationStrategy
+
 private case class PreferFixed(hostMap: ju.Map[TopicPartition, String]) extends LocationStrategy
 
 /**
@@ -54,6 +56,12 @@ object LocationStrategies {
    */
   def PreferConsistent: LocationStrategy =
     org.apache.spark.streaming.kafka010.PreferConsistent
+
+  /**
+   * Use this in some cases, it will randomly distribute partitions across all executors.
+   */
+  def PreferRandom: LocationStrategy =
+    org.apache.spark.streaming.kafka010.PreferRandom
 
   /**
    * Use this to place particular TopicPartitions on particular hosts if your load is uneven.


### PR DESCRIPTION
There are three LocationStrategy: PreferBrokers, PreferConsistent, PreferFixed. I got a scenario that I need a random one. There are plenty of topic partitions that are varies from each other with different records inside. And I have a lot of executors. PreferBrokers does not help here. PreferConsistent will make things worse that some executor will always get heavy tasks. PreferFixed does not help too, because it is fixed, neither to say I have to create a mapping manually.

this is another PR for SPARK-35212 compare to #32326

A random LocationStrategy should dispatch a topic partition to different executors in different window. This would balance the load among spark executors.

### What changes were proposed in this pull request?
I added a PreferRandom case object, which will pass null to KafkaRDD constructor. And in KafkaRDD.getPreferredLocations method, if the parameter is null, it will randomly pick an executor for a partition.

### Does this PR introduce any user-facing change?
User will have another option that may be helpful.

### How was this patch tested?
I constructed PreferFixed with a faked RandomLocationStrategyMap inside which always return a random executor hostname, and verified with 1000+ topic partitions across against 2000+ executors. It worked.