### PR TITLE
[SPARK-35232][SQL] Nested column pruning should retain column metadata

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
@@ -73,7 +73,8 @@ object SchemaPruning extends SQLConfHelper {
           val leftFieldType = resolvedLeftStruct.dataType
           val rightFieldType = rightStruct(fieldName).dataType
           val sortedLeftFieldType = sortLeftFieldsByRight(leftFieldType, rightFieldType)
-          StructField(fieldName, sortedLeftFieldType, nullable = resolvedLeftStruct.nullable)
+          StructField(fieldName, sortedLeftFieldType, nullable = resolvedLeftStruct.nullable,
+            metadata = resolvedLeftStruct.metadata)
         }
         StructType(sortedLeftFields)
       case _ => left
@@ -127,7 +128,8 @@ object SchemaPruning extends SQLConfHelper {
   private def getRootFields(expr: Expression): Seq[RootField] = {
     expr match {
       case att: Attribute =>
-        RootField(StructField(att.name, att.dataType, att.nullable), derivedFromAtt = true) :: Nil
+        RootField(StructField(att.name, att.dataType, att.nullable, att.metadata),
+          derivedFromAtt = true) :: Nil
       case SelectedField(field) => RootField(field, derivedFromAtt = false) :: Nil
       // Root field accesses by `IsNotNull` and `IsNull` are special cases as the expressions
       // don't actually use any nested fields. These root field accesses might be excluded later

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
@@ -125,7 +125,7 @@ object SchemaPruning extends SQLConfHelper {
    * When expr is an [[Attribute]], construct a field around it and indicate that that
    * field was derived from an attribute.
    */
-  private def getRootFields(expr: Expression): Seq[RootField] = {
+  private[catalyst] def getRootFields(expr: Expression): Seq[RootField] = {
     expr match {
       case att: Attribute =>
         RootField(StructField(att.name, att.dataType, att.nullable, att.metadata),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruningSuite.scala
@@ -129,4 +129,18 @@ class SchemaPruningSuite extends SparkFunSuite with SQLHelper {
       }
     }
   }
+
+  test("SPARK-35232: getRootFields/pruneDataSchema should retain attribute metadata") {
+    val metadata = new MetadataBuilder().putString("foo", "bar").build()
+    val attr = AttributeReference("my_attr", IntegerType, metadata = metadata)()
+
+    val rootFields = SchemaPruning.getRootFields(attr)
+    assert(rootFields.length == 1)
+    val field = rootFields.head.field
+    assert(field.metadata.getString("foo") == "bar")
+
+    val schema = StructType(Seq(field))
+    val prunedSchema = SchemaPruning.pruneDataSchema(schema, rootFields)
+    assert(prunedSchema.head.metadata.getString("foo") == "bar")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
@@ -240,9 +240,8 @@ class InMemoryTable(
       new InMemoryBatchScan(data.map(_.asInstanceOf[InputPartition]), schema, tableSchema)
 
     override def pruneColumns(requiredSchema: StructType): Unit = {
-      schema = StructType(requiredSchema.filter { f =>
-        (metadataColumnNames ++ tableSchema.map(_.name)).contains(f.name)
-      })
+      val schemaNames = metadataColumnNames ++ tableSchema.map(_.name)
+      schema = StructType(requiredSchema.filter(f => schemaNames.contains(f.name)))
     }
   }
 
@@ -539,7 +538,7 @@ private class BufferedRowsReader(
         }
         new GenericInternalRow(resultValue)
       case dt =>
-        row.get(index, CharVarcharUtils.replaceCharVarcharWithString(dt))
+        row.get(index, dt)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
@@ -526,10 +526,10 @@ private class BufferedRowsReader(
     val index = schema.fieldIndex(field.name)
     field.dataType match {
       case StructType(fields) =>
-        val childRow = row.toSeq(schema)(index).asInstanceOf[InternalRow]
-        if (childRow == null) {
+        if (row.isNullAt(index)) {
           return null
         }
+        val childRow = row.toSeq(schema)(index).asInstanceOf[InternalRow]
         val childSchema = schema(index).dataType.asInstanceOf[StructType]
         val resultValue = new Array[Any](fields.length)
         fields.zipWithIndex.foreach { case (childField, idx) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
@@ -237,29 +237,29 @@ class InMemoryTable(
     private var schema: StructType = tableSchema
 
     override def build: Scan =
-      new InMemoryBatchScan(data.map(_.asInstanceOf[InputPartition]), schema)
+      new InMemoryBatchScan(data.map(_.asInstanceOf[InputPartition]), schema, tableSchema)
 
     override def pruneColumns(requiredSchema: StructType): Unit = {
-      // if metadata columns are projected, return the table schema and metadata columns
-      val hasMetadataColumns = requiredSchema.map(_.name).exists(metadataColumnNames.contains)
-      if (hasMetadataColumns) {
-        schema = StructType(tableSchema ++ metadataColumnNames
-            .flatMap(name => metadataColumns.find(_.name == name))
-            .map(col => StructField(col.name, col.dataType, col.isNullable)))
-      }
+      schema = StructType(requiredSchema.filter { f =>
+        (metadataColumnNames ++ tableSchema.map(_.name)).contains(f.name)
+      })
     }
   }
 
-  class InMemoryBatchScan(data: Array[InputPartition], schema: StructType) extends Scan with Batch {
-    override def readSchema(): StructType = schema
+  class InMemoryBatchScan(
+      data: Array[InputPartition],
+      readSchema: StructType,
+      tableSchema: StructType) extends Scan with Batch {
+    override def readSchema(): StructType = readSchema
 
     override def toBatch: Batch = this
 
     override def planInputPartitions(): Array[InputPartition] = data
 
     override def createReaderFactory(): PartitionReaderFactory = {
-      val metadataColumns = schema.map(_.name).filter(metadataColumnNames.contains)
-      new BufferedRowsReaderFactory(metadataColumns)
+      val metadataColumns = readSchema.map(_.name).filter(metadataColumnNames.contains)
+      val nonMetadataColumns = schema.filterNot(f => metadataColumns.contains(f.name))
+      new BufferedRowsReaderFactory(metadataColumns, nonMetadataColumns, tableSchema)
     }
   }
 
@@ -480,17 +480,22 @@ class BufferedRows(
 }
 
 private class BufferedRowsReaderFactory(
-    metadataColumns: Seq[String]) extends PartitionReaderFactory {
+    metadataColumnNames: Seq[String],
+    nonMetaDataColumns: Seq[StructField],
+    tableSchema: StructType) extends PartitionReaderFactory {
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
-    new BufferedRowsReader(partition.asInstanceOf[BufferedRows], metadataColumns)
+    new BufferedRowsReader(partition.asInstanceOf[BufferedRows], metadataColumnNames,
+      nonMetaDataColumns, tableSchema)
   }
 }
 
 private class BufferedRowsReader(
     partition: BufferedRows,
-    metadataColumns: Seq[String]) extends PartitionReader[InternalRow] {
+    metadataColumnNames: Seq[String],
+    nonMetadataColumns: Seq[StructField],
+    tableSchema: StructType) extends PartitionReader[InternalRow] {
   private def addMetadata(row: InternalRow): InternalRow = {
-    val metadataRow = new GenericInternalRow(metadataColumns.map {
+    val metadataRow = new GenericInternalRow(metadataColumnNames.map {
       case "index" => index
       case "_partition" => UTF8String.fromString(partition.key)
     }.toArray)
@@ -504,9 +509,36 @@ private class BufferedRowsReader(
     index < partition.rows.length
   }
 
-  override def get(): InternalRow = addMetadata(partition.rows(index))
+  override def get(): InternalRow = {
+    val originalRow = partition.rows(index)
+    val values = new Array[Any](nonMetadataColumns.length)
+    nonMetadataColumns.zipWithIndex.foreach { case (col, idx) =>
+      values(idx) = extractFieldValue(col, tableSchema, originalRow)
+    }
+    addMetadata(new GenericInternalRow(values))
+  }
 
   override def close(): Unit = {}
+
+  private def extractFieldValue(
+      field: StructField,
+      schema: StructType,
+      row: InternalRow): Any = {
+    val index = schema.fieldIndex(field.name)
+    field.dataType match {
+      case StructType(fields) =>
+        val childRow = row.toSeq(schema)(index).asInstanceOf[InternalRow]
+        val childSchema = schema(index).dataType.asInstanceOf[StructType]
+        val resultValue = new Array[Any](fields.length)
+        fields.zipWithIndex.foreach { case (childField, idx) =>
+          val childValue = extractFieldValue(childField, childSchema, childRow)
+          resultValue(idx) = childValue
+        }
+        new GenericInternalRow(resultValue)
+      case dt =>
+        row.get(index, dt)
+    }
+  }
 }
 
 private object BufferedRowsWriterFactory extends DataWriterFactory with StreamingDataWriterFactory {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Retain column metadata during the process of nested column pruning, when constructing `StructField`. 

To test the above change, this also added the logic of column projection in `InMemoryTable`. Without the fix `DSV2CharVarcharDDLTestSuite` will fail.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The column metadata is used in a few places such as re-constructing CHAR/VARCHAR information such as in [SPARK-33901](https://issues.apache.org/jira/browse/SPARK-33901). Therefore, we should retain the info during nested column pruning.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing tests.