### PR TITLE
[SPARK-35238][DOC] Add JindoFS SDK in cloud integration documents

### DIFF
--- a/docs/cloud-integration.md
+++ b/docs/cloud-integration.md
@@ -288,4 +288,4 @@ Here is the documentation on the standard connectors both from Apache and the cl
 * [The Azure Blob Filesystem driver (ABFS)](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-abfs-driver)
 * IBM Cloud Object Storage connector for Apache Spark: [Stocator](https://github.com/CODAIT/stocator),
   [IBM Object Storage](https://www.ibm.com/cloud/object-storage). From IBM.
-
+* [Using JindoFS SDK to access Alibaba Cloud OSS](https://github.com/aliyun/alibabacloud-jindofs).


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add JindoFS SDK documents link in the cloud integration section of Spark's official document.

### Why are the changes needed?
If Spark users need to interact with Alibaba Cloud OSS, JindoFS SDK is the official solution provided by Alibaba Cloud.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
tested the url manually.
