### PR TITLE
[SPARK-35248] Spark shall load system class first in IsolatedClientLoader

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -398,7 +398,7 @@ private[spark] object HiveUtils extends Logging {
         case childFirst: ChildFirstURLClassLoader =>
           childFirst.getURLs() ++ allJars(Utils.getSparkClassLoader)
         case urlClassLoader: URLClassLoader =>
-          urlClassLoader.getURLs ++ allJars(urlClassLoader.getParent)
+          allJars(urlClassLoader.getParent) ++ urlClassLoader.getURLs
         case other => allJars(other.getParent)
       }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUtilsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveUtilsSuite.scala
@@ -67,7 +67,7 @@ class HiveUtilsSuite extends QueryTest with SQLTestUtils with TestHiveSingleton 
     }
   }
 
-  test("IsolatedClientLoader shall use system classpath first") {
+  test("SPARK-35248: IsolatedClientLoader shall use system classpath first") {
     val conf = new SparkConf
     val contextClassLoader = Thread.currentThread().getContextClassLoader
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the behavior of IsolatedClientLoader to load system classes first. IsolatedClientLoader is used to load HMS client classes to provide isolation of HMS classes. For non-shared classes, IsolatedClientLoader will load from execJars list. The list comes either from maven pom file (spark.sql.hive.metastore.jars=maven), or figure out from the context classloader (spark.sql.hive.metastore.jars=builtin). In the later case, Spark should resolve classes in the same order of other (non-HMS) classes. That is, if spark.driver.userClassPathFirst=true, search user path first then system path. Otherwise, system path first then user path. HiveUtils.allJars aim to compose an ordered list of jars representing the resolution order of either childFirst or urlClassLoader. In case of urlClassLoader, the normal behavior is urlClassLoader would delegate to parent to resolve the class first (system path), if fail then resolve use it's own path (user path). However, current code list the user jars (urlClassLoader.getURLs) in front of system jars (allJars(urlClassLoader.getParent)), which reverse the order.

### Why are the changes needed?
By convention, Spark shall use system jars first unless spark.driver.userClassPathFirst is defined. There's no reason the break the contract when loading HMS client jar using IsolatedClientLoader.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test added in HiveUtilsSuite