### PR TITLE
[SPARK-35229][WEBUI] Limit the maximum number of items on the timeline view.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -129,6 +129,21 @@ private[spark] object UI {
     .intConf
     .createWithDefault(1000)
 
+  val UI_TIMELINE_JOBS_MAXIMUM = ConfigBuilder("spark.ui.timeline.jobs.maximum")
+    .version("3.2.0")
+    .intConf
+    .createWithDefault(500)
+
+  val UI_TIMELINE_STAGES_MAXIMUM = ConfigBuilder("spark.ui.timeline.stages.maximum")
+    .version("3.2.0")
+    .intConf
+    .createWithDefault(500)
+
+  val UI_TIMELINE_EXECUTORS_MAXIMUM = ConfigBuilder("spark.ui.timeline.executors.maximum")
+    .version("3.2.0")
+    .intConf
+    .createWithDefault(250)
+
   val ACLS_ENABLE = ConfigBuilder("spark.acls.enable")
     .version("1.1.0")
     .booleanConf

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -68,10 +68,11 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
     </svg></div>.toString.filter(_ != '\n')
 
   private def makeJobEvent(jobs: Seq[v1.JobData]): Seq[String] = {
+    val now = System.currentTimeMillis()
     jobs.filter { job =>
       job.status != JobExecutionStatus.UNKNOWN && job.submissionTime.isDefined
     }.sortBy { j =>
-      -math.max(j.submissionTime.get.getTime, j.completionTime.map(_.getTime).getOrElse(-1L))
+      (-j.completionTime.map(_.getTime).getOrElse(now), -j.submissionTime.get.getTime)
     }.take(MAX_TIMELINE_JOBS).map { job =>
       val jobId = job.jobId
       val status = job.status
@@ -82,7 +83,7 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
         plainText = true).text
 
       val submissionTime = job.submissionTime.get.getTime()
-      val completionTime = job.completionTime.map(_.getTime()).getOrElse(System.currentTimeMillis())
+      val completionTime = job.completionTime.map(_.getTime()).getOrElse(now)
       val classNameByStatus = status match {
         case JobExecutionStatus.SUCCEEDED => "succeeded"
         case JobExecutionStatus.FAILED => "failed"

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -72,8 +72,8 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
     jobs.filter { job =>
       job.status != JobExecutionStatus.UNKNOWN && job.submissionTime.isDefined
     }.sortBy { j =>
-      (-j.completionTime.map(_.getTime).getOrElse(now), -j.submissionTime.get.getTime)
-    }.take(MAX_TIMELINE_JOBS).map { job =>
+      (j.completionTime.map(_.getTime).getOrElse(now), j.submissionTime.get.getTime)
+    }.takeRight(MAX_TIMELINE_JOBS).map { job =>
       val jobId = job.jobId
       val status = job.status
       val (_, lastStageDescription) = lastStageNameAndDescription(store, job)
@@ -126,8 +126,8 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
       Seq[String] = {
     val events = ListBuffer[String]()
     executors.sortBy { e =>
-      -math.max(e.addTime.getTime, e.removeTime.map(_.getTime).getOrElse(-1L))
-    }.take(MAX_TIMELINE_EXECUTORS).foreach { e =>
+      e.removeTime.map(_.getTime).getOrElse(e.addTime.getTime)
+    }.takeRight(MAX_TIMELINE_EXECUTORS).foreach { e =>
       val addedEvent =
         s"""
            |{
@@ -205,8 +205,7 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
         if (MAX_TIMELINE_JOBS < jobs.size) {
           <div>
             <strong>
-              This page has more than the maximum number of jobs that can be shown in the
-              visualization! Only the most recent {MAX_TIMELINE_JOBS} submitted/completed jobs
+              Only the most recent {MAX_TIMELINE_JOBS} submitted/completed jobs
               (of {jobs.size} total) are shown.
             </strong>
           </div>
@@ -218,8 +217,7 @@ private[ui] class AllJobsPage(parent: JobsTab, store: AppStatusStore) extends We
         if (MAX_TIMELINE_EXECUTORS < executors.size) {
           <div>
             <strong>
-              This page has more than the maximum number of executors that can be shown in the
-              visualization! Only the most recent {MAX_TIMELINE_EXECUTORS} added/removed executors
+              Only the most recent {MAX_TIMELINE_EXECUTORS} added/removed executors
               (of {executors.size} total) are shown.
             </strong>
           </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -64,8 +64,8 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
   private def makeStageEvent(stageInfos: Seq[v1.StageData]): Seq[String] = {
     val now = System.currentTimeMillis()
     stageInfos.sortBy { s =>
-      (-s.completionTime.map(_.getTime).getOrElse(now), -s.submissionTime.get.getTime)
-    }.take(MAX_TIMELINE_STAGES).map { stage =>
+      (s.completionTime.map(_.getTime).getOrElse(now), s.submissionTime.get.getTime)
+    }.takeRight(MAX_TIMELINE_STAGES).map { stage =>
       val stageId = stage.stageId
       val attemptId = stage.attemptId
       val name = stage.name
@@ -106,8 +106,8 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
   def makeExecutorEvent(executors: Seq[v1.ExecutorSummary]): Seq[String] = {
     val events = ListBuffer[String]()
     executors.sortBy { e =>
-      -math.max(e.addTime.getTime, e.removeTime.map(_.getTime).getOrElse(-1L))
-    }.take(MAX_TIMELINE_EXECUTORS).foreach { e =>
+      e.removeTime.map(_.getTime).getOrElse(e.addTime.getTime)
+    }.takeRight(MAX_TIMELINE_EXECUTORS).foreach { e =>
       val addedEvent =
         s"""
            |{
@@ -185,8 +185,7 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
       if (MAX_TIMELINE_STAGES < stages.size) {
         <div>
           <strong>
-            This page has more than the maximum number of stages that can be shown in the
-            visualization! Only the most recent {MAX_TIMELINE_STAGES} submitted/completed stages
+            Only the most recent {MAX_TIMELINE_STAGES} submitted/completed stages
             (of {stages.size} total) are shown.
           </strong>
         </div>
@@ -198,8 +197,7 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
       if (MAX_TIMELINE_EXECUTORS < executors.size) {
         <div>
           <strong>
-            This page has more than the maximum number of executors that can be shown in the
-            visualization! Only the most recent {MAX_TIMELINE_EXECUTORS} added/removed executors
+            Only the most recent {MAX_TIMELINE_EXECUTORS} added/removed executors
             (of {executors.size} total) are shown.
           </strong>
         </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -62,8 +62,9 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
     </svg></div>.toString.filter(_ != '\n')
 
   private def makeStageEvent(stageInfos: Seq[v1.StageData]): Seq[String] = {
+    val now = System.currentTimeMillis()
     stageInfos.sortBy { s =>
-      -math.max(s.submissionTime.get.getTime, s.completionTime.map(_.getTime).getOrElse(-1L))
+      (-s.completionTime.map(_.getTime).getOrElse(now), -s.submissionTime.get.getTime)
     }.take(MAX_TIMELINE_STAGES).map { stage =>
       val stageId = stage.stageId
       val attemptId = stage.attemptId
@@ -71,7 +72,7 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
       val status = stage.status.toString.toLowerCase(Locale.ROOT)
       val submissionTime = stage.submissionTime.get.getTime()
       val completionTime = stage.completionTime.map(_.getTime())
-        .getOrElse(System.currentTimeMillis())
+        .getOrElse(now)
 
       // The timeline library treats contents as HTML, so we have to escape them. We need to add
       // extra layers of escaping in order to embed this in a JavaScript string literal.

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobsTab.scala
@@ -30,6 +30,7 @@ private[ui] class JobsTab(parent: SparkUI, store: AppStatusStore)
   extends SparkUITab(parent, "jobs") {
 
   val sc = parent.sc
+  val conf = parent.conf
   val killEnabled = parent.killEnabled
 
   // Show pool information for only live UI.

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -398,8 +398,7 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
       {
         if (MAX_TIMELINE_TASKS < tasks.size) {
           <strong>
-            This page has more than the maximum number of tasks that can be shown in the
-            visualization! Only the most recent {MAX_TIMELINE_TASKS} tasks
+            Only the most recent {MAX_TIMELINE_TASKS} tasks
             (of {tasks.size} total) are shown.
           </strong>
         } else {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1365,6 +1365,38 @@ Apart from these, the following properties are also available, and may be useful
   </td>
   <td>2.2.3</td>
 </tr>
+<tr>
+  <td><code>spark.ui.timeline.executors.maximum</code></td>
+  <td>250</td>
+  <td>
+    The maximum number of executors shown in the event timeline.
+  </td>
+  <td>3.2.0</td>
+</tr>
+<tr>
+  <td><code>spark.ui.timeline.jobs.maximum</code></td>
+  <td>500</td>
+  <td>
+    The maximum number of jobs shown in the event timeline.
+  </td>
+  <td>3.2.0</td>
+</tr>
+<tr>
+  <td><code>spark.ui.timeline.stages.maximum</code></td>
+  <td>500</td>
+  <td>
+    The maximum number of stages shown in the event timeline.
+  </td>
+  <td>3.2.0</td>
+</tr>
+<tr>
+  <td><code>spark.ui.timeline.tasks.maximum</code></td>
+  <td>1000</td>
+  <td>
+    The maximum number of tasks shown in the event timeline.
+  </td>
+  <td>1.4.0</td>
+</tr>
 </table>
 
 ### Compression and Serialization


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to introduces three new configurations to limit the maximum number of jobs/stages/executors on the timeline view.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If the number of items on the timeline view grows +1000, rendering can be significantly slow.
https://issues.apache.org/jira/browse/SPARK-35229

The maximum number of tasks on the timeline is already limited by `spark.ui.timeline.tasks.maximum` so l proposed to mitigate this issue with the same manner.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. the maximum number of items shown on the timeline view is limited.
I proposed the default value 500 for jobs and stages, and 250 for executors.
A executor has at most 2 items (added and removed) 250 is chosen.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I manually confirm this change works with the following procedures.
```
# launch a cluster
$ bin/spark-shell --conf spark.ui.retainedDeadExecutors=300 --master "local-cluster[4, 1, 1024]"

// Confirm the maximum number of jobs
(1 to 1000).foreach { _ => sc.parallelize(List(1)).collect }

// Confirm the maximum number of stages
var df = sc.parallelize(1 to 2)
(1 to 1000).foreach { i =>  df = df.repartition(i % 5 + 1) }
df.collect


// Confirm the maximum number of executors
(1 to 300).foreach { _ => try sc.parallelize(List(1)).foreach { _ => System.exit(0) } catch { case e => }}
```

Screenshots here.
![jobs_limited](https://user-images.githubusercontent.com/4736016/116386937-3e8c4a00-a855-11eb-8f4c-151cf7ddd3b8.png)
![stages_limited](https://user-images.githubusercontent.com/4736016/116386990-49df7580-a855-11eb-9f71-8e129e3336ab.png)
![executors_limited](https://user-images.githubusercontent.com/4736016/116387009-4f3cc000-a855-11eb-8697-a2eb4c9c99e6.png)
