### PR TITLE
[SPARK-35257][TESTS] Speed up `HadoopVersionInfoSuite` with `SPARK_VERSIONS_SUITE_IVY_PATH`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientBuilder.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientBuilder.scala
@@ -28,7 +28,7 @@ import org.apache.spark.util.Utils
 private[client] object HiveClientBuilder {
   // In order to speed up test execution during development or in Jenkins, you can specify the path
   // of an existing Ivy cache:
-  private val ivyPath: Option[String] = {
+  private[client] val ivyPath: Option[String] = {
     sys.env.get("SPARK_VERSIONS_SUITE_IVY_PATH").orElse(
       Some(new File(sys.props("java.io.tmpdir"), "hive-ivy-cache").getAbsolutePath))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`HadoopVersionInfoSuite` use a separate `ivyPath` to download the jars when create a new `IsolatedClientLoader`,  and the ivy cache directory will be deleted after this suite, so `HadoopVersionInfoSuite` can't reuse `hive-ivy-cache` by specifying environment variables `SPARK_VERSIONS_SUITE_IVY_PATH` like `VersionsSuite` and `HiveVersionSuites`.

The main change of this pr is change to use `HiveClientBuilder.ivyPath` to store jars, then we can speed up this test suite with specify environment variables `SPARK_VERSIONS_SUITE_IVY_PATH`.
 
### Why are the changes needed?
Speed up `HadoopVersionInfoSuite`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass the Jenkins or GitHub Action
- Manual test

**Before**

1. Execute command: `mvn clean test -Phadoop-3.2 -Phive-2.3 -Phadoop-cloud -Pmesos -Pyarn -Pkinesis-asl -Phive-thriftserver -Pspark-ganglia-lgpl -Pkubernetes -Phive -pl sql/hive -Dtest=none -DwildcardSuites=org.apache.spark.sql.hive.client.HadoopVersionInfoSuite`

```
Run completed in 1 minute, 48 seconds.
Total number of tests run: 3
Suites: completed 2, aborted 0
Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

**After**

1. Execute command: `export SPARK_VERSIONS_SUITE_IVY_PATH=/XXX/hive-ivy-cache` 
2. Execute command: `mvn clean test -Phadoop-3.2 -Phive-2.3 -Phadoop-cloud -Pmesos -Pyarn -Pkinesis-asl -Phive-thriftserver -Pspark-ganglia-lgpl -Pkubernetes -Phive -pl sql/hive -Dtest=none -DwildcardSuites=org.apache.spark.sql.hive.client.HadoopVersionInfoSuite`

```
Run completed in 14 seconds, 958 milliseconds.
Total number of tests run: 3
Suites: completed 2, aborted 0
Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
```

