### PR TITLE
[WIP][SPARK-35275][CORE] Add checksum for shuffle blocks and diagnose corruption

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/corruption/Cause.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/corruption/Cause.java
@@ -15,23 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.spark.shuffle.sort;
+package org.apache.spark.network.corruption;
 
-import java.io.File;
-
-import org.apache.spark.storage.TempShuffleBlockId;
-
-/**
- * Metadata for a block of data written by {@link ShuffleExternalSorter}.
- */
-final class SpillInfo {
-  final long[] partitionLengths;
-  final long[] partitionChecksums;
-  final File file;
-
-  SpillInfo(int numPartitions, File file, boolean checksumEnabled) {
-    this.partitionLengths = new long[numPartitions];
-    this.partitionChecksums = checksumEnabled ? new long[numPartitions] : new long[0];
-    this.file = file;
-  }
+public enum Cause {
+    DISK, NETWORK, UNKNOWN;
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -33,6 +33,7 @@ import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.client.RpcResponseCallback;
 import org.apache.spark.network.client.TransportClient;
 import org.apache.spark.network.client.TransportClientFactory;
+import org.apache.spark.network.corruption.Cause;
 import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
 import org.apache.spark.network.shuffle.protocol.GetLocalDirsForExecutors;
 import org.apache.spark.network.shuffle.protocol.LocalDirsForExecutors;
@@ -46,6 +47,15 @@ public abstract class BlockStoreClient implements Closeable {
 
   protected volatile TransportClientFactory clientFactory;
   protected String appId;
+
+  public Cause diagnoseCorruption(
+      String host,
+      int port,
+      String execId,
+      String blockId,
+      long checksum) {
+    return Cause.UNKNOWN;
+  }
 
   /**
    * Fetch a sequence of blocks from a remote node asynchronously,

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -90,7 +90,7 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
       String execId,
       String blockId,
       long checksum) {
-    return null;
+    return Cause.UNKNOWN;
   }
 
   @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -34,6 +34,7 @@ import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.client.RpcResponseCallback;
 import org.apache.spark.network.client.TransportClient;
 import org.apache.spark.network.client.TransportClientBootstrap;
+import org.apache.spark.network.corruption.Cause;
 import org.apache.spark.network.crypto.AuthClientBootstrap;
 import org.apache.spark.network.sasl.SecretKeyHolder;
 import org.apache.spark.network.server.NoOpRpcHandler;
@@ -80,6 +81,16 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
       bootstraps.add(new AuthClientBootstrap(conf, appId, secretKeyHolder));
     }
     clientFactory = context.createClientFactory(bootstraps);
+  }
+
+  @Override
+  public Cause diagnoseCorruption(
+      String host,
+      int port,
+      String execId,
+      String blockId,
+      long checksum) {
+    return null;
   }
 
   @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
@@ -48,7 +48,8 @@ public abstract class BlockTransferMessage implements Encodable {
     OPEN_BLOCKS(0), UPLOAD_BLOCK(1), REGISTER_EXECUTOR(2), STREAM_HANDLE(3), REGISTER_DRIVER(4),
     HEARTBEAT(5), UPLOAD_BLOCK_STREAM(6), REMOVE_BLOCKS(7), BLOCKS_REMOVED(8),
     FETCH_SHUFFLE_BLOCKS(9), GET_LOCAL_DIRS_FOR_EXECUTORS(10), LOCAL_DIRS_FOR_EXECUTORS(11),
-    PUSH_BLOCK_STREAM(12), FINALIZE_SHUFFLE_MERGE(13), MERGE_STATUSES(14);
+    PUSH_BLOCK_STREAM(12), FINALIZE_SHUFFLE_MERGE(13), MERGE_STATUSES(14),
+    DIAGNOSE_CORRUPTION(15), CORRUPTION_CAUSE(16);
 
     private final byte id;
 
@@ -82,6 +83,8 @@ public abstract class BlockTransferMessage implements Encodable {
         case 12: return PushBlockStream.decode(buf);
         case 13: return FinalizeShuffleMerge.decode(buf);
         case 14: return MergeStatuses.decode(buf);
+        case 15: return DiagnoseCorruption.decode(buf);
+        case 16: return CorruptionCause.decode(buf);
         default: throw new IllegalArgumentException("Unknown message type: " + type);
       }
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/CorruptionCause.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/CorruptionCause.java
@@ -27,48 +27,48 @@ public class CorruptionCause extends BlockTransferMessage {
     public Cause cause;
 
     public CorruptionCause(Cause cause) {
-        this.cause = cause;
+      this.cause = cause;
     }
 
     @Override
     protected Type type() {
-        return Type.CORRUPTION_CAUSE;
+      return Type.CORRUPTION_CAUSE;
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-          .append("cause", cause)
-          .toString();
+      return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("cause", cause)
+        .toString();
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
 
-        CorruptionCause that = (CorruptionCause) o;
-        return cause == that.cause;
+      CorruptionCause that = (CorruptionCause) o;
+      return cause == that.cause;
     }
 
     @Override
     public int hashCode() {
-        return cause.hashCode();
+      return cause.hashCode();
     }
 
     @Override
     public int encodedLength() {
-        return 4; /* encoded length of cause */
+      return 4; /* encoded length of cause */
     }
 
     @Override
     public void encode(ByteBuf buf) {
-        buf.writeInt(cause.ordinal());
+      buf.writeInt(cause.ordinal());
     }
 
     public static CorruptionCause decode(ByteBuf buf) {
-        int ordinal = buf.readInt();
-        return new CorruptionCause(Cause.values()[ordinal]);
+      int ordinal = buf.readInt();
+      return new CorruptionCause(Cause.values()[ordinal]);
     }
 
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/CorruptionCause.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/CorruptionCause.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.protocol;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.spark.network.corruption.Cause;
+
+/** Response to the {@link DiagnoseCorruption} */
+public class CorruptionCause extends BlockTransferMessage {
+    public Cause cause;
+
+    public CorruptionCause(Cause cause) {
+        this.cause = cause;
+    }
+
+    @Override
+    protected Type type() {
+        return Type.CORRUPTION_CAUSE;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+          .append("cause", cause)
+          .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CorruptionCause that = (CorruptionCause) o;
+        return cause == that.cause;
+    }
+
+    @Override
+    public int hashCode() {
+        return cause.hashCode();
+    }
+
+    @Override
+    public int encodedLength() {
+        return 4; /* encoded length of cause */
+    }
+
+    @Override
+    public void encode(ByteBuf buf) {
+        buf.writeInt(cause.ordinal());
+    }
+
+    public static CorruptionCause decode(ByteBuf buf) {
+        int ordinal = buf.readInt();
+        return new CorruptionCause(Cause.values()[ordinal]);
+    }
+
+}

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/DiagnoseCorruption.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/DiagnoseCorruption.java
@@ -38,7 +38,7 @@ public class DiagnoseCorruption extends BlockTransferMessage {
 
     @Override
     protected Type type() {
-        return Type.DIAGNOSE_CORRUPTION;
+      return Type.DIAGNOSE_CORRUPTION;
     }
 
     @Override
@@ -53,24 +53,24 @@ public class DiagnoseCorruption extends BlockTransferMessage {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
 
-        DiagnoseCorruption that = (DiagnoseCorruption) o;
+      DiagnoseCorruption that = (DiagnoseCorruption) o;
 
-        if (!appId.equals(that.appId)) return false;
-        if (!execId.equals(that.execId)) return false;
-        if (!blockId.equals(that.blockId)) return false;
-        return checksum == that.checksum;
+      if (!appId.equals(that.appId)) return false;
+      if (!execId.equals(that.execId)) return false;
+      if (!blockId.equals(that.blockId)) return false;
+      return checksum == that.checksum;
     }
 
     @Override
     public int hashCode() {
-        int result = appId.hashCode();
-        result = 31 * result + execId.hashCode();
-        result = 31 * result + blockId.hashCode();
-        result = 31 * result + (int) checksum;
-        return result;
+      int result = appId.hashCode();
+      result = 31 * result + execId.hashCode();
+      result = 31 * result + blockId.hashCode();
+      result = 31 * result + (int) checksum;
+      return result;
     }
 
     @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/DiagnoseCorruption.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/DiagnoseCorruption.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.protocol;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.spark.network.protocol.Encoders;
+
+/** Request to get the cause of a corrupted block. Returns {@link CorruptionCause} */
+public class DiagnoseCorruption extends BlockTransferMessage {
+    private final String appId;
+    private final String execId;
+    public final String blockId;
+    public final long checksum;
+
+    public DiagnoseCorruption(String appId, String execId, String blockId, long checksum) {
+      this.appId = appId;
+      this.execId = execId;
+      this.blockId = blockId;
+      this.checksum = checksum;
+    }
+
+    @Override
+    protected Type type() {
+        return Type.DIAGNOSE_CORRUPTION;
+    }
+
+    @Override
+    public String toString() {
+      return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("appId", appId)
+        .append("execId", execId)
+        .append("blockId", blockId)
+        .append("checksum", checksum)
+        .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DiagnoseCorruption that = (DiagnoseCorruption) o;
+
+        if (!appId.equals(that.appId)) return false;
+        if (!execId.equals(that.execId)) return false;
+        if (!blockId.equals(that.blockId)) return false;
+        return checksum == that.checksum;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = appId.hashCode();
+        result = 31 * result + execId.hashCode();
+        result = 31 * result + blockId.hashCode();
+        result = 31 * result + (int) checksum;
+        return result;
+    }
+
+    @Override
+    public int encodedLength() {
+      return Encoders.Strings.encodedLength(appId)
+        + Encoders.Strings.encodedLength(execId)
+        + Encoders.Strings.encodedLength(blockId)
+        + 8; /* encoded length of checksum */
+    }
+
+    @Override
+    public void encode(ByteBuf buf) {
+      Encoders.Strings.encode(buf, appId);
+      Encoders.Strings.encode(buf, execId);
+      Encoders.Strings.encode(buf, blockId);
+      buf.writeLong(checksum);
+    }
+
+    public static DiagnoseCorruption decode(ByteBuf buf) {
+      String appId = Encoders.Strings.decode(buf);
+      String execId = Encoders.Strings.decode(buf);
+      String blockId = Encoders.Strings.decode(buf);
+      long checksum = buf.readLong();
+      return new DiagnoseCorruption(appId, execId, blockId, checksum);
+    }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputCommitMessage.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputCommitMessage.java
@@ -36,25 +36,37 @@ import org.apache.spark.annotation.Private;
 public final class MapOutputCommitMessage {
 
   private final long[] partitionLengths;
+  private final long[] partitionChecksums;
   private final Optional<MapOutputMetadata> mapOutputMetadata;
 
   private MapOutputCommitMessage(
-      long[] partitionLengths, Optional<MapOutputMetadata> mapOutputMetadata) {
+      long[] partitionLengths,
+      long[] partitionChecksums,
+      Optional<MapOutputMetadata> mapOutputMetadata) {
     this.partitionLengths = partitionLengths;
+    this.partitionChecksums = partitionChecksums;
     this.mapOutputMetadata = mapOutputMetadata;
   }
 
   public static MapOutputCommitMessage of(long[] partitionLengths) {
-    return new MapOutputCommitMessage(partitionLengths, Optional.empty());
+    return new MapOutputCommitMessage(partitionLengths, null, Optional.empty());
+  }
+
+  public static MapOutputCommitMessage of(long[] partitionLengths, long[] partitionChecksums) {
+    return new MapOutputCommitMessage(partitionLengths, partitionChecksums, Optional.empty());
   }
 
   public static MapOutputCommitMessage of(
       long[] partitionLengths, MapOutputMetadata mapOutputMetadata) {
-    return new MapOutputCommitMessage(partitionLengths, Optional.of(mapOutputMetadata));
+    return new MapOutputCommitMessage(partitionLengths, null, Optional.of(mapOutputMetadata));
   }
 
   public long[] getPartitionLengths() {
     return partitionLengths;
+  }
+
+  public long[] getPartitionChecksums() {
+    return partitionChecksums;
   }
 
   public Optional<MapOutputMetadata> getMapOutputMetadata() {

--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Optional;
 import javax.annotation.Nullable;

--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -277,7 +277,8 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
         partitionLengths = spills[0].partitionLengths;
         logger.debug("Merge shuffle spills for mapId {} with length {}", mapId,
             partitionLengths.length);
-        maybeSingleFileWriter.get().transferMapSpillFile(spills[0].file, partitionLengths);
+        maybeSingleFileWriter.get()
+          .transferMapSpillFile(spills[0].file, partitionLengths, spills[0].partitionChecksums);
       } else {
         partitionLengths = mergeSpillsUsingStandardWriter(spills);
       }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
@@ -126,20 +126,6 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     log.debug("Writing shuffle index file for mapId {} with length {}", mapId,
         partitionLengths.length);
     blockResolver.writeMetadataFileAndCommit(shuffleId, mapId, partitionLengths, partitionChecksums, resolvedTmp);
-    // test
-    FileOutputStream f = new FileOutputStream(blockResolver.getDataFile(shuffleId, mapId), true);
-    long sum = 0;
-    for (long partitionLength : partitionLengths) {
-      sum += partitionLength;
-    }
-    // scalastyle:off
-    System.out.println("write 12 sum=" + sum);
-    f.write(12);
-    byte[] ba = new byte[1];
-    ba[0] = 12;
-    ByteBuffer buffer = ByteBuffer.wrap(ba);
-    f.getChannel().write(buffer, sum - 1);
-    f.close();
     return MapOutputCommitMessage.of(partitionLengths, partitionChecksums);
   }
 

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
@@ -150,7 +150,9 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     if (outputFileStream != null) {
       outputFileStream.close();
     }
-    checksumCal.reset();
+    if (checksumCal != null) {
+      checksumCal.reset();
+    }
   }
 
   private void initStream() throws IOException {

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
@@ -17,14 +17,14 @@
 
 package org.apache.spark.shuffle.sort.io;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.channels.FileChannel;
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.Optional;
+import java.util.zip.Adler32;
+import java.util.zip.CheckedOutputStream;
+import java.util.zip.Checksum;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +34,7 @@ import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
 import org.apache.spark.shuffle.api.ShufflePartitionWriter;
 import org.apache.spark.shuffle.api.WritableByteChannelWrapper;
 import org.apache.spark.internal.config.package$;
+import org.apache.spark.io.CountingWritableChannel;
 import org.apache.spark.shuffle.IndexShuffleBlockResolver;
 import org.apache.spark.shuffle.api.metadata.MapOutputCommitMessage;
 import org.apache.spark.util.Utils;
@@ -57,11 +58,15 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
   private long currChannelPosition;
   private long bytesWrittenToMergedFile = 0L;
 
+  private Checksum checksumCal = null;
+  private long[] partitionChecksums = new long[0];
+
   private final File outputFile;
   private File outputTempFile;
   private FileOutputStream outputFileStream;
-  private FileChannel outputFileChannel;
+  private CountingWritableChannel outputChannel;
   private BufferedOutputStream outputBufferedFileStream;
+  private CheckedOutputStream checkedOutputStream;
 
   public LocalDiskShuffleMapOutputWriter(
       int shuffleId,
@@ -76,6 +81,11 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
       (int) (long) sparkConf.get(
         package$.MODULE$.SHUFFLE_UNSAFE_FILE_OUTPUT_BUFFER_SIZE()) * 1024;
     this.partitionLengths = new long[numPartitions];
+    boolean checksumEnabled = (boolean) sparkConf.get(package$.MODULE$.SHUFFLE_CHECKSUM());
+    if (checksumEnabled) {
+      this.checksumCal = new Adler32();
+      this.partitionChecksums = new long[numPartitions];
+    }
     this.outputFile = blockResolver.getDataFile(shuffleId, mapId);
     this.outputTempFile = null;
   }
@@ -89,8 +99,8 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     if (outputTempFile == null) {
       outputTempFile = Utils.tempFileWith(outputFile);
     }
-    if (outputFileChannel != null) {
-      currChannelPosition = outputFileChannel.position();
+    if (outputChannel != null) {
+      currChannelPosition = outputChannel.getCount();
     } else {
       currChannelPosition = 0L;
     }
@@ -100,12 +110,12 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
   @Override
   public MapOutputCommitMessage commitAllPartitions() throws IOException {
     // Check the position after transferTo loop to see if it is in the right position and raise a
-    // exception if it is incorrect. The position will not be increased to the expected length
+    // exception if it is incorrect. The po sition will not be increased to the expected length
     // after calling transferTo in kernel version 2.6.32. This issue is described at
     // https://bugs.openjdk.java.net/browse/JDK-7052359 and SPARK-3948.
-    if (outputFileChannel != null && outputFileChannel.position() != bytesWrittenToMergedFile) {
+    if (outputChannel != null && outputChannel.getCount() != bytesWrittenToMergedFile) {
       throw new IOException(
-          "Current position " + outputFileChannel.position() + " does not equal expected " +
+          "Current position " + outputChannel.getCount() + " does not equal expected " +
               "position " + bytesWrittenToMergedFile + " after transferTo. Please check your " +
               " kernel version to see if it is 2.6.32, as there is a kernel bug which will lead " +
               "to unexpected behavior when using transferTo. You can set " +
@@ -115,8 +125,22 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     File resolvedTmp = outputTempFile != null && outputTempFile.isFile() ? outputTempFile : null;
     log.debug("Writing shuffle index file for mapId {} with length {}", mapId,
         partitionLengths.length);
-    blockResolver.writeIndexFileAndCommit(shuffleId, mapId, partitionLengths, resolvedTmp);
-    return MapOutputCommitMessage.of(partitionLengths);
+    blockResolver.writeMetadataFileAndCommit(shuffleId, mapId, partitionLengths, partitionChecksums, resolvedTmp);
+    // test
+    FileOutputStream f = new FileOutputStream(blockResolver.getDataFile(shuffleId, mapId), true);
+    long sum = 0;
+    for (long partitionLength : partitionLengths) {
+      sum += partitionLength;
+    }
+    // scalastyle:off
+    System.out.println("write 12 sum=" + sum);
+    f.write(12);
+    byte[] ba = new byte[1];
+    ba[0] = 12;
+    ByteBuffer buffer = ByteBuffer.wrap(ba);
+    f.getChannel().write(buffer, sum - 1);
+    f.close();
+    return MapOutputCommitMessage.of(partitionLengths, partitionChecksums);
   }
 
   @Override
@@ -131,28 +155,38 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     if (outputBufferedFileStream != null) {
       outputBufferedFileStream.close();
     }
-    if (outputFileChannel != null) {
-      outputFileChannel.close();
+    if (outputChannel != null) {
+      outputChannel.close();
+    }
+    if (checkedOutputStream != null) {
+      checkedOutputStream.close();
     }
     if (outputFileStream != null) {
       outputFileStream.close();
     }
+    checksumCal.reset();
   }
 
   private void initStream() throws IOException {
     if (outputFileStream == null) {
       outputFileStream = new FileOutputStream(outputTempFile, true);
     }
+    if (checksumCal != null && checkedOutputStream == null) {
+      checkedOutputStream = new CheckedOutputStream(outputFileStream, checksumCal);
+    }
     if (outputBufferedFileStream == null) {
-      outputBufferedFileStream = new BufferedOutputStream(outputFileStream, bufferSize);
+      outputBufferedFileStream = new BufferedOutputStream(
+        checksumCal != null ? checkedOutputStream : outputFileStream, bufferSize);
     }
   }
 
   private void initChannel() throws IOException {
     // This file needs to opened in append mode in order to work around a Linux kernel bug that
     // affects transferTo; see SPARK-3948 for more details.
-    if (outputFileChannel == null) {
-      outputFileChannel = new FileOutputStream(outputTempFile, true).getChannel();
+    if (outputChannel == null) {
+      FileOutputStream fileOut = new FileOutputStream(outputTempFile, true);
+      OutputStream out = checksumCal != null ? new CheckedOutputStream(fileOut, checksumCal) : fileOut;
+      outputChannel = new CountingWritableChannel(Channels.newChannel(out));
     }
   }
 
@@ -169,7 +203,7 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     @Override
     public OutputStream openStream() throws IOException {
       if (partStream == null) {
-        if (outputFileChannel != null) {
+        if (outputChannel != null) {
           throw new IllegalStateException("Requested an output channel for a previous write but" +
               " now an output stream has been requested. Should not be using both channels" +
               " and streams to write.");
@@ -243,6 +277,10 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
       isClosed = true;
       partitionLengths[partitionId] = count;
       bytesWrittenToMergedFile += count;
+      if (checksumCal != null) {
+        partitionChecksums[partitionId] = checksumCal.getValue();
+        checksumCal.reset();
+      }
     }
 
     private void verifyNotClosed() {
@@ -261,19 +299,23 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     }
 
     public long getCount() throws IOException {
-      long writtenPosition = outputFileChannel.position();
+      long writtenPosition = outputChannel.getCount();
       return writtenPosition - currChannelPosition;
     }
 
     @Override
     public WritableByteChannel channel() {
-      return outputFileChannel;
+      return outputChannel;
     }
 
     @Override
     public void close() throws IOException {
       partitionLengths[partitionId] = getCount();
       bytesWrittenToMergedFile += partitionLengths[partitionId];
+      if (checksumCal != null) {
+        partitionChecksums[partitionId] = checksumCal.getValue();
+        checksumCal.reset();
+      }
     }
   }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskSingleSpillMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskSingleSpillMapOutputWriter.java
@@ -44,12 +44,14 @@ public class LocalDiskSingleSpillMapOutputWriter
   @Override
   public void transferMapSpillFile(
       File mapSpillFile,
-      long[] partitionLengths) throws IOException {
+      long[] partitionLengths,
+      long[] partitionChecksums) throws IOException {
     // The map spill file already has the proper format, and it contains all of the partition data.
     // So just transfer it directly to the destination without any merging.
     File outputFile = blockResolver.getDataFile(shuffleId, mapId);
     File tempFile = Utils.tempFileWith(outputFile);
     Files.move(mapSpillFile.toPath(), tempFile.toPath());
-    blockResolver.writeIndexFileAndCommit(shuffleId, mapId, partitionLengths, tempFile);
+    blockResolver.writeMetadataFileAndCommit(
+      shuffleId, mapId, partitionLengths, partitionChecksums, tempFile);
   }
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1359,6 +1359,14 @@ package object config {
         s"The buffer size must be greater than 0 and less than or equal to ${Int.MaxValue}.")
       .createWithDefault(4096)
 
+  private[spark] val SHUFFLE_CHECKSUM =
+    ConfigBuilder("spark.shuffle.checksum")
+      .doc("Whether to calculate the checksum of shuffle output. If enabled, Spark will try " +
+        "its best to tell if shuffle data corruption is caused by network or disk or others.")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(true)
+
   private[spark] val SHUFFLE_COMPRESS =
     ConfigBuilder("spark.shuffle.compress")
       .doc("Whether to compress shuffle output. Compression will use " +

--- a/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
@@ -22,10 +22,13 @@ import scala.reflect.ClassTag
 import org.apache.spark.TaskContext
 import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.client.StreamCallbackWithID
+import org.apache.spark.network.corruption.Cause
 import org.apache.spark.storage.{BlockId, StorageLevel}
 
 private[spark]
 trait BlockDataManager {
+
+  def diagnoseShuffleBlockCorruption(blockId: BlockId, clientChecksum: Long): Cause
 
   /**
    * Get the local directories that used by BlockManager to save the blocks to disk

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
@@ -54,6 +54,11 @@ class NettyBlockRpcServer(
     logTrace(s"Received request: $message")
 
     message match {
+      case diagnose: DiagnoseCorruption =>
+        val cause = blockManager
+          .diagnoseShuffleBlockCorruption(BlockId.apply(diagnose.blockId), diagnose.checksum)
+        responseContext.onSuccess(new CorruptionCause(cause).toByteBuffer)
+
       case openBlocks: OpenBlocks =>
         val blocksNum = openBlocks.blockIds.length
         val blocks = (0 until blocksNum).map { i =>

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -127,8 +127,6 @@ private[spark] class NettyBlockTransferService(
 
         override def onFailure(e: Throwable): Unit = {
           logger.warn("Failed to get the corruption cause.", e)
-          // scalastyle:off
-          println(s"NOT THIS UNKNOWN-2 ${e.getMessage}")
           result.success(Cause.UNKNOWN)
         }
     })
@@ -140,8 +138,6 @@ private[spark] class NettyBlockTransferService(
     } catch {
       case _: TimeoutException =>
         logger.warn("Failed to get the corruption cause due to timeout.")
-        // scalastyle:off
-        println("NOT THIS UNKNOWN-3")
         Cause.UNKNOWN
     }
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1762,7 +1762,7 @@ private[spark] class DAGScheduler(
           }
 
           if (shouldAbortStage) {
-            val abortMessage = if (disallowStageRetryForTest) {
+            val abortMessage = if (false) {
               "Fetch failure will not retry stage due to testing config"
             } else {
               s"""$failedStage (${failedStage.name})

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -410,10 +410,7 @@ private[spark] class IndexShuffleBlockResolver(
             if (checksumFile.exists()) {
               checksumFile.delete()
             }
-            // scalastyle:off
-            println(checksumFile.toString)
             if (!checksumTmp.renameTo(checksumFile)) {
-              println("FAILED to rename checksumFile")
               // It's not worthwhile to fail here after index file and data file are already
               // successfully stored due to checksum is only used for the corner error case.
               logWarning("fail to rename file " + checksumTmp + " to " + checksumFile)

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -81,6 +81,11 @@ case class ShuffleIndexBlockId(shuffleId: Int, mapId: Long, reduceId: Int) exten
   override def name: String = "shuffle_" + shuffleId + "_" + mapId + "_" + reduceId + ".index"
 }
 
+@DeveloperApi
+case class ShuffleChecksumBlockId(shuffleId: Int, mapId: Long, reduceId: Int) extends BlockId {
+  override def name: String = "shuffle_" + shuffleId + "_" + mapId + "_" + reduceId + ".checksum"
+}
+
 @Since("3.2.0")
 @DeveloperApi
 case class ShufflePushBlockId(shuffleId: Int, mapIndex: Int, reduceId: Int) extends BlockId {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -298,28 +298,21 @@ private[spark] class BlockManager(
         val buffer = new Array[Byte](8192)
         while (checksumIn.read(buffer, 0, 8192) != -1) {}
         val recalculatedChecksum = checksumIn.getChecksum.getValue
-        // scalastyle:off
-        println(s"golden=${goldenChecksum}")
-        println(s"Recal=${recalculatedChecksum}")
-        println(s"client=${clientChecksum}")
         if (goldenChecksum != recalculatedChecksum) {
           Cause.DISK
         } else if (goldenChecksum != clientChecksum) {
           Cause.NETWORK
         } else {
-          println("NOT THIS UNKNONW-4")
           Cause.UNKNOWN
         }
       } catch {
         case NonFatal(e) =>
           logWarning("Exception throws while diagnosing shuffle block corruption.", e)
-          println(s"NOT THIS UNKNONW-5 ${e}")
           Cause.UNKNOWN
       } finally {
         in.close()
       }
     } else {
-      println(s"NOT THIS UNKNONW-6")
       println(checksumFile.toString)
       // Even if checksum is enabled, a checksum file may not exist if error throws during writing.
       Cause.UNKNOWN

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -313,7 +313,6 @@ private[spark] class BlockManager(
         in.close()
       }
     } else {
-      println(checksumFile.toString)
       // Even if checksum is enabled, a checksum file may not exist if error throws during writing.
       Cause.UNKNOWN
     }

--- a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
@@ -31,6 +31,7 @@ import org.apache.commons.io.FileUtils
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.io.CountingWritableChannel
 import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.util.{AbstractFileRegion, JavaUtils}
 import org.apache.spark.security.CryptoStreamUtils
@@ -327,24 +328,4 @@ private class ReadableChannelFileRegion(source: ReadableByteChannel, blockSize: 
   }
 
   override def deallocate(): Unit = source.close()
-}
-
-private class CountingWritableChannel(sink: WritableByteChannel) extends WritableByteChannel {
-
-  private var count = 0L
-
-  def getCount: Long = count
-
-  override def write(src: ByteBuffer): Int = {
-    val written = sink.write(src)
-    if (written > 0) {
-      count += written
-    }
-    written
-  }
-
-  override def isOpen(): Boolean = sink.isOpen()
-
-  override def close(): Unit = sink.close()
-
 }

--- a/core/src/main/scala/org/apache/spark/storage/FileSegment.scala
+++ b/core/src/main/scala/org/apache/spark/storage/FileSegment.scala
@@ -23,10 +23,15 @@ import java.io.File
  * References a particular segment of a file (potentially the entire file),
  * based off an offset and a length.
  */
-private[spark] class FileSegment(val file: File, val offset: Long, val length: Long) {
+private[spark] class FileSegment(
+    val file: File,
+    val offset: Long,
+    val length: Long,
+    val checksum: Option[Long] = None) {
   require(offset >= 0, s"File segment offset cannot be negative (got $offset)")
   require(length >= 0, s"File segment length cannot be negative (got $length)")
   override def toString: String = {
-    "(name=%s, offset=%d, length=%d)".format(file.getName, offset, length)
+    val checksumStr = checksum.map(c => s", checksum=$c").getOrElse("")
+    s"(name=${file.getName}, offset=$offset, length=$length$checksumStr)"
   }
 }

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -870,8 +870,6 @@ private class BufferReleasingInputStream(
     if (!closed) {
       delegate.close()
       iterator.releaseCurrentResultBuffer()
-      // scalastyle:off
-      println("buffer released")
       closed = true
     }
   }

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -902,7 +902,6 @@ private class BufferReleasingInputStream(
     } catch {
       case e: IOException if detectCorruption =>
         val message = checkedInOpt.map { checkedIn =>
-          println("diagnoseCorruption")
           val cause = iterator.diagnoseCorruption(checkedIn, address, blockId)
           s"Block $blockId is corrupted due to $cause"
         }.orNull

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -903,7 +903,7 @@ private class BufferReleasingInputStream(
       case e: IOException if detectCorruption =>
         val message = checkedInOpt.map { checkedIn =>
           val cause = iterator.diagnoseCorruption(checkedIn, address, blockId)
-          s"Block $blockId is corrupted due to $cause"
+          s"Block $blockId is corrupted due to $cause issue"
         }.orNull
         IOUtils.closeQuietly(this)
         // We'd never retry the block whatever the cause is since the block has been

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -152,11 +152,13 @@ public class UnsafeShuffleWriterSuite {
 
     doAnswer(renameTempAnswer)
         .when(shuffleBlockResolver)
-        .writeIndexFileAndCommit(anyInt(), anyLong(), any(long[].class), any(File.class));
+        .writeMetadataFileAndCommit(
+           anyInt(), anyLong(), any(long[].class), any(long[].class), any(File.class));
 
     doAnswer(renameTempAnswer)
         .when(shuffleBlockResolver)
-        .writeIndexFileAndCommit(anyInt(), anyLong(), any(long[].class), eq(null));
+        .writeMetadataFileAndCommit(
+           anyInt(), anyLong(), any(long[].class), any(long[].class), eq(null));
 
     when(diskBlockManager.createTempShuffleBlock()).thenAnswer(invocationOnMock -> {
       TempShuffleBlockId blockId = new TempShuffleBlockId(UUID.randomUUID());

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
@@ -76,8 +76,8 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
     when(blockManager.diskBlockManager).thenReturn(diskBlockManager)
     when(taskContext.taskMemoryManager()).thenReturn(taskMemoryManager)
 
-    when(blockResolver.writeIndexFileAndCommit(
-      anyInt, anyLong, any(classOf[Array[Long]]), any(classOf[File])))
+    when(blockResolver.writeMetadataFileAndCommit(
+      anyInt, anyLong, any(classOf[Array[Long]]), any(classOf[Array[Long]]), any(classOf[File])))
       .thenAnswer { invocationOnMock =>
         val tmp = invocationOnMock.getArguments()(3).asInstanceOf[File]
         if (tmp != null) {

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -72,7 +72,7 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
     } {
       out.close()
     }
-    resolver.writeIndexFileAndCommit(shuffleId, mapId, lengths, dataTmp)
+    resolver.writeMetadataFileAndCommit(shuffleId, mapId, lengths, Array.empty[Long], dataTmp)
 
     val indexFile = new File(tempDir.getAbsolutePath, idxName)
     val dataFile = resolver.getDataFile(shuffleId, mapId)
@@ -92,7 +92,7 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
     } {
       out2.close()
     }
-    resolver.writeIndexFileAndCommit(shuffleId, mapId, lengths2, dataTmp2)
+    resolver.writeMetadataFileAndCommit(shuffleId, mapId, lengths2, Array.empty[Long], dataTmp2)
 
     assert(indexFile.length() === (lengths.length + 1) * 8)
     assert(lengths2.toSeq === lengths.toSeq)
@@ -131,7 +131,7 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
     } {
       out3.close()
     }
-    resolver.writeIndexFileAndCommit(shuffleId, mapId, lengths3, dataTmp3)
+    resolver.writeMetadataFileAndCommit(shuffleId, mapId, lengths3, Array.empty[Long], dataTmp3)
     assert(indexFile.length() === (lengths3.length + 1) * 8)
     assert(lengths3.toSeq != lengths.toSeq)
     assert(dataFile.exists())

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
@@ -74,8 +74,8 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
       .set("spark.app.id", "example.spark.app")
       .set("spark.shuffle.unsafe.file.output.buffer", "16k")
     when(blockResolver.getDataFile(anyInt, anyLong)).thenReturn(mergedOutputFile)
-    when(blockResolver.writeIndexFileAndCommit(
-      anyInt, anyLong, any(classOf[Array[Long]]), any(classOf[File])))
+    when(blockResolver.writeMetadataFileAndCommit(
+      anyInt, anyLong, any(classOf[Array[Long]]), any(classOf[Array[Long]]), any(classOf[File])))
       .thenAnswer { invocationOnMock =>
         partitionSizesInMergedFile = invocationOnMock.getArguments()(2).asInstanceOf[Array[Long]]
         val tmp: File = invocationOnMock.getArguments()(3).asInstanceOf[File]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to add checksum support for shuffle blocks. The basic idea is: 

On the mapper side, we'll wrap a `CheckedOutputStream` upon the `FileOutputStream` to calculate the checksum (use the same checksum calculator `Adler32` with broadcast) for each shuffle block (a.k.a partition) at the same time when we writing map output files.  And similar to the index file, we'll have a checksum file to save these checksums.

On the reducer side, we'll also wrap a `CheckedInputStream` upon the `FileInputStream` to read the block.  When block corruption is detected, we'll try to diagnose corruption for the cause:

First, we'll use the `CheckedInputStream` to consume the remaining data of the corrupted block to calculate the checksum (`c1`);

Second, the reducer send an RPC request called `DiagnoseCorruption` (which contains `c1`) to the server (where the reducer executed)

Third, the server will read (using a very small memory) the corresponding block back from the disk and calculate the checksum (`c2`) again for it. And also read back the checksum(`c3`) of the block saved in the checksum file. Then, if `c2 != c3`, we'll suspect the corruption is caused by the disk issue. Otherwise, if `c1 != c3`, we'll suspect the corruption is caused by the network issue. Otherwise, the cause remains unknown. The server then will reply to the reducer with `CorruptionCause` containing the cause.

Fourth, the reducer needs to take action after it receives the cause. If it's a disk issue or unknown, it will throw fetch failure directly. If it's a network issue, it will re-fetch the block later. Also note that, if the corruption happens inside `BufferReleasingInputStream`, the reducer will throw the fetch failure immediately no matter what the cause is since the data has been partially consumed by downstream RDDs.  If corruption happens again after retry, the reducer will throw the fetch failure directly this time without the diagnosis.

Overall, I think we don't introduce severe overhead with this proposal. In a normal case, the checksum is calculated in the streaming way as well as other streams, e.g., encryption, compression. And the major overhead here is that we need an extra data file traverse in the error case in order to calculate the checksum (`c2`).

And the proposal in this PR is much simpler compared to the previous one https://github.com/apache/spark/pull/15894/ (abandoned due to complexity ), which introduce more overhead as it need to traverse the data file twice for every block. In that proposal, the checksum is appended to each block data, so it's also invasive to the existing code.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Shuffle data corruption is a long-standing issue in Spark. For example, in SPARK-18105, people continually reports corruption issue. However, data corruption is difficult to reproduce in most cases and even harder to tell the root cause. We don't know if it's a Spark issue or not.  With the checksum support for the shuffle, Spark itself can at least distinguish the cause between disk and network, which is very important for users.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes.  

1) Added a conf `spark.shuffle.checksum` to let user enables/disables the checksum (enabled by default)
2) With checksum enabled, users can know the possible cause of corruption rather than "Stream is corrupted" only.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added an end-to-end unit test in `ShuffleSuite`.

I'll add more tests if the community accepts the proposal.
