### PR TITLE
[SPARK-35258][SHUFFLE][YARN] Add new metrics to ExternalShuffleService for better monitoring

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -107,10 +107,10 @@ public class ExternalBlockHandler extends RpcHandler
       OneForOneStreamManager streamManager,
       ExternalShuffleBlockResolver blockManager,
       MergedShuffleFileManager mergeManager) {
+    this.metrics = new ShuffleMetrics();
     this.streamManager = streamManager;
     this.blockManager = blockManager;
     this.mergeManager = mergeManager;
-    this.metrics = new ShuffleMetrics();
   }
 
   @Override
@@ -332,7 +332,7 @@ public class ExternalBlockHandler extends RpcHandler
         }
       });
       allMetrics.put("registeredExecutorsSize",
-          (Gauge<Integer>) blockManager::getRegisteredExecutorsSize);
+                     (Gauge<Integer>) () -> blockManager.getRegisteredExecutorsSize());
       allMetrics.put("numActiveConnections", activeConnections);
       allMetrics.put("numCaughtExceptions", caughtExceptions);
     }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
@@ -20,8 +20,10 @@ package org.apache.spark.network.shuffle;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
+import java.util.Map;
 
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
 import org.junit.Before;
 import org.junit.Test;
@@ -103,7 +105,7 @@ public class ExternalBlockHandlerSuite {
 
     verify(blockResolver, times(1)).getBlockData("app0", "exec1", 0, 0, 0);
     verify(blockResolver, times(1)).getBlockData("app0", "exec1", 0, 0, 1);
-    verifyOpenBlockLatencyMetrics();
+    verifyOpenBlockLatencyMetrics(2);
   }
 
   @Test
@@ -117,7 +119,7 @@ public class ExternalBlockHandlerSuite {
 
     verify(blockResolver, times(1)).getBlockData("app0", "exec1", 0, 0, 0);
     verify(blockResolver, times(1)).getBlockData("app0", "exec1", 0, 0, 1);
-    verifyOpenBlockLatencyMetrics();
+    verifyOpenBlockLatencyMetrics(2);
   }
 
   @Test
@@ -133,7 +135,7 @@ public class ExternalBlockHandlerSuite {
     checkOpenBlocksReceive(fetchShuffleBlocks, batchBlockMarkers);
 
     verify(blockResolver, times(1)).getContinuousBlocksData("app0", "exec1", 0, 0, 0, 1);
-    verifyOpenBlockLatencyMetrics();
+    verifyOpenBlockLatencyMetrics(1);
   }
 
   @Test
@@ -147,7 +149,7 @@ public class ExternalBlockHandlerSuite {
 
     verify(blockResolver, times(1)).getRddBlockData("app0", "exec1", 0, 0);
     verify(blockResolver, times(1)).getRddBlockData("app0", "exec1", 0, 1);
-    verifyOpenBlockLatencyMetrics();
+    verifyOpenBlockLatencyMetrics(2);
   }
 
   @Test
@@ -195,17 +197,16 @@ public class ExternalBlockHandlerSuite {
     assertFalse(buffers.hasNext());
   }
 
-  private void verifyOpenBlockLatencyMetrics() {
-    Timer openBlockRequestLatencyMillis = (Timer) ((ExternalBlockHandler) handler)
+  private void verifyOpenBlockLatencyMetrics(int blockTransferCount) {
+    Map<String, Metric> metricMap = ((ExternalBlockHandler) handler)
         .getAllMetrics()
-        .getMetrics()
-        .get("openBlockRequestLatencyMillis");
+        .getMetrics();
+    Timer openBlockRequestLatencyMillis = (Timer) metricMap.get("openBlockRequestLatencyMillis");
     assertEquals(1, openBlockRequestLatencyMillis.getCount());
     // Verify block transfer metrics
-    Meter blockTransferRateBytes = (Meter) ((ExternalBlockHandler) handler)
-        .getAllMetrics()
-        .getMetrics()
-        .get("blockTransferRateBytes");
+    Meter blockTransferRate = (Meter) metricMap.get("blockTransferRate");
+    assertEquals(blockTransferCount, blockTransferRate.getCount());
+    Meter blockTransferRateBytes = (Meter) metricMap.get("blockTransferRateBytes");
     assertEquals(10, blockTransferRateBytes.getCount());
   }
 

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
@@ -101,7 +101,7 @@ class YarnShuffleServiceMetrics implements MetricsSource {
             percentileStr = "99.9thPercentile";
             break;
           default:
-            percentileStr = String.format("%d%sPercentile", percentileThousands / 10, "th");
+            percentileStr = String.format("%dthPercentile", percentileThousands / 10);
             break;
         }
         metricsRecordBuilder.addGauge(

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
@@ -98,7 +98,7 @@ class YarnShuffleServiceMetrics implements MetricsSource {
             percentileStr = "1stPercentile";
             break;
           case 999:
-            percentileStr = "99.9thPercentile";
+            percentileStr = "999thPercentile";
             break;
           default:
             percentileStr = String.format("%dthPercentile", percentileThousands / 10);

--- a/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceMetricsSuite.scala
@@ -53,7 +53,9 @@ class ExternalShuffleServiceMetricsSuite extends SparkFunSuite {
     val source = sourceRef.get(externalShuffleService).asInstanceOf[ExternalShuffleServiceSource]
     assert(source.metricRegistry.getMetrics.keySet().asScala ==
       Set(
+        "blockTransferRate",
         "blockTransferRateBytes",
+        "blockTransferAvgSize_1min",
         "numActiveConnections",
         "numCaughtExceptions",
         "numRegisteredConnections",

--- a/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceMetricsSuite.scala
@@ -51,8 +51,9 @@ class ExternalShuffleServiceMetricsSuite extends SparkFunSuite {
     val sourceRef = classOf[ExternalShuffleService].getDeclaredField("shuffleServiceSource")
     sourceRef.setAccessible(true)
     val source = sourceRef.get(externalShuffleService).asInstanceOf[ExternalShuffleServiceSource]
-    assert(source.metricRegistry.getMetrics.keySet().asScala ==
-      Set(
+    // Use sorted Seq instead of Set for easier comparison when there is a mismatch
+    assert(source.metricRegistry.getMetrics.keySet().asScala.toSeq.sorted ==
+      Seq(
         "blockTransferRate",
         "blockTransferRateBytes",
         "blockTransferAvgSize_1min",
@@ -65,7 +66,7 @@ class ExternalShuffleServiceMetricsSuite extends SparkFunSuite {
         "shuffle-server.usedDirectMemory",
         "shuffle-server.usedHeapMemory",
         "finalizeShuffleMergeLatencyMillis",
-        "fetchMergedBlocksMetaLatencyMillis")
+        "fetchMergedBlocksMetaLatencyMillis").sorted
     )
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceMetricsSuite.scala
@@ -55,6 +55,7 @@ class ExternalShuffleServiceMetricsSuite extends SparkFunSuite {
     assert(source.metricRegistry.getMetrics.keySet().asScala.toSeq.sorted ==
       Seq(
         "blockTransferRate",
+        "blockTransferMessageRate",
         "blockTransferRateBytes",
         "blockTransferAvgSize_1min",
         "numActiveConnections",

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1377,7 +1377,9 @@ Note: applies when running in Spark standalone as worker
 ### Component instance = shuffleService
 Note: applies to the shuffle service
 
-- blockTransferRate (meter)
+- blockTransferRate (meter) - rate of blocks being transferred
+- blockTransferMessageRate (meter) - rate of block transfer messages,
+  i.e. if batch fetches are enabled, this represents number of batches rather than number of blocks
 - blockTransferRateBytes (meter)
 - blockTransferAvgTime_1min (gauge - 1-minute moving average)
 - numActiveConnections.count

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1379,7 +1379,7 @@ Note: applies to the shuffle service
 
 - blockTransferRate (meter)
 - blockTransferRateBytes (meter)
-- blockTransferAvgTime_1min (gauge - 1 minute moving average)
+- blockTransferAvgTime_1min (gauge - 1-minute moving average)
 - numActiveConnections.count
 - numRegisteredConnections.count
 - numCaughtExceptions.count

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1377,7 +1377,9 @@ Note: applies when running in Spark standalone as worker
 ### Component instance = shuffleService
 Note: applies to the shuffle service
 
+- blockTransferRate (meter)
 - blockTransferRateBytes (meter)
+- blockTransferAvgTime_1min (gauge - 1 minute moving average)
 - numActiveConnections.count
 - numRegisteredConnections.count
 - numCaughtExceptions.count

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
@@ -85,7 +85,8 @@ class YarnShuffleServiceMetricsSuite extends SparkFunSuite with Matchers {
             Seq("rate1", "rate5", "rate15", "rateMean", "nanos_mean", "nanos_stdDev",
               "nanos_1stPercentile", "nanos_5thPercentile", "nanos_25thPercentile",
               "nanos_50thPercentile", "nanos_75thPercentile", "nanos_95thPercentile",
-              "nanos_99thPercentile").map(suffix => s"${testname}_$suffix")
+              "nanos_98thPercentile", "nanos_99thPercentile", "nanos_99.9thPercentile")
+                .map(suffix => s"${testname}_$suffix")
         )
       }
       assert(gaugeLongNames.sorted === expectLong.sorted)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
@@ -86,7 +86,7 @@ class YarnShuffleServiceMetricsSuite extends SparkFunSuite with Matchers {
               Seq("rate1", "rate5", "rate15", "rateMean", "nanos_mean", "nanos_stdDev",
                 "nanos_1stPercentile", "nanos_5thPercentile", "nanos_25thPercentile",
                 "nanos_50thPercentile", "nanos_75thPercentile", "nanos_95thPercentile",
-                "nanos_98thPercentile", "nanos_99thPercentile", "nanos_99.9thPercentile")
+                "nanos_98thPercentile", "nanos_99thPercentile", "nanos_999thPercentile")
                   .map(suffix => s"${testname}_$suffix")
           )
         }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceMetricsSuite.scala
@@ -17,10 +17,11 @@
 package org.apache.spark.network.yarn
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
-import org.apache.hadoop.metrics2.MetricsRecordBuilder
+import org.apache.hadoop.metrics2.{MetricsInfo, MetricsRecordBuilder}
 import org.mockito.ArgumentMatchers.{any, anyDouble, anyInt, anyLong}
-import org.mockito.Mockito.{mock, times, verify, when}
+import org.mockito.Mockito.{mock, verify, when}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
@@ -37,29 +38,58 @@ class YarnShuffleServiceMetricsSuite extends SparkFunSuite with Matchers {
   val metrics = new ExternalBlockHandler(streamManager, blockResolver).getAllMetrics
 
   test("metrics named as expected") {
-    val allMetrics = Set(
+    val allMetrics = Seq(
       "openBlockRequestLatencyMillis", "registerExecutorRequestLatencyMillis",
+      "blockTransferRate", "blockTransferAvgSize_1min",
       "blockTransferRateBytes", "registeredExecutorsSize", "numActiveConnections",
       "numCaughtExceptions", "finalizeShuffleMergeLatencyMillis",
       "fetchMergedBlocksMetaLatencyMillis")
 
-    metrics.getMetrics.keySet().asScala should be (allMetrics)
+    // Use sorted Seq instead of Set for easier comparison when there is a mismatch
+    metrics.getMetrics.keySet().asScala.toSeq.sorted should be (allMetrics.sorted)
   }
 
-  // these three metrics have the same effect on the collector
+  // these metrics will generate more metrics on the collector
   for (testname <- Seq("openBlockRequestLatencyMillis",
       "registerExecutorRequestLatencyMillis",
-      "blockTransferRateBytes")) {
+      "blockTransferRateBytes", "blockTransferRate")) {
     test(s"$testname - collector receives correct types") {
       val builder = mock(classOf[MetricsRecordBuilder])
-      when(builder.addCounter(any(), anyLong())).thenReturn(builder)
-      when(builder.addGauge(any(), anyDouble())).thenReturn(builder)
+      val counterNames = mutable.Buffer[String]()
+      when(builder.addCounter(any(), anyLong())).thenAnswer(iom => {
+        counterNames += iom.getArgument[MetricsInfo](0).name()
+        builder
+      })
+      val gaugeLongNames = mutable.Buffer[String]()
+      when(builder.addGauge(any(), anyLong())).thenAnswer(iom => {
+        gaugeLongNames += iom.getArgument[MetricsInfo](0).name()
+        builder
+      })
+      val gaugeDoubleNames = mutable.Buffer[String]()
+      when(builder.addGauge(any(), anyDouble())).thenAnswer(iom => {
+        gaugeDoubleNames += iom.getArgument[MetricsInfo](0).name()
+        builder
+      })
 
       YarnShuffleServiceMetrics.collectMetric(builder, testname,
         metrics.getMetrics.get(testname))
 
-      verify(builder).addCounter(any(), anyLong())
-      verify(builder, times(4)).addGauge(any(), anyDouble())
+      assert(counterNames === Seq(s"${testname}_count"))
+      val (expectLong, expectDouble) = if (testname.matches("blockTransferRate(Bytes)?$")) {
+        // blockTransferRate(Bytes)? metrics are Meter so just have rate information
+        (Seq(), Seq("1", "5", "15", "Mean").map(suffix => s"${testname}_rate$suffix"))
+      } else {
+        // other metrics are Timer so have rate and timing information
+        (
+            Seq(s"${testname}_nanos_max", s"${testname}_nanos_min"),
+            Seq("rate1", "rate5", "rate15", "rateMean", "nanos_mean", "nanos_stdDev",
+              "nanos_1stPercentile", "nanos_5thPercentile", "nanos_25thPercentile",
+              "nanos_50thPercentile", "nanos_75thPercentile", "nanos_95thPercentile",
+              "nanos_99thPercentile").map(suffix => s"${testname}_$suffix")
+        )
+      }
+      assert(gaugeLongNames.sorted === expectLong.sorted)
+      assert(gaugeDoubleNames.sorted === expectDouble.sorted)
     }
   }
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -403,7 +403,9 @@ class YarnShuffleServiceSuite extends SparkFunSuite with Matchers with BeforeAnd
     val metrics = metricSetRef.get(metricsSource).asInstanceOf[MetricSet].getMetrics
 
     assert(metrics.keySet().asScala == Set(
+      "blockTransferRate",
       "blockTransferRateBytes",
+      "blockTransferAvgSize_1min",
       "numActiveConnections",
       "numCaughtExceptions",
       "numRegisteredConnections",

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -405,6 +405,7 @@ class YarnShuffleServiceSuite extends SparkFunSuite with Matchers with BeforeAnd
     // Use sorted Seq instead of Set for easier comparison when there is a mismatch
     assert(metrics.keySet().asScala.toSeq.sorted == Seq(
       "blockTransferRate",
+      "blockTransferMessageRate",
       "blockTransferRateBytes",
       "blockTransferAvgSize_1min",
       "numActiveConnections",

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -402,7 +402,8 @@ class YarnShuffleServiceSuite extends SparkFunSuite with Matchers with BeforeAnd
     metricSetRef.setAccessible(true)
     val metrics = metricSetRef.get(metricsSource).asInstanceOf[MetricSet].getMetrics
 
-    assert(metrics.keySet().asScala == Set(
+    // Use sorted Seq instead of Set for easier comparison when there is a mismatch
+    assert(metrics.keySet().asScala.toSeq.sorted == Seq(
       "blockTransferRate",
       "blockTransferRateBytes",
       "blockTransferAvgSize_1min",
@@ -416,7 +417,7 @@ class YarnShuffleServiceSuite extends SparkFunSuite with Matchers with BeforeAnd
       "shuffle-server.usedDirectMemory",
       "shuffle-server.usedHeapMemory",
       "fetchMergedBlocksMetaLatencyMillis"
-    ))
+    ).sorted)
   }
 
   test("SPARK-34828: metrics should be registered with configured name") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This adds two new additional metrics to `ExternalBlockHandler`:
- `blockTransferRate` -- for indicating the rate of transferring blocks, vs. the data within them
- `blockTransferAvgSize_1min` -- a 1-minute trailing average of block sizes transferred by the ESS

Additionally, this enhances `YarnShuffleServiceMetrics` to expose the histogram/`Snapshot` information from `Timer` metrics within `ExternalBlockHandler`.

### Why are the changes needed?
Currently `ExternalBlockHandler` exposes some useful metrics, but is lacking around metrics for the rate of block transfers. We have `blockTransferRateBytes` to tell us the rate of _bytes_, but no metric to tell us the rate of _blocks_, which is especially relevant when running the ESS on HDDs that are sensitive to random reads. Many small block transfers can have a negative impact on performance, but won't show up as a spike in `blockTransferRateBytes` since the sizes are small. Thus the new metrics to show information around average block size and block transfer rate are very useful to monitor the health/performance of the ESS, especially when running on HDDs. 

For the `YarnShuffleServiceMetrics`, currently the three `Timer` metrics exposed by `ExternalBlockHandler` are being underutilized in a YARN-based environment -- they are basically treated as a `Meter`, only exposing rate-based information, when the metrics themselves are collected detailed histograms of timing information. We should expose this information for better observability.

### Does this PR introduce _any_ user-facing change?
Yes, there are two entirely new metrics for the ESS, as documented in `monitoring.md`. Additionally in a YARN environment, `Timer` metrics exposed by the ESS will include more rich timing information.

### How was this patch tested?
New unit tests are added to verify that new metrics are showing up as expected.

We have been running this patch internally for approx. 1 year and have found it to be useful for monitoring the health of ESS and diagnosing performance issues.