### PR TITLE
[SPARK-35264][SQL] Support AQE side broadcastJoin threshold

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -278,7 +278,8 @@ trait JoinSelectionHelper {
    * Matches a plan whose output should be small enough to be used in broadcast join.
    */
   def canBroadcastBySize(plan: LogicalPlan, conf: SQLConf): Boolean = {
-    plan.stats.sizeInBytes >= 0 && plan.stats.sizeInBytes <= conf.autoBroadcastJoinThreshold
+    plan.stats.sizeInBytes >= 0 &&
+      plan.stats.sizeInBytes <= autoBroadcastJoinThreshold(plan.stats.isAdaptive, conf)
   }
 
   def canBuildBroadcastLeft(joinType: JoinType): Boolean = {
@@ -376,7 +377,8 @@ trait JoinSelectionHelper {
    * dynamic.
    */
   private def canBuildLocalHashMapBySize(plan: LogicalPlan, conf: SQLConf): Boolean = {
-    plan.stats.sizeInBytes < conf.autoBroadcastJoinThreshold * conf.numShufflePartitions
+    plan.stats.sizeInBytes <
+      autoBroadcastJoinThreshold(plan.stats.isAdaptive, conf) * conf.numShufflePartitions
   }
 
   /**
@@ -388,6 +390,15 @@ trait JoinSelectionHelper {
    */
   private def muchSmaller(a: LogicalPlan, b: LogicalPlan): Boolean = {
     a.stats.sizeInBytes * 3 <= b.stats.sizeInBytes
+  }
+
+  private def autoBroadcastJoinThreshold(isAdaptive: Boolean, conf: SQLConf): Long = {
+   if (isAdaptive) {
+      conf.getConf(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD)
+        .getOrElse(conf.autoBroadcastJoinThreshold)
+    } else {
+      conf.autoBroadcastJoinThreshold
+    }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -279,7 +279,7 @@ trait JoinSelectionHelper {
    */
   def canBroadcastBySize(plan: LogicalPlan, conf: SQLConf): Boolean = {
     plan.stats.sizeInBytes >= 0 &&
-      plan.stats.sizeInBytes <= autoBroadcastJoinThreshold(plan.stats.isAdaptive, conf)
+      plan.stats.sizeInBytes <= autoBroadcastJoinThreshold(plan.stats.isRuntime, conf)
   }
 
   def canBuildBroadcastLeft(joinType: JoinType): Boolean = {
@@ -377,8 +377,7 @@ trait JoinSelectionHelper {
    * dynamic.
    */
   private def canBuildLocalHashMapBySize(plan: LogicalPlan, conf: SQLConf): Boolean = {
-    plan.stats.sizeInBytes <
-      autoBroadcastJoinThreshold(plan.stats.isAdaptive, conf) * conf.numShufflePartitions
+    plan.stats.sizeInBytes < conf.autoBroadcastJoinThreshold * conf.numShufflePartitions
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
@@ -47,13 +47,14 @@ object Statistics {
  *                    defaults to the product of children's `sizeInBytes`.
  * @param rowCount Estimated number of rows.
  * @param attributeStats Statistics for Attributes.
- * @param isAdaptive Statistics from AQE.
+ * @param isRuntime Whether the statistics is inferred from query stage runtime statistics during
+ *                  adaptive query execution.
  */
 case class Statistics(
     sizeInBytes: BigInt,
     rowCount: Option[BigInt] = None,
     attributeStats: AttributeMap[ColumnStat] = AttributeMap(Nil),
-    isAdaptive: Boolean = false) {
+    isRuntime: Boolean = false) {
 
   override def toString: String = "Statistics(" + simpleString + ")"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
@@ -47,11 +47,13 @@ object Statistics {
  *                    defaults to the product of children's `sizeInBytes`.
  * @param rowCount Estimated number of rows.
  * @param attributeStats Statistics for Attributes.
+ * @param isAdaptive Statistics from AQE.
  */
 case class Statistics(
     sizeInBytes: BigInt,
     rowCount: Option[BigInt] = None,
-    attributeStats: AttributeMap[ColumnStat] = AttributeMap(Nil)) {
+    attributeStats: AttributeMap[ColumnStat] = AttributeMap(Nil),
+    isAdaptive: Boolean = false) {
 
   override def toString: String = "Statistics(" + simpleString + ")"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -588,6 +588,16 @@ object SQLConf {
       .stringConf
       .createOptional
 
+  val ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD =
+    buildConf("spark.sql.adaptive.autoBroadcastJoinThreshold")
+      .doc("Configures the maximum size in bytes for a table that will be broadcast to all " +
+        "worker nodes when performing a join. By setting this value to -1 broadcasting can be " +
+        s"disabled. The default value is same with ${AUTO_BROADCASTJOIN_THRESHOLD.key}. " +
+        "Note that, this config is used only in adaptive framework.")
+      .version("3.2.0")
+      .bytesConf(ByteUnit.BYTE)
+      .createOptional
+
   val SUBEXPRESSION_ELIMINATION_ENABLED =
     buildConf("spark.sql.subexpressionElimination.enabled")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -99,7 +99,7 @@ abstract class QueryStageExec extends LeafExecNode {
     val runtimeStats = getRuntimeStatistics
     val dataSize = runtimeStats.sizeInBytes.max(0)
     val numOutputRows = runtimeStats.rowCount.map(_.max(0))
-    Statistics(dataSize, numOutputRows, isAdaptive = true)
+    Statistics(dataSize, numOutputRows, isRuntime = true)
   }
 
   @transient

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -99,7 +99,7 @@ abstract class QueryStageExec extends LeafExecNode {
     val runtimeStats = getRuntimeStatistics
     val dataSize = runtimeStats.sizeInBytes.max(0)
     val numOutputRows = runtimeStats.rowCount.map(_.max(0))
-    Statistics(dataSize, numOutputRows)
+    Statistics(dataSize, numOutputRows, isAdaptive = true)
   }
 
   @transient

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1608,7 +1608,7 @@ class AdaptiveQueryExecSuite
   }
 
   test("SPARK-35264: Support AQE side broadcastJoin threshold") {
-    withTable("t1", "t2") {
+    withTempView("t1", "t2") {
       def checkJoinStrategy(adaptiveJoinStrategy: String): Unit = {
         withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
           val (origin1, adaptive1) = runAdaptiveAndVerifyResult(
@@ -1651,18 +1651,6 @@ class AdaptiveQueryExecSuite
 
       withSQLConf(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "160") {
         checkJoinStrategy("BHJ")
-      }
-
-      Seq(true, false).foreach { preferSMJ =>
-        withSQLConf(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "159",
-          SQLConf.PREFER_SORTMERGEJOIN.key -> preferSMJ.toString,
-          SQLConf.SHUFFLE_PARTITIONS.key -> "2") {
-          if (preferSMJ) {
-            checkJoinStrategy("SMJ")
-          } else {
-            checkJoinStrategy("SHJ")
-          }
-        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1609,27 +1609,16 @@ class AdaptiveQueryExecSuite
 
   test("SPARK-35264: Support AQE side broadcastJoin threshold") {
     withTempView("t1", "t2") {
-      def checkJoinStrategy(adaptiveJoinStrategy: String): Unit = {
+      def checkJoinStrategy(shouldBroadcast: Boolean): Unit = {
         withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
           val (origin1, adaptive1) = runAdaptiveAndVerifyResult(
             "SELECT t1.c1, t2.c1 FROM t1 JOIN t2 ON t1.c1 = t2.c1")
           assert(findTopLevelSortMergeJoin(origin1).size == 1)
-          adaptiveJoinStrategy match {
-            case "BHJ" =>
-              assert(findTopLevelBroadcastHashJoin(adaptive1).size == 1)
-            case "SHJ" =>
-              assert(findTopLevelShuffledHashJoin(adaptive1).size == 1)
-            case "SMJ" =>
-              assert(findTopLevelSortMergeJoin(adaptive1).size == 1)
-            case _ =>
-              throw new IllegalArgumentException(s"Not support strategy: $adaptiveJoinStrategy")
+          if (shouldBroadcast) {
+            assert(findTopLevelBroadcastHashJoin(adaptive1).size == 1)
+          } else {
+            assert(findTopLevelSortMergeJoin(adaptive1).size == 1)
           }
-
-          // respect user specified join hint
-          val (origin2, adaptive2) = runAdaptiveAndVerifyResult(
-            "SELECT /*+ MERGE(t1) */ t1.c1, t2.c1 FROM t1 JOIN t2 ON t1.c1 = t2.c1")
-          assert(findTopLevelSortMergeJoin(origin2).size == 1)
-          assert(findTopLevelSortMergeJoin(adaptive2).size == 1)
         }
       }
 
@@ -1642,15 +1631,13 @@ class AdaptiveQueryExecSuite
         (1 to 10).map(i => TestData(i, i.toString)), 5)
         .toDF("c1", "c2").createOrReplaceTempView("t2")
 
-      Seq("" -> "", SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1")
-        .foreach { adaptiveThreshold =>
-          withSQLConf(adaptiveThreshold) {
-            checkJoinStrategy("SMJ")
-          }
-        }
+      checkJoinStrategy(false)
+      withSQLConf(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+        checkJoinStrategy(false)
+      }
 
       withSQLConf(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "160") {
-        checkJoinStrategy("BHJ")
+        checkJoinStrategy(true)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1611,13 +1611,13 @@ class AdaptiveQueryExecSuite
     withTempView("t1", "t2") {
       def checkJoinStrategy(shouldBroadcast: Boolean): Unit = {
         withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-          val (origin1, adaptive1) = runAdaptiveAndVerifyResult(
+          val (origin, adaptive) = runAdaptiveAndVerifyResult(
             "SELECT t1.c1, t2.c1 FROM t1 JOIN t2 ON t1.c1 = t2.c1")
-          assert(findTopLevelSortMergeJoin(origin1).size == 1)
+          assert(findTopLevelSortMergeJoin(origin).size == 1)
           if (shouldBroadcast) {
-            assert(findTopLevelBroadcastHashJoin(adaptive1).size == 1)
+            assert(findTopLevelBroadcastHashJoin(adaptive).size == 1)
           } else {
-            assert(findTopLevelSortMergeJoin(adaptive1).size == 1)
+            assert(findTopLevelSortMergeJoin(adaptive).size == 1)
           }
         }
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
~~This PR aims to add a new AQE optimizer rule `DynamicJoinSelection`. Like other AQE partition number configs, this rule add a new broadcast threshold config `spark.sql.adaptive.autoBroadcastJoinThreshold`.~~
This PR amis to add a flag in `Statistics` to distinguish AQE stats or normal stats, so that we can make some sql configs isolation between AQE and normal.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The main idea here is that make join config isolation between normal planner and aqe planner which shared the same code path.

Actually we do not very trust using the static stats to consider if it can build broadcast hash join. In our experience it's very common that Spark throw broadcast timeout or driver side OOM exception when execute a bit large plan. And due to braodcast join is not reversed which means if we covert join to braodcast hash join at first time, we(AQE) can not optimize it again, so it should make sense to decide if we can do broadcast at aqe side using different sql config.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, a new config `spark.sql.adaptive.autoBroadcastJoinThreshold` added.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add new test.