### PR TITLE
[SPARK-35270][SQL][CORE] Remove the use of guava in order to upgrade guava version to 27

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
@@ -31,7 +32,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 import org.apache.spark.annotation.Private;
@@ -70,7 +70,7 @@ public class InMemoryStore implements KVStore {
     Object comparable = asKey(indexedValue);
     KVTypeInfo.Accessor accessor = list.getIndexAccessor(index);
     for (Object o : view(type)) {
-      if (Objects.equal(comparable, asKey(accessor.get(o)))) {
+      if (Objects.equals(comparable, asKey(accessor.get(o)))) {
         count++;
       }
     }

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/AbstractMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/AbstractMessage.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.network.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 
@@ -48,7 +48,7 @@ public abstract class AbstractMessage implements Message {
   }
 
   protected boolean equals(AbstractMessage other) {
-    return isBodyInFrame == other.isBodyInFrame && Objects.equal(body, other.body);
+    return isBodyInFrame == other.isBodyInFrame && Objects.equals(body, other.body);
   }
 
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -32,13 +32,13 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -47,6 +47,8 @@ import com.google.common.cache.Weigher;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -760,19 +762,19 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
         return false;
       }
       AppShuffleId that = (AppShuffleId) o;
-      return shuffleId == that.shuffleId && Objects.equal(appId, that.appId);
+      return shuffleId == that.shuffleId && Objects.equals(appId, that.appId);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(appId, shuffleId);
+      return Objects.hash(appId, shuffleId);
     }
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
-        .add("appId", appId)
-        .add("shuffleId", shuffleId)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("appId", appId)
+        .append("shuffleId", shuffleId)
         .toString();
     }
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/FinalizeShuffleMerge.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/FinalizeShuffleMerge.java
@@ -17,8 +17,11 @@
 
 package org.apache.spark.network.shuffle.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.spark.network.protocol.Encoders;
 
@@ -46,14 +49,14 @@ public class FinalizeShuffleMerge extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, shuffleId);
+    return Objects.hash(appId, shuffleId);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("appId", appId)
-      .add("shuffleId", shuffleId)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+      .append("appId", appId)
+      .append("shuffleId", shuffleId)
       .toString();
   }
 
@@ -61,7 +64,7 @@ public class FinalizeShuffleMerge extends BlockTransferMessage {
   public boolean equals(Object other) {
     if (other != null && other instanceof FinalizeShuffleMerge) {
       FinalizeShuffleMerge o = (FinalizeShuffleMerge) other;
-      return Objects.equal(appId, o.appId)
+      return Objects.equals(appId, o.appId)
         && shuffleId == o.shuffleId;
     }
     return false;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/MergeStatuses.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/MergeStatuses.java
@@ -18,9 +18,11 @@
 package org.apache.spark.network.shuffle.protocol;
 
 import java.util.Arrays;
+import java.util.Objects;
 
-import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.roaringbitmap.RoaringBitmap;
 
 import org.apache.spark.network.protocol.Encoders;
@@ -69,16 +71,16 @@ public class MergeStatuses extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    int objectHashCode = Objects.hashCode(shuffleId);
+    int objectHashCode = Objects.hash(shuffleId);
     return (objectHashCode * 41 + Arrays.hashCode(reduceIds) * 41
       + Arrays.hashCode(bitmaps) * 41 + Arrays.hashCode(sizes));
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("shuffleId", shuffleId)
-      .add("reduceId size", reduceIds.length)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+      .append("shuffleId", shuffleId)
+      .append("reduceId size", reduceIds.length)
       .toString();
   }
 
@@ -86,7 +88,7 @@ public class MergeStatuses extends BlockTransferMessage {
   public boolean equals(Object other) {
     if (other != null && other instanceof MergeStatuses) {
       MergeStatuses o = (MergeStatuses) other;
-      return Objects.equal(shuffleId, o.shuffleId)
+      return Objects.equals(shuffleId, o.shuffleId)
         && Arrays.equals(bitmaps, o.bitmaps)
         && Arrays.equals(reduceIds, o.reduceIds)
         && Arrays.equals(sizes, o.sizes);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/PushBlockStream.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/PushBlockStream.java
@@ -17,8 +17,11 @@
 
 package org.apache.spark.network.shuffle.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.spark.network.protocol.Encoders;
 
@@ -54,17 +57,17 @@ public class PushBlockStream extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, shuffleId, mapIndex , reduceId, index);
+    return Objects.hash(appId, shuffleId, mapIndex , reduceId, index);
   }
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("appId", appId)
-      .add("shuffleId", shuffleId)
-      .add("mapIndex", mapIndex)
-      .add("reduceId", reduceId)
-      .add("index", index)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+      .append("appId", appId)
+      .append("shuffleId", shuffleId)
+      .append("mapIndex", mapIndex)
+      .append("reduceId", reduceId)
+      .append("index", index)
       .toString();
   }
 
@@ -72,7 +75,7 @@ public class PushBlockStream extends BlockTransferMessage {
   public boolean equals(Object other) {
     if (other != null && other instanceof PushBlockStream) {
       PushBlockStream o = (PushBlockStream) other;
-      return Objects.equal(appId, o.appId)
+      return Objects.equals(appId, o.appId)
         && shuffleId == o.shuffleId
         && mapIndex == o.mapIndex
         && reduceId == o.reduceId

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/mesos/RegisterDriver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/mesos/RegisterDriver.java
@@ -17,7 +17,6 @@
 
 package org.apache.spark.network.shuffle.protocol.mesos;
 
-import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.spark.network.protocol.Encoders;
@@ -25,6 +24,8 @@ import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
 
 // Needed by ScalaDoc. See SPARK-7726
 import static org.apache.spark.network.shuffle.protocol.BlockTransferMessage.Type;
+
+import java.util.Objects;
 
 /**
  * A message sent from the driver to register with the MesosExternalShuffleService.
@@ -58,7 +59,7 @@ public class RegisterDriver extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, heartbeatTimeoutMs);
+    return Objects.hash(appId, heartbeatTimeoutMs);
   }
 
   @Override
@@ -66,7 +67,7 @@ public class RegisterDriver extends BlockTransferMessage {
     if (!(o instanceof RegisterDriver)) {
       return false;
     }
-    return Objects.equal(appId, ((RegisterDriver) o).appId);
+    return Objects.equals(appId, ((RegisterDriver) o).appId);
   }
 
   public static RegisterDriver decode(ByteBuf buf) {

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -17,13 +17,13 @@
 
 package org.apache.spark.rdd
 
+import java.util.Objects
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonPropertyOrder}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.google.common.base.Objects
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
@@ -69,7 +69,7 @@ private[spark] class RDDOperationScope(
     }
   }
 
-  override def hashCode(): Int = Objects.hashCode(id, name, parent)
+  override def hashCode(): Int = Objects.hash(id, name, parent)
 
   override def toString: String = toJson
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.mllib.linalg
 
-import java.util.{Arrays, Random}
+import java.util.{Arrays, Objects, Random}
 
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder => MArrayBuilder, HashSet => MHashSet}
 import scala.language.implicitConversions
@@ -313,7 +313,7 @@ class DenseMatrix @Since("1.3.0") (
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(numRows: Integer, numCols: Integer, toArray)
+    Objects.hash(numRows: Integer, numCols: Integer, toArray)
   }
 
   private[mllib] def asBreeze: BM[Double] = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.linalg.distributed
 
+import java.util.Objects
+
 import breeze.linalg.{DenseMatrix => BDM, DenseVector => BDV, Matrix => BM}
 import scala.collection.mutable.ArrayBuffer
 
@@ -90,7 +92,7 @@ private[mllib] class GridPartitioner(
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(
+    Objects.hash(
       rows: java.lang.Integer,
       cols: java.lang.Integer,
       rowsPerPart: java.lang.Integer,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.tree.model
 
+import java.util.Objects
+
 import org.apache.spark.annotation.Since
 import org.apache.spark.mllib.tree.impurity.ImpurityCalculator
 
@@ -56,7 +58,7 @@ class InformationGainStats(
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(
+    Objects.hash(
       gain: java.lang.Double,
       impurity: java.lang.Double,
       leftImpurity: java.lang.Double,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Predict.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Predict.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.tree.model
 
+import java.util.Objects
+
 import org.apache.spark.annotation.Since
 
 /**
@@ -39,6 +41,6 @@ class Predict @Since("1.2.0") (
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(predict: java.lang.Double, prob: java.lang.Double)
+    Objects.hash(predict: java.lang.Double, prob: java.lang.Double)
   }
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -22,7 +22,7 @@ import java.net.{InetAddress, UnknownHostException, URI}
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.util.{Locale, Properties, UUID}
+import java.util.{Locale, Objects, Properties, UUID}
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.collection.JavaConverters._
@@ -30,7 +30,6 @@ import scala.collection.immutable.{Map => IMap}
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, ListBuffer, Map}
 import scala.util.control.NonFatal
 
-import com.google.common.base.Objects
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.hadoop.fs.permission.FsPermission
@@ -1567,7 +1566,7 @@ private object Client extends Logging {
       }
     }
 
-    Objects.equal(srcHost, dstHost) && srcUri.getPort() == dstUri.getPort()
+    Objects.equals(srcHost, dstHost) && srcUri.getPort() == dstUri.getPort()
 
   }
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -35,7 +35,6 @@ import scala.Tuple3;
 import scala.Tuple4;
 import scala.Tuple5;
 
-import com.google.common.base.Objects;
 import org.junit.*;
 
 import org.apache.spark.api.java.JavaPairRDD;
@@ -807,12 +806,12 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       SmallBean smallBean = (SmallBean) o;
-      return b == smallBean.b && com.google.common.base.Objects.equal(a, smallBean.a);
+      return b == smallBean.b && Objects.equals(a, smallBean.a);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(a, b);
+      return Objects.hash(a, b);
     }
   }
 
@@ -832,7 +831,7 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       NestedSmallBean that = (NestedSmallBean) o;
-      return Objects.equal(f, that.f);
+      return Objects.equals(f, that.f);
     }
 
     @Override
@@ -874,13 +873,13 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       NestedSmallBeanWithNonNullField that = (NestedSmallBeanWithNonNullField) o;
-      return Objects.equal(nullable_f, that.nullable_f) &&
-        Objects.equal(nonNull_f, that.nonNull_f) && Objects.equal(childMap, that.childMap);
+      return Objects.equals(nullable_f, that.nullable_f) &&
+        Objects.equals(nonNull_f, that.nonNull_f) && Objects.equals(childMap, that.childMap);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(nullable_f, nonNull_f, childMap);
+      return Objects.hash(nullable_f, nonNull_f, childMap);
     }
   }
 
@@ -901,7 +900,7 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       NestedSmallBean2 that = (NestedSmallBean2) o;
-      return Objects.equal(f, that.f);
+      return Objects.equals(f, that.f);
     }
 
     @Override
@@ -1447,7 +1446,7 @@ public class JavaDatasetSuite implements Serializable {
     }
 
     public int hashCode() {
-      return Objects.hashCode(enumField, regularField);
+      return Objects.hash(enumField, regularField);
     }
 
     public boolean equals(Object other) {
@@ -1684,14 +1683,14 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       SpecificListsBean that = (SpecificListsBean) o;
-      return Objects.equal(arrayList, that.arrayList) &&
-        Objects.equal(linkedList, that.linkedList) &&
-        Objects.equal(list, that.list);
+      return Objects.equals(arrayList, that.arrayList) &&
+        Objects.equals(linkedList, that.linkedList) &&
+        Objects.equals(list, that.list);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(arrayList, linkedList, list);
+      return Objects.hash(arrayList, linkedList, list);
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -18,11 +18,11 @@
 package org.apache.spark.sql.hive
 
 import java.rmi.server.UID
+import java.util.Objects
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 
-import com.google.common.base.Objects
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -128,7 +128,7 @@ private[hive] object HiveShim {
 
     override def hashCode(): Int = {
       if (functionClassName == HIVE_GENERIC_UDF_MACRO_CLS) {
-        Objects.hashCode(functionClassName, instance.asInstanceOf[GenericUDFMacro].getBody())
+        Objects.hash(functionClassName, instance.asInstanceOf[GenericUDFMacro].getBody())
       } else {
         functionClassName.hashCode()
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the use of guava in order to upgrade guava version to 27.


### Why are the changes needed?

Hadoop 3.2.2 uses Guava 27, the change is for the guava version upgrade.


### Does this PR introduce _any_ user-facing change?

no


### How was this patch tested?

Modify the guava version to 27.0-jre, and then compile.