### PR TITLE
[SPARK-35285][SQL] Parse ANSI interval types in SQL schema

### DIFF
--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -254,6 +254,7 @@ Below is a list of all the keywords in Spark SQL.
 |DATA|non-reserved|non-reserved|non-reserved|
 |DATABASE|non-reserved|non-reserved|non-reserved|
 |DATABASES|non-reserved|non-reserved|non-reserved|
+|DAY|non-reserved|non-reserved|non-reserved|
 |DBPROPERTIES|non-reserved|non-reserved|non-reserved|
 |DEFINED|non-reserved|non-reserved|non-reserved|
 |DELETE|non-reserved|non-reserved|reserved|
@@ -336,6 +337,7 @@ Below is a list of all the keywords in Spark SQL.
 |MATCHED|non-reserved|non-reserved|non-reserved|
 |MERGE|non-reserved|non-reserved|non-reserved|
 |MINUS|non-reserved|strict-non-reserved|non-reserved|
+|MONTH|non-reserved|non-reserved|non-reserved|
 |MSCK|non-reserved|non-reserved|non-reserved|
 |NAMESPACE|non-reserved|non-reserved|non-reserved|
 |NAMESPACES|non-reserved|non-reserved|non-reserved|
@@ -396,6 +398,7 @@ Below is a list of all the keywords in Spark SQL.
 |ROWS|non-reserved|non-reserved|reserved|
 |SCHEMA|non-reserved|non-reserved|non-reserved|
 |SCHEMAS|non-reserved|non-reserved|not a keyword|
+|SECOND|non-reserved|non-reserved|non-reserved|
 |SELECT|reserved|non-reserved|reserved|
 |SEMI|non-reserved|strict-non-reserved|non-reserved|
 |SEPARATED|non-reserved|non-reserved|non-reserved|
@@ -456,4 +459,5 @@ Below is a list of all the keywords in Spark SQL.
 |WHERE|reserved|non-reserved|reserved|
 |WINDOW|non-reserved|non-reserved|reserved|
 |WITH|reserved|non-reserved|reserved|
+|YEAR|non-reserved|non-reserved|non-reserved|
 |ZONE|non-reserved|non-reserved|non-reserved|

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -1079,6 +1079,7 @@ ansiNonReserved
     | DATA
     | DATABASE
     | DATABASES
+    | DAY
     | DBPROPERTIES
     | DEFINED
     | DELETE
@@ -1137,6 +1138,7 @@ ansiNonReserved
     | MAP
     | MATCHED
     | MERGE
+    | MONTH
     | MSCK
     | NAMESPACE
     | NAMESPACES
@@ -1183,6 +1185,7 @@ ansiNonReserved
     | ROW
     | ROWS
     | SCHEMA
+    | SECOND
     | SEMI
     | SEPARATED
     | SERDE
@@ -1227,6 +1230,7 @@ ansiNonReserved
     | VIEW
     | VIEWS
     | WINDOW
+    | YEAR
     | ZONE
 //--ANSI-NON-RESERVED-END
     ;
@@ -1310,6 +1314,7 @@ nonReserved
     | DATA
     | DATABASE
     | DATABASES
+    | DAY
     | DBPROPERTIES
     | DEFINED
     | DELETE
@@ -1385,6 +1390,7 @@ nonReserved
     | MAP
     | MATCHED
     | MERGE
+    | MONTH
     | MSCK
     | NAMESPACE
     | NAMESPACES
@@ -1440,6 +1446,7 @@ nonReserved
     | ROW
     | ROWS
     | SCHEMA
+    | SECOND
     | SELECT
     | SEPARATED
     | SERDE
@@ -1496,6 +1503,7 @@ nonReserved
     | WHERE
     | WINDOW
     | WITH
+    | YEAR
     | ZONE
 //--DEFAULT-NON-RESERVED-END
     ;

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -904,6 +904,8 @@ dataType
     : complex=ARRAY '<' dataType '>'                            #complexDataType
     | complex=MAP '<' dataType ',' dataType '>'                 #complexDataType
     | complex=STRUCT ('<' complexColTypeList? '>' | NEQ)        #complexDataType
+    | INTERVAL YEAR TO MONTH                                    #yearMonthIntervalDataType
+    | INTERVAL DAY TO SECOND                                    #dayTimeIntervalDataType
     | identifier ('(' INTEGER_VALUE (',' INTEGER_VALUE)* ')')?  #primitiveDataType
     ;
 
@@ -1554,6 +1556,7 @@ CURRENT_DATE: 'CURRENT_DATE';
 CURRENT_TIME: 'CURRENT_TIME';
 CURRENT_TIMESTAMP: 'CURRENT_TIMESTAMP';
 CURRENT_USER: 'CURRENT_USER';
+DAY: 'DAY';
 DATA: 'DATA';
 DATABASE: 'DATABASE';
 DATABASES: 'DATABASES' | 'SCHEMAS';
@@ -1638,6 +1641,7 @@ MACRO: 'MACRO';
 MAP: 'MAP';
 MATCHED: 'MATCHED';
 MERGE: 'MERGE';
+MONTH: 'MONTH';
 MSCK: 'MSCK';
 NAMESPACE: 'NAMESPACE';
 NAMESPACES: 'NAMESPACES';
@@ -1695,6 +1699,7 @@ ROLLBACK: 'ROLLBACK';
 ROLLUP: 'ROLLUP';
 ROW: 'ROW';
 ROWS: 'ROWS';
+SECOND: 'SECOND';
 SCHEMA: 'SCHEMA';
 SELECT: 'SELECT';
 SEMI: 'SEMI';
@@ -1756,6 +1761,7 @@ WHEN: 'WHEN';
 WHERE: 'WHERE';
 WINDOW: 'WINDOW';
 WITH: 'WITH';
+YEAR: 'YEAR';
 ZONE: 'ZONE';
 //--SPARK-KEYWORD-LIST-END
 //============================

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2484,6 +2484,14 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
     }
   }
 
+  override def visitYearMonthIntervalDataType(ctx: YearMonthIntervalDataTypeContext): DataType = {
+    YearMonthIntervalType
+  }
+
+  override def visitDayTimeIntervalDataType(ctx: DayTimeIntervalDataTypeContext): DataType = {
+    DayTimeIntervalType
+  }
+
   /**
    * Create a complex DataType. Arrays, Maps and Structures are supported.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DayTimeIntervalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DayTimeIntervalType.scala
@@ -57,7 +57,7 @@ class DayTimeIntervalType private() extends AtomicType {
 
   private[spark] override def asNullable: DayTimeIntervalType = this
 
-  override def typeName: String = "day-time interval"
+  override def typeName: String = "interval day to second"
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/YearMonthIntervalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/YearMonthIntervalType.scala
@@ -55,7 +55,7 @@ class YearMonthIntervalType private() extends AtomicType {
 
   private[spark] override def asNullable: YearMonthIntervalType = this
 
-  override def typeName: String = "year-month interval"
+  override def typeName: String = "interval year to month"
 }
 
 /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -78,9 +78,9 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
     assertErrorForDifferingTypes(BitwiseXor(Symbol("intField"), Symbol("booleanField")))
 
     assertError(Add(Symbol("booleanField"), Symbol("booleanField")),
-      "requires (numeric or interval or day-time interval or year-month interval) type")
+      "requires (numeric or interval or interval day to second or interval year to month) type")
     assertError(Subtract(Symbol("booleanField"), Symbol("booleanField")),
-      "requires (numeric or interval or day-time interval or year-month interval) type")
+      "requires (numeric or interval or interval day to second or interval year to month) type")
     assertError(Multiply(Symbol("booleanField"), Symbol("booleanField")), "requires numeric type")
     assertError(Divide(Symbol("booleanField"), Symbol("booleanField")),
       "requires (double or decimal) type")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1098,7 +1098,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
           Literal(Date.valueOf("2018-01-05")),
           Literal(Period.ofDays(2))),
         EmptyRow,
-        "sequence step must be a day year-month interval if start and end values are dates")
+        "sequence step must be a day interval year to month if start and end values are dates")
 
       checkExceptionInExpression[IllegalArgumentException](
         new Sequence(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DataTypeParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DataTypeParserSuite.scala
@@ -63,6 +63,8 @@ class DataTypeParserSuite extends SparkFunSuite {
   checkDataType("BINARY", BinaryType)
   checkDataType("void", NullType)
   checkDataType("interval", CalendarIntervalType)
+  checkDataType("INTERVAL YEAR TO MONTH", YearMonthIntervalType)
+  checkDataType("interval day to second", DayTimeIntervalType)
 
   checkDataType("array<doublE>", ArrayType(DoubleType, true))
   checkDataType("Array<map<int, tinYint>>", ArrayType(MapType(IntegerType, ByteType, true), true))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -255,6 +255,9 @@ class DataTypeSuite extends SparkFunSuite {
   checkDataTypeFromJson(VarcharType(10))
   checkDataTypeFromDDL(VarcharType(11))
 
+  checkDataTypeFromDDL(YearMonthIntervalType)
+  checkDataTypeFromDDL(DayTimeIntervalType)
+
   val metadata = new MetadataBuilder()
     .putString("name", "age")
     .build()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -235,4 +235,12 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
         .exists(_.sameType(missing4)))
     }
   }
+
+  test("SPARK-35285: ANSI interval types in schema") {
+    val yearMonthInterval = "`ymi` INTERVAL YEAR TO MONTH"
+    assert(fromDDL(yearMonthInterval).toDDL === yearMonthInterval)
+
+    val dayTimeInterval = "`dti` INTERVAL DAY TO SECOND"
+    assert(fromDDL(dayTimeInterval).toDDL === dayTimeInterval)
+  }
 }

--- a/sql/core/src/test/resources/sql-tests/results/ansi/datetime.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/datetime.sql.out
@@ -359,7 +359,7 @@ cannot resolve '1 + (- INTERVAL '2 seconds')' due to data type mismatch: argumen
 -- !query
 select date'2020-01-01' - timestamp'2019-10-06 10:11:12.345678'
 -- !query schema
-struct<(DATE '2020-01-01' - TIMESTAMP '2019-10-06 10:11:12.345678'):day-time interval>
+struct<(DATE '2020-01-01' - TIMESTAMP '2019-10-06 10:11:12.345678'):interval day to second>
 -- !query output
 86 13:48:47.654322000
 
@@ -367,7 +367,7 @@ struct<(DATE '2020-01-01' - TIMESTAMP '2019-10-06 10:11:12.345678'):day-time int
 -- !query
 select timestamp'2019-10-06 10:11:12.345678' - date'2020-01-01'
 -- !query schema
-struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):day-time interval>
+struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):interval day to second>
 -- !query output
 -86 13:48:47.654322000
 
@@ -375,7 +375,7 @@ struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):day-time int
 -- !query
 select timestamp'2019-10-06 10:11:12.345678' - null
 -- !query schema
-struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - NULL):day-time interval>
+struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - NULL):interval day to second>
 -- !query output
 NULL
 
@@ -383,7 +383,7 @@ NULL
 -- !query
 select null - timestamp'2019-10-06 10:11:12.345678'
 -- !query schema
-struct<(NULL - TIMESTAMP '2019-10-06 10:11:12.345678'):day-time interval>
+struct<(NULL - TIMESTAMP '2019-10-06 10:11:12.345678'):interval day to second>
 -- !query output
 NULL
 
@@ -625,7 +625,7 @@ cannot resolve 'date_sub(CAST('2011-11-11' AS DATE), v.str)' due to data type mi
 -- !query
 select null - date '2019-10-06'
 -- !query schema
-struct<(NULL - DATE '2019-10-06'):day-time interval>
+struct<(NULL - DATE '2019-10-06'):interval day to second>
 -- !query output
 NULL
 
@@ -633,7 +633,7 @@ NULL
 -- !query
 select date '2001-10-01' - date '2001-09-28'
 -- !query schema
-struct<(DATE '2001-10-01' - DATE '2001-09-28'):day-time interval>
+struct<(DATE '2001-10-01' - DATE '2001-09-28'):interval day to second>
 -- !query output
 3 00:00:00.000000000
 

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -5,7 +5,7 @@
 -- !query
 select 3 * (timestamp'2019-10-15 10:11:12.001002' - date'2019-10-15')
 -- !query schema
-struct<((TIMESTAMP '2019-10-15 10:11:12.001002' - DATE '2019-10-15') * 3):day-time interval>
+struct<((TIMESTAMP '2019-10-15 10:11:12.001002' - DATE '2019-10-15') * 3):interval day to second>
 -- !query output
 1 06:33:36.003006000
 
@@ -21,7 +21,7 @@ struct<multiply_interval(INTERVAL '4 months 14 days 0.000003 seconds', 1.5):inte
 -- !query
 select (timestamp'2019-10-15' - timestamp'2019-10-14') / 1.5
 -- !query schema
-struct<((TIMESTAMP '2019-10-15 00:00:00' - TIMESTAMP '2019-10-14 00:00:00') / 1.5):day-time interval>
+struct<((TIMESTAMP '2019-10-15 00:00:00' - TIMESTAMP '2019-10-14 00:00:00') / 1.5):interval day to second>
 -- !query output
 0 16:00:00.000000000
 
@@ -130,7 +130,7 @@ struct<(+ INTERVAL '-1 months 1 days -1 seconds'):interval>
 -- !query
 select interval -'1-1' year to month
 -- !query schema
-struct<INTERVAL '-1-1' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '-1-1' YEAR TO MONTH:interval year to month>
 -- !query output
 -1-1
 
@@ -138,7 +138,7 @@ struct<INTERVAL '-1-1' YEAR TO MONTH:year-month interval>
 -- !query
 select interval -'-1-1' year to month
 -- !query schema
-struct<INTERVAL '1-1' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '1-1' YEAR TO MONTH:interval year to month>
 -- !query output
 1-1
 
@@ -146,7 +146,7 @@ struct<INTERVAL '1-1' YEAR TO MONTH:year-month interval>
 -- !query
 select interval +'-1-1' year to month
 -- !query schema
-struct<INTERVAL '-1-1' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '-1-1' YEAR TO MONTH:interval year to month>
 -- !query output
 -1-1
 
@@ -154,7 +154,7 @@ struct<INTERVAL '-1-1' YEAR TO MONTH:year-month interval>
 -- !query
 select interval - '1 2:3:4.001' day to second
 -- !query schema
-struct<INTERVAL '-1 02:03:04.001' DAY TO SECOND:day-time interval>
+struct<INTERVAL '-1 02:03:04.001' DAY TO SECOND:interval day to second>
 -- !query output
 -1 02:03:04.001000000
 
@@ -162,7 +162,7 @@ struct<INTERVAL '-1 02:03:04.001' DAY TO SECOND:day-time interval>
 -- !query
 select interval +'1 2:3:4.001' day to second
 -- !query schema
-struct<INTERVAL '1 02:03:04.001' DAY TO SECOND:day-time interval>
+struct<INTERVAL '1 02:03:04.001' DAY TO SECOND:interval day to second>
 -- !query output
 1 02:03:04.001000000
 
@@ -170,7 +170,7 @@ struct<INTERVAL '1 02:03:04.001' DAY TO SECOND:day-time interval>
 -- !query
 select interval -'-1 2:3:4.001' day to second
 -- !query schema
-struct<INTERVAL '1 02:03:04.001' DAY TO SECOND:day-time interval>
+struct<INTERVAL '1 02:03:04.001' DAY TO SECOND:interval day to second>
 -- !query output
 1 02:03:04.001000000
 
@@ -331,7 +331,7 @@ struct<INTERVAL '32 years 1 months -100 days 41 hours 24 minutes 59.889987 secon
 -- !query
 select interval '0-0' year to month
 -- !query schema
-struct<INTERVAL '0-0' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '0-0' YEAR TO MONTH:interval year to month>
 -- !query output
 0-0
 
@@ -339,7 +339,7 @@ struct<INTERVAL '0-0' YEAR TO MONTH:year-month interval>
 -- !query
 select interval '0 0:0:0' day to second
 -- !query schema
-struct<INTERVAL '0 00:00:00' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 00:00:00' DAY TO SECOND:interval day to second>
 -- !query output
 0 00:00:00.000000000
 
@@ -347,7 +347,7 @@ struct<INTERVAL '0 00:00:00' DAY TO SECOND:day-time interval>
 -- !query
 select interval '0 0:0:0.1' day to second
 -- !query schema
-struct<INTERVAL '0 00:00:00.1' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 00:00:00.1' DAY TO SECOND:interval day to second>
 -- !query output
 0 00:00:00.100000000
 
@@ -355,7 +355,7 @@ struct<INTERVAL '0 00:00:00.1' DAY TO SECOND:day-time interval>
 -- !query
 select interval '10-9' year to month
 -- !query schema
-struct<INTERVAL '10-9' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '10-9' YEAR TO MONTH:interval year to month>
 -- !query output
 10-9
 
@@ -363,7 +363,7 @@ struct<INTERVAL '10-9' YEAR TO MONTH:year-month interval>
 -- !query
 select interval '20 15' day to hour
 -- !query schema
-struct<INTERVAL '20 15:00:00' DAY TO SECOND:day-time interval>
+struct<INTERVAL '20 15:00:00' DAY TO SECOND:interval day to second>
 -- !query output
 20 15:00:00.000000000
 
@@ -371,7 +371,7 @@ struct<INTERVAL '20 15:00:00' DAY TO SECOND:day-time interval>
 -- !query
 select interval '20 15:40' day to minute
 -- !query schema
-struct<INTERVAL '20 15:40:00' DAY TO SECOND:day-time interval>
+struct<INTERVAL '20 15:40:00' DAY TO SECOND:interval day to second>
 -- !query output
 20 15:40:00.000000000
 
@@ -379,7 +379,7 @@ struct<INTERVAL '20 15:40:00' DAY TO SECOND:day-time interval>
 -- !query
 select interval '20 15:40:32.99899999' day to second
 -- !query schema
-struct<INTERVAL '20 15:40:32.998999' DAY TO SECOND:day-time interval>
+struct<INTERVAL '20 15:40:32.998999' DAY TO SECOND:interval day to second>
 -- !query output
 20 15:40:32.998999000
 
@@ -387,7 +387,7 @@ struct<INTERVAL '20 15:40:32.998999' DAY TO SECOND:day-time interval>
 -- !query
 select interval '15:40' hour to minute
 -- !query schema
-struct<INTERVAL '0 15:40:00' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 15:40:00' DAY TO SECOND:interval day to second>
 -- !query output
 0 15:40:00.000000000
 
@@ -395,7 +395,7 @@ struct<INTERVAL '0 15:40:00' DAY TO SECOND:day-time interval>
 -- !query
 select interval '15:40:32.99899999' hour to second
 -- !query schema
-struct<INTERVAL '0 15:40:32.998999' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 15:40:32.998999' DAY TO SECOND:interval day to second>
 -- !query output
 0 15:40:32.998999000
 
@@ -403,7 +403,7 @@ struct<INTERVAL '0 15:40:32.998999' DAY TO SECOND:day-time interval>
 -- !query
 select interval '40:32.99899999' minute to second
 -- !query schema
-struct<INTERVAL '0 00:40:32.998999' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 00:40:32.998999' DAY TO SECOND:interval day to second>
 -- !query output
 0 00:40:32.998999000
 
@@ -411,7 +411,7 @@ struct<INTERVAL '0 00:40:32.998999' DAY TO SECOND:day-time interval>
 -- !query
 select interval '40:32' minute to second
 -- !query schema
-struct<INTERVAL '0 00:40:32' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 00:40:32' DAY TO SECOND:interval day to second>
 -- !query output
 0 00:40:32.000000000
 
@@ -783,7 +783,7 @@ select interval 30 days days days
 -- !query
 SELECT INTERVAL '178956970-7' YEAR TO MONTH
 -- !query schema
-struct<INTERVAL '178956970-7' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '178956970-7' YEAR TO MONTH:interval year to month>
 -- !query output
 178956970-7
 
@@ -805,7 +805,7 @@ SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query
 SELECT INTERVAL '-178956970-8' YEAR TO MONTH
 -- !query schema
-struct<INTERVAL '-178956970-8' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '-178956970-8' YEAR TO MONTH:interval year to month>
 -- !query output
 -178956970-8
 
@@ -813,7 +813,7 @@ struct<INTERVAL '-178956970-8' YEAR TO MONTH:year-month interval>
 -- !query
 SELECT INTERVAL -'178956970-8' YEAR TO MONTH
 -- !query schema
-struct<INTERVAL '-178956970-8' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '-178956970-8' YEAR TO MONTH:interval year to month>
 -- !query output
 -178956970-8
 
@@ -867,7 +867,7 @@ select
   interval '2-2' year to month - interval '3-3' year to month
 from interval_arithmetic
 -- !query schema
-struct<(INTERVAL '2-2' YEAR TO MONTH + INTERVAL '3-3' YEAR TO MONTH):year-month interval,(INTERVAL '2-2' YEAR TO MONTH - INTERVAL '3-3' YEAR TO MONTH):year-month interval>
+struct<(INTERVAL '2-2' YEAR TO MONTH + INTERVAL '3-3' YEAR TO MONTH):interval year to month,(INTERVAL '2-2' YEAR TO MONTH - INTERVAL '3-3' YEAR TO MONTH):interval year to month>
 -- !query output
 5-5	-1-1
 
@@ -926,7 +926,7 @@ select
   interval '99 11:22:33.123456789' day to second - interval '10 9:8:7.123456789' day to second
 from interval_arithmetic
 -- !query schema
-struct<(INTERVAL '99 11:22:33.123456' DAY TO SECOND + INTERVAL '10 09:08:07.123456' DAY TO SECOND):day-time interval,(INTERVAL '99 11:22:33.123456' DAY TO SECOND - INTERVAL '10 09:08:07.123456' DAY TO SECOND):day-time interval>
+struct<(INTERVAL '99 11:22:33.123456' DAY TO SECOND + INTERVAL '10 09:08:07.123456' DAY TO SECOND):interval day to second,(INTERVAL '99 11:22:33.123456' DAY TO SECOND - INTERVAL '10 09:08:07.123456' DAY TO SECOND):interval day to second>
 -- !query output
 109 20:30:40.246912000	89 02:14:26.000000000
 
@@ -974,7 +974,7 @@ struct<INTERVAL '1 days':interval>
 -- !query
 select interval '2-2\t' year to month
 -- !query schema
-struct<INTERVAL '2-2' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '2-2' YEAR TO MONTH:interval year to month>
 -- !query output
 2-2
 
@@ -996,7 +996,7 @@ select interval '-\t2-2\t' year to month
 -- !query
 select interval '\n0 12:34:46.789\t' day to second
 -- !query schema
-struct<INTERVAL '0 12:34:46.789' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 12:34:46.789' DAY TO SECOND:interval day to second>
 -- !query output
 0 12:34:46.789000000
 
@@ -1264,7 +1264,7 @@ struct<INTERVAL '-1 days':interval>
 -- !query
 SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / 2
 -- !query schema
-struct<(INTERVAL '-178956970-8' YEAR TO MONTH / 2):year-month interval>
+struct<(INTERVAL '-178956970-8' YEAR TO MONTH / 2):interval year to month>
 -- !query output
 -89478485-4
 
@@ -1272,7 +1272,7 @@ struct<(INTERVAL '-178956970-8' YEAR TO MONTH / 2):year-month interval>
 -- !query
 SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / 5
 -- !query schema
-struct<(INTERVAL '-178956970-8' YEAR TO MONTH / 5):year-month interval>
+struct<(INTERVAL '-178956970-8' YEAR TO MONTH / 5):interval year to month>
 -- !query output
 -35791394-2
 
@@ -1316,7 +1316,7 @@ not in range
 -- !query
 SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / 2
 -- !query schema
-struct<(INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND / 2):day-time interval>
+struct<(INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND / 2):interval day to second>
 -- !query output
 -53375995 14:00:27.387904000
 
@@ -1324,7 +1324,7 @@ struct<(INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND / 2):day-time interv
 -- !query
 SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / 5
 -- !query schema
-struct<(INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND / 5):day-time interval>
+struct<(INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND / 5):interval day to second>
 -- !query output
 -21350398 05:36:10.955162000
 

--- a/sql/core/src/test/resources/sql-tests/results/ansi/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/literals.sql.out
@@ -436,7 +436,7 @@ select +date '1999-01-01'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ DATE '1999-01-01')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'DATE '1999-01-01'' is of date type.; line 1 pos 7
+cannot resolve '(+ DATE '1999-01-01')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'DATE '1999-01-01'' is of date type.; line 1 pos 7
 
 
 -- !query
@@ -445,7 +445,7 @@ select +timestamp '1999-01-01'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ TIMESTAMP '1999-01-01 00:00:00')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'TIMESTAMP '1999-01-01 00:00:00'' is of timestamp type.; line 1 pos 7
+cannot resolve '(+ TIMESTAMP '1999-01-01 00:00:00')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'TIMESTAMP '1999-01-01 00:00:00'' is of timestamp type.; line 1 pos 7
 
 
 -- !query
@@ -462,7 +462,7 @@ select +map(1, 2)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ map(1, 2))' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'map(1, 2)' is of map<int,int> type.; line 1 pos 7
+cannot resolve '(+ map(1, 2))' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'map(1, 2)' is of map<int,int> type.; line 1 pos 7
 
 
 -- !query
@@ -471,7 +471,7 @@ select +array(1,2)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ array(1, 2))' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'array(1, 2)' is of array<int> type.; line 1 pos 7
+cannot resolve '(+ array(1, 2))' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'array(1, 2)' is of array<int> type.; line 1 pos 7
 
 
 -- !query
@@ -480,7 +480,7 @@ select +named_struct('a', 1, 'b', 'spark')
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ named_struct('a', 1, 'b', 'spark'))' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'named_struct('a', 1, 'b', 'spark')' is of struct<a:int,b:string> type.; line 1 pos 7
+cannot resolve '(+ named_struct('a', 1, 'b', 'spark'))' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'named_struct('a', 1, 'b', 'spark')' is of struct<a:int,b:string> type.; line 1 pos 7
 
 
 -- !query
@@ -489,7 +489,7 @@ select +X'1'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ X'01')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'X'01'' is of binary type.; line 1 pos 7
+cannot resolve '(+ X'01')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'X'01'' is of binary type.; line 1 pos 7
 
 
 -- !query
@@ -498,7 +498,7 @@ select -date '1999-01-01'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(- DATE '1999-01-01')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'DATE '1999-01-01'' is of date type.; line 1 pos 7
+cannot resolve '(- DATE '1999-01-01')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'DATE '1999-01-01'' is of date type.; line 1 pos 7
 
 
 -- !query
@@ -507,7 +507,7 @@ select -timestamp '1999-01-01'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(- TIMESTAMP '1999-01-01 00:00:00')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'TIMESTAMP '1999-01-01 00:00:00'' is of timestamp type.; line 1 pos 7
+cannot resolve '(- TIMESTAMP '1999-01-01 00:00:00')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'TIMESTAMP '1999-01-01 00:00:00'' is of timestamp type.; line 1 pos 7
 
 
 -- !query
@@ -516,4 +516,4 @@ select -x'2379ACFe'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(- X'2379ACFE')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'X'2379ACFE'' is of binary type.; line 1 pos 7
+cannot resolve '(- X'2379ACFE')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'X'2379ACFE'' is of binary type.; line 1 pos 7

--- a/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
@@ -336,7 +336,7 @@ cannot resolve '1 + (- INTERVAL '2 seconds')' due to data type mismatch: argumen
 -- !query
 select date'2020-01-01' - timestamp'2019-10-06 10:11:12.345678'
 -- !query schema
-struct<(DATE '2020-01-01' - TIMESTAMP '2019-10-06 10:11:12.345678'):day-time interval>
+struct<(DATE '2020-01-01' - TIMESTAMP '2019-10-06 10:11:12.345678'):interval day to second>
 -- !query output
 86 13:48:47.654322000
 
@@ -344,7 +344,7 @@ struct<(DATE '2020-01-01' - TIMESTAMP '2019-10-06 10:11:12.345678'):day-time int
 -- !query
 select timestamp'2019-10-06 10:11:12.345678' - date'2020-01-01'
 -- !query schema
-struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):day-time interval>
+struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):interval day to second>
 -- !query output
 -86 13:48:47.654322000
 
@@ -352,7 +352,7 @@ struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):day-time int
 -- !query
 select timestamp'2019-10-06 10:11:12.345678' - null
 -- !query schema
-struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - NULL):day-time interval>
+struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - NULL):interval day to second>
 -- !query output
 NULL
 
@@ -360,7 +360,7 @@ NULL
 -- !query
 select null - timestamp'2019-10-06 10:11:12.345678'
 -- !query schema
-struct<(NULL - TIMESTAMP '2019-10-06 10:11:12.345678'):day-time interval>
+struct<(NULL - TIMESTAMP '2019-10-06 10:11:12.345678'):interval day to second>
 -- !query output
 NULL
 
@@ -602,7 +602,7 @@ cannot resolve 'date_sub(CAST('2011-11-11' AS DATE), v.str)' due to data type mi
 -- !query
 select null - date '2019-10-06'
 -- !query schema
-struct<(NULL - DATE '2019-10-06'):day-time interval>
+struct<(NULL - DATE '2019-10-06'):interval day to second>
 -- !query output
 NULL
 
@@ -610,7 +610,7 @@ NULL
 -- !query
 select date '2001-10-01' - date '2001-09-28'
 -- !query schema
-struct<(DATE '2001-10-01' - DATE '2001-09-28'):day-time interval>
+struct<(DATE '2001-10-01' - DATE '2001-09-28'):interval day to second>
 -- !query output
 3 00:00:00.000000000
 

--- a/sql/core/src/test/resources/sql-tests/results/datetime.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime.sql.out
@@ -336,7 +336,7 @@ cannot resolve '1 + (- INTERVAL '2 seconds')' due to data type mismatch: argumen
 -- !query
 select date'2020-01-01' - timestamp'2019-10-06 10:11:12.345678'
 -- !query schema
-struct<(DATE '2020-01-01' - TIMESTAMP '2019-10-06 10:11:12.345678'):day-time interval>
+struct<(DATE '2020-01-01' - TIMESTAMP '2019-10-06 10:11:12.345678'):interval day to second>
 -- !query output
 86 13:48:47.654322000
 
@@ -344,7 +344,7 @@ struct<(DATE '2020-01-01' - TIMESTAMP '2019-10-06 10:11:12.345678'):day-time int
 -- !query
 select timestamp'2019-10-06 10:11:12.345678' - date'2020-01-01'
 -- !query schema
-struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):day-time interval>
+struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):interval day to second>
 -- !query output
 -86 13:48:47.654322000
 
@@ -352,7 +352,7 @@ struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):day-time int
 -- !query
 select timestamp'2019-10-06 10:11:12.345678' - null
 -- !query schema
-struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - NULL):day-time interval>
+struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - NULL):interval day to second>
 -- !query output
 NULL
 
@@ -360,7 +360,7 @@ NULL
 -- !query
 select null - timestamp'2019-10-06 10:11:12.345678'
 -- !query schema
-struct<(NULL - TIMESTAMP '2019-10-06 10:11:12.345678'):day-time interval>
+struct<(NULL - TIMESTAMP '2019-10-06 10:11:12.345678'):interval day to second>
 -- !query output
 NULL
 
@@ -602,7 +602,7 @@ cannot resolve 'date_sub(CAST('2011-11-11' AS DATE), v.str)' due to data type mi
 -- !query
 select null - date '2019-10-06'
 -- !query schema
-struct<(NULL - DATE '2019-10-06'):day-time interval>
+struct<(NULL - DATE '2019-10-06'):interval day to second>
 -- !query output
 NULL
 
@@ -610,7 +610,7 @@ NULL
 -- !query
 select date '2001-10-01' - date '2001-09-28'
 -- !query schema
-struct<(DATE '2001-10-01' - DATE '2001-09-28'):day-time interval>
+struct<(DATE '2001-10-01' - DATE '2001-09-28'):interval day to second>
 -- !query output
 3 00:00:00.000000000
 

--- a/sql/core/src/test/resources/sql-tests/results/extract.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/extract.sql.out
@@ -869,7 +869,7 @@ select extract(DAY from interval '2-1' YEAR TO MONTH)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Literals of type 'DAY' are currently not supported for the year-month interval type.; line 1 pos 7
+Literals of type 'DAY' are currently not supported for the interval year to month type.; line 1 pos 7
 
 
 -- !query
@@ -878,7 +878,7 @@ select date_part('DAY', interval '2-1' YEAR TO MONTH)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Literals of type 'DAY' are currently not supported for the year-month interval type.; line 1 pos 7
+Literals of type 'DAY' are currently not supported for the interval year to month type.; line 1 pos 7
 
 
 -- !query
@@ -887,7 +887,7 @@ select date_part('not_supported', interval '2-1' YEAR TO MONTH)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Literals of type 'not_supported' are currently not supported for the year-month interval type.; line 1 pos 7
+Literals of type 'not_supported' are currently not supported for the interval year to month type.; line 1 pos 7
 
 
 -- !query
@@ -1000,7 +1000,7 @@ select extract(MONTH from interval '123 12:34:56.789123123' DAY TO SECOND)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Literals of type 'MONTH' are currently not supported for the day-time interval type.; line 1 pos 7
+Literals of type 'MONTH' are currently not supported for the interval day to second type.; line 1 pos 7
 
 
 -- !query
@@ -1009,4 +1009,4 @@ select date_part('not_supported', interval '123 12:34:56.789123123' DAY TO SECON
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Literals of type 'not_supported' are currently not supported for the day-time interval type.; line 1 pos 7
+Literals of type 'not_supported' are currently not supported for the interval day to second type.; line 1 pos 7

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -5,7 +5,7 @@
 -- !query
 select 3 * (timestamp'2019-10-15 10:11:12.001002' - date'2019-10-15')
 -- !query schema
-struct<((TIMESTAMP '2019-10-15 10:11:12.001002' - DATE '2019-10-15') * 3):day-time interval>
+struct<((TIMESTAMP '2019-10-15 10:11:12.001002' - DATE '2019-10-15') * 3):interval day to second>
 -- !query output
 1 06:33:36.003006000
 
@@ -21,7 +21,7 @@ struct<multiply_interval(INTERVAL '4 months 14 days 0.000003 seconds', 1.5):inte
 -- !query
 select (timestamp'2019-10-15' - timestamp'2019-10-14') / 1.5
 -- !query schema
-struct<((TIMESTAMP '2019-10-15 00:00:00' - TIMESTAMP '2019-10-14 00:00:00') / 1.5):day-time interval>
+struct<((TIMESTAMP '2019-10-15 00:00:00' - TIMESTAMP '2019-10-14 00:00:00') / 1.5):interval day to second>
 -- !query output
 0 16:00:00.000000000
 
@@ -125,7 +125,7 @@ struct<(+ INTERVAL '-1 months 1 days -1 seconds'):interval>
 -- !query
 select interval -'1-1' year to month
 -- !query schema
-struct<INTERVAL '-1-1' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '-1-1' YEAR TO MONTH:interval year to month>
 -- !query output
 -1-1
 
@@ -133,7 +133,7 @@ struct<INTERVAL '-1-1' YEAR TO MONTH:year-month interval>
 -- !query
 select interval -'-1-1' year to month
 -- !query schema
-struct<INTERVAL '1-1' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '1-1' YEAR TO MONTH:interval year to month>
 -- !query output
 1-1
 
@@ -141,7 +141,7 @@ struct<INTERVAL '1-1' YEAR TO MONTH:year-month interval>
 -- !query
 select interval +'-1-1' year to month
 -- !query schema
-struct<INTERVAL '-1-1' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '-1-1' YEAR TO MONTH:interval year to month>
 -- !query output
 -1-1
 
@@ -149,7 +149,7 @@ struct<INTERVAL '-1-1' YEAR TO MONTH:year-month interval>
 -- !query
 select interval - '1 2:3:4.001' day to second
 -- !query schema
-struct<INTERVAL '-1 02:03:04.001' DAY TO SECOND:day-time interval>
+struct<INTERVAL '-1 02:03:04.001' DAY TO SECOND:interval day to second>
 -- !query output
 -1 02:03:04.001000000
 
@@ -157,7 +157,7 @@ struct<INTERVAL '-1 02:03:04.001' DAY TO SECOND:day-time interval>
 -- !query
 select interval +'1 2:3:4.001' day to second
 -- !query schema
-struct<INTERVAL '1 02:03:04.001' DAY TO SECOND:day-time interval>
+struct<INTERVAL '1 02:03:04.001' DAY TO SECOND:interval day to second>
 -- !query output
 1 02:03:04.001000000
 
@@ -165,7 +165,7 @@ struct<INTERVAL '1 02:03:04.001' DAY TO SECOND:day-time interval>
 -- !query
 select interval -'-1 2:3:4.001' day to second
 -- !query schema
-struct<INTERVAL '1 02:03:04.001' DAY TO SECOND:day-time interval>
+struct<INTERVAL '1 02:03:04.001' DAY TO SECOND:interval day to second>
 -- !query output
 1 02:03:04.001000000
 
@@ -325,7 +325,7 @@ struct<INTERVAL '32 years 1 months -100 days 41 hours 24 minutes 59.889987 secon
 -- !query
 select interval '0-0' year to month
 -- !query schema
-struct<INTERVAL '0-0' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '0-0' YEAR TO MONTH:interval year to month>
 -- !query output
 0-0
 
@@ -333,7 +333,7 @@ struct<INTERVAL '0-0' YEAR TO MONTH:year-month interval>
 -- !query
 select interval '0 0:0:0' day to second
 -- !query schema
-struct<INTERVAL '0 00:00:00' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 00:00:00' DAY TO SECOND:interval day to second>
 -- !query output
 0 00:00:00.000000000
 
@@ -341,7 +341,7 @@ struct<INTERVAL '0 00:00:00' DAY TO SECOND:day-time interval>
 -- !query
 select interval '0 0:0:0.1' day to second
 -- !query schema
-struct<INTERVAL '0 00:00:00.1' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 00:00:00.1' DAY TO SECOND:interval day to second>
 -- !query output
 0 00:00:00.100000000
 
@@ -349,7 +349,7 @@ struct<INTERVAL '0 00:00:00.1' DAY TO SECOND:day-time interval>
 -- !query
 select interval '10-9' year to month
 -- !query schema
-struct<INTERVAL '10-9' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '10-9' YEAR TO MONTH:interval year to month>
 -- !query output
 10-9
 
@@ -357,7 +357,7 @@ struct<INTERVAL '10-9' YEAR TO MONTH:year-month interval>
 -- !query
 select interval '20 15' day to hour
 -- !query schema
-struct<INTERVAL '20 15:00:00' DAY TO SECOND:day-time interval>
+struct<INTERVAL '20 15:00:00' DAY TO SECOND:interval day to second>
 -- !query output
 20 15:00:00.000000000
 
@@ -365,7 +365,7 @@ struct<INTERVAL '20 15:00:00' DAY TO SECOND:day-time interval>
 -- !query
 select interval '20 15:40' day to minute
 -- !query schema
-struct<INTERVAL '20 15:40:00' DAY TO SECOND:day-time interval>
+struct<INTERVAL '20 15:40:00' DAY TO SECOND:interval day to second>
 -- !query output
 20 15:40:00.000000000
 
@@ -373,7 +373,7 @@ struct<INTERVAL '20 15:40:00' DAY TO SECOND:day-time interval>
 -- !query
 select interval '20 15:40:32.99899999' day to second
 -- !query schema
-struct<INTERVAL '20 15:40:32.998999' DAY TO SECOND:day-time interval>
+struct<INTERVAL '20 15:40:32.998999' DAY TO SECOND:interval day to second>
 -- !query output
 20 15:40:32.998999000
 
@@ -381,7 +381,7 @@ struct<INTERVAL '20 15:40:32.998999' DAY TO SECOND:day-time interval>
 -- !query
 select interval '15:40' hour to minute
 -- !query schema
-struct<INTERVAL '0 15:40:00' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 15:40:00' DAY TO SECOND:interval day to second>
 -- !query output
 0 15:40:00.000000000
 
@@ -389,7 +389,7 @@ struct<INTERVAL '0 15:40:00' DAY TO SECOND:day-time interval>
 -- !query
 select interval '15:40:32.99899999' hour to second
 -- !query schema
-struct<INTERVAL '0 15:40:32.998999' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 15:40:32.998999' DAY TO SECOND:interval day to second>
 -- !query output
 0 15:40:32.998999000
 
@@ -397,7 +397,7 @@ struct<INTERVAL '0 15:40:32.998999' DAY TO SECOND:day-time interval>
 -- !query
 select interval '40:32.99899999' minute to second
 -- !query schema
-struct<INTERVAL '0 00:40:32.998999' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 00:40:32.998999' DAY TO SECOND:interval day to second>
 -- !query output
 0 00:40:32.998999000
 
@@ -405,7 +405,7 @@ struct<INTERVAL '0 00:40:32.998999' DAY TO SECOND:day-time interval>
 -- !query
 select interval '40:32' minute to second
 -- !query schema
-struct<INTERVAL '0 00:40:32' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 00:40:32' DAY TO SECOND:interval day to second>
 -- !query output
 0 00:40:32.000000000
 
@@ -777,7 +777,7 @@ select interval 30 days days days
 -- !query
 SELECT INTERVAL '178956970-7' YEAR TO MONTH
 -- !query schema
-struct<INTERVAL '178956970-7' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '178956970-7' YEAR TO MONTH:interval year to month>
 -- !query output
 178956970-7
 
@@ -799,7 +799,7 @@ SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query
 SELECT INTERVAL '-178956970-8' YEAR TO MONTH
 -- !query schema
-struct<INTERVAL '-178956970-8' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '-178956970-8' YEAR TO MONTH:interval year to month>
 -- !query output
 -178956970-8
 
@@ -807,7 +807,7 @@ struct<INTERVAL '-178956970-8' YEAR TO MONTH:year-month interval>
 -- !query
 SELECT INTERVAL -'178956970-8' YEAR TO MONTH
 -- !query schema
-struct<INTERVAL '-178956970-8' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '-178956970-8' YEAR TO MONTH:interval year to month>
 -- !query output
 -178956970-8
 
@@ -861,7 +861,7 @@ select
   interval '2-2' year to month - interval '3-3' year to month
 from interval_arithmetic
 -- !query schema
-struct<(INTERVAL '2-2' YEAR TO MONTH + INTERVAL '3-3' YEAR TO MONTH):year-month interval,(INTERVAL '2-2' YEAR TO MONTH - INTERVAL '3-3' YEAR TO MONTH):year-month interval>
+struct<(INTERVAL '2-2' YEAR TO MONTH + INTERVAL '3-3' YEAR TO MONTH):interval year to month,(INTERVAL '2-2' YEAR TO MONTH - INTERVAL '3-3' YEAR TO MONTH):interval year to month>
 -- !query output
 5-5	-1-1
 
@@ -920,7 +920,7 @@ select
   interval '99 11:22:33.123456789' day to second - interval '10 9:8:7.123456789' day to second
 from interval_arithmetic
 -- !query schema
-struct<(INTERVAL '99 11:22:33.123456' DAY TO SECOND + INTERVAL '10 09:08:07.123456' DAY TO SECOND):day-time interval,(INTERVAL '99 11:22:33.123456' DAY TO SECOND - INTERVAL '10 09:08:07.123456' DAY TO SECOND):day-time interval>
+struct<(INTERVAL '99 11:22:33.123456' DAY TO SECOND + INTERVAL '10 09:08:07.123456' DAY TO SECOND):interval day to second,(INTERVAL '99 11:22:33.123456' DAY TO SECOND - INTERVAL '10 09:08:07.123456' DAY TO SECOND):interval day to second>
 -- !query output
 109 20:30:40.246912000	89 02:14:26.000000000
 
@@ -968,7 +968,7 @@ struct<INTERVAL '1 days':interval>
 -- !query
 select interval '2-2\t' year to month
 -- !query schema
-struct<INTERVAL '2-2' YEAR TO MONTH:year-month interval>
+struct<INTERVAL '2-2' YEAR TO MONTH:interval year to month>
 -- !query output
 2-2
 
@@ -990,7 +990,7 @@ select interval '-\t2-2\t' year to month
 -- !query
 select interval '\n0 12:34:46.789\t' day to second
 -- !query schema
-struct<INTERVAL '0 12:34:46.789' DAY TO SECOND:day-time interval>
+struct<INTERVAL '0 12:34:46.789' DAY TO SECOND:interval day to second>
 -- !query output
 0 12:34:46.789000000
 
@@ -1253,7 +1253,7 @@ struct<INTERVAL '-1 days':interval>
 -- !query
 SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / 2
 -- !query schema
-struct<(INTERVAL '-178956970-8' YEAR TO MONTH / 2):year-month interval>
+struct<(INTERVAL '-178956970-8' YEAR TO MONTH / 2):interval year to month>
 -- !query output
 -89478485-4
 
@@ -1261,7 +1261,7 @@ struct<(INTERVAL '-178956970-8' YEAR TO MONTH / 2):year-month interval>
 -- !query
 SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / 5
 -- !query schema
-struct<(INTERVAL '-178956970-8' YEAR TO MONTH / 5):year-month interval>
+struct<(INTERVAL '-178956970-8' YEAR TO MONTH / 5):interval year to month>
 -- !query output
 -35791394-2
 
@@ -1305,7 +1305,7 @@ not in range
 -- !query
 SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / 2
 -- !query schema
-struct<(INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND / 2):day-time interval>
+struct<(INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND / 2):interval day to second>
 -- !query output
 -53375995 14:00:27.387904000
 
@@ -1313,7 +1313,7 @@ struct<(INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND / 2):day-time interv
 -- !query
 SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / 5
 -- !query schema
-struct<(INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND / 5):day-time interval>
+struct<(INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND / 5):interval day to second>
 -- !query output
 -21350398 05:36:10.955162000
 

--- a/sql/core/src/test/resources/sql-tests/results/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/literals.sql.out
@@ -436,7 +436,7 @@ select +date '1999-01-01'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ DATE '1999-01-01')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'DATE '1999-01-01'' is of date type.; line 1 pos 7
+cannot resolve '(+ DATE '1999-01-01')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'DATE '1999-01-01'' is of date type.; line 1 pos 7
 
 
 -- !query
@@ -445,7 +445,7 @@ select +timestamp '1999-01-01'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ TIMESTAMP '1999-01-01 00:00:00')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'TIMESTAMP '1999-01-01 00:00:00'' is of timestamp type.; line 1 pos 7
+cannot resolve '(+ TIMESTAMP '1999-01-01 00:00:00')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'TIMESTAMP '1999-01-01 00:00:00'' is of timestamp type.; line 1 pos 7
 
 
 -- !query
@@ -462,7 +462,7 @@ select +map(1, 2)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ map(1, 2))' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'map(1, 2)' is of map<int,int> type.; line 1 pos 7
+cannot resolve '(+ map(1, 2))' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'map(1, 2)' is of map<int,int> type.; line 1 pos 7
 
 
 -- !query
@@ -471,7 +471,7 @@ select +array(1,2)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ array(1, 2))' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'array(1, 2)' is of array<int> type.; line 1 pos 7
+cannot resolve '(+ array(1, 2))' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'array(1, 2)' is of array<int> type.; line 1 pos 7
 
 
 -- !query
@@ -480,7 +480,7 @@ select +named_struct('a', 1, 'b', 'spark')
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ named_struct('a', 1, 'b', 'spark'))' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'named_struct('a', 1, 'b', 'spark')' is of struct<a:int,b:string> type.; line 1 pos 7
+cannot resolve '(+ named_struct('a', 1, 'b', 'spark'))' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'named_struct('a', 1, 'b', 'spark')' is of struct<a:int,b:string> type.; line 1 pos 7
 
 
 -- !query
@@ -489,7 +489,7 @@ select +X'1'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(+ X'01')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'X'01'' is of binary type.; line 1 pos 7
+cannot resolve '(+ X'01')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'X'01'' is of binary type.; line 1 pos 7
 
 
 -- !query
@@ -498,7 +498,7 @@ select -date '1999-01-01'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(- DATE '1999-01-01')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'DATE '1999-01-01'' is of date type.; line 1 pos 7
+cannot resolve '(- DATE '1999-01-01')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'DATE '1999-01-01'' is of date type.; line 1 pos 7
 
 
 -- !query
@@ -507,7 +507,7 @@ select -timestamp '1999-01-01'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(- TIMESTAMP '1999-01-01 00:00:00')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'TIMESTAMP '1999-01-01 00:00:00'' is of timestamp type.; line 1 pos 7
+cannot resolve '(- TIMESTAMP '1999-01-01 00:00:00')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'TIMESTAMP '1999-01-01 00:00:00'' is of timestamp type.; line 1 pos 7
 
 
 -- !query
@@ -516,4 +516,4 @@ select -x'2379ACFe'
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(- X'2379ACFE')' due to data type mismatch: argument 1 requires (numeric or interval or day-time interval or year-month interval) type, however, 'X'2379ACFE'' is of binary type.; line 1 pos 7
+cannot resolve '(- X'2379ACFE')' due to data type mismatch: argument 1 requires (numeric or interval or interval day to second or interval year to month) type, however, 'X'2379ACFE'' is of binary type.; line 1 pos 7

--- a/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/promoteStrings.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/promoteStrings.sql.out
@@ -204,7 +204,7 @@ cannot resolve '('1' - CAST('2017-12-11 09:30:00.0' AS TIMESTAMP))' due to data 
 -- !query
 SELECT '1' - cast('2017-12-11 09:30:00' as date)        FROM t
 -- !query schema
-struct<(1 - CAST(2017-12-11 09:30:00 AS DATE)):day-time interval>
+struct<(1 - CAST(2017-12-11 09:30:00 AS DATE)):interval day to second>
 -- !query output
 NULL
 

--- a/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/windowFrameCoercion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/windowFrameCoercion.sql.out
@@ -168,7 +168,7 @@ SELECT COUNT(*) OVER (PARTITION BY 1 ORDER BY cast(1 as string) DESC RANGE BETWE
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'RANGE BETWEEN CURRENT ROW AND CAST(1 AS STRING) FOLLOWING' due to data type mismatch: The data type of the upper bound 'string' does not match the expected data type '(numeric or interval or day-time interval or year-month interval)'.; line 1 pos 21
+cannot resolve 'RANGE BETWEEN CURRENT ROW AND CAST(1 AS STRING) FOLLOWING' due to data type mismatch: The data type of the upper bound 'string' does not match the expected data type '(numeric or interval or interval day to second or interval year to month)'.; line 1 pos 21
 
 
 -- !query
@@ -177,7 +177,7 @@ SELECT COUNT(*) OVER (PARTITION BY 1 ORDER BY cast('1' as binary) DESC RANGE BET
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'RANGE BETWEEN CURRENT ROW AND CAST(1 AS BINARY) FOLLOWING' due to data type mismatch: The data type of the upper bound 'binary' does not match the expected data type '(numeric or interval or day-time interval or year-month interval)'.; line 1 pos 21
+cannot resolve 'RANGE BETWEEN CURRENT ROW AND CAST(1 AS BINARY) FOLLOWING' due to data type mismatch: The data type of the upper bound 'binary' does not match the expected data type '(numeric or interval or interval day to second or interval year to month)'.; line 1 pos 21
 
 
 -- !query
@@ -186,7 +186,7 @@ SELECT COUNT(*) OVER (PARTITION BY 1 ORDER BY cast(1 as boolean) DESC RANGE BETW
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'RANGE BETWEEN CURRENT ROW AND CAST(1 AS BOOLEAN) FOLLOWING' due to data type mismatch: The data type of the upper bound 'boolean' does not match the expected data type '(numeric or interval or day-time interval or year-month interval)'.; line 1 pos 21
+cannot resolve 'RANGE BETWEEN CURRENT ROW AND CAST(1 AS BOOLEAN) FOLLOWING' due to data type mismatch: The data type of the upper bound 'boolean' does not match the expected data type '(numeric or interval or interval day to second or interval year to month)'.; line 1 pos 21
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/window.sql.out
@@ -273,7 +273,7 @@ ORDER BY cate, val_date
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve '(PARTITION BY testdata.cate ORDER BY testdata.val_date ASC NULLS FIRST RANGE BETWEEN CURRENT ROW AND INTERVAL '1 02:03:04.001' DAY TO SECOND FOLLOWING)' due to data type mismatch: The data type 'date' used in the order specification does not match the data type 'day-time interval' which is used in the range frame.; line 1 pos 46
+cannot resolve '(PARTITION BY testdata.cate ORDER BY testdata.val_date ASC NULLS FIRST RANGE BETWEEN CURRENT ROW AND INTERVAL '1 02:03:04.001' DAY TO SECOND FOLLOWING)' due to data type mismatch: The data type 'date' used in the order specification does not match the data type 'interval day to second' which is used in the range frame.; line 1 pos 46
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Extend Spark SQL parser to support parsing of:
    - `INTERVAL YEAR TO MONTH` to `YearMonthIntervalType`
    - `INTERVAL DAY TO SECOND` to `DayTimeIntervalType`
2. Assign new names to the ANSI interval types according to the SQL standard to be able to parse the names back by Spark SQL parser. Override the `typeName()` name of `YearMonthIntervalType`/`DayTimeIntervalType`.

### Why are the changes needed?
To be able to use new ANSI interval types in SQL. The SQL standard requires the types to be defined according to the rules:
```
<interval type> ::= INTERVAL <interval qualifier>
<interval qualifier> ::= <start field> TO <end field> | <single datetime field>
<start field> ::= <non-second primary datetime field> [ <left paren> <interval leading field precision> <right paren> ]
<end field> ::= <non-second primary datetime field> | SECOND [ <left paren> <interval fractional seconds precision> <right paren> ]
<primary datetime field> ::= <non-second primary datetime field | SECOND
<non-second primary datetime field> ::= YEAR | MONTH | DAY | HOUR | MINUTE
<interval fractional seconds precision> ::= <unsigned integer>
<interval leading field precision> ::= <unsigned integer>
```
Currently, Spark SQL supports only `YEAR TO MONTH` and `DAY TO SECOND` as `<interval qualifier>`.

### Does this PR introduce _any_ user-facing change?
Should not since the types has not been released yet.

### How was this patch tested?
By running the affected tests such as:
```
$ build/sbt "sql/testOnly *SQLQueryTestSuite -- -z interval.sql"
$ build/sbt "sql/testOnly *SQLQueryTestSuite -- -z datetime.sql"
$ build/sbt "test:testOnly *ExpressionTypeCheckingSuite"
$ build/sbt "sql/testOnly *SQLQueryTestSuite -- -z windowFrameCoercion.sql"
$ build/sbt "sql/testOnly *SQLQueryTestSuite -- -z literals.sql"
```