### PR TITLE
[SPARK-35281][SQL] StaticInvoke should not apply boxing if return type is primitive

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -256,25 +256,21 @@ case class StaticInvoke(
       ""
     }
 
-    val evaluate = if (returnNullable) {
+    val evaluate = if (returnNullable && !method.getReturnType.isPrimitive) {
       if (CodeGenerator.defaultValue(dataType) == "null") {
         s"""
           ${ev.value} = $callFunc;
           ${ev.isNull} = ${ev.value} == null;
         """
       } else {
-        if (method.getReturnType.isPrimitive) {
-          s"${ev.value} = $callFunc;"
-        } else {
-          val boxedResult = ctx.freshName("boxedResult")
-          s"""
-            ${CodeGenerator.boxedType(dataType)} $boxedResult = $callFunc;
-            ${ev.isNull} = $boxedResult == null;
-            if (!${ev.isNull}) {
-              ${ev.value} = $boxedResult;
-            }
-          """
-        }
+        val boxedResult = ctx.freshName("boxedResult")
+        s"""
+          ${CodeGenerator.boxedType(dataType)} $boxedResult = $callFunc;
+          ${ev.isNull} = $boxedResult == null;
+          if (!${ev.isNull}) {
+            ${ev.value} = $boxedResult;
+          }
+        """
       }
     } else {
       s"${ev.value} = $callFunc;"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -263,14 +263,18 @@ case class StaticInvoke(
           ${ev.isNull} = ${ev.value} == null;
         """
       } else {
-        val boxedResult = ctx.freshName("boxedResult")
-        s"""
-          ${CodeGenerator.boxedType(dataType)} $boxedResult = $callFunc;
-          ${ev.isNull} = $boxedResult == null;
-          if (!${ev.isNull}) {
-            ${ev.value} = $boxedResult;
-          }
-        """
+        if (method.getReturnType.isPrimitive) {
+          s"${ev.value} = $callFunc;"
+        } else {
+          val boxedResult = ctx.freshName("boxedResult")
+          s"""
+            ${CodeGenerator.boxedType(dataType)} $boxedResult = $callFunc;
+            ${ev.isNull} = $boxedResult == null;
+            if (!${ev.isNull}) {
+              ${ev.value} = $boxedResult;
+            }
+          """
+        }
       }
     } else {
       s"${ev.value} = $callFunc;"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In `StaticInvoke`, when result is nullable, don't box the return value if its type is primitive.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

It is unnecessary to apply boxing when the method return value is of primitive type, and it would hurt performance a lot if the method is simple. The check is done in `Invoke` but not in `StaticInvoke`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added a UT.