### PR TITLE
[SPARK-35289][SQL] Make CatalogString contains nullable information

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
@@ -91,7 +91,8 @@ case class ArrayType(elementType: DataType, containsNull: Boolean) extends DataT
 
   override def simpleString: String = s"array<${elementType.simpleString}>"
 
-  override def catalogString: String = s"array<${elementType.catalogString}>"
+  override def catalogString: String =
+    s"array<${elementType.catalogString}(nullable=$containsNull)>"
 
   override def sql: String = s"ARRAY<${elementType.sql}>"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
@@ -69,7 +69,8 @@ case class MapType(
 
   override def simpleString: String = s"map<${keyType.simpleString},${valueType.simpleString}>"
 
-  override def catalogString: String = s"map<${keyType.catalogString},${valueType.catalogString}>"
+  override def catalogString: String =
+    s"map<${keyType.catalogString},${valueType.catalogString}(nullable=$valueContainsNull)>"
 
   override def sql: String = s"MAP<${keyType.sql}, ${valueType.sql}>"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -435,7 +435,8 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     stringConcat.append("struct<")
     var i = 0
     while (i < len) {
-      stringConcat.append(s"${fields(i).name}:${fields(i).dataType.catalogString}")
+      stringConcat.append(
+        s"${fields(i).name}:${fields(i).dataType.catalogString}(nullable=${fields(i).nullable})")
       i += 1
       if (i < len) stringConcat.append(",")
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
This patch proposes to make CatalogString contains nullable information to help understand Casting failure message.

### Why are the changes needed?
When trying to cast ArrayType/MapType/StructType from containing NULL to not contain NULL, we will get a confusing failure message.
Here's a example:
```scala
  test("casting from nullable to non-nullable") {
    // ArrayType
    val arrayContainsNull = Literal.create(Seq("contains", "null", null),
      ArrayType(StringType, containsNull = true))
    val arrayCastRet = cast(arrayContainsNull, ArrayType(StringType, containsNull = false))

    // MapType
    val mapValueContainsNull = Literal.create(
      Map("a" -> "false", "b" -> "true", "c" -> null),
      MapType(StringType, StringType, valueContainsNull = true))
    val mapCastRet =
      cast(mapValueContainsNull, MapType(StringType, StringType, valueContainsNull = false))

    // StructType
    val structContainsNull = Literal.create(
      Row(0),
      StructType(Seq(StructField("i", IntegerType, nullable = true)))
    )
    val structCastRet =
      cast(structContainsNull, StructType(Seq(StructField("i", IntegerType, nullable = false))))


    assert(!arrayCastRet.resolved && !mapCastRet.resolved && !structCastRet.resolved)

    println(arrayCastRet.typeCheckFailureMessage)
    println(mapCastRet.typeCheckFailureMessage)
    println(structCastRet.typeCheckFailureMessage)
  }
```
Failure massage before this path:
```
cannot cast array<string> to array<string>
cannot cast map<string,string> to map<string,string>
cannot cast struct<i:int> to struct<i:int>
```
From the above error message, it is not clear why the error is reported, because the data type before and after is the same.
Therefore, we need to specify nullable info for ArrayType/MapType/StructType in the Catalog String to identify the reason for Casting Failures.

Failure massage after this patch:
```
cannot cast array<string(nullable=true)> to array<string(nullable=false)>
cannot cast map<string,string(nullable=true)> to map<string,string(nullable=false)>
cannot cast struct<i:int(nullable=true)> to struct<i:int(nullable=false)>
```

This PR adds a nullable message in the catalog string with the format '(nullable=true/false)', so we can observe why the error message is returned when the cast failed due to nullability.

### Does this PR introduce _any_ user-facing change?
Yes, this PR changes the Catalog String of ArrayType, MapType and StructType.

### How was this patch tested?
New UT