### PR TITLE
[SPARK-35173][SQL][PYTHON] Add multiple columns adding support

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2911,6 +2911,43 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             support = 0.01
         return DataFrame(self._jdf.stat().freqItems(_to_seq(self._sc, cols), support), self.sql_ctx)
 
+    def with_columns(self, col_names, cols):
+        """
+        Returns a new :class:`DataFrame` by adding multiple columns or replacing the
+        existing columns that has the same name.
+
+        The cols expression must be a list of expression over this :class:`DataFrame`;
+        attempting to add columns from some other :class:`DataFrame` will raise an error.
+
+        .. versionadded:: 3.2.0
+           Added support for multiple columns adding
+
+        Parameters
+        ----------
+        col_names : tuple or list
+            a list of names for multiple columns.
+        cols : tuple or list
+            a list of names for multiple columns.
+
+        Examples
+        --------
+        >>> df.with_columns(['age2', 'age3'], [df.age + 2, df.age + 3]).collect()
+        [Row(age=2, name='Alice', age2=4, age3=5), Row(age=5, name='Bob', age2=7, age3=8)]
+        """
+        if not isinstance(col_names, (list, tuple)):
+            raise TypeError("colName must be string or list/tuple of column names.")
+        if not isinstance(cols, (list, tuple)):
+            raise TypeError("col must be a column or list/tuple of columns.")
+
+        # Covert tuple to list
+        col_names = list(col_names) if isinstance(col_names, tuple) else col_names
+        cols = list(cols) if isinstance(cols, tuple) else cols
+
+        return DataFrame(
+            self._jdf.withColumns(_to_seq(self._sc, col_names), self._jcols(cols)),
+            self.sql_ctx
+        )
+
     def withColumn(self, colName: str, col: Column) -> "DataFrame":
         """
         Returns a new :class:`DataFrame` by adding a column or replacing the

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2911,7 +2911,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             support = 0.01
         return DataFrame(self._jdf.stat().freqItems(_to_seq(self._sc, cols), support), self.sql_ctx)
 
-    def withColumns(self, colsMap):
+    def withColumns(self, colsMap: Dict[str, Column]) -> "DataFrame":
         """
         Returns a new :class:`DataFrame` by adding multiple columns or replacing the
         existing columns that has the same names.
@@ -2919,7 +2919,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         The colsMap is a map of column name and column, the column must only refer to attributes
         supplied by this Dataset. It is an error to add columns that refer to some other Dataset.
 
-        .. versionadded:: 3.2.0
+        .. versionadded:: 3.3.0
            Added support for multiple columns adding
 
         Parameters
@@ -2939,8 +2939,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         cols = list(colsMap.values())
 
         return DataFrame(
-            self._jdf.withColumns(_to_seq(self._sc, col_names), self._jcols(cols)),
-            self.sql_ctx
+            self._jdf.withColumns(_to_seq(self._sc, col_names), self._jcols(*cols)), self.sql_ctx
         )
 
     def withColumn(self, colName: str, col: Column) -> "DataFrame":

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2914,10 +2914,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
     def withColumns(self, colsMap):
         """
         Returns a new :class:`DataFrame` by adding multiple columns or replacing the
-        existing columns that has the same name.
+        existing columns that has the same names.
 
-        The colsMap is a map of column name and column, the column must only refer to attribute
-        supplied by this Dataset. It is an error to add columns that refers to some other Dataset.
+        The colsMap is a map of column name and column, the column must only refer to attributes
+        supplied by this Dataset. It is an error to add columns that refer to some other Dataset.
 
         .. versionadded:: 3.2.0
            Added support for multiple columns adding

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2911,7 +2911,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             support = 0.01
         return DataFrame(self._jdf.stat().freqItems(_to_seq(self._sc, cols), support), self.sql_ctx)
 
-    def withColumns(self, colsMap: Dict[str, Column]) -> "DataFrame":
+    def withColumns(self, *colsMap: Dict[str, Column]) -> "DataFrame":
         """
         Returns a new :class:`DataFrame` by adding multiple columns or replacing the
         existing columns that has the same names.
@@ -2932,6 +2932,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> df.withColumns({'age2': df.age + 2, 'age3': df.age + 3}).collect()
         [Row(age=2, name='Alice', age2=4, age3=5), Row(age=5, name='Bob', age2=7, age3=8)]
         """
+        # Below code is to help enable kwargs in future.
+        assert len(colsMap) == 1
+        colsMap = colsMap[0]  # type: ignore[assignment]
+
         if not isinstance(colsMap, dict):
             raise TypeError("colsMap must be dict of column name and column.")
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2911,37 +2911,32 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             support = 0.01
         return DataFrame(self._jdf.stat().freqItems(_to_seq(self._sc, cols), support), self.sql_ctx)
 
-    def with_columns(self, col_names, cols):
+    def withColumns(self, colsMap):
         """
         Returns a new :class:`DataFrame` by adding multiple columns or replacing the
         existing columns that has the same name.
 
-        The cols expression must be a list of expression over this :class:`DataFrame`;
-        attempting to add columns from some other :class:`DataFrame` will raise an error.
+        The colsMap is a map of column name and column, the column must only refer to attribute
+        supplied by this Dataset. It is an error to add columns that refers to some other Dataset.
 
         .. versionadded:: 3.2.0
            Added support for multiple columns adding
 
         Parameters
         ----------
-        col_names : tuple or list
-            a list of names for multiple columns.
-        cols : tuple or list
-            a list of names for multiple columns.
+        colsMap : dict
+            a dict of column name and :class:`Column`.
 
         Examples
         --------
-        >>> df.with_columns(['age2', 'age3'], [df.age + 2, df.age + 3]).collect()
+        >>> df.withColumns({'age2': df.age + 2, 'age3': df.age + 3}).collect()
         [Row(age=2, name='Alice', age2=4, age3=5), Row(age=5, name='Bob', age2=7, age3=8)]
         """
-        if not isinstance(col_names, (list, tuple)):
-            raise TypeError("colName must be string or list/tuple of column names.")
-        if not isinstance(cols, (list, tuple)):
-            raise TypeError("col must be a column or list/tuple of columns.")
+        if not isinstance(colsMap, dict):
+            raise TypeError("colsMap must be dict of column name and column.")
 
-        # Covert tuple to list
-        col_names = list(col_names) if isinstance(col_names, tuple) else col_names
-        cols = list(cols) if isinstance(cols, tuple) else cols
+        col_names = list(colsMap.keys())
+        cols = list(colsMap.values())
 
         return DataFrame(
             self._jdf.withColumns(_to_seq(self._sc, col_names), self._jcols(cols)),

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2925,7 +2925,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         Parameters
         ----------
         colsMap : dict
-            a dict of column name and :class:`Column`.
+            a dict of column name and :class:`Column`. Currently, only single map is supported.
 
         Examples
         --------

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -479,6 +479,35 @@ class DataFrameTests(ReusedSQLTestCase):
 
         self.assertRaises(TypeError, foo)
 
+    def test_with_columns(self):
+        # With key and value columns
+        kvs = self.df.with_columns(
+            ["key", "value"], [self.df.key, self.df.value]
+        ).select("key", "value").collect()
+        self.assertEqual([(r.key, r.value) for r in kvs], [(i, str(i)) for i in range(100)])
+
+        # With list style names and values
+        keys = self.df.with_columns(["key"], [self.df.key]).select("key").collect()
+        self.assertEqual([r.key for r in keys], list(range(100)))
+
+        # With tuple style names and values
+        keys = self.df.with_columns(("key",), (self.df.key,)).select("key").collect()
+        self.assertEqual([r.key for r in keys], list(range(100)))
+
+        # Columns rename
+        kvs = self.df.with_columns(
+            ["key_alias", "value_alias"], [self.df.key, self.df.value]
+        ).select("key_alias", "value_alias").collect()
+        self.assertEqual(
+            [(r.key_alias, r.value_alias) for r in kvs],
+            [(i, str(i)) for i in range(100)]
+        )
+
+        # Type check
+        erorr_type_val = ""
+        self.assertRaises(TypeError, self.df.with_columns, erorr_type_val, [self.df.key])
+        self.assertRaises(TypeError, self.df.with_columns, ["key"], erorr_type_val)
+
     def test_generic_hints(self):
         from pyspark.sql import DataFrame
 

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -480,29 +480,30 @@ class DataFrameTests(ReusedSQLTestCase):
         self.assertRaises(TypeError, foo)
 
     def test_with_columns(self):
-        # With key and value columns
-        kvs = self.df.withColumns(
-            {"key": self.df.key, "value": self.df.value}
-        ).select("key", "value").collect()
-        self.assertEqual([(r.key, r.value) for r in kvs], [(i, str(i)) for i in range(100)])
-
-        # With list style names and values
+        # With single column
         keys = self.df.withColumns({"key": self.df.key}).select("key").collect()
         self.assertEqual([r.key for r in keys], list(range(100)))
 
+        # With key and value columns
+        kvs = (
+            self.df.withColumns({"key": self.df.key, "value": self.df.value})
+            .select("key", "value")
+            .collect()
+        )
+        self.assertEqual([(r.key, r.value) for r in kvs], [(i, str(i)) for i in range(100)])
+
         # Columns rename
-        kvs = self.df.withColumns(
-            {"key_alias": self.df.key, "value_alias": self.df.value}
-        ).select("key_alias", "value_alias").collect()
+        kvs = (
+            self.df.withColumns({"key_alias": self.df.key, "value_alias": self.df.value})
+            .select("key_alias", "value_alias")
+            .collect()
+        )
         self.assertEqual(
-            [(r.key_alias, r.value_alias) for r in kvs],
-            [(i, str(i)) for i in range(100)]
+            [(r.key_alias, r.value_alias) for r in kvs], [(i, str(i)) for i in range(100)]
         )
 
         # Type check
-        erorr_type_val = ""
-        self.assertRaises(TypeError, self.df.withColumns, erorr_type_val, [self.df.key])
-        self.assertRaises(TypeError, self.df.withColumns, ["key"], erorr_type_val)
+        self.assertRaises(TypeError, self.df.withColumns, ["key"])
 
     def test_generic_hints(self):
         from pyspark.sql import DataFrame

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -481,22 +481,18 @@ class DataFrameTests(ReusedSQLTestCase):
 
     def test_with_columns(self):
         # With key and value columns
-        kvs = self.df.with_columns(
-            ["key", "value"], [self.df.key, self.df.value]
+        kvs = self.df.withColumns(
+            {"key": self.df.key, "value": self.df.value}
         ).select("key", "value").collect()
         self.assertEqual([(r.key, r.value) for r in kvs], [(i, str(i)) for i in range(100)])
 
         # With list style names and values
-        keys = self.df.with_columns(["key"], [self.df.key]).select("key").collect()
-        self.assertEqual([r.key for r in keys], list(range(100)))
-
-        # With tuple style names and values
-        keys = self.df.with_columns(("key",), (self.df.key,)).select("key").collect()
+        keys = self.df.withColumns({"key": self.df.key}).select("key").collect()
         self.assertEqual([r.key for r in keys], list(range(100)))
 
         # Columns rename
-        kvs = self.df.with_columns(
-            ["key_alias", "value_alias"], [self.df.key, self.df.value]
+        kvs = self.df.withColumns(
+            {"key_alias": self.df.key, "value_alias": self.df.value}
         ).select("key_alias", "value_alias").collect()
         self.assertEqual(
             [(r.key_alias, r.value_alias) for r in kvs],
@@ -505,8 +501,8 @@ class DataFrameTests(ReusedSQLTestCase):
 
         # Type check
         erorr_type_val = ""
-        self.assertRaises(TypeError, self.df.with_columns, erorr_type_val, [self.df.key])
-        self.assertRaises(TypeError, self.df.with_columns, ["key"], erorr_type_val)
+        self.assertRaises(TypeError, self.df.withColumns, erorr_type_val, [self.df.key])
+        self.assertRaises(TypeError, self.df.withColumns, ["key"], erorr_type_val)
 
     def test_generic_hints(self):
         from pyspark.sql import DataFrame

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -504,6 +504,7 @@ class DataFrameTests(ReusedSQLTestCase):
 
         # Type check
         self.assertRaises(TypeError, self.df.withColumns, ["key"])
+        self.assertRaises(AssertionError, self.df.withColumns)
 
     def test_generic_hints(self):
         from pyspark.sql import DataFrame

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2479,16 +2479,40 @@ class Dataset[T] private[sql](
   def withColumn(colName: String, col: Column): DataFrame = withColumns(Seq(colName), Seq(col))
 
   /**
-   * Returns a new Dataset by adding columns or replacing the existing columns that has
-   * the same names.
+   * (Scala-specific) Returns a new Dataset by adding columns or replacing the existing columns
+   * that has the same names.
    *
-   * `column`'s expression in `cols` must only refer to attributes supplied by this Dataset.
-   * It is an error to add columns that refers to some other Dataset.
+   * `colsMap` is a map of column name and column, the column must only refer to attributes
+   * supplied by this Dataset. It is an error to add columns that refers to some other Dataset.
    *
    * @group untypedrel
    * @since 3.2.0
    */
-  def withColumns(colNames: Seq[String], cols: Seq[Column]): DataFrame = {
+  def withColumns(colsMap: Map[String, Column]): DataFrame = {
+    val colNames = colsMap.flatMap{ case (colName, _) => Seq(colName) }.toSeq
+    val newCols = colsMap.flatMap{ case (_, col) => Seq(col) }.toSeq
+    withColumns(colNames, newCols)
+  }
+
+  /**
+   * (Java-specific) Returns a new Dataset by adding columns or replacing the existing columns
+   * that has the same names.
+   *
+   * `colsMap` is a map of column name and column, the column must only refer to attribute
+   * supplied by this Dataset. It is an error to add columns that refers to some other Dataset.
+   *
+   * @group untypedrel
+   * @since 3.2.0
+   */
+  def withColumns(colsMap: java.util.Map[String, Column]): DataFrame = withColumns(
+    colsMap.asScala.toMap
+  )
+
+  /**
+   * Returns a new Dataset by adding columns or replacing the existing columns that has
+   * the same names.
+   */
+  private[spark] def withColumns(colNames: Seq[String], cols: Seq[Column]): DataFrame = {
     require(colNames.size == cols.size,
       s"The size of column names: ${colNames.size} isn't equal to " +
         s"the size of columns: ${cols.size}")

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2489,8 +2489,7 @@ class Dataset[T] private[sql](
    * @since 3.2.0
    */
   def withColumns(colsMap: Map[String, Column]): DataFrame = {
-    val colNames = colsMap.flatMap{ case (colName, _) => Seq(colName) }.toSeq
-    val newCols = colsMap.flatMap{ case (_, col) => Seq(col) }.toSeq
+    val (colNames, newCols) = colsMap.toSeq.unzip
     withColumns(colNames, newCols)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2481,8 +2481,14 @@ class Dataset[T] private[sql](
   /**
    * Returns a new Dataset by adding columns or replacing the existing columns that has
    * the same names.
+   *
+   * `column`'s expression in `cols` must only refer to attributes supplied by this Dataset.
+   * It is an error to add columns that refers to some other Dataset.
+   *
+   * @group untypedrel
+   * @since 3.2.0
    */
-  private[spark] def withColumns(colNames: Seq[String], cols: Seq[Column]): DataFrame = {
+  def withColumns(colNames: Seq[String], cols: Seq[Column]): DataFrame = {
     require(colNames.size == cols.size,
       s"The size of column names: ${colNames.size} isn't equal to " +
         s"the size of columns: ${cols.size}")

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2486,7 +2486,7 @@ class Dataset[T] private[sql](
    * supplied by this Dataset. It is an error to add columns that refers to some other Dataset.
    *
    * @group untypedrel
-   * @since 3.2.0
+   * @since 3.3.0
    */
   def withColumns(colsMap: Map[String, Column]): DataFrame = {
     val (colNames, newCols) = colsMap.toSeq.unzip
@@ -2501,7 +2501,7 @@ class Dataset[T] private[sql](
    * supplied by this Dataset. It is an error to add columns that refers to some other Dataset.
    *
    * @group untypedrel
-   * @since 3.2.0
+   * @since 3.3.0
    */
   def withColumns(colsMap: java.util.Map[String, Column]): DataFrame = withColumns(
     colsMap.asScala.toMap

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -322,15 +322,13 @@ public class JavaDataFrameSuite {
   @Test
   public void testwithColumns() {
     Dataset<Row> df = spark.table("testData2");
-    List<String> colNames = new ArrayList<>(Arrays.asList("a1", "b1"));
-    List<Column> cols = new ArrayList<>(Arrays.asList(col("a"), col("b")));
+    Map<String, Column> colMaps = new HashMap<>();
+    colMaps.put("a1", col("a"));
+    colMaps.put("b1", col("b"));
 
     StructType expected = df.withColumn("a1", col("a")).withColumn("b1", col("b")).schema();
-    StructType actual = df.withColumns(
-            JavaConverters.collectionAsScalaIterableConverter(colNames).asScala().toSeq(),
-            JavaConverters.collectionAsScalaIterableConverter(cols).asScala().toSeq()
-    ).schema();
-    // Validate same result with withColumn loop call
+    StructType actual = df.withColumns(colMaps).schema();
+    // Validate geting same result with withColumn loop call
     Assert.assertEquals(expected, actual);
     // Validate the col names
     Assert.assertArrayEquals(actual.fieldNames(), new String[] {"a", "b", "a1", "b1"});

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -33,6 +33,7 @@ import org.junit.*;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -316,6 +317,23 @@ public class JavaDataFrameSuite {
     Assert.assertTrue(0 <= actual.get(0).getLong(1) && actual.get(0).getLong(1) <= 8);
     Assert.assertEquals(1, actual.get(1).getLong(0));
     Assert.assertTrue(2 <= actual.get(1).getLong(1) && actual.get(1).getLong(1) <= 13);
+  }
+
+  @Test
+  public void testwithColumns() {
+    Dataset<Row> df = spark.table("testData2");
+    List<String> colNames = new ArrayList<>(Arrays.asList("a1", "b1"));
+    List<Column> cols = new ArrayList<>(Arrays.asList(col("a"), col("b")));
+
+    StructType expected = df.withColumn("a1", col("a")).withColumn("b1", col("b")).schema();
+    StructType actual = df.withColumns(
+            JavaConverters.collectionAsScalaIterableConverter(colNames).asScala().toSeq(),
+            JavaConverters.collectionAsScalaIterableConverter(cols).asScala().toSeq()
+    ).schema();
+    // Validate same result with withColumn loop call
+    Assert.assertEquals(expected, actual);
+    // Validate the col names
+    Assert.assertArrayEquals(actual.fieldNames(), new String[] {"a", "b", "a1", "b1"});
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR added the multiple columns adding support for Spark scala/java/python API.
- Expose `withColumns` with Map input as public API in Scala/Java
- Add `withColumns` in PySpark

There was also some discussion about adding multiple columns in past JIRA([SPARK-1225](https://issues.apache.org/jira/browse/SPARK-12225), [SPARK-26224](https://issues.apache.org/jira/browse/SPARK-26224)) and [ML](http://apache-spark-developers-list.1001551.n3.nabble.com/DISCUSS-Multiple-columns-adding-replacing-support-in-PySpark-DataFrame-API-td31164.html).

### Why are the changes needed?
There were a private method `withColumns` can add columns at one pass [1]:
https://github.com/apache/spark/blob/b5241c97b17a1139a4ff719bfce7f68aef094d95/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala#L2402

However, it was not exposed as public API in Scala/Java, and also PySpark user can only use `withColumn` to add one column or replacing the existing one column that has the same name. 

For example, if the PySpark user want to add multiple columns, they should call `withColumn` again and again like:
```Python
df.withColumn("key1", col("key1")).withColumn("key2", col("key2")).withColumn("key3", col("key3"))
```
After this patch, the user can use the `withColumns` with map of colume name and column :
```Python
df.withColumns({"key1":  col("key1"), "key2":col("key2"), "key3": col("key3")})
```

### Does this PR introduce _any_ user-facing change?
Yes, this PR exposes `withColumns` as public API, and also adds `withColumns` API in PySpark .


### How was this patch tested?
- Add new multiple columns adding test, passed
- Existing test, passed