### PR TITLE
[SPARK-35308][TESTS] Fix bug in SPARK-35266 that creates benchmark files in invalid path with wrong name

### DIFF
--- a/core/src/test/scala/org/apache/spark/benchmark/BenchmarkBase.scala
+++ b/core/src/test/scala/org/apache/spark/benchmark/BenchmarkBase.scala
@@ -56,7 +56,7 @@ abstract class BenchmarkBase {
         // scalastyle:on println
         dir.mkdirs()
       }
-      val file = new File(s"${dir}/$resultFileName")
+      val file = new File(s"${dir.getCanonicalPath}/$resultFileName")
       if (!file.exists()) {
         file.createNewFile()
       }

--- a/core/src/test/scala/org/apache/spark/benchmark/BenchmarkBase.scala
+++ b/core/src/test/scala/org/apache/spark/benchmark/BenchmarkBase.scala
@@ -56,7 +56,7 @@ abstract class BenchmarkBase {
         // scalastyle:on println
         dir.mkdirs()
       }
-      val file = new File(s"${dir.getCanonicalPath}/$resultFileName")
+      val file = new File(dir, resultFileName)
       if (!file.exists()) {
         file.createNewFile()
       }

--- a/core/src/test/scala/org/apache/spark/benchmark/BenchmarkBase.scala
+++ b/core/src/test/scala/org/apache/spark/benchmark/BenchmarkBase.scala
@@ -56,7 +56,7 @@ abstract class BenchmarkBase {
         // scalastyle:on println
         dir.mkdirs()
       }
-      val file = new File(s"${dir}$resultFileName")
+      val file = new File(s"${dir}/$resultFileName")
       if (!file.exists()) {
         file.createNewFile()
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a bug in [SPARK-35266](https://issues.apache.org/jira/browse/SPARK-35266) that creates benchmark files in the invalid path with the wrong name. 
e.g. For `BLASBenchmark`, 
- AS-IS: Creates `benchmarksBLASBenchmark-results.txt` in `{SPARK_HOME}/mllib-local/`
- TO-BE: Creates `BLASBenchmark-results.txt` in `{SPARK_HOME}/mllib-local/benchmarks/`

### Why are the changes needed?
As you can see in the above example, new benchmark files cannot be created as intended due to this bug. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
After building Spark, manually tested with the following command:
```
SPARK_GENERATE_BENCHMARK_FILES=1 bin/spark-submit --class \
    org.apache.spark.benchmark.Benchmarks --jars \
    "`find . -name '*-SNAPSHOT-tests.jar' -o -name '*avro*-SNAPSHOT.jar' | paste -sd ',' -`" \
    "`find . -name 'spark-core*-SNAPSHOT-tests.jar'`" \
    "org.apache.spark.ml.linalg.BLASBenchmark"
```
It successfully generated the benchmark files as intended (`BLASBenchmark-results.txt` in `{SPARK_HOME}/mllib-local/benchmarks/`). 
