### PR TITLE
[SPARK-35312][SS] Introduce new Option in Kafka source to specify minimum number of records to read per trigger

### DIFF
--- a/docs/structured-streaming-kafka-integration.md
+++ b/docs/structured-streaming-kafka-integration.md
@@ -467,6 +467,21 @@ The following configurations are optional:
   <td>Rate limit on maximum number of offsets processed per trigger interval. The specified total number of offsets will be proportionally split across topicPartitions of different volume.</td>
 </tr>
 <tr>
+  <td>minOffsetsPerTrigger</td>
+  <td>long</td>
+  <td>none</td>
+  <td>streaming and batch</td>
+  <td>Minimum number of offsets to be processed per trigger interval. The specified total number of offsets will
+   be proportionally split across topicPartitions of different volume.</td>
+</tr>
+<tr>
+  <td>maxTriggerDelay</td>
+  <td>time with units</td>
+  <td>15m</td>
+  <td>streaming and batch</td>
+  <td>Maximum amount of time for which trigger can be delayed between two triggers provided some data is available from the source.</td>
+</tr>
+<tr>
   <td>minPartitions</td>
   <td>int</td>
   <td>none</td>

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -23,6 +23,7 @@ import java.util.Optional
 import scala.collection.JavaConverters._
 
 import org.apache.kafka.common.TopicPartition
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.Network.NETWORK_TIMEOUT

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -118,6 +118,7 @@ private[kafka010] class KafkaMicroBatchStream(
       // Pass same curret offsets as output to skip trigger
       start
     } else {
+      lastTriggerMillis = System.currentTimeMillis()
       endPartitionOffsets = KafkaSourceOffset(readLimit match {
         case rows: ReadMaxRows =>
           rateLimit(rows.maxRows(), startPartitionOffsets, latestPartitionOffsets)

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -153,8 +153,9 @@ private[kafka010] class KafkaSource(
     val latest = kafkaReader.fetchLatestOffsets(currentOffsets)
 
     // checking if we need to skip batch based on minoffsetPerTrigger criteria
-    val skipBatch = if (minOffsetPerTrigger.isDefined) delayBatch(latest, currentOffsets.get)
-    else false
+    val skipBatch = if (minOffsetPerTrigger.isDefined) {
+      delayBatch(latest, currentOffsets.get)
+    } else false
 
     if (skipBatch) {
       logDebug(

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -163,6 +163,7 @@ private[kafka010] class KafkaSource(
       // Pass same curret offsets as output to skip trigger
       KafkaSourceOffset(currentOffsets.get)
     } else {
+      lastTriggerMillis = System.currentTimeMillis()
       val offsets = limit match {
         case rows: ReadMaxRows =>
           if (currentPartitionOffsets.isEmpty) {

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.connector.read.streaming.{ReadAllAvailable, ReadLimi
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.kafka010.KafkaSourceProvider._
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
 
 /**
  * A [[Source]] that reads data from Kafka using the following design.
@@ -94,7 +95,7 @@ private[kafka010] class KafkaSource(
     sourceOptions.get(MIN_OFFSET_PER_TRIGGER).map(_.toLong)
 
   private val maxTriggerDelayMs =
-    sc.conf.getTimeAsMs(sourceOptions.getOrElse(MAX_TRIGGER_DELAY, DEFAULT_MAX_TRIGGER_DELAY))
+    Utils.timeStringAsMs(sourceOptions.getOrElse(MAX_TRIGGER_DELAY, DEFAULT_MAX_TRIGGER_DELAY))
 
   private var lastTriggerMillis = 0L
 

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -172,6 +172,7 @@ private[kafka010] class KafkaSource(
       }
       currentPartitionOffsets = Some(offsets)
       latestPartitionOffsets = Some(latest)
+      lastTriggerMillis = System.currentTimeMillis()
       logDebug(s"GetOffset: ${offsets.toSeq.map(_.toString).sorted}")
       KafkaSourceOffset(offsets)
     }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -191,7 +191,6 @@ private[kafka010] class KafkaSource(
         case (topic, offset) =>
           Some(topic -> (offset - currentOffsets.getOrElse(topic, 0L)))
       }.values.sum.toDouble
-
       if (newRecords < minOffsetPerTrigger.get) true else false
     }
   }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -157,6 +157,7 @@ private[kafka010] class KafkaSource(
     if (skipBatch) {
       logDebug(
         s"Delaying batch as number of records available is less than minOffserPerTrigger")
+      // Pass same curret offsets as output to skip trigger
       KafkaSourceOffset(currentOffsets.get)
     } else {
       val offsets = limit match {
@@ -176,6 +177,7 @@ private[kafka010] class KafkaSource(
     }
   }
 
+  /** Checks if we need to skip this trigger based on minOffsetsPerTrigger & maxTriggerDelay */
   private def delayBatch(
       latestOffsets: Map[TopicPartition, Long],
       currentOffsets: Map[TopicPartition, Long]) : Boolean = {

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -152,7 +152,8 @@ private[kafka010] class KafkaSource(
     val latest = kafkaReader.fetchLatestOffsets(currentOffsets)
 
     // checking if we need to skip batch based on minoffsetPerTrigger criteria
-    val skipBatch = if (minOffsetPerTrigger.isDefined) delayBatch(latest, currentOffsets.get) else false
+    val skipBatch = if (minOffsetPerTrigger.isDefined) delayBatch(latest, currentOffsets.get)
+    else false
 
     if (skipBatch) {
       logDebug(

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -374,7 +374,7 @@ private[kafka010] class KafkaSourceProvider extends DataSourceRegister
       logWarning("maxOffsetsPerTrigger option ignored in batch queries")
     }
 
-    if (caseInsensitiveParams.get("minoffsetspertrigger").isDefined) {
+    if (params.contains(MIN_OFFSET_PER_TRIGGER)) {
       logWarning("minOffsetsPerTrigger option ignored in batch queries")
     }
   }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -373,6 +373,10 @@ private[kafka010] class KafkaSourceProvider extends DataSourceRegister
     if (params.contains(MAX_OFFSET_PER_TRIGGER)) {
       logWarning("maxOffsetsPerTrigger option ignored in batch queries")
     }
+
+    if (caseInsensitiveParams.get("minoffsetspertrigger").isDefined) {
+      logWarning("minOffsetsPerTrigger option ignored in batch queries")
+    }
   }
 
   class KafkaTable(includeHeaders: Boolean) extends Table with SupportsRead with SupportsWrite {
@@ -524,6 +528,9 @@ private[kafka010] object KafkaSourceProvider extends Logging {
   private val FAIL_ON_DATA_LOSS_OPTION_KEY = "failondataloss"
   private[kafka010] val MIN_PARTITIONS_OPTION_KEY = "minpartitions"
   private[kafka010] val MAX_OFFSET_PER_TRIGGER = "maxoffsetspertrigger"
+  private[kafka010] val MIN_OFFSET_PER_TRIGGER = "minOffsetsPerTrigger"
+  private[kafka010] val MAX_TRIGGER_DELAY = "maxTriggerDelay"
+  private[kafka010] val DEFAULT_MAX_TRIGGER_DELAY = "15m"
   private[kafka010] val FETCH_OFFSET_NUM_RETRY = "fetchoffset.numretries"
   private[kafka010] val FETCH_OFFSET_RETRY_INTERVAL_MS = "fetchoffset.retryintervalms"
   private[kafka010] val CONSUMER_POLL_TIMEOUT = "kafkaconsumer.polltimeoutms"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch introduces a new option to specify the minimum number of offsets to read per trigger i.e. minOffsetsPerTrigger and maxTriggerDelay to avoid the infinite wait for the trigger.

This new option will allow skipping trigger/batch when the number of records available in Kafka is low. This is a very useful feature in cases where we have a sudden burst of data at certain intervals in a day and data volume is low for the rest of the day. 
'maxTriggerDelay' option will help to avoid cases of infinite delay in scheduling trigger and the trigger will happen irrespective of records available if the maxTriggerDelay time exceeds the last trigger. It would be an optional parameter with a default value of 15 mins. This option will be only applicable if minOffsetsPerTrigger is set.

minOffsetsPerTrigger option would be optional of course, but once specified it would take precedence over maxOffestsPerTrigger which will be honored only after minOffsetsPerTrigger is satisfied.

### Why are the changes needed?
There are many scenarios where there is a sudden burst of data at certain intervals in a day and data volume is low for the rest of the day. Tunning such jobs is difficult as decreasing trigger processing time increasing the number of batches and hence cluster resource usage and adds to small file issues. Increasing trigger processing time adds consumer lag. This patch tries to address this issue.

### How was this patch tested?
This patch was tested manually on a cluster where the job was running for a full one day with data burst happening once a day.
Here is the picture of databurst and hence consumer lag:
<img width="1198" alt="Screenshot 2021-04-29 at 11 39 35 PM" src="https://user-images.githubusercontent.com/1044003/116997587-9b2ab180-acfa-11eb-91fd-524802ce3316.png">

This is how the job behaved at burst time running every 4.5 mins (which is the specified trigger time): 
<img width="1154" alt="Burst Time" src="https://user-images.githubusercontent.com/1044003/116997919-12f8dc00-acfb-11eb-9b0a-98387fc67560.png">

This is job behavior during non-burst time where it is skipping 2 to 3 triggers and running once every 9 to 13.5 mins
<img width="1154" alt="Non Burst Time" src="https://user-images.githubusercontent.com/1044003/116998244-8b5f9d00-acfb-11eb-8340-33d47149ef81.png">

Here are some more stats from the two run i.e. one normal run and other with minOffsetsperTrigger set:

| Run | Data Size | Number of Batch Runs | Number of Files |
| ------------- | ------------- |------------- |------------- |
| Normal Run | 54.2 GB | 320 | 21968 |
| Run with minOffsetsperTrigger | 54.2 GB | 120 | 12104 |