### PR TITLE
[SPARK-35279][CORE][SQL] Code change to fix the missing "_SUCCESS" file

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -215,6 +215,16 @@ class HadoopMapReduceCommitProtocol(
           }
           fs.rename(new Path(stagingDir, part), finalPartPath)
         }
+        // move the _SUCCESS/_ERROR file to the final location
+        fs.globStatus(new Path(s"${stagingDir.toString}/*")).foreach {
+          x => x.getPath.getName match {
+            case ("_SUCCESS") =>
+              fs.rename(new Path(stagingDir, "_SUCCESS"), new Path(path))
+            case ("_ERROR") =>
+              fs.rename(new Path(stagingDir, "_ERROR"), new Path(path))
+            case _ =>
+          }
+        }
       }
 
       fs.delete(stagingDir, true)

--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -215,13 +215,11 @@ class HadoopMapReduceCommitProtocol(
           }
           fs.rename(new Path(stagingDir, part), finalPartPath)
         }
-        // move the _SUCCESS/_ERROR file to the final location
+        // move the _SUCCESS file to the final location
         fs.globStatus(new Path(s"${stagingDir.toString}/*")).foreach {
           x => x.getPath.getName match {
             case ("_SUCCESS") =>
               fs.rename(new Path(stagingDir, "_SUCCESS"), new Path(path))
-            case ("_ERROR") =>
-              fs.rename(new Path(stagingDir, "_ERROR"), new Path(path))
             case _ =>
           }
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -189,6 +189,19 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-35279 _SUCCESS file is present when using dynamic partition overwrite mode") {
+    withTempPath { f =>
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key ->
+        SQLConf.PartitionOverwriteMode.DYNAMIC.toString) {
+        val path = f.getAbsolutePath
+        val df = Seq(("p", "q"), ("c", "d")).toDF("a", "b")
+        df.write.mode("overwrite").partitionBy("a").parquet(path)
+        val listFiles = new File(path).listFiles().filter(_.getName == "_SUCCESS")
+        assert(listFiles.nonEmpty)
+      }
+    }
+  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -190,15 +190,16 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-35279 _SUCCESS file is present when using dynamic partition overwrite mode") {
+  test("SPARK-35279: _SUCCESS file is present when using dynamic partition overwrite mode") {
     withTempPath { f =>
       withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key ->
         SQLConf.PartitionOverwriteMode.DYNAMIC.toString) {
         val path = f.getAbsolutePath
         val df = Seq(("p", "q"), ("c", "d")).toDF("a", "b")
-        df.write.mode("overwrite").partitionBy("a").parquet(path)
+        df.write.mode("overwrite").partitionBy("b").parquet(path)
         val listFiles = new File(path).listFiles().filter(_.getName == "_SUCCESS")
         assert(listFiles.nonEmpty)
+        checkAnswer(spark.read.parquet(path), df)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
After the code change done as the part of the PR raised SPARK-29302 the final "_SUCCESS" is not present in the final location when the Spark job completes successfully.
Reason why the _SUCCESS before the change SPARK-29302
After the change of this code 
```
val committerOutputPath = if (dynamicPartitionOverwrite) stagingDir else new Path(path)
committer = ctor.newInstance(committerOutputPath, context)

```
For dynamicPartitionOverwrite code is now selecting the stagingDir 

Now after commitJob  in the HadoopMapReduceCommitProtocol

`committer.commitJob(jobContext)`
 
_SUCCESS file is created inside the stagingDir, So there is code change needed to move the _SUCCESS file as well to the final location before deleting the stagingDir. 


### Why are the changes needed?
Since "_SUCCESS" is not present, Its is difficult to predict whether the job completed successfully or not.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added the Unit test and also added the tested  manually the scenario using the spark shell
