### PR TITLE
[WIP][SPARK-33236][SHUFFLE][CORE] Enable Push-based shuffle service to store state in NM level DB for work preserving restart

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -68,7 +68,7 @@ public class ExternalBlockHandler extends RpcHandler {
     throws IOException {
     this(new OneForOneStreamManager(),
       new ExternalShuffleBlockResolver(conf, registeredExecutorFile),
-      new NoOpMergedShuffleFileManager(conf));
+      new NoOpMergedShuffleFileManager(conf, null));
   }
 
   public ExternalBlockHandler(
@@ -89,7 +89,7 @@ public class ExternalBlockHandler extends RpcHandler {
   public ExternalBlockHandler(
       OneForOneStreamManager streamManager,
       ExternalShuffleBlockResolver blockManager) {
-    this(streamManager, blockManager, new NoOpMergedShuffleFileManager(null));
+    this(streamManager, blockManager, new NoOpMergedShuffleFileManager(null, null));
   }
 
   /** Enables mocking out the StreamManager, BlockManager, and MergeManager. */
@@ -440,7 +440,7 @@ public class ExternalBlockHandler extends RpcHandler {
     // This constructor is needed because we use this constructor to instantiate an implementation
     // of MergedShuffleFileManager using reflection.
     // See YarnShuffleService#newMergedShuffleFileManagerInstance.
-    public NoOpMergedShuffleFileManager(TransportConf transportConf) {}
+    public NoOpMergedShuffleFileManager(TransportConf transportConf, File recoveryFile) {}
 
     @Override
     public StreamCallbackWithID receiveBlockDataAsStream(PushBlockStream msg) {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -258,6 +258,7 @@ public class ExternalBlockHandler extends RpcHandler {
 
   public void close() {
     blockManager.close();
+    mergeManager.close();
   }
 
   private void checkAuth(TransportClient client, String appId) {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedShuffleFileManager.java
@@ -107,4 +107,10 @@ public interface MergedShuffleFileManager {
    * @param appId application ID
    */
   String[] getMergedBlockDirs(String appId);
+
+  /**
+   * Optionally close any resources associated the MergedShuffleFileManager, such as the
+   * leveldb for state persistence.
+   */
+  default void close() {}
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -941,7 +941,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
           Map<Integer, AppShufflePartitionInfo> shufflePartitions =
             mergeManager.partitions.get(partitionInfo.appShuffleId);
           if (shufflePartitions != null && shufflePartitions.containsKey(partitionInfo.reduceId)) {
-            logger.debug("{} shuffleId {} reduceId {} encountered failure",
+            logger.info("{} shuffleId {} reduceId {} encountered failure",
               partitionInfo.appShuffleId.appId, partitionInfo.appShuffleId.shuffleId,
               partitionInfo.reduceId);
             partitionInfo.setCurrentMapIndex(-1);

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -112,6 +112,7 @@ public class YarnShuffleService extends AuxiliaryService {
 
   private static final String RECOVERY_FILE_NAME = "registeredExecutors.ldb";
   private static final String SECRETS_RECOVERY_FILE_NAME = "sparkShuffleRecovery.ldb";
+  private static final String MERGE_MANAGER_FILE_NAME = "mergeManager.ldb";
 
   // Whether failure during service initialization should stop the NM.
   @VisibleForTesting
@@ -166,6 +167,10 @@ public class YarnShuffleService extends AuxiliaryService {
   @VisibleForTesting
   File secretsFile;
 
+  // Where to store & reload merge manager info for recovering state after an NM restart
+  @VisibleForTesting
+  File mergeManagerFile;
+
   private DB db;
 
   public YarnShuffleService() {
@@ -215,11 +220,12 @@ public class YarnShuffleService extends AuxiliaryService {
       // when it comes back
       if (_recoveryPath != null) {
         registeredExecutorFile = initRecoveryDb(RECOVERY_FILE_NAME);
+        mergeManagerFile = initRecoveryDb(MERGE_MANAGER_FILE_NAME);
       }
 
       TransportConf transportConf = new TransportConf("shuffle", new HadoopConfigProvider(_conf));
       MergedShuffleFileManager shuffleMergeManager = newMergedShuffleFileManagerInstance(
-        transportConf);
+        transportConf, mergeManagerFile);
       blockHandler = new ExternalBlockHandler(
         transportConf, registeredExecutorFile, shuffleMergeManager);
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/shuffle/ShuffleTestAccessor.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/shuffle/ShuffleTestAccessor.scala
@@ -99,8 +99,9 @@ object ShuffleTestAccessor {
   }
 
   def getPartitionFileHandlers(
-      partitionInfo: AppShufflePartitionInfo): (FileChannel, FileChannel, DataOutputStream) = {
-    (partitionInfo.channel, partitionInfo.metaChannel, partitionInfo.indexWriteStream)
+      partitionInfo: AppShufflePartitionInfo):
+      (MergeShuffleDataFile, MergeShuffleMetaFile, MergeShuffleMetaFile) = {
+    (partitionInfo.getDataFile(), partitionInfo.getMetaFile(), partitionInfo.getIndexFile())
   }
 
   def closePartitionFiles(partitionInfo: AppShufflePartitionInfo): Unit = {


### PR DESCRIPTION
Making this WIP since it is also affected by multiple attempts. The data from previous attempt from level db needs to be deleted when the server identifies a new attempt with the registration. This will depend on changes in #32007

### What changes were proposed in this pull request?
This change enables push-based shuffle service (`RemoteBlockPushResolver`) to store state in level DB. This helps to restore the state when the NM is restarted.

### Why are the changes needed?
The changes are needed to support work preserving restart which was missing from push-based shuffle services

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added unit tests. We have a version of this change internally which has been running in production.

Lead-authored-by: Min Shen mshen@linkedin.com
Co-authored-by: Chandni Singh chsingh@linkedin.com