### PR TITLE
[SPARK-35111][SPARK-35112][SQL][FOLLOWUP] Rename ANSI interval patterns and regexps

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -99,16 +99,16 @@ object IntervalUtils {
     result
   }
 
-  private val unquotedYearMonthRegex = "([+|-])?(\\d+)-(\\d+)"
-  private val quotedYearMonthPattern = (s"^$unquotedYearMonthRegex$$").r
-  private val yearMonthLiteralPattern =
-    (s"(?i)^INTERVAL\\s+([+|-])?'$unquotedYearMonthRegex'\\s+YEAR\\s+TO\\s+MONTH$$").r
+  private val yearMonthPatternString = "([+|-])?(\\d+)-(\\d+)"
+  private val yearMonthRegex = (s"^$yearMonthPatternString$$").r
+  private val yearMonthLiteralRegex =
+    (s"(?i)^INTERVAL\\s+([+|-])?'$yearMonthPatternString'\\s+YEAR\\s+TO\\s+MONTH$$").r
 
   def castStringToYMInterval(input: UTF8String): Int = {
     input.trimAll().toString match {
-      case quotedYearMonthPattern("-", year, month) => toYMInterval(year, month, -1)
-      case quotedYearMonthPattern(_, year, month) => toYMInterval(year, month, 1)
-      case yearMonthLiteralPattern(firstSign, secondSign, year, month) =>
+      case yearMonthRegex("-", year, month) => toYMInterval(year, month, -1)
+      case yearMonthRegex(_, year, month) => toYMInterval(year, month, 1)
+      case yearMonthLiteralRegex(firstSign, secondSign, year, month) =>
         (firstSign, secondSign) match {
           case ("-", "-") => toYMInterval(year, month, 1)
           case ("-", _) => toYMInterval(year, month, -1)
@@ -129,9 +129,9 @@ object IntervalUtils {
   def fromYearMonthString(input: String): CalendarInterval = {
     require(input != null, "Interval year-month string must be not null")
     input.trim match {
-      case quotedYearMonthPattern("-", yearStr, monthStr) =>
+      case yearMonthRegex("-", yearStr, monthStr) =>
         new CalendarInterval(toYMInterval(yearStr, monthStr, -1), 0, 0)
-      case quotedYearMonthPattern(_, yearStr, monthStr) =>
+      case yearMonthRegex(_, yearStr, monthStr) =>
         new CalendarInterval(toYMInterval(yearStr, monthStr, 1), 0, 0)
       case _ =>
         throw new IllegalArgumentException(
@@ -151,11 +151,11 @@ object IntervalUtils {
     }
   }
 
-  private val unquotedDaySecondRegex =
+  private val daySecondPatternString =
     "([+|-])?(\\d+) (\\d{1,2}):(\\d{1,2}):(\\d{1,2})(\\.\\d{1,9})?"
-  private val quotedDaySecondPattern = (s"^$unquotedDaySecondRegex$$").r
-  private val daySecondLiteralPattern =
-    (s"(?i)^INTERVAL\\s+([+|-])?\\'$unquotedDaySecondRegex\\'\\s+DAY\\s+TO\\s+SECOND$$").r
+  private val daySecondRegex = (s"^$daySecondPatternString$$").r
+  private val daySecondLiteralRegex =
+    (s"(?i)^INTERVAL\\s+([+|-])?\\'$daySecondPatternString\\'\\s+DAY\\s+TO\\s+SECOND$$").r
 
   def castStringToDTInterval(input: UTF8String): Long = {
     def secondAndMicro(second: String, micro: String): String = {
@@ -167,11 +167,11 @@ object IntervalUtils {
     }
 
     input.trimAll().toString match {
-      case quotedDaySecondPattern("-", day, hour, minute, second, micro) =>
+      case daySecondRegex("-", day, hour, minute, second, micro) =>
         toDTInterval(day, hour, minute, secondAndMicro(second, micro), -1)
-      case quotedDaySecondPattern(_, day, hour, minute, second, micro) =>
+      case daySecondRegex(_, day, hour, minute, second, micro) =>
         toDTInterval(day, hour, minute, secondAndMicro(second, micro), 1)
-      case daySecondLiteralPattern(firstSign, secondSign, day, hour, minute, second, micro) =>
+      case daySecondLiteralRegex(firstSign, secondSign, day, hour, minute, second, micro) =>
         (firstSign, secondSign) match {
           case ("-", "-") => toDTInterval(day, hour, minute, secondAndMicro(second, micro), 1)
           case ("-", _) => toDTInterval(day, hour, minute, secondAndMicro(second, micro), -1)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -99,7 +99,7 @@ object IntervalUtils {
     result
   }
 
-  private val unquotedYearMonthRegex = "([+|-])?(\\d+)-(\\d+)".r
+  private val unquotedYearMonthRegex = "([+|-])?(\\d+)-(\\d+)"
   private val quotedYearMonthPattern = (s"^$unquotedYearMonthRegex$$").r
   private val yearMonthLiteralPattern =
     (s"(?i)^INTERVAL\\s+([+|-])?'$unquotedYearMonthRegex'\\s+YEAR\\s+TO\\s+MONTH$$").r

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -99,10 +99,10 @@ object IntervalUtils {
     result
   }
 
-  private val unquotedYearMonthPattern = "^([+|-])?(\\d+)-(\\d+)$".r
-  private val quotedYearMonthPattern = (s"^$unquotedYearMonthPattern$$").r
+  private val unquotedYearMonthRegex = "([+|-])?(\\d+)-(\\d+)".r
+  private val quotedYearMonthPattern = (s"^$unquotedYearMonthRegex$$").r
   private val yearMonthLiteralPattern =
-    "(?i)^INTERVAL\\s+([+|-])?'([+|-])?(\\d+)-(\\d+)'\\s+YEAR\\s+TO\\s+MONTH$".r
+    (s"(?i)^INTERVAL\\s+([+|-])?'$unquotedYearMonthRegex'\\s+YEAR\\s+TO\\s+MONTH$$").r
 
   def castStringToYMInterval(input: UTF8String): Int = {
     input.trimAll().toString match {
@@ -151,11 +151,11 @@ object IntervalUtils {
     }
   }
 
-  private val unquotedDaySecondPattern =
+  private val unquotedDaySecondRegex =
     "([+|-])?(\\d+) (\\d{1,2}):(\\d{1,2}):(\\d{1,2})(\\.\\d{1,9})?"
-  private val quotedDaySecondPattern = (s"^$unquotedDaySecondPattern$$").r
+  private val quotedDaySecondPattern = (s"^$unquotedDaySecondRegex$$").r
   private val daySecondLiteralPattern =
-    (s"(?i)^INTERVAL\\s+([+|-])?\\'$unquotedDaySecondPattern\\'\\s+DAY\\s+TO\\s+SECOND$$").r
+    (s"(?i)^INTERVAL\\s+([+|-])?\\'$unquotedDaySecondRegex\\'\\s+DAY\\s+TO\\s+SECOND$$").r
 
   def castStringToDTInterval(input: UTF8String): Long = {
     def secondAndMicro(second: String, micro: String): String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rename pattern strings and regexps of year-month and day-time intervals.

### Why are the changes needed?
To improve code maintainability.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
By existing test suites.