### PR TITLE
[SPARK-35290][SQL] Append new nested struct fields rather than sort for unionByName with null filling

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -96,6 +96,8 @@ license: |
   - In Spark 3.2, `FloatType` is mapped to `FLOAT` in MySQL. Prior to this, it used to be mapped to `REAL`, which is by default a synonym to `DOUBLE PRECISION` in MySQL. 
 
   - In Spark 3.2, the query executions triggered by `DataFrameWriter` are always named `command` when being sent to `QueryExecutionListener`. In Spark 3.1 and earlier, the name is one of `save`, `insertInto`, `saveAsTable`, `create`, `append`, `overwrite`, `overwritePartitions`, `replace`.
+  
+  - In Spark 3.2, `Dataset.unionByName` with `allowMissingColumns` set to true will add missing nested fields to the end of structs. In Spark 3.1, nested struct fields are sorted alphabetically.
 
 ## Upgrading from Spark SQL 3.0 to 3.1
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnion.scala
@@ -40,18 +40,21 @@ object ResolveUnion extends Rule[LogicalPlan] {
    * already contain them. Currently we don't support merging structs nested inside of arrays
    * or maps.
    */
-  private def addFields(col: Expression, expectedFields: Seq[StructField]): Expression = {
+  private def addFields(col: Expression, targetType: StructType): Expression = {
     assert(col.dataType.isInstanceOf[StructType], "Only support StructType.")
 
     val resolver = conf.resolver
     val colType = col.dataType.asInstanceOf[StructType]
-    val newStructFields = expectedFields.flatMap { expectedField =>
+
+    val newStructFields = mutable.ArrayBuffer.empty[Expression]
+
+    val targetStructFields = targetType.fields.foreach { expectedField =>
       val currentField = colType.fields.find(f => resolver(f.name, expectedField.name))
 
       val newExpression = (currentField, expectedField.dataType) match {
         case (Some(cf), expectedType: StructType) if cf.dataType.isInstanceOf[StructType] =>
             val extractedValue = ExtractValue(col, Literal(cf.name), resolver)
-            val combinedStruct = addFields(extractedValue, expectedType.fields)
+            val combinedStruct = addFields(extractedValue, expectedType)
             if (extractedValue.nullable) {
               If(IsNull(extractedValue),
                 Literal(null, combinedStruct.dataType),
@@ -64,9 +67,16 @@ object ResolveUnion extends Rule[LogicalPlan] {
         case (None, expectedType) =>
           Literal(null, expectedType)
       }
-      Literal(expectedField.name) :: newExpression :: Nil
+      newStructFields ++= Literal(expectedField.name) :: newExpression :: Nil
     }
-    CreateNamedStruct(newStructFields)
+
+    colType.fields
+      .filter(f => targetType.fields.find(tf => resolver(f.name, tf.name)).isEmpty)
+      .foreach { f =>
+        newStructFields ++= Literal(f.name) :: ExtractValue(col, Literal(f.name), resolver) :: Nil
+      }
+
+    CreateNamedStruct(newStructFields.toSeq)
   }
 
 
@@ -100,8 +110,7 @@ object ResolveUnion extends Rule[LogicalPlan] {
             // like that. We will sort columns in the struct expression to make sure two sides of
             // union have consistent schema.
             aliased += foundAttr
-            val targetType = target.merge(source, conf.resolver)
-            Alias(addFields(foundAttr, targetType.fields.toSeq), foundAttr.name)()
+            Alias(addFields(foundAttr, target), foundAttr.name)()
           case _ =>
             // We don't need/try to add missing fields if:
             // 1. The attributes of left and right side are the same struct type

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SchemaPruning.scala
@@ -38,7 +38,7 @@ object SchemaPruning extends SQLConfHelper {
     // original schema
     val mergedSchema = requestedRootFields
       .map { root: RootField => StructType(Array(root.field)) }
-      .reduceLeft(_ merge _)
+      .reduceLeft((left, right) => left.merge(right, resolver))
     val mergedDataSchema =
       StructType(dataSchema.map(d => mergedSchema.find(m => resolver(m.name, d.name)).getOrElse(d)))
     // Sort the fields of mergedDataSchema according to their order in dataSchema,
@@ -113,7 +113,7 @@ object SchemaPruning extends SQLConfHelper {
           //    this optional root field too.
           val rootFieldType = StructType(Array(root.field))
           val optFieldType = StructType(Array(opt.field))
-          val merged = optFieldType.merge(rootFieldType)
+          val merged = optFieldType.merge(rootFieldType, conf.resolver)
           merged.sameType(optFieldType)
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -307,7 +307,7 @@ case class Union(
     children.map(_.output).transpose.map { attrs =>
       val firstAttr = attrs.head
       val nullable = attrs.exists(_.nullable)
-      val newDt = attrs.map(_.dataType).reduce(StructType.merge)
+      val newDt = attrs.map(_.dataType).reduce(StructType.merge(conf.resolver))
       if (firstAttr.dataType == newDt) {
         firstAttr.withNullability(nullable)
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -483,7 +483,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
    * 4. Otherwise, `this` and `that` are considered as conflicting schemas and an exception would be
    *    thrown.
    */
-  private[sql] def merge(that: StructType, resolver: Resolver = _ == _): StructType =
+  private[sql] def merge(that: StructType, resolver: Resolver): StructType =
     StructType.merge(resolver)(this, that).asInstanceOf[StructType]
 
   override private[spark] def asNullable: StructType = {
@@ -629,40 +629,5 @@ object StructType extends AbstractDataType {
     map.sizeHint(fields.length)
     fields.foreach(s => map.put(s.name, s))
     map
-  }
-
-  /**
-   * Returns a `StructType` that contains missing fields recursively from `source` to `target`.
-   * Note that this doesn't support looking into array type and map type recursively.
-   */
-  def findMissingFields(
-      source: StructType,
-      target: StructType,
-      resolver: Resolver): Option[StructType] = {
-    def bothStructType(dt1: DataType, dt2: DataType): Boolean =
-      dt1.isInstanceOf[StructType] && dt2.isInstanceOf[StructType]
-
-    val newFields = mutable.ArrayBuffer.empty[StructField]
-
-    target.fields.foreach { field =>
-      val found = source.fields.find(f => resolver(field.name, f.name))
-      if (found.isEmpty) {
-        // Found a missing field in `source`.
-        newFields += field
-      } else if (bothStructType(found.get.dataType, field.dataType) &&
-          !found.get.dataType.sameType(field.dataType)) {
-        // Found a field with same name, but different data type.
-        findMissingFields(found.get.dataType.asInstanceOf[StructType],
-          field.dataType.asInstanceOf[StructType], resolver).map { missingType =>
-          newFields += found.get.copy(dataType = missingType)
-        }
-      }
-    }
-
-    if (newFields.isEmpty) {
-      None
-    } else {
-      Some(StructType(newFields.toSeq))
-    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonParseException
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DataTypeTestUtils.dayTimeIntervalTypes
 
 class DataTypeSuite extends SparkFunSuite {
@@ -153,7 +154,7 @@ class DataTypeSuite extends SparkFunSuite {
       StructField("b", LongType) :: Nil)
 
     val message = intercept[SparkException] {
-      left.merge(right)
+      left.merge(right, SQLConf.get.resolver)
     }.getMessage
     assert(message.equals("Failed to merge fields 'b' and 'b'. " +
       "Failed to merge incompatible data types float and bigint"))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -155,13 +155,13 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
     val schema2 = StructType.fromDDL("A2 STRING, a3 DOUBLE, nested STRUCT<B2: STRING, b3: DOUBLE>")
     val resolver = SQLConf.get.resolver
 
-    assert(schema1.merge(schema2, resolver).sameType(StructType.fromDDL(
+    assert(schema1.merge(schema2, resolver) === StructType.fromDDL(
       "a1 INT, a2 STRING, nested STRUCT<b1: INT, b2: STRING, b3: DOUBLE>, a3 DOUBLE"
-    )))
+    ))
 
-    assert(schema2.merge(schema1, resolver).sameType(StructType.fromDDL(
-      "a2 STRING, a3 DOUBLE, nested STRUCT<b2: STRING, b3: DOUBLE, b1: INT>, a1 INT"
-    )))
+    assert(schema2.merge(schema1, resolver) === StructType.fromDDL(
+      "A2 STRING, a3 DOUBLE, nested STRUCT<B2: STRING, b3: DOUBLE, b1: INT>, a1 INT"
+    ))
   }
 
   test("SPARK-35290: Struct merging case sensitive") {
@@ -171,15 +171,15 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
         "A2 STRING, a3 DOUBLE, nested STRUCT<B2: STRING, b3: DOUBLE>")
       val resolver = SQLConf.get.resolver
 
-      assert(schema1.merge(schema2, resolver).sameType(StructType.fromDDL(
+      assert(schema1.merge(schema2, resolver) === StructType.fromDDL(
         "a1 INT, a2 STRING, nested STRUCT<b1: INT, b2: STRING, B2: STRING, b3: DOUBLE>, " +
           "A2 STRING, a3 DOUBLE"
-      )))
+      ))
 
-      assert(schema2.merge(schema1, resolver).sameType(StructType.fromDDL(
+      assert(schema2.merge(schema1, resolver) === StructType.fromDDL(
         "A2 STRING, a3 DOUBLE, nested STRUCT<B2: STRING, b3: DOUBLE, b1: INT, b2: STRING>, " +
           "a1 INT, a2 STRING"
-      )))
+      ))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2080,10 +2080,8 @@ class Dataset[T] private[sql](
    * }}}
    *
    * Note that `allowMissingColumns` supports nested column in struct types. Missing nested columns
-   * of struct columns with same name will also be filled with null values. This currently does not
-   * support nested columns in array and map types. Note that if there is any missing nested columns
-   * to be filled, in order to make consistent schema between two sides of union, the nested fields
-   * of structs will be sorted after merging schema.
+   * of struct columns with the same name will also be filled with null values and added to the end
+   * of struct. This currently does not support nested columns in array and map types.
    *
    * @group typedrel
    * @since 3.1.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -684,7 +684,7 @@ case class UnionExec(children: Seq[SparkPlan]) extends SparkPlan {
     children.map(_.output).transpose.map { attrs =>
       val firstAttr = attrs.head
       val nullable = attrs.exists(_.nullable)
-      val newDt = attrs.map(_.dataType).reduce(StructType.merge)
+      val newDt = attrs.map(_.dataType).reduce(StructType.merge(conf.resolver))
       if (firstAttr.dataType == newDt) {
         firstAttr.withNullability(nullable)
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -385,6 +385,8 @@ object ParquetFileFormat extends Logging {
   private[parquet] def readSchema(
       footers: Seq[Footer], sparkSession: SparkSession): Option[StructType] = {
 
+    val resolver = sparkSession.sessionState.conf.resolver
+
     val converter = new ParquetToSparkSchemaConverter(
       sparkSession.sessionState.conf.isParquetBinaryAsString,
       sparkSession.sessionState.conf.isParquetINT96AsTimestamp)
@@ -429,7 +431,7 @@ object ParquetFileFormat extends Logging {
     }
 
     finalSchemas.reduceOption { (left, right) =>
-      try left.merge(right) catch { case e: Throwable =>
+      try left.merge(right, resolver) catch { case e: Throwable =>
         throw QueryExecutionErrors.failedToMergeIncompatibleSchemasError(left, right, e)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -677,27 +677,30 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
     val df1 = Seq((0, UnionClass1a(0, 1L, UnionClass2(1, "2")))).toDF("id", "a")
     val df2 = Seq((1, UnionClass1b(1, 2L, UnionClass3(2, 3L)))).toDF("id", "a")
 
-    val expectedSchema = "`id` INT,`a` STRUCT<`a`: INT, `b`: BIGINT, " +
-      "`nested`: STRUCT<`a`: INT, `b`: BIGINT, `c`: STRING>>"
-
     var unionDf = df1.unionByName(df2, true)
+    assert(unionDf.schema.toDDL ==
+      "`id` INT,`a` STRUCT<`a`: INT, `b`: BIGINT, " +
+        "`nested`: STRUCT<`a`: INT, `c`: STRING, `b`: BIGINT>>")
     checkAnswer(unionDf,
-      Row(0, Row(0, 1, Row(1, null, "2"))) ::
-        Row(1, Row(1, 2, Row(2, 3L, null))) :: Nil)
-    assert(unionDf.schema.toDDL == expectedSchema)
+      Row(0, Row(0, 1, Row(1, "2", null))) ::
+        Row(1, Row(1, 2, Row(2, null, 3L))) :: Nil)
 
     unionDf = df2.unionByName(df1, true)
+    assert(unionDf.schema.toDDL ==
+      "`id` INT,`a` STRUCT<`a`: INT, `b`: BIGINT, " +
+        "`nested`: STRUCT<`a`: INT, `b`: BIGINT, `c`: STRING>>")
     checkAnswer(unionDf,
       Row(1, Row(1, 2, Row(2, 3L, null))) ::
         Row(0, Row(0, 1, Row(1, null, "2"))) :: Nil)
-    assert(unionDf.schema.toDDL == expectedSchema)
 
     val df3 = Seq((2, UnionClass1b(2, 3L, null))).toDF("id", "a")
     unionDf = df1.unionByName(df3, true)
+    assert(unionDf.schema.toDDL ==
+      "`id` INT,`a` STRUCT<`a`: INT, `b`: BIGINT, " +
+        "`nested`: STRUCT<`a`: INT, `c`: STRING, `b`: BIGINT>>")
     checkAnswer(unionDf,
-      Row(0, Row(0, 1, Row(1, null, "2"))) ::
+      Row(0, Row(0, 1, Row(1, "2", null))) ::
         Row(2, Row(2, 3, null)) :: Nil)
-    assert(unionDf.schema.toDDL == expectedSchema)
   }
 
   test("SPARK-32376: Make unionByName null-filling behavior work with struct columns" +
@@ -707,30 +710,61 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
       val df2 = Seq((1, UnionClass1c(1, 2L, UnionClass4(2, 3L)))).toDF("id", "a")
 
       var unionDf = df1.unionByName(df2, true)
-      checkAnswer(unionDf,
-        Row(0, Row(0, 1, Row(null, 1, null, "2"))) ::
-          Row(1, Row(1, 2, Row(2, null, 3L, null))) :: Nil)
       assert(unionDf.schema.toDDL ==
         "`id` INT,`a` STRUCT<`a`: INT, `b`: BIGINT, " +
-          "`nested`: STRUCT<`A`: INT, `a`: INT, `b`: BIGINT, `c`: STRING>>")
+          "`nested`: STRUCT<`a`: INT, `c`: STRING, `A`: INT, `b`: BIGINT>>")
+      checkAnswer(unionDf,
+        Row(0, Row(0, 1, Row(1, "2", null, null))) ::
+          Row(1, Row(1, 2, Row(null, null, 2, 3L))) :: Nil)
 
       unionDf = df2.unionByName(df1, true)
-      checkAnswer(unionDf,
-        Row(1, Row(1, 2, Row(2, null, 3L, null))) ::
-          Row(0, Row(0, 1, Row(null, 1, null, "2"))) :: Nil)
       assert(unionDf.schema.toDDL ==
         "`id` INT,`a` STRUCT<`a`: INT, `b`: BIGINT, " +
-          "`nested`: STRUCT<`A`: INT, `a`: INT, `b`: BIGINT, `c`: STRING>>")
+          "`nested`: STRUCT<`A`: INT, `b`: BIGINT, `a`: INT, `c`: STRING>>")
+      checkAnswer(unionDf,
+        Row(1, Row(1, 2, Row(2, 3L, null, null))) ::
+          Row(0, Row(0, 1, Row(null, null, 1, "2"))) :: Nil)
 
       val df3 = Seq((2, UnionClass1b(2, 3L, UnionClass3(4, 5L)))).toDF("id", "a")
       unionDf = df2.unionByName(df3, true)
-      checkAnswer(unionDf,
-        Row(1, Row(1, 2, Row(2, null, 3L))) ::
-          Row(2, Row(2, 3, Row(null, 4, 5L))) :: Nil)
       assert(unionDf.schema.toDDL ==
         "`id` INT,`a` STRUCT<`a`: INT, `b`: BIGINT, " +
-          "`nested`: STRUCT<`A`: INT, `a`: INT, `b`: BIGINT>>")
+          "`nested`: STRUCT<`A`: INT, `b`: BIGINT, `a`: INT>>")
+      checkAnswer(unionDf,
+        Row(1, Row(1, 2, Row(2, 3L, null))) ::
+          Row(2, Row(2, 3, Row(null, 5L, 4))) :: Nil)
     }
+  }
+
+  test("SPARK-32376: Make unionByName null-filling behavior work with struct columns" +
+      " - case-insensitive cases") {
+    val df1 = Seq((0, UnionClass1d(0, 1L, UnionClass2(1, "2")))).toDF("id", "a")
+    val df2 = Seq((1, UnionClass1c(1, 2L, UnionClass4(2, 3L)))).toDF("id", "a")
+
+    var unionDf = df1.unionByName(df2, true)
+    assert(unionDf.schema.toDDL ==
+      "`id` INT,`a` STRUCT<`a`: INT, `b`: BIGINT, " +
+        "`Nested`: STRUCT<`a`: INT, `c`: STRING, `b`: BIGINT>>")
+    checkAnswer(unionDf,
+      Row(0, Row(0, 1, Row(1, "2", null))) ::
+        Row(1, Row(1, 2, Row(2, null, 3L))) :: Nil)
+
+    unionDf = df2.unionByName(df1, true)
+    assert(unionDf.schema.toDDL ==
+      "`id` INT,`a` STRUCT<`a`: INT, `b`: BIGINT, " +
+        "`nested`: STRUCT<`A`: INT, `b`: BIGINT, `c`: STRING>>")
+    checkAnswer(unionDf,
+      Row(1, Row(1, 2, Row(2, 3L, null))) ::
+        Row(0, Row(0, 1, Row(1, null, "2"))) :: Nil)
+
+    val df3 = Seq((2, UnionClass1b(2, 3L, UnionClass3(4, 5L)))).toDF("id", "a")
+    unionDf = df2.unionByName(df3, true)
+    assert(unionDf.schema.toDDL ==
+      "`id` INT,`a` STRUCT<`a`: INT, `b`: BIGINT, " +
+        "`nested`: STRUCT<`A`: INT, `b`: BIGINT>>")
+    checkAnswer(unionDf,
+      Row(1, Row(1, 2, Row(2, 3L))) ::
+        Row(2, Row(2, 3, Row(4, 5L))) :: Nil)
   }
 
   test("SPARK-32376: Make unionByName null-filling behavior work with struct columns - edge case") {
@@ -752,8 +786,50 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
       StructType(Seq(StructField("topLevelCol", nestedStructType2))))
 
     val union = df1.unionByName(df2, allowMissingColumns = true)
-    checkAnswer(union, Row(Row(null, "b")) :: Row(Row("a", "b")) :: Nil)
-    assert(union.schema.toDDL == "`topLevelCol` STRUCT<`a`: STRING, `b`: STRING>")
+    assert(union.schema.toDDL == "`topLevelCol` STRUCT<`b`: STRING, `a`: STRING>")
+    checkAnswer(union, Row(Row("b", null)) :: Row(Row("b", "a")) :: Nil)
+  }
+
+  test("SPARK-35290: Make unionByName null-filling behavior work with struct columns"
+      + " - sorting edge case") {
+    val nestedStructType1 = StructType(Seq(
+      StructField("b", StructType(Seq(
+        StructField("ba", StringType)
+      )))
+    ))
+    val nestedStructValues1 = Row(Row("ba"))
+
+    val nestedStructType2 = StructType(Seq(
+      StructField("a", StructType(Seq(
+        StructField("aa", StringType)
+      ))),
+      StructField("b", StructType(Seq(
+        StructField("bb", StringType)
+      )))
+    ))
+    val nestedStructValues2 = Row(Row("aa"), Row("bb"))
+
+    val df1: DataFrame = spark.createDataFrame(
+      sparkContext.parallelize(Row(nestedStructValues1) :: Nil),
+      StructType(Seq(StructField("topLevelCol", nestedStructType1))))
+
+    val df2: DataFrame = spark.createDataFrame(
+      sparkContext.parallelize(Row(nestedStructValues2) :: Nil),
+      StructType(Seq(StructField("topLevelCol", nestedStructType2))))
+
+    var unionDf = df1.unionByName(df2, true)
+    assert(unionDf.schema.toDDL == "`topLevelCol` " +
+      "STRUCT<`b`: STRUCT<`ba`: STRING, `bb`: STRING>, `a`: STRUCT<`aa`: STRING>>")
+    checkAnswer(unionDf,
+      Row(Row(Row("ba", null), null)) ::
+      Row(Row(Row(null, "bb"), Row("aa"))) :: Nil)
+
+    unionDf = df2.unionByName(df1, true)
+    assert(unionDf.schema.toDDL == "`topLevelCol` STRUCT<`a`: STRUCT<`aa`: STRING>, " +
+      "`b`: STRUCT<`bb`: STRING, `ba`: STRING>>")
+    checkAnswer(unionDf,
+      Row(Row(null, Row(null, "ba"))) ::
+      Row(Row(Row("aa"), Row("bb", null))) :: Nil)
   }
 
   test("SPARK-32376: Make unionByName null-filling behavior work with struct columns - deep expr") {
@@ -800,16 +876,16 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
       1, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null),
       1, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null))
     val row2 = Row(Row(Row(Row(Row(Row(Row(Row(Row(Row(
-      Row(0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 3, 4, 5, 6, 7, 8, 9),
-      1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 3, 4, 5, 6, 7, 8, 9),
-      1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 3, 4, 5, 6, 7, 8, 9),
-      1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 3, 4, 5, 6, 7, 8, 9),
-      1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 3, 4, 5, 6, 7, 8, 9),
-      1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 3, 4, 5, 6, 7, 8, 9),
-      1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 3, 4, 5, 6, 7, 8, 9),
-      1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 3, 4, 5, 6, 7, 8, 9),
-      1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 3, 4, 5, 6, 7, 8, 9),
-      1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 3, 4, 5, 6, 7, 8, 9))
+      Row(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20))
     // scalastyle:on
     checkAnswer(union, row1 :: row2 :: Nil)
   }
@@ -882,6 +958,7 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
 case class UnionClass1a(a: Int, b: Long, nested: UnionClass2)
 case class UnionClass1b(a: Int, b: Long, nested: UnionClass3)
 case class UnionClass1c(a: Int, b: Long, nested: UnionClass4)
+case class UnionClass1d(a: Int, b: Long, Nested: UnionClass2)
 
 case class UnionClass2(a: Int, c: String)
 case class UnionClass3(a: Int, b: Long)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR changes the unionByName with null filling logic to append new nested struct fields from the right side of the union to the schema versus sorting fields alphabetically. It removes the need to use UpdateField expressions, and just directly projects new nested structs from each side of the union with the correct schema. This changes the union'd schema from being alphabetically sorted previously to now "left dominant", where the fields from the left side of the union are included and then the missing ones from the right are added in the same order found originally.

Also adds a resolver to the StructType merging to handle case insensitivity, as the resulting union logical and physical expressions using StructType.merge to provide the resulting schema of the union.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Certain nested structs would cause unionByName with null filling to error out due to part of the logic for rewriting the expression tree to sort the structs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Shouldn't other than fixing certain cases that caused errors. I don't know if adding the resolver to the StructType merging has any unintended side effects, so definitely would like some thoughts on that. Also the order of the StructFields is slightly different now, though that shouldn't have too much of an effect.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Updated existing tests based on the new StructField ordering and added a new test for the case that was broken originally.