### PR TITLE
[SPARK-35335][SQL] Coalesce shuffle partition as much as possible for REPARTITION_BY_NONE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -504,6 +504,19 @@ object SQLConf {
       .checkValue(_ > 0, "The minimum number of partitions must be positive.")
       .createOptional
 
+  val COALESCE_PARTITIONS_FINAL_STAGE_MIN_PARTITION_NUM =
+    buildConf("spark.sql.adaptive.coalescePartitions.finalStageMinPartitionNum")
+      .doc("The suggested (not guaranteed) minimum number of shuffle partitions after " +
+        "coalescing for final stage. Usually used to reduce small files." +
+        s"If not set, the default value is ${COALESCE_PARTITIONS_MIN_PARTITION_NUM.key}. " +
+        "This configuration only has an effect when " +
+        s"'${ADAPTIVE_EXECUTION_ENABLED.key}' and " +
+        s"'${COALESCE_PARTITIONS_ENABLED.key}' are both true.")
+      .version("3.2.0")
+      .intConf
+      .checkValue(_ > 0, "The minimum number of partitions must be positive.")
+      .createOptional
+
   val COALESCE_PARTITIONS_INITIAL_PARTITION_NUM =
     buildConf("spark.sql.adaptive.coalescePartitions.initialPartitionNum")
       .doc("The initial number of shuffle partitions before coalescing. If not set, it equals to " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -504,19 +504,6 @@ object SQLConf {
       .checkValue(_ > 0, "The minimum number of partitions must be positive.")
       .createOptional
 
-  val COALESCE_PARTITIONS_FINAL_STAGE_MIN_PARTITION_NUM =
-    buildConf("spark.sql.adaptive.coalescePartitions.finalStageMinPartitionNum")
-      .doc("The suggested (not guaranteed) minimum number of shuffle partitions after " +
-        "coalescing for final stage. Usually used to reduce small files." +
-        s"If not set, the default value is ${COALESCE_PARTITIONS_MIN_PARTITION_NUM.key}. " +
-        "This configuration only has an effect when " +
-        s"'${ADAPTIVE_EXECUTION_ENABLED.key}' and " +
-        s"'${COALESCE_PARTITIONS_ENABLED.key}' are both true.")
-      .version("3.2.0")
-      .intConf
-      .checkValue(_ > 0, "The minimum number of partitions must be positive.")
-      .createOptional
-
   val COALESCE_PARTITIONS_INITIAL_PARTITION_NUM =
     buildConf("spark.sql.adaptive.coalescePartitions.initialPartitionNum")
       .doc("The initial number of shuffle partitions before coalescing. If not set, it equals to " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set minPartitionNum to 1 for `CoalesceShufflePartitions` to coalesce shuffle partition as much as possible for `REPARTITION_BY_NONE`.

### Why are the changes needed?

Before this PR. We use `repartition` to avoid generating small files. But it still generates `spark.sql.adaptive.coalescePartitions.minPartitionNum` number of files, which may leads to exceeding the directory item limitation:
```
org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.hdfs.protocol.FSLimitException$MaxDirectoryItemsExceededException): The directory item limit of /path/to/table is exceeded: limit=1048576 items=1048576
```

After this PR. We can avoid generating small files:
```sql
INSERT INTO TABLE target_tbl SELECT /*+ REPARTITION */ * FROM t
```
```scala
df.repartition().write.saveAsTable("target_tbl")
```


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
