### PR TITLE
[SPARK-35348][SQL] Support the utils for escapse the regex for ANSI SQL: SIMILAR TO … ESCAPE syntax

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -31,6 +31,9 @@ import org.apache.spark.unsafe.types.UTF8String
 
 object StringUtils extends Logging {
 
+  private def fail(pattern: String, message: String) =
+    throw QueryCompilationErrors.invalidPatternError(pattern, message)
+
   /**
    * Validate and convert SQL 'like' pattern to a Java regular expression.
    *
@@ -40,14 +43,12 @@ object StringUtils extends Logging {
    * throw an [[AnalysisException]].
    *
    * @param pattern the SQL pattern to convert
-   * @param escapeChar the escape string contains one character.
+   * @param escapeChar the escape character.
    * @return the equivalent Java regular expression of the pattern
    */
   def escapeLikeRegex(pattern: String, escapeChar: Char): String = {
     val in = pattern.iterator
     val out = new StringBuilder()
-
-    def fail(message: String) = throw QueryCompilationErrors.invalidPatternError(pattern, message)
 
     while (in.hasNext) {
       in.next match {
@@ -56,12 +57,59 @@ object StringUtils extends Logging {
           c match {
             case '_' | '%' => out ++= Pattern.quote(Character.toString(c))
             case c if c == escapeChar => out ++= Pattern.quote(Character.toString(c))
-            case _ => fail(s"the escape character is not allowed to precede '$c'")
+            case _ => fail(pattern, s"the escape character is not allowed to precede '$c'")
           }
-        case c if c == escapeChar => fail("it is not allowed to end with the escape character")
+        case c if c == escapeChar =>
+          fail(pattern, "it is not allowed to end with the escape character")
         case '_' => out ++= "."
         case '%' => out ++= ".*"
         case c => out ++= Pattern.quote(Character.toString(c))
+      }
+    }
+    "(?s)" + out.result() // (?s) enables dotall mode, causing "." to match new lines
+  }
+
+  /**
+   * Validate and convert SQL 'similar to' pattern to a Java regular expression.
+   *
+   * This function is similar to escapeLikeRegex, but there are some differences as follows:
+   * 1. If the escape character precedes the meta character for SIMILAR TO, the meta character
+   *    should convert to quote literal.
+   * 2. If '\' is not escape character, need convert to quote literal.
+   * 3. '.', '^' and '$' is not a meta character for SIMILAR TO,
+   *    so we need convert it to quote literal.
+   * 4. Avoid convert the characters of Java regular expression to quote literal.
+   * @param pattern the SQL pattern to convert
+   * @param escapeChar the escape character.
+   * @return the equivalent Java regular expression of the pattern for SIMILAR TO
+   */
+  def escapeSimilarRegex(pattern: String, escapeChar: Char): String = {
+    val in = pattern.toIterator
+    val out = new StringBuilder()
+
+    while (in.hasNext) {
+      in.next match {
+        case c1 if c1 == escapeChar && in.hasNext =>
+          val c = in.next
+          c match {
+            // The meta character for SIMILAR TO.
+            case '_' | '%' | '|' | '*' | '+' | '?' | '{' | '}' | '(' | ')' | '[' | ']' =>
+              out ++= Pattern.quote(Character.toString(c))
+            case c if c == escapeChar => out ++= Pattern.quote(Character.toString(c))
+            // Avoid convert the characters of Java regular expression to quote literal.
+            case 'w' | 'W' | 's' | 'S' | 'd' | 'D' | 'b' | 'B' | 'n' | 'r' | 't' | 'f' | 'v' =>
+              out ++= s"\\$c"
+            case _ => fail(pattern, s"the escape character is not allowed to precede '$c'")
+          }
+        case c if c == escapeChar =>
+          fail(pattern, "it is not allowed to end with the escape character")
+        case '_' => out ++= "."
+        case '%' => out ++= ".*"
+        // If '\' is not the escape character, need convert to literal.
+        case '\\' => out ++= Pattern.quote(Character.toString('\\'))
+        // '.', '^' and '$' is not a meta character for SIMILAR TO.
+        case c if c == '.' || c == '^' || c == '$' => out ++= Pattern.quote(Character.toString(c))
+        case c => out ++= Character.toString(c)
       }
     }
     "(?s)" + out.result() // (?s) enables dotall mode, causing "." to match new lines

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -55,6 +55,63 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
     assert(escapeLikeRegex("a_b", '\"') === expectedEscapedStrSeven)
   }
 
+  test("escapeSimilarRegex") {
+    val expectedEscapedStrs =
+      Seq("(?s)abdef", "(?s).*(b|d).*", "(?s)\\Q|\\E(b|d)*", "(?s)a(b|d)*", "(?s)((Ab)?c)+",
+        "(?s)(\\w)+", "(?s)a.b", "(?s)\\Q\\\\E|(b|d)*", "(?s)\\Q^\\E(b|d)*", "(?s)(b|d)*\\Q$\\E",
+        "(?s)((Ab)?c)+d((efg)+(12))+", "(?s)a{6}.[0-9]{5}(x|y){2}",
+        "(?s)\\Q$\\E[0-9]+(\\Q.\\E[0-9][0-9])?")
+
+    val expectedEscapedStrEleven = "(?s)((Ab)?c)+d((efg)+(12))+"
+    assert(escapeSimilarRegex("abdef", '\\') === expectedEscapedStrs(0))
+    assert(escapeSimilarRegex("abdef", '/') === expectedEscapedStrs(0))
+    assert(escapeSimilarRegex("abdef", '\"') === expectedEscapedStrs(0))
+    assert(escapeSimilarRegex("%(b|d)%", '\\') === expectedEscapedStrs(1))
+    assert(escapeSimilarRegex("%(b|d)%", '/') === expectedEscapedStrs(1))
+    assert(escapeSimilarRegex("%(b|d)%", '\"') === expectedEscapedStrs(1))
+    assert(escapeSimilarRegex("\\|(b|d)*", '\\') === expectedEscapedStrs(2))
+    assert(escapeSimilarRegex("/|(b|d)*", '/') === expectedEscapedStrs(2))
+    assert(escapeSimilarRegex("\"|(b|d)*", '\"') === expectedEscapedStrs(2))
+    assert(escapeSimilarRegex("a(b|d)*", '\\') === expectedEscapedStrs(3))
+    assert(escapeSimilarRegex("a(b|d)*", '/') === expectedEscapedStrs(3))
+    assert(escapeSimilarRegex("a(b|d)*", '\"') === expectedEscapedStrs(3))
+    assert(escapeSimilarRegex("((Ab)?c)+", '\\') === expectedEscapedStrs(4))
+    assert(escapeSimilarRegex("((Ab)?c)+", '/') === expectedEscapedStrs(4))
+    assert(escapeSimilarRegex("((Ab)?c)+", '\"') === expectedEscapedStrs(4))
+    assert(escapeSimilarRegex("(\\w)+", '\\') === expectedEscapedStrs(5))
+    assert(escapeSimilarRegex("(/w)+", '/') === expectedEscapedStrs(5))
+    assert(escapeSimilarRegex("(\"w)+", '\"') === expectedEscapedStrs(5))
+    assert(escapeSimilarRegex("a_b", '\\') === expectedEscapedStrs(6))
+    assert(escapeSimilarRegex("a_b", '/') === expectedEscapedStrs(6))
+    assert(escapeSimilarRegex("a_b", '\"') === expectedEscapedStrs(6))
+    assert(escapeSimilarRegex("\\|(b|d)*", '/') === expectedEscapedStrs(7))
+    assert(escapeSimilarRegex("\\|(b|d)*", '\"') === expectedEscapedStrs(7))
+    assert(escapeSimilarRegex("^(b|d)*", '\\') === expectedEscapedStrs(8))
+    assert(escapeSimilarRegex("^(b|d)*", '/') === expectedEscapedStrs(8))
+    assert(escapeSimilarRegex("^(b|d)*", '\"') === expectedEscapedStrs(8))
+    assert(escapeSimilarRegex("(b|d)*$", '\\') === expectedEscapedStrs(9))
+    assert(escapeSimilarRegex("(b|d)*$", '/') === expectedEscapedStrs(9))
+    assert(escapeSimilarRegex("(b|d)*$", '\"') === expectedEscapedStrs(9))
+    assert(escapeSimilarRegex("((Ab)?c)+d((efg)+(12))+", '\\') ===
+      expectedEscapedStrs(10))
+    assert(escapeSimilarRegex("((Ab)?c)+d((efg)+(12))+", '/') ===
+      expectedEscapedStrs(10))
+    assert(escapeSimilarRegex("((Ab)?c)+d((efg)+(12))+", '\"') ===
+      expectedEscapedStrs(10))
+    assert(escapeSimilarRegex("a{6}_[0-9]{5}(x|y){2}", '\\') ===
+      expectedEscapedStrs(11))
+    assert(escapeSimilarRegex("a{6}_[0-9]{5}(x|y){2}", '/') ===
+      expectedEscapedStrs(11))
+    assert(escapeSimilarRegex("a{6}_[0-9]{5}(x|y){2}", '\"') ===
+      expectedEscapedStrs(11))
+    assert(escapeSimilarRegex("$[0-9]+(.[0-9][0-9])?", '\\') ===
+      expectedEscapedStrs(12))
+    assert(escapeSimilarRegex("$[0-9]+(.[0-9][0-9])?", '/') ===
+      expectedEscapedStrs(12))
+    assert(escapeSimilarRegex("$[0-9]+(.[0-9][0-9])?", '\"') ===
+      expectedEscapedStrs(12))
+  }
+
   test("filter pattern") {
     val names = Seq("a1", "a2", "b2", "c3")
     assert(filterPattern(names, " * ") === Seq("a1", "a2", "b2", "c3"))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -59,10 +59,8 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
     val expectedEscapedStrs =
       Seq("(?s)abdef", "(?s).*(b|d).*", "(?s)\\Q|\\E(b|d)*", "(?s)a(b|d)*", "(?s)((Ab)?c)+",
         "(?s)(\\w)+", "(?s)a.b", "(?s)\\Q\\\\E|(b|d)*", "(?s)\\Q^\\E(b|d)*", "(?s)(b|d)*\\Q$\\E",
-        "(?s)((Ab)?c)+d((efg)+(12))+", "(?s)a{6}.[0-9]{5}(x|y){2}",
-        "(?s)\\Q$\\E[0-9]+(\\Q.\\E[0-9][0-9])?")
+        "(?s)((Ab)?c)+d((efg)+(12))+", "(?s)\\Q$\\E[0-9]+(\\Q.\\E[0-9][0-9])?")
 
-    val expectedEscapedStrEleven = "(?s)((Ab)?c)+d((efg)+(12))+"
     assert(escapeSimilarRegex("abdef", '\\') === expectedEscapedStrs(0))
     assert(escapeSimilarRegex("abdef", '/') === expectedEscapedStrs(0))
     assert(escapeSimilarRegex("abdef", '\"') === expectedEscapedStrs(0))
@@ -98,18 +96,20 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
       expectedEscapedStrs(10))
     assert(escapeSimilarRegex("((Ab)?c)+d((efg)+(12))+", '\"') ===
       expectedEscapedStrs(10))
-    assert(escapeSimilarRegex("a{6}_[0-9]{5}(x|y){2}", '\\') ===
-      expectedEscapedStrs(11))
-    assert(escapeSimilarRegex("a{6}_[0-9]{5}(x|y){2}", '/') ===
-      expectedEscapedStrs(11))
-    assert(escapeSimilarRegex("a{6}_[0-9]{5}(x|y){2}", '\"') ===
-      expectedEscapedStrs(11))
     assert(escapeSimilarRegex("$[0-9]+(.[0-9][0-9])?", '\\') ===
-      expectedEscapedStrs(12))
+      expectedEscapedStrs(11))
     assert(escapeSimilarRegex("$[0-9]+(.[0-9][0-9])?", '/') ===
-      expectedEscapedStrs(12))
+      expectedEscapedStrs(11))
     assert(escapeSimilarRegex("$[0-9]+(.[0-9][0-9])?", '\"') ===
-      expectedEscapedStrs(12))
+      expectedEscapedStrs(11))
+    // scalastyle:off
+    assert(escapeSimilarRegex("a{6}_[0-9]{5}(x|y){2}", '\\') ===
+      "(?s)a{6}.[0-9]{5}(x|y){2}")
+    assert(escapeSimilarRegex("a{6}_[0-9]{5}(x|y){2}", '/') ===
+      "(?s)a{6}.[0-9]{5}(x|y){2}")
+    assert(escapeSimilarRegex("a{6}_[0-9]{5}(x|y){2}", '\"') ===
+      "(?s)a{6}.[0-9]{5}(x|y){2}")
+    // scalastyle:on
   }
 
   test("filter pattern") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
`ANSI SQL: SIMILAR TO ... ESCAPE` is very useful.
There are some mainstream database support the syntax.
**PostgreSQL**:
https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-SIMILARTO-REGEXP

**Redshift**:
https://docs.aws.amazon.com/redshift/latest/dg/pattern-matching-conditions-similar-to.html

**Sybase**:
http://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.help.sqlanywhere.12.0.0/dbreference/like-regexp-similarto.html

**Firebird**:
http://firebirdsql.org/file/documentation/html/en/refdocs/fblangref25/firebird-25-language-reference.html#fblangref25-commons-predsiimilarto

This util supports the following pattern-matching metacharacters:

Operator | Description
-- | --
% | Matches any sequence of zero or more characters.
_ | Matches any single character.
\| | Denotes alternation (either of two alternatives).
\* | Repeat the previous item zero or more times.
\+ | Repeat the previous item one or more times.
? | Repeat the previous item zero or one time.
{m} | Repeat the previous item exactly m times.
{m,} | Repeat the previous item m or more times.
{m,n} | Repeat the previous item at least m and not more than n times.
() | Parentheses group items into a single logical item.
[...] | A bracket expression specifies a character class, just as in POSIX regular expressions.

**Note**
`SIMILAR TO` is similar to `RLIKE`, but with the following differences:
       1. The `SIMILAR TO` operator returns true only if its pattern matches the entire string,
          unlike `RLIKE` behavior, where the pattern can match any portion of the string.
       2. The regex string allow use _ and % as wildcard characters denoting any single character
          and any string, respectively (these are comparable to . and .* in POSIX regular
          expressions).
       3. The regex string allow use escape character like `LIKE` behavior.
       4. '.', '^' and '$' is not a meta character for `SIMILAR TO`.

### Why are the changes needed?
`ANSI SQL: SIMILAR TO ... ESCAPE` is very useful.


### Does this PR introduce _any_ user-facing change?
Yes, a new feature.


### How was this patch tested?
New tests
