### PR TITLE
[SPARK-35261][SQL][TESTS][FOLLOW-UP] Change failOnError to false for NativeAdd in V2FunctionBenchmark

### DIFF
--- a/sql/core/benchmarks/V2FunctionBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/V2FunctionBenchmark-jdk11-results.txt
@@ -1,44 +1,44 @@
 OpenJDK 64-Bit Server VM 11.0.11+9-LTS on Linux 5.4.0-1046-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = true codegen = true:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                       17789          18405         580         28.1          35.6       1.0X
-java_long_add_default                                                                 85058          87073         NaN          5.9         170.1       0.2X
-java_long_add_magic                                                                   20262          20641         352         24.7          40.5       0.9X
-java_long_add_static_magic                                                            19458          19524         105         25.7          38.9       0.9X
-scala_long_add_default                                                                85892          86496         560          5.8         171.8       0.2X
-scala_long_add_magic                                                                  20164          20330         212         24.8          40.3       0.9X
+native_long_add                                                                       18526          18837         403         27.0          37.1       1.0X
+java_long_add_default                                                                 71274          71488         189          7.0         142.5       0.3X
+java_long_add_magic                                                                   18467          18712         378         27.1          36.9       1.0X
+java_long_add_static_magic                                                            18376          18387          11         27.2          36.8       1.0X
+scala_long_add_default                                                                70770          70888         123          7.1         141.5       0.3X
+scala_long_add_magic                                                                  18492          18545          55         27.0          37.0       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.11+9-LTS on Linux 5.4.0-1046-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = false codegen = true:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                        18290          18467         157         27.3          36.6       1.0X
-java_long_add_default                                                                  82415          82687         270          6.1         164.8       0.2X
-java_long_add_magic                                                                    19941          20032          85         25.1          39.9       0.9X
-java_long_add_static_magic                                                             17861          17940          92         28.0          35.7       1.0X
-scala_long_add_default                                                                 83800          85639         NaN          6.0         167.6       0.2X
-scala_long_add_magic                                                                   20103          20123          18         24.9          40.2       0.9X
+native_long_add                                                                        16658          16805         223         30.0          33.3       1.0X
+java_long_add_default                                                                  69215          69370         145          7.2         138.4       0.2X
+java_long_add_magic                                                                    18488          18610         139         27.0          37.0       0.9X
+java_long_add_static_magic                                                             16505          16534          27         30.3          33.0       1.0X
+scala_long_add_default                                                                 69036          69121          74          7.2         138.1       0.2X
+scala_long_add_magic                                                                   18414          18463          44         27.2          36.8       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.11+9-LTS on Linux 5.4.0-1046-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = true codegen = false:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                        46039          46199         162         10.9          92.1       1.0X
-java_long_add_default                                                                 113199         113773         720          4.4         226.4       0.4X
-java_long_add_magic                                                                   158252         159419        1075          3.2         316.5       0.3X
-java_long_add_static_magic                                                            157162         157676         516          3.2         314.3       0.3X
-scala_long_add_default                                                                112363         113264        1503          4.4         224.7       0.4X
-scala_long_add_magic                                                                  158122         159010         835          3.2         316.2       0.3X
+native_long_add                                                                        40877          41045         166         12.2          81.8       1.0X
+java_long_add_default                                                                  80090          80112          23          6.2         160.2       0.5X
+java_long_add_magic                                                                   123386         123485          92          4.1         246.8       0.3X
+java_long_add_static_magic                                                            120648         120764         184          4.1         241.3       0.3X
+scala_long_add_default                                                                 80140          80776        1051          6.2         160.3       0.5X
+scala_long_add_magic                                                                  122739         122909         148          4.1         245.5       0.3X
 
 OpenJDK 64-Bit Server VM 11.0.11+9-LTS on Linux 5.4.0-1046-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = false codegen = false:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                         42685          42743          54         11.7          85.4       1.0X
-java_long_add_default                                                                   92041          92236         202          5.4         184.1       0.5X
-java_long_add_magic                                                                    148299         148722         397          3.4         296.6       0.3X
-java_long_add_static_magic                                                             140599         141064         442          3.6         281.2       0.3X
-scala_long_add_default                                                                  91896          92980         959          5.4         183.8       0.5X
-scala_long_add_magic                                                                   148031         148802         759          3.4         296.1       0.3X
+native_long_add                                                                         37374          37746         502         13.4          74.7       1.0X
+java_long_add_default                                                                   75753          75961         211          6.6         151.5       0.5X
+java_long_add_magic                                                                    117556         118129         988          4.3         235.1       0.3X
+java_long_add_static_magic                                                             115822         116904        1002          4.3         231.6       0.3X
+scala_long_add_default                                                                  76098          76332         213          6.6         152.2       0.5X
+scala_long_add_magic                                                                   117451         118082         875          4.3         234.9       0.3X
 

--- a/sql/core/benchmarks/V2FunctionBenchmark-results.txt
+++ b/sql/core/benchmarks/V2FunctionBenchmark-results.txt
@@ -1,44 +1,44 @@
 OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Linux 5.4.0-1046-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = true codegen = true:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                       10559          11585         903         47.4          21.1       1.0X
-java_long_add_default                                                                 78979          80089         987          6.3         158.0       0.1X
-java_long_add_magic                                                                   14061          14326         305         35.6          28.1       0.8X
-java_long_add_static_magic                                                            11971          12150         242         41.8          23.9       0.9X
-scala_long_add_default                                                                77254          78565        1254          6.5         154.5       0.1X
-scala_long_add_magic                                                                  13174          13232          51         38.0          26.3       0.8X
+native_long_add                                                                       10680          12281        1537         46.8          21.4       1.0X
+java_long_add_default                                                                132934         133550         909          3.8         265.9       0.1X
+java_long_add_magic                                                                   14108          14513         388         35.4          28.2       0.8X
+java_long_add_static_magic                                                            11701          11860         163         42.7          23.4       0.9X
+scala_long_add_default                                                               131935         132358         531          3.8         263.9       0.1X
+scala_long_add_magic                                                                  13762          14071         268         36.3          27.5       0.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Linux 5.4.0-1046-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = false codegen = true:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                        10489          10665         162         47.7          21.0       1.0X
-java_long_add_default                                                                  66636          68422         NaN          7.5         133.3       0.2X
-java_long_add_magic                                                                    13504          14213         883         37.0          27.0       0.8X
-java_long_add_static_magic                                                             11726          11984         240         42.6          23.5       0.9X
-scala_long_add_default                                                                 75906          76130         196          6.6         151.8       0.1X
-scala_long_add_magic                                                                   14480          14770         261         34.5          29.0       0.7X
+native_long_add                                                                        10649          10802         168         47.0          21.3       1.0X
+java_long_add_default                                                                 130644         131830        1034          3.8         261.3       0.1X
+java_long_add_magic                                                                    14195          14376         254         35.2          28.4       0.8X
+java_long_add_static_magic                                                             10998          11045          42         45.5          22.0       1.0X
+scala_long_add_default                                                                133295         136396         NaN          3.8         266.6       0.1X
+scala_long_add_magic                                                                   14017          14055          34         35.7          28.0       0.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Linux 5.4.0-1046-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = true codegen = false:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                        39178          39548         323         12.8          78.4       1.0X
-java_long_add_default                                                                  84756          85509        1092          5.9         169.5       0.5X
-java_long_add_magic                                                                   199140         200801        1823          2.5         398.3       0.2X
-java_long_add_static_magic                                                            203500         207050         NaN          2.5         407.0       0.2X
-scala_long_add_default                                                                101180         101421         387          4.9         202.4       0.4X
-scala_long_add_magic                                                                  193277         197006        1138          2.6         386.6       0.2X
+native_long_add                                                                        35847          36138         264         13.9          71.7       1.0X
+java_long_add_default                                                                  79210          79686         525          6.3         158.4       0.5X
+java_long_add_magic                                                                   253904         255356        1275          2.0         507.8       0.1X
+java_long_add_static_magic                                                            258790         264585         980          1.9         517.6       0.1X
+scala_long_add_default                                                                103844         104310         514          4.8         207.7       0.3X
+scala_long_add_magic                                                                  269234         270824         NaN          1.9         538.5       0.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Linux 5.4.0-1046-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = false codegen = false:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                         37064          37333         235         13.5          74.1       1.0X
-java_long_add_default                                                                  104439         107802         NaN          4.8         208.9       0.4X
-java_long_add_magic                                                                    212496         214321         NaN          2.4         425.0       0.2X
-java_long_add_static_magic                                                             239551         240619        1652          2.1         479.1       0.2X
-scala_long_add_default                                                                 122413         123171         788          4.1         244.8       0.3X
-scala_long_add_magic                                                                   215912         222715         NaN          2.3         431.8       0.2X
+native_long_add                                                                         32437          32896         434         15.4          64.9       1.0X
+java_long_add_default                                                                   85675          97045         NaN          5.8         171.3       0.4X
+java_long_add_magic                                                                    273730         276053        2111          1.8         547.5       0.1X
+java_long_add_static_magic                                                             277269         278847        1478          1.8         554.5       0.1X
+scala_long_add_default                                                                 106925         107298         323          4.7         213.9       0.3X
+scala_long_add_magic                                                                   280643         281611         847          1.8         561.3       0.1X
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/functions/V2FunctionBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/functions/V2FunctionBenchmark.scala
@@ -104,10 +104,9 @@ object V2FunctionBenchmark extends SqlBasedBenchmark {
       left: Expression,
       right: Expression,
       override val nullable: Boolean) extends BinaryArithmetic {
-    override protected val failOnError: Boolean = true
+    override protected val failOnError: Boolean = false
     override def inputType: AbstractDataType = NumericType
     override def symbol: String = "+"
-    override def exactMathMethod: Option[String] = Some("addExact")
 
     private lazy val numeric = TypeUtils.getNumeric(dataType, failOnError)
     protected override def nullSafeEval(input1: Any, input2: Any): Any =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Change `failOnError` to false for `NativeAdd` in `V2FunctionBenchmark`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Since `NativeAdd` is simply doing addition on long it's better to set `failOnError` to false so it will use native long addition instead of `Math.addExact`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

N/A