### PR TITLE
[SPARK-35316][SQL] UnwrapCastInBinaryComparison support In/InSet predicate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -137,7 +137,8 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
     // As the analyzer makes sure that the list of In is already of the same data type, then the
     // rule can simply check the first literal in `in.list` can implicitly cast to `toType` or not,
     // and note that:
-    // 1. this rule doesn't convert in when `in.list` is empty.
+    // 1. this rule doesn't convert in when `in.list` is empty or `in.list` contains only null
+    // values.
     // 2. this rule only handles the case when both `fromExp` and value in `in.list` are of numeric
     // type.
     case in @ In(Cast(fromExp, toType: NumericType, _), list @ Seq(firstLit, _*))
@@ -161,7 +162,7 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
         case _ => throw new IllegalStateException("Illegal value found in in.list.")
       }
 
-      // return original expression when in.list only contains null values.
+      // return original expression when in.list contains only null values.
       if (canCastList.isEmpty && cannotCastList.isEmpty) {
         exp
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -129,10 +129,8 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
         if canImplicitlyCast(fromExp, toType, literalType) =>
       simplifyNumericComparison(be, fromExp, toType, value)
 
-    case in @ In(Cast(fromExp, toType: NumericType, _), list)
-      if list.forall(v =>
-        v.isInstanceOf[Literal] && canImplicitlyCast(fromExp, toType, v.dataType)
-      ) =>
+    case in @ In(Cast(fromExp, _: NumericType, _), list)
+        if in.inSetConvertible =>
       val (newValueList, exp) =
         list.map(lit => unwrapCast(EqualTo(in.value, lit)))
           .partition {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.{BINARY_COMPARISON, IN, I
 import org.apache.spark.sql.types._
 
 /**
- * Unwrap casts in binary comparison or `In` operations with patterns like following:
+ * Unwrap casts in binary comparison or `In/InSet` operations with patterns like following:
  *
  * - `BinaryComparison(Cast(fromExp, toType), Literal(value, toType))`
  * - `BinaryComparison(Literal(value, toType), Cast(fromExp, toType))`

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -169,7 +169,7 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
         // cast null value to fromExp.dataType, to make sure the new return list is in the same data
         // type.
         val newList = nullList.map(lit => Cast(lit, fromExp.dataType)) ++ canCastList
-        val unwrapIn = In(fromExp, newList)
+        val unwrapIn = In(fromExp, newList.toSeq)
         cannotCastList.headOption match {
           case None => unwrapIn
           // since `cannotCastList` are all the same,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -202,6 +202,7 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
               case e @ And(IsNull(_), Literal(null, BooleanType)) => cannotCastSet += e
               case _ => throw new IllegalStateException("Illegal unwrap cast result found.")
             }
+          case _ => throw new IllegalStateException("Illegal value found in hset.")
         }
 
       if (canCastSet.isEmpty && cannotCastSet.isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import scala.collection.immutable.HashSet
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.catalyst.expressions._
@@ -133,9 +134,20 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
         if canImplicitlyCast(fromExp, toType, literalType) =>
       simplifyNumericComparison(be, fromExp, toType, value)
 
+    // As the analyzer makes sure that the list of In is already of the same data type, then the
+    // rule can simply check the first literal in `in.list` can implicitly cast to `toType` or not,
+    // and note that:
+    // 1. this rule doesn't convert in when `in.list` is empty.
+    // 2. this rule only handles the case when both `fromExp` and value in `in.list` are of numeric
+    // type.
     case in @ In(Cast(fromExp, toType: NumericType, _), list @ Seq(firstLit, _*))
       if canImplicitlyCast(fromExp, toType, firstLit.dataType) =>
 
+      // There are 3 kinds of literals in the list:
+      // 1. null literals
+      // 2. The literals that can cast to fromExp.dataType
+      // 3. The literals that cannot cast to fromExp.dataType
+      // null literals is special as we can cast null literals to any data type.
       val (nullList, canCastList, cannotCastList) =
         (ArrayBuffer[Literal](), ArrayBuffer[Literal](), ArrayBuffer[Expression]())
       list.foreach {
@@ -149,9 +161,12 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
         case _ => throw new IllegalStateException("Illegal value found in in.list.")
       }
 
-      if (canCastList.isEmpty) {
+      // return original expression when in.list only contains null values.
+      if (canCastList.isEmpty && cannotCastList.isEmpty) {
         exp
       } else {
+        // cast null value to fromExp.dataType, to make sure the new return list is in the same data
+        // type.
         val newList = nullList.map(lit => Cast(lit, fromExp.dataType)) ++ canCastList
         val unwrapIn = In(fromExp, newList)
         cannotCastList.headOption match {
@@ -159,111 +174,44 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
           // since `cannotCastList` are all the same,
           // convert to a single value `And(IsNull(_), Literal(null, BooleanType))`.
           case Some(falseIfNotNull @ And(IsNull(_), Literal(null, BooleanType)))
-            if canCastList.map(_.canonicalized).distinct.length == 1 => Or(falseIfNotNull, unwrapIn)
+              if cannotCastList.map(_.canonicalized).distinct.length == 1 =>
+            Or(falseIfNotNull, unwrapIn)
           case _ => exp
         }
       }
-
-    // As the analyzer makes sure that the list of In is already of the same data type, then the
-    // rule can simply check the first literal in `in.list` can implicitly cast to `toType` or not,
-    // and note that:
-    // 1. this rule doesn't convert in when `in.list` is empty.
-    // 2. this rule only handles the case when both `fromExp` and value in `in.list` are of numeric
-    // type.
-//    case in @ In(Cast(fromExp, toType: NumericType, _), list @ Seq(firstLit, _*))
-//        if canImplicitlyCast(fromExp, toType, firstLit.dataType) && in.inSetConvertible =>
-//      val (newValueList, expr) =
-//        list.map(lit => unwrapCast(EqualTo(in.value, lit)))
-//          .partition {
-//            case EqualTo(_, _: Literal) => true
-//            case And(IsNull(_), Literal(null, BooleanType)) => false
-//            case _ => throw new IllegalStateException("Illegal unwrap cast result found.")
-//          }
-//
-//      val (nonNullValueList, nullValueList) = newValueList.partition {
-//        case EqualTo(_, NonNullLiteral(_, _: NumericType)) => true
-//        case EqualTo(_, Literal(null, _)) => false
-//        case _ => throw new IllegalStateException("Illegal unwrap cast result found.")
-//      }
-//      // make sure the new return list have the same dataType.
-//      val newList = {
-//        if (nonNullValueList.nonEmpty) {
-//          // cast the null value to the dataType of nonNullValueList
-//          // when the nonNullValueList is nonEmpty.
-//          nullValueList.map {
-//            case EqualTo(_, lit) =>
-//              Cast(lit, nonNullValueList.head.asInstanceOf[EqualTo].left.dataType)
-//          } ++ nonNullValueList.map {case EqualTo(_, lit) => lit}
-//        } else {
-//          // the new value list only contains null value,
-//          // cast the null value to fromExp.dataType.
-//          nullValueList.map {
-//            case EqualTo(_, lit) =>
-//              Cast(lit, fromExp.dataType)
-//          }
-//        }
-//      }
-//
-//      val unwrapIn = In(fromExp, newList)
-//      expr.headOption match {
-//        case None => unwrapIn
-//        // since `expr` are all the same,
-//        // convert to a single value `And(IsNull(_), Literal(null, BooleanType))`.
-//        case Some(falseIfNotNull @ And(IsNull(_), Literal(null, BooleanType)))
-//            if expr.map(_.canonicalized).distinct.length == 1 => Or(falseIfNotNull, unwrapIn)
-//        case _ => exp
-//      }
-
-//    case inSet @ InSet(Cast(fromExp, toType: NumericType, _), hset)
-//      if hset.nonEmpty && canImplicitlyCast(fromExp, toType, toType) =>
-//      val (nullList, canCastList, cannotCastList) =
-//        (ArrayBuffer[Literal](), ArrayBuffer[Literal](), ArrayBuffer[Expression]())
-//      hset.map(lit => EqualTo(inSet.child, Literal.create(lit, toType)))
-//        .foreach {
-//        case lit @ Literal(null, _) => nullList += lit
-//        case lit @ NonNullLiteral(_, _) =>
-//          unwrapCast(EqualTo(inSet.child, lit)) match {
-//            case EqualTo(_, unwrapLit: Literal) => canCastList += unwrapLit
-//            case e @ And(IsNull(_), Literal(null, BooleanType)) => cannotCastList += e
-//            case _ => throw new IllegalStateException("Illegal unwrap cast result found.")
-//          }
-//        case _ => throw new IllegalStateException("Illegal value found in in.list.")
-//      }
-//
-//      if (canCastList.isEmpty) {
-//        exp
-//      } else {
-//        val newList = nullList.map(lit => Cast(lit, fromExp.dataType)) ++ canCastList
-//        val unwrapIn = In(fromExp, newList)
-//        cannotCastList.headOption match {
-//          case None => unwrapIn
-//          // since `cannotCastList` are all the same,
-//          // convert to a single value `And(IsNull(_), Literal(null, BooleanType))`.
-//          case Some(falseIfNotNull @ And(IsNull(_), Literal(null, BooleanType)))
-//            if canCastList.map(_.canonicalized).distinct.length == 1 => Or(falseIfNotNull, unwrapIn)
-//          case _ => exp
-//        }
-//      }
 
     // The same with `In` expression, the analyzer makes sure that the hset of InSet is already of
     // the same data type, so simply check `fromExp.dataType` can implicitly cast to `toType` and
     // both `fromExp.dataType` and `toType` is numeric type or not.
     case inSet @ InSet(Cast(fromExp, toType: NumericType, _), hset)
-        if hset.nonEmpty && canImplicitlyCast(fromExp, toType, toType) =>
-      val (newValueSet, expr) =
-        hset.map(lit => unwrapCast(EqualTo(inSet.child, Literal.create(lit, toType))))
-          .partition {
-            case EqualTo(_, _: Literal) => true
-            case And(IsNull(_), Literal(null, BooleanType)) => false
-            case _ => throw new IllegalStateException("Illegal unwrap cast result found.")
-          }
-      val newSet = newValueSet.map {case EqualTo(_, lit: Literal) => lit.value}
-      val unwrapInSet = InSet(fromExp, newSet)
-      expr.headOption match {
-        case None => unwrapInSet
-        case Some(falseIfNotNull @ And(IsNull(_), Literal(null, BooleanType)))
-          if expr.map(_.canonicalized).size == 1 => Or(falseIfNotNull, unwrapInSet)
-        case _ => exp
+      if hset.nonEmpty && canImplicitlyCast(fromExp, toType, toType) =>
+
+      var (nullList, canCastList, cannotCastList) =
+        (HashSet[Literal](), HashSet[Literal](), HashSet[Expression]())
+      hset.map(value => Literal.create(value, toType))
+        .foreach {
+          case lit @ Literal(null, _) => nullList += lit
+          case lit @ NonNullLiteral(_, _) =>
+            unwrapCast(EqualTo(inSet.child, lit)) match {
+              case EqualTo(_, unwrapLit: Literal) => canCastList += unwrapLit
+              case e @ And(IsNull(_), Literal(null, BooleanType)) => cannotCastList += e
+              case _ => throw new IllegalStateException("Illegal unwrap cast result found.")
+            }
+        }
+
+      if (canCastList.isEmpty && cannotCastList.isEmpty) {
+        exp
+      } else {
+        val newHSet = nullList ++ canCastList
+        val unwrapInSet = InSet(fromExp, newHSet.map(_.value))
+        cannotCastList.headOption match {
+          case None => unwrapInSet
+          // since `cannotCastList` are all the same,
+          // convert to a single value `And(IsNull(_), Literal(null, BooleanType))`.
+          case Some(falseIfNotNull @ And(IsNull(_), Literal(null, BooleanType)))
+            if cannotCastList.map(_.canonicalized).size == 1 => Or(falseIfNotNull, unwrapInSet)
+          case _ => exp
+        }
       }
 
     case _ => exp

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.types._
  *
  * - `BinaryComparison(Cast(fromExp, toType), Literal(value, toType))`
  * - `BinaryComparison(Literal(value, toType), Cast(fromExp, toType))`
- * - `In(Cast(fromExp, toType), Seq((v1, toType), (v2, toType), ...)`
+ * - `In(Cast(fromExp, toType), Seq(Literal(v1, toType), Literal(v2, toType), ...)`
  *
  * This rule optimizes expressions with the above pattern by either replacing the cast with simpler
  * constructs, or moving the cast from the expression side to the literal side, which enables them
@@ -138,12 +138,12 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
         list.map(lit => unwrapCast(EqualTo(in.value, lit)))
           .partition {
             case EqualTo(_, _: Literal) => true
-            case And(IsNull(_), Literal(null, BooleanType)) => false
+            case _ => false
           }
 
       val (nonNullValueList, nullValueList) = newValueList.partition {
         case EqualTo(_, NonNullLiteral(_, _: NumericType)) => true
-        case EqualTo(_, Literal(null, _)) => false
+        case _ => false
       }
       // make sure the new return list have the same dataType.
       val newList = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -261,13 +261,18 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
       In(Cast(f, LongType), Seq(1.toLong, Int.MaxValue.toLong, Long.MaxValue)),
       Or(falseIfNotNull(f), f.in(1.toShort)))
 
+    // in.list only contains the value which out of `fromType` range
+    checkInAndInSet(
+      In(Cast(f, LongType), Seq(Int.MaxValue.toLong, Long.MaxValue)),
+      In(Cast(f, LongType), Seq(Int.MaxValue.toLong, Long.MaxValue)))
+
     // in.list is empty
     checkInAndInSet(
       In(Cast(f, IntegerType), Seq.empty), Cast(f, IntegerType).in())
 
     // in.list contains null value
     checkInAndInSet(
-      In(Cast(f, IntegerType), Seq(intLit)), f.in(shortLit))
+      In(Cast(f, IntegerType), Seq(intLit)), In(Cast(f, IntegerType), Seq(intLit)))
     checkInAndInSet(
       In(Cast(f, IntegerType), Seq(intLit, 1)), f.in(shortLit, 1.toShort))
     checkInAndInSet(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -233,7 +233,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
     assert(getRange(DecimalType(5, 2)).isEmpty)
   }
 
-  test("SPARK-35316: unwrap should support In/InSet predicate.") {
+  test("SPARK-35316: unwrap should support In predicate.") {
     assertEquivalent(
       Cast(f, LongType).in(1.toLong, 2.toLong, 3.toLong), f.in(1.toShort, 2.toShort, 3.toShort))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -233,6 +233,15 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
     assert(getRange(DecimalType(5, 2)).isEmpty)
   }
 
+  test("SPARK-35316: unwrap should support In/InSet predicate.") {
+    assertEquivalent(
+      Cast(f, LongType).in(1.toLong, 2.toLong, 3.toLong), f.in(1.toShort, 2.toShort, 3.toShort))
+
+    // Literal list contains the value which out of fromExp range
+    assertEquivalent(
+      Cast(f, LongType).in(1.toLong, Int.MaxValue.toLong), f.in(1.toShort))
+  }
+
   private def castInt(e: Expression): Expression = Cast(e, IntegerType)
   private def castDouble(e: Expression): Expression = Cast(e, DoubleType)
   private def castDecimal2(e: Expression): Expression = Cast(e, DecimalType(10, 4))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -237,9 +237,10 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
     assertEquivalent(
       Cast(f, LongType).in(1.toLong, 2.toLong, 3.toLong), f.in(1.toShort, 2.toShort, 3.toShort))
 
-    // Literal list contains the value which out of fromExp range
+    // in.list contains the value which out of `fromType` range
     assertEquivalent(
-      Cast(f, LongType).in(1.toLong, Int.MaxValue.toLong), Or(falseIfNotNull(f), f.in(1.toShort)))
+      Cast(f, LongType).in(1.toLong, Int.MaxValue.toLong, Long.MaxValue),
+      Or(falseIfNotNull(f), f.in(1.toShort)))
   }
 
   private def castInt(e: Expression): Expression = Cast(e, IntegerType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -239,7 +239,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
 
     // Literal list contains the value which out of fromExp range
     assertEquivalent(
-      Cast(f, LongType).in(1.toLong, Int.MaxValue.toLong), f.in(1.toShort))
+      Cast(f, LongType).in(1.toLong, Int.MaxValue.toLong), Or(falseIfNotNull(f), f.in(1.toShort)))
   }
 
   private def castInt(e: Expression): Expression = Cast(e, IntegerType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -264,7 +264,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
     // in.list only contains the value which out of `fromType` range
     checkInAndInSet(
       In(Cast(f, LongType), Seq(Int.MaxValue.toLong, Long.MaxValue)),
-      In(Cast(f, LongType), Seq(Int.MaxValue.toLong, Long.MaxValue)))
+      Or(falseIfNotNull(f), f.in()))
 
     // in.list is empty
     checkInAndInSet(
@@ -273,6 +273,8 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
     // in.list contains null value
     checkInAndInSet(
       In(Cast(f, IntegerType), Seq(intLit)), In(Cast(f, IntegerType), Seq(intLit)))
+    checkInAndInSet(
+      In(Cast(f, IntegerType), Seq(intLit, intLit)), In(Cast(f, IntegerType), Seq(intLit, intLit)))
     checkInAndInSet(
       In(Cast(f, IntegerType), Seq(intLit, 1)), f.in(shortLit, 1.toShort))
     checkInAndInSet(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?

This pr add in/inset predicate support for `UnwrapCastInBinaryComparison`.

Current implement doesn't pushdown filters for `In/InSet` which contains `Cast`.

For instance:

```scala
spark.range(50).selectExpr("cast(id as int) as id").write.mode("overwrite").parquet("/tmp/parquet/t1")
spark.read.parquet("/tmp/parquet/t1").where("id in (1L, 2L, 4L)").explain
```

before this pr:

```
== Physical Plan ==
*(1) Filter cast(id#5 as bigint) IN (1,2,4)
+- *(1) ColumnarToRow
   +- FileScan parquet [id#5] Batched: true, DataFilters: [cast(id#5 as bigint) IN (1,2,4)], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/tmp/parquet/t1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<id:int>
```

after this pr:

```
== Physical Plan ==
*(1) Filter id#95 IN (1,2,4)
+- *(1) ColumnarToRow
   +- FileScan parquet [id#95] Batched: true, DataFilters: [id#95 IN (1,2,4)], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/tmp/parquet/t1], PartitionFilters: [], PushedFilters: [In(id, [1,2,4])], ReadSchema: struct<id:int>
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

New test.
