### PR TITLE
[MINOR][DOCS] Avoid some python docs where first sentence has "e.g." or similar

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -738,7 +738,7 @@ class LinearSVCModel(_JavaClassificationModel, _LinearSVCParams, JavaMLWritable,
     @since("3.1.0")
     def summary(self):
         """
-        Gets summary (e.g. accuracy/precision/recall, objective history, total iterations) of model
+        Gets summary (accuracy/precision/recall, objective history, total iterations) of model
         trained on the training set. An exception is thrown if `trainingSummary is None`.
         """
         if self.hasSummary:
@@ -1237,7 +1237,7 @@ class LogisticRegressionModel(_JavaProbabilisticClassificationModel, _LogisticRe
     @since("2.0.0")
     def summary(self):
         """
-        Gets summary (e.g. accuracy/precision/recall, objective history, total iterations) of model
+        Gets summary (accuracy/precision/recall, objective history, total iterations) of model
         trained on the training set. An exception is thrown if `trainingSummary is None`.
         """
         if self.hasSummary:
@@ -1843,7 +1843,7 @@ class RandomForestClassificationModel(_TreeEnsembleModel, _JavaProbabilisticClas
     @since("3.1.0")
     def summary(self):
         """
-        Gets summary (e.g. accuracy/precision/recall, objective history, total iterations) of model
+        Gets summary (accuracy/precision/recall, objective history, total iterations) of model
         trained on the training set. An exception is thrown if `trainingSummary is None`.
         """
         if self.hasSummary:
@@ -2700,7 +2700,7 @@ class MultilayerPerceptronClassificationModel(_JavaProbabilisticClassificationMo
     @since("3.1.0")
     def summary(self):
         """
-        Gets summary (e.g. accuracy/precision/recall, objective history, total iterations) of model
+        Gets summary (accuracy/precision/recall, objective history, total iterations) of model
         trained on the training set. An exception is thrown if `trainingSummary is None`.
         """
         if self.hasSummary:
@@ -3500,7 +3500,7 @@ class FMClassificationModel(_JavaProbabilisticClassificationModel, _Factorizatio
     @since("3.1.0")
     def summary(self):
         """
-        Gets summary (e.g. accuracy/precision/recall, objective history, total iterations) of model
+        Gets summary (accuracy/precision/recall, objective history, total iterations) of model
         trained on the training set. An exception is thrown if `trainingSummary is None`.
         """
         if self.hasSummary:

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -189,7 +189,7 @@ class GaussianMixtureModel(JavaModel, _GaussianMixtureParams, JavaMLWritable, Ja
     @since("2.1.0")
     def summary(self):
         """
-        Gets summary (e.g. cluster assignments, cluster sizes) of the model trained on the
+        Gets summary (cluster assignments, cluster sizes) of the model trained on the
         training set. An exception is thrown if no summary exists.
         """
         if self.hasSummary:
@@ -560,7 +560,7 @@ class KMeansModel(JavaModel, _KMeansParams, GeneralJavaMLWritable, JavaMLReadabl
     @since("2.1.0")
     def summary(self):
         """
-        Gets summary (e.g. cluster assignments, cluster sizes) of the model trained on the
+        Gets summary (cluster assignments, cluster sizes) of the model trained on the
         training set. An exception is thrown if no summary exists.
         """
         if self.hasSummary:
@@ -828,7 +828,7 @@ class BisectingKMeansModel(JavaModel, _BisectingKMeansParams, JavaMLWritable, Ja
     @since("2.1.0")
     def summary(self):
         """
-        Gets summary (e.g. cluster assignments, cluster sizes) of the model trained on the
+        Gets summary (cluster assignments, cluster sizes) of the model trained on the
         training set. An exception is thrown if no summary exists.
         """
         if self.hasSummary:

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -348,7 +348,7 @@ class LinearRegressionModel(_JavaRegressionModel, _LinearRegressionParams, Gener
     @since("2.0.0")
     def summary(self):
         """
-        Gets summary (e.g. residuals, mse, r-squared ) of model on
+        Gets summary (residuals, MSE, r-squared ) of model on
         training set. An exception is thrown if
         `trainingSummary is None`.
         """
@@ -2270,7 +2270,7 @@ class GeneralizedLinearRegressionModel(_JavaRegressionModel, _GeneralizedLinearR
     @since("2.0.0")
     def summary(self):
         """
-        Gets summary (e.g. residuals, deviance, pValues) of model on
+        Gets summary (residuals, deviance, p-values) of model on
         training set. An exception is thrown if
         `trainingSummary is None`.
         """

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -152,7 +152,7 @@ class GeneralMLWriter(MLWriter):
 
     def format(self, source):
         """
-        Specifies the format of ML export (e.g. "pmml", "internal", or the fully qualified class
+        Specifies the format of ML export ("pmml", "internal", or the fully qualified class
         name for export).
         """
         self.source = source
@@ -202,7 +202,7 @@ class GeneralJavaMLWriter(JavaMLWriter):
 
     def format(self, source):
         """
-        Specifies the format of ML export (e.g. "pmml", "internal", or the fully qualified class
+        Specifies the format of ML export ("pmml", "internal", or the fully qualified class
         name for export).
         """
         self._jwrite.format(source)

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -576,7 +576,7 @@ class DatetimeMethods(object):
         Parameters
         ----------
         date_format : str
-            Date format string (e.g. "%%Y-%%m-%%d").
+            Date format string (example: "%%Y-%%m-%%d").
 
         Returns
         -------

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -2994,7 +2994,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         axis: Union[int, str] = 0,
     ) -> "DataFrame":
         """
-        Select values between particular times of the day (e.g., 9:00-9:30 AM).
+        Select values between particular times of the day (example: 9:00-9:30 AM).
 
         By setting ``start_time`` to be later than ``end_time``,
         you can get the times that are *not* between the two times.
@@ -3088,7 +3088,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         self, time: Union[datetime.time, str], asof: bool = False, axis: Union[int, str] = 0
     ) -> "DataFrame":
         """
-        Select values at particular time of day (e.g., 9:30AM).
+        Select values at particular time of day (example: 9:30AM).
 
         Parameters
         ----------

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -762,7 +762,7 @@ class Index(IndexOpsMixin):
         Parameters
         ----------
         value : scalar
-            Scalar value to use to fill holes (e.g. 0). This value cannot be a list-likes.
+            Scalar value to use to fill holes (example: 0). This value cannot be a list-likes.
 
         Returns
         -------

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -614,7 +614,7 @@ class DatetimeIndex(Index):
         Parameters
         ----------
         date_format : str
-            Date format string (e.g. "%%Y-%%m-%%d").
+            Date format string (example: "%%Y-%%m-%%d").
 
         Returns
         -------
@@ -646,7 +646,7 @@ class DatetimeIndex(Index):
     ) -> Index:
         """
         Return index locations of values between particular times of day
-        (e.g., 9:00-9:30AM).
+        (example: 9:00-9:30AM).
 
         Parameters
         ----------
@@ -694,7 +694,7 @@ class DatetimeIndex(Index):
     def indexer_at_time(self, time: Union[datetime.time, str], asof: bool = False) -> Index:
         """
         Return index locations of values at particular time of day
-        (e.g. 9:30AM).
+        (example: 9:30AM).
 
         Parameters
         ----------

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -1229,7 +1229,7 @@ def read_html(
         the encoding provided by the document).
 
     decimal : str, default '.'
-        Character to recognize as decimal point (e.g. use ',' for European
+        Character to recognize as decimal point (example: use ',' for European
         data).
 
     converters : dict, default None

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5834,7 +5834,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         axis: Union[int, str] = 0,
     ) -> "Series":
         """
-        Select values between particular times of the day (e.g., 9:00-9:30 AM).
+        Select values between particular times of the day (example: 9:00-9:30 AM).
 
         By setting ``start_time`` to be later than ``end_time``,
         you can get the times that are *not* between the two times.
@@ -5893,7 +5893,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         self, time: Union[datetime.time, str], asof: bool = False, axis: Union[int, str] = 0
     ) -> "Series":
         """
-        Select values at particular time of day (e.g., 9:30AM).
+        Select values at particular time of day (example: 9:30AM).
 
         Parameters
         ----------

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -302,7 +302,7 @@ class SQLContext(object):
         Parameters
         ----------
         data : :class:`RDD` or iterable
-            an RDD of any kind of SQL data representation(e.g. :class:`Row`,
+            an RDD of any kind of SQL data representation (:class:`Row`,
             :class:`tuple`, ``int``, ``boolean``, etc.), or :class:`list`, or
             :class:`pandas.DataFrame`.
         schema : :class:`pyspark.sql.types.DataType`, str or list, optional

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -580,7 +580,7 @@ class SparkSession(SparkConversionMixin):
         Parameters
         ----------
         data : :class:`RDD` or iterable
-            an RDD of any kind of SQL data representation(e.g. :class:`Row`,
+            an RDD of any kind of SQL data representation (:class:`Row`,
             :class:`tuple`, ``int``, ``boolean``, etc.), or :class:`list`, or
             :class:`pandas.DataFrame`.
         schema : :class:`pyspark.sql.types.DataType`, str or list, optional


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid some python docs where first sentence has "e.g." or similar as the period causes the docs to show only half of the first sentence as the summary.

### Why are the changes needed?

See for example https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.ml.regression.LinearRegressionModel.html?highlight=linearregressionmodel#pyspark.ml.regression.LinearRegressionModel.summary where the method description is clearly truncated.

### Does this PR introduce _any_ user-facing change?

Only changes docs.

### How was this patch tested?

Manual testing of docs.