### PR TITLE
[WIP][SPARK-XXXXX][SQL] Show explain formatted strings for logical plans

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ExplainLogicalPlanUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ExplainLogicalPlanUtils.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+
+object ExplainLogicalPlanUtils extends BaseExplainUtils[LogicalPlan] {
+
+  override protected def generateOperatorIDs(
+      plan: QueryPlan[_],
+      startOperatorID: Int,
+      operatorIDs: mutable.ArrayBuffer[(Int, QueryPlan[_])]): Int = {
+    var currentOperationID = startOperatorID
+    plan.foreachUp { case plan: QueryPlan[_] =>
+      def setOpId(): Unit = if (plan.getTagValue(QueryPlan.OP_ID_TAG).isEmpty) {
+        currentOperationID += 1
+        plan.setTagValue(QueryPlan.OP_ID_TAG, currentOperationID)
+        operatorIDs += ((currentOperationID, plan))
+      }
+      setOpId()
+
+      // Skip the subqueries as they are not printed as part of main query block.
+      val subquries = plan.subqueries.map(_.canonicalized)
+      val nonSubquries = plan.innerChildren.filterNot { p =>
+        subquries.exists(_ == p.canonicalized)
+      }
+      nonSubquries.foldLeft(currentOperationID) {
+        (curId, ip) => generateOperatorIDs(ip, curId, operatorIDs)
+      }
+    }
+    currentOperationID
+  }
+
+  override def getSubqueries(
+      plan: => LogicalPlan,
+      subqueries: ArrayBuffer[(LogicalPlan, Expression, LogicalPlan)]): Unit = {
+    plan.foreach { p =>
+      p.expressions.foreach (_.collect {
+        case e: SubqueryExpression =>
+          subqueries += ((p, e, e.plan))
+          getSubqueries(e.plan, subqueries)
+      })
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -174,6 +174,14 @@ case class Filter(condition: Expression, child: LogicalPlan)
 
   override protected def withNewChildInternal(newChild: LogicalPlan): Filter =
     copy(child = newChild)
+
+  override def verboseStringWithOperatorId(): String = {
+    s"""
+       |$formattedNodeName
+       |${ExplainLogicalPlanUtils.generateFieldString("Input", child.output)}
+       |Condition : $condition
+       |""".stripMargin
+  }
 }
 
 abstract class SetOperation(left: LogicalPlan, right: LogicalPlan) extends BinaryNode {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -77,7 +77,7 @@ trait DataSourceScanExec extends LeafExecNode {
 
     s"""
        |$formattedNodeName
-       |${ExplainUtils.generateFieldString("Output", output)}
+       |${ExplainSparkPlanUtils.generateFieldString("Output", output)}
        |${metadataStr.mkString("\n")}
        |""".stripMargin
   }
@@ -390,7 +390,7 @@ case class FileSourceScanExec(
 
     s"""
        |$formattedNodeName
-       |${ExplainUtils.generateFieldString("Output", output)}
+       |${ExplainSparkPlanUtils.generateFieldString("Output", output)}
        |${metadataStr.mkString("\n")}
        |""".stripMargin
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainSparkPlanUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainSparkPlanUtils.scala
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, PlanExpression}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.BaseExplainUtils
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStageExec}
+
+object ExplainSparkPlanUtils extends BaseExplainUtils[SparkPlan] {
+
+  override protected def processSubquries(
+    append: String => Unit,
+    startOperatorID: Int,
+    subqueries: Seq[(SparkPlan, Expression, SparkPlan)]): Unit = {
+    var i = 0
+    var currentOperatorID = startOperatorID
+    for (sub <- subqueries) {
+      if (i == 0) {
+        append("\n===== Subqueries =====\n\n")
+      }
+      i = i + 1
+      append(s"Subquery:$i Hosting operator id = " +
+        s"${getOpId(sub._1)} Hosting Expression = ${sub._2}\n")
+
+      // For each subquery expression in the parent plan, process its child plan to compute
+      // the explain output. In case of subquery reuse, we don't print subquery plan more
+      // than once. So we skip [[ReusedSubqueryExec]] here.
+      if (!sub._3.isInstanceOf[ReusedSubqueryExec]) {
+        currentOperatorID = processPlanSkippingSubqueries(
+          sub._3.children.head,
+          append,
+          currentOperatorID)
+      }
+      append("\n")
+    }
+  }
+
+  override protected def generateOperatorIDs(
+      plan: QueryPlan[_],
+      startOperatorID: Int,
+      operatorIDs: mutable.ArrayBuffer[(Int, QueryPlan[_])]): Int = {
+    var currentOperationID = startOperatorID
+    // Skip the subqueries as they are not printed as part of main query block.
+    if (plan.isInstanceOf[BaseSubqueryExec]) {
+      return currentOperationID
+    }
+    plan.foreachUp {
+      case p: WholeStageCodegenExec =>
+      case p: InputAdapter =>
+      case other: QueryPlan[_] =>
+
+        def setOpId(): Unit = if (other.getTagValue(QueryPlan.OP_ID_TAG).isEmpty) {
+          currentOperationID += 1
+          other.setTagValue(QueryPlan.OP_ID_TAG, currentOperationID)
+          operatorIDs += ((currentOperationID, other))
+        }
+
+        other match {
+          case p: AdaptiveSparkPlanExec =>
+            currentOperationID =
+              generateOperatorIDs(p.executedPlan, currentOperationID, operatorIDs)
+            setOpId()
+          case p: QueryStageExec =>
+            currentOperationID = generateOperatorIDs(p.plan, currentOperationID, operatorIDs)
+            setOpId()
+          case _ =>
+            setOpId()
+            other.innerChildren.foldLeft(currentOperationID) {
+              (curId, plan) => generateOperatorIDs(plan, curId, operatorIDs)
+            }
+        }
+    }
+
+    generateWholeStageCodegenIds(plan)
+    currentOperationID
+  }
+
+  /**
+   * Traverses the supplied input plan in a top-down fashion and records the
+   * whole stage code gen id in the plan via setting a tag.
+   */
+  private def generateWholeStageCodegenIds(plan: QueryPlan[_]): Unit = {
+    var currentCodegenId = -1
+
+    def setCodegenId(p: QueryPlan[_], children: Seq[QueryPlan[_]]): Unit = {
+      if (currentCodegenId != -1) {
+        p.setTagValue(QueryPlan.CODEGEN_ID_TAG, currentCodegenId)
+      }
+      children.foreach(generateWholeStageCodegenIds)
+    }
+
+    // Skip the subqueries as they are not printed as part of main query block.
+    if (plan.isInstanceOf[BaseSubqueryExec]) {
+      return
+    }
+    plan.foreach {
+      case p: WholeStageCodegenExec => currentCodegenId = p.codegenStageId
+      case _: InputAdapter => currentCodegenId = -1
+      case p: AdaptiveSparkPlanExec => setCodegenId(p, Seq(p.executedPlan))
+      case p: QueryStageExec => setCodegenId(p, Seq(p.plan))
+      case other: QueryPlan[_] => setCodegenId(other, other.innerChildren)
+    }
+  }
+
+  override def getSubqueries(
+      plan: => SparkPlan,
+      subqueries: ArrayBuffer[(SparkPlan, Expression, SparkPlan)]): Unit = {
+    plan.foreach {
+      case a: AdaptiveSparkPlanExec =>
+        getSubqueries(a.executedPlan, subqueries)
+      case p: SparkPlan =>
+        p.expressions.foreach (_.collect {
+          case e: PlanExpression[_] =>
+            e.plan match {
+              case s: BaseSubqueryExec =>
+                subqueries += ((p, e, s))
+                getSubqueries(s, subqueries)
+              case _ =>
+            }
+        })
+    }
+  }
+
+  override def removeTags(plan: QueryPlan[_]): Unit = {
+    plan foreach {
+      case p: AdaptiveSparkPlanExec => removeIdTags(p, Seq(p.executedPlan))
+      case p: QueryStageExec => removeIdTags(p, Seq(p.plan))
+      case plan: QueryPlan[_] => removeIdTags(plan, plan.innerChildren)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -511,6 +511,10 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   protected[sql] def cleanupResources(): Unit = {
     children.foreach(_.cleanupResources())
   }
+
+  override def formatString(append: String => Unit): Unit = {
+    ExplainSparkPlanUtils.processPlan(this, append)
+  }
 }
 
 trait LeafExecNode extends SparkPlan with LeafLike[SparkPlan] {
@@ -518,7 +522,7 @@ trait LeafExecNode extends SparkPlan with LeafLike[SparkPlan] {
   override def producedAttributes: AttributeSet = outputSet
   override def verboseStringWithOperatorId(): String = {
     val argumentString = argString(conf.maxToStringFields)
-    val outputStr = s"${ExplainUtils.generateFieldString("Output", output)}"
+    val outputStr = s"${ExplainSparkPlanUtils.generateFieldString("Output", output)}"
 
     if (argumentString.nonEmpty) {
       s"""
@@ -546,7 +550,7 @@ trait UnaryExecNode extends SparkPlan with UnaryLike[SparkPlan] {
 
   override def verboseStringWithOperatorId(): String = {
     val argumentString = argString(conf.maxToStringFields)
-    val inputStr = s"${ExplainUtils.generateFieldString("Input", child.output)}"
+    val inputStr = s"${ExplainSparkPlanUtils.generateFieldString("Input", child.output)}"
 
     if (argumentString.nonEmpty) {
       s"""
@@ -567,8 +571,9 @@ trait BinaryExecNode extends SparkPlan with BinaryLike[SparkPlan] {
 
   override def verboseStringWithOperatorId(): String = {
     val argumentString = argString(conf.maxToStringFields)
-    val leftOutputStr = s"${ExplainUtils.generateFieldString("Left output", left.output)}"
-    val rightOutputStr = s"${ExplainUtils.generateFieldString("Right output", right.output)}"
+    val leftOutputStr = s"${ExplainSparkPlanUtils.generateFieldString("Left output", left.output)}"
+    val rightOutputStr =
+      s"${ExplainSparkPlanUtils.generateFieldString("Right output", right.output)}"
 
     if (argumentString.nonEmpty) {
       s"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/BaseAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/BaseAggregateExec.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.aggregate
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Final, PartialMerge}
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, UnspecifiedDistribution}
-import org.apache.spark.sql.execution.{AliasAwareOutputPartitioning, ExplainUtils, UnaryExecNode}
+import org.apache.spark.sql.execution.{AliasAwareOutputPartitioning, ExplainSparkPlanUtils, UnaryExecNode}
 
 /**
  * Holds common logic for aggregate operators
@@ -35,11 +35,11 @@ trait BaseAggregateExec extends UnaryExecNode with AliasAwareOutputPartitioning 
   override def verboseStringWithOperatorId(): String = {
     s"""
        |$formattedNodeName
-       |${ExplainUtils.generateFieldString("Input", child.output)}
-       |${ExplainUtils.generateFieldString("Keys", groupingExpressions)}
-       |${ExplainUtils.generateFieldString("Functions", aggregateExpressions)}
-       |${ExplainUtils.generateFieldString("Aggregate Attributes", aggregateAttributes)}
-       |${ExplainUtils.generateFieldString("Results", resultExpressions)}
+       |${ExplainSparkPlanUtils.generateFieldString("Input", child.output)}
+       |${ExplainSparkPlanUtils.generateFieldString("Keys", groupingExpressions)}
+       |${ExplainSparkPlanUtils.generateFieldString("Functions", aggregateExpressions)}
+       |${ExplainSparkPlanUtils.generateFieldString("Aggregate Attributes", aggregateAttributes)}
+       |${ExplainSparkPlanUtils.generateFieldString("Results", resultExpressions)}
        |""".stripMargin
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -103,8 +103,8 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
   override def verboseStringWithOperatorId(): String = {
     s"""
        |$formattedNodeName
-       |${ExplainUtils.generateFieldString("Output", projectList)}
-       |${ExplainUtils.generateFieldString("Input", child.output)}
+       |${ExplainSparkPlanUtils.generateFieldString("Output", projectList)}
+       |${ExplainSparkPlanUtils.generateFieldString("Input", child.output)}
        |""".stripMargin
   }
 
@@ -285,7 +285,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
   override def verboseStringWithOperatorId(): String = {
     s"""
        |$formattedNodeName
-       |${ExplainUtils.generateFieldString("Input", child.output)}
+       |${ExplainSparkPlanUtils.generateFieldString("Input", child.output)}
        |Condition : ${condition}
        |""".stripMargin
   }
@@ -766,36 +766,6 @@ abstract class BaseSubqueryExec extends SparkPlan {
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override def outputOrdering: Seq[SortOrder] = child.outputOrdering
-
-  override def generateTreeString(
-      depth: Int,
-      lastChildren: Seq[Boolean],
-      append: String => Unit,
-      verbose: Boolean,
-      prefix: String = "",
-      addSuffix: Boolean = false,
-      maxFields: Int,
-      printNodeId: Boolean,
-      indent: Int = 0): Unit = {
-    /**
-     * In the new explain mode `EXPLAIN FORMATTED`, the subqueries are not shown in the
-     * main plan and are printed separately along with correlation information with
-     * its parent plan. The condition below makes sure that subquery plans are
-     * excluded from the main plan.
-     */
-    if (!printNodeId) {
-      super.generateTreeString(
-        depth,
-        lastChildren,
-        append,
-        verbose,
-        "",
-        false,
-        maxFields,
-        printNodeId,
-        indent)
-    }
-  }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.plans.physical
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReaderFactory, Scan, SupportsReportPartitioning}
-import org.apache.spark.sql.execution.{ExplainUtils, LeafExecNode}
+import org.apache.spark.sql.execution.{ExplainSparkPlanUtils, LeafExecNode}
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.internal.connector.SupportsMetadata
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -73,7 +73,7 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
     }
     s"""
        |$formattedNodeName
-       |${ExplainUtils.generateFieldString("Output", output)}
+       |${ExplainSparkPlanUtils.generateFieldString("Output", output)}
        |${metaDataStr.mkString("\n")}
        |""".stripMargin
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -87,10 +87,10 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
   }
 
   override def verboseStringWithOperatorId(): String = {
-    val reuse_op_str = ExplainUtils.getOpId(child)
+    val reuse_op_str = ExplainSparkPlanUtils.getOpId(child)
     s"""
        |$formattedNodeName [Reuses operator id: $reuse_op_str]
-       |${ExplainUtils.generateFieldString("Output", output)}
+       |${ExplainSparkPlanUtils.generateFieldString("Output", output)}
        |""".stripMargin
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BaseJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BaseJoinExec.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.joins
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.JoinType
-import org.apache.spark.sql.execution.{BinaryExecNode, ExplainUtils}
+import org.apache.spark.sql.execution.{BinaryExecNode, ExplainSparkPlanUtils}
 
 /**
  * Holds common logic for join operators
@@ -31,7 +31,7 @@ trait BaseJoinExec extends BinaryExecNode {
   def rightKeys: Seq[Expression]
 
   override def simpleStringWithNodeId(): String = {
-    val opId = ExplainUtils.getOpId(this)
+    val opId = ExplainSparkPlanUtils.getOpId(this)
     s"$nodeName $joinType ($opId)".trim
   }
 
@@ -42,14 +42,14 @@ trait BaseJoinExec extends BinaryExecNode {
     if (leftKeys.nonEmpty || rightKeys.nonEmpty) {
       s"""
          |$formattedNodeName
-         |${ExplainUtils.generateFieldString("Left keys", leftKeys)}
-         |${ExplainUtils.generateFieldString("Right keys", rightKeys)}
-         |${ExplainUtils.generateFieldString("Join condition", joinCondStr)}
+         |${ExplainSparkPlanUtils.generateFieldString("Left keys", leftKeys)}
+         |${ExplainSparkPlanUtils.generateFieldString("Right keys", rightKeys)}
+         |${ExplainSparkPlanUtils.generateFieldString("Join condition", joinCondStr)}
          |""".stripMargin
     } else {
       s"""
          |$formattedNodeName
-         |${ExplainUtils.generateFieldString("Join condition", joinCondStr)}
+         |${ExplainSparkPlanUtils.generateFieldString("Join condition", joinCondStr)}
          |""".stripMargin
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinExec.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCo
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical._
-import org.apache.spark.sql.execution.{CodegenSupport, ExplainUtils, SparkPlan}
+import org.apache.spark.sql.execution.{CodegenSupport, ExplainSparkPlanUtils, SparkPlan}
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.util.collection.{BitSet, CompactBuffer}
 
@@ -49,7 +49,7 @@ case class BroadcastNestedLoopJoinExec(
   }
 
   override def simpleStringWithNodeId(): String = {
-    val opId = ExplainUtils.getOpId(this)
+    val opId = ExplainSparkPlanUtils.getOpId(this)
     s"$nodeName $joinType $buildSide ($opId)".trim
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.execution.{CodegenSupport, ExplainUtils, RowIterator}
+import org.apache.spark.sql.execution.{CodegenSupport, ExplainSparkPlanUtils, RowIterator}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.{BooleanType, IntegralType, LongType}
 
@@ -43,7 +43,7 @@ trait HashJoin extends JoinCodegenSupport {
   def buildSide: BuildSide
 
   override def simpleStringWithNodeId(): String = {
-    val opId = ExplainUtils.getOpId(this)
+    val opId = ExplainSparkPlanUtils.getOpId(this)
     s"$nodeName $joinType ${buildSide} ($opId)".trim
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to print formatted strings for logical plans in the `formatted` mode, e.g.,
```
scala> sql("""SELECT (SELECT avg(a) FROM t GROUP BY b), (SELECT sum(b) FROM t WHERE b > 1 GROUP BY b)""").explain("formatted")

== Parsed Logical Plan ==
'Project [unresolvedalias(scalar-subquery#0 [], None), unresolvedalias(scalar-subquery#1 [], None)]
:  :- 'Aggregate ['b], [unresolvedalias('avg('a), None)]
:  :  +- 'UnresolvedRelation [t], [], false
:  +- 'Aggregate ['b], [unresolvedalias('sum('b), None)]
:     +- 'Filter ('b > 1)
:        +- 'UnresolvedRelation [t], [], false
+- OneRowRelation

== Analyzed Logical Plan ==
scalarsubquery(): double, scalarsubquery(): bigint
Project (2)
+- OneRowRelation (1)

(1) OneRowRelation
Output: []

(2) Project
Input: []
Arguments: [scalar-subquery#0 [] AS scalarsubquery()#10, scalar-subquery#1 [] AS scalarsubquery()#11L]

===== Subqueries =====

Subquery:1 Hosting operator id = 2 Hosting Expression = scalar-subquery#0 []
Aggregate (5)
+- SubqueryAlias (4)
   +- Relation parquet default.t (3)

(3) Relation parquet default.t
Output [2]: [a#2, b#3]

(4) SubqueryAlias
Input [2]: [a#2, b#3]
Arguments: spark_catalog.default.t

(5) Aggregate
Input [2]: [a#2, b#3]
Arguments: [b#3], [avg(a#2) AS avg(a)#5]

Subquery:2 Hosting operator id = 2 Hosting Expression = scalar-subquery#1 []
Aggregate (9)
+- Filter (8)
   +- SubqueryAlias (7)
      +- Relation parquet default.t (6)

(6) Relation parquet default.t
Output [2]: [a#8, b#9]

(7) SubqueryAlias
Input [2]: [a#8, b#9]
Arguments: spark_catalog.default.t

(8) Filter
Input [2]: [a#8, b#9]
Condition : (b#9 > 1)

(9) Aggregate
Input [2]: [a#8, b#9]
Arguments: [b#9], [sum(b#9) AS sum(b)#7L]

== Optimized Logical Plan ==
Project (2)
+- OneRowRelation (1)

(1) OneRowRelation
Output: []

(2) Project
Input: []
Arguments: [scalar-subquery#0 [] AS scalarsubquery()#10, scalar-subquery#1 [] AS scalarsubquery()#11L]

===== Subqueries =====

Subquery:1 Hosting operator id = 2 Hosting Expression = scalar-subquery#0 []
Aggregate (4)
+- Relation parquet default.t (3)

(3) Relation parquet default.t
Output [2]: [a#2, b#3]

(4) Aggregate
Input [2]: [a#2, b#3]
Arguments: [b#3], [avg(a#2) AS avg(a)#5]

Subquery:2 Hosting operator id = 2 Hosting Expression = scalar-subquery#1 []
Aggregate (8)
+- Project (7)
   +- Filter (6)
      +- Relation parquet default.t (5)

(5) Relation parquet default.t
Output [2]: [a#8, b#9]

(6) Filter
Input [2]: [a#8, b#9]
Condition : (isnotnull(b#9) AND (b#9 > 1))

(7) Project
Input [2]: [a#8, b#9]
Arguments: [b#9]

(8) Aggregate
Input [1]: [b#9]
Arguments: [b#9], [sum(b#9) AS sum(b)#7L]

== Physical Plan ==
AdaptiveSparkPlan (3)
+- Project (2)
   +- Scan OneRowRelation (1)

(1) Scan OneRowRelation
Output: []
Arguments: ParallelCollectionRDD[0] at explain at <console>:24, OneRowRelation, UnknownPartitioning(0)

(2) Project
Output [2]: [Subquery subquery#0, [id=#17] AS scalarsubquery()#10, Subquery subquery#1, [id=#32] AS scalarsubquery()#11L]
Input: []

(3) AdaptiveSparkPlan
Output [2]: [scalarsubquery()#10, scalarsubquery()#11L]
Arguments: isFinalPlan=false

===== Subqueries =====

Subquery:1 Hosting operator id = 2 Hosting Expression = Subquery subquery#0, [id=#17]
AdaptiveSparkPlan (8)
+- HashAggregate (7)
   +- Exchange (6)
      +- HashAggregate (5)
         +- Scan parquet default.t (4)

(4) Scan parquet default.t
Output [2]: [a#2, b#3]
Batched: true
Location: InMemoryFileIndex [file:/Users/maropu/Repositories/spark/spark-master/spark-warehouse/t]
ReadSchema: struct<a:int,b:int>

(5) HashAggregate
Input [2]: [a#2, b#3]
Keys [1]: [b#3]
Functions [1]: [partial_avg(a#2)]
Aggregate Attributes [2]: [sum#14, count#15L]
Results [3]: [b#3, sum#16, count#17L]

(6) Exchange
Input [3]: [b#3, sum#16, count#17L]
Arguments: hashpartitioning(b#3, 200), ENSURE_REQUIREMENTS, [id=#15]

(7) HashAggregate
Input [3]: [b#3, sum#16, count#17L]
Keys [1]: [b#3]
Functions [1]: [avg(a#2)]
Aggregate Attributes [1]: [avg(a#2)#4]
Results [1]: [avg(a#2)#4 AS avg(a)#5]

(8) AdaptiveSparkPlan
Output [1]: [avg(a)#5]
Arguments: isFinalPlan=false

Subquery:2 Hosting operator id = 2 Hosting Expression = Subquery subquery#1, [id=#32]
AdaptiveSparkPlan (14)
+- HashAggregate (13)
   +- Exchange (12)
      +- HashAggregate (11)
         +- Filter (10)
            +- Scan parquet default.t (9)

(9) Scan parquet default.t
Output [1]: [b#9]
Batched: true
Location: InMemoryFileIndex [file:/Users/maropu/Repositories/spark/spark-master/spark-warehouse/t]
PushedFilters: [IsNotNull(b), GreaterThan(b,1)]
ReadSchema: struct<b:int>

(10) Filter
Input [1]: [b#9]
Condition : (isnotnull(b#9) AND (b#9 > 1))

(11) HashAggregate
Input [1]: [b#9]
Keys [1]: [b#9]
Functions [1]: [partial_sum(b#9)]
Aggregate Attributes [1]: [sum#18L]
Results [2]: [b#9, sum#19L]

(12) Exchange
Input [2]: [b#9, sum#19L]
Arguments: hashpartitioning(b#9, 200), ENSURE_REQUIREMENTS, [id=#30]

(13) HashAggregate
Input [2]: [b#9, sum#19L]
Keys [1]: [b#9]
Functions [1]: [sum(b#9)]
Aggregate Attributes [1]: [sum(b#9)#6L]
Results [1]: [sum(b#9)#6L AS sum(b)#7L]

(14) AdaptiveSparkPlan
Output [1]: [sum(b)#7L]
Arguments: isFinalPlan=false
```

This PR comes from the @cloud-fan comment: https://github.com/apache/spark/pull/28097#issuecomment-833177979

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For better explain mode.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this PR makes the explain results of the `formatted` mode change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Will add tests later.