### PR TITLE
[SPARK-35396]Add AutoCloseable close to BlockManager and InMemoryRelation

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -390,7 +390,7 @@ private[spark] class MemoryStore(
     }
   }
 
-  def manual_close[T <: MemoryEntry[_]](entry: T): T = {
+  def manualClose[T <: MemoryEntry[_]](entry: T): T = {
     val entryManualCloseTasks = Future {
       entry match {
         case e: DeserializedMemoryEntry[_] => e.value.foreach {
@@ -416,7 +416,7 @@ private[spark] class MemoryStore(
   def remove(blockId: BlockId): Boolean = memoryManager.synchronized {
     val entry = entries.synchronized {
       val removed = entries.remove(blockId)
-      manual_close(removed)
+      manualClose(removed)
     }
     if (entry != null) {
       entry match {
@@ -434,7 +434,7 @@ private[spark] class MemoryStore(
 
   def clear(): Unit = memoryManager.synchronized {
     entries.synchronized {
-      entries.values.asScala.foreach(manual_close)
+      entries.values.asScala.foreach(manualClose)
       entries.clear()
     }
     onHeapUnrollMemoryMap.clear()

--- a/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
@@ -583,7 +583,7 @@ class MemoryStoreSuite
       memoryStore.putIteratorAsValues(blockId, iter, classTag)
     }
 
-    // Unroll with plenty of space. This should succeed and cache both blocks. 
+    // Unroll with plenty of space. This should succeed and cache both blocks.
     assert(putIteratorAsValues("b1", nativeObjIterator, ClassTag.Any).isRight)
     assert(putIteratorAsValues("b2", nativeObjIterator, ClassTag.Any).isRight)
 


### PR DESCRIPTION
This PR is proposing a add-on to support to manual close entries in MemoryStore and InMemoryRelation

### What changes were proposed in this pull request?
Currently:
    MemoryStore uses a LinkedHashMap[BlockId, MemoryEntry[_]] to store all OnHeap or OffHeap entries.
And when memoryStore.remove(blockId) is called, codes will simply remove one entry from LinkedHashMap and leverage Java GC to do release work.

This PR:
    We are proposing a add-on to manually close any object stored in MemoryStore and InMemoryRelation if this object is extended from AutoCloseable.

Veifiication:
    In our own use case, we implemented a user-defined off-heap-hashRelation for BHJ, and we verified that by adding this manual close, we can make sure our defined off-heap-hashRelation can be released when evict is called.
    Also, we implemented user-defined cachedBatch and will be release when InMemoryRelation.clearCache() is called by this PR 


### Why are the changes needed?
This changes can help to clean some off-heap user-defined object may be cached in InMemoryRelation or MemoryStore


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
WIP

Signed-off-by: Chendi Xue <chendi.xue@intel.com>


