### PR TITLE
[SPARK-34941][PYTHON] Fix mypy errors and enable mypy check for pandas-on-Spark.

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -85,6 +85,10 @@ disallow_untyped_defs = False
 [mypy-pyspark.sql.utils]
 disallow_untyped_defs = False
 
+[mypy-pyspark.pandas.*]
+strict_optional = False
+disallow_untyped_defs = False
+
 [mypy-pyspark.tests.*]
 disallow_untyped_defs = False
 
@@ -125,6 +129,14 @@ ignore_missing_imports = True
 [mypy-psutil.*]
 ignore_missing_imports = True
 
-# TODO(SPARK-34941): Enable mypy for pandas-on-Spark
-[mypy-pyspark.pandas.*]
-ignore_errors = True
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-plotly.*]
+ignore_missing_imports = True
+
+[mypy-mlflow.*]
+ignore_missing_imports = True
+
+[mypy-sklearn.*]
+ignore_missing_imports = True

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -592,10 +592,8 @@ class PandasOnSparkFrameMethods(object):
                     self._kdf, apply_func, return_schema, retain_index=False
                 )
 
-                pudf = pandas_udf(
-                    pandas_series_func(output_func),
-                    returnType=spark_return_type,
-                    functionType=PandasUDFType.SCALAR,
+                pudf = pandas_udf(returnType=spark_return_type, functionType=PandasUDFType.SCALAR)(
+                    pandas_series_func(output_func)
                 )
                 columns = self._kdf._internal.spark_columns
                 # TODO: Index will be lost in this case.
@@ -627,8 +625,8 @@ class PandasOnSparkFrameMethods(object):
                 )
                 columns = self_applied._internal.spark_columns
 
-                pudf = pandas_udf(
-                    output_func, returnType=return_schema, functionType=PandasUDFType.SCALAR
+                pudf = pandas_udf(returnType=return_schema, functionType=PandasUDFType.SCALAR)(
+                    output_func
                 )
                 temp_struct_column = verify_temp_column_name(
                     self_applied._internal.spark_frame, "__temp_struct__"
@@ -658,10 +656,8 @@ class PandasOnSparkFrameMethods(object):
                     self._kdf, apply_func, return_schema, retain_index=False
                 )
 
-                pudf = pandas_udf(
-                    pandas_series_func(output_func),
-                    returnType=spark_return_type,
-                    functionType=PandasUDFType.SCALAR,
+                pudf = pandas_udf(returnType=spark_return_type, functionType=PandasUDFType.SCALAR)(
+                    pandas_series_func(output_func)
                 )
                 columns = self._kdf._internal.spark_columns
                 internal = self._kdf._internal.copy(
@@ -681,8 +677,8 @@ class PandasOnSparkFrameMethods(object):
                 )
                 columns = self_applied._internal.spark_columns
 
-                pudf = pandas_udf(
-                    output_func, returnType=return_schema, functionType=PandasUDFType.SCALAR
+                pudf = pandas_udf(returnType=return_schema, functionType=PandasUDFType.SCALAR)(
+                    output_func
                 )
                 temp_struct_column = verify_temp_column_name(
                     self_applied._internal.spark_frame, "__temp_struct__"
@@ -873,10 +869,8 @@ class PandasOnSparkSeriesMethods(object):
             kdf, apply_func, return_schema, retain_index=False
         )
 
-        pudf = pandas_udf(
-            lambda *series: first_series(output_func(pandas_concat(series))),
-            returnType=spark_return_type,
-            functionType=PandasUDFType.SCALAR,
+        pudf = pandas_udf(returnType=spark_return_type, functionType=PandasUDFType.SCALAR)(
+            lambda *series: first_series(output_func(pandas_concat(series)))
         )
 
         return self._kser._with_new_scol(

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -720,7 +720,8 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         else:
             # TODO: support more APIs?
             raise NotImplementedError(
-                "pandas-on-Spark objects currently do not support %s." % ufunc)
+                "pandas-on-Spark objects currently do not support %s." % ufunc
+            )
 
     @property
     def dtype(self) -> Dtype:
@@ -1098,15 +1099,10 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             if len(categories) == 0:
                 scol = F.lit(None)
             else:
-                kvs = list(
-                    chain(
-                        *[
-                            (F.lit(code), F.lit(category))
-                            for code, category in enumerate(categories)
-                        ]
-                    )
+                kvs = chain(
+                    *[(F.lit(code), F.lit(category)) for code, category in enumerate(categories)]
                 )
-                map_scol = F.create_map(kvs)
+                map_scol = F.create_map(*kvs)
                 scol = map_scol.getItem(self.spark.column)
             return self._with_new_scol(
                 scol.alias(self._internal.data_spark_column_names[0])
@@ -1122,15 +1118,13 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                 if len(categories) == 0:
                     scol = F.lit(-1)
                 else:
-                    kvs = list(
-                        chain(
-                            *[
-                                (F.lit(category), F.lit(code))
-                                for code, category in enumerate(categories)
-                            ]
-                        )
+                    kvs = chain(
+                        *[
+                            (F.lit(category), F.lit(code))
+                            for code, category in enumerate(categories)
+                        ]
                     )
-                    map_scol = F.create_map(kvs)
+                    map_scol = F.create_map(*kvs)
 
                     scol = F.coalesce(map_scol.getItem(self.spark.column), F.lit(-1))
                 return self._with_new_scol(
@@ -1926,7 +1920,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                         ]
                     )
                 )
-                map_scol = F.create_map(kvs)
+                map_scol = F.create_map(*kvs)
                 scol = map_scol.getItem(self.spark.column)
             codes, uniques = self._with_new_scol(
                 scol.alias(self._internal.data_spark_column_names[0])
@@ -1980,7 +1974,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                 cond = scol.isNull() | F.isnan(scol)
             else:
                 cond = scol.isNull()
-            map_scol = F.create_map(kvs)
+            map_scol = F.create_map(*kvs)
 
             null_scol = F.when(cond, F.lit(na_sentinel_code))
             new_scol = null_scol.otherwise(map_scol.getItem(scol))

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2353,11 +2353,12 @@ class Frame(object, metaclass=ABCMeta):
 
         with sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
             # Disable Arrow to keep row ordering.
-            first_valid_row = (
+            first_valid_row = cast(
+                pd.DataFrame,
                 self._internal.spark_frame.filter(cond)
                 .select(self._internal.index_spark_columns)
                 .limit(1)
-                .toPandas()
+                .toPandas(),
             )
 
         # For Empty Series or DataFrame, returns None.

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -33,7 +33,7 @@ import pandas as pd
 from pandas.api.types import is_hashable, is_list_like
 
 from pyspark.sql import Column, Window, functions as F
-from pyspark.sql.types import (
+from pyspark.sql.types import (  # noqa: F401
     DataType,
     FloatType,
     DoubleType,
@@ -41,7 +41,7 @@ from pyspark.sql.types import (
     StructField,
     StructType,
     StringType,
-)  # noqa: F401
+)
 from pyspark.sql.functions import PandasUDFType, pandas_udf
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -32,8 +32,9 @@ from typing import Any, List, Set, Tuple, Union, cast
 import pandas as pd
 from pandas.api.types import is_hashable, is_list_like
 
-from pyspark.sql import Window, functions as F
+from pyspark.sql import Column, Window, functions as F
 from pyspark.sql.types import (
+    DataType,
     FloatType,
     DoubleType,
     NumericType,
@@ -41,7 +42,7 @@ from pyspark.sql.types import (
     StructType,
     StringType,
 )
-from pyspark.sql.functions import PandasUDFType, pandas_udf, Column
+from pyspark.sql.functions import PandasUDFType, pandas_udf
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.typedef import infer_return_type, DataFrameType, ScalarType, SeriesType
@@ -1171,7 +1172,7 @@ class GroupBy(object, metaclass=ABCMeta):
                 as_nullable_spark_type(
                     kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
                 )
-            )
+            )  # type: DataType
         else:
             return_type = infer_return_type(func)
             if not is_series_groupby and isinstance(return_type, SeriesType):
@@ -1513,7 +1514,7 @@ class GroupBy(object, metaclass=ABCMeta):
                 order_column = Column(c._jc.desc_nulls_last())
             else:
                 order_column = Column(c._jc.desc_nulls_first())
-            window = Window.partitionBy(groupkey_names).orderBy(
+            window = Window.partitionBy(*groupkey_names).orderBy(
                 order_column, NATURAL_ORDER_COLUMN_NAME
             )
             sdf = sdf.withColumn(
@@ -1592,7 +1593,7 @@ class GroupBy(object, metaclass=ABCMeta):
                 order_column = Column(c._jc.asc_nulls_last())
             else:
                 order_column = Column(c._jc.asc_nulls_first())
-            window = Window.partitionBy(groupkey_names).orderBy(
+            window = Window.partitionBy(*groupkey_names).orderBy(
                 order_column, NATURAL_ORDER_COLUMN_NAME
             )
             sdf = sdf.withColumn(
@@ -1812,9 +1813,11 @@ class GroupBy(object, metaclass=ABCMeta):
 
         # This part is handled differently depending on whether it is a tail or a head.
         window = (
-            Window.partitionBy(groupkey_scols).orderBy(F.col(NATURAL_ORDER_COLUMN_NAME).asc())
+            Window.partitionBy(*groupkey_scols).orderBy(F.col(NATURAL_ORDER_COLUMN_NAME).asc())
             if asc
-            else Window.partitionBy(groupkey_scols).orderBy(F.col(NATURAL_ORDER_COLUMN_NAME).desc())
+            else Window.partitionBy(*groupkey_scols).orderBy(
+                F.col(NATURAL_ORDER_COLUMN_NAME).desc()
+            )
         )
 
         sdf = (
@@ -2131,7 +2134,7 @@ class GroupBy(object, metaclass=ABCMeta):
                 as_nullable_spark_type(
                     kdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
                 )
-            )
+            )  # type: DataType
             if len(pdf) <= limit:
                 return kdf_from_pandas
 
@@ -2899,16 +2902,16 @@ class SeriesGroupBy(GroupBy):
 
         groupkey_col_names = [SPARK_INDEX_NAME_FORMAT(i) for i in range(len(self._groupkeys))]
         sdf = self._kser._internal.spark_frame.select(
-            [scol.alias(name) for scol, name in zip(self._groupkeys_scols, groupkey_col_names)]
-            + [
+            *[scol.alias(name) for scol, name in zip(self._groupkeys_scols, groupkey_col_names)],
+            *[
                 scol.alias(SPARK_INDEX_NAME_FORMAT(i + len(self._groupkeys)))
                 for i, scol in enumerate(self._kser._internal.index_spark_columns)
-            ]
-            + [self._kser.spark.column]
-            + [NATURAL_ORDER_COLUMN_NAME]
+            ],
+            self._kser.spark.column,
+            NATURAL_ORDER_COLUMN_NAME,
         )
 
-        window = Window.partitionBy(groupkey_col_names).orderBy(
+        window = Window.partitionBy(*groupkey_col_names).orderBy(
             scol_for(sdf, self._kser._internal.data_spark_column_names[0]).asc(),
             NATURAL_ORDER_COLUMN_NAME,
         )
@@ -2976,16 +2979,16 @@ class SeriesGroupBy(GroupBy):
 
         groupkey_col_names = [SPARK_INDEX_NAME_FORMAT(i) for i in range(len(self._groupkeys))]
         sdf = self._kser._internal.spark_frame.select(
-            [scol.alias(name) for scol, name in zip(self._groupkeys_scols, groupkey_col_names)]
-            + [
+            *[scol.alias(name) for scol, name in zip(self._groupkeys_scols, groupkey_col_names)],
+            *[
                 scol.alias(SPARK_INDEX_NAME_FORMAT(i + len(self._groupkeys)))
                 for i, scol in enumerate(self._kser._internal.index_spark_columns)
-            ]
-            + [self._kser.spark.column]
-            + [NATURAL_ORDER_COLUMN_NAME]
+            ],
+            self._kser.spark.column,
+            NATURAL_ORDER_COLUMN_NAME,
         )
 
-        window = Window.partitionBy(groupkey_col_names).orderBy(
+        window = Window.partitionBy(*groupkey_col_names).orderBy(
             scol_for(sdf, self._kser._internal.data_spark_column_names[0]).desc(),
             NATURAL_ORDER_COLUMN_NAME,
         )

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -34,14 +34,14 @@ from pandas.api.types import is_hashable, is_list_like
 
 from pyspark.sql import Column, Window, functions as F
 from pyspark.sql.types import (
-    DataType,  # noqa: F401
+    DataType,
     FloatType,
     DoubleType,
     NumericType,
     StructField,
     StructType,
     StringType,
-)
+)  # noqa: F401
 from pyspark.sql.functions import PandasUDFType, pandas_udf
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -34,7 +34,7 @@ from pandas.api.types import is_hashable, is_list_like
 
 from pyspark.sql import Column, Window, functions as F
 from pyspark.sql.types import (
-    DataType,
+    DataType,  # noqa: F401
     FloatType,
     DoubleType,
     NumericType,

--- a/python/pyspark/pandas/ml.py
+++ b/python/pyspark/pandas/ml.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import List, Tuple, TYPE_CHECKING
+from typing import List, Tuple, TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
@@ -53,7 +53,7 @@ def corr(kdf: "ps.DataFrame", method: str = "pearson") -> pd.DataFrame:
     assert method in ("pearson", "spearman")
     ndf, column_labels = to_numeric_df(kdf)
     corr = Correlation.corr(ndf, CORRELATION_OUTPUT_COLUMN, method)
-    pcorr = corr.toPandas()
+    pcorr = cast(pd.DataFrame, corr.toPandas())
     arr = pcorr.iloc[0, 0].toArray()
     if column_labels_level(column_labels) > 1:
         idx = pd.MultiIndex.from_tuples(column_labels)

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -18,7 +18,7 @@
 """
 Wrappers around spark that correspond to common pandas functions.
 """
-from typing import Any, Optional, Union, List, Tuple, Sized, cast
+from typing import Any, Optional, Union, List, Tuple, Type, Sized, cast
 from collections import OrderedDict
 from collections.abc import Iterable
 from distutils.version import LooseVersion
@@ -47,6 +47,7 @@ from pyspark.sql.types import (
     StringType,
     DateType,
     StructType,
+    DataType,
 )
 
 from pyspark import pandas as ps  # noqa: F401
@@ -1939,7 +1940,9 @@ def get_dummies(
     ):
         raise NotImplementedError(
             "get_dummies currently only accept {} values".format(
-                ", ".join([t.typeName() for t in _get_dummies_acceptable_types])
+                ", ".join(
+                    [cast(Type[DataType], t).typeName() for t in _get_dummies_acceptable_types]
+                )
             )
         )
 

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -19,6 +19,7 @@ from typing import Callable, Any
 
 import numpy as np
 from pyspark.sql import functions as F, Column
+from pyspark.sql.pandas.functions import pandas_udf, PandasUDFType
 from pyspark.sql.types import DoubleType, LongType, BooleanType
 
 
@@ -27,11 +28,11 @@ unary_np_spark_mappings = OrderedDict(
         "abs": F.abs,
         "absolute": F.abs,
         "arccos": F.acos,
-        "arccosh": F.pandas_udf(lambda s: np.arccosh(s), DoubleType()),
+        "arccosh": pandas_udf(lambda s: np.arccosh(s), DoubleType(), PandasUDFType.SCALAR),
         "arcsin": F.asin,
-        "arcsinh": F.pandas_udf(lambda s: np.arcsinh(s), DoubleType()),
+        "arcsinh": pandas_udf(lambda s: np.arcsinh(s), DoubleType(), PandasUDFType.SCALAR),
         "arctan": F.atan,
-        "arctanh": F.pandas_udf(lambda s: np.arctanh(s), DoubleType()),
+        "arctanh": pandas_udf(lambda s: np.arctanh(s), DoubleType(), PandasUDFType.SCALAR),
         "bitwise_not": F.bitwiseNOT,
         "cbrt": F.cbrt,
         "ceil": F.ceil,
@@ -39,17 +40,17 @@ unary_np_spark_mappings = OrderedDict(
         "conj": lambda _: NotImplemented,
         "conjugate": lambda _: NotImplemented,  # It requires complex type
         "cos": F.cos,
-        "cosh": F.pandas_udf(lambda s: np.cosh(s), DoubleType()),
-        "deg2rad": F.pandas_udf(lambda s: np.deg2rad(s), DoubleType()),
+        "cosh": pandas_udf(lambda s: np.cosh(s), DoubleType(), PandasUDFType.SCALAR),
+        "deg2rad": pandas_udf(lambda s: np.deg2rad(s), DoubleType(), PandasUDFType.SCALAR),
         "degrees": F.degrees,
         "exp": F.exp,
-        "exp2": F.pandas_udf(lambda s: np.exp2(s), DoubleType()),
+        "exp2": pandas_udf(lambda s: np.exp2(s), DoubleType(), PandasUDFType.SCALAR),
         "expm1": F.expm1,
-        "fabs": F.pandas_udf(lambda s: np.fabs(s), DoubleType()),
+        "fabs": pandas_udf(lambda s: np.fabs(s), DoubleType(), PandasUDFType.SCALAR),
         "floor": F.floor,
         "frexp": lambda _: NotImplemented,  # 'frexp' output lengths become different
         # and it cannot be supported via pandas UDF.
-        "invert": F.pandas_udf(lambda s: np.invert(s), DoubleType()),
+        "invert": pandas_udf(lambda s: np.invert(s), DoubleType(), PandasUDFType.SCALAR),
         "isfinite": lambda c: c != float("inf"),
         "isinf": lambda c: c == float("inf"),
         "isnan": F.isnan,
@@ -57,25 +58,25 @@ unary_np_spark_mappings = OrderedDict(
         "log": F.log,
         "log10": F.log10,
         "log1p": F.log1p,
-        "log2": F.pandas_udf(lambda s: np.log2(s), DoubleType()),
+        "log2": pandas_udf(lambda s: np.log2(s), DoubleType(), PandasUDFType.SCALAR),
         "logical_not": lambda c: ~(c.cast(BooleanType())),
         "matmul": lambda _: NotImplemented,  # Can return a NumPy array in pandas.
         "negative": lambda c: c * -1,
         "positive": lambda c: c,
-        "rad2deg": F.pandas_udf(lambda s: np.rad2deg(s), DoubleType()),
+        "rad2deg": pandas_udf(lambda s: np.rad2deg(s), DoubleType(), PandasUDFType.SCALAR),
         "radians": F.radians,
-        "reciprocal": F.pandas_udf(lambda s: np.reciprocal(s), DoubleType()),
-        "rint": F.pandas_udf(lambda s: np.rint(s), DoubleType()),
+        "reciprocal": pandas_udf(lambda s: np.reciprocal(s), DoubleType(), PandasUDFType.SCALAR),
+        "rint": pandas_udf(lambda s: np.rint(s), DoubleType(), PandasUDFType.SCALAR),
         "sign": lambda c: F.when(c == 0, 0).when(c < 0, -1).otherwise(1),
         "signbit": lambda c: F.when(c < 0, True).otherwise(False),
         "sin": F.sin,
-        "sinh": F.pandas_udf(lambda s: np.sinh(s), DoubleType()),
-        "spacing": F.pandas_udf(lambda s: np.spacing(s), DoubleType()),
+        "sinh": pandas_udf(lambda s: np.sinh(s), DoubleType(), PandasUDFType.SCALAR),
+        "spacing": pandas_udf(lambda s: np.spacing(s), DoubleType(), PandasUDFType.SCALAR),
         "sqrt": F.sqrt,
-        "square": F.pandas_udf(lambda s: np.square(s), DoubleType()),
+        "square": pandas_udf(lambda s: np.square(s), DoubleType(), PandasUDFType.SCALAR),
         "tan": F.tan,
-        "tanh": F.pandas_udf(lambda s: np.tanh(s), DoubleType()),
-        "trunc": F.pandas_udf(lambda s: np.trunc(s), DoubleType()),
+        "tanh": pandas_udf(lambda s: np.tanh(s), DoubleType(), PandasUDFType.SCALAR),
+        "trunc": pandas_udf(lambda s: np.trunc(s), DoubleType(), PandasUDFType.SCALAR),
     }
 )
 
@@ -85,20 +86,34 @@ binary_np_spark_mappings = OrderedDict(
         "bitwise_and": lambda c1, c2: c1.bitwiseAND(c2),
         "bitwise_or": lambda c1, c2: c1.bitwiseOR(c2),
         "bitwise_xor": lambda c1, c2: c1.bitwiseXOR(c2),
-        "copysign": F.pandas_udf(lambda s1, s2: np.copysign(s1, s2), DoubleType()),
-        "float_power": F.pandas_udf(lambda s1, s2: np.float_power(s1, s2), DoubleType()),
-        "floor_divide": F.pandas_udf(lambda s1, s2: np.floor_divide(s1, s2), DoubleType()),
-        "fmax": F.pandas_udf(lambda s1, s2: np.fmax(s1, s2), DoubleType()),
-        "fmin": F.pandas_udf(lambda s1, s2: np.fmin(s1, s2), DoubleType()),
-        "fmod": F.pandas_udf(lambda s1, s2: np.fmod(s1, s2), DoubleType()),
-        "gcd": F.pandas_udf(lambda s1, s2: np.gcd(s1, s2), DoubleType()),
-        "heaviside": F.pandas_udf(lambda s1, s2: np.heaviside(s1, s2), DoubleType()),
+        "copysign": pandas_udf(
+            lambda s1, s2: np.copysign(s1, s2), DoubleType(), PandasUDFType.SCALAR
+        ),
+        "float_power": pandas_udf(
+            lambda s1, s2: np.float_power(s1, s2), DoubleType(), PandasUDFType.SCALAR
+        ),
+        "floor_divide": pandas_udf(
+            lambda s1, s2: np.floor_divide(s1, s2), DoubleType(), PandasUDFType.SCALAR
+        ),
+        "fmax": pandas_udf(lambda s1, s2: np.fmax(s1, s2), DoubleType(), PandasUDFType.SCALAR),
+        "fmin": pandas_udf(lambda s1, s2: np.fmin(s1, s2), DoubleType(), PandasUDFType.SCALAR),
+        "fmod": pandas_udf(lambda s1, s2: np.fmod(s1, s2), DoubleType(), PandasUDFType.SCALAR),
+        "gcd": pandas_udf(lambda s1, s2: np.gcd(s1, s2), DoubleType(), PandasUDFType.SCALAR),
+        "heaviside": pandas_udf(
+            lambda s1, s2: np.heaviside(s1, s2), DoubleType(), PandasUDFType.SCALAR
+        ),
         "hypot": F.hypot,
-        "lcm": F.pandas_udf(lambda s1, s2: np.lcm(s1, s2), DoubleType()),
-        "ldexp": F.pandas_udf(lambda s1, s2: np.ldexp(s1, s2), DoubleType()),
-        "left_shift": F.pandas_udf(lambda s1, s2: np.left_shift(s1, s2), LongType()),
-        "logaddexp": F.pandas_udf(lambda s1, s2: np.logaddexp(s1, s2), DoubleType()),
-        "logaddexp2": F.pandas_udf(lambda s1, s2: np.logaddexp2(s1, s2), DoubleType()),
+        "lcm": pandas_udf(lambda s1, s2: np.lcm(s1, s2), DoubleType(), PandasUDFType.SCALAR),
+        "ldexp": pandas_udf(lambda s1, s2: np.ldexp(s1, s2), DoubleType(), PandasUDFType.SCALAR),
+        "left_shift": pandas_udf(
+            lambda s1, s2: np.left_shift(s1, s2), LongType(), PandasUDFType.SCALAR
+        ),
+        "logaddexp": pandas_udf(
+            lambda s1, s2: np.logaddexp(s1, s2), DoubleType(), PandasUDFType.SCALAR
+        ),
+        "logaddexp2": pandas_udf(
+            lambda s1, s2: np.logaddexp2(s1, s2), DoubleType(), PandasUDFType.SCALAR
+        ),
         "logical_and": lambda c1, c2: c1.cast(BooleanType()) & c2.cast(BooleanType()),
         "logical_or": lambda c1, c2: c1.cast(BooleanType()) | c2.cast(BooleanType()),
         "logical_xor": lambda c1, c2: (
@@ -108,9 +123,13 @@ binary_np_spark_mappings = OrderedDict(
         ),
         "maximum": F.greatest,
         "minimum": F.least,
-        "modf": F.pandas_udf(lambda s1, s2: np.modf(s1, s2), DoubleType()),
-        "nextafter": F.pandas_udf(lambda s1, s2: np.nextafter(s1, s2), DoubleType()),
-        "right_shift": F.pandas_udf(lambda s1, s2: np.right_shift(s1, s2), LongType()),
+        "modf": pandas_udf(lambda s1, s2: np.modf(s1, s2), DoubleType(), PandasUDFType.SCALAR),
+        "nextafter": pandas_udf(
+            lambda s1, s2: np.nextafter(s1, s2), DoubleType(), PandasUDFType.SCALAR
+        ),
+        "right_shift": pandas_udf(
+            lambda s1, s2: np.right_shift(s1, s2), LongType(), PandasUDFType.SCALAR
+        ),
     }
 )
 

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5095,7 +5095,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if not should_return_series:
             with sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
                 # Disable Arrow to keep row ordering.
-                result = sdf.limit(1).toPandas().iloc[0, 0]
+                result = cast(pd.DataFrame, sdf.limit(1).toPandas()).iloc[0, 0]
             return result if result is not None else np.nan
 
         # The data is expected to be small so it's fine to transpose/use default index.
@@ -5717,7 +5717,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             this_scol = this_data_scol.alias(this_column_label)
             that_scol = that_data_scol.alias(that_column_label)
 
-        sdf = sdf.select(index_scols + [this_scol, that_scol, NATURAL_ORDER_COLUMN_NAME])
+        sdf = sdf.select(*index_scols, this_scol, that_scol, NATURAL_ORDER_COLUMN_NAME)
         internal = InternalFrame(
             spark_frame=sdf,
             index_spark_columns=[

--- a/python/pyspark/pandas/spark/accessors.py
+++ b/python/pyspark/pandas/spark/accessors.py
@@ -941,7 +941,8 @@ class SparkFrameMethods(object):
                 "The output of the function [%s] should be of a "
                 "pyspark.sql.DataFrame; however, got [%s]." % (func, type(output))
             )
-        return output.to_koalas(index_col)
+        kdf = output.to_koalas(index_col)  # type: ignore
+        return cast("ps.DataFrame", kdf)
 
     def repartition(self, num_partitions: int) -> "ps.DataFrame":
         """

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -19,7 +19,7 @@ Additional Spark functions used in pandas-on-Spark.
 """
 
 from pyspark import SparkContext
-from pyspark.sql.column import Column, _to_java_column, _create_column_from_literal
+from pyspark.sql.column import Column, _to_java_column, _create_column_from_literal  # type: ignore
 
 
 def repeat(col, n):

--- a/python/pyspark/pandas/spark/utils.py
+++ b/python/pyspark/pandas/spark/utils.py
@@ -91,82 +91,30 @@ StructField(B,FloatType,true)))
 
 
 @overload
-def force_decimal_precision_scale(dt: StructType) -> StructType:
+def force_decimal_precision_scale(
+    dt: StructType, *, precision: int = ..., scale: int = ...
+) -> StructType:
     ...
 
 
 @overload
-def force_decimal_precision_scale(dt: StructType, *, precision: int) -> StructType:
+def force_decimal_precision_scale(
+    dt: ArrayType, *, precision: int = ..., scale: int = ...
+) -> ArrayType:
     ...
 
 
 @overload
-def force_decimal_precision_scale(dt: StructType, *, scale: int) -> StructType:
+def force_decimal_precision_scale(
+    dt: MapType, *, precision: int = ..., scale: int = ...
+) -> MapType:
     ...
 
 
 @overload
-def force_decimal_precision_scale(dt: StructType, *, precision: int, scale: int) -> StructType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: ArrayType) -> ArrayType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: ArrayType, *, precision: int) -> ArrayType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: ArrayType, *, scale: int) -> ArrayType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: ArrayType, *, precision: int, scale: int) -> ArrayType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: MapType) -> MapType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: MapType, *, precision: int) -> MapType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: MapType, *, scale: int) -> MapType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: MapType, *, precision: int, scale: int) -> MapType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: DataType) -> DataType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: DataType, *, precision: int) -> DataType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: DataType, *, scale: int) -> DataType:
-    ...
-
-
-@overload
-def force_decimal_precision_scale(dt: DataType, *, precision: int, scale: int) -> DataType:
+def force_decimal_precision_scale(
+    dt: DataType, *, precision: int = ..., scale: int = ...
+) -> DataType:
     ...
 
 

--- a/python/pyspark/pandas/spark/utils.py
+++ b/python/pyspark/pandas/spark/utils.py
@@ -17,7 +17,29 @@
 """
 Helpers and utilities to deal with PySpark instances
 """
+from typing import overload
+
 from pyspark.sql.types import DecimalType, StructType, MapType, ArrayType, StructField, DataType
+
+
+@overload
+def as_nullable_spark_type(dt: StructType) -> StructType:
+    ...
+
+
+@overload
+def as_nullable_spark_type(dt: ArrayType) -> ArrayType:
+    ...
+
+
+@overload
+def as_nullable_spark_type(dt: MapType) -> MapType:
+    ...
+
+
+@overload
+def as_nullable_spark_type(dt: DataType) -> DataType:
+    ...
 
 
 def as_nullable_spark_type(dt: DataType) -> DataType:
@@ -68,7 +90,89 @@ StructField(B,FloatType,true)))
         return dt
 
 
-def force_decimal_precision_scale(dt: DataType, precision: int = 38, scale: int = 18) -> DataType:
+@overload
+def force_decimal_precision_scale(dt: StructType) -> StructType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: StructType, *, precision: int) -> StructType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: StructType, *, scale: int) -> StructType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: StructType, *, precision: int, scale: int) -> StructType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: ArrayType) -> ArrayType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: ArrayType, *, precision: int) -> ArrayType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: ArrayType, *, scale: int) -> ArrayType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: ArrayType, *, precision: int, scale: int) -> ArrayType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: MapType) -> MapType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: MapType, *, precision: int) -> MapType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: MapType, *, scale: int) -> MapType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: MapType, *, precision: int, scale: int) -> MapType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: DataType) -> DataType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: DataType, *, precision: int) -> DataType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: DataType, *, scale: int) -> DataType:
+    ...
+
+
+@overload
+def force_decimal_precision_scale(dt: DataType, *, precision: int, scale: int) -> DataType:
+    ...
+
+
+def force_decimal_precision_scale(
+    dt: DataType, *, precision: int = 38, scale: int = 18
+) -> DataType:
     """
     Returns a data type with a fixed decimal type.
 
@@ -101,7 +205,7 @@ StructField(B,DecimalType(30,15),false)))
             new_fields.append(
                 StructField(
                     field.name,
-                    force_decimal_precision_scale(field.dataType, precision, scale),
+                    force_decimal_precision_scale(field.dataType, precision=precision, scale=scale),
                     nullable=field.nullable,
                     metadata=field.metadata,
                 )
@@ -109,13 +213,13 @@ StructField(B,DecimalType(30,15),false)))
         return StructType(new_fields)
     elif isinstance(dt, ArrayType):
         return ArrayType(
-            force_decimal_precision_scale(dt.elementType, precision, scale),
+            force_decimal_precision_scale(dt.elementType, precision=precision, scale=scale),
             containsNull=dt.containsNull,
         )
     elif isinstance(dt, MapType):
         return MapType(
-            force_decimal_precision_scale(dt.keyType, precision, scale),
-            force_decimal_precision_scale(dt.valueType, precision, scale),
+            force_decimal_precision_scale(dt.keyType, precision=precision, scale=scale),
+            force_decimal_precision_scale(dt.valueType, precision=precision, scale=scale),
             valueContainsNull=dt.valueContainsNull,
         )
     elif isinstance(dt, DecimalType):

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-import _string
+import _string  # type: ignore
 from typing import Dict, Any, Optional  # noqa: F401 (SPARK-34943)
 import inspect
 import pandas as pd
@@ -168,7 +168,7 @@ def _get_ipython_scope():
     in an IPython notebook environment.
     """
     try:
-        from IPython import get_ipython
+        from IPython import get_ipython  # type: ignore
 
         shell = get_ipython()
         return shell.user_ns

--- a/python/pyspark/pandas/strings.py
+++ b/python/pyspark/pandas/strings.py
@@ -1144,7 +1144,7 @@ class StringMethods(object):
         """
         # type hint does not support to specify array type yet.
         pudf = pandas_udf(
-            lambda s: s.str.findall(pat, flags),
+            lambda s, *_: s.str.findall(pat, flags),
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )
@@ -1989,7 +1989,7 @@ class StringMethods(object):
 
         # type hint does not support to specify array type yet.
         pudf = pandas_udf(
-            lambda s: s.str.split(pat, n),
+            lambda s, *_: s.str.split(pat, n),
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )
@@ -2127,7 +2127,7 @@ class StringMethods(object):
 
         # type hint does not support to specify array type yet.
         pudf = pandas_udf(
-            lambda s: s.str.rsplit(pat, n),
+            lambda s, *_: s.str.rsplit(pat, n),
             returnType=ArrayType(StringType(), containsNull=True),
             functionType=PandasUDFType.SCALAR,
         )

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -58,11 +58,7 @@ except ImportError:
 
 import pyarrow as pa
 import pyspark.sql.types as types
-
-try:
-    from pyspark.sql.types import to_arrow_type, from_arrow_type
-except ImportError:
-    from pyspark.sql.pandas.types import to_arrow_type, from_arrow_type
+from pyspark.sql.pandas.types import to_arrow_type, from_arrow_type
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.typedef.string_typehints import resolve_string_type_hint

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -22,7 +22,7 @@ import functools
 from collections import OrderedDict
 from contextlib import contextmanager
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TYPE_CHECKING, overload
 import warnings
 
 from pyspark import sql as spark
@@ -82,7 +82,7 @@ def same_anchor(
         this_internal.spark_frame is that_internal.spark_frame
         and this_internal.index_level == that_internal.index_level
         and all(
-            this_scol._jc.equals(that_scol._jc)
+            this_scol._jc.equals(that_scol._jc)  # type: ignore
             for this_scol, that_scol in zip(
                 this_internal.index_spark_columns, that_internal.index_spark_columns
             )
@@ -713,6 +713,18 @@ def validate_how(how: str) -> str:
             "['inner', 'left', 'right', 'outer']",
         )
     return how
+
+
+@overload
+def verify_temp_column_name(df: spark.DataFrame, column_name_or_label: str) -> str:
+    ...
+
+
+@overload
+def verify_temp_column_name(
+    df: "DataFrame", column_name_or_label: Union[Any, Tuple]
+) -> Union[Any, Tuple]:
+    ...
 
 
 def verify_temp_column_name(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `mypy` errors and enables `mypy` check for pandas-on-Spark.

### Why are the changes needed?

The `mypy` check for pandas-on-Spark was disabled when the initial porting.
It should be enabled again; otherwise we will miss type checking errors.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The enabled `mypy` check and existing unit tests should pass.
