### PR TITLE
[SPARK-34764][UI][FOLLOW-UP] Fix indentation and missing arguments for JavaScript linter

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -31,12 +31,12 @@ function getThreadDumpEnabled() {
   return threadDumpEnabled;
 }
 
-function formatLossReason(removeReason, type, row) {
-    if (removeReason) {
-       return removeReason
-    } else {
-       return ""
-    }
+function formatLossReason(removeReason) {
+  if (removeReason) {
+    return removeReason
+  } else {
+    return ""
+  }
 }
 
 function formatStatus(status, type, row) {
@@ -553,8 +553,8 @@ $(document).ready(function () {
               }
             },
             {
-                data: 'removeReason',
-                render: formatLossReason
+              data: 'removeReason',
+              render: formatLossReason
             }
           ],
           "order": [[0, "asc"]],


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/32436 which broke JavaScript linter. There was a logical conflict - the linter was added after the last successful test run in that PR.

```
added 118 packages in 1.482s

/__w/spark/spark/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
   34:41  error  'type' is defined but never used. Allowed unused args must match /^_ignored_.*/u  no-unused-vars
   34:47  error  'row' is defined but never used. Allowed unused args must match /^_ignored_.*/u   no-unused-vars
   35:1   error  Expected indentation of 2 spaces but found 4                                      indent
   36:1   error  Expected indentation of 4 spaces but found 7                                      indent
   37:1   error  Expected indentation of 2 spaces but found 4                                      indent
   38:1   error  Expected indentation of 4 spaces but found 7                                      indent
   39:1   error  Expected indentation of 2 spaces but found 4                                      indent
  556:1   error  Expected indentation of 14 spaces but found 16                                    indent
  557:1   error  Expected indentation of 14 spaces but found 16                                    indent
```

### Why are the changes needed?

To recover the build

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested:

```bash
 ./dev/lint-js
lint-js checks passed.
```