### PR TITLE
[SPARK-32484][SQL] Fix log info BroadcastExchangeExec.scala

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -138,11 +138,12 @@ case class BroadcastExchangeExec(
                   s"type: ${relation.getClass.getName}")
             }
 
-            longMetric("dataSize") += dataSize
-            if (dataSize >= MAX_BROADCAST_TABLE_BYTES) {
-              throw new SparkException(
-                s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")
-            }
+        longMetric("dataSize") += dataSize
+        if (dataSize >= MAX_BROADCAST_TABLE_BYTES) {
+          throw new SparkException(
+            s"Cannot broadcast the table that is larger than" +
+              s" ${MAX_BROADCAST_TABLE_BYTES >> 30}GB: ${dataSize >> 30} GB")
+        }
 
             val beforeBroadcast = System.nanoTime()
             longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeBuild)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -138,12 +138,12 @@ case class BroadcastExchangeExec(
                   s"type: ${relation.getClass.getName}")
             }
 
-        longMetric("dataSize") += dataSize
-        if (dataSize >= MAX_BROADCAST_TABLE_BYTES) {
-          throw new SparkException(
-            s"Cannot broadcast the table that is larger than" +
-              s" ${MAX_BROADCAST_TABLE_BYTES >> 30}GB: ${dataSize >> 30} GB")
-        }
+            longMetric("dataSize") += dataSize
+            if (dataSize >= MAX_BROADCAST_TABLE_BYTES) {
+              throw new SparkException(
+                s"Cannot broadcast the table that is larger than" +
+                  s" ${MAX_BROADCAST_TABLE_BYTES >> 30}GB: ${dataSize >> 30} GB")
+            }
 
             val beforeBroadcast = System.nanoTime()
             longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeBuild)


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix log info in BroadcastExchangeExec.scala

### Why are the changes needed?
Log info s"Cannot broadcast the table that is larger than 8GB: ${dataSize >> 30} GB")  is not accurate info , because  8GB  is not accurate.
### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
no