### PR TITLE
[SPARK-35389][SQL] V2 ScalarFunction should support magic method with null arguments

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/functions/ScalarFunction.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/functions/ScalarFunction.java
@@ -31,6 +31,7 @@ import org.apache.spark.sql.types.DataType;
  * InternalRow API for the {@link DataType SQL data type} returned by {@link #resultType()}.
  * The mapping between {@link DataType} and the corresponding JVM type is defined below.
  * <p>
+ * <h2> Magic method </h2>
  * <b>IMPORTANT</b>: the default implementation of {@link #produceResult} throws
  * {@link UnsupportedOperationException}. Users must choose to either override this method, or
  * implement a magic method with name {@link #MAGIC_METHOD_NAME}, which takes individual parameters
@@ -82,6 +83,24 @@ import org.apache.spark.sql.types.DataType;
  * following the mapping defined below, and then checking if there is a matching method from all the
  * declared methods in the UDF class, using method name and the Java types.
  * <p>
+ * <h2> Handling of nullable primitive arguments </h2>
+ * The handling of null primitive arguments is different between the magic method approach and
+ * the {@link #produceResult} approach. With the former, whenever any of the method arguments meet
+ * the following conditions:
+ * <ol>
+ *   <li>the argument is of primitive type</li>
+ *   <li>the argument is nullable</li>
+ *   <li>the value of the argument is null</li>
+ * </ol>
+ * Spark will return null directly instead of calling the magic method. On the other hand, Spark
+ * will pass null primitive arguments to {@link #produceResult} and it is user's responsibility to
+ * handle them in the function implementation.
+ * <p>
+ * Because of the difference, if Spark users want to implement special handling of nulls for
+ * nullable primitive arguments, they should override the {@link #produceResult} method instead
+ * of using the magic method approach.
+ * <p>
+ * <h2> Spark data type to Java type mapping </h2>
  * The following are the mapping from {@link DataType SQL data type} to Java type which is used
  * by Spark to infer parameter types for the magic methods as well as return value type for
  * {@link #produceResult}:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2204,11 +2204,12 @@ class Analyzer(override val catalogManager: CatalogManager)
         findMethod(scalarFunc, MAGIC_METHOD_NAME, argClasses) match {
           case Some(m) if Modifier.isStatic(m.getModifiers) =>
             StaticInvoke(scalarFunc.getClass, scalarFunc.resultType(),
-              MAGIC_METHOD_NAME, arguments, returnNullable = scalarFunc.isResultNullable)
+              MAGIC_METHOD_NAME, arguments, propagateNull = false,
+              returnNullable = scalarFunc.isResultNullable)
           case Some(_) =>
             val caller = Literal.create(scalarFunc, ObjectType(scalarFunc.getClass))
             Invoke(caller, MAGIC_METHOD_NAME, scalarFunc.resultType(),
-              arguments, returnNullable = scalarFunc.isResultNullable)
+              arguments, propagateNull = false, returnNullable = scalarFunc.isResultNullable)
           case _ =>
             // TODO: handle functions defined in Scala too - in Scala, even if a
             //  subclass do not override the default method in parent interface

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2205,11 +2205,12 @@ class Analyzer(override val catalogManager: CatalogManager)
           case Some(m) if Modifier.isStatic(m.getModifiers) =>
             StaticInvoke(scalarFunc.getClass, scalarFunc.resultType(),
               MAGIC_METHOD_NAME, arguments, propagateNull = false,
-              returnNullable = scalarFunc.isResultNullable)
+              returnNullable = scalarFunc.isResultNullable, propagateNullForPrimitive = true)
           case Some(_) =>
             val caller = Literal.create(scalarFunc, ObjectType(scalarFunc.getClass))
             Invoke(caller, MAGIC_METHOD_NAME, scalarFunc.resultType(),
-              arguments, propagateNull = false, returnNullable = scalarFunc.isResultNullable)
+              arguments, propagateNull = false, returnNullable = scalarFunc.isResultNullable,
+              propagateNullForPrimitive = true)
           case _ =>
             // TODO: handle functions defined in Scala too - in Scala, even if a
             //  subclass do not override the default method in parent interface

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2205,12 +2205,11 @@ class Analyzer(override val catalogManager: CatalogManager)
           case Some(m) if Modifier.isStatic(m.getModifiers) =>
             StaticInvoke(scalarFunc.getClass, scalarFunc.resultType(),
               MAGIC_METHOD_NAME, arguments, propagateNull = false,
-              returnNullable = scalarFunc.isResultNullable, propagateNullForPrimitive = true)
+              returnNullable = scalarFunc.isResultNullable)
           case Some(_) =>
             val caller = Literal.create(scalarFunc, ObjectType(scalarFunc.getClass))
             Invoke(caller, MAGIC_METHOD_NAME, scalarFunc.resultType(),
-              arguments, propagateNull = false, returnNullable = scalarFunc.isResultNullable,
-              propagateNullForPrimitive = true)
+              arguments, propagateNull = false, returnNullable = scalarFunc.isResultNullable)
           case _ =>
             // TODO: handle functions defined in Scala too - in Scala, even if a
             //  subclass do not override the default method in parent interface

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -401,7 +401,8 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       arguments = Literal.fromObject(List(1, 2, 3)) :: Nil,
       propagateNull = false,
       dataType = ArrayType(IntegerType),
-      outerPointer = None)
+      outerPointer = None,
+      propagateNullForPrimitive = false)
     checkObjectExprEvaluation(newInst1, new GenericArrayData(List(1, 2, 3)))
 
     // Inner class case test
@@ -411,7 +412,8 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       arguments = Literal(1) :: Nil,
       propagateNull = false,
       dataType = ObjectType(classOf[outerObj.Inner]),
-      outerPointer = Some(() => outerObj))
+      outerPointer = Some(() => outerObj),
+      propagateNullForPrimitive = false)
     checkObjectExprEvaluation(newInst2, new outerObj.Inner(1))
 
     // SPARK-8288: A class with only a companion object constructor
@@ -420,7 +422,8 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       arguments = Literal(1) :: Nil,
       propagateNull = false,
       dataType = ObjectType(classOf[ScroogeLikeExample]),
-      outerPointer = Some(() => outerObj))
+      outerPointer = Some(() => outerObj),
+      propagateNullForPrimitive = false)
     checkObjectExprEvaluation(newInst3, ScroogeLikeExample(1))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -401,8 +401,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       arguments = Literal.fromObject(List(1, 2, 3)) :: Nil,
       propagateNull = false,
       dataType = ArrayType(IntegerType),
-      outerPointer = None,
-      propagateNullForPrimitive = false)
+      outerPointer = None)
     checkObjectExprEvaluation(newInst1, new GenericArrayData(List(1, 2, 3)))
 
     // Inner class case test
@@ -412,8 +411,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       arguments = Literal(1) :: Nil,
       propagateNull = false,
       dataType = ObjectType(classOf[outerObj.Inner]),
-      outerPointer = Some(() => outerObj),
-      propagateNullForPrimitive = false)
+      outerPointer = Some(() => outerObj))
     checkObjectExprEvaluation(newInst2, new outerObj.Inner(1))
 
     // SPARK-8288: A class with only a companion object constructor
@@ -422,8 +420,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       arguments = Literal(1) :: Nil,
       propagateNull = false,
       dataType = ObjectType(classOf[ScroogeLikeExample]),
-      outerPointer = Some(() => outerObj),
-      propagateNullForPrimitive = false)
+      outerPointer = Some(() => outerObj))
     checkObjectExprEvaluation(newInst3, ScroogeLikeExample(1))
   }
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/catalog/functions/JavaStrLen.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/catalog/functions/JavaStrLen.java
@@ -120,5 +120,24 @@ public class JavaStrLen implements UnboundFunction {
 
   public static class JavaStrLenNoImpl extends JavaStrLenBase {
   }
+
+  // a null-safe version which returns 0 for null arguments
+  public static class JavaStrLenMagicNullSafe extends JavaStrLenBase {
+    public int invoke(UTF8String str) {
+      if (str == null) {
+        return 0;
+      }
+      return str.toString().length();
+    }
+  }
+
+  public static class JavaStrLenStaticMagicNullSafe extends JavaStrLenBase {
+    public static int invoke(UTF8String str) {
+      if (str == null) {
+        return 0;
+      }
+      return str.toString().length();
+    }
+  }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
@@ -20,12 +20,14 @@ package org.apache.spark.sql.connector
 import java.util
 import java.util.Collections
 
-import test.org.apache.spark.sql.connector.catalog.functions.{JavaAverage, JavaStrLen}
+import test.org.apache.spark.sql.connector.catalog.functions.{JavaAverage, JavaLongAdd, JavaStrLen}
+import test.org.apache.spark.sql.connector.catalog.functions.JavaLongAdd.JavaLongAddMagic
 import test.org.apache.spark.sql.connector.catalog.functions.JavaStrLen._
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode.{FALLBACK, NO_CODEGEN}
 import org.apache.spark.sql.connector.catalog.{BasicInMemoryTableCatalog, Identifier, InMemoryCatalog, SupportsNamespaces}
 import org.apache.spark.sql.connector.catalog.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -220,6 +222,29 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
       new JavaStrLen(new JavaStrLenStaticMagicNullSafe))
     Seq("strlen", "strlen2").foreach { name =>
       checkAnswer(sql(s"SELECT testcat.ns.$name(CAST(NULL as STRING))"), Row(0) :: Nil)
+    }
+  }
+
+  test("SPARK-35389: magic function should handle null primitive arguments") {
+    catalog("testcat").asInstanceOf[SupportsNamespaces].createNamespace(Array("ns"), emptyProps)
+    addFunction(Identifier.of(Array("ns"), "add"), new JavaLongAdd(new JavaLongAddMagic(false)))
+    addFunction(Identifier.of(Array("ns"), "static_add"),
+      new JavaLongAdd(new JavaLongAddMagic(false)))
+
+    Seq("add", "static_add").foreach { name =>
+      Seq(true, false).foreach { codegenEnabled =>
+        val codeGenFactoryMode = if (codegenEnabled) FALLBACK else NO_CODEGEN
+
+        withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> codegenEnabled.toString,
+          SQLConf.CODEGEN_FACTORY_MODE.key -> codeGenFactoryMode.toString) {
+
+          checkAnswer(sql(s"SELECT testcat.ns.$name(CAST(NULL as BIGINT), 42L)"), Row(null) :: Nil)
+          checkAnswer(sql(s"SELECT testcat.ns.$name(42L, CAST(NULL as BIGINT))"), Row(null) :: Nil)
+          checkAnswer(sql(s"SELECT testcat.ns.$name(42L, 58L)"), Row(100) :: Nil)
+          checkAnswer(sql(s"SELECT testcat.ns.$name(CAST(NULL as BIGINT), CAST(NULL as BIGINT))"),
+            Row(null) :: Nil)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When creating `Invoke` and `StaticInvoke` for `ScalarFunction`'s magic method, set `propagateNull` to false.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When `propgagateNull` is true (which is the default value), `Invoke` and `StaticInvoke` will return null if any of the argument is null. For scalar function this is incorrect, as we should leave the logic to function implementation instead.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. Now null arguments shall be properly handled with magic method.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added new tests.