### PR TITLE
[SPARK-35408][PYTHON] Improve parameter validation in DataFrame.show

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -448,7 +448,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         ----------
         n : int, optional
             Number of rows to show.
-        truncate : bool, optional
+        truncate : bool or int, optional
             If set to ``True``, truncate strings longer than 20 chars by default.
             If set to a number greater than one, truncates long strings to length ``truncate``
             and align cells right.
@@ -484,20 +484,21 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """
 
         if not isinstance(n, int) or isinstance(n, bool):
-            raise TypeError(f'Parameter `n` (number of rows) must be an int')
+            raise TypeError("Parameter 'n' (number of rows) must be an int")
 
         if not isinstance(vertical, bool):
-            raise TypeError(f'Parameter `vertical` must be a bool')
+            raise TypeError("Parameter 'vertical' must be a bool")
 
         if isinstance(truncate, bool) and truncate:
             print(self._jdf.showString(n, 20, vertical))
         else:
             try:
                 int_truncate = int(truncate)
-                print(self._jdf.showString(n, int_truncate, vertical))
             except ValueError:
-                raise ValueError(f'Non-bool parameter `truncate`=`{truncate}` '
-                                 f'could not be converted to an int')
+                raise ValueError(f"Non-bool parameter 'truncate={truncate}'"
+                                 f"could not be converted to an int")
+
+            print(self._jdf.showString(n, int_truncate, vertical))
 
     def __repr__(self):
         if not self._support_repr_html and self.sql_ctx._conf.isReplEagerEvalEnabled():

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -482,10 +482,22 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
          age  | 5
          name | Bob
         """
+
+        if not isinstance(n, int) or isinstance(n, bool):
+            raise TypeError(f'Parameter `n` (number of rows) must be an int')
+
+        if not isinstance(vertical, bool):
+            raise TypeError(f'Parameter `vertical` must be a bool')
+
         if isinstance(truncate, bool) and truncate:
             print(self._jdf.showString(n, 20, vertical))
         else:
-            print(self._jdf.showString(n, int(truncate), vertical))
+            try:
+                int_truncate = int(truncate)
+                print(self._jdf.showString(n, int_truncate, vertical))
+            except ValueError:
+                raise ValueError(f'Non-bool parameter `truncate`=`{truncate}` '
+                                 f'could not be converted to an int')
 
     def __repr__(self):
         if not self._support_repr_html and self.sql_ctx._conf.isReplEagerEvalEnabled():

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -495,8 +495,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             try:
                 int_truncate = int(truncate)
             except ValueError:
-                raise ValueError(f"Non-bool parameter 'truncate={truncate}'"
-                                 f"could not be converted to an int")
+                raise TypeError(f"Parameter 'truncate={truncate}' should be either bool or int.")
 
             print(self._jdf.showString(n, int_truncate, vertical))
 

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -837,6 +837,21 @@ class DataFrameTests(ReusedSQLTestCase):
         finally:
             shutil.rmtree(tpath)
 
+    def test_df_show(self):
+        df = self.spark.createDataFrame([('foo',)])
+        df.show(5)
+        df.show(5, True)
+        df.show(5, 1, True)
+        df.show(n=5, truncate='1', vertical=False)
+        df.show(n=5, truncate=1.5, vertical=False)
+
+        with self.assertRaisesRegex(TypeError, 'Parameter `n`'):
+            df.show(True)
+        with self.assertRaisesRegex(TypeError, 'Parameter `vertical`'):
+            df.show(vertical='foo')
+        with self.assertRaisesRegex(ValueError, 'Non-bool parameter `truncate`=`foo`'):
+            df.show(truncate='foo')
+
 
 class QueryExecutionListenerTests(unittest.TestCase, SQLTestUtils):
     # These tests are separate because it uses 'spark.sql.queryExecutionListeners' which is

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -838,6 +838,9 @@ class DataFrameTests(ReusedSQLTestCase):
             shutil.rmtree(tpath)
 
     def test_df_show(self):
+        # SPARK-35408: ensure better diagnostics if incorrect parameters are passed
+        # to DataFrame.show
+
         df = self.spark.createDataFrame([('foo',)])
         df.show(5)
         df.show(5, True)
@@ -845,11 +848,11 @@ class DataFrameTests(ReusedSQLTestCase):
         df.show(n=5, truncate='1', vertical=False)
         df.show(n=5, truncate=1.5, vertical=False)
 
-        with self.assertRaisesRegex(TypeError, 'Parameter `n`'):
+        with self.assertRaisesRegex(TypeError, "Parameter 'n'"):
             df.show(True)
-        with self.assertRaisesRegex(TypeError, 'Parameter `vertical`'):
+        with self.assertRaisesRegex(TypeError, "Parameter 'vertical'"):
             df.show(vertical='foo')
-        with self.assertRaisesRegex(ValueError, 'Non-bool parameter `truncate`=`foo`'):
+        with self.assertRaisesRegex(ValueError, "Non-bool parameter 'truncate=foo'"):
             df.show(truncate='foo')
 
 

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -852,7 +852,7 @@ class DataFrameTests(ReusedSQLTestCase):
             df.show(True)
         with self.assertRaisesRegex(TypeError, "Parameter 'vertical'"):
             df.show(vertical='foo')
-        with self.assertRaisesRegex(ValueError, "Non-bool parameter 'truncate=foo'"):
+        with self.assertRaisesRegex(TypeError, "Parameter 'truncate=foo'"):
             df.show(truncate='foo')
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Provide clearer error message tied to the user's Python code if incorrect parameters are passed to `DataFrame.show` rather than the message about a missing JVM method the user is not calling directly. 

```
py4j.Py4JException: Method showString([class java.lang.Boolean, class java.lang.Integer, class java.lang.Boolean]) does not exist
	at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:318)
	at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:326)
	at py4j.Gateway.invoke(Gateway.java:274)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:238)
	at java.lang.Thread.run(Thread.java:748
```

### Why are the changes needed?
For faster debugging through actionable error message.

### Does this PR introduce _any_ user-facing change?
No change for the correct parameters but different error messages for the parameters triggering an exception. 

### How was this patch tested?
- unit test
- manually in PySpark REPL