### PR TITLE
[SPARK-35409][SQL] Skip escaping meta-characters for EXPLAIN command using show()

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2775,6 +2775,13 @@ object SQLConf {
       .stringConf
       .createOptional
 
+  val ESCAPE_META_CHARACTERS_FOR_SHOW_ENABLED =
+    buildConf("spark.sql.escapeMetaCharactersForShow.enabled")
+      .doc("When true, the meta-characters `\n`, `\t`, `\r`, `\f` etc  are escaped in the `show()` action.")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(true)
+
   object MapKeyDedupPolicy extends Enumeration {
     val EXCEPTION, LAST_WIN = Value
   }
@@ -3871,6 +3878,8 @@ class SQLConf extends Serializable with Logging {
   def decorrelateInnerQueryEnabled: Boolean = getConf(SQLConf.DECORRELATE_INNER_QUERY_ENABLED)
 
   def maxConcurrentOutputFileWriters: Int = getConf(SQLConf.MAX_CONCURRENT_OUTPUT_FILE_WRITERS)
+
+  def escapeMetaCharactersForShowEnabled: Boolean = getConf(ESCAPE_META_CHARACTERS_FOR_SHOW_ENABLED)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2709,6 +2709,14 @@ object SQLConf {
     .checkValue(_ > 3, "This value must be bigger than 3.")
     .createWithDefault(100)
 
+  val ESCAPE_META_CHARACTERS_FOR_SHOW_ENABLED =
+    buildConf("spark.sql.escapeMetaCharactersForShow.enabled")
+      .doc("When true, the meta-characters `\n`, `\t`, `\r`, `\f` etc  are escaped in the" +
+        " `show()` action.")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val SET_COMMAND_REJECTS_SPARK_CORE_CONFS =
     buildConf("spark.sql.legacy.setCommandRejectsSparkCoreConfs")
       .internal()
@@ -2774,13 +2782,6 @@ object SQLConf {
       .version("3.0.0")
       .stringConf
       .createOptional
-
-  val ESCAPE_META_CHARACTERS_FOR_SHOW_ENABLED =
-    buildConf("spark.sql.escapeMetaCharactersForShow.enabled")
-      .doc("When true, the meta-characters `\n`, `\t`, `\r`, `\f` etc  are escaped in the `show()` action.")
-      .version("3.2.0")
-      .booleanConf
-      .createWithDefault(true)
 
   object MapKeyDedupPolicy extends Enumeration {
     val EXCEPTION, LAST_WIN = Value
@@ -3840,6 +3841,9 @@ class SQLConf extends Serializable with Logging {
 
   def maxMetadataStringLength: Int = getConf(SQLConf.MAX_METADATA_STRING_LENGTH)
 
+  def escapeMetaCharactersForShowEnabled: Boolean =
+    getConf(ESCAPE_META_CHARACTERS_FOR_SHOW_ENABLED)
+
   def setCommandRejectsSparkCoreConfs: Boolean =
     getConf(SQLConf.SET_COMMAND_REJECTS_SPARK_CORE_CONFS)
 
@@ -3878,8 +3882,6 @@ class SQLConf extends Serializable with Logging {
   def decorrelateInnerQueryEnabled: Boolean = getConf(SQLConf.DECORRELATE_INNER_QUERY_ENABLED)
 
   def maxConcurrentOutputFileWriters: Int = getConf(SQLConf.MAX_CONCURRENT_OUTPUT_FILE_WRITERS)
-
-  def escapeMetaCharactersForShowEnabled: Boolean = getConf(ESCAPE_META_CHARACTERS_FOR_SHOW_ENABLED)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2709,14 +2709,6 @@ object SQLConf {
     .checkValue(_ > 3, "This value must be bigger than 3.")
     .createWithDefault(100)
 
-  val ESCAPE_META_CHARACTERS_FOR_SHOW_ENABLED =
-    buildConf("spark.sql.escapeMetaCharactersForShow.enabled")
-      .doc("When true, the meta-characters `\n`, `\t`, `\r`, `\f` etc  are escaped in the" +
-        " `show()` action.")
-      .version("3.2.0")
-      .booleanConf
-      .createWithDefault(true)
-
   val SET_COMMAND_REJECTS_SPARK_CORE_CONFS =
     buildConf("spark.sql.legacy.setCommandRejectsSparkCoreConfs")
       .internal()
@@ -3840,9 +3832,6 @@ class SQLConf extends Serializable with Logging {
   def maxPlanStringLength: Int = getConf(SQLConf.MAX_PLAN_STRING_LENGTH).toInt
 
   def maxMetadataStringLength: Int = getConf(SQLConf.MAX_METADATA_STRING_LENGTH)
-
-  def escapeMetaCharactersForShowEnabled: Boolean =
-    getConf(ESCAPE_META_CHARACTERS_FOR_SHOW_ENABLED)
 
   def setCommandRejectsSparkCoreConfs: Boolean =
     getConf(SQLConf.SET_COMMAND_REJECTS_SPARK_CORE_CONFS)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -315,8 +315,6 @@ class Dataset[T] private[sql](
             } else {
               cell.toString
             }
-
-            //
         }
         if (truncate > 0 && str.length > truncate) {
           // do not show ellipses for strings shorter than 4 characters.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -309,8 +309,14 @@ class Dataset[T] private[sql](
           case null => "null"
           case binary: Array[Byte] => binary.map("%02X".format(_)).mkString("[", " ", "]")
           case _ =>
-            // Escapes meta-characters not to break the `showString` format
-            SchemaUtils.escapeMetaCharacters(cell.toString)
+            if (sparkSession.sessionState.conf.escapeMetaCharactersForShowEnabled) {
+              // Escapes meta-characters not to break the `showString` format
+              SchemaUtils.escapeMetaCharacters(cell.toString)
+            } else {
+              cell.toString
+            }
+
+            //
         }
         if (truncate > 0 && str.length > truncate) {
           // do not show ellipses for strings shorter than 4 characters.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?

Explain SQL command using show is not user friendly. New line characters are escaped by default in spark3.2, hence plan is not showing in the tree structure. In this PR, we are preventing skipping meta characters in case of Explain command.

### Why are the changes needed?

`scala>sql("EXPLAIN COST SELECT item.i_brand, count(1), date_dim.d_year, item.i_brand_id, sum(store_sales.ss_ext_sales_price) AS ext_price, item.i_item_sk
FROM store_sales INNER JOIN date_dim ON (date_dim.d_date_sk = store_sales.ss_sold_date_sk) INNER JOIN item ON (store_sales.ss_item_sk = item.i_item_sk)
GROUP BY item.i_brand, date_dim.d_date, item.i_item_desc, date_dim.d_year, item.i_brand_id, item.i_item_sk").show(false)`


**Before**
![image](https://user-images.githubusercontent.com/23054875/118353372-8c0df400-b583-11eb-8976-aea4e8c39ee0.png)



**After**
`
![image](https://user-images.githubusercontent.com/23054875/118353306-4b15df80-b583-11eb-9091-344f218e6a6d.png)

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Manual testing