### PR TITLE
[SPARK-34953][CORE][SQL] Add the code change for adding the DateType in the infer schema while reading in CSV and JSON

### DIFF
--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -251,7 +251,7 @@ Data source options of CSV can be set via:
   <tr>
     <td><code>inferDateType</code></td>
     <td>false</td>
-    <td>Infers all DateType format for the csv. If this is not set, it uses the default value, <code>false</code>.</td>
+    <td>Infers all DateType format for the CSV. If this is not set, it uses the default value, <code>false</code>.</td>
     <td>read</td>
   </tr>
 </table>

--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -248,5 +248,11 @@ Data source options of CSV can be set via:
     <td>Compression codec to use when saving to file. This can be one of the known case-insensitive shorten names (<code>none</code>, <code>bzip2</code>, <code>gzip</code>, <code>lz4</code>, <code>snappy</code> and <code>deflate</code>).</td>
     <td>write</td>
   </tr>
+  <tr>
+    <td><code>inferDateType</code></td>
+    <td>false</td>
+    <td>Infers all DateType format for the csv. If this is not set, it uses the default value, <code>false</code>.</td>
+    <td>read</td>
+  </tr>
 </table>
 Other generic options can be found in <a href="https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html">Generic File Source Options</a>.

--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -251,7 +251,7 @@ Data source options of CSV can be set via:
   <tr>
     <td><code>inferDateType</code></td>
     <td>false</td>
-    <td>Infers all DateType format for the CSV. If this is not set, it uses the default value, <code>false</code>.</td>
+    <td>Infers dateFormat for the CSV. If this is not set, it uses the default value, <code>false</code>.</td>
     <td>read</td>
   </tr>
 </table>

--- a/docs/sql-data-sources-json.md
+++ b/docs/sql-data-sources-json.md
@@ -158,7 +158,7 @@ Data source options of JSON can be set via:
   <tr>
     <td><code>inferDateType</code></td>
     <td>false</td>
-    <td>Infers all DateType format for the json. If this is not set, it uses the default value, <code>false</code>.</td>
+    <td>Infers all DateType format for the JSON. If this is not set, it uses the default value, <code>false</code>.</td>
     <td>read</td>
   </tr>
   <tr>

--- a/docs/sql-data-sources-json.md
+++ b/docs/sql-data-sources-json.md
@@ -156,6 +156,12 @@ Data source options of JSON can be set via:
     <td>read</td>
   </tr>
   <tr>
+    <td><code>inferDateType</code></td>
+    <td>false</td>
+    <td>Infers all DateType format for the json. If this is not set, it uses the default value, <code>false</code>.</td>
+    <td>read</td>
+  </tr>
+  <tr>
     <td><code>allowBackslashEscapingAnyCharacter</code></td>
     <td>None</td>
     <td>Allows accepting quoting of all character using backslash quoting mechanism. If None is set, it uses the default value, <code>false</code>.</td>

--- a/docs/sql-data-sources-json.md
+++ b/docs/sql-data-sources-json.md
@@ -158,7 +158,7 @@ Data source options of JSON can be set via:
   <tr>
     <td><code>inferDateType</code></td>
     <td>false</td>
-    <td>Infers all DateType format for the JSON. If this is not set, it uses the default value, <code>false</code>.</td>
+    <td>Infers dateFormat for the JSON. If this is not set, it uses the default value, <code>false</code>.</td>
     <td>read</td>
   </tr>
   <tr>

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -353,7 +353,7 @@ class DataFrameReader(OptionUtils):
             columnNameOfCorruptRecord=None, multiLine=None, charToEscapeQuoteEscaping=None,
             samplingRatio=None, enforceSchema=None, emptyValue=None, locale=None, lineSep=None,
             pathGlobFilter=None, recursiveFileLookup=None, modifiedBefore=None, modifiedAfter=None,
-            unescapedQuoteHandling=None):
+            unescapedQuoteHandling=None, inferDateType=None):
         r"""Loads a CSV file and returns the result as a  :class:`DataFrame`.
 
         This function will go through the input once to determine the input schema if
@@ -403,7 +403,7 @@ class DataFrameReader(OptionUtils):
             enforceSchema=enforceSchema, emptyValue=emptyValue, locale=locale, lineSep=lineSep,
             pathGlobFilter=pathGlobFilter, recursiveFileLookup=recursiveFileLookup,
             modifiedBefore=modifiedBefore, modifiedAfter=modifiedAfter,
-            unescapedQuoteHandling=unescapedQuoteHandling)
+            unescapedQuoteHandling=unescapedQuoteHandling, inferDateType= inferDateType)
         if isinstance(path, str):
             path = [path]
         if type(path) == list:

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -403,7 +403,7 @@ class DataFrameReader(OptionUtils):
             enforceSchema=enforceSchema, emptyValue=emptyValue, locale=locale, lineSep=lineSep,
             pathGlobFilter=pathGlobFilter, recursiveFileLookup=recursiveFileLookup,
             modifiedBefore=modifiedBefore, modifiedAfter=modifiedAfter,
-            unescapedQuoteHandling=unescapedQuoteHandling, inferDateType= inferDateType)
+            unescapedQuoteHandling=unescapedQuoteHandling, inferDateType=inferDateType)
         if isinstance(path, str):
             path = [path]
         if type(path) == list:

--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -636,7 +636,8 @@ class DataStreamReader(OptionUtils):
             maxCharsPerColumn=None, maxMalformedLogPerPartition=None, mode=None,
             columnNameOfCorruptRecord=None, multiLine=None, charToEscapeQuoteEscaping=None,
             enforceSchema=None, emptyValue=None, locale=None, lineSep=None,
-            pathGlobFilter=None, recursiveFileLookup=None, unescapedQuoteHandling=None):
+            pathGlobFilter=None, recursiveFileLookup=None, unescapedQuoteHandling=None,
+            inferDateType=None):
         r"""Loads a CSV file stream and returns the result as a :class:`DataFrame`.
 
         This function will go through the input once to determine the input schema if
@@ -686,7 +687,7 @@ class DataStreamReader(OptionUtils):
             charToEscapeQuoteEscaping=charToEscapeQuoteEscaping, enforceSchema=enforceSchema,
             emptyValue=emptyValue, locale=locale, lineSep=lineSep,
             pathGlobFilter=pathGlobFilter, recursiveFileLookup=recursiveFileLookup,
-            unescapedQuoteHandling=unescapedQuoteHandling)
+            unescapedQuoteHandling=unescapedQuoteHandling, inferDateType=inferDateType)
         if isinstance(path, str):
             return self._df(self._jreader.csv(path))
         else:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
@@ -176,8 +176,10 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
   }
 
   private def tryParseDateFormat(field: String): DataType = {
-    if ((allCatch opt new SimpleDateFormat(
-      options.dateFormat, Locale.US).parse(field)).isDefined) {
+    if ((allCatch opt {
+      val dtFormat = new SimpleDateFormat(options.dateFormat, Locale.US)
+      dtFormat.setLenient(false)
+      dtFormat.parse(field)}).isDefined) {
       DateType
     } else {
       tryParseBoolean(field)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
@@ -24,9 +24,8 @@ import scala.util.control.Exception.allCatch
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.analysis.TypeCoercion
 import org.apache.spark.sql.catalyst.expressions.ExprUtils
-import org.apache.spark.sql.catalyst.util.{DateFormatter, TimestampFormatter}
+import org.apache.spark.sql.catalyst.util.{DateFormatter, LegacyFastDateFormatter, TimestampFormatter}
 import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
-import org.apache.spark.sql.catalyst.util.LegacySimpleDateFormatter
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types._
 
@@ -175,7 +174,7 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
 
   private def tryParseDateFormat(field: String): DataType = {
     if (options.inferDateType
-      && !dateFormatter.isInstanceOf[LegacySimpleDateFormatter]
+      && !dateFormatter.isInstanceOf[LegacyFastDateFormatter]
       && (allCatch opt dateFormatter.parse(field)).isDefined) {
       DateType
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.csv
 
+import java.text.SimpleDateFormat
 import java.util.Locale
 
 import scala.util.control.Exception.allCatch
@@ -169,6 +170,15 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
     // This case infers a custom `dataFormat` is set.
     if ((allCatch opt timestampParser.parse(field)).isDefined) {
       TimestampType
+    } else {
+      tryParseDateFormat(field)
+    }
+  }
+
+  private def tryParseDateFormat(field: String): DataType = {
+    if ((allCatch opt new SimpleDateFormat(
+      options.dateFormat, Locale.US).parse(field)).isDefined) {
+      DateType
     } else {
       tryParseBoolean(field)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
@@ -25,7 +25,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.analysis.TypeCoercion
 import org.apache.spark.sql.catalyst.expressions.ExprUtils
 import org.apache.spark.sql.catalyst.util.{DateFormatter, TimestampFormatter}
-import org.apache.spark.sql.catalyst.util.LegacyDateFormats.{FAST_DATE_FORMAT, SIMPLE_DATE_FORMAT}
+import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
 import org.apache.spark.sql.catalyst.util.LegacySimpleDateFormatter
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types._
@@ -43,7 +43,7 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
     options.dateFormat,
     options.zoneId,
     options.locale,
-    legacyFormat = SIMPLE_DATE_FORMAT,
+    legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)
 
   private val decimalParser = if (options.locale == Locale.US) {
@@ -175,7 +175,8 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
   }
 
   private def tryParseDateFormat(field: String): DataType = {
-    if (!dateFormatter.isInstanceOf[LegacySimpleDateFormatter]
+    if (options.inferDateType
+      && !dateFormatter.isInstanceOf[LegacySimpleDateFormatter]
       && (allCatch opt dateFormatter.parse(field)).isDefined) {
       DateType
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
@@ -41,7 +41,6 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
 
   private val dateFormatter = DateFormatter(
     options.dateFormat,
-    options.zoneId,
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.catalyst.csv
 
-import java.text.SimpleDateFormat
 import java.util.Locale
 
 import scala.util.control.Exception.allCatch
@@ -25,8 +24,9 @@ import scala.util.control.Exception.allCatch
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.analysis.TypeCoercion
 import org.apache.spark.sql.catalyst.expressions.ExprUtils
-import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
-import org.apache.spark.sql.catalyst.util.TimestampFormatter
+import org.apache.spark.sql.catalyst.util.{DateFormatter, TimestampFormatter}
+import org.apache.spark.sql.catalyst.util.LegacyDateFormats.{FAST_DATE_FORMAT, SIMPLE_DATE_FORMAT}
+import org.apache.spark.sql.catalyst.util.LegacySimpleDateFormatter
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types._
 
@@ -37,6 +37,13 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
     options.zoneId,
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
+    isParsing = true)
+
+  private val dateFormatter = DateFormatter(
+    options.dateFormat,
+    options.zoneId,
+    options.locale,
+    legacyFormat = SIMPLE_DATE_FORMAT,
     isParsing = true)
 
   private val decimalParser = if (options.locale == Locale.US) {
@@ -110,6 +117,7 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
         case LongType => tryParseLong(field)
         case _: DecimalType => tryParseDecimal(field)
         case DoubleType => tryParseDouble(field)
+        case DateType => tryParseDateFormat(field)
         case TimestampType => tryParseTimestamp(field)
         case BooleanType => tryParseBoolean(field)
         case StringType => StringType
@@ -162,6 +170,15 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
     if ((allCatch opt field.toDouble).isDefined || isInfOrNan(field)) {
       DoubleType
     } else {
+      tryParseDateFormat(field)
+    }
+  }
+
+  private def tryParseDateFormat(field: String): DataType = {
+    if (!dateFormatter.isInstanceOf[LegacySimpleDateFormatter]
+      && (allCatch opt dateFormatter.parse(field)).isDefined) {
+      DateType
+    } else {
       tryParseTimestamp(field)
     }
   }
@@ -170,17 +187,6 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
     // This case infers a custom `dataFormat` is set.
     if ((allCatch opt timestampParser.parse(field)).isDefined) {
       TimestampType
-    } else {
-      tryParseDateFormat(field)
-    }
-  }
-
-  private def tryParseDateFormat(field: String): DataType = {
-    if ((allCatch opt {
-      val dtFormat = new SimpleDateFormat(options.dateFormat, Locale.US)
-      dtFormat.setLenient(false)
-      dtFormat.parse(field)}).isDefined) {
-      DateType
     } else {
       tryParseBoolean(field)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -206,6 +206,12 @@ class CSVOptions(
     sep
   }
 
+  /**
+   * option to infer date Type in the schema
+   */
+  val inferDateType =
+    parameters.get("inferDateType").map(_.toBoolean).getOrElse(false)
+
   val lineSeparatorInRead: Option[Array[Byte]] = lineSeparator.map { lineSep =>
     lineSep.getBytes(charset)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -68,6 +68,8 @@ private[sql] class JSONOptions(
     parameters.get("allowNonNumericNumbers").map(_.toBoolean).getOrElse(true)
   val allowBackslashEscapingAnyCharacter =
     parameters.get("allowBackslashEscapingAnyCharacter").map(_.toBoolean).getOrElse(false)
+  val allowDateFormat =
+    parameters.get("allowDateFormat").map(_.toBoolean).getOrElse(false)
   private val allowUnquotedControlChars =
     parameters.get("allowUnquotedControlChars").map(_.toBoolean).getOrElse(false)
   val compressionCodec = parameters.get("compression").map(CompressionCodecs.getCodecClassName)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -68,8 +68,8 @@ private[sql] class JSONOptions(
     parameters.get("allowNonNumericNumbers").map(_.toBoolean).getOrElse(true)
   val allowBackslashEscapingAnyCharacter =
     parameters.get("allowBackslashEscapingAnyCharacter").map(_.toBoolean).getOrElse(false)
-  val allowDateFormat =
-    parameters.get("allowDateFormat").map(_.toBoolean).getOrElse(false)
+  val inferDateType =
+    parameters.get("inferDateType").map(_.toBoolean).getOrElse(false)
   private val allowUnquotedControlChars =
     parameters.get("allowUnquotedControlChars").map(_.toBoolean).getOrElse(false)
   val compressionCodec = parameters.get("compression").map(CompressionCodecs.getCodecClassName)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.analysis.TypeCoercion
 import org.apache.spark.sql.catalyst.expressions.ExprUtils
 import org.apache.spark.sql.catalyst.json.JacksonUtils.nextUntil
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.catalyst.util.LegacyDateFormats.{FAST_DATE_FORMAT, SIMPLE_DATE_FORMAT}
+import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -49,7 +49,7 @@ private[sql] class JsonInferSchema(options: JSONOptions) extends Serializable {
     options.dateFormat,
     options.zoneId,
     options.locale,
-    legacyFormat = SIMPLE_DATE_FORMAT,
+    legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)
 
   /**
@@ -134,7 +134,7 @@ private[sql] class JsonInferSchema(options: JSONOptions) extends Serializable {
         }
         if (options.prefersDecimal && decimalTry.isDefined) {
           decimalTry.get
-        } else if (options.allowDateFormat
+        } else if (options.inferDateType
             && !dateFormatter.isInstanceOf[LegacySimpleDateFormatter] &&
             (allCatch opt dateFormatter.parse(field)).isDefined) {
           DateType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.catalyst.json
 
+import java.text.SimpleDateFormat
 import java.util.Comparator
+import java.util.Locale
 
 import scala.util.control.Exception.allCatch
 
@@ -130,6 +132,10 @@ private[sql] class JsonInferSchema(options: JSONOptions) extends Serializable {
         } else if (options.inferTimestamp &&
             (allCatch opt timestampFormatter.parse(field)).isDefined) {
           TimestampType
+        } else if (options.allowDateFormat &&
+          (allCatch opt new SimpleDateFormat(
+            options.dateFormat, Locale.US).parse(field)).isDefined) {
+          DateType
         } else {
           StringType
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
@@ -133,8 +133,11 @@ private[sql] class JsonInferSchema(options: JSONOptions) extends Serializable {
             (allCatch opt timestampFormatter.parse(field)).isDefined) {
           TimestampType
         } else if (options.allowDateFormat &&
-          (allCatch opt new SimpleDateFormat(
-            options.dateFormat, Locale.US).parse(field)).isDefined) {
+          (allCatch opt { val dtFormat = new SimpleDateFormat(
+            options.dateFormat, Locale.US)
+            dtFormat.setLenient(false)
+            dtFormat.parse(field)
+          }).isDefined) {
           DateType
         } else {
           StringType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
@@ -134,7 +134,7 @@ private[sql] class JsonInferSchema(options: JSONOptions) extends Serializable {
         if (options.prefersDecimal && decimalTry.isDefined) {
           decimalTry.get
         } else if (options.inferDateType
-            && !dateFormatter.isInstanceOf[LegacySimpleDateFormatter] &&
+            && !dateFormatter.isInstanceOf[LegacyFastDateFormatter] &&
             (allCatch opt dateFormatter.parse(field)).isDefined) {
           DateType
         } else if (options.inferTimestamp &&

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
@@ -47,7 +47,6 @@ private[sql] class JsonInferSchema(options: JSONOptions) extends Serializable {
 
   private val dateFormatter = DateFormatter(
     options.dateFormat,
-    options.zoneId,
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
@@ -194,11 +194,18 @@ class CSVInferSchemaSuite extends SparkFunSuite with SQLHelper {
   }
 
   test("SPARK-34953 - DateType should be inferred when user defined format are provided") {
-    val options = new CSVOptions(Map("dateFormat" -> "dd-MM-yyyy",
+    var options = new CSVOptions(Map("dateFormat" -> "dd-MM-yyyy",
       "inferSchema" -> "true"), false, "UTC")
-    val inferSchema = new CSVInferSchema(options)
+    var inferSchema = new CSVInferSchema(options)
 
     assert(inferSchema.inferField(NullType, "21-10-2021") == DateType)
+    assert(inferSchema.inferField(NullType, "03.31.2021") == StringType)
+
+    // For default type
+    options = new CSVOptions(Map("inferSchema" -> "true"), false, "UTC")
+    inferSchema = new CSVInferSchema(options)
+
+    assert(inferSchema.inferField(NullType, "2021-10-05") == DateType)
     assert(inferSchema.inferField(NullType, "03.31.2021") == StringType)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
@@ -192,4 +192,13 @@ class CSVInferSchemaSuite extends SparkFunSuite with SQLHelper {
     Seq("en-US").foreach(checkDecimalInfer(_, StringType))
     Seq("ko-KR", "ru-RU", "de-DE").foreach(checkDecimalInfer(_, DecimalType(7, 0)))
   }
+
+  test("SPARK-34953 - DateType should be inferred when user defined format are provided") {
+    val options = new CSVOptions(Map("dateFormat" -> "dd-MM-yyyy",
+      "inferSchema" -> "true"), false, "UTC")
+    val inferSchema = new CSVInferSchema(options)
+
+    assert(inferSchema.inferField(NullType, "21-10-2021") == DateType)
+    assert(inferSchema.inferField(NullType, "03.31.2021") == StringType)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
@@ -193,7 +193,7 @@ class CSVInferSchemaSuite extends SparkFunSuite with SQLHelper {
     Seq("ko-KR", "ru-RU", "de-DE").foreach(checkDecimalInfer(_, DecimalType(7, 0)))
   }
 
-  test("SPARK-34953 - DateType should be inferred when user defined format are provided") {
+  test("SPARK-34953: DateType should be inferred when user defined format are provided") {
     Seq(true, false).foreach { inferDateType =>
       val options = new CSVOptions(Map("dateFormat" -> "dd-MM-yyyy",
         "inferSchema" -> "true", "inferDateType" -> inferDateType.toString), false, "UTC")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
@@ -194,18 +194,25 @@ class CSVInferSchemaSuite extends SparkFunSuite with SQLHelper {
   }
 
   test("SPARK-34953 - DateType should be inferred when user defined format are provided") {
-    var options = new CSVOptions(Map("dateFormat" -> "dd-MM-yyyy",
-      "inferSchema" -> "true"), false, "UTC")
-    var inferSchema = new CSVInferSchema(options)
+    Seq(true, false).foreach { inferDateType =>
+      val options = new CSVOptions(Map("dateFormat" -> "dd-MM-yyyy",
+        "inferSchema" -> "true", "inferDateType" -> inferDateType.toString), false, "UTC")
+      val inferSchema = new CSVInferSchema(options)
 
-    assert(inferSchema.inferField(NullType, "21-10-2021") == DateType)
-    assert(inferSchema.inferField(NullType, "03.31.2021") == StringType)
+      val inferredDataType = if (inferDateType) { DateType } else { StringType }
+      assert(inferSchema.inferField(NullType, "21-10-2021") == inferredDataType)
+      assert(inferSchema.inferField(NullType, "03.31.2021") == StringType)
+    }
 
-    // For default type
-    options = new CSVOptions(Map("inferSchema" -> "true"), false, "UTC")
-    inferSchema = new CSVInferSchema(options)
+    // For default type where dateFormat is not present in the option
+    Seq(true, false).foreach { inferDateType =>
+      val options = new CSVOptions(Map("inferSchema" -> "true",
+        "inferDateType" -> inferDateType.toString), false, "UTC")
+      val inferSchema = new CSVInferSchema(options)
 
-    assert(inferSchema.inferField(NullType, "2021-10-05") == DateType)
-    assert(inferSchema.inferField(NullType, "03.31.2021") == StringType)
+      val inferredDataType = if (inferDateType) { DateType } else { StringType }
+      assert(inferSchema.inferField(NullType, "2021-10-05") == inferredDataType)
+      assert(inferSchema.inferField(NullType, "03.31.2021") == StringType)
+    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
@@ -112,4 +112,14 @@ class JsonInferSchemaSuite extends SparkFunSuite with SQLHelper {
     checkType(Map("inferTimestamp" -> "true"), json, TimestampType)
     checkType(Map("inferTimestamp" -> "false"), json, StringType)
   }
+
+  test("SPARK-34953 - Allow DateType format while inferring") {
+    val json = """{"a": "29-01-2020"}"""
+    Seq(true, false).foreach { allowDateFormat =>
+      checkType(Map("dateFormat" -> "dd-MM-YYYY", "allowDateFormat" -> allowDateFormat.toString),
+        json, dt = if (allowDateFormat) DateType else StringType)
+      checkType(Map("dateFormat" -> "YYYY.MM.dd", "allowDateFormat" -> allowDateFormat.toString),
+        json, StringType)
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
@@ -113,7 +113,7 @@ class JsonInferSchemaSuite extends SparkFunSuite with SQLHelper {
     checkType(Map("inferTimestamp" -> "false"), json, StringType)
   }
 
-  test("SPARK-34953 - Allow DateType format while inferring") {
+  test("SPARK-34953: Allow DateType format while inferring") {
     val json = """{"a": "29-01-2020"}"""
     Seq(true, false).foreach { inferDateType =>
       checkType(Map("dateFormat" -> "dd-MM-yyyy", "inferDateType" -> inferDateType.toString),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
@@ -116,9 +116,9 @@ class JsonInferSchemaSuite extends SparkFunSuite with SQLHelper {
   test("SPARK-34953 - Allow DateType format while inferring") {
     val json = """{"a": "29-01-2020"}"""
     Seq(true, false).foreach { allowDateFormat =>
-      checkType(Map("dateFormat" -> "dd-MM-YYYY", "allowDateFormat" -> allowDateFormat.toString),
+      checkType(Map("dateFormat" -> "dd-MM-yyyy", "allowDateFormat" -> allowDateFormat.toString),
         json, dt = if (allowDateFormat) DateType else StringType)
-      checkType(Map("dateFormat" -> "YYYY.MM.dd", "allowDateFormat" -> allowDateFormat.toString),
+      checkType(Map("dateFormat" -> "yyyy.MM.dd", "allowDateFormat" -> allowDateFormat.toString),
         json, StringType)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
@@ -115,10 +115,10 @@ class JsonInferSchemaSuite extends SparkFunSuite with SQLHelper {
 
   test("SPARK-34953 - Allow DateType format while inferring") {
     val json = """{"a": "29-01-2020"}"""
-    Seq(true, false).foreach { allowDateFormat =>
-      checkType(Map("dateFormat" -> "dd-MM-yyyy", "allowDateFormat" -> allowDateFormat.toString),
-        json, dt = if (allowDateFormat) DateType else StringType)
-      checkType(Map("dateFormat" -> "yyyy.MM.dd", "allowDateFormat" -> allowDateFormat.toString),
+    Seq(true, false).foreach { inferDateType =>
+      checkType(Map("dateFormat" -> "dd-MM-yyyy", "inferDateType" -> inferDateType.toString),
+        json, dt = if (inferDateType) DateType else StringType)
+      checkType(Map("dateFormat" -> "yyyy.MM.dd", "inferDateType" -> inferDateType.toString),
         json, StringType)
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Till now there is no support in infer schema for the DateType format while reading the CSV/json. In this PR, code change is done to support the DateType when inferschema set true in the options

### Why are the changes needed?
Many times there are multiple columns which are DateType but after inferred from schema they are added as StringType in the schema and than there is need to convert into to_date before we start the running any query. After this change DateType will be added in the schema instead of the StringType

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test added , also testing is done while running read command on spark shell.
