### PR TITLE
[SPARK-35417][BUILD] Upgrade SBT to 1.5.2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=1.5.1
+sbt.version=1.5.2


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade SBT to 1.5.2 for better Scala 2.13.x support.

### Why are the changes needed?

SBT 1.5.2 Release Note: https://github.com/sbt/sbt/releases/tag/v1.5.2
- Fixes ConcurrentModificationException while compiling Scala 2.13.4 and Java sources zinc
- Uses -Duser.home instead of $HOME to download launcher JAR
- Fixes -client by making it the same as --client
- Fixes metabuild ClassLoader missing util-interface
- Fixes sbt new leaving behind target directory
- Fixes "zip END header not found" error during pushRemoteCache

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.