### PR TITLE
[SPARK-35443][K8S] Mark K8s ConfigMaps and Secrets created by Spark as immutable

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStep.scala
@@ -202,6 +202,7 @@ private[spark] class DriverKubernetesCredentialsFeatureStep(kubernetesConf: Kube
       .withNewMetadata()
         .withName(driverCredentialsSecretName)
         .endMetadata()
+      .withImmutable(true)
       .withData(allSecretData.asJava)
       .build()
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
@@ -114,6 +114,7 @@ private[spark] class HadoopConfDriverFeatureStep(conf: KubernetesConf)
         .withNewMetadata()
           .withName(newConfigMapName)
           .endMetadata()
+        .withImmutable(true)
         .addToData(fileMap)
         .build())
     } else {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
@@ -228,6 +228,7 @@ private[spark] class KerberosConfDriverFeatureStep(kubernetesConf: KubernetesDri
           .withNewMetadata()
             .withName(newConfigMapName)
             .endMetadata()
+          .withImmutable(true)
           .addToData(
             Map(file.getName() -> Files.toString(file, StandardCharsets.UTF_8)).asJava)
           .build()
@@ -240,6 +241,7 @@ private[spark] class KerberosConfDriverFeatureStep(kubernetesConf: KubernetesDri
           .withNewMetadata()
             .withName(ktSecretName)
             .endMetadata()
+          .withImmutable(true)
           .addToData(kt.getName(), Base64.encodeBase64String(Files.toByteArray(kt)))
           .build())
       } else {
@@ -251,6 +253,7 @@ private[spark] class KerberosConfDriverFeatureStep(kubernetesConf: KubernetesDri
           .withNewMetadata()
             .withName(dtSecretName)
             .endMetadata()
+          .withImmutable(true)
           .addToData(KERBEROS_SECRET_KEY, Base64.encodeBase64String(delegationTokens))
           .build())
       } else {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStep.scala
@@ -86,6 +86,7 @@ private[spark] class PodTemplateConfigMapStep(conf: KubernetesConf)
           .withNewMetadata()
             .withName(configmapName)
           .endMetadata()
+          .withImmutable(true)
           .addToData(POD_TEMPLATE_KEY, podTemplateString)
         .build())
     } else {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -90,6 +90,7 @@ private[spark] object KubernetesClientUtils extends Logging {
         .withName(configMapName)
         .withLabels(withLabels.asJava)
         .endMetadata()
+      .withImmutable(true)
       .addToData(confFileMap.asJava)
       .build()
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStepSuite.scala
@@ -76,6 +76,7 @@ class PodTemplateConfigMapStepSuite extends SparkFunSuite {
     assert(resources.head.isInstanceOf[ConfigMap])
     val configMap = resources.head.asInstanceOf[ConfigMap]
     assert(configMap.getData.size() === 1)
+    assert(configMap.getImmutable())
     assert(configMap.getData.containsKey(Constants.POD_TEMPLATE_KEY))
     assert(configMap.getData.containsValue("pod-template-contents"))
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -186,6 +186,7 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     val configMap = configMaps.head
     assert(configMap.getMetadata.getName ===
       KubernetesClientUtils.configMapNameDriver)
+    assert(configMap.getImmutable())
     assert(configMap.getData.containsKey(SPARK_CONF_FILE_NAME))
     assert(configMap.getData.get(SPARK_CONF_FILE_NAME).contains("conf1key=conf1value"))
     assert(configMap.getData.get(SPARK_CONF_FILE_NAME).contains("conf2key=conf2value"))


### PR DESCRIPTION
Kubernetes supports marking secrets and config maps as immutable to gain performance. 

https://kubernetes.io/docs/concepts/configuration/configmap/#configmap-immutable
https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable

For K8s clusters that run many thousands of Spark applications, this can yield significant reduction in load on the kube-apiserver.

From the K8s docs:

> For clusters that extensively use Secrets (at least tens of thousands of unique Secret to Pod mounts), preventing changes to their data has the following advantages:
> - protects you from accidental (or unwanted) updates that could cause applications outages
> - improves performance of your cluster by significantly reducing load on kube-apiserver, by closing watches for secrets marked as immutable.
 

For any secrets and config maps we create in Spark that are immutable, we could mark them as immutable by including the following when building the secret/config map
```
.withImmutable(true)
```
This feature has been supported in K8s as beta since K8s 1.19 and as GA since K8s 1.21

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
All K8s secrets and config maps created by Spark are marked "immutable".


### Why are the changes needed?
See description above.

### Does this PR introduce _any_ user-facing change?
Don't think so


### How was this patch tested?
Augmented existing unit tests.
