### PR TITLE
[SPARK-35444][SQL] Imporve the logic of createTable if table already exist and ignoreIfExists=true

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -367,6 +367,7 @@ class SessionCatalog(
       if (!ignoreIfExists) {
         throw new TableAlreadyExistsException(db = db, table = table)
       }
+      return;
     } else if (validateLocation) {
       validateTableLocation(newTableDefinition)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -367,7 +367,6 @@ class SessionCatalog(
       if (!ignoreIfExists) {
         throw new TableAlreadyExistsException(db = db, table = table)
       }
-      return;
     } else if (validateLocation) {
       validateTableLocation(newTableDefinition)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -367,6 +367,7 @@ class SessionCatalog(
       if (!ignoreIfExists) {
         throw new TableAlreadyExistsException(db = db, table = table)
       }
+      return
     } else if (validateLocation) {
       validateTableLocation(newTableDefinition)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
We should `return` directly if table already exist and ignoreIfExists=`true`

Current logic：
```
requireDbExists(db)
if (tableExists(newTableDefinition.identifier)) {
  if (!ignoreIfExists) {
      throw new TableAlreadyExistsException(db = db, table = table)
    }
} else if (validateLocation) {
  validateTableLocation(newTableDefinition)
}
externalCatalog.createTable(newTableDefinition, ignoreIfExists)
```

### Why are the changes needed?
this is a improve

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
exists now
