### PR TITLE
[SPARK-35445][SQL] Reduce the execution time of DeduplicateRelations

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
@@ -78,7 +78,7 @@ object DeduplicateRelations extends Rule[LogicalPlan] {
    * @param existingRelations the known unique relations for a LogicalPlan
    * @param plan the LogicalPlan that requires the deduplication
    * @return (the new LogicalPlan which already deduplicate all duplicated relations (if any),
-   *         all relations of the new LogicalPlan, whether the plan has changed or not)
+   *         all relations of the new LogicalPlan, whether the plan is changed or not)
    */
   private def renewDuplicatedRelations(
       existingRelations: mutable.HashSet[ReferenceEqualPlanWrapper],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
@@ -17,16 +17,30 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeMap, AttributeSet, NamedExpression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.AlwaysProcess
 
+/**
+ * A help class that used to detect duplicate relations fast in `DeduplicateRelations`
+ */
+case class ReferenceEqualPlanWrapper(plan: LogicalPlan) {
+  private val _hashCode = System.identityHashCode(plan)
+  override def hashCode(): Int = _hashCode
+  override def equals(obj: Any): Boolean = obj match {
+    case wrapper: ReferenceEqualPlanWrapper =>
+      plan.eq(wrapper.plan)
+    case _ =>
+      false
+  }
+}
+
 object DeduplicateRelations extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = {
-    renewDuplicatedRelations(Nil, plan)._1.resolveOperatorsUpWithPruning(
+    renewDuplicatedRelations(mutable.HashSet.empty, plan)._1.resolveOperatorsUpWithPruning(
       AlwaysProcess.fn, ruleId) {
       case p: LogicalPlan if !p.childrenResolved => p
       // To resolve duplicate expression IDs for Join.
@@ -67,39 +81,57 @@ object DeduplicateRelations extends Rule[LogicalPlan] {
    *         all relations of the new LogicalPlan )
    */
   private def renewDuplicatedRelations(
-      existingRelations: Seq[MultiInstanceRelation],
-      plan: LogicalPlan): (LogicalPlan, Seq[MultiInstanceRelation]) = plan match {
-    case p: LogicalPlan if p.isStreaming => (plan, Nil)
+      existingRelations: mutable.HashSet[ReferenceEqualPlanWrapper],
+      plan: LogicalPlan)
+    : (LogicalPlan, mutable.HashSet[ReferenceEqualPlanWrapper], Boolean) = plan match {
+    case p: LogicalPlan if p.isStreaming => (plan, mutable.HashSet.empty, false)
 
     case m: MultiInstanceRelation =>
-      if (isDuplicated(existingRelations, m)) {
+      val planWrapper = ReferenceEqualPlanWrapper(m)
+      if (isDuplicated(existingRelations, planWrapper)) {
         val newNode = m.newInstance()
         newNode.copyTagsFrom(m)
-        (newNode, Nil)
+        (newNode, mutable.HashSet.empty, true)
       } else {
-        (m, Seq(m))
+        val mWrapper = new mutable.HashSet[ReferenceEqualPlanWrapper]()
+        mWrapper.add(planWrapper)
+        (m, mWrapper, false)
       }
 
     case plan: LogicalPlan =>
-      val relations = ArrayBuffer.empty[MultiInstanceRelation]
+      val relations = new mutable.HashSet[ReferenceEqualPlanWrapper]()
+      var planChanged = false
       val newPlan = if (plan.children.nonEmpty) {
-        val newChildren = ArrayBuffer.empty[LogicalPlan]
+        val newChildren = mutable.ArrayBuffer.empty[LogicalPlan]
         for (c <- plan.children) {
-          val (renewed, collected) = renewDuplicatedRelations(existingRelations ++ relations, c)
+          val (renewed, collected, changed) =
+            renewDuplicatedRelations(existingRelations ++ relations, c)
           newChildren += renewed
           relations ++= collected
+          if (changed) {
+            planChanged = true
+          }
         }
 
-        if (plan.childrenResolved) {
-          val attrMap = AttributeMap(
-            plan
-              .children
-              .flatMap(_.output).zip(newChildren.flatMap(_.output))
-              .filter { case (a1, a2) => a1.exprId != a2.exprId }
-          )
-          plan.withNewChildren(newChildren.toSeq).rewriteAttrs(attrMap)
+        if (planChanged) {
+          if (plan.childrenResolved) {
+            val planWithNewChildren = plan.withNewChildren(newChildren.toSeq)
+            val attrMap = AttributeMap(
+              plan
+                .children
+                .flatMap(_.output).zip(newChildren.flatMap(_.output))
+                .filter { case (a1, a2) => a1.exprId != a2.exprId }
+            )
+            if (attrMap.isEmpty) {
+              planWithNewChildren
+            } else {
+              planWithNewChildren.rewriteAttrs(attrMap)
+            }
+          } else {
+            plan.withNewChildren(newChildren.toSeq)
+          }
         } else {
-          plan.withNewChildren(newChildren.toSeq)
+          plan
         }
       } else {
         plan
@@ -107,21 +139,20 @@ object DeduplicateRelations extends Rule[LogicalPlan] {
 
       val planWithNewSubquery = newPlan.transformExpressions {
         case subquery: SubqueryExpression =>
-          val (renewed, collected) = renewDuplicatedRelations(
+          val (renewed, collected, changed) = renewDuplicatedRelations(
             existingRelations ++ relations, subquery.plan)
           relations ++= collected
+          if (changed) planChanged = true
           subquery.withNewPlan(renewed)
       }
-      (planWithNewSubquery, relations.toSeq)
+      (planWithNewSubquery, relations, planChanged)
   }
 
+  @inline
   private def isDuplicated(
-      existingRelations: Seq[MultiInstanceRelation],
-      relation: MultiInstanceRelation): Boolean = {
-    existingRelations.exists { er =>
-      er.asInstanceOf[LogicalPlan].outputSet
-        .intersect(relation.asInstanceOf[LogicalPlan].outputSet).nonEmpty
-    }
+      existingRelations: mutable.HashSet[ReferenceEqualPlanWrapper],
+      planWrapper: ReferenceEqualPlanWrapper): Boolean = {
+    existingRelations.contains(planWrapper)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR reduces the execution time of `DeduplicateRelations` by:

1) use `Set` instead `Seq` to check duplicate relations

2) avoid plan output traverse and attribute rewrites when there are no changes in the children plan


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Rule `DeduplicateRelations` is slow.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Run `TPCDSQuerySuite` and checked the run time of `DeduplicateRelations`. The time has been reduced by 77.9% after this PR.
