### PR TITLE
[SPARK-35373][BUILD][FOLLOWUP][3.1] Update zinc installation

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -142,7 +142,10 @@ install_zinc() {
     local TYPESAFE_MIRROR=${TYPESAFE_MIRROR:-https://downloads.lightbend.com}
 
     install_app \
-      "${TYPESAFE_MIRROR}/zinc/${ZINC_VERSION}/zinc-${ZINC_VERSION}.tgz" \
+      "${TYPESAFE_MIRROR}" \
+      "zinc/${ZINC_VERSION}/zinc-${ZINC_VERSION}.tgz" \
+      "" \
+      "" \
       "zinc-${ZINC_VERSION}.tgz" \
       "${zinc_path}"
     ZINC_BIN="${_DIR}/${zinc_path}"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of https://github.com/apache/spark/pull/32505 to fix `zinc` installation.

### Why are the changes needed?

Currently, branch-3.1/3.0 is broken.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action.