### PR TITLE
[SPARK-35447][SQL] Optimize skew join before coalescing shuffle partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -96,10 +96,9 @@ case class AdaptiveSparkPlanExec(
   @transient private val queryStageOptimizerRules: Seq[Rule[SparkPlan]] = Seq(
     PlanAdaptiveDynamicPruningFilters(this),
     ReuseAdaptiveSubquery(context.subqueryCache),
-    CoalesceShufflePartitions(context.session),
-    // The following two rules need to make use of 'CustomShuffleReaderExec.partitionSpecs'
-    // added by `CoalesceShufflePartitions`. So they must be executed after it.
+    // Skew join does not handle `CustomShuffleReader` so needs to be applied first.
     OptimizeSkewedJoin,
+    CoalesceShufflePartitions(context.session),
     OptimizeLocalShuffleReader
   )
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -99,6 +99,8 @@ case class AdaptiveSparkPlanExec(
     // Skew join does not handle `CustomShuffleReader` so needs to be applied first.
     OptimizeSkewedJoin,
     CoalesceShufflePartitions(context.session),
+    // `OptimizeLocalShuffleReader` needs to make use of 'CustomShuffleReaderExec.partitionSpecs'
+    // added by `CoalesceShufflePartitions`, and must be executed after it.
     OptimizeLocalShuffleReader
   )
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -35,72 +35,73 @@ case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffl
     if (!conf.coalesceShufflePartitionsEnabled) {
       return plan
     }
-    if (!plan.collectLeaves().forall(_.isInstanceOf[QueryStageExec])
-        || plan.find(_.isInstanceOf[CustomShuffleReaderExec]).isDefined) {
+    if (!plan.collectLeaves().forall(_.isInstanceOf[QueryStageExec])) {
       // If not all leaf nodes are query stages, it's not safe to reduce the number of
       // shuffle partitions, because we may break the assumption that all children of a spark plan
       // have same number of output partitions.
       return plan
     }
 
-    def collectShuffleStages(plan: SparkPlan): Seq[ShuffleQueryStageExec] = plan match {
-      case stage: ShuffleQueryStageExec => Seq(stage)
-      case _ => plan.children.flatMap(collectShuffleStages)
+    def collectShuffleStageInfos(plan: SparkPlan): Seq[ShuffleStageInfo] = plan match {
+      case ShuffleStageInfo(stage, specs) => Seq(new ShuffleStageInfo(stage, specs))
+      case _ => plan.children.flatMap(collectShuffleStageInfos)
     }
 
-    val shuffleStages = collectShuffleStages(plan)
+    val shuffleStageInfos = collectShuffleStageInfos(plan)
     // ShuffleExchanges introduced by repartition do not support changing the number of partitions.
     // We change the number of partitions in the stage only if all the ShuffleExchanges support it.
-    if (!shuffleStages.forall(s => supportCoalesce(s.shuffle))) {
+    if (!shuffleStageInfos.forall(s => supportCoalesce(s.shuffleStage.shuffle))) {
       plan
     } else {
-      def insertCustomShuffleReader(partitionSpecs: Seq[ShufflePartitionSpec]): SparkPlan = {
-        // This transformation adds new nodes, so we must use `transformUp` here.
-        val stageIds = shuffleStages.map(_.id).toSet
-        plan.transformUp {
-          // even for shuffle exchange whose input RDD has 0 partition, we should still update its
-          // `partitionStartIndices`, so that all the leaf shuffles in a stage have the same
-          // number of output partitions.
-          case stage: ShuffleQueryStageExec if stageIds.contains(stage.id) =>
-            CustomShuffleReaderExec(stage, partitionSpecs)
-        }
-      }
+      // We fall back to Spark default parallelism if the minimum number of coalesced partitions
+      // is not set, so to avoid perf regressions compared to no coalescing.
+      val minPartitionNum = conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM)
+        .getOrElse(session.sparkContext.defaultParallelism)
+      val newPartitionSpecs = ShufflePartitionsUtil.coalescePartitions(
+        shuffleStageInfos.map(_.shuffleStage.mapStats),
+        shuffleStageInfos.map(_.partitionSpecs),
+        advisoryTargetSize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES),
+        minNumPartitions = minPartitionNum)
 
-      // `ShuffleQueryStageExec#mapStats` returns None when the input RDD has 0 partitions,
-      // we should skip it when calculating the `partitionStartIndices`.
-      // If all input RDDs have 0 partition, we create empty partition for every shuffle reader.
-      val validMetrics = shuffleStages.flatMap(_.mapStats)
-
-      // We may have different pre-shuffle partition numbers, don't reduce shuffle partition number
-      // in that case. For example when we union fully aggregated data (data is arranged to a single
-      // partition) and a result of a SortMergeJoin (multiple partitions).
-      val distinctNumPreShufflePartitions =
-        validMetrics.map(stats => stats.bytesByPartitionId.length).distinct
-      if (validMetrics.isEmpty) {
-        insertCustomShuffleReader(ShufflePartitionsUtil.createEmptyPartition() :: Nil)
-      } else if (distinctNumPreShufflePartitions.length == 1) {
-        // We fall back to Spark default parallelism if the minimum number of coalesced partitions
-        // is not set, so to avoid perf regressions compared to no coalescing.
-        val minPartitionNum = conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM)
-          .getOrElse(session.sparkContext.defaultParallelism)
-        val partitionSpecs = ShufflePartitionsUtil.coalescePartitions(
-          validMetrics.toArray,
-          advisoryTargetSize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES),
-          minNumPartitions = minPartitionNum)
-        // We can never extend the shuffle partition number, so if we get the same number here,
-        // that means we can not coalesce shuffle partition. Just return the origin plan.
-        if (partitionSpecs.length == distinctNumPreShufflePartitions.head) {
-          plan
-        } else {
-          insertCustomShuffleReader(partitionSpecs)
-        }
+      if (newPartitionSpecs.nonEmpty) {
+        val specsMap = shuffleStageInfos.zip(newPartitionSpecs).map { case (stageInfo, partSpecs) =>
+          (stageInfo.shuffleStage.id, partSpecs)
+        }.toMap
+        updateShuffleReaders(plan, specsMap)
       } else {
         plan
       }
     }
   }
 
+  private def updateShuffleReaders(
+      plan: SparkPlan, specsMap: Map[Int, Seq[ShufflePartitionSpec]]): SparkPlan = plan match {
+    // Even for shuffle exchange whose input RDD has 0 partition, we should still update its
+    // `partitionStartIndices`, so that all the leaf shuffles in a stage have the same
+    // number of output partitions.
+    case ShuffleStageInfo(stage, _) =>
+      specsMap.get(stage.id).map { specs =>
+        CustomShuffleReaderExec(stage, specs)
+      }.getOrElse(plan)
+    case other => other.mapChildren(updateShuffleReaders(_, specsMap))
+  }
+
   private def supportCoalesce(s: ShuffleExchangeLike): Boolean = {
     s.outputPartitioning != SinglePartition && supportedShuffleOrigins.contains(s.shuffleOrigin)
+  }
+}
+
+private class ShuffleStageInfo(
+    val shuffleStage: ShuffleQueryStageExec,
+    val partitionSpecs: Option[Seq[ShufflePartitionSpec]])
+
+private object ShuffleStageInfo {
+  def unapply(plan: SparkPlan)
+  : Option[(ShuffleQueryStageExec, Option[Seq[ShufflePartitionSpec]])] = plan match {
+    case stage: ShuffleQueryStageExec =>
+      Some((stage, None))
+    case CustomShuffleReaderExec(s: ShuffleQueryStageExec, partitionSpecs) =>
+      Some((s, Some(partitionSpecs)))
+    case _ => None
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -204,7 +204,6 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
         noSkewPartitionSpec
       }
 
-      // A skewed partition should never be coalesced, but skip it here just to be safe.
       val rightParts = if (isRightSkew) {
         val skewSpecs = createSkewPartitionSpecs(
           right.mapStats.get.shuffleId, partitionIndex, rightTargetSize)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable
 
 import org.apache.commons.io.FileUtils
 
-import org.apache.spark.{MapOutputStatistics, MapOutputTrackerMaster, SparkEnv}
+import org.apache.spark.{MapOutputTrackerMaster, SparkEnv}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, EnsureRequirements, ShuffleExchangeExec, ShuffleOrigin}
@@ -48,9 +48,6 @@ import org.apache.spark.sql.internal.SQLConf
  * (L2-1, R2), (L2-2, R2),
  * (L3, R3-1), (L3, R3-2),
  * (L4-1, R4-1), (L4-2, R4-1), (L4-1, R4-2), (L4-2, R4-2)
- *
- * Note that, when this rule is enabled, it also coalesces non-skewed partitions like
- * `CoalesceShufflePartitions` does.
  */
 object OptimizeSkewedJoin extends CustomShuffleReaderRule {
 
@@ -71,9 +68,9 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
       size > conf.getConf(SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD)
   }
 
-  private def medianSize(stats: MapOutputStatistics): Long = {
-    val numPartitions = stats.bytesByPartitionId.length
-    val bytes = stats.bytesByPartitionId.sorted
+  private def medianSize(sizes: Array[Long]): Long = {
+    val numPartitions = sizes.length
+    val bytes = sizes.sorted
     numPartitions match {
       case _ if (numPartitions % 2 == 0) =>
         math.max((bytes(numPartitions / 2) + bytes(numPartitions / 2 - 1)) / 2, 1)
@@ -86,7 +83,7 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
    * to split skewed partitions is the average size of non-skewed partition, or the
    * advisory partition size if avg size is smaller than it.
    */
-  private def targetSize(sizes: Seq[Long], medianSize: Long): Long = {
+  private def targetSize(sizes: Array[Long], medianSize: Long): Long = {
     val advisorySize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES)
     val nonSkewSizes = sizes.filterNot(isSkewed(_, medianSize))
     if (nonSkewSizes.isEmpty) {
@@ -140,7 +137,7 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
     joinType == Inner || joinType == Cross || joinType == RightOuter
   }
 
-  private def getSizeInfo(medianSize: Long, sizes: Seq[Long]): String = {
+  private def getSizeInfo(medianSize: Long, sizes: Array[Long]): String = {
     s"median size: $medianSize, max size: ${sizes.max}, min size: ${sizes.min}, avg size: " +
       sizes.sum / sizes.length
   }
@@ -158,76 +155,68 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
    *    3 tasks separately.
    */
   private def tryOptimizeJoinChildren(
-      left: ShuffleStageInfo,
-      right: ShuffleStageInfo,
+      left: ShuffleQueryStageExec,
+      right: ShuffleQueryStageExec,
       joinType: JoinType): Option[(SparkPlan, SparkPlan)] = {
-    assert(left.partitionsWithSizes.length == right.partitionsWithSizes.length)
-    val numPartitions = left.partitionsWithSizes.length
+    val leftSizes = left.mapStats.get.bytesByPartitionId
+    val rightSizes = right.mapStats.get.bytesByPartitionId
+    assert(leftSizes.length == rightSizes.length)
+    val numPartitions = leftSizes.length
     // We use the median size of the original shuffle partitions to detect skewed partitions.
-    val leftMedSize = medianSize(left.mapStats)
-    val rightMedSize = medianSize(right.mapStats)
+    val leftMedSize = medianSize(leftSizes)
+    val rightMedSize = medianSize(rightSizes)
     logDebug(
       s"""
          |Optimizing skewed join.
          |Left side partitions size info:
-         |${getSizeInfo(leftMedSize, left.mapStats.bytesByPartitionId)}
+         |${getSizeInfo(leftMedSize, leftSizes)}
          |Right side partitions size info:
-         |${getSizeInfo(rightMedSize, right.mapStats.bytesByPartitionId)}
+         |${getSizeInfo(rightMedSize, rightSizes)}
       """.stripMargin)
+
     val canSplitLeft = canSplitLeftSide(joinType)
     val canSplitRight = canSplitRightSide(joinType)
-    // We use the actual partition sizes (may be coalesced) to calculate target size, so that
-    // the final data distribution is even (coalesced partitions + split partitions).
-    val leftActualSizes = left.partitionsWithSizes.map(_._2)
-    val rightActualSizes = right.partitionsWithSizes.map(_._2)
-    val leftTargetSize = targetSize(leftActualSizes, leftMedSize)
-    val rightTargetSize = targetSize(rightActualSizes, rightMedSize)
+    val leftTargetSize = targetSize(leftSizes, leftMedSize)
+    val rightTargetSize = targetSize(rightSizes, rightMedSize)
 
     val leftSidePartitions = mutable.ArrayBuffer.empty[ShufflePartitionSpec]
     val rightSidePartitions = mutable.ArrayBuffer.empty[ShufflePartitionSpec]
     var numSkewedLeft = 0
     var numSkewedRight = 0
     for (partitionIndex <- 0 until numPartitions) {
-      val leftActualSize = leftActualSizes(partitionIndex)
-      val isLeftSkew = isSkewed(leftActualSize, leftMedSize) && canSplitLeft
-      val leftPartSpec = left.partitionsWithSizes(partitionIndex)._1
-      val isLeftCoalesced = leftPartSpec.startReducerIndex + 1 < leftPartSpec.endReducerIndex
+      val leftSize = leftSizes(partitionIndex)
+      val isLeftSkew = isSkewed(leftSize, leftMedSize) && canSplitLeft
+      val rightSize = rightSizes(partitionIndex)
+      val isRightSkew = isSkewed(rightSize, rightMedSize) && canSplitRight
+      val noSkewPartitionSpec = Seq(CoalescedPartitionSpec(partitionIndex, partitionIndex + 1))
 
-      val rightActualSize = rightActualSizes(partitionIndex)
-      val isRightSkew = isSkewed(rightActualSize, rightMedSize) && canSplitRight
-      val rightPartSpec = right.partitionsWithSizes(partitionIndex)._1
-      val isRightCoalesced = rightPartSpec.startReducerIndex + 1 < rightPartSpec.endReducerIndex
-
-      // A skewed partition should never be coalesced, but skip it here just to be safe.
-      val leftParts = if (isLeftSkew && !isLeftCoalesced) {
-        val reducerId = leftPartSpec.startReducerIndex
+      val leftParts = if (isLeftSkew) {
         val skewSpecs = createSkewPartitionSpecs(
-          left.mapStats.shuffleId, reducerId, leftTargetSize)
+          left.mapStats.get.shuffleId, partitionIndex, leftTargetSize)
         if (skewSpecs.isDefined) {
           logDebug(s"Left side partition $partitionIndex " +
-            s"(${FileUtils.byteCountToDisplaySize(leftActualSize)}) is skewed, " +
+            s"(${FileUtils.byteCountToDisplaySize(leftSize)}) is skewed, " +
             s"split it into ${skewSpecs.get.length} parts.")
           numSkewedLeft += 1
         }
-        skewSpecs.getOrElse(Seq(leftPartSpec))
+        skewSpecs.getOrElse(noSkewPartitionSpec)
       } else {
-        Seq(leftPartSpec)
+        noSkewPartitionSpec
       }
 
       // A skewed partition should never be coalesced, but skip it here just to be safe.
-      val rightParts = if (isRightSkew && !isRightCoalesced) {
-        val reducerId = rightPartSpec.startReducerIndex
+      val rightParts = if (isRightSkew) {
         val skewSpecs = createSkewPartitionSpecs(
-          right.mapStats.shuffleId, reducerId, rightTargetSize)
+          right.mapStats.get.shuffleId, partitionIndex, rightTargetSize)
         if (skewSpecs.isDefined) {
           logDebug(s"Right side partition $partitionIndex " +
-            s"(${FileUtils.byteCountToDisplaySize(rightActualSize)}) is skewed, " +
+            s"(${FileUtils.byteCountToDisplaySize(rightSize)}) is skewed, " +
             s"split it into ${skewSpecs.get.length} parts.")
           numSkewedRight += 1
         }
-        skewSpecs.getOrElse(Seq(rightPartSpec))
+        skewSpecs.getOrElse(noSkewPartitionSpec)
       } else {
-        Seq(rightPartSpec)
+        noSkewPartitionSpec
       }
 
       for {
@@ -240,8 +229,8 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
     }
     logDebug(s"number of skewed partitions: left $numSkewedLeft, right $numSkewedRight")
     if (numSkewedLeft > 0 || numSkewedRight > 0) {
-      Some((CustomShuffleReaderExec(left.shuffleStage, leftSidePartitions.toSeq),
-        CustomShuffleReaderExec(right.shuffleStage, rightSidePartitions.toSeq)))
+      Some((CustomShuffleReaderExec(left, leftSidePartitions.toSeq),
+        CustomShuffleReaderExec(right, rightSidePartitions.toSeq)))
     } else {
       None
     }
@@ -249,8 +238,8 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
 
   def optimizeSkewJoin(plan: SparkPlan): SparkPlan = plan.transformUp {
     case smj @ SortMergeJoinExec(_, _, joinType, _,
-        s1 @ SortExec(_, _, ShuffleStage(left: ShuffleStageInfo), _),
-        s2 @ SortExec(_, _, ShuffleStage(right: ShuffleStageInfo), _), isSkewJoin)
+        s1 @ SortExec(_, _, ShuffleStage(left: ShuffleQueryStageExec), _),
+        s2 @ SortExec(_, _, ShuffleStage(right: ShuffleQueryStageExec), _), isSkewJoin)
         if !isSkewJoin && supportedJoinTypes.contains(joinType) =>
       val newChildren = tryOptimizeJoinChildren(left, right, joinType)
       if (newChildren.isDefined) {
@@ -262,8 +251,8 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
       }
 
     case shj @ ShuffledHashJoinExec(_, _, joinType, _, _,
-        ShuffleStage(left: ShuffleStageInfo),
-        ShuffleStage(right: ShuffleStageInfo), isSkewJoin)
+        ShuffleStage(left: ShuffleQueryStageExec),
+        ShuffleStage(right: ShuffleQueryStageExec), isSkewJoin)
         if !isSkewJoin && supportedJoinTypes.contains(joinType) =>
       val newChildren = tryOptimizeJoinChildren(left, right, joinType)
       if (newChildren.isDefined) {
@@ -313,41 +302,10 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
 }
 
 private object ShuffleStage {
-  def unapply(plan: SparkPlan): Option[ShuffleStageInfo] = plan match {
-    case s: ShuffleQueryStageExec
-        if s.mapStats.isDefined &&
-          OptimizeSkewedJoin.supportedShuffleOrigins.contains(s.shuffle.shuffleOrigin) =>
-      val mapStats = s.mapStats.get
-      val sizes = mapStats.bytesByPartitionId
-      val partitions = sizes.zipWithIndex.map {
-        case (size, i) => CoalescedPartitionSpec(i, i + 1) -> size
-      }
-      Some(ShuffleStageInfo(s, mapStats, partitions))
-
-    case CustomShuffleReaderExec(s: ShuffleQueryStageExec, partitionSpecs)
-        if s.mapStats.isDefined && partitionSpecs.nonEmpty &&
-          OptimizeSkewedJoin.supportedShuffleOrigins.contains(s.shuffle.shuffleOrigin) =>
-      val mapStats = s.mapStats.get
-      val sizes = mapStats.bytesByPartitionId
-      val partitions = partitionSpecs.map {
-        case spec @ CoalescedPartitionSpec(start, end) =>
-          var sum = 0L
-          var i = start
-          while (i < end) {
-            sum += sizes(i)
-            i += 1
-          }
-          spec -> sum
-        case other => throw new IllegalArgumentException(
-          s"Expect CoalescedPartitionSpec but got $other")
-      }
-      Some(ShuffleStageInfo(s, mapStats, partitions))
-
+  def unapply(plan: SparkPlan): Option[ShuffleQueryStageExec] = plan match {
+    case s: ShuffleQueryStageExec if s.mapStats.isDefined &&
+        OptimizeSkewedJoin.supportedShuffleOrigins.contains(s.shuffle.shuffleOrigin) =>
+      Some(s)
     case _ => None
   }
 }
-
-private case class ShuffleStageInfo(
-    shuffleStage: ShuffleQueryStageExec,
-    mapStats: MapOutputStatistics,
-    partitionsWithSizes: Seq[(CoalescedPartitionSpec, Long)])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -176,7 +176,7 @@ object ShufflePartitionsUtil extends Logging {
     }
     // only return coalesced result if any coalescing has happened.
     if (newPartitionSpecsSeq.head.length < numPartitions) {
-      newPartitionSpecsSeq.toSeq
+      newPartitionSpecsSeq.map(_.toSeq)
     } else {
       Seq.empty
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -21,16 +21,160 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.MapOutputStatistics
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.execution.{CoalescedPartitionSpec, ShufflePartitionSpec}
+import org.apache.spark.sql.execution.{CoalescedPartitionSpec, PartialReducerPartitionSpec, ShufflePartitionSpec}
 
 object ShufflePartitionsUtil extends Logging {
   final val SMALL_PARTITION_FACTOR = 0.2
   final val MERGED_PARTITION_FACTOR = 1.2
 
   /**
-   * Coalesce the partitions from multiple shuffles. This method assumes that all the shuffles
-   * have the same number of partitions, and the partitions of same index will be read together
-   * by one task.
+   * Coalesce the partitions from multiple shuffles, either in their original states, or applied
+   * with skew handling partition specs. If called on partitions containing skew partition specs,
+   * this method will keep the skew partition specs intact and only coalesce the partitions outside
+   * the skew sections.
+   *
+   * This method will return an empty result if the shuffles have been coalesced already, or if
+   * they do not have the same number of partitions, or if the coalesced result is the same as the
+   * input partition layout.
+   *
+   * @return A sequence of sequence of [[ShufflePartitionSpec]]s, which each inner sequence as the
+   *         new partition specs for its corresponding shuffle after coalescing. If Nil is returned,
+   *         then no coalescing is applied.
+   */
+  def coalescePartitions(
+      mapOutputStatistics: Seq[Option[MapOutputStatistics]],
+      inputPartitionSpecs: Seq[Option[Seq[ShufflePartitionSpec]]],
+      advisoryTargetSize: Long,
+      minNumPartitions: Int): Seq[Seq[ShufflePartitionSpec]] = {
+    assert(mapOutputStatistics.length == inputPartitionSpecs.length)
+
+    if (mapOutputStatistics.isEmpty) {
+      return Seq.empty
+    }
+
+    // If `minNumPartitions` is very large, it is possible that we need to use a value less than
+    // `advisoryTargetSize` as the target size of a coalesced task.
+    val totalPostShuffleInputSize = mapOutputStatistics.flatMap(_.map(_.bytesByPartitionId.sum)).sum
+    // The max at here is to make sure that when we have an empty table, we only have a single
+    // coalesced partition.
+    // There is no particular reason that we pick 16. We just need a number to prevent
+    // `maxTargetSize` from being set to 0.
+    val maxTargetSize = math.max(
+      math.ceil(totalPostShuffleInputSize / minNumPartitions.toDouble).toLong, 16)
+    val targetSize = math.min(maxTargetSize, advisoryTargetSize)
+
+    val shuffleIds = mapOutputStatistics.flatMap(_.map(_.shuffleId)).mkString(", ")
+    logInfo(s"For shuffle($shuffleIds), advisory target size: $advisoryTargetSize, " +
+      s"actual target size $targetSize.")
+
+    val numShuffles = mapOutputStatistics.length
+    // `ShuffleQueryStageExec#mapStats` returns None when the input RDD has 0 partitions,
+    // we should skip it when calculating the `partitionStartIndices`.
+    val validMetrics = mapOutputStatistics.flatten
+
+    if (inputPartitionSpecs.forall(_.isEmpty)) {
+      // If all input RDDs have 0 partition, we create an empty partition for every shuffle reader.
+      if (validMetrics.isEmpty) {
+        return Seq.fill(numShuffles)(Seq(CoalescedPartitionSpec(0, 0)))
+      }
+
+      // We may have different pre-shuffle partition numbers, don't reduce shuffle partition number
+      // in that case. For example when we union fully aggregated data (data is arranged to a single
+      // partition) and a result of a SortMergeJoin (multiple partitions).
+      if (validMetrics.map(_.bytesByPartitionId.length).distinct.length > 1) {
+        return Seq.empty
+      }
+
+      val numPartitions = validMetrics.head.bytesByPartitionId.length
+      val newPartitionSpecs = coalescePartitions(
+        0, numPartitions, validMetrics, targetSize)
+      if (newPartitionSpecs.length < numPartitions) {
+        return Seq.fill(numShuffles)(newPartitionSpecs)
+      } else {
+        return Seq.empty
+      }
+    }
+
+    // Do not coalesce if any of the map output stats are missing or if not all shuffles have
+    // partition specs, which should not happen in practice.
+    if (!mapOutputStatistics.forall(_.isDefined) || !inputPartitionSpecs.forall(_.isDefined)) {
+      logWarning("Could not apply partition coalescing because of missing MapOutputStatistics " +
+        "or shuffle partition specs.")
+      return Seq.empty
+    }
+
+    // Extract the start indices of each partition spec. Give invalid index -1 to unexpected
+    // partition specs. When we reach here, it means skew join optimization has been applied.
+    val partitionIndicesSeq = inputPartitionSpecs.map(_.get.map {
+      case CoalescedPartitionSpec(start, end) if start + 1 == end => start
+      case PartialReducerPartitionSpec(reducerId, _, _, _) => reducerId
+      case _ => -1 // invalid
+    })
+
+    // There should be no unexpected partition specs and the start indices should be identical
+    // across all different shuffles.
+    assert(partitionIndicesSeq.distinct.length == 1 && partitionIndicesSeq.head.forall(_ >= 0),
+      s"Invalid shuffle partition specs: $inputPartitionSpecs")
+
+    // The indices may look like [0, 1, 2, 2, 2, 3, 4, 4, 5], and the repeated `2` and `4` mean
+    // skewed partitions.
+    val partitionIndices = partitionIndicesSeq.head
+    val newPartitionSpecsSeq = Seq.fill(numShuffles)(ArrayBuffer.empty[ShufflePartitionSpec])
+    val numPartitions = partitionIndices.length
+    var i = 0
+    var start = 0
+    while (i < numPartitions) {
+      if (i > 0 && partitionIndices(i - 1) == partitionIndices(i)) {
+        // a skew section detected, starting from partition(i - 1).
+        val repeatValue = partitionIndices(i)
+        // coalesce any partitions before partition(i - 1) and after the end of latest skew section.
+        if (i - 1 > start) {
+          val partitionSpecs = coalescePartitions(
+            partitionIndices(start), repeatValue, validMetrics, targetSize)
+          newPartitionSpecsSeq.foreach(_ ++= partitionSpecs)
+        }
+        // find the end of this skew section, skipping partition(i - 1) and partition(i).
+        var repeatIndex = i + 1
+        while (repeatIndex < numPartitions && partitionIndices(repeatIndex) == repeatValue) {
+          repeatIndex += 1
+        }
+        // copy the partition specs in the skew section to the new partition specs.
+        newPartitionSpecsSeq.zip(inputPartitionSpecs).foreach { case (newSpecs, oldSpecs) =>
+          newSpecs ++= oldSpecs.get.slice(i - 1, repeatIndex)
+        }
+        // start from after the skew section
+        start = repeatIndex
+        i = repeatIndex
+      } else {
+        // The first index must be 0. Other indices outside of the skew section should be larger
+        // than the previous one by 1.
+        if (i == 0) {
+          assert(partitionIndices(i) == 0)
+        } else {
+          assert(partitionIndices(i - 1) + 1 == partitionIndices(i))
+        }
+        // no skew section detected, advance to the next index.
+        i += 1
+      }
+    }
+    // coalesce any partitions after the end of last skew section.
+    if (numPartitions > start) {
+      val partitionSpecs = coalescePartitions(
+        partitionIndices(start), partitionIndices.last + 1, validMetrics, targetSize)
+      newPartitionSpecsSeq.foreach(_ ++= partitionSpecs)
+    }
+    // only return coalesced result if any coalescing has happened.
+    if (newPartitionSpecsSeq.head.length < numPartitions) {
+      newPartitionSpecsSeq
+    } else {
+      Seq.empty
+    }
+  }
+
+  /**
+   * Coalesce the partitions of [start, end) from multiple shuffles. This method assumes that all
+   * the shuffles have the same number of partitions, and the partitions of same index will be read
+   * together by one task.
    *
    * The strategy used to determine the number of coalesced partitions is described as follows.
    * To determine the number of coalesced partitions, we have a target size for a coalesced
@@ -53,44 +197,15 @@ object ShufflePartitionsUtil extends Logging {
    *          CoalescedPartitionSpec(0, 2), CoalescedPartitionSpec(2, 3) and
    *          CoalescedPartitionSpec(3, 5).
    */
-  def coalescePartitions(
-      mapOutputStatistics: Array[MapOutputStatistics],
-      advisoryTargetSize: Long,
-      minNumPartitions: Int): Seq[ShufflePartitionSpec] = {
-    // If `minNumPartitions` is very large, it is possible that we need to use a value less than
-    // `advisoryTargetSize` as the target size of a coalesced task.
-    val totalPostShuffleInputSize = mapOutputStatistics.map(_.bytesByPartitionId.sum).sum
-    // The max at here is to make sure that when we have an empty table, we only have a single
-    // coalesced partition.
-    // There is no particular reason that we pick 16. We just need a number to prevent
-    // `maxTargetSize` from being set to 0.
-    val maxTargetSize = math.max(
-      math.ceil(totalPostShuffleInputSize / minNumPartitions.toDouble).toLong, 16)
-    val targetSize = math.min(maxTargetSize, advisoryTargetSize)
-
-    val shuffleIds = mapOutputStatistics.map(_.shuffleId).mkString(", ")
-    logInfo(s"For shuffle($shuffleIds), advisory target size: $advisoryTargetSize, " +
-      s"actual target size $targetSize.")
-
-    // Make sure these shuffles have the same number of partitions.
-    val distinctNumShufflePartitions =
-      mapOutputStatistics.map(stats => stats.bytesByPartitionId.length).distinct
-    // The reason that we are expecting a single value of the number of shuffle partitions
-    // is that when we add Exchanges, we set the number of shuffle partitions
-    // (i.e. map output partitions) using a static setting, which is the value of
-    // `spark.sql.shuffle.partitions`. Even if two input RDDs are having different
-    // number of partitions, they will have the same number of shuffle partitions
-    // (i.e. map output partitions).
-    assert(
-      distinctNumShufflePartitions.length == 1,
-      "There should be only one distinct value of the number of shuffle partitions " +
-        "among registered Exchange operators.")
-
-    val numPartitions = distinctNumShufflePartitions.head
-    val partitionSpecs = ArrayBuffer[CoalescedPartitionSpec]()
-    var latestSplitPoint = 0
+  private def coalescePartitions(
+      start: Int,
+      end: Int,
+      mapOutputStatistics: Seq[MapOutputStatistics],
+      targetSize: Long): Seq[CoalescedPartitionSpec] = {
+    val partitionSpecs = ArrayBuffer.empty[CoalescedPartitionSpec]
     var coalescedSize = 0L
-    var i = 0
+    var i = start
+    var latestSplitPoint = i
 
     def createPartitionSpec(forceCreate: Boolean = false): Unit = {
       // Skip empty inputs, as it is a waste to launch an empty task.
@@ -99,7 +214,7 @@ object ShufflePartitionsUtil extends Logging {
       }
     }
 
-    while (i < numPartitions) {
+    while (i < end) {
       // We calculate the total size of i-th shuffle partitions from all shuffles.
       var totalSizeOfCurrentPartition = 0L
       var j = 0
@@ -123,10 +238,6 @@ object ShufflePartitionsUtil extends Logging {
     // Create at least one partition if all partitions are empty.
     createPartitionSpec(partitionSpecs.isEmpty)
     partitionSpecs.toSeq
-  }
-
-  def createEmptyPartition(): ShufflePartitionSpec = {
-    CoalescedPartitionSpec(0, 0)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -176,7 +176,7 @@ object ShufflePartitionsUtil extends Logging {
     }
     // only return coalesced result if any coalescing has happened.
     if (newPartitionSpecsSeq.head.length < numPartitions) {
-      newPartitionSpecsSeq
+      newPartitionSpecsSeq.toSeq
     } else {
       Seq.empty
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
@@ -283,6 +283,12 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
     }
   }
 
+  test("return Nil if cannot coalesce") {
+    val targetSize = 100
+    val bytesByPartitionId = Array[Long](110, 120, 130)
+    checkEstimation(Array(bytesByPartitionId), Nil, targetSize)
+  }
+
   test("coalesce after skew splitting") {
     val targetSize = 100
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
@@ -29,13 +29,14 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       minNumPartitions: Int = 1): Unit = {
     val mapOutputStatistics = bytesByPartitionIdArray.zipWithIndex.map {
       case (bytesByPartitionId, index) =>
-        new MapOutputStatistics(index, bytesByPartitionId)
+        Some(new MapOutputStatistics(index, bytesByPartitionId))
     }
     val estimatedPartitionStartIndices = ShufflePartitionsUtil.coalescePartitions(
       mapOutputStatistics,
+      Seq.fill(mapOutputStatistics.length)(None),
       targetSize,
       minNumPartitions)
-    assert(estimatedPartitionStartIndices === expectedPartitionStartIndices)
+    assert(estimatedPartitionStartIndices.forall(_ === expectedPartitionStartIndices))
   }
 
   test("1 shuffle") {
@@ -92,12 +93,15 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
 
     {
       // If there are multiple values of the number of shuffle partitions,
-      // we should see an assertion error.
+      // we should return empty coalesced result.
       val bytesByPartitionId1 = Array[Long](0, 0, 0, 0, 0)
       val bytesByPartitionId2 = Array[Long](0, 0, 0, 0, 0, 0)
-      intercept[AssertionError] {
-        checkEstimation(Array(bytesByPartitionId1, bytesByPartitionId2), Seq.empty, targetSize)
-      }
+      val coalesced = ShufflePartitionsUtil.coalescePartitions(
+        Array(
+          Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+          Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+        Seq.fill(2)(None), targetSize, 1)
+      assert(coalesced.isEmpty)
     }
 
     {
@@ -276,6 +280,333 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
         Array(bytesByPartitionId1, bytesByPartitionId2),
         expectedPartitionSpecs,
         targetSize, minNumPartitions)
+    }
+  }
+
+  test("coalesce after skew splitting") {
+    val targetSize = 100
+
+    {
+      // Skew sections in the middle.
+      val bytesByPartitionId1 = Array[Long](10, 5, 300, 10, 8, 10, 10, 20)
+      val bytesByPartitionId2 = Array[Long](10, 10, 10, 8, 10, 200, 7, 20)
+      val specs1 =
+        Seq.tabulate(2)(i => CoalescedPartitionSpec(i, i + 1)) ++ // 0, 1
+        Seq.tabulate(3)(i => PartialReducerPartitionSpec(2, i, i + 1, 100L)) ++ // 2 - skew
+        Seq.tabulate(2)(i => CoalescedPartitionSpec(i + 3, i + 4)) ++ // 3, 4
+        Seq.fill(2)(CoalescedPartitionSpec(5, 6)) ++ // 5 - other side skew
+        Seq.tabulate(2)(i => CoalescedPartitionSpec(i + 6, i + 7)) // 6, 7
+      val specs2 =
+        Seq.tabulate(2)(i => CoalescedPartitionSpec(i, i + 1)) ++ // 0, 1
+        Seq.fill(3)(CoalescedPartitionSpec(2, 3)) ++ // 2 - other side skew
+        Seq.tabulate(2)(i => CoalescedPartitionSpec(i + 3, i + 4)) ++ // 3, 4
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(5, i, i + 1, 100L)) ++ // 5 - skew
+        Seq.tabulate(2)(i => CoalescedPartitionSpec(i + 6, i + 7)) // 6, 7
+      val expected1 =
+        Seq(CoalescedPartitionSpec(0, 2)) ++ // 0, 1 - coalesced
+        Seq.tabulate(3)(i => PartialReducerPartitionSpec(2, i, i + 1, 100L)) ++ // 2 - skew
+        Seq(CoalescedPartitionSpec(3, 5)) ++ // 3, 4 - coalesced
+        Seq.fill(2)(CoalescedPartitionSpec(5, 6)) ++ // 5 - other side skew
+        Seq(CoalescedPartitionSpec(6, 8)) // 6, 7 - coalesced
+      val expected2 =
+        Seq(CoalescedPartitionSpec(0, 2)) ++ // 0, 1 - coalesced
+        Seq.fill(3)(CoalescedPartitionSpec(2, 3)) ++ // 2 - other side skew
+        Seq(CoalescedPartitionSpec(3, 5)) ++ // 3, 4 - coalesced
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(5, i, i + 1, 100L)) ++ // 5 - skew
+        Seq(CoalescedPartitionSpec(6, 8)) // 6, 7 - coalesced
+      val coalesced = ShufflePartitionsUtil.coalescePartitions(
+        Array(
+          Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+          Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+        Seq(
+          Some(specs1),
+          Some(specs2)),
+        targetSize, 1)
+      assert(coalesced == Seq(expected1, expected2))
+    }
+
+    {
+      // Skew sections at both ends.
+      val bytesByPartitionId1 = Array[Long](300, 5, 10, 10, 8, 10, 10, 20)
+      val bytesByPartitionId2 = Array[Long](10, 10, 10, 8, 10, 20, 7, 200)
+      val specs1 =
+        Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
+        Seq.tabulate(6)(i => CoalescedPartitionSpec(i + 1, i + 2)) ++ // 1, 2, 3, 4, 5, 6
+        Seq.fill(2)(CoalescedPartitionSpec(7, 8)) // 7 - other side skew
+      val specs2 =
+        Seq.fill(3)(CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
+        Seq.tabulate(6)(i => CoalescedPartitionSpec(i + 1, i + 2)) ++ // 1, 2, 3, 4, 5, 6
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(7, i, i + 1, 100L)) // 7 - skew
+      val expected1 =
+        Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
+        Seq(CoalescedPartitionSpec(1, 5)) ++ // 1, 2, 3, 4 - coalesced
+        Seq(CoalescedPartitionSpec(5, 7)) ++ // 6, 7 - coalesced
+        Seq.fill(2)(CoalescedPartitionSpec(7, 8)) // 7 - other side skew
+      val expected2 =
+        Seq.fill(3)(CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
+        Seq(CoalescedPartitionSpec(1, 5)) ++ // 1, 2, 3, 4 - coalesced
+        Seq(CoalescedPartitionSpec(5, 7)) ++ // 6, 7 - coalesced
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(7, i, i + 1, 100L)) // 7 - skew
+      val coalesced = ShufflePartitionsUtil.coalescePartitions(
+        Array(
+          Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+          Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+        Seq(
+          Some(specs1),
+          Some(specs2)),
+        targetSize, 1)
+      assert(coalesced == Seq(expected1, expected2))
+    }
+
+    {
+      // Back-to-back skew sections.
+      val bytesByPartitionId1 = Array[Long](300, 50, 10, 10, 8, 10, 400, 200)
+      val bytesByPartitionId2 = Array[Long](10, 500, 10, 8, 10, 20, 7, 20)
+      val specs1 =
+        Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
+        Seq.fill(5)(CoalescedPartitionSpec(1, 2)) ++ // 1 - other side skew
+        Seq.tabulate(4)(i => CoalescedPartitionSpec(i + 2, i + 3)) ++ // 2, 3, 4, 5
+        Seq.tabulate(4)(i => PartialReducerPartitionSpec(6, i, i + 1, 100L)) ++ // 6 - skew
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(7, i, i + 1, 100L)) // 7 - skew
+      val specs2 =
+        Seq.fill(3)(CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
+        Seq.tabulate(5)(i => PartialReducerPartitionSpec(1, i, i + 1, 100L)) ++ // 1 - skew
+        Seq.tabulate(4)(i => CoalescedPartitionSpec(i + 2, i + 3)) ++ // 2, 3, 4, 5
+        Seq.fill(4)(CoalescedPartitionSpec(6, 7)) ++ // 6 - other side skew
+        Seq.fill(2)(CoalescedPartitionSpec(7, 8)) // 7 - other side skew
+      val expected1 =
+        Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
+        Seq.fill(5)(CoalescedPartitionSpec(1, 2)) ++ // 1 - other side skew
+        Seq(CoalescedPartitionSpec(2, 6)) ++ // 2, 3, 4, 5 - coalesced
+        Seq.tabulate(4)(i => PartialReducerPartitionSpec(6, i, i + 1, 100L)) ++ // 6 - skew
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(7, i, i + 1, 100L)) // 7 - skew
+      val expected2 =
+        Seq.fill(3)(CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
+        Seq.tabulate(5)(i => PartialReducerPartitionSpec(1, i, i + 1, 100L)) ++ // 1 - skew
+        Seq(CoalescedPartitionSpec(2, 6)) ++ // 2, 3, 4, 5 - coalesced
+        Seq.fill(4)(CoalescedPartitionSpec(6, 7)) ++ // 6 - other side skew
+        Seq.fill(2)(CoalescedPartitionSpec(7, 8)) // 7 - other side skew
+      val coalesced = ShufflePartitionsUtil.coalescePartitions(
+        Array(
+          Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+          Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+        Seq(
+          Some(specs1),
+          Some(specs2)),
+        targetSize, 1)
+      assert(coalesced == Seq(expected1, expected2))
+    }
+
+    {
+      // Singled out partitions in between skew sections and at the end.
+      val bytesByPartitionId1 = Array[Long](300, 16, 30, 10, 8, 10, 10, 20)
+      val bytesByPartitionId2 = Array[Long](10, 10, 500, 8, 10, 7, 200, 20)
+      val specs1 =
+        Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
+        Seq(CoalescedPartitionSpec(1, 2)) ++ // 1
+        Seq.fill(5)(CoalescedPartitionSpec(2, 3)) ++ // 2 - other side skew
+        Seq.tabulate(3)(i => CoalescedPartitionSpec(i + 3, i + 4)) ++ // 3, 4, 5
+        Seq.fill(2)(CoalescedPartitionSpec(6, 7)) ++ // 6 - other side skew
+        Seq(CoalescedPartitionSpec(7, 8)) // 7
+      val specs2 =
+        Seq.tabulate(3)(i => CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
+        Seq(CoalescedPartitionSpec(1, 2)) ++ // 1
+        Seq.tabulate(5)(i => PartialReducerPartitionSpec(2, i, i + 1, 100L)) ++ // 2- skew
+        Seq.tabulate(3)(i => CoalescedPartitionSpec(i + 3, i + 4)) ++ // 3, 4, 5
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(6, i, i + 1, 100L)) ++ // 6 - skew
+        Seq(CoalescedPartitionSpec(7, 8)) // 7
+      val expected1 =
+        Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
+        Seq(CoalescedPartitionSpec(1, 2)) ++ // 1
+        Seq.fill(5)(CoalescedPartitionSpec(2, 3)) ++ // 2 - other side skew
+        Seq(CoalescedPartitionSpec(3, 6)) ++ // 3, 4, 5 - coalesced
+        Seq.fill(2)(CoalescedPartitionSpec(6, 7)) ++ // 6 - other side skew
+        Seq(CoalescedPartitionSpec(7, 8)) // 7
+      val expected2 =
+        Seq.tabulate(3)(i => CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
+        Seq(CoalescedPartitionSpec(1, 2)) ++ // 1
+        Seq.tabulate(5)(i => PartialReducerPartitionSpec(2, i, i + 1, 100L)) ++ // 2- skew
+        Seq(CoalescedPartitionSpec(3, 6)) ++ // 3, 4, 5 - coalesced
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(6, i, i + 1, 100L)) ++ // 6 - skew
+        Seq(CoalescedPartitionSpec(7, 8)) // 7
+      val coalesced = ShufflePartitionsUtil.coalescePartitions(
+        Array(
+          Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+          Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+        Seq(
+          Some(specs1),
+          Some(specs2)),
+        targetSize, 1)
+      assert(coalesced == Seq(expected1, expected2))
+    }
+  }
+
+  test("coalesce after skew splitting - counter cases") {
+    val targetSize = 100
+
+    {
+      // If not all shuffles have shuffle partition specs, return empty result.
+      val bytesByPartitionId1 = Array[Long](10, 10, 10, 10, 10)
+      val bytesByPartitionId2 = Array[Long](10, 10, 10, 10, 10)
+      val specs1 = Seq.tabulate(5)(i => CoalescedPartitionSpec(i, i + 1))
+      val coalesced = ShufflePartitionsUtil.coalescePartitions(
+        Array(
+          Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+          Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+        Seq(
+          Some(specs1),
+          None),
+        targetSize, 1)
+      assert(coalesced.isEmpty)
+    }
+
+    {
+      // If not all shuffles have map output stats, return empty result.
+      val bytesByPartitionId1 = Array[Long](10, 10, 10, 10, 10)
+      val specs1 = Seq.tabulate(5)(i => CoalescedPartitionSpec(i, i + 1))
+      val specs2 = specs1
+      val coalesced = ShufflePartitionsUtil.coalescePartitions(
+        Array(
+          Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+          None),
+        Seq(
+          Some(specs1),
+          Some(specs2)),
+        targetSize, 1)
+      assert(coalesced.isEmpty)
+    }
+
+    {
+      // Assertion error if shuffle partition specs contain `CoalescedShuffleSpec` that has
+      // `end` - `start` > 1.
+      val bytesByPartitionId1 = Array[Long](10, 10, 10, 10, 10)
+      val bytesByPartitionId2 = Array[Long](10, 10, 10, 10, 10)
+      val specs1 = Seq(CoalescedPartitionSpec(0, 1), CoalescedPartitionSpec(1, 5))
+      val specs2 = specs1
+      intercept[AssertionError] {
+        ShufflePartitionsUtil.coalescePartitions(
+          Array(
+            Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+            Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+          Seq(
+            Some(specs1),
+            Some(specs2)),
+          targetSize, 1)
+      }
+    }
+
+    {
+      // Assertion error if shuffle partition specs contain `PartialMapperShuffleSpec`.
+      val bytesByPartitionId1 = Array[Long](10, 10, 10, 10, 10)
+      val bytesByPartitionId2 = Array[Long](10, 10, 10, 10, 10)
+      val specs1 = Seq(CoalescedPartitionSpec(0, 1), PartialMapperPartitionSpec(1, 0, 1))
+      val specs2 = specs1
+      intercept[AssertionError] {
+        ShufflePartitionsUtil.coalescePartitions(
+          Array(
+            Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+            Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+          Seq(
+            Some(specs1),
+            Some(specs2)),
+          targetSize, 1)
+      }
+    }
+
+    {
+      // Assertion error if partition specs of different shuffles have different lengths.
+      val bytesByPartitionId1 = Array[Long](10, 10, 10, 10, 10)
+      val bytesByPartitionId2 = Array[Long](10, 10, 10, 10, 10)
+      val specs1 = Seq.tabulate(4)(i => CoalescedPartitionSpec(i, i + 1)) ++
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(4, i, i + 1, 10L))
+      val specs2 = Seq.tabulate(5)(i => CoalescedPartitionSpec(i, i + 1))
+      intercept[AssertionError] {
+        ShufflePartitionsUtil.coalescePartitions(
+          Array(
+            Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+            Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+          Seq(
+            Some(specs1),
+            Some(specs2)),
+          targetSize, 1)
+      }
+    }
+
+    {
+      // Assertion error if start indices of partition specs are not identical among all shuffles.
+      val bytesByPartitionId1 = Array[Long](10, 10, 10, 10, 10)
+      val bytesByPartitionId2 = Array[Long](10, 10, 10, 10, 10)
+      val specs1 = Seq.tabulate(4)(i => CoalescedPartitionSpec(i, i + 1)) ++
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(4, i, i + 1, 10L))
+      val specs2 = Seq.tabulate(2)(i => CoalescedPartitionSpec(i, i + 1)) ++
+        Seq.tabulate(2)(i => PartialReducerPartitionSpec(2, i, i + 1, 10L)) ++
+        Seq.tabulate(2)(i => CoalescedPartitionSpec(i + 3, i + 4))
+      intercept[AssertionError] {
+        ShufflePartitionsUtil.coalescePartitions(
+          Array(
+            Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+            Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+          Seq(
+            Some(specs1),
+            Some(specs2)),
+          targetSize, 1)
+      }
+    }
+
+    {
+      // Assertion error if partition indices are out of order (in the beginning).
+      val bytesByPartitionId1 = Array[Long](10, 10, 10, 10, 10)
+      val bytesByPartitionId2 = Array[Long](10, 10, 10, 10, 10)
+      val specs1 = Seq.tabulate(4)(i => CoalescedPartitionSpec(i + 1, i + 2))
+      val specs2 = specs1
+      intercept[AssertionError] {
+        ShufflePartitionsUtil.coalescePartitions(
+          Array(
+            Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+            Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+          Seq(
+            Some(specs1),
+            Some(specs2)),
+          targetSize, 1)
+      }
+    }
+
+    {
+      // Assertion error if partition indices are out of order (before skew section).
+      val bytesByPartitionId1 = Array[Long](10, 10, 10, 10, 10)
+      val bytesByPartitionId2 = Array[Long](10, 10, 10, 10, 10)
+      val specs1 = (Seq.tabulate(2)(i => CoalescedPartitionSpec(i, i + 1)) :+
+        CoalescedPartitionSpec(0, 1)) ++ Seq.fill(3)(CoalescedPartitionSpec(2, 3))
+      val specs2 = specs1
+      intercept[AssertionError] {
+        ShufflePartitionsUtil.coalescePartitions(
+          Array(
+            Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+            Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+          Seq(
+            Some(specs1),
+            Some(specs2)),
+          targetSize, 1)
+      }
+    }
+
+    {
+      // Assertion error if partition indices are out of order (after skew section).
+      val bytesByPartitionId1 = Array[Long](10, 10, 10, 10, 10)
+      val bytesByPartitionId2 = Array[Long](10, 10, 10, 10, 10)
+      val specs1 = Seq.fill(2)(CoalescedPartitionSpec(0, 1)) ++
+        Seq.tabulate(2)(i => CoalescedPartitionSpec(i + 2, i + 3)) :+ CoalescedPartitionSpec(4, 5)
+      val specs2 = specs1
+      intercept[AssertionError] {
+        ShufflePartitionsUtil.coalescePartitions(
+          Array(
+            Some(new MapOutputStatistics(0, bytesByPartitionId1)),
+            Some(new MapOutputStatistics(1, bytesByPartitionId2))),
+          Seq(
+            Some(specs1),
+            Some(specs2)),
+          targetSize, 1)
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR improves the interaction between partition coalescing and skew handling by moving the skew join rule ahead of the partition coalescing rule and making corresponding changes to the two rules:
1. Simplify `OptimizeSkewedJoin` as it doesn't need to handle `CustomShuffleReaderExec` anymore.
2. Update `CoalesceShufflePartitions` to support coalescing non-skewed partitions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's a bit hard to reason about skew join if partitions have been coalesced. A skewed partition needs to be much larger than other partitions and we need to look at the raw sizes before coalescing.

It also makes `OptimizeSkewedJoin` more robust, as we don't need to worry about a skewed partition being coalesced with a small partition and breaks skew join handling.

It also helps with https://github.com/apache/spark/pull/31653 , which needs to move `OptimizeSkewedJoin` to an earlier phase and run before `CoalesceShufflePartitions`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new UT and existing tests