### PR TITLE
[SPARK-35456][CORE] Print the invalid value in config validation error message

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
@@ -104,7 +104,7 @@ private[spark] class TypedConfigBuilder[T](
   /** Checks if the user-provided value for the config matches the validator. */
   def checkValue(validator: T => Boolean, errorMsg: String): TypedConfigBuilder[T] = {
     transform { v =>
-      if (!validator(v)) throw new IllegalArgumentException(errorMsg)
+      if (!validator(v)) throw new IllegalArgumentException(s"'$v' is invalid. $errorMsg")
       v
     }
   }

--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
@@ -104,7 +104,7 @@ private[spark] class TypedConfigBuilder[T](
   /** Checks if the user-provided value for the config matches the validator. */
   def checkValue(validator: T => Boolean, errorMsg: String): TypedConfigBuilder[T] = {
     transform { v =>
-      if (!validator(v)) throw new IllegalArgumentException(s"'$v' is invalid. $errorMsg")
+      if (!validator(v)) throw new IllegalArgumentException(s"'$v' is invalid because: $errorMsg")
       v
     }
   }

--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala
@@ -104,7 +104,9 @@ private[spark] class TypedConfigBuilder[T](
   /** Checks if the user-provided value for the config matches the validator. */
   def checkValue(validator: T => Boolean, errorMsg: String): TypedConfigBuilder[T] = {
     transform { v =>
-      if (!validator(v)) throw new IllegalArgumentException(s"'$v' is invalid because: $errorMsg")
+      if (!validator(v)) {
+        throw new IllegalArgumentException(s"'$v' in ${parent.key} is invalid. $errorMsg")
+      }
       v
     }
   }

--- a/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
@@ -145,7 +145,7 @@ class ConfigEntrySuite extends SparkFunSuite {
     def createEntry(default: Int): ConfigEntry[Int] =
       ConfigBuilder(testKey("checkValue"))
         .intConf
-        .checkValue(value => value >= 0, "'-1' is invalid. value must be non-negative")
+        .checkValue(value => value >= 0, "value must be non-negative")
         .createWithDefault(default)
 
     val conf = new SparkConf()

--- a/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
@@ -145,7 +145,7 @@ class ConfigEntrySuite extends SparkFunSuite {
     def createEntry(default: Int): ConfigEntry[Int] =
       ConfigBuilder(testKey("checkValue"))
         .intConf
-        .checkValue(value => value >= 0, "value must be non-negative")
+        .checkValue(value => value >= 0, "'-1' is invalid. value must be non-negative")
         .createWithDefault(default)
 
     val conf = new SparkConf()
@@ -155,12 +155,12 @@ class ConfigEntrySuite extends SparkFunSuite {
     val e1 = intercept[IllegalArgumentException] {
       conf.get(entry)
     }
-    assert(e1.getMessage == "value must be non-negative")
+    assert(e1.getMessage == "'-1' is invalid. value must be non-negative")
 
     val e2 = intercept[IllegalArgumentException] {
       createEntry(-1)
     }
-    assert(e2.getMessage == "value must be non-negative")
+    assert(e2.getMessage == "'-1' is invalid. value must be non-negative")
   }
 
   test("conf entry: valid values check") {

--- a/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
@@ -155,12 +155,12 @@ class ConfigEntrySuite extends SparkFunSuite {
     val e1 = intercept[IllegalArgumentException] {
       conf.get(entry)
     }
-    assert(e1.getMessage == "'-1' is invalid. value must be non-negative")
+    assert(e1.getMessage == "'-1' is invalid because: value must be non-negative")
 
     val e2 = intercept[IllegalArgumentException] {
       createEntry(-1)
     }
-    assert(e2.getMessage == "'-1' is invalid. value must be non-negative")
+    assert(e2.getMessage == "'-1' is invalid because: value must be non-negative")
   }
 
   test("conf entry: valid values check") {

--- a/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
@@ -155,12 +155,14 @@ class ConfigEntrySuite extends SparkFunSuite {
     val e1 = intercept[IllegalArgumentException] {
       conf.get(entry)
     }
-    assert(e1.getMessage == "'-1' is invalid because: value must be non-negative")
+    assert(e1.getMessage ===
+      s"'-1' in ${testKey("checkValue")} is invalid. value must be non-negative")
 
     val e2 = intercept[IllegalArgumentException] {
       createEntry(-1)
     }
-    assert(e2.getMessage == "'-1' is invalid because: value must be non-negative")
+    assert(e2.getMessage ===
+      s"'-1' in ${testKey("checkValue")} is invalid. value must be non-negative")
   }
 
   test("conf entry: valid values check") {

--- a/sql/core/src/test/resources/sql-tests/results/timezone.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timezone.sql.out
@@ -62,7 +62,7 @@ SET TIME ZONE 'invalid/zone'
 struct<>
 -- !query output
 java.lang.IllegalArgumentException
-Cannot resolve the given timezone with ZoneId.of(_, ZoneId.SHORT_IDS)
+'invalid/zone' is invalid. Cannot resolve the given timezone with ZoneId.of(_, ZoneId.SHORT_IDS)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/timezone.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timezone.sql.out
@@ -62,7 +62,7 @@ SET TIME ZONE 'invalid/zone'
 struct<>
 -- !query output
 java.lang.IllegalArgumentException
-'invalid/zone' is invalid. Cannot resolve the given timezone with ZoneId.of(_, ZoneId.SHORT_IDS)
+'invalid/zone' is invalid because: Cannot resolve the given timezone with ZoneId.of(_, ZoneId.SHORT_IDS)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/timezone.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timezone.sql.out
@@ -62,7 +62,7 @@ SET TIME ZONE 'invalid/zone'
 struct<>
 -- !query output
 java.lang.IllegalArgumentException
-'invalid/zone' is invalid because: Cannot resolve the given timezone with ZoneId.of(_, ZoneId.SHORT_IDS)
+'invalid/zone' in spark.sql.session.timeZone is invalid. Cannot resolve the given timezone with ZoneId.of(_, ZoneId.SHORT_IDS)
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfEntrySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfEntrySuite.scala
@@ -185,12 +185,12 @@ class SQLConfEntrySuite extends SparkFunSuite {
     val e1 = intercept[IllegalArgumentException] {
       conf.getConf(confEntry)
     }
-    assert(e1.getMessage === "The maximum size of the cache must not be negative")
+    assert(e1.getMessage === "'-1' is invalid. The maximum size of the cache must not be negative")
 
     val e2 = intercept[IllegalArgumentException] {
       conf.setConfString(confEntry.key, "-1")
     }
-    assert(e2.getMessage === "The maximum size of the cache must not be negative")
+    assert(e2.getMessage === "'-1' is invalid. The maximum size of the cache must not be negative")
   }
 
   test("clone SQLConf") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfEntrySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfEntrySuite.scala
@@ -185,12 +185,14 @@ class SQLConfEntrySuite extends SparkFunSuite {
     val e1 = intercept[IllegalArgumentException] {
       conf.getConf(confEntry)
     }
-    assert(e1.getMessage === "'-1' is invalid. The maximum size of the cache must not be negative")
+    assert(e1.getMessage ===
+      "'-1' is invalid because: The maximum size of the cache must not be negative")
 
     val e2 = intercept[IllegalArgumentException] {
       conf.setConfString(confEntry.key, "-1")
     }
-    assert(e2.getMessage === "'-1' is invalid. The maximum size of the cache must not be negative")
+    assert(e2.getMessage ===
+      "'-1' is invalid because: The maximum size of the cache must not be negative")
   }
 
   test("clone SQLConf") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfEntrySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfEntrySuite.scala
@@ -185,14 +185,14 @@ class SQLConfEntrySuite extends SparkFunSuite {
     val e1 = intercept[IllegalArgumentException] {
       conf.getConf(confEntry)
     }
-    assert(e1.getMessage ===
-      "'-1' is invalid because: The maximum size of the cache must not be negative")
+    assert(e1.getMessage === s"'-1' in ${confEntry.key} is invalid." +
+      s" The maximum size of the cache must not be negative")
 
     val e2 = intercept[IllegalArgumentException] {
       conf.setConfString(confEntry.key, "-1")
     }
-    assert(e2.getMessage ===
-      "'-1' is invalid because: The maximum size of the cache must not be negative")
+    assert(e2.getMessage === s"'-1' in ${confEntry.key} is invalid." +
+      s" The maximum size of the cache must not be negative")
   }
 
   test("clone SQLConf") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -438,7 +438,8 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     val e = intercept[IllegalArgumentException] {
       spark.conf.set(SQLConf.SESSION_LOCAL_TIMEZONE.key, "Asia/shanghai")
     }
-    assert(e.getMessage === "Cannot resolve the given timezone with ZoneId.of(_, ZoneId.SHORT_IDS)")
+    assert(e.getMessage === "'Asia/shanghai' is invalid. Cannot resolve the given timezone" +
+      " with ZoneId.of(_, ZoneId.SHORT_IDS)")
   }
 
   test("set time zone") {
@@ -450,7 +451,7 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     assert(spark.conf.get(SQLConf.SESSION_LOCAL_TIMEZONE) === TimeZone.getDefault.getID)
 
     val e1 = intercept[IllegalArgumentException](sql("set time zone 'invalid'"))
-    assert(e1.getMessage === "Cannot resolve the given timezone with" +
+    assert(e1.getMessage === "'invalid' is invalid. Cannot resolve the given timezone with" +
       " ZoneId.of(_, ZoneId.SHORT_IDS)")
 
     (-18 to 18).map(v => (v, s"interval '$v' hours")).foreach { case (i, interval) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -438,8 +438,9 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     val e = intercept[IllegalArgumentException] {
       spark.conf.set(SQLConf.SESSION_LOCAL_TIMEZONE.key, "Asia/shanghai")
     }
-    assert(e.getMessage === "'Asia/shanghai' is invalid because: Cannot resolve the given" +
-      " timezone with ZoneId.of(_, ZoneId.SHORT_IDS)")
+    assert(e.getMessage ===
+      s"'Asia/shanghai' in ${SQLConf.SESSION_LOCAL_TIMEZONE.key} is invalid." +
+        " Cannot resolve the given timezone with ZoneId.of(_, ZoneId.SHORT_IDS)")
   }
 
   test("set time zone") {
@@ -451,8 +452,8 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     assert(spark.conf.get(SQLConf.SESSION_LOCAL_TIMEZONE) === TimeZone.getDefault.getID)
 
     val e1 = intercept[IllegalArgumentException](sql("set time zone 'invalid'"))
-    assert(e1.getMessage === "'invalid' is invalid because: Cannot resolve the given timezone" +
-      " with ZoneId.of(_, ZoneId.SHORT_IDS)")
+    assert(e1.getMessage === s"'invalid' in ${SQLConf.SESSION_LOCAL_TIMEZONE.key} is invalid." +
+      " Cannot resolve the given timezone with ZoneId.of(_, ZoneId.SHORT_IDS)")
 
     (-18 to 18).map(v => (v, s"interval '$v' hours")).foreach { case (i, interval) =>
       sql(s"set time zone $interval")

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -438,8 +438,8 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     val e = intercept[IllegalArgumentException] {
       spark.conf.set(SQLConf.SESSION_LOCAL_TIMEZONE.key, "Asia/shanghai")
     }
-    assert(e.getMessage === "'Asia/shanghai' is invalid. Cannot resolve the given timezone" +
-      " with ZoneId.of(_, ZoneId.SHORT_IDS)")
+    assert(e.getMessage === "'Asia/shanghai' is invalid because: Cannot resolve the given" +
+      " timezone with ZoneId.of(_, ZoneId.SHORT_IDS)")
   }
 
   test("set time zone") {
@@ -451,8 +451,8 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     assert(spark.conf.get(SQLConf.SESSION_LOCAL_TIMEZONE) === TimeZone.getDefault.getID)
 
     val e1 = intercept[IllegalArgumentException](sql("set time zone 'invalid'"))
-    assert(e1.getMessage === "'invalid' is invalid. Cannot resolve the given timezone with" +
-      " ZoneId.of(_, ZoneId.SHORT_IDS)")
+    assert(e1.getMessage === "'invalid' is invalid because: Cannot resolve the given timezone" +
+      " with ZoneId.of(_, ZoneId.SHORT_IDS)")
 
     (-18 to 18).map(v => (v, s"interval '$v' hours")).foreach { case (i, interval) =>
       sql(s"set time zone $interval")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Print the invalid value in config validation error message for `checkValue` just like `checkValues`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Invalid configuration values may come in many ways, this PR can help different kinds of users or developers to identify what the config the error is related to

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, but only error msg
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
yes, modified tests