### PR TITLE
[SPARK-35458][BUILD] Use ` > /dev/null` to replace `-q` in shasum

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -78,7 +78,7 @@ install_app() {
       echo "  ${local_tarball}" >> ${local_checksum} # two spaces + file are important!
       # Assuming SHA512 here for now
       echo "Veryfing checksum from ${local_checksum}" 1>&2
-      if ! shasum -a 512 -c "${local_checksum}" > /dev/null 2>&1 ; then
+      if ! shasum -a 512 -c "${local_checksum}" > /dev/null ; then
         echo "Bad checksum from ${remote_checksum}"
         exit 2
       fi

--- a/build/mvn
+++ b/build/mvn
@@ -78,7 +78,7 @@ install_app() {
       echo "  ${local_tarball}" >> ${local_checksum} # two spaces + file are important!
       # Assuming SHA512 here for now
       echo "Veryfing checksum from ${local_checksum}" 1>&2
-      if ! shasum -a 512 -q -c "${local_checksum}" ; then
+      if ! shasum -a 512 -c "${local_checksum}" > /dev/null 2>&1 ; then
         echo "Bad checksum from ${remote_checksum}"
         exit 2
       fi


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use ` > /dev/null` to replace `-q` in shasum validation.

### Why are the changes needed?
In PR https://github.com/apache/spark/pull/32505 , added the shasum check on maven. The `shasum -a 512 -q -c xxx.sha` is used to validate checksum, the `-q` args is for "don't print OK for each successfully verified file", but `-q` arg is introduce in shasum 6.x version.

So we got the `Unknown option: q`.

```
➜  ~ uname -a
Darwin MacBook.local 19.6.0 Darwin Kernel Version 19.6.0: Mon Apr 12 20:57:45 PDT 2021; root:xnu-6153.141.28.1~1/RELEASE_X86_64 x86_64
➜  ~ shasum -v
5.84
➜  ~ shasum -q
Unknown option: q
Type shasum -h for help
```

it makes ARM CI failed:
[1] https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-maven-arm/

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`shasum -a 512 -c wrong.sha  > /dev/null` return code 1 without print
`shasum -a 512 -c right.sha  > /dev/null` return code 0 without print
e2e test:
```
rm -f build/apache-maven-3.6.3-bin.tar.gz
rm -r build/apache-maven-3.6.3-bin
mvn -v
```