### PR TITLE
[SPARK-35373][BUILD][FOLLOWUP]Fix "binary operator expected" error on build/mvn

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -51,7 +51,7 @@ install_app() {
     # check if we already have the tarball
     # check if we have curl installed
     # download application
-    if [ ! -f "${local_tarball}" -a $(command -v curl) ]; then
+    if [ ! -f "${local_tarball}" -a "$(command -v curl)" ]; then
       echo "exec: curl ${curl_opts} ${remote_tarball}" 1>&2
       curl ${curl_opts} "${remote_tarball}" > "${local_tarball}"
       if [ ! -z "${checksum_suffix}" ]; then
@@ -60,7 +60,7 @@ install_app() {
       fi
     fi
     # if the file still doesn't exist, lets try `wget` and cross our fingers
-    if [ ! -f "${local_tarball}" -a $(command -v wget) ]; then
+    if [ ! -f "${local_tarball}" -a "$(command -v wget)" ]; then
       echo "exec: wget ${wget_opts} ${remote_tarball}" 1>&2
       wget ${wget_opts} -O "${local_tarball}" "${remote_tarball}"
       if [ ! -z "${checksum_suffix}" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?
change $(command -v curl) to "$(command -v curl)" 


### Why are the changes needed?
We need change $(command -v curl) to "$(command -v curl)" to make sure it work when `curl` or `wget` is uninstall. othewise raised:
`build/mvn: line 56: [: /root/spark/build/apache-maven-3.6.3-bin.tar.gz: binary operator expected`



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
```
apt remove curl
rm -f build/apache-maven-3.6.3-bin.tar.gz
rm -r build/apache-maven-3.6.3-bin
mvn -v
```