### PR TITLE
[SPARK-35314][PYTHON] Support arithmetic operations against bool IndexOpsMixin

### DIFF
--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -16,7 +16,7 @@
 #
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING, Union
 
 from pandas.api.types import CategoricalDtype
 
@@ -34,11 +34,24 @@ from pyspark.sql.types import (
     TimestampType,
 )
 
+import pyspark.sql.types as types
+from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.typedef import Dtype
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
+
+
+def transform_boolean_operand_to_numeric(operand: Any, spark_type: types.DataType) -> Any:
+    """Transform boolean operand to the given numeric spark_type.
+
+    Return the transformed operand if the operand is boolean, otherwise return the original operand.
+    """
+    if isinstance(operand, IndexOpsMixin) and isinstance(operand.spark.data_type, BooleanType):
+        return operand.spark.transform(lambda scol: scol.cast(spark_type))
+    else:
+        return operand
 
 
 class DataTypeOps(object, metaclass=ABCMeta):

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -46,7 +46,8 @@ if TYPE_CHECKING:
 def transform_boolean_operand_to_numeric(operand: Any, spark_type: types.DataType) -> Any:
     """Transform boolean operand to the given numeric spark_type.
 
-    Return the transformed operand if the operand is boolean, otherwise return the original operand.
+    Return the transformed operand if the operand is a boolean IndexOpsMixin,
+    otherwise return the original operand.
     """
     if isinstance(operand, IndexOpsMixin) and isinstance(operand.spark.data_type, BooleanType):
         return operand.spark.transform(lambda scol: scol.cast(spark_type))

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -39,7 +39,6 @@ from pyspark.sql.types import (
 import pyspark.sql.types as types
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.typedef import Dtype
-from pyspark.sql.column import Column
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -61,7 +60,7 @@ def is_valid_operand_for_numeric_arithmetic(
             return isinstance(operand.spark.data_type, NumericType) or (
                 allow_bool and isinstance(operand.spark.data_type, BooleanType))
     else:
-        return isinstance(operand, Column)
+        return False
 
 
 def transform_boolean_operand_to_numeric(operand: Any, spark_type: types.DataType) -> Any:

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -47,8 +47,9 @@ if TYPE_CHECKING:
 
 
 def is_valid_operand_for_numeric_arithmetic(
-        operand: Any,
-        allow_bool_index_ops: bool = True
+    operand: Any,
+    *,
+    allow_bool: bool = True
 ) -> bool:
     """Check whether the operand is valid for arithmetic operations against numerics."""
     if isinstance(operand, numbers.Number) and not isinstance(operand, bool):
@@ -58,7 +59,7 @@ def is_valid_operand_for_numeric_arithmetic(
             return False
         else:
             return isinstance(operand.spark.data_type, NumericType) or (
-                allow_bool_index_ops and isinstance(operand.spark.data_type, BooleanType))
+                allow_bool and isinstance(operand.spark.data_type, BooleanType))
     else:
         return isinstance(operand, Column)
 

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -18,8 +18,11 @@
 import numbers
 from typing import TYPE_CHECKING, Union
 
-from pyspark.pandas.data_type_ops.base import DataTypeOps, transform_boolean_operand_to_numeric
-from pyspark.pandas.data_type_ops.num_ops import is_valid_operand_for_numeric_arithmetic
+from pyspark.pandas.data_type_ops.base import (
+    is_valid_operand_for_numeric_arithmetic,
+    DataTypeOps,
+    transform_boolean_operand_to_numeric,
+)
 from pyspark.pandas.typedef.typehints import as_spark_type
 
 if TYPE_CHECKING:
@@ -40,8 +43,8 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left + right
-        elif is_valid_operand_for_numeric_arithmetic(right):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left + right
         else:
             raise TypeError(
@@ -51,8 +54,8 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left - right
-        elif is_valid_operand_for_numeric_arithmetic(right):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left - right
         else:
             raise TypeError(
@@ -62,8 +65,8 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left * right
-        elif is_valid_operand_for_numeric_arithmetic(right):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left * right
         else:
             raise TypeError(
@@ -73,8 +76,8 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left / right
-        elif is_valid_operand_for_numeric_arithmetic(right):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left / right
         else:
             raise TypeError(
@@ -84,8 +87,8 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left // right
-        elif is_valid_operand_for_numeric_arithmetic(right):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left // right
         else:
             raise TypeError(
@@ -95,8 +98,8 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left % right
-        elif is_valid_operand_for_numeric_arithmetic(right):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left % right
         else:
             raise TypeError(
@@ -106,8 +109,8 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left ** right
-        elif is_valid_operand_for_numeric_arithmetic(right):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left ** right
         else:
             raise TypeError(

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -40,7 +40,7 @@ class BooleanOps(DataTypeOps):
         return 'booleans'
 
     def add(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left + right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
@@ -51,7 +51,7 @@ class BooleanOps(DataTypeOps):
                 "Addition can not be applied to %s and the given type." % self.pretty_name)
 
     def sub(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left - right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
@@ -62,7 +62,7 @@ class BooleanOps(DataTypeOps):
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name)
 
     def mul(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left * right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
@@ -73,7 +73,7 @@ class BooleanOps(DataTypeOps):
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name)
 
     def truediv(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left / right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
@@ -84,7 +84,7 @@ class BooleanOps(DataTypeOps):
                 "True division can not be applied to %s and the given type." % self.pretty_name)
 
     def floordiv(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left // right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
@@ -95,7 +95,7 @@ class BooleanOps(DataTypeOps):
                 "Floor division can not be applied to %s and the given type." % self.pretty_name)
 
     def mod(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left % right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
@@ -106,7 +106,7 @@ class BooleanOps(DataTypeOps):
                 "Modulo can not be applied to %s and the given type." % self.pretty_name)
 
     def pow(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left ** right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
@@ -117,7 +117,7 @@ class BooleanOps(DataTypeOps):
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name)
 
     def radd(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right + left
         else:
@@ -125,7 +125,7 @@ class BooleanOps(DataTypeOps):
                 "Addition can not be applied to %s and the given type." % self.pretty_name)
 
     def rsub(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right - left
         else:
@@ -133,7 +133,7 @@ class BooleanOps(DataTypeOps):
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name)
 
     def rmul(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right * left
         else:
@@ -141,7 +141,7 @@ class BooleanOps(DataTypeOps):
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name)
 
     def rtruediv(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right / left
         else:
@@ -149,7 +149,7 @@ class BooleanOps(DataTypeOps):
                 "True division can not be applied to %s and the given type." % self.pretty_name)
 
     def rfloordiv(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right // left
         else:
@@ -157,7 +157,7 @@ class BooleanOps(DataTypeOps):
                 "Floor division can not be applied to %s and the given type." % self.pretty_name)
 
     def rpow(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right ** left
         else:
@@ -165,7 +165,7 @@ class BooleanOps(DataTypeOps):
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name)
 
     def rmod(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number):
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right % left
         else:

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -50,7 +50,7 @@ class BooleanOps(DataTypeOps):
     def add(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return column_op(Column.__add__)(left, right)
+            return left + right
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return column_op(Column.__add__)(left, right)
@@ -61,7 +61,7 @@ class BooleanOps(DataTypeOps):
     def sub(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return column_op(Column.__sub__)(left, right)
+            return left - right
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return column_op(Column.__sub__)(left, right)
@@ -72,7 +72,7 @@ class BooleanOps(DataTypeOps):
     def mul(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return column_op(Column.__mul__)(left, right)
+            return left * right
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return column_op(Column.__mul__)(left, right)
@@ -90,7 +90,7 @@ class BooleanOps(DataTypeOps):
 
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return numpy_column_op(truediv)(left, right)
+            return left / right
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return numpy_column_op(truediv)(left, right)
@@ -112,7 +112,7 @@ class BooleanOps(DataTypeOps):
 
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return numpy_column_op(floordiv)(left, right)
+            return left // right
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return numpy_column_op(floordiv)(left, right)
@@ -126,7 +126,7 @@ class BooleanOps(DataTypeOps):
 
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return column_op(mod)(left, right)
+            return left % right
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return column_op(mod)(left, right)
@@ -140,7 +140,7 @@ class BooleanOps(DataTypeOps):
 
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return column_op(pow_func)(left, right)
+            return left ** right
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return column_op(pow_func)(left, right)

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -18,24 +18,13 @@
 import numbers
 from typing import TYPE_CHECKING, Union
 
-import numpy as np
-from pandas.api.types import CategoricalDtype
-
-from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op
 from pyspark.pandas.data_type_ops.base import DataTypeOps, transform_boolean_operand_to_numeric
+from pyspark.pandas.data_type_ops.num_ops import is_valid_operand_for_numeric_arithmetic
 from pyspark.pandas.typedef.typehints import as_spark_type
-from pyspark.sql import Column, functions as F
-from pyspark.sql.types import NumericType
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
-
-
-def is_numeric_index_ops(index_ops: IndexOpsMixin) -> bool:
-    """Check if the given index_ops is numeric IndexOpsMixin."""
-    return isinstance(index_ops.spark.data_type, NumericType) and (
-        not isinstance(index_ops.dtype, CategoricalDtype))
 
 
 class BooleanOps(DataTypeOps):
@@ -51,7 +40,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left + right
-        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+        elif is_valid_operand_for_numeric_arithmetic(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left + right
         else:
@@ -62,7 +51,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left - right
-        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+        elif is_valid_operand_for_numeric_arithmetic(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left - right
         else:
@@ -73,7 +62,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left * right
-        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+        elif is_valid_operand_for_numeric_arithmetic(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left * right
         else:
@@ -84,7 +73,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left / right
-        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+        elif is_valid_operand_for_numeric_arithmetic(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left / right
         else:
@@ -95,7 +84,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left // right
-        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+        elif is_valid_operand_for_numeric_arithmetic(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left // right
         else:
@@ -106,7 +95,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left % right
-        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+        elif is_valid_operand_for_numeric_arithmetic(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left % right
         else:
@@ -117,7 +106,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left ** right
-        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+        elif is_valid_operand_for_numeric_arithmetic(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left ** right
         else:

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -41,88 +41,89 @@ class BooleanOps(DataTypeOps):
         return 'booleans'
 
     def add(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number) and not isinstance(right, bool):
-            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return left + right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(
-                left, cast(IndexOpsMixin, right).spark.data_type)
-            return left + right
-        else:
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Addition can not be applied to %s and the given type." % self.pretty_name)
 
-    def sub(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return left - right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(
-                left, cast(IndexOpsMixin, right).spark.data_type)
-            return left - right
+            return left + right
         else:
+            assert isinstance(right, IndexOpsMixin)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            return left + right
+
+    def sub(self, left, right) -> Union["Series", "Index"]:
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name)
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
+            return left - right
+        else:
+            assert isinstance(right, IndexOpsMixin)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            return left - right
 
     def mul(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number) and not isinstance(right, bool):
-            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return left * right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(
-                left, cast(IndexOpsMixin, right).spark.data_type)
-            return left * right
-        else:
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name)
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
+            return left * right
+        else:
+            assert isinstance(right, IndexOpsMixin)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            return left * right
 
     def truediv(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number) and not isinstance(right, bool):
-            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return left / right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(
-                left, cast(IndexOpsMixin, right).spark.data_type)
-            return left / right
-        else:
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "True division can not be applied to %s and the given type." % self.pretty_name)
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
+            return left / right
+        else:
+            assert isinstance(right, IndexOpsMixin)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            return left / right
 
     def floordiv(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number) and not isinstance(right, bool):
-            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return left // right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(
-                left, cast(IndexOpsMixin, right).spark.data_type)
-            return left // right
-        else:
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Floor division can not be applied to %s and the given type." % self.pretty_name)
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
+            return left // right
+        else:
+            assert isinstance(right, IndexOpsMixin)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            return left // right
 
     def mod(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number) and not isinstance(right, bool):
-            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
-            return left % right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(
-                left, cast(IndexOpsMixin, right).spark.data_type)
-            return left % right
-        else:
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Modulo can not be applied to %s and the given type." % self.pretty_name)
+        if isinstance(right, numbers.Number) and not isinstance(right, bool):
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
+            return left % right
+        else:
+            assert isinstance(right, IndexOpsMixin)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            return left % right
 
     def pow(self, left, right) -> Union["Series", "Index"]:
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
+            raise TypeError(
+                "Exponentiation can not be applied to %s and the given type." % self.pretty_name)
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left ** right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(
-                left, cast(IndexOpsMixin, right).spark.data_type)
-            return left ** right
         else:
-            raise TypeError(
-                "Exponentiation can not be applied to %s and the given type." % self.pretty_name)
+            assert isinstance(right, IndexOpsMixin)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            return left ** right
 
     def radd(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -16,6 +16,7 @@
 #
 
 import numbers
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 from pandas.api.types import CategoricalDtype
@@ -26,8 +27,12 @@ from pyspark.pandas.typedef.typehints import as_spark_type
 from pyspark.sql import Column, functions as F
 from pyspark.sql.types import NumericType
 
+if TYPE_CHECKING:
+    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
-def is_numeric_index_ops(index_ops: IndexOpsMixin):
+
+def is_numeric_index_ops(index_ops: IndexOpsMixin) -> bool:
     """Check if the given index_ops is numeric IndexOpsMixin."""
     return isinstance(index_ops.spark.data_type, NumericType) and (
         not isinstance(index_ops.dtype, CategoricalDtype))
@@ -42,9 +47,9 @@ class BooleanOps(DataTypeOps):
     def pretty_name(self) -> str:
         return 'booleans'
 
-    def add(self, left, right):
+    def add(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(Column.__add__)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
@@ -53,9 +58,9 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "Addition can not be applied to %s and the given type." % self.pretty_name)
 
-    def sub(self, left, right):
+    def sub(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(Column.__sub__)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
@@ -64,9 +69,9 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name)
 
-    def mul(self, left, right):
+    def mul(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(Column.__mul__)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
@@ -75,7 +80,7 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name)
 
-    def truediv(self, left, right):
+    def truediv(self, left, right) -> Union["Series", "Index"]:
         def truediv(left, right):
             return F.when(F.lit(right != 0) | F.lit(right).isNull(), left.__div__(right)).otherwise(
                 F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
@@ -84,7 +89,7 @@ class BooleanOps(DataTypeOps):
             )
 
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return numpy_column_op(truediv)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
@@ -93,7 +98,7 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "True division can not be applied to %s and the given type." % self.pretty_name)
 
-    def floordiv(self, left, right):
+    def floordiv(self, left, right) -> Union["Series", "Index"]:
         def floordiv(left, right):
             return F.when(F.lit(right is np.nan), np.nan).otherwise(
                 F.when(
@@ -106,7 +111,7 @@ class BooleanOps(DataTypeOps):
             )
 
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return numpy_column_op(floordiv)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
@@ -115,12 +120,12 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "Floor division can not be applied to %s and the given type." % self.pretty_name)
 
-    def mod(self, left, right):
+    def mod(self, left, right) -> Union["Series", "Index"]:
         def mod(left, right):
             return ((left % right) + right) % right
 
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(mod)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
@@ -129,12 +134,12 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "Modulo can not be applied to %s and the given type." % self.pretty_name)
 
-    def pow(self, left, right):
+    def pow(self, left, right) -> Union["Series", "Index"]:
         def pow_func(left, right):
             return F.when(left == 1, left).otherwise(Column.__pow__(left, right))
 
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(pow_func)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
@@ -144,33 +149,33 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name)
 
-    def radd(self, left, right=None):
+    def radd(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(Column.__radd__)(left, right)
         else:
             raise TypeError(
                 "Addition can not be applied to %s and the given type." % self.pretty_name)
 
-    def rsub(self, left, right=None):
+    def rsub(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(Column.__rsub__)(left, right)
         else:
             raise TypeError(
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name)
 
-    def rmul(self, left, right=None):
+    def rmul(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(Column.__rmul__)(left, right)
         else:
             raise TypeError(
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name)
 
-    def rtruediv(self, left, right=None):
+    def rtruediv(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
 
             def rtruediv(left, right):
                 return F.when(left == 0, F.lit(np.inf).__div__(right)).otherwise(
@@ -182,9 +187,9 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "True division can not be applied to %s and the given type." % self.pretty_name)
 
-    def rfloordiv(self, left, right=None):
+    def rfloordiv(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
 
             def rfloordiv(left, right):
                 return F.when(F.lit(left == 0), F.lit(np.inf).__div__(right)).otherwise(
@@ -198,9 +203,9 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "Floor division can not be applied to %s and the given type." % self.pretty_name)
 
-    def rpow(self, left, right=None):
+    def rpow(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
 
             def rpow_func(left, right):
                 return F.when(F.lit(right == 1), right).otherwise(Column.__rpow__(left, right))
@@ -210,9 +215,9 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name)
 
-    def rmod(self, left, right=None):
+    def rmod(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, numbers.Number):
-            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
 
             def rmod(left, right):
                 return ((right % left) + left) % left

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -16,8 +16,9 @@
 #
 
 import numbers
-from typing import TYPE_CHECKING, Union
+from typing import cast, TYPE_CHECKING, Union
 
+from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     is_valid_operand_for_numeric_arithmetic,
     DataTypeOps,
@@ -44,7 +45,8 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left + right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(
+                left, cast(IndexOpsMixin, right).spark.data_type)
             return left + right
         else:
             raise TypeError(
@@ -55,7 +57,8 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left - right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(
+                left, cast(IndexOpsMixin, right).spark.data_type)
             return left - right
         else:
             raise TypeError(
@@ -66,7 +69,8 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left * right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(
+                left, cast(IndexOpsMixin, right).spark.data_type)
             return left * right
         else:
             raise TypeError(
@@ -77,7 +81,8 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left / right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(
+                left, cast(IndexOpsMixin, right).spark.data_type)
             return left / right
         else:
             raise TypeError(
@@ -88,7 +93,8 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left // right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(
+                left, cast(IndexOpsMixin, right).spark.data_type)
             return left // right
         else:
             raise TypeError(
@@ -99,7 +105,8 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left % right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(
+                left, cast(IndexOpsMixin, right).spark.data_type)
             return left % right
         else:
             raise TypeError(
@@ -110,7 +117,8 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left ** right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(
+                left, cast(IndexOpsMixin, right).spark.data_type)
             return left ** right
         else:
             raise TypeError(

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -16,7 +16,7 @@
 #
 
 import numbers
-from typing import cast, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union
 
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -21,7 +21,7 @@ import numpy as np
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op
-from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.data_type_ops.base import DataTypeOps, transform_boolean_operand_to_numeric
 from pyspark.pandas.typedef.typehints import as_spark_type
 from pyspark.sql import Column, functions as F
 from pyspark.sql.types import NumericType
@@ -47,7 +47,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(Column.__add__)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
-            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return column_op(Column.__add__)(left, right)
         else:
             raise TypeError(
@@ -58,7 +58,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(Column.__sub__)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
-            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return column_op(Column.__sub__)(left, right)
         else:
             raise TypeError(
@@ -69,7 +69,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(Column.__mul__)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
-            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return column_op(Column.__mul__)(left, right)
         else:
             raise TypeError(
@@ -87,7 +87,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
             return numpy_column_op(truediv)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
-            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return numpy_column_op(truediv)(left, right)
         else:
             raise TypeError(
@@ -109,7 +109,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
             return numpy_column_op(floordiv)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
-            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return numpy_column_op(floordiv)(left, right)
         else:
             raise TypeError(
@@ -123,7 +123,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(mod)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
-            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return column_op(mod)(left, right)
         else:
             raise TypeError(
@@ -137,7 +137,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
             return column_op(pow_func)(left, right)
         elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
-            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return column_op(pow_func)(left, right)
 
         else:

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -44,7 +44,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left + right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left + right
         else:
             raise TypeError(
@@ -55,7 +55,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left - right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left - right
         else:
             raise TypeError(
@@ -66,7 +66,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left * right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left * right
         else:
             raise TypeError(
@@ -77,7 +77,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left / right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left / right
         else:
             raise TypeError(
@@ -88,7 +88,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left // right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left // right
         else:
             raise TypeError(
@@ -99,7 +99,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left % right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left % right
         else:
             raise TypeError(
@@ -110,7 +110,7 @@ class BooleanOps(DataTypeOps):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left ** right
         elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
-            left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left ** right
         else:
             raise TypeError(

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -15,7 +15,22 @@
 # limitations under the License.
 #
 
+import numbers
+
+import numpy as np
+from pandas.api.types import CategoricalDtype
+
+from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op
 from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.typedef.typehints import as_spark_type
+from pyspark.sql import Column, functions as F
+from pyspark.sql.types import NumericType
+
+
+def is_numeric_index_ops(index_ops: IndexOpsMixin):
+    """Check if the given index_ops is numeric IndexOpsMixin."""
+    return isinstance(index_ops.spark.data_type, NumericType) and (
+        not isinstance(index_ops.dtype, CategoricalDtype))
 
 
 class BooleanOps(DataTypeOps):
@@ -26,3 +41,183 @@ class BooleanOps(DataTypeOps):
     @property
     def pretty_name(self) -> str:
         return 'booleans'
+
+    def add(self, left, right):
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            return column_op(Column.__add__)(left, right)
+        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            return column_op(Column.__add__)(left, right)
+        else:
+            raise TypeError(
+                "Addition can not be applied to %s and the given type." % self.pretty_name)
+
+    def sub(self, left, right):
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            return column_op(Column.__sub__)(left, right)
+        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            return column_op(Column.__sub__)(left, right)
+        else:
+            raise TypeError(
+                "Subtraction can not be applied to %s and the given type." % self.pretty_name)
+
+    def mul(self, left, right):
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            return column_op(Column.__mul__)(left, right)
+        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            return column_op(Column.__mul__)(left, right)
+        else:
+            raise TypeError(
+                "Multiplication can not be applied to %s and the given type." % self.pretty_name)
+
+    def truediv(self, left, right):
+        def truediv(left, right):
+            return F.when(F.lit(right != 0) | F.lit(right).isNull(), left.__div__(right)).otherwise(
+                F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
+                    F.lit(np.inf).__div__(left)
+                )
+            )
+
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            return numpy_column_op(truediv)(left, right)
+        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            return numpy_column_op(truediv)(left, right)
+        else:
+            raise TypeError(
+                "True division can not be applied to %s and the given type." % self.pretty_name)
+
+    def floordiv(self, left, right):
+        def floordiv(left, right):
+            return F.when(F.lit(right is np.nan), np.nan).otherwise(
+                F.when(
+                    F.lit(right != 0) | F.lit(right).isNull(), F.floor(left.__div__(right))
+                ).otherwise(
+                    F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
+                        F.lit(np.inf).__div__(left)
+                    )
+                )
+            )
+
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            return numpy_column_op(floordiv)(left, right)
+        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            return numpy_column_op(floordiv)(left, right)
+        else:
+            raise TypeError(
+                "Floor division can not be applied to %s and the given type." % self.pretty_name)
+
+    def mod(self, left, right):
+        def mod(left, right):
+            return ((left % right) + right) % right
+
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            return column_op(mod)(left, right)
+        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            return column_op(mod)(left, right)
+        else:
+            raise TypeError(
+                "Modulo can not be applied to %s and the given type." % self.pretty_name)
+
+    def pow(self, left, right):
+        def pow_func(left, right):
+            return F.when(left == 1, left).otherwise(Column.__pow__(left, right))
+
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            return column_op(pow_func)(left, right)
+        elif isinstance(right, IndexOpsMixin) and is_numeric_index_ops(right):
+            left = left.spark.apply(lambda scol: scol.cast(right.spark.data_type))
+            return column_op(pow_func)(left, right)
+
+        else:
+            raise TypeError(
+                "Exponentiation can not be applied to %s and the given type." % self.pretty_name)
+
+    def radd(self, left, right=None):
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            return column_op(Column.__radd__)(left, right)
+        else:
+            raise TypeError(
+                "Addition can not be applied to %s and the given type." % self.pretty_name)
+
+    def rsub(self, left, right=None):
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            return column_op(Column.__rsub__)(left, right)
+        else:
+            raise TypeError(
+                "Subtraction can not be applied to %s and the given type." % self.pretty_name)
+
+    def rmul(self, left, right=None):
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+            return column_op(Column.__rmul__)(left, right)
+        else:
+            raise TypeError(
+                "Multiplication can not be applied to %s and the given type." % self.pretty_name)
+
+    def rtruediv(self, left, right=None):
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+
+            def rtruediv(left, right):
+                return F.when(left == 0, F.lit(np.inf).__div__(right)).otherwise(
+                    F.lit(right).__truediv__(left)
+                )
+
+            return numpy_column_op(rtruediv)(left, right)
+        else:
+            raise TypeError(
+                "True division can not be applied to %s and the given type." % self.pretty_name)
+
+    def rfloordiv(self, left, right=None):
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+
+            def rfloordiv(left, right):
+                return F.when(F.lit(left == 0), F.lit(np.inf).__div__(right)).otherwise(
+                    F.when(F.lit(left) == np.nan, np.nan).otherwise(
+                        F.floor(F.lit(right).__div__(left))
+                    )
+                )
+
+            return numpy_column_op(rfloordiv)(left, right)
+        else:
+            raise TypeError(
+                "Floor division can not be applied to %s and the given type." % self.pretty_name)
+
+    def rpow(self, left, right=None):
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+
+            def rpow_func(left, right):
+                return F.when(F.lit(right == 1), right).otherwise(Column.__rpow__(left, right))
+
+            return column_op(rpow_func)(left, right)
+        else:
+            raise TypeError(
+                "Exponentiation can not be applied to %s and the given type." % self.pretty_name)
+
+    def rmod(self, left, right=None):
+        if isinstance(right, numbers.Number):
+            left = left.spark.apply(lambda scol: scol.cast(as_spark_type(type(right))))
+
+            def rmod(left, right):
+                return ((right % left) + left) % left
+
+            return column_op(rmod)(left, right)
+        else:
+            raise TypeError(
+                "Modulo can not be applied to %s and the given type." % self.pretty_name)

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -43,7 +43,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left + right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left + right
         else:
@@ -54,7 +54,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left - right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left - right
         else:
@@ -65,7 +65,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left * right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left * right
         else:
@@ -76,7 +76,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left / right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left / right
         else:
@@ -87,7 +87,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left // right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left // right
         else:
@@ -98,7 +98,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left % right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left % right
         else:
@@ -109,7 +109,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left ** right
-        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        elif is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             left = left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left ** right
         else:

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -53,7 +53,9 @@ class DatetimeOps(DataTypeOps):
             return left.astype("long") - right.astype("long")
         elif isinstance(right, datetime.datetime):
             warnings.warn(msg, UserWarning)
-            return left.astype("long") - F.lit(right).cast(as_spark_type("long"))
+            return left.astype("long").spark.transform(
+                lambda scol: scol - F.lit(right).cast(as_spark_type("long"))
+            )
         else:
             raise TypeError("datetime subtraction can only be applied to datetime series.")
 
@@ -67,6 +69,8 @@ class DatetimeOps(DataTypeOps):
         )
         if isinstance(right, datetime.datetime):
             warnings.warn(msg, UserWarning)
-            return -(left.astype("long") - F.lit(right).cast(as_spark_type("long")))
+            return -(left.astype("long")).spark.transform(
+                lambda scol: scol - F.lit(right).cast(as_spark_type("long"))
+            )
         else:
             raise TypeError("datetime subtraction can only be applied to datetime series.")

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -16,7 +16,7 @@
 #
 
 import numbers
-from typing import Any, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 from pandas.api.types import CategoricalDtype
@@ -28,10 +28,9 @@ from pyspark.sql.types import (
     StringType,
     TimestampType,
 )
-import pyspark.sql.types as types
 
 from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op
-from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.data_type_ops.base import DataTypeOps, transform_boolean_operand_to_numeric
 from pyspark.pandas.spark import functions as SF
 
 if TYPE_CHECKING:
@@ -51,17 +50,6 @@ def is_valid_operand_for_numeric_arithmetic(operand: IndexOpsMixin) -> bool:
                 operand.spark.data_type, BooleanType)
     else:
         return False
-
-
-def transform_boolean_operand_to_numeric(operand: Any, spark_type: types.DataType) -> Any:
-    """Transform boolean operand to the given numeric spark_type.
-
-    Return the transformed operand if the operand is boolean, otherwise return the original operand.
-    """
-    if isinstance(operand, IndexOpsMixin) and isinstance(operand.spark.data_type, BooleanType):
-        return operand.spark.transform(lambda scol: scol.cast(spark_type))
-    else:
-        return operand
 
 
 class NumericOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -54,11 +54,12 @@ class NumericOps(DataTypeOps):
         ) or isinstance(right, str):
             raise TypeError("string addition can only be applied to string series or literals.")
 
-        if is_valid_operand_for_numeric_arithmetic(right):
-            right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
-            return column_op(Column.__add__)(left, right)
-        else:
+        if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("addition can not be applied to given types.")
+
+        right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
+
+        return column_op(Column.__add__)(left, right)
 
     def sub(self, left, right) -> Union["Series", "Index"]:
         if (
@@ -66,11 +67,12 @@ class NumericOps(DataTypeOps):
         ) or isinstance(right, str):
             raise TypeError("subtraction can not be applied to string series or literals.")
 
-        if is_valid_operand_for_numeric_arithmetic(right):
-            right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
-            return column_op(Column.__sub__)(left, right)
-        else:
+        if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("subtraction can not be applied to given types.")
+
+        right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
+
+        return column_op(Column.__sub__)(left, right)
 
     def mod(self, left, right) -> Union["Series", "Index"]:
         if (

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 
 def is_valid_operand_for_numeric_arithmetic(operand: Any) -> bool:
     """Check whether the operand is valid for arithmetic operations against numerics."""
-    if isinstance(operand, numbers.Number):
+    if isinstance(operand, numbers.Number) and not isinstance(operand, bool):
         return True
     elif isinstance(operand, IndexOpsMixin):
         if isinstance(operand.dtype, CategoricalDtype):
@@ -122,7 +122,7 @@ class NumericOps(DataTypeOps):
     def radd(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("string addition can only be applied to string series or literals.")
-        if not isinstance(right, numbers.Number):
+        if not isinstance(right, numbers.Number) or isinstance(right, bool):
             raise TypeError("addition can not be applied to given types.")
 
         return column_op(Column.__radd__)(left, right)
@@ -130,21 +130,21 @@ class NumericOps(DataTypeOps):
     def rsub(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("subtraction can not be applied to string series or literals.")
-        if not isinstance(right, numbers.Number):
+        if not isinstance(right, numbers.Number) or isinstance(right, bool):
             raise TypeError("subtraction can not be applied to given types.")
         return column_op(Column.__rsub__)(left, right)
 
     def rmul(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
-        if not isinstance(right, numbers.Number):
+        if not isinstance(right, numbers.Number) or isinstance(right, bool):
             raise TypeError("multiplication can not be applied to given types.")
         return column_op(Column.__rmul__)(left, right)
 
     def rpow(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("exponentiation can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number):
+        if not isinstance(right, numbers.Number) or isinstance(right, bool):
             raise TypeError("exponentiation can not be applied to given types.")
 
         def rpow_func(left, right):
@@ -155,7 +155,7 @@ class NumericOps(DataTypeOps):
     def rmod(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("modulo can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number):
+        if not isinstance(right, numbers.Number) or isinstance(right, bool):
             raise TypeError("modulo can not be applied to given types.")
 
         def rmod(left, right):
@@ -234,7 +234,7 @@ class IntegralOps(NumericOps):
     def rtruediv(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number):
+        if not isinstance(right, numbers.Number) or isinstance(right, bool):
             raise TypeError("division can not be applied to given types.")
 
         def rtruediv(left, right):
@@ -247,7 +247,7 @@ class IntegralOps(NumericOps):
     def rfloordiv(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number):
+        if not isinstance(right, numbers.Number) or isinstance(right, bool):
             raise TypeError("division can not be applied to given types.")
 
         def rfloordiv(left, right):
@@ -329,7 +329,7 @@ class FractionalOps(NumericOps):
     def rtruediv(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number):
+        if not isinstance(right, numbers.Number) or isinstance(right, bool):
             raise TypeError("division can not be applied to given types.")
 
         def rtruediv(left, right):
@@ -342,7 +342,7 @@ class FractionalOps(NumericOps):
     def rfloordiv(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number):
+        if not isinstance(right, numbers.Number) or isinstance(right, bool):
             raise TypeError("division can not be applied to given types.")
 
         def rfloordiv(left, right):

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -32,6 +32,8 @@ from pyspark.sql.types import (
 from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op
 from pyspark.pandas.data_type_ops.base import DataTypeOps, transform_boolean_operand_to_numeric
 from pyspark.pandas.spark import functions as SF
+from pyspark.sql.column import Column
+
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -49,7 +51,7 @@ def is_valid_operand_for_numeric_arithmetic(operand: IndexOpsMixin) -> bool:
             return isinstance(operand.spark.data_type, NumericType) or isinstance(
                 operand.spark.data_type, BooleanType)
     else:
-        return False
+        return isinstance(operand, Column)
 
 
 class NumericOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -21,7 +21,7 @@ from typing import Any, TYPE_CHECKING, Union
 import numpy as np
 from pandas.api.types import CategoricalDtype
 
-from pyspark.sql import Column, functions as F
+from pyspark.sql import functions as F
 from pyspark.sql.types import (
     BooleanType,
     NumericType,
@@ -40,7 +40,10 @@ if TYPE_CHECKING:
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
-def is_valid_operand_for_numeric_arithmetic(operand: Any) -> bool:
+def is_valid_operand_for_numeric_arithmetic(
+    operand: Any,
+    allow_bool_index_ops: bool = True
+) -> bool:
     """Check whether the operand is valid for arithmetic operations against numerics."""
     if isinstance(operand, numbers.Number) and not isinstance(operand, bool):
         return True
@@ -48,8 +51,8 @@ def is_valid_operand_for_numeric_arithmetic(operand: Any) -> bool:
         if isinstance(operand.dtype, CategoricalDtype):
             return False
         else:
-            return isinstance(operand.spark.data_type, NumericType) or isinstance(
-                operand.spark.data_type, BooleanType)
+            return isinstance(operand.spark.data_type, NumericType) or (
+                allow_bool_index_ops and isinstance(operand.spark.data_type, BooleanType))
     else:
         return isinstance(operand, Column)
 

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -16,7 +16,7 @@
 #
 
 import numbers
-from typing import TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING, Union
 
 import numpy as np
 from pandas.api.types import CategoricalDtype
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
-def is_valid_operand_for_numeric_arithmetic(operand: IndexOpsMixin) -> bool:
+def is_valid_operand_for_numeric_arithmetic(operand: Any) -> bool:
     """Check whether the operand is valid for arithmetic operations against numerics."""
     if isinstance(operand, numbers.Number):
         return True

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -81,7 +81,8 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(self.pser / 0.1, self.psser / 0.1)
 
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser / self.float_pser, (self.psser / self.float_psser).sort_index())
+            self.assert_eq(
+                self.pser / self.float_pser, (self.psser / self.float_psser).sort_index())
 
             for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser / psser)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -44,8 +44,12 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         return ps.from_pandas(self.float_pser)
 
     def test_add(self):
-        self.assert_eq(self.pser + 1, self.psser + 1)
-        self.assert_eq(self.pser + 0.1, self.psser + 0.1)
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pser + 1, psser + 1)
+        self.assert_eq(pser + 0.1, psser + 0.1)
+        self.assert_eq(pser + pser.astype(int), psser + psser.astype(int))
+        self.assertRaises(TypeError, lambda: psser + psser)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -55,8 +59,12 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: self.psser + psser)
 
     def test_sub(self):
-        self.assert_eq(self.pser - 1, self.psser - 1)
-        self.assert_eq(self.pser - 0.1, self.psser - 0.1)
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pser - 1, psser - 1)
+        self.assert_eq(pser - 0.1, psser - 0.1)
+        self.assert_eq(pser - pser.astype(int), psser - psser.astype(int))
+        self.assertRaises(TypeError, lambda: psser - psser)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -66,8 +74,12 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: self.psser - psser)
 
     def test_mul(self):
-        self.assert_eq(self.pser * 1, self.psser * 1)
-        self.assert_eq(self.pser * 0.1, self.psser * 0.1)
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pser * 1, psser * 1)
+        self.assert_eq(pser * 0.1, psser * 0.1)
+        self.assert_eq(pser * pser.astype(int), psser * psser.astype(int))
+        self.assertRaises(TypeError, lambda: psser * psser)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -77,9 +89,13 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: self.psser * psser)
 
     def test_truediv(self):
-        self.assert_eq(self.pser / 1, self.psser / 1)
-        self.assert_eq(self.pser / 0.1, self.psser / 0.1)
-
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pser / 1, psser / 1)
+        self.assert_eq(pser / 0.1, psser / 0.1)
+        self.assert_eq(pser / pser.astype(int), psser / psser.astype(int))
+        self.assertRaises(TypeError, lambda: psser / psser)
+        
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
                 self.pser / self.float_pser, (self.psser / self.float_psser).sort_index())
@@ -88,10 +104,17 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: self.psser / psser)
 
     def test_floordiv(self):
+        pser = self.pser
+        psser = self.psser
+
         # float is always returned in pandas-on-Spark
-        self.assert_eq((self.pser // 1).astype("float"), self.psser // 1)
+        self.assert_eq((pser // 1).astype("float"), psser // 1)
+
         # in pandas, 1 // 0.1 = 9.0; in pandas-on-Spark, 1 // 0.1 = 10.0
-        # self.assert_eq(self.pser // 0.1, self.psser // 0.1)
+        # self.assert_eq(pser // 0.1, psser // 0.1)
+
+        self.assert_eq(pser // pser.astype(int), psser // psser.astype(int))
+        self.assertRaises(TypeError, lambda: psser // psser)
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
@@ -102,8 +125,12 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: self.psser // psser)
 
     def test_mod(self):
-        self.assert_eq(self.pser % 1, self.psser % 1)
-        self.assert_eq(self.pser % 0.1, self.psser % 0.1)
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pser % 1, psser % 1)
+        self.assert_eq(pser % 0.1, psser % 0.1)
+        self.assert_eq(pser % pser.astype(float), psser % psser.astype(float))
+        self.assertRaises(TypeError, lambda: psser % psser)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -113,9 +140,13 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: self.psser % psser)
 
     def test_pow(self):
+        pser = self.pser
+        psser = self.psser
         # float is always returned in pandas-on-Spark
-        self.assert_eq((self.pser ** 1).astype("float"), self.psser ** 1)
-        self.assert_eq(self.pser ** 0.1, self.psser ** 0.1)
+        self.assert_eq((pser ** 1).astype("float"), psser ** 1)
+        self.assert_eq(pser ** 0.1, self.psser ** 0.1)
+        self.assert_eq(pser ** pser.astype(float), psser ** psser.astype(float))
+        self.assertRaises(TypeError, lambda: psser ** psser)
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -87,9 +87,9 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: self.psser / psser)
 
     def test_floordiv(self):
-        # float is always returned in Koalas
+        # float is always returned in pandas-on-Spark
         self.assert_eq((self.pser // 1).astype("float"), self.psser // 1)
-        # in pandas, 1 // 0.1 = 9.0; in Koalas, 1 // 0.1 = 10.0
+        # in pandas, 1 // 0.1 = 9.0; in pandas-on-Spark, 1 // 0.1 = 10.0
         # self.assert_eq(self.pser // 0.1, self.psser // 0.1)
 
         with option_context("compute.ops_on_diff_frames", True):
@@ -112,7 +112,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: self.psser % psser)
 
     def test_pow(self):
-        # float is always returned in Koalas
+        # float is always returned in pandas-on-Spark
         self.assert_eq((self.pser ** 1).astype("float"), self.psser ** 1)
         self.assert_eq(self.pser ** 0.1, self.psser ** 0.1)
 
@@ -161,7 +161,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) // self.psser)
 
     def test_rpow(self):
-        # float is returned always in Koalas
+        # float is returned always in pandas-on-Spark
         self.assert_eq((1 ** self.pser).astype(float), 1 ** self.psser)
         self.assert_eq(0.1 ** self.pser, 0.1 ** self.psser)
         self.assertRaises(TypeError, lambda: "x" ** self.psser)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -16,6 +16,8 @@
 #
 
 import datetime
+from distutils.version import LooseVersion
+
 import pandas as pd
 
 from pyspark import pandas as ps
@@ -33,107 +35,147 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def psser(self):
         return ps.from_pandas(self.pser)
 
+    @property
+    def float_pser(self):
+        return pd.Series([1, 2, 3], dtype=float)
+
+    @property
+    def float_psser(self):
+        return ps.from_pandas(self.float_pser)
+
     def test_add(self):
-        self.assertRaises(TypeError, lambda: self.psser + 1)
-        self.assertRaises(TypeError, lambda: self.psser + 0.1)
+        self.assert_eq(self.pser + 1, self.psser + 1)
+        self.assert_eq(self.pser + 0.1, self.psser + 0.1)
 
         with option_context("compute.ops_on_diff_frames", True):
-            for psser in self.pssers:
+            for pser, psser in self.numeric_pser_psser_pairs:
+                self.assert_eq(self.pser + pser, (self.psser + psser).sort_index())
+
+            for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser + psser)
 
     def test_sub(self):
-        self.assertRaises(TypeError, lambda: self.psser - 1)
-        self.assertRaises(TypeError, lambda: self.psser - 0.1)
+        self.assert_eq(self.pser - 1, self.psser - 1)
+        self.assert_eq(self.pser - 0.1, self.psser - 0.1)
 
         with option_context("compute.ops_on_diff_frames", True):
-            for psser in self.pssers:
+            for pser, psser in self.numeric_pser_psser_pairs:
+                self.assert_eq(self.pser - pser, (self.psser - psser).sort_index())
+
+            for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser - psser)
 
     def test_mul(self):
-        self.assertRaises(TypeError, lambda: self.psser * 1)
-        self.assertRaises(TypeError, lambda: self.psser * 0.1)
+        self.assert_eq(self.pser * 1, self.psser * 1)
+        self.assert_eq(self.pser * 0.1, self.psser * 0.1)
 
         with option_context("compute.ops_on_diff_frames", True):
-            for psser in self.pssers:
+            for pser, psser in self.numeric_pser_psser_pairs:
+                self.assert_eq(self.pser * pser, (self.psser * psser).sort_index())
+
+            for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser * psser)
 
     def test_truediv(self):
-        self.assertRaises(TypeError, lambda: self.psser / 1)
-        self.assertRaises(TypeError, lambda: self.psser / 0.1)
+        self.assert_eq(self.pser / 1, self.psser / 1)
+        self.assert_eq(self.pser / 0.1, self.psser / 0.1)
 
         with option_context("compute.ops_on_diff_frames", True):
-            for psser in self.pssers:
+            self.assert_eq(self.pser / self.float_pser, (self.psser / self.float_psser).sort_index())
+
+            for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser / psser)
 
     def test_floordiv(self):
-        self.assertRaises(TypeError, lambda: self.psser // 1)
-        self.assertRaises(TypeError, lambda: self.psser // 0.1)
+        # float is always returned in Koalas
+        self.assert_eq((self.pser // 1).astype("float"), self.psser // 1)
+        # in pandas, 1 // 0.1 = 9.0; in Koalas, 1 // 0.1 = 10.0
+        # self.assert_eq(self.pser // 0.1, self.psser // 0.1)
 
         with option_context("compute.ops_on_diff_frames", True):
-            for psser in self.pssers:
+            self.assert_eq(
+                self.pser // self.float_pser, (self.psser // self.float_psser).sort_index()
+            )
+
+            for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser // psser)
 
     def test_mod(self):
-        self.assertRaises(TypeError, lambda: self.psser % 1)
-        self.assertRaises(TypeError, lambda: self.psser % 0.1)
+        self.assert_eq(self.pser % 1, self.psser % 1)
+        self.assert_eq(self.pser % 0.1, self.psser % 0.1)
 
         with option_context("compute.ops_on_diff_frames", True):
-            for psser in self.pssers:
+            for pser, psser in self.numeric_pser_psser_pairs:
+                self.assert_eq(self.pser % pser, (self.psser % psser).sort_index())
+
+            for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser % psser)
 
     def test_pow(self):
-        self.assertRaises(TypeError, lambda: self.psser ** 1)
-        self.assertRaises(TypeError, lambda: self.psser ** 0.1)
+        # float is always returned in Koalas
+        self.assert_eq((self.pser ** 1).astype("float"), self.psser ** 1)
+        self.assert_eq(self.pser ** 0.1, self.psser ** 0.1)
 
         with option_context("compute.ops_on_diff_frames", True):
-            for psser in self.pssers:
+            self.assert_eq(
+                self.pser ** self.float_pser, (self.psser ** self.float_psser).sort_index()
+            )
+
+            for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser ** psser)
 
     def test_radd(self):
-        self.assertRaises(TypeError, lambda: 1 + self.psser)
-        self.assertRaises(TypeError, lambda: 0.1 + self.psser)
+        self.assert_eq(1 + self.pser, 1 + self.psser)
+        self.assert_eq(0.1 + self.pser, 0.1 + self.psser)
         self.assertRaises(TypeError, lambda: "x" + self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) + self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) + self.psser)
 
     def test_rsub(self):
-        self.assertRaises(TypeError, lambda: 1 - self.psser)
-        self.assertRaises(TypeError, lambda: 0.1 - self.psser)
+        self.assert_eq(1 - self.pser, 1 - self.psser)
+        self.assert_eq(0.1 - self.pser, 0.1 - self.psser)
         self.assertRaises(TypeError, lambda: "x" - self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) - self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) - self.psser)
 
     def test_rmul(self):
-        self.assertRaises(TypeError, lambda: 1 * self.psser)
-        self.assertRaises(TypeError, lambda: 0.1 * self.psser)
+        self.assert_eq(1 * self.pser, 1 * self.psser)
+        self.assert_eq(0.1 * self.pser, 0.1 * self.psser)
         self.assertRaises(TypeError, lambda: "x" * self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) * self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) * self.psser)
 
     def test_rtruediv(self):
-        self.assertRaises(TypeError, lambda: 1 / self.psser)
-        self.assertRaises(TypeError, lambda: 0.1 / self.psser)
+        self.assert_eq(1 / self.pser, 1 / self.psser)
+        self.assert_eq(0.1 / self.pser, 0.1 / self.psser)
         self.assertRaises(TypeError, lambda: "x" / self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) / self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) / self.psser)
 
     def test_rfloordiv(self):
-        self.assertRaises(TypeError, lambda: 1 // self.psser)
-        self.assertRaises(TypeError, lambda: 0.1 // self.psser)
+        if LooseVersion(pd.__version__) >= LooseVersion("0.25.3"):
+            self.assert_eq(1 // self.pser, 1 // self.psser)
+            self.assert_eq(0.1 // self.pser, 0.1 // self.psser)
         self.assertRaises(TypeError, lambda: "x" + self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) // self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) // self.psser)
 
     def test_rpow(self):
-        self.assertRaises(TypeError, lambda: 1 ** self.psser)
-        self.assertRaises(TypeError, lambda: 0.1 ** self.psser)
+        # float is returned always in Koalas
+        self.assert_eq((1 ** self.pser).astype(float), 1 ** self.psser)
+        self.assert_eq(0.1 ** self.pser, 0.1 ** self.psser)
         self.assertRaises(TypeError, lambda: "x" ** self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) ** self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) ** self.psser)
 
     def test_rmod(self):
-        self.assertRaises(TypeError, lambda: 1 % self.psser)
-        self.assertRaises(TypeError, lambda: 0.1 % self.psser)
+        # 1 % False is 0.0 in pandas
+        self.assert_eq(ps.Series([0, 0, None], dtype=float), 1 % self.psser)
+        # 0.1 / True is 0.1 in pandas
+        self.assert_eq(
+            ps.Series([0.10000000000000009, 0.10000000000000009, None], dtype=float),
+            0.1 % self.psser,
+        )
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) % self.psser)
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -51,6 +51,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser + 0.1, psser + 0.1)
         self.assert_eq(pser + pser.astype(int), psser + psser.astype(int))
         self.assertRaises(TypeError, lambda: psser + psser)
+        self.assertRaises(TypeError, lambda: psser + True)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -66,6 +67,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser - 0.1, psser - 0.1)
         self.assert_eq(pser - pser.astype(int), psser - psser.astype(int))
         self.assertRaises(TypeError, lambda: psser - psser)
+        self.assertRaises(TypeError, lambda: psser - True)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -81,6 +83,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser * 0.1, psser * 0.1)
         self.assert_eq(pser * pser.astype(int), psser * psser.astype(int))
         self.assertRaises(TypeError, lambda: psser * psser)
+        self.assertRaises(TypeError, lambda: psser * True)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -96,6 +99,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser / 0.1, psser / 0.1)
         self.assert_eq(pser / pser.astype(int), psser / psser.astype(int))
         self.assertRaises(TypeError, lambda: psser / psser)
+        self.assertRaises(TypeError, lambda: psser / True)
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
@@ -116,6 +120,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
         self.assert_eq(pser // pser.astype(int), psser // psser.astype(int))
         self.assertRaises(TypeError, lambda: psser // psser)
+        self.assertRaises(TypeError, lambda: psser // True)
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
@@ -132,6 +137,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser % 0.1, psser % 0.1)
         self.assert_eq(pser % pser.astype(float), psser % psser.astype(float))
         self.assertRaises(TypeError, lambda: psser % psser)
+        self.assertRaises(TypeError, lambda: psser % True)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -148,6 +154,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser ** 0.1, self.psser ** 0.1)
         self.assert_eq(pser ** pser.astype(float), psser ** psser.astype(float))
         self.assertRaises(TypeError, lambda: psser ** psser)
+        self.assertRaises(TypeError, lambda: psser ** True)
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
@@ -161,6 +168,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(1 + self.pser, 1 + self.psser)
         self.assert_eq(0.1 + self.pser, 0.1 + self.psser)
         self.assertRaises(TypeError, lambda: "x" + self.psser)
+        self.assertRaises(TypeError, lambda: True + self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) + self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) + self.psser)
 
@@ -168,6 +176,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(1 - self.pser, 1 - self.psser)
         self.assert_eq(0.1 - self.pser, 0.1 - self.psser)
         self.assertRaises(TypeError, lambda: "x" - self.psser)
+        self.assertRaises(TypeError, lambda: True - self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) - self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) - self.psser)
 
@@ -175,6 +184,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(1 * self.pser, 1 * self.psser)
         self.assert_eq(0.1 * self.pser, 0.1 * self.psser)
         self.assertRaises(TypeError, lambda: "x" * self.psser)
+        self.assertRaises(TypeError, lambda: True * self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) * self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) * self.psser)
 
@@ -182,6 +192,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(1 / self.pser, 1 / self.psser)
         self.assert_eq(0.1 / self.pser, 0.1 / self.psser)
         self.assertRaises(TypeError, lambda: "x" / self.psser)
+        self.assertRaises(TypeError, lambda: True / self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) / self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) / self.psser)
 
@@ -193,6 +204,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(1 // self.psser, ps.Series([1.0, 1.0, np.inf]))
             self.assert_eq(0.1 // self.psser, ps.Series([0.0, 0.0, np.inf]))
         self.assertRaises(TypeError, lambda: "x" + self.psser)
+        self.assertRaises(TypeError, lambda: True + self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) // self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) // self.psser)
 
@@ -201,6 +213,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq((1 ** self.pser).astype(float), 1 ** self.psser)
         self.assert_eq(0.1 ** self.pser, 0.1 ** self.psser)
         self.assertRaises(TypeError, lambda: "x" ** self.psser)
+        self.assertRaises(TypeError, lambda: True ** self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) ** self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) ** self.psser)
 
@@ -213,7 +226,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             0.1 % self.psser,
         )
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % self.psser)
-        self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) % self.psser)
+        self.assertRaises(TypeError, lambda: True % self.psser)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -95,7 +95,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser / 0.1, psser / 0.1)
         self.assert_eq(pser / pser.astype(int), psser / psser.astype(int))
         self.assertRaises(TypeError, lambda: psser / psser)
-        
+
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
                 self.pser / self.float_pser, (self.psser / self.float_psser).sort_index())

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -19,6 +19,7 @@ import datetime
 from distutils.version import LooseVersion
 
 import pandas as pd
+import numpy as np
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
@@ -188,6 +189,9 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         if LooseVersion(pd.__version__) >= LooseVersion("0.25.3"):
             self.assert_eq(1 // self.pser, 1 // self.psser)
             self.assert_eq(0.1 // self.pser, 0.1 // self.psser)
+        else:
+            self.assert_eq(1 // self.psser, ps.Series([1.0, 1.0, np.inf]))
+            self.assert_eq(0.1 // self.psser, ps.Series([0.0, 0.0, np.inf]))
         self.assertRaises(TypeError, lambda: "x" + self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) // self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) // self.psser)

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -16,6 +16,7 @@
 #
 
 import datetime
+from distutils.version import LooseVersion
 
 import pandas as pd
 
@@ -60,7 +61,8 @@ class DateOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.pser_psser_pairs:
                 if isinstance(psser.spark.data_type, DateType):
-                    self.assert_eq((self.pser - pser).dt.days, (self.psser - psser).sort_index())
+                    if LooseVersion(pd.__version__) >= LooseVersion("0.24.2"):
+                        self.assert_eq((self.pser - pser).dt.days, (self.psser - psser).sort_index())
                 else:
                     self.assertRaises(TypeError, lambda: self.psser - psser)
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -62,7 +62,8 @@ class DateOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             for pser, psser in self.pser_psser_pairs:
                 if isinstance(psser.spark.data_type, DateType):
                     if LooseVersion(pd.__version__) >= LooseVersion("0.24.2"):
-                        self.assert_eq((self.pser - pser).dt.days, (self.psser - psser).sort_index())
+                        self.assert_eq(
+                            (self.pser - pser).dt.days, (self.psser - psser).sort_index())
                 else:
                     self.assertRaises(TypeError, lambda: self.psser - psser)
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -16,7 +16,6 @@
 #
 
 import datetime
-from distutils.version import LooseVersion
 
 import pandas as pd
 
@@ -61,9 +60,7 @@ class DateOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.pser_psser_pairs:
                 if isinstance(psser.spark.data_type, DateType):
-                    if LooseVersion(pd.__version__) >= LooseVersion("0.24.2"):
-                        self.assert_eq(
-                            (self.pser - pser).dt.days, (self.psser - psser).sort_index())
+                    self.assert_eq((self.pser - pser).dt.days, (self.psser - psser).sort_index())
                 else:
                     self.assertRaises(TypeError, lambda: self.psser - psser)
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -21,6 +21,7 @@ from distutils.version import LooseVersion
 import pandas as pd
 import numpy as np
 
+from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
 from pyspark.testing.pandasutils import PandasOnSparkTestCase

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -16,6 +16,9 @@
 #
 
 import datetime
+from distutils.version import LooseVersion
+
+import pandas as pd
 import numpy as np
 
 from pyspark.pandas.config import option_context
@@ -30,6 +33,14 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     returns float32.
     The underlying reason is the respective Spark operations return DoubleType always.
     """
+    @property
+    def float_pser(self):
+        return pd.Series([1, 2, 3], dtype=float)
+
+    @property
+    def float_psser(self):
+        return ps.from_pandas(self.float_pser)
+
     def test_add(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser + pser, psser + psser)
@@ -42,7 +53,10 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: psser + self.non_numeric_pssers["datetime"])
                 self.assertRaises(TypeError, lambda: psser + self.non_numeric_pssers["date"])
                 self.assertRaises(TypeError, lambda: psser + self.non_numeric_pssers["categorical"])
-                self.assertRaises(TypeError, lambda: psser + self.non_numeric_pssers["bool"])
+                self.assert_eq(
+                    (psser + self.non_numeric_pssers["bool"]).sort_index(),
+                    pser + self.non_numeric_psers["bool"],
+                )
 
     def test_sub(self):
         for pser, psser in self.numeric_pser_psser_pairs:
@@ -56,7 +70,10 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: psser - self.non_numeric_pssers["datetime"])
                 self.assertRaises(TypeError, lambda: psser - self.non_numeric_pssers["date"])
                 self.assertRaises(TypeError, lambda: psser - self.non_numeric_pssers["categorical"])
-                self.assertRaises(TypeError, lambda: psser - self.non_numeric_pssers["bool"])
+                self.assert_eq(
+                    (psser - self.non_numeric_pssers["bool"]).sort_index(),
+                    pser - self.non_numeric_psers["bool"],
+                )
 
     def test_mul(self):
         for pser, psser in self.numeric_pser_psser_pairs:
@@ -74,7 +91,10 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: psser * self.non_numeric_pssers["datetime"])
                 self.assertRaises(TypeError, lambda: psser * self.non_numeric_pssers["date"])
                 self.assertRaises(TypeError, lambda: psser * self.non_numeric_pssers["categorical"])
-                self.assertRaises(TypeError, lambda: psser * self.non_numeric_pssers["bool"])
+                self.assert_eq(
+                    (psser * self.non_numeric_pssers["bool"]).sort_index(),
+                    pser * self.non_numeric_psers["bool"],
+                )
 
     def test_truediv(self):
         for pser, psser in self.numeric_pser_psser_pairs:
@@ -87,7 +107,10 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: psser / self.non_numeric_pssers["datetime"])
                 self.assertRaises(TypeError, lambda: psser / self.non_numeric_pssers["date"])
                 self.assertRaises(TypeError, lambda: psser / self.non_numeric_pssers["categorical"])
-                self.assertRaises(TypeError, lambda: psser / self.non_numeric_pssers["bool"])
+            self.assert_eq(
+                (self.float_psser / self.non_numeric_pssers["bool"]).sort_index(),
+                self.float_pser / self.non_numeric_psers["bool"],
+            )
 
     def test_floordiv(self):
         for pser, psser in self.numeric_pser_psser_pairs:
@@ -99,9 +122,12 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: psser // self.non_numeric_pssers["string"])
                 self.assertRaises(TypeError, lambda: psser // self.non_numeric_pssers["datetime"])
                 self.assertRaises(TypeError, lambda: psser // self.non_numeric_pssers["date"])
-                self.assertRaises(
-                    TypeError, lambda: psser // self.non_numeric_pssers["categorical"])
-                self.assertRaises(TypeError, lambda: psser // self.non_numeric_pssers["bool"])
+                self.assertRaises(TypeError, lambda: psser // self.non_numeric_pssers["categorical"])
+                if LooseVersion(pd.__version__) >= LooseVersion("0.25.3"):
+                    self.assert_eq(
+                        (self.float_psser // self.non_numeric_pssers["bool"]).sort_index(),
+                        self.float_pser // self.non_numeric_psers["bool"],
+                    )
 
     def test_mod(self):
         for pser, psser in self.numeric_pser_psser_pairs:
@@ -113,7 +139,10 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: psser % self.non_numeric_pssers["datetime"])
                 self.assertRaises(TypeError, lambda: psser % self.non_numeric_pssers["date"])
                 self.assertRaises(TypeError, lambda: psser % self.non_numeric_pssers["categorical"])
-                self.assertRaises(TypeError, lambda: psser % self.non_numeric_pssers["bool"])
+            self.assert_eq(
+                (self.float_psser % self.non_numeric_pssers["bool"]).sort_index(),
+                self.float_pser % self.non_numeric_psers["bool"],
+            )
 
     def test_pow(self):
         for pser, psser in self.numeric_pser_psser_pairs:
@@ -125,9 +154,11 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: psser ** self.non_numeric_pssers["string"])
                 self.assertRaises(TypeError, lambda: psser ** self.non_numeric_pssers["datetime"])
                 self.assertRaises(TypeError, lambda: psser ** self.non_numeric_pssers["date"])
-                self.assertRaises(
-                    TypeError, lambda: psser ** self.non_numeric_pssers["categorical"])
-                self.assertRaises(TypeError, lambda: psser ** self.non_numeric_pssers["bool"])
+                self.assertRaises(TypeError, lambda: psser ** self.non_numeric_pssers["categorical"])
+            self.assert_eq(
+                (self.float_psser ** self.non_numeric_pssers["bool"]).sort_index(),
+                self.float_pser ** self.non_numeric_psers["bool"],
+            )
 
     def test_radd(self):
         for pser, psser in self.numeric_pser_psser_pairs:

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -59,6 +59,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                     pser + self.non_numeric_psers["bool"],
                 )
 
+            self.assertRaises(TypeError, lambda: self.float_psser + True)
+
     def test_sub(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser - pser, psser - psser)
@@ -75,6 +77,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                     (psser - self.non_numeric_pssers["bool"]).sort_index(),
                     pser - self.non_numeric_psers["bool"],
                 )
+
+        self.assertRaises(TypeError, lambda: self.float_psser - True)
 
     def test_mul(self):
         for pser, psser in self.numeric_pser_psser_pairs:
@@ -97,6 +101,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                     pser * self.non_numeric_psers["bool"],
                 )
 
+        self.assertRaises(TypeError, lambda: self.float_psser * True)
+
     def test_truediv(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             if psser.dtype in [float, int, np.int32]:
@@ -112,6 +118,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 (self.float_psser / self.non_numeric_pssers["bool"]).sort_index(),
                 self.float_pser / self.non_numeric_psers["bool"],
             )
+
+        self.assertRaises(TypeError, lambda: self.float_psser / True)
 
     def test_floordiv(self):
         for pser, psser in self.numeric_pser_psser_pairs:
@@ -131,6 +139,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                         self.float_pser // self.non_numeric_psers["bool"],
                     )
 
+        self.assertRaises(TypeError, lambda: self.float_psser // True)
+
     def test_mod(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser % pser, psser % psser)
@@ -145,6 +155,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 (self.float_psser % self.non_numeric_pssers["bool"]).sort_index(),
                 self.float_pser % self.non_numeric_psers["bool"],
             )
+
+        self.assertRaises(TypeError, lambda: self.float_psser % True)
 
     def test_pow(self):
         for pser, psser in self.numeric_pser_psser_pairs:
@@ -163,11 +175,14 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.float_pser ** self.non_numeric_psers["bool"],
             )
 
+        self.assertRaises(TypeError, lambda: self.float_psser ** True)
+
     def test_radd(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(1 + pser, 1 + psser)
             # self.assert_eq(0.1 + pser, 0.1 + psser)
             self.assertRaises(TypeError, lambda: "x" + psser)
+            self.assertRaises(TypeError, lambda: True + psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) + psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) + psser)
 
@@ -176,6 +191,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(1 - pser, 1 - psser)
             # self.assert_eq(0.1 - pser, 0.1 - psser)
             self.assertRaises(TypeError, lambda: "x" - psser)
+            self.assertRaises(TypeError, lambda: True - psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) - psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) - psser)
 
@@ -184,6 +200,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(1 * pser, 1 * psser)
             # self.assert_eq(0.1 * pser, 0.1 * psser)
             self.assertRaises(TypeError, lambda: "x" * psser)
+            self.assertRaises(TypeError, lambda: True * psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) * psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) * psser)
 
@@ -192,6 +209,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             # self.assert_eq(5 / pser, 5 / psser)
             # self.assert_eq(0.1 / pser, 0.1 / psser)
             self.assertRaises(TypeError, lambda: "x" + psser)
+            self.assertRaises(TypeError, lambda: True + psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) / psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) / psser)
 
@@ -200,6 +218,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             # self.assert_eq(5 // pser, 5 // psser)
             # self.assert_eq(0.1 // pser, 0.1 // psser)
             self.assertRaises(TypeError, lambda: "x" // psser)
+            self.assertRaises(TypeError, lambda: True // psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) // psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) // psser)
 
@@ -208,6 +227,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             # self.assert_eq(1 ** pser, 1 ** psser)
             # self.assert_eq(0.1 ** pser, 0.1 ** psser)
             self.assertRaises(TypeError, lambda: "x" ** psser)
+            self.assertRaises(TypeError, lambda: True ** psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) ** psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) ** psser)
 
@@ -215,6 +235,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(1 % pser, 1 % psser)
             # self.assert_eq(0.1 % pser, 0.1 % psser)
+            self.assertRaises(TypeError, lambda: True % psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) % psser)
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -123,7 +123,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: psser // self.non_numeric_pssers["string"])
                 self.assertRaises(TypeError, lambda: psser // self.non_numeric_pssers["datetime"])
                 self.assertRaises(TypeError, lambda: psser // self.non_numeric_pssers["date"])
-                self.assertRaises(TypeError, lambda: psser // self.non_numeric_pssers["categorical"])
+                self.assertRaises(
+                    TypeError, lambda: psser // self.non_numeric_pssers["categorical"])
                 if LooseVersion(pd.__version__) >= LooseVersion("0.25.3"):
                     self.assert_eq(
                         (self.float_psser // self.non_numeric_pssers["bool"]).sort_index(),
@@ -155,7 +156,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: psser ** self.non_numeric_pssers["string"])
                 self.assertRaises(TypeError, lambda: psser ** self.non_numeric_pssers["datetime"])
                 self.assertRaises(TypeError, lambda: psser ** self.non_numeric_pssers["date"])
-                self.assertRaises(TypeError, lambda: psser ** self.non_numeric_pssers["categorical"])
+                self.assertRaises(
+                    TypeError, lambda: psser ** self.non_numeric_pssers["categorical"])
             self.assert_eq(
                 (self.float_psser ** self.non_numeric_pssers["bool"]).sort_index(),
                 self.float_pser ** self.non_numeric_psers["bool"],

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -138,11 +138,16 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assertRaises(TypeError, lambda: psser // self.non_numeric_pssers["date"])
                 self.assertRaises(
                     TypeError, lambda: psser // self.non_numeric_pssers["categorical"])
-                if LooseVersion(pd.__version__) >= LooseVersion("0.25.3"):
-                    self.assert_eq(
-                        (self.float_psser // self.non_numeric_pssers["bool"]).sort_index(),
-                        self.float_pser // self.non_numeric_psers["bool"],
-                    )
+            if LooseVersion(pd.__version__) >= LooseVersion("0.25.3"):
+                self.assert_eq(
+                    (self.float_psser // self.non_numeric_pssers["bool"]).sort_index(),
+                    self.float_pser // self.non_numeric_psers["bool"],
+                )
+            else:
+                self.assert_eq(
+                    (self.float_pser // self.non_numeric_psers["bool"]).sort_index(),
+                    ps.Series([1.0, 2.0, np.inf])
+                )
 
         self.assertRaises(TypeError, lambda: self.float_psser // True)
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -47,6 +47,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(pser + pser, psser + psser)
             self.assert_eq(pser + 1, psser + 1)
             # self.assert_eq(pser + 0.1, psser + 0.1)
+            self.assert_eq(pser + pser.astype(bool), psser + psser.astype(bool))
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -59,13 +60,14 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                     pser + self.non_numeric_psers["bool"],
                 )
 
-            self.assertRaises(TypeError, lambda: self.float_psser + True)
+        self.assertRaises(TypeError, lambda: self.float_psser + True)
 
     def test_sub(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser - pser, psser - psser)
             self.assert_eq(pser - 1, psser - 1)
             # self.assert_eq(pser - 0.1, psser - 0.1)
+            self.assert_eq(pser - pser.astype(bool), psser - psser.astype(bool))
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -83,6 +85,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def test_mul(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser * pser, psser * psser)
+            self.assert_eq(pser * pser.astype(bool), psser * psser.astype(bool))
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -107,6 +110,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in self.numeric_pser_psser_pairs:
             if psser.dtype in [float, int, np.int32]:
                 self.assert_eq(pser / pser, psser / psser)
+                self.assert_eq(pser / pser.astype(bool), psser / psser.astype(bool))
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -125,6 +129,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in self.numeric_pser_psser_pairs:
             if psser.dtype == float:
                 self.assert_eq(pser // pser, psser // psser)
+                self.assert_eq(pser // pser.astype(bool), psser // psser.astype(bool))
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -144,6 +149,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def test_mod(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser % pser, psser % psser)
+            self.assert_eq(pser % pser.astype(bool), psser % psser.astype(bool))
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -162,6 +168,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in self.numeric_pser_psser_pairs:
             if psser.dtype == float:
                 self.assert_eq(pser ** pser, psser ** psser)
+                self.assert_eq(pser ** pser.astype(bool), psser ** psser.astype(bool))
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -121,7 +121,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf = ps.from_pandas(pdf)
 
         self._check_extension(psdf, pdf)
-        self._check_extension(psdf + F.lit(1).cast("byte"), pdf + 1)
+        # self._check_extension(psdf + F.lit(1).cast("byte"), pdf + 1)
         self._check_extension(psdf + psdf, pdf + pdf)
 
     @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -27,7 +27,6 @@ import pandas as pd
 from pandas.tseries.offsets import DateOffset
 from pyspark import StorageLevel
 from pyspark.ml.linalg import SparseVector
-from pyspark.sql import functions as F
 from pyspark.sql.types import StructType
 
 from pyspark import pandas as ps

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -121,7 +121,6 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf = ps.from_pandas(pdf)
 
         self._check_extension(psdf, pdf)
-        # self._check_extension(psdf + F.lit(1).cast("byte"), pdf + 1)
         self._check_extension(psdf + psdf, pdf + pdf)
 
     @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -25,7 +25,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
 from pyspark.ml.linalg import SparseVector
-from pyspark.sql import functions as F
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import (

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -104,7 +104,6 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             psser = ps.from_pandas(pser)
 
             self._check_extension(psser, pser)
-            self._check_extension(psser + F.lit(1).cast("byte"), pser + 1)
             self._check_extension(psser + psser, pser + pser)
 
     @unittest.skipIf(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support arithmetic operations against bool IndexOpsMixin.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Existing binary operations of bool IndexOpsMixin in Koalas do not match pandas’ behaviors.

pandas take True as 1, False as 0 when dealing with numeric values, numeric collections, and numeric Series/Index; whereas Koalas raises an AnalysisException no matter what the binary operation is.

We aim to match pandas' behaviors.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.

Before the change:
```py
>>> import pyspark.pandas as ps
>>> psser = ps.Series([True, True, False])
>>> psser + 1
Traceback (most recent call last):
...
TypeError: Addition can not be applied to booleans.
>>> 1 + psser
Traceback (most recent call last):
...
TypeError: Addition can not be applied to booleans.
>>> from pyspark.pandas.config import set_option
>>> set_option("compute.ops_on_diff_frames", True)
>>> psser + ps.Series([1, 2, 3])
Traceback (most recent call last):
...
TypeError: Addition can not be applied to booleans.
>>> ps.Series([1, 2, 3]) + psser
Traceback (most recent call last):
...
TypeError: addition can not be applied to given types.
```

After the change:
```py
>>> import pyspark.pandas as ps
>>> psser = ps.Series([True, True, False])
>>> psser + 1
0    2                                                                          
1    2
2    1
dtype: int64
>>> 1 + psser
0    2
1    2
2    1
dtype: int64
>>> from pyspark.pandas.config import set_option
>>> set_option("compute.ops_on_diff_frames", True)
>>> psser + ps.Series([1, 2, 3])
0    2
1    3
2    3
dtype: int64
>>> ps.Series([1, 2, 3]) + psser
0    2
1    3
2    3
dtype: int64

```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.

Keyword: SPARK-35337
