### PR TITLE
[SPARK-35463][BUILD] Skip checking checksum on a system without `shasum`

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -75,7 +75,7 @@ install_app() {
     fi
     # Checksum may not have been specified; don't check if doesn't exist
     if [ "$(command -v shasum)" ]; then
-      if [ -f "${local_checksum}" -a "$(command -v shasum)" ]; then
+      if [ -f "${local_checksum}" ]; then
         echo "  ${local_tarball}" >> ${local_checksum} # two spaces + file are important!
         # Assuming SHA512 here for now
         echo "Veryfing checksum from ${local_checksum}" 1>&2

--- a/build/mvn
+++ b/build/mvn
@@ -74,7 +74,7 @@ install_app() {
       exit 2
     fi
     # Checksum may not have been specified; don't check if doesn't exist
-    if [ -f "${local_checksum}" ]; then
+    if [ -f "${local_checksum}" -a "$(command -v shasum)" ]; then
       echo "  ${local_tarball}" >> ${local_checksum} # two spaces + file are important!
       # Assuming SHA512 here for now
       echo "Veryfing checksum from ${local_checksum}" 1>&2

--- a/build/mvn
+++ b/build/mvn
@@ -74,14 +74,18 @@ install_app() {
       exit 2
     fi
     # Checksum may not have been specified; don't check if doesn't exist
-    if [ -f "${local_checksum}" -a "$(command -v shasum)" ]; then
-      echo "  ${local_tarball}" >> ${local_checksum} # two spaces + file are important!
-      # Assuming SHA512 here for now
-      echo "Veryfing checksum from ${local_checksum}" 1>&2
-      if ! shasum -a 512 -c "${local_checksum}" > /dev/null ; then
-        echo "Bad checksum from ${remote_checksum}"
-        exit 2
+    if [ "$(command -v shasum)" ]; then
+      if [ -f "${local_checksum}" -a "$(command -v shasum)" ]; then
+        echo "  ${local_tarball}" >> ${local_checksum} # two spaces + file are important!
+        # Assuming SHA512 here for now
+        echo "Veryfing checksum from ${local_checksum}" 1>&2
+        if ! shasum -a 512 -c "${local_checksum}" > /dev/null ; then
+          echo "Bad checksum from ${remote_checksum}"
+          exit 2
+        fi
       fi
+    else
+      echo "Skipping checksum because shasum is not installed."
     fi
 
     cd "${_DIR}" && tar -xzf "${local_tarball}"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Not every build system has `shasum`. This PR aims to skip checksum checks on a system without `shasum`.

### Why are the changes needed?

**PREPARE**
```
$ docker run -it --rm -v $PWD:/spark openjdk:11-slim /bin/bash
root@a0e001a6e50f:/# cd /spark/
root@a0e001a6e50f:/spark# apt-get update
root@a0e001a6e50f:/spark# apt-get install curl
```

**BEFORE (Failure due to `command not found`)**
```
root@a0e001a6e50f:/spark# build/mvn clean
exec: curl --silent --show-error -L https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.tgz
exec: curl --silent --show-error -L https://www.apache.org/dyn/closer.lua/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz?action=download
exec: curl --silent --show-error -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz.sha512
Veryfing checksum from /spark/build/apache-maven-3.6.3-bin.tar.gz.sha512
build/mvn: line 81: shasum: command not found
Bad checksum from https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz.sha512
```

**AFTER**
```
root@a0e001a6e50f:/spark# build/mvn clean
exec: curl --silent --show-error -L https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.tgz
Skipping checksum because shasum is not installed.
exec: curl --silent --show-error -L https://www.apache.org/dyn/closer.lua/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz?action=download
exec: curl --silent --show-error -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz.sha512
Skipping checksum because shasum is not installed.
Using `mvn` from path: /spark/build/apache-maven-3.6.3/bin/mvn
```

### Does this PR introduce _any_ user-facing change?

Yes, this will recover the build.

### How was this patch tested?

Manually with the above process.