### PR TITLE
[SPARK-35465][PYTHON] Set up the mypy configuration to enable disallow_untyped_defs check for pandas APIs on Spark module.

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -85,8 +85,16 @@ disallow_untyped_defs = False
 [mypy-pyspark.sql.utils]
 disallow_untyped_defs = False
 
-[mypy-pyspark.pandas.*]
-strict_optional = False
+[mypy-pyspark.pandas.missing.*]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.plot.*]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.usage_logging.*]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.tests.*]
 disallow_untyped_defs = False
 
 [mypy-pyspark.tests.*]
@@ -103,6 +111,11 @@ disallow_untyped_defs = False
 
 [mypy-pyspark.worker]
 disallow_untyped_defs = False
+
+; Allow non-strict optional for pyspark.pandas
+
+[mypy-pyspark.pandas.*]
+strict_optional = False
 
 ; Ignore errors in embedded third party code
 
@@ -140,3 +153,44 @@ ignore_missing_imports = True
 
 [mypy-sklearn.*]
 ignore_missing_imports = True
+
+; TODO(SPARK-35464): Enable disallow_untyped_defs
+
+[mypy-pyspark.pandas.data_type_ops.*]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.spark.accessors]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.typedef.typehints]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.accessors]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.base]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.frame]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.generic]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.groupby]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.indexing]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.namespace]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.series]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.utils]
+disallow_untyped_defs = False
+
+[mypy-pyspark.pandas.window]
+disallow_untyped_defs = False

--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -34,7 +34,7 @@ except ImportError as e:
 from pyspark.pandas.version import __version__  # noqa: F401
 
 
-def assert_python_version():
+def assert_python_version() -> None:
     major = 3
     minor = 5
     deprecated_version = (major, minor)
@@ -114,7 +114,7 @@ __all__ = [  # noqa: F405
 ]
 
 
-def _auto_patch_spark():
+def _auto_patch_spark() -> None:
     import os
     import logging
 
@@ -144,10 +144,14 @@ def _auto_patch_spark():
 
         from pyspark.sql import dataframe as df
 
-        df.DataFrame.to_pandas_on_spark = DataFrame.to_pandas_on_spark
+        df.DataFrame.to_pandas_on_spark = DataFrame.to_pandas_on_spark  # type: ignore
 
 
-def _auto_patch_pandas():
+_frame_has_class_getitem = False
+_series_has_class_getitem = False
+
+
+def _auto_patch_pandas() -> None:
     import pandas as pd
 
     # In order to use it in test cases.

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -299,7 +299,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def _column_label(self) -> Tuple:
+    def _column_label(self) -> Optional[Tuple]:
         pass
 
     @property

--- a/python/pyspark/pandas/categorical.py
+++ b/python/pyspark/pandas/categorical.py
@@ -82,7 +82,7 @@ class CategoricalAccessor(object):
         return self._data.dtype.categories
 
     @categories.setter
-    def categories(self, categories) -> None:
+    def categories(self, categories: pd.Index) -> None:
         raise NotImplementedError()
 
     @property
@@ -137,34 +137,40 @@ class CategoricalAccessor(object):
         """
         return self._data._with_new_scol(self._data.spark.column).rename()
 
-    def add_categories(self, new_categories, inplace: bool = False):
+    def add_categories(self, new_categories: pd.Index, inplace: bool = False) -> "ps.Series":
         raise NotImplementedError()
 
-    def as_ordered(self, inplace: bool = False):
+    def as_ordered(self, inplace: bool = False) -> "ps.Series":
         raise NotImplementedError()
 
-    def as_unordered(self, inplace: bool = False):
+    def as_unordered(self, inplace: bool = False) -> "ps.Series":
         raise NotImplementedError()
 
-    def remove_categories(self, removals, inplace: bool = False):
+    def remove_categories(self, removals: pd.Index, inplace: bool = False) -> "ps.Series":
         raise NotImplementedError()
 
-    def remove_unused_categories(self):
+    def remove_unused_categories(self) -> "ps.Series":
         raise NotImplementedError()
 
-    def rename_categories(self, new_categories, inplace: bool = False):
+    def rename_categories(self, new_categories: pd.Index, inplace: bool = False) -> "ps.Series":
         raise NotImplementedError()
 
-    def reorder_categories(self, new_categories, ordered: bool = None, inplace: bool = False):
+    def reorder_categories(
+        self, new_categories: pd.Index, ordered: bool = None, inplace: bool = False
+    ) -> "ps.Series":
         raise NotImplementedError()
 
     def set_categories(
-        self, new_categories, ordered: bool = None, rename: bool = False, inplace: bool = False
-    ):
+        self,
+        new_categories: pd.Index,
+        ordered: bool = None,
+        rename: bool = False,
+        inplace: bool = False,
+    ) -> "ps.Series":
         raise NotImplementedError()
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -20,7 +20,7 @@ Infrastructure of options for pandas-on-Spark.
 """
 from contextlib import contextmanager
 import json
-from typing import Union, Any, Tuple, Callable, List, Dict  # noqa: F401 (SPARK-34943)
+from typing import Any, Callable, Dict, Iterator, List, Tuple, Union  # noqa: F401 (SPARK-34943)
 
 from pyspark._globals import _NoValue, _NoValueType
 
@@ -243,7 +243,7 @@ class OptionError(AttributeError, KeyError):
     pass
 
 
-def show_options():
+def show_options() -> None:
     """
     Make a pretty table that can be copied and pasted into public documentation.
     This is currently for an internal purpose.
@@ -344,7 +344,7 @@ def reset_option(key: str) -> None:
 
 
 @contextmanager
-def option_context(*args):
+def option_context(*args: Any) -> Iterator[None]:
     """
     Context manager to temporarily set options in the `with` statement context.
 
@@ -383,11 +383,11 @@ def _check_option(key: str) -> None:
 class DictWrapper:
     """ provide attribute-style access to a nested dict"""
 
-    def __init__(self, d, prefix=""):
+    def __init__(self, d: Dict[str, Option], prefix: str = ""):
         object.__setattr__(self, "d", d)
         object.__setattr__(self, "prefix", prefix)
 
-    def __setattr__(self, key, val):
+    def __setattr__(self, key: str, val: Any) -> None:
         prefix = object.__getattribute__(self, "prefix")
         d = object.__getattribute__(self, "d")
         if prefix:
@@ -398,7 +398,7 @@ class DictWrapper:
             k for k in d.keys() if all(x in k.split(".") for x in canonical_key.split("."))
         ]
         if len(candidates) == 1 and candidates[0] == canonical_key:
-            return set_option(canonical_key, val)
+            set_option(canonical_key, val)
         else:
             raise OptionError(
                 "No such option: '{}'. Available options are [{}]".format(
@@ -406,7 +406,7 @@ class DictWrapper:
                 )
             )
 
-    def __getattr__(self, key):
+    def __getattr__(self, key: str) -> Union["DictWrapper", Any]:
         prefix = object.__getattribute__(self, "prefix")
         d = object.__getattribute__(self, "d")
         if prefix:
@@ -427,7 +427,7 @@ class DictWrapper:
         else:
             return DictWrapper(d, canonical_key)
 
-    def __dir__(self):
+    def __dir__(self) -> List[str]:
         prefix = object.__getattribute__(self, "prefix")
         d = object.__getattribute__(self, "d")
 
@@ -443,7 +443,7 @@ class DictWrapper:
 options = DictWrapper(_options_dict)
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -18,10 +18,11 @@
 """
 Date/Time related functions on pandas-on-Spark Series
 """
-from typing import TYPE_CHECKING
+from typing import Any, Optional, Union, TYPE_CHECKING, no_type_check
 
 import numpy as np  # noqa: F401 (SPARK-34943)
 import pandas as pd  # noqa: F401
+from pandas.tseries.offsets import DateOffset
 import pyspark.sql.functions as F
 from pyspark.sql.types import DateType, TimestampType, LongType
 
@@ -106,6 +107,7 @@ class DatetimeMethods(object):
         The microseconds of the datetime.
         """
 
+        @no_type_check
         def pandas_microsecond(s) -> "ps.Series[np.int64]":
             return s.dt.microsecond
 
@@ -165,6 +167,7 @@ class DatetimeMethods(object):
         dtype: int64
         """
 
+        @no_type_check
         def pandas_dayofweek(s) -> "ps.Series[np.int64]":
             return s.dt.dayofweek
 
@@ -182,6 +185,7 @@ class DatetimeMethods(object):
         The ordinal day of the year.
         """
 
+        @no_type_check
         def pandas_dayofyear(s) -> "ps.Series[np.int64]":
             return s.dt.dayofyear
 
@@ -193,6 +197,7 @@ class DatetimeMethods(object):
         The quarter of the date.
         """
 
+        @no_type_check
         def pandas_quarter(s) -> "ps.Series[np.int64]":
             return s.dt.quarter
 
@@ -232,6 +237,7 @@ class DatetimeMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_is_month_start(s) -> "ps.Series[bool]":
             return s.dt.is_month_start
 
@@ -271,6 +277,7 @@ class DatetimeMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_is_month_end(s) -> "ps.Series[bool]":
             return s.dt.is_month_end
 
@@ -321,6 +328,7 @@ class DatetimeMethods(object):
         Name: dates, dtype: bool
         """
 
+        @no_type_check
         def pandas_is_quarter_start(s) -> "ps.Series[bool]":
             return s.dt.is_quarter_start
 
@@ -371,6 +379,7 @@ class DatetimeMethods(object):
         Name: dates, dtype: bool
         """
 
+        @no_type_check
         def pandas_is_quarter_end(s) -> "ps.Series[bool]":
             return s.dt.is_quarter_end
 
@@ -410,6 +419,7 @@ class DatetimeMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_is_year_start(s) -> "ps.Series[bool]":
             return s.dt.is_year_start
 
@@ -449,6 +459,7 @@ class DatetimeMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_is_year_end(s) -> "ps.Series[bool]":
             return s.dt.is_year_end
 
@@ -488,6 +499,7 @@ class DatetimeMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_is_leap_year(s) -> "ps.Series[bool]":
             return s.dt.is_leap_year
 
@@ -499,6 +511,7 @@ class DatetimeMethods(object):
         The number of days in the month.
         """
 
+        @no_type_check
         def pandas_daysinmonth(s) -> "ps.Series[np.int64]":
             return s.dt.daysinmonth
 
@@ -512,6 +525,7 @@ class DatetimeMethods(object):
 
     # Methods
 
+    @no_type_check
     def tz_localize(self, tz) -> "ps.Series":
         """
         Localize tz-naive Datetime column to tz-aware Datetime column.
@@ -519,6 +533,7 @@ class DatetimeMethods(object):
         # Neither tz-naive or tz-aware datetime exists in Spark
         raise NotImplementedError()
 
+    @no_type_check
     def tz_convert(self, tz) -> "ps.Series":
         """
         Convert tz-aware Datetime column from one time zone to another.
@@ -559,12 +574,13 @@ class DatetimeMethods(object):
         dtype: datetime64[ns]
         """
 
+        @no_type_check
         def pandas_normalize(s) -> "ps.Series[np.datetime64]":
             return s.dt.normalize()
 
         return self._data.koalas.transform_batch(pandas_normalize)
 
-    def strftime(self, date_format) -> "ps.Series":
+    def strftime(self, date_format: str) -> "ps.Series":
         """
         Convert to a string Series using specified date_format.
 
@@ -607,12 +623,13 @@ class DatetimeMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_strftime(s) -> "ps.Series[str]":
             return s.dt.strftime(date_format)
 
         return self._data.koalas.transform_batch(pandas_strftime)
 
-    def round(self, freq, *args, **kwargs) -> "ps.Series":
+    def round(self, freq: Union[str, DateOffset], *args: Any, **kwargs: Any) -> "ps.Series":
         """
         Perform round operation on the data to the specified freq.
 
@@ -662,12 +679,13 @@ class DatetimeMethods(object):
         dtype: datetime64[ns]
         """
 
+        @no_type_check
         def pandas_round(s) -> "ps.Series[np.datetime64]":
             return s.dt.round(freq, *args, **kwargs)
 
         return self._data.koalas.transform_batch(pandas_round)
 
-    def floor(self, freq, *args, **kwargs) -> "ps.Series":
+    def floor(self, freq: Union[str, DateOffset], *args: Any, **kwargs: Any) -> "ps.Series":
         """
         Perform floor operation on the data to the specified freq.
 
@@ -717,12 +735,13 @@ class DatetimeMethods(object):
         dtype: datetime64[ns]
         """
 
+        @no_type_check
         def pandas_floor(s) -> "ps.Series[np.datetime64]":
             return s.dt.floor(freq, *args, **kwargs)
 
         return self._data.koalas.transform_batch(pandas_floor)
 
-    def ceil(self, freq, *args, **kwargs) -> "ps.Series":
+    def ceil(self, freq: Union[str, DateOffset], *args: Any, **kwargs: Any) -> "ps.Series":
         """
         Perform ceil operation on the data to the specified freq.
 
@@ -772,12 +791,13 @@ class DatetimeMethods(object):
         dtype: datetime64[ns]
         """
 
+        @no_type_check
         def pandas_ceil(s) -> "ps.Series[np.datetime64]":
             return s.dt.ceil(freq, *args, **kwargs)
 
         return self._data.koalas.transform_batch(pandas_ceil)
 
-    def month_name(self, locale=None) -> "ps.Series":
+    def month_name(self, locale: Optional[str] = None) -> "ps.Series":
         """
         Return the month names of the series with specified locale.
 
@@ -808,12 +828,13 @@ class DatetimeMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_month_name(s) -> "ps.Series[str]":
             return s.dt.month_name(locale=locale)
 
         return self._data.koalas.transform_batch(pandas_month_name)
 
-    def day_name(self, locale=None) -> "ps.Series":
+    def day_name(self, locale: Optional[str] = None) -> "ps.Series":
         """
         Return the day names of the series with specified locale.
 
@@ -844,13 +865,14 @@ class DatetimeMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_day_name(s) -> "ps.Series[str]":
             return s.dt.day_name(locale=locale)
 
         return self._data.koalas.transform_batch(pandas_day_name)
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/exceptions.py
+++ b/python/pyspark/pandas/exceptions.py
@@ -18,6 +18,7 @@
 """
 Exceptions/Errors used in pandas-on-Spark.
 """
+from typing import Optional
 
 
 class DataError(Exception):
@@ -28,7 +29,7 @@ class SparkPandasIndexingError(Exception):
     pass
 
 
-def code_change_hint(pandas_function, spark_target_function):
+def code_change_hint(pandas_function: Optional[str], spark_target_function: Optional[str]) -> str:
     if pandas_function is not None and spark_target_function is not None:
         return "You are trying to use pandas function {}, use spark function {}".format(
             pandas_function, spark_target_function
@@ -45,7 +46,12 @@ def code_change_hint(pandas_function, spark_target_function):
 
 
 class SparkPandasNotImplementedError(NotImplementedError):
-    def __init__(self, pandas_function=None, spark_target_function=None, description=""):
+    def __init__(
+        self,
+        pandas_function: Optional[str] = None,
+        spark_target_function: Optional[str] = None,
+        description: str = "",
+    ):
         self.pandas_source = pandas_function
         self.spark_target = spark_target_function
         hint = code_change_hint(pandas_function, spark_target_function)
@@ -59,12 +65,12 @@ class SparkPandasNotImplementedError(NotImplementedError):
 class PandasNotImplementedError(NotImplementedError):
     def __init__(
         self,
-        class_name,
-        method_name=None,
-        arg_name=None,
-        property_name=None,
-        deprecated=False,
-        reason="",
+        class_name: str,
+        method_name: Optional[str] = None,
+        arg_name: Optional[str] = None,
+        property_name: Optional[str] = None,
+        deprecated: bool = False,
+        reason: str = "",
     ):
         assert (method_name is None) != (property_name is None)
         self.class_name = class_name
@@ -106,7 +112,7 @@ class PandasNotImplementedError(NotImplementedError):
         super().__init__(msg)
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/extensions.py
+++ b/python/pyspark/pandas/extensions.py
@@ -14,10 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import Callable, Generic, Optional, Type, TypeVar, Union, TYPE_CHECKING
 import warnings
 
+if TYPE_CHECKING:
+    from pyspark.pandas.frame import DataFrame
+    from pyspark.pandas.indexes import Index
+    from pyspark.pandas.series import Series
 
-class CachedAccessor:
+
+T = TypeVar("T")
+
+
+class CachedAccessor(Generic[T]):
     """
     Custom property-like object.
 
@@ -42,19 +51,23 @@ class CachedAccessor:
     The pandas-on-Spark accessor is modified based on pandas.core.accessor.
     """
 
-    def __init__(self, name, accessor):
+    def __init__(self, name: str, accessor: Type[T]) -> None:
         self._name = name
         self._accessor = accessor
 
-    def __get__(self, obj, cls):
+    def __get__(
+        self, obj: Optional[Union["DataFrame", "Series", "Index"]], cls: Type[T]
+    ) -> Union[T, Type[T]]:
         if obj is None:
             return self._accessor
-        accessor_obj = self._accessor(obj)
+        accessor_obj = self._accessor(obj)  # type: ignore
         object.__setattr__(obj, self._name, accessor_obj)
         return accessor_obj
 
 
-def _register_accessor(name, cls):
+def _register_accessor(
+    name: str, cls: Union[Type["DataFrame"], Type["Series"], Type["Index"]]
+) -> Callable[[Type[T]], Type[T]]:
     """
     Register a custom accessor on {klass} objects.
 
@@ -103,7 +116,7 @@ def _register_accessor(name, cls):
     register_series_accessor, or register_index_accessor.
     """
 
-    def decorator(accessor):
+    def decorator(accessor: Type[T]) -> Type[T]:
         if hasattr(cls, name):
             msg = (
                 "registration of accessor {0} under name '{1}' for type {2} is overriding "
@@ -119,7 +132,7 @@ def _register_accessor(name, cls):
     return decorator
 
 
-def register_dataframe_accessor(name):
+def register_dataframe_accessor(name: str) -> Callable[[Type[T]], Type[T]]:
     """
     Register a custom accessor with a DataFrame
 
@@ -197,7 +210,7 @@ def register_dataframe_accessor(name):
     return _register_accessor(name, DataFrame)
 
 
-def register_series_accessor(name):
+def register_series_accessor(name: str) -> Callable[[Type[T]], Type[T]]:
     """
     Register a custom accessor with a Series object
 
@@ -269,7 +282,7 @@ def register_series_accessor(name):
     return _register_accessor(name, Series)
 
 
-def register_index_accessor(name):
+def register_index_accessor(name: str) -> Callable[[Type[T]], Type[T]]:
     """
     Register a custom accessor with an Index
 
@@ -342,7 +355,7 @@ def register_index_accessor(name):
     return _register_accessor(name, Index)
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/extensions.py
+++ b/python/pyspark/pandas/extensions.py
@@ -18,9 +18,9 @@ from typing import Callable, Generic, Optional, Type, TypeVar, Union, TYPE_CHECK
 import warnings
 
 if TYPE_CHECKING:
-    from pyspark.pandas.frame import DataFrame
-    from pyspark.pandas.indexes import Index
-    from pyspark.pandas.series import Series
+    from pyspark.pandas.frame import DataFrame  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 T = TypeVar("T")

--- a/python/pyspark/pandas/indexes/category.py
+++ b/python/pyspark/pandas/indexes/category.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 from functools import partial
-from typing import Any
+from typing import Any, no_type_check
 
 import pandas as pd
 from pandas.api.types import is_hashable
@@ -97,6 +97,7 @@ class CategoricalIndex(Index):
                      categories=['a', 'b', 'c'], ordered=False, dtype='category')
     """
 
+    @no_type_check
     def __new__(cls, data=None, categories=None, ordered=None, dtype=None, copy=False, name=None):
         if not is_hashable(name):
             raise TypeError("Index.name must be a hashable type")
@@ -158,7 +159,7 @@ class CategoricalIndex(Index):
         return self.dtype.categories
 
     @categories.setter
-    def categories(self, categories):
+    def categories(self, categories: pd.Index) -> None:
         raise NotImplementedError()
 
     @property
@@ -188,7 +189,7 @@ class CategoricalIndex(Index):
         raise AttributeError("'CategoricalIndex' object has no attribute '{}'".format(item))
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -17,7 +17,7 @@
 
 from distutils.version import LooseVersion
 from functools import partial
-from typing import Any, Optional, Tuple, Union, cast
+from typing import Any, Callable, Iterator, List, Optional, Tuple, Union, cast, no_type_check
 import warnings
 
 import pandas as pd
@@ -26,6 +26,7 @@ from pandas.api.types import is_hashable
 
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Window
+from pyspark.sql.types import DataType
 
 # For running doctests and reference resolution in PyCharm.
 from pyspark import pandas as ps  # noqa: F401
@@ -46,7 +47,7 @@ from pyspark.pandas.internal import (
     NATURAL_ORDER_COLUMN_NAME,
     SPARK_INDEX_NAME_FORMAT,
 )
-from pyspark.pandas.typedef import Scalar
+from pyspark.pandas.typedef import Dtype, Scalar
 
 
 class MultiIndex(Index):
@@ -94,6 +95,7 @@ class MultiIndex(Index):
                )
     """
 
+    @no_type_check
     def __new__(
         cls,
         levels=None,
@@ -104,7 +106,7 @@ class MultiIndex(Index):
         copy=False,
         name=None,
         verify_integrity: bool = True,
-    ):
+    ) -> "MultiIndex":
         if LooseVersion(pd.__version__) < LooseVersion("0.24"):
             if levels is None or codes is None:
                 raise TypeError("Must pass both levels and codes")
@@ -133,9 +135,9 @@ class MultiIndex(Index):
         return ps.from_pandas(pidx)
 
     @property
-    def _internal(self):
+    def _internal(self) -> InternalFrame:
         internal = self._psdf._internal
-        scol = F.struct(internal.index_spark_columns)
+        scol = F.struct(*internal.index_spark_columns)
         return internal.copy(
             column_labels=[None],
             data_spark_columns=[scol],
@@ -144,26 +146,29 @@ class MultiIndex(Index):
         )
 
     @property
-    def _column_label(self):
+    def _column_label(self) -> Optional[Tuple]:
         return None
 
-    def __abs__(self):
+    def __abs__(self) -> Index:
         raise TypeError("TypeError: cannot perform __abs__ with this index type: MultiIndex")
 
-    def _with_new_scol(self, scol: spark.Column, *, dtype=None):
+    def _with_new_scol(self, scol: spark.Column, *, dtype: Optional[Dtype] = None) -> Index:
         raise NotImplementedError("Not supported for type MultiIndex")
 
-    def _align_and_column_op(self, f, *args) -> Index:
-        raise NotImplementedError("Not supported for type MultiIndex")
-
+    @no_type_check
     def any(self, *args, **kwargs) -> None:
         raise TypeError("cannot perform any with this index type: MultiIndex")
 
+    @no_type_check
     def all(self, *args, **kwargs) -> None:
         raise TypeError("cannot perform all with this index type: MultiIndex")
 
     @staticmethod
-    def from_tuples(tuples, sortorder=None, names=None) -> "MultiIndex":
+    def from_tuples(
+        tuples: List[Tuple],
+        sortorder: Optional[int] = None,
+        names: Optional[List[Union[Any, Tuple]]] = None,
+    ) -> "MultiIndex":
         """
         Convert list of tuples to MultiIndex.
 
@@ -200,7 +205,11 @@ class MultiIndex(Index):
         )
 
     @staticmethod
-    def from_arrays(arrays, sortorder=None, names=None) -> "MultiIndex":
+    def from_arrays(
+        arrays: List[List],
+        sortorder: Optional[int] = None,
+        names: Optional[List[Union[Any, Tuple]]] = None,
+    ) -> "MultiIndex":
         """
         Convert arrays to MultiIndex.
 
@@ -237,7 +246,11 @@ class MultiIndex(Index):
         )
 
     @staticmethod
-    def from_product(iterables, sortorder=None, names=None) -> "MultiIndex":
+    def from_product(
+        iterables: List[List],
+        sortorder: Optional[int] = None,
+        names: Optional[List[Union[Any, Tuple]]] = None,
+    ) -> "MultiIndex":
         """
         Make a MultiIndex from the cartesian product of multiple iterables.
 
@@ -282,7 +295,7 @@ class MultiIndex(Index):
         )
 
     @staticmethod
-    def from_frame(df, names=None) -> "MultiIndex":
+    def from_frame(df: DataFrame, names: Optional[List[Union[Any, Tuple]]] = None) -> "MultiIndex":
         """
         Make a MultiIndex from a DataFrame.
 
@@ -354,14 +367,16 @@ class MultiIndex(Index):
         return cast(MultiIndex, DataFrame(internal).index)
 
     @property
-    def name(self) -> str:
+    def name(self) -> Union[Any, Tuple]:
         raise PandasNotImplementedError(class_name="pd.MultiIndex", property_name="name")
 
     @name.setter
-    def name(self, name: str) -> None:
+    def name(self, name: Union[Any, Tuple]) -> None:
         raise PandasNotImplementedError(class_name="pd.MultiIndex", property_name="name")
 
-    def _verify_for_rename(self, name):
+    def _verify_for_rename(  # type: ignore[override]
+        self, name: List[Union[Any, Tuple]]
+    ) -> List[Tuple]:
         if is_list_like(name):
             if self._internal.index_level != len(name):
                 raise ValueError(
@@ -375,7 +390,7 @@ class MultiIndex(Index):
         else:
             raise TypeError("Must pass list-like as `names`.")
 
-    def swaplevel(self, i=-2, j=-1) -> "MultiIndex":
+    def swaplevel(self, i: int = -2, j: int = -1) -> "MultiIndex":
         """
         Swap level i with level j.
         Calling this method does not change the ordering of the values.
@@ -468,16 +483,21 @@ class MultiIndex(Index):
         return tuple(result)
 
     @staticmethod
-    def _comparator_for_monotonic_increasing(data_type):
+    def _comparator_for_monotonic_increasing(
+        data_type: DataType,
+    ) -> Callable[
+        [spark.Column, spark.Column, Callable[[spark.Column, spark.Column], spark.Column]],
+        spark.Column,
+    ]:
         return compare_disallow_null
 
-    def _is_monotonic(self, order):
+    def _is_monotonic(self, order: str) -> bool:
         if order == "increasing":
             return self._is_monotonic_increasing().all()
         else:
             return self._is_monotonic_decreasing().all()
 
-    def _is_monotonic_increasing(self):
+    def _is_monotonic_increasing(self) -> Series:
         window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-1, -1)
 
         cond = F.lit(True)
@@ -516,10 +536,15 @@ class MultiIndex(Index):
         return first_series(DataFrame(internal))
 
     @staticmethod
-    def _comparator_for_monotonic_decreasing(data_type):
+    def _comparator_for_monotonic_decreasing(
+        data_type: DataType,
+    ) -> Callable[
+        [spark.Column, spark.Column, Callable[[spark.Column, spark.Column], spark.Column]],
+        spark.Column,
+    ]:
         return compare_disallow_null
 
-    def _is_monotonic_decreasing(self):
+    def _is_monotonic_decreasing(self) -> Series:
         window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(-1, -1)
 
         cond = F.lit(True)
@@ -557,7 +582,9 @@ class MultiIndex(Index):
 
         return first_series(DataFrame(internal))
 
-    def to_frame(self, index=True, name=None) -> DataFrame:
+    def to_frame(  # type: ignore[override]
+        self, index: bool = True, name: Optional[List[Union[Any, Tuple]]] = None
+    ) -> DataFrame:
         """
         Create a DataFrame with the levels of the MultiIndex as columns.
         Column ordering is determined by the DataFrame constructor with data as
@@ -664,11 +691,13 @@ class MultiIndex(Index):
 
     toPandas.__doc__ = to_pandas.__doc__
 
-    def nunique(self, dropna=True) -> None:  # type: ignore
+    def nunique(self, dropna: bool = True, approx: bool = False, rsd: float = 0.05) -> int:
         raise NotImplementedError("nunique is not defined for MultiIndex")
 
     # TODO: add 'name' parameter after pd.MultiIndex.name is implemented
-    def copy(self, deep=None) -> "MultiIndex":  # type: ignore
+    def copy(  # type: ignore[override]
+        self, deep: Optional[bool] = None
+    ) -> "MultiIndex":
         """
         Make a copy of this object.
 
@@ -700,7 +729,12 @@ class MultiIndex(Index):
         """
         return super().copy(deep=deep)  # type: ignore
 
-    def symmetric_difference(self, other, result_name=None, sort=None) -> "MultiIndex":
+    def symmetric_difference(  # type: ignore[override]
+        self,
+        other: Index,
+        result_name: Optional[List[Union[Any, Tuple]]] = None,
+        sort: Optional[bool] = None,
+    ) -> "MultiIndex":
         """
         Compute the symmetric difference of two MultiIndex objects.
 
@@ -776,7 +810,7 @@ class MultiIndex(Index):
         sdf_symdiff = sdf_self.union(sdf_other).subtract(sdf_self.intersect(sdf_other))
 
         if sort:
-            sdf_symdiff = sdf_symdiff.sort(self._internal.index_spark_columns)
+            sdf_symdiff = sdf_symdiff.sort(*self._internal.index_spark_columns)
 
         internal = InternalFrame(  # TODO: dtypes?
             spark_frame=sdf_symdiff,
@@ -793,7 +827,9 @@ class MultiIndex(Index):
         return result
 
     # TODO: ADD error parameter
-    def drop(self, codes, level=None) -> "MultiIndex":
+    def drop(
+        self, codes: List[Any], level: Optional[Union[int, Any, Tuple]] = None
+    ) -> "MultiIndex":
         """
         Make new MultiIndex with passed list of labels deleted
 
@@ -868,7 +904,7 @@ class MultiIndex(Index):
     def argmin(self) -> None:
         raise TypeError("reduction operation 'argmin' not allowed for this dtype")
 
-    def asof(self, label) -> None:
+    def asof(self, label: Any) -> None:
         raise NotImplementedError(
             "only the default get_loc method is currently supported for MultiIndex"
         )
@@ -904,7 +940,7 @@ class MultiIndex(Index):
                 return partial(property_or_func, self)
         raise AttributeError("'MultiIndex' object has no attribute '{}'".format(item))
 
-    def _get_level_number(self, level) -> Optional[int]:
+    def _get_level_number(self, level: Union[int, Any, Tuple]) -> int:
         """
         Return the level number if a valid level is given.
         """
@@ -929,11 +965,10 @@ class MultiIndex(Index):
                 level = level + nlevels
         else:
             raise KeyError("Level %s not found" % str(level))
-            return None
 
         return level
 
-    def get_level_values(self, level) -> Index:
+    def get_level_values(self, level: Union[int, Any, Tuple]) -> Index:
         """
         Return vector of label values for requested level,
         equal to the length of the index.
@@ -980,7 +1015,7 @@ class MultiIndex(Index):
         )
         return DataFrame(internal).index
 
-    def insert(self, loc: int, item) -> Index:
+    def insert(self, loc: int, item: Any) -> Index:
         """
         Make new MultiIndex inserting new item at location.
 
@@ -1029,7 +1064,9 @@ class MultiIndex(Index):
                     "index {} is out of bounds for axis 0 with size {}".format(loc, length)
                 )
 
-        index_name = self._internal.index_spark_column_names
+        index_name = [
+            (name,) for name in self._internal.index_spark_column_names
+        ]  # type: List[Tuple]
         sdf_before = self.to_frame(name=index_name)[:loc].to_spark()
         sdf_middle = Index([item]).to_frame(name=index_name).to_spark()
         sdf_after = self.to_frame(name=index_name)[loc:].to_spark()
@@ -1066,7 +1103,7 @@ class MultiIndex(Index):
         """
         return self._psdf.head(2)._to_internal_pandas().index.item()
 
-    def intersection(self, other) -> "MultiIndex":
+    def intersection(self, other: Union[DataFrame, Series, Index, List]) -> "MultiIndex":
         """
         Form the intersection of two Index objects.
 
@@ -1101,11 +1138,10 @@ class MultiIndex(Index):
         elif not all(isinstance(item, tuple) for item in other):
             raise TypeError("other must be a MultiIndex or a list of tuples")
         else:
-            other = MultiIndex.from_tuples(list(other))
-            spark_frame_other = other.to_frame().to_spark()
+            spark_frame_other = MultiIndex.from_tuples(list(other)).to_frame().to_spark()
             keep_name = True
 
-        default_name = [SPARK_INDEX_NAME_FORMAT(i) for i in range(self.nlevels)]
+        default_name = [SPARK_INDEX_NAME_FORMAT(i) for i in range(self.nlevels)]  # type: List
         spark_frame_self = self.to_frame(name=default_name).to_spark()
         spark_frame_intersected = spark_frame_self.intersect(spark_frame_other)
         if keep_name:
@@ -1120,7 +1156,7 @@ class MultiIndex(Index):
         return cast(MultiIndex, DataFrame(internal).index)
 
     @property
-    def hasnans(self):
+    def hasnans(self) -> bool:
         raise NotImplementedError("hasnans is not defined for MultiIndex")
 
     @property
@@ -1144,11 +1180,11 @@ class MultiIndex(Index):
     ) -> Tuple[Union["Series", "Index"], pd.Index]:
         return MissingPandasLikeMultiIndex.factorize(self, sort=sort, na_sentinel=na_sentinel)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator:
         return MissingPandasLikeMultiIndex.__iter__(self)
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/indexes/numeric.py
+++ b/python/pyspark/pandas/indexes/numeric.py
@@ -14,12 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import Any, Optional, Tuple, Union, cast
+
 import pandas as pd
 from pandas.api.types import is_hashable
 
 from pyspark import pandas as ps
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.series import Series
+from pyspark.pandas.typedef.typehints import Dtype
 
 
 class NumericIndex(Index):
@@ -81,16 +84,24 @@ class Int64Index(IntegerIndex):
     Int64Index([1, 2, 3], dtype='int64')
     """
 
-    def __new__(cls, data=None, dtype=None, copy=False, name=None):
+    def __new__(
+        cls,
+        data: Optional[Any] = None,
+        dtype: Optional[Union[str, Dtype]] = None,
+        copy: bool = False,
+        name: Optional[Union[Any, Tuple]] = None,
+    ) -> "Int64Index":
         if not is_hashable(name):
             raise TypeError("Index.name must be a hashable type")
 
         if isinstance(data, (Series, Index)):
             if dtype is None:
                 dtype = "int64"
-            return Index(data, dtype=dtype, copy=copy, name=name)
+            return cast(Int64Index, Index(data, dtype=dtype, copy=copy, name=name))
 
-        return ps.from_pandas(pd.Int64Index(data=data, dtype=dtype, copy=copy, name=name))
+        return cast(
+            Int64Index, ps.from_pandas(pd.Int64Index(data=data, dtype=dtype, copy=copy, name=name))
+        )
 
 
 class Float64Index(NumericIndex):
@@ -135,19 +146,28 @@ class Float64Index(NumericIndex):
     Float64Index([1.0, 2.0, 3.0], dtype='float64')
     """
 
-    def __new__(cls, data=None, dtype=None, copy=False, name=None):
+    def __new__(
+        cls,
+        data: Optional[Any] = None,
+        dtype: Optional[Union[str, Dtype]] = None,
+        copy: bool = False,
+        name: Optional[Union[Any, Tuple]] = None,
+    ) -> "Float64Index":
         if not is_hashable(name):
             raise TypeError("Index.name must be a hashable type")
 
         if isinstance(data, (Series, Index)):
             if dtype is None:
                 dtype = "float64"
-            return Index(data, dtype=dtype, copy=copy, name=name)
+            return cast(Float64Index, Index(data, dtype=dtype, copy=copy, name=name))
 
-        return ps.from_pandas(pd.Float64Index(data=data, dtype=dtype, copy=copy, name=name))
+        return cast(
+            Float64Index,
+            ps.from_pandas(pd.Float64Index(data=data, dtype=dtype, copy=copy, name=name)),
+        )
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/ml.py
+++ b/python/pyspark/pandas/ml.py
@@ -91,7 +91,7 @@ def to_numeric_df(psdf: "ps.DataFrame") -> Tuple[pyspark.sql.DataFrame, List[Tup
     return v, numeric_column_labels
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/mlflow.py
+++ b/python/pyspark/pandas/mlflow.py
@@ -18,6 +18,8 @@
 """
 MLflow-related functions to load models and apply them to pandas-on-Spark dataframes.
 """
+from typing import List, Tuple, Union
+
 from pyspark.sql.types import DataType
 import pandas as pd
 import numpy as np
@@ -25,7 +27,7 @@ from typing import Any
 
 from pyspark.pandas.utils import lazy_property, default_session
 from pyspark.pandas.frame import DataFrame
-from pyspark.pandas.series import first_series
+from pyspark.pandas.series import Series, first_series
 from pyspark.pandas.typedef import as_spark_type
 
 __all__ = ["PythonModelWrapper", "load_model"]
@@ -39,8 +41,8 @@ class PythonModelWrapper(object):
 
     """
 
-    def __init__(self, model_uri, return_type_hint):
-        self._model_uri = model_uri  # type: str
+    def __init__(self, model_uri: str, return_type_hint: str):
+        self._model_uri = model_uri
         self._return_type_hint = return_type_hint
 
     @lazy_property
@@ -66,19 +68,19 @@ class PythonModelWrapper(object):
         return pyfunc.load_model(model_uri=self._model_uri)
 
     @lazy_property
-    def _model_udf(self):
+    def _model_udf(self) -> Any:
         from mlflow import pyfunc
 
         spark = default_session()
         return pyfunc.spark_udf(spark, model_uri=self._model_uri, result_type=self._return_type)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "PythonModelWrapper({})".format(str(self._model))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "PythonModelWrapper({})".format(repr(self._model))
 
-    def predict(self, data):
+    def predict(self, data: Union[DataFrame, pd.DataFrame]) -> Union[Series, pd.Series]:
         """
         Returns a prediction on the data.
 
@@ -89,7 +91,7 @@ class PythonModelWrapper(object):
         """
         if isinstance(data, pd.DataFrame):
             return self._model.predict(data)
-        if isinstance(data, DataFrame):
+        elif isinstance(data, DataFrame):
             return_col = self._model_udf(*data._internal.data_spark_columns)
             # TODO: the columns should be named according to the mlflow spec
             # However, this is only possible with spark >= 3.0
@@ -97,14 +99,16 @@ class PythonModelWrapper(object):
             # return_col = self._model_udf(s)
             column_labels = [
                 (col,) for col in data._internal.spark_frame.select(return_col).columns
-            ]
+            ]  # type: List[Tuple]
             internal = data._internal.copy(
                 column_labels=column_labels, data_spark_columns=[return_col], data_dtypes=None
             )
             return first_series(DataFrame(internal))
+        else:
+            raise ValueError("unknown data type: {}".format(type(data).__name__))
 
 
-def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:
+def load_model(model_uri: str, predict_type: str = "infer") -> PythonModelWrapper:
     """
     Loads an MLflow model into an wrapper that can be used both for pandas and pandas-on-Spark
     DataFrame.
@@ -197,7 +201,7 @@ def load_model(model_uri, predict_type="infer") -> PythonModelWrapper:
     return PythonModelWrapper(model_uri, predict_type)
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/mlflow.py
+++ b/python/pyspark/pandas/mlflow.py
@@ -18,7 +18,7 @@
 """
 MLflow-related functions to load models and apply them to pandas-on-Spark dataframes.
 """
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union  # noqa: F401 (SPARK-34943)
 
 from pyspark.sql.types import DataType
 import pandas as pd

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -417,7 +417,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         return self._psdf._internal.select_column(self._column_label)
 
     @property
-    def _column_label(self) -> Tuple:
+    def _column_label(self) -> Optional[Tuple]:
         return self._col_label
 
     def _update_anchor(self, psdf: DataFrame):

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -17,24 +17,27 @@
 """
 Additional Spark functions used in pandas-on-Spark.
 """
+from typing import Union, no_type_check
 
 from pyspark import SparkContext
 from pyspark.sql.column import Column, _to_java_column, _create_column_from_literal  # type: ignore
 
 
-def repeat(col, n):
+def repeat(col: Column, n: Union[int, Column]) -> Column:
     """
     Repeats a string column n times, and returns it as a new string column.
     """
-    sc = SparkContext._active_spark_context
+    sc = SparkContext._active_spark_context  # type: ignore
     n = _to_java_column(n) if isinstance(n, Column) else _create_column_from_literal(n)
     return _call_udf(sc, "repeat", _to_java_column(col), n)
 
 
+@no_type_check
 def _call_udf(sc, name, *cols):
     return Column(sc._jvm.functions.callUDF(name, _make_arguments(sc, *cols)))
 
 
+@no_type_check
 def _make_arguments(sc, *cols):
     java_arr = sc._gateway.new_array(sc._jvm.Column, len(cols))
     for i, col in enumerate(cols):

--- a/python/pyspark/pandas/spark/utils.py
+++ b/python/pyspark/pandas/spark/utils.py
@@ -176,7 +176,7 @@ StructField(B,DecimalType(30,15),false)))
         return dt
 
 
-def _test():
+def _test() -> None:
     import doctest
     import sys
     import pyspark.pandas.spark.utils

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -16,7 +16,7 @@
 #
 
 import _string  # type: ignore
-from typing import Dict, Any, Optional  # noqa: F401 (SPARK-34943)
+from typing import Any, Dict, Optional  # noqa: F401 (SPARK-34943)
 import inspect
 import pandas as pd
 
@@ -34,7 +34,12 @@ from builtins import globals as builtin_globals
 from builtins import locals as builtin_locals
 
 
-def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
+def sql(
+    query: str,
+    globals: Optional[Dict[str, Any]] = None,
+    locals: Optional[Dict[str, Any]] = None,
+    **kwargs: Any
+) -> DataFrame:
     """
     Execute a SQL query and return the result as a pandas-on-Spark DataFrame.
 
@@ -152,7 +157,7 @@ def sql(query: str, globals=None, locals=None, **kwargs) -> DataFrame:
 _CAPTURE_SCOPES = 2
 
 
-def _get_local_scope():
+def _get_local_scope() -> Dict[str, Any]:
     # Get 2 scopes above (_get_local_scope -> sql -> ...) to capture the vars there.
     try:
         return inspect.stack()[_CAPTURE_SCOPES][0].f_locals
@@ -162,7 +167,7 @@ def _get_local_scope():
         return {}
 
 
-def _get_ipython_scope():
+def _get_ipython_scope() -> Dict[str, Any]:
     """
     Tries to extract the dictionary of variables if the program is running
     in an IPython notebook environment.
@@ -257,7 +262,7 @@ class SQLProcessor(object):
                 self._session.catalog.dropTempView(v)
         return DataFrame(sdf)
 
-    def _convert(self, key) -> Any:
+    def _convert(self, key: str) -> Any:
         """
         Given a {} key, returns an equivalent SQL representation.
         This conversion performs all the necessary escaping so that the string
@@ -277,7 +282,7 @@ class SQLProcessor(object):
         self._cached_vars[key] = fillin
         return fillin
 
-    def _convert_var(self, var) -> Any:
+    def _convert_var(self, var: Any) -> Any:
         """
         Converts a python object into a string that is legal SQL.
         """
@@ -303,7 +308,7 @@ class SQLProcessor(object):
         raise ValueError("Unsupported variable type {}: {}".format(type(var).__name__, str(var)))
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/strings.py
+++ b/python/pyspark/pandas/strings.py
@@ -18,7 +18,17 @@
 """
 String functions on pandas-on-Spark Series
 """
-from typing import Union, TYPE_CHECKING, cast, Optional, List
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Union,
+    TYPE_CHECKING,
+    cast,
+    no_type_check,
+)
 
 import numpy as np
 
@@ -63,6 +73,7 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_capitalize(s) -> "ps.Series[str]":
             return s.str.capitalize()
 
@@ -90,6 +101,7 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_title(s) -> "ps.Series[str]":
             return s.str.title()
 
@@ -163,12 +175,13 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_swapcase(s) -> "ps.Series[str]":
             return s.str.swapcase()
 
         return self._data.koalas.transform_batch(pandas_swapcase)
 
-    def startswith(self, pattern, na=None) -> "ps.Series":
+    def startswith(self, pattern: str, na: Optional[Any] = None) -> "ps.Series":
         """
         Test if the start of each string element matches a pattern.
 
@@ -214,12 +227,13 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_startswith(s) -> "ps.Series[bool]":
             return s.str.startswith(pattern, na)
 
         return self._data.koalas.transform_batch(pandas_startswith)
 
-    def endswith(self, pattern, na=None) -> "ps.Series":
+    def endswith(self, pattern: str, na: Optional[Any] = None) -> "ps.Series":
         """
         Test if the end of each string element matches a pattern.
 
@@ -265,12 +279,13 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_endswith(s) -> "ps.Series[bool]":
             return s.str.endswith(pattern, na)
 
         return self._data.koalas.transform_batch(pandas_endswith)
 
-    def strip(self, to_strip=None) -> "ps.Series":
+    def strip(self, to_strip: Optional[str] = None) -> "ps.Series":
         """
         Remove leading and trailing characters.
 
@@ -317,12 +332,13 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_strip(s) -> "ps.Series[str]":
             return s.str.strip(to_strip)
 
         return self._data.koalas.transform_batch(pandas_strip)
 
-    def lstrip(self, to_strip=None) -> "ps.Series":
+    def lstrip(self, to_strip: Optional[str] = None) -> "ps.Series":
         """
         Remove leading characters.
 
@@ -357,12 +373,13 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_lstrip(s) -> "ps.Series[str]":
             return s.str.lstrip(to_strip)
 
         return self._data.koalas.transform_batch(pandas_lstrip)
 
-    def rstrip(self, to_strip=None) -> "ps.Series":
+    def rstrip(self, to_strip: Optional[str] = None) -> "ps.Series":
         """
         Remove trailing characters.
 
@@ -397,12 +414,13 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_rstrip(s) -> "ps.Series[str]":
             return s.str.rstrip(to_strip)
 
         return self._data.koalas.transform_batch(pandas_rstrip)
 
-    def get(self, i) -> "ps.Series":
+    def get(self, i: int) -> "ps.Series":
         """
         Extract element from each string or string list/tuple in the Series
         at the specified position.
@@ -451,6 +469,7 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_get(s) -> "ps.Series[str]":
             return s.str.get(i)
 
@@ -487,6 +506,7 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_isalnum(s) -> "ps.Series[bool]":
             return s.str.isalnum()
 
@@ -512,6 +532,7 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_isalpha(s) -> "ps.Series[bool]":
             return s.str.isalpha()
 
@@ -562,6 +583,7 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_isdigit(s) -> "ps.Series[bool]":
             return s.str.isdigit()
 
@@ -585,6 +607,7 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_isspace(s) -> "ps.Series[bool]":
             return s.str.isspace()
 
@@ -609,6 +632,7 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_isspace(s) -> "ps.Series[bool]":
             return s.str.islower()
 
@@ -633,6 +657,7 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_isspace(s) -> "ps.Series[bool]":
             return s.str.isupper()
 
@@ -663,6 +688,7 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_istitle(s) -> "ps.Series[bool]":
             return s.str.istitle()
 
@@ -721,6 +747,7 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_isnumeric(s) -> "ps.Series[bool]":
             return s.str.isnumeric()
 
@@ -771,18 +798,20 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_isdecimal(s) -> "ps.Series[bool]":
             return s.str.isdecimal()
 
         return self._data.koalas.transform_batch(pandas_isdecimal)
 
+    @no_type_check
     def cat(self, others=None, sep=None, na_rep=None, join=None) -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def center(self, width, fillchar=" ") -> "ps.Series":
+    def center(self, width: int, fillchar: str = " ") -> "ps.Series":
         """
         Filling left and right side of strings in the Series/Index with an
         additional character. Equivalent to :func:`str.center`.
@@ -813,12 +842,15 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_center(s) -> "ps.Series[str]":
             return s.str.center(width, fillchar)
 
         return self._data.koalas.transform_batch(pandas_center)
 
-    def contains(self, pat, case=True, flags=0, na=None, regex=True) -> "ps.Series":
+    def contains(
+        self, pat: str, case: bool = True, flags: int = 0, na: Any = None, regex: bool = True
+    ) -> "ps.Series":
         """
         Test if pattern or regex is contained within a string of a Series.
 
@@ -930,12 +962,13 @@ class StringMethods(object):
         dtype: bool
         """
 
+        @no_type_check
         def pandas_contains(s) -> "ps.Series[bool]":
             return s.str.contains(pat, case, flags, na, regex)
 
         return self._data.koalas.transform_batch(pandas_contains)
 
-    def count(self, pat, flags=0) -> "ps.Series":
+    def count(self, pat: str, flags: int = 0) -> "ps.Series":
         """
         Count occurrences of pattern in each string of the Series.
 
@@ -980,36 +1013,41 @@ class StringMethods(object):
         dtype: int64
         """
 
+        @no_type_check
         def pandas_count(s) -> "ps.Series[int]":
             return s.str.count(pat, flags)
 
         return self._data.koalas.transform_batch(pandas_count)
 
+    @no_type_check
     def decode(self, encoding, errors="strict") -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
+    @no_type_check
     def encode(self, encoding, errors="strict") -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
+    @no_type_check
     def extract(self, pat, flags=0, expand=True) -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
+    @no_type_check
     def extractall(self, pat, flags=0) -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def find(self, sub, start=0, end=None) -> "ps.Series":
+    def find(self, sub: str, start: int = 0, end: Optional[int] = None) -> "ps.Series":
         """
         Return lowest indexes in each strings in the Series where the
         substring is fully contained between [start:end].
@@ -1059,12 +1097,13 @@ class StringMethods(object):
         dtype: int64
         """
 
+        @no_type_check
         def pandas_find(s) -> "ps.Series[int]":
             return s.str.find(sub, start, end)
 
         return self._data.koalas.transform_batch(pandas_find)
 
-    def findall(self, pat, flags=0) -> "ps.Series":
+    def findall(self, pat: str, flags: int = 0) -> "ps.Series":
         """
         Find all occurrences of pattern or regular expression in the Series.
 
@@ -1150,7 +1189,7 @@ class StringMethods(object):
         )
         return self._data._with_new_scol(scol=pudf(self._data.spark.column))
 
-    def index(self, sub, start=0, end=None) -> "ps.Series":
+    def index(self, sub: str, start: int = 0, end: Optional[int] = None) -> "ps.Series":
         """
         Return lowest indexes in each strings where the substring is fully
         contained between [start:end].
@@ -1188,12 +1227,13 @@ class StringMethods(object):
         >>> s.str.index('a', start=2) # doctest: +SKIP
         """
 
+        @no_type_check
         def pandas_index(s) -> "ps.Series[np.int64]":
             return s.str.index(sub, start, end)
 
         return self._data.koalas.transform_batch(pandas_index)
 
-    def join(self, sep) -> "ps.Series":
+    def join(self, sep: str) -> "ps.Series":
         """
         Join lists contained as elements in the Series with passed delimiter.
 
@@ -1237,6 +1277,7 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_join(s) -> "ps.Series[str]":
             return s.str.join(sep)
 
@@ -1276,7 +1317,7 @@ class StringMethods(object):
         else:
             return self._data.spark.transform(lambda c: F.length(c).cast(LongType()))
 
-    def ljust(self, width, fillchar=" ") -> "ps.Series":
+    def ljust(self, width: int, fillchar: str = " ") -> "ps.Series":
         """
         Filling right side of strings in the Series with an additional
         character. Equivalent to :func:`str.ljust`.
@@ -1307,12 +1348,13 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_ljust(s) -> "ps.Series[str]":
             return s.str.ljust(width, fillchar)
 
         return self._data.koalas.transform_batch(pandas_ljust)
 
-    def match(self, pat, case=True, flags=0, na=np.NaN) -> "ps.Series":
+    def match(self, pat: str, case: bool = True, flags: int = 0, na: Any = np.NaN) -> "ps.Series":
         """
         Determine if each string matches a regular expression.
 
@@ -1373,12 +1415,13 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_match(s) -> "ps.Series[bool]":
             return s.str.match(pat, case, flags, na)
 
         return self._data.koalas.transform_batch(pandas_match)
 
-    def normalize(self, form) -> "ps.Series":
+    def normalize(self, form: str) -> "ps.Series":
         """
         Return the Unicode normal form for the strings in the Series.
 
@@ -1396,12 +1439,13 @@ class StringMethods(object):
             A Series of normalized strings.
         """
 
+        @no_type_check
         def pandas_normalize(s) -> "ps.Series[str]":
             return s.str.normalize(form)
 
         return self._data.koalas.transform_batch(pandas_normalize)
 
-    def pad(self, width, side="left", fillchar=" ") -> "ps.Series":
+    def pad(self, width: int, side: str = "left", fillchar: str = " ") -> "ps.Series":
         """
         Pad strings in the Series up to width.
 
@@ -1444,18 +1488,19 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_pad(s) -> "ps.Series[str]":
             return s.str.pad(width, side, fillchar)
 
         return self._data.koalas.transform_batch(pandas_pad)
 
-    def partition(self, sep=" ", expand=True) -> "ps.Series":
+    def partition(self, sep: str = " ", expand: bool = True) -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def repeat(self, repeats) -> "ps.Series":
+    def repeat(self, repeats: int) -> "ps.Series":
         """
         Duplicate each string in the Series.
 
@@ -1492,7 +1537,15 @@ class StringMethods(object):
             raise TypeError("repeats expects an int parameter")
         return self._data.spark.transform(lambda c: SF.repeat(col=c, n=repeats))
 
-    def replace(self, pat, repl, n=-1, case=None, flags=0, regex=True) -> "ps.Series":
+    def replace(
+        self,
+        pat: str,
+        repl: Union[str, Callable[[str], str]],
+        n: int = -1,
+        case: Optional[bool] = None,
+        flags: int = 0,
+        regex: bool = True,
+    ) -> "ps.Series":
         """
         Replace occurrences of pattern/regex in the Series with some other
         string. Equivalent to :func:`str.replace` or :func:`re.sub`.
@@ -1581,12 +1634,13 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_replace(s) -> "ps.Series[str]":
             return s.str.replace(pat, repl, n=n, case=case, flags=flags, regex=regex)
 
         return self._data.koalas.transform_batch(pandas_replace)
 
-    def rfind(self, sub, start=0, end=None) -> "ps.Series":
+    def rfind(self, sub: str, start: int = 0, end: Optional[int] = None) -> "ps.Series":
         """
         Return highest indexes in each strings in the Series where the
         substring is fully contained between [start:end].
@@ -1636,12 +1690,13 @@ class StringMethods(object):
         dtype: int64
         """
 
+        @no_type_check
         def pandas_rfind(s) -> "ps.Series[int]":
             return s.str.rfind(sub, start, end)
 
         return self._data.koalas.transform_batch(pandas_rfind)
 
-    def rindex(self, sub, start=0, end=None) -> "ps.Series":
+    def rindex(self, sub: str, start: int = 0, end: Optional[int] = None) -> "ps.Series":
         """
         Return highest indexes in each strings where the substring is fully
         contained between [start:end].
@@ -1679,12 +1734,13 @@ class StringMethods(object):
         >>> s.str.rindex('a', start=2) # doctest: +SKIP
         """
 
+        @no_type_check
         def pandas_rindex(s) -> "ps.Series[np.int64]":
             return s.str.rindex(sub, start, end)
 
         return self._data.koalas.transform_batch(pandas_rindex)
 
-    def rjust(self, width, fillchar=" ") -> "ps.Series":
+    def rjust(self, width: int, fillchar: str = " ") -> "ps.Series":
         """
         Filling left side of strings in the Series with an additional
         character. Equivalent to :func:`str.rjust`.
@@ -1720,18 +1776,21 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_rjust(s) -> "ps.Series[str]":
             return s.str.rjust(width, fillchar)
 
         return self._data.koalas.transform_batch(pandas_rjust)
 
-    def rpartition(self, sep=" ", expand=True) -> "ps.Series":
+    def rpartition(self, sep: str = " ", expand: bool = True) -> "ps.Series":
         """
         Not supported.
         """
         raise NotImplementedError()
 
-    def slice(self, start=None, stop=None, step=None) -> "ps.Series":
+    def slice(
+        self, start: Optional[int] = None, stop: Optional[int] = None, step: Optional[int] = None
+    ) -> "ps.Series":
         """
         Slice substrings from each element in the Series.
 
@@ -1783,12 +1842,15 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_slice(s) -> "ps.Series[str]":
             return s.str.slice(start, stop, step)
 
         return self._data.koalas.transform_batch(pandas_slice)
 
-    def slice_replace(self, start=None, stop=None, repl=None) -> "ps.Series":
+    def slice_replace(
+        self, start: Optional[int] = None, stop: Optional[int] = None, repl: Optional[str] = None
+    ) -> "ps.Series":
         """
         Slice substrings from each element in the Series.
 
@@ -1857,12 +1919,15 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_slice_replace(s) -> "ps.Series[str]":
             return s.str.slice_replace(start, stop, repl)
 
         return self._data.koalas.transform_batch(pandas_slice_replace)
 
-    def split(self, pat=None, n=-1, expand=False) -> Union["ps.Series", "ps.DataFrame"]:
+    def split(
+        self, pat: Optional[str] = None, n: int = -1, expand: bool = False
+    ) -> Union["ps.Series", "ps.DataFrame"]:
         """
         Split strings around given separator/delimiter.
 
@@ -2009,7 +2074,9 @@ class StringMethods(object):
         else:
             return psser
 
-    def rsplit(self, pat=None, n=-1, expand=False) -> Union["ps.Series", "ps.DataFrame"]:
+    def rsplit(
+        self, pat: Optional[str] = None, n: int = -1, expand: bool = False
+    ) -> Union["ps.Series", "ps.DataFrame"]:
         """
         Split strings around given separator/delimiter.
 
@@ -2147,7 +2214,7 @@ class StringMethods(object):
         else:
             return psser
 
-    def translate(self, table) -> "ps.Series":
+    def translate(self, table: Dict) -> "ps.Series":
         """
         Map all characters in the string through the given mapping table.
         Equivalent to standard :func:`str.translate`.
@@ -2176,12 +2243,13 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_translate(s) -> "ps.Series[str]":
             return s.str.translate(table)
 
         return self._data.koalas.transform_batch(pandas_translate)
 
-    def wrap(self, width, **kwargs) -> "ps.Series":
+    def wrap(self, width: int, **kwargs: bool) -> "ps.Series":
         """
         Wrap long strings in the Series to be formatted in paragraphs with
         length less than a given width.
@@ -2227,12 +2295,13 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_wrap(s) -> "ps.Series[str]":
             return s.str.wrap(width, **kwargs)
 
         return self._data.koalas.transform_batch(pandas_wrap)
 
-    def zfill(self, width) -> "ps.Series":
+    def zfill(self, width: int) -> "ps.Series":
         """
         Pad strings in the Series by prepending ‘0’ characters.
 
@@ -2277,19 +2346,21 @@ class StringMethods(object):
         dtype: object
         """
 
+        @no_type_check
         def pandas_zfill(s) -> "ps.Series[str]":
             return s.str.zfill(width)
 
         return self._data.koalas.transform_batch(pandas_zfill)
 
-    def get_dummies(self, sep="|"):
+    @no_type_check
+    def get_dummies(self, sep: str = "|") -> "ps.DataFrame":
         """
         Not supported.
         """
         raise NotImplementedError()
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/typedef/string_typehints.py
+++ b/python/pyspark/pandas/typedef/string_typehints.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from inspect import FullArgSpec
+from typing import List, Optional, Type, cast as _cast  # noqa: F401
+
 import numpy as np  # noqa: F401
 import pandas  # noqa: F401
 import pandas as pd  # noqa: F401
@@ -22,7 +25,7 @@ from pandas import *  # noqa: F401
 from inspect import getfullargspec  # noqa: F401
 
 
-def resolve_string_type_hint(tpe):
+def resolve_string_type_hint(tpe: str) -> Optional[Type]:
     import pyspark.pandas as ps
     from pyspark.pandas import DataFrame, Series
 
@@ -34,4 +37,4 @@ def resolve_string_type_hint(tpe):
     }
     # This is a hack to resolve the forward reference string.
     exec("def func() -> %s: pass\narg_spec = getfullargspec(func)" % tpe, globals(), locs)
-    return locs["arg_spec"].annotations.get("return", None)
+    return _cast(FullArgSpec, locs["arg_spec"]).annotations.get("return", None)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Sets up the `mypy` configuration to enable `disallow_untyped_defs` check for pandas APIs on Spark module.

### Why are the changes needed?

Currently many functions in the main codes in pandas APIs on Spark module are still missing type annotations and disabled `mypy` check `disallow_untyped_defs`.

We should add more type annotations and enable the mypy check.

### Does this PR introduce _any_ user-facing change?

Yes.
This PR adds more type annotations in pandas APIs on Spark module, which can impact interaction with development tools for users.

### How was this patch tested?

The mypy check with a new configuration and existing tests should pass.
