### PR TITLE
[SPARK-34558][SQL][FOLLOWUP] Do not fail Spark startup with a broken FileSystem

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -75,7 +75,13 @@ private[sql] class SharedState(
         logDebug(s"Applying other initial session options to HadoopConf: $k -> $v")
         hadoopConfClone.set(k, v)
     }
-    val qualified = SharedState.qualifyWarehousePath(hadoopConfClone, warehousePath)
+    val qualified = try {
+      SharedState.qualifyWarehousePath(hadoopConfClone, warehousePath)
+    } catch {
+      case NonFatal(e) =>
+        logWarning("Cannot qualify the warehouse path, leaving it unqualified.", e)
+        warehousePath
+    }
     // Set warehouse path in the SparkConf and Hadoop conf, so that it's application wide reachable
     // from `SparkContext`.
     SharedState.setWarehousePathConf(sparkContext.conf, sparkContext.hadoopConfiguration, qualified)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -472,4 +472,13 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach wit
         expected)
     }
   }
+
+  test("SPARK-33944: Create a working SparkSession with a broken FileSystem") {
+    val session = SparkSession.builder()
+      .master("local")
+      .config(WAREHOUSE_PATH.key, "my_dir")
+      .config("fs.file.impl", "non.existing.class")
+      .getOrCreate()
+    session.sql("SELECT 1").collect()
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -474,11 +474,17 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach wit
   }
 
   test("SPARK-33944: Create a working SparkSession with a broken FileSystem") {
-    val session = SparkSession.builder()
-      .master("local")
-      .config(WAREHOUSE_PATH.key, "my_dir")
-      .config("fs.file.impl", "non.existing.class")
-      .getOrCreate()
-    session.sql("SELECT 1").collect()
+    val msg = "Cannot qualify the warehouse path, leaving it unqualified"
+    val logAppender = new LogAppender(msg)
+    withLogAppender(logAppender) {
+      val session =
+        SparkSession.builder()
+          .master("local")
+          .config(WAREHOUSE_PATH.key, "my_dir")
+          .config("fs.file.impl", "non.existing.class")
+          .getOrCreate()
+      session.sql("SELECT 1").collect()
+    }
+    assert(logAppender.loggingEvents.exists(_.getRenderedMessage.contains(msg)))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/31671

https://github.com/apache/spark/pull/31671 qualifies the warehouse at the beginning, which may fail Spark startup if something goes wrong, like the underlying FileSystem can't be initialized.

This PR falls back to the old behavior and leave the warehouse path unqualified if qualifying fails.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix a regression. It's important to be always able to start Spark app (e.g. spark-shell), so that we can debug.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
a new test case