### PR TITLE
[SPARK-34558][SQL][TESTS][FOLLOWUP] Fix a test to use a unknown filesystem

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -473,15 +473,14 @@ class SparkSessionBuilderSuite extends SparkFunSuite with BeforeAndAfterEach wit
     }
   }
 
-  test("SPARK-33944: Create a working SparkSession with a broken FileSystem") {
+  test("SPARK-34558: Create a working SparkSession with a broken FileSystem") {
     val msg = "Cannot qualify the warehouse path, leaving it unqualified"
     val logAppender = new LogAppender(msg)
     withLogAppender(logAppender) {
       val session =
         SparkSession.builder()
           .master("local")
-          .config(WAREHOUSE_PATH.key, "my_dir")
-          .config("fs.file.impl", "non.existing.class")
+          .config(WAREHOUSE_PATH.key, "unknown:///mydir")
           .getOrCreate()
       session.sql("SELECT 1").collect()
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/32622 to fix a test case.

### Why are the changes needed?

Fix a wrong test case name and fix the test case to cause the expected error correctly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.
