### PR TITLE
[SPARK-35452][PYTHON] Introduce ArrayOps, MapOps and StructOps

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -613,6 +613,7 @@ pyspark_pandas = Module(
         # unittests
         "pyspark.pandas.tests.data_type_ops.test_boolean_ops",
         "pyspark.pandas.tests.data_type_ops.test_categorical_ops",
+        "pyspark.pandas.tests.data_type_ops.test_complex_ops",
         "pyspark.pandas.tests.data_type_ops.test_date_ops",
         "pyspark.pandas.tests.data_type_ops.test_datetime_ops",
         "pyspark.pandas.tests.data_type_ops.test_num_ops",

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -21,12 +21,15 @@ from typing import TYPE_CHECKING, Union
 from pandas.api.types import CategoricalDtype
 
 from pyspark.sql.types import (
+    ArrayType,
     BooleanType,
     DataType,
     DateType,
     FractionalType,
     IntegralType,
+    MapType,
     StringType,
+    StructType,
     TimestampType,
 )
 
@@ -43,6 +46,7 @@ class DataTypeOps(object, metaclass=ABCMeta):
     def __new__(cls, dtype: Dtype, spark_type: DataType):
         from pyspark.pandas.data_type_ops.boolean_ops import BooleanOps
         from pyspark.pandas.data_type_ops.categorical_ops import CategoricalOps
+        from pyspark.pandas.data_type_ops.complex_ops import ArrayOps, ComplexOps
         from pyspark.pandas.data_type_ops.date_ops import DateOps
         from pyspark.pandas.data_type_ops.datetime_ops import DatetimeOps
         from pyspark.pandas.data_type_ops.num_ops import (
@@ -65,6 +69,10 @@ class DataTypeOps(object, metaclass=ABCMeta):
             return object.__new__(DatetimeOps)
         elif isinstance(spark_type, DateType):
             return object.__new__(DateOps)
+        elif isinstance(spark_type, ArrayType):
+            return object.__new__(ArrayOps)
+        elif isinstance(spark_type, MapType) or isinstance(spark_type, StructType):
+            return object.__new__(ComplexOps)
         else:
             raise TypeError("Type %s was not understood." % dtype)
 

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -46,7 +46,7 @@ class DataTypeOps(object, metaclass=ABCMeta):
     def __new__(cls, dtype: Dtype, spark_type: DataType):
         from pyspark.pandas.data_type_ops.boolean_ops import BooleanOps
         from pyspark.pandas.data_type_ops.categorical_ops import CategoricalOps
-        from pyspark.pandas.data_type_ops.complex_ops import ArrayOps, ComplexOps
+        from pyspark.pandas.data_type_ops.complex_ops import ArrayOps, MapOps, StructOps
         from pyspark.pandas.data_type_ops.date_ops import DateOps
         from pyspark.pandas.data_type_ops.datetime_ops import DatetimeOps
         from pyspark.pandas.data_type_ops.num_ops import (
@@ -71,8 +71,10 @@ class DataTypeOps(object, metaclass=ABCMeta):
             return object.__new__(DateOps)
         elif isinstance(spark_type, ArrayType):
             return object.__new__(ArrayOps)
-        elif isinstance(spark_type, MapType) or isinstance(spark_type, StructType):
-            return object.__new__(ComplexOps)
+        elif isinstance(spark_type, MapType):
+            return object.__new__(MapOps)
+        elif isinstance(spark_type, StructType):
+            return object.__new__(StructOps)
         else:
             raise TypeError("Type %s was not understood." % dtype)
 

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import TYPE_CHECKING, Union
+
+from pyspark.pandas.base import column_op, IndexOpsMixin
+from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.sql import functions as F
+from pyspark.sql.types import ArrayType, NumericType
+
+if TYPE_CHECKING:
+    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
+
+
+class ComplexOps(DataTypeOps):
+    """
+    The class for binary operations of pandas-on-Spark objects with complex types:
+    ArrayType, MapType and StructType.
+    """
+
+    @property
+    def pretty_name(self) -> str:
+        return 'complex types'
+
+
+class ArrayOps(ComplexOps):
+    """
+    The class for binary operations of pandas-on-Spark objects with ArrayType.
+    """
+
+    @property
+    def pretty_name(self) -> str:
+        return 'arrays'
+
+    def add(self, left, right) -> Union["Series", "Index"]:
+        if not isinstance(right, IndexOpsMixin) or (
+            isinstance(right, IndexOpsMixin) and not isinstance(right.spark.data_type, ArrayType)
+        ):
+            raise TypeError(
+                "Concatenation can not be applied to %s and the given type." % self.pretty_name)
+
+        left_type = left.spark.data_type.elementType
+        right_type = right.spark.data_type.elementType
+
+        if left_type != right_type and not (
+                isinstance(left_type, NumericType) and isinstance(right_type, NumericType)):
+            raise TypeError(
+                "Concatenation can only be applied to %s of the same type" % self.pretty_name)
+
+        return column_op(F.concat)(left, right)

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -27,18 +27,7 @@ if TYPE_CHECKING:
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
-class ComplexOps(DataTypeOps):
-    """
-    The class for binary operations of pandas-on-Spark objects with complex types:
-    ArrayType, MapType and StructType.
-    """
-
-    @property
-    def pretty_name(self) -> str:
-        return 'complex types'
-
-
-class ArrayOps(ComplexOps):
+class ArrayOps(DataTypeOps):
     """
     The class for binary operations of pandas-on-Spark objects with ArrayType.
     """
@@ -63,3 +52,23 @@ class ArrayOps(ComplexOps):
                 "Concatenation can only be applied to %s of the same type" % self.pretty_name)
 
         return column_op(F.concat)(left, right)
+
+
+class MapOps(DataTypeOps):
+    """
+    The class for binary operations of pandas-on-Spark objects with MapType.
+    """
+
+    @property
+    def pretty_name(self) -> str:
+        return 'PySpark MapType'
+
+
+class StructOps(DataTypeOps):
+    """
+    The class for binary operations of pandas-on-Spark objects with StructType.
+    """
+
+    @property
+    def pretty_name(self) -> str:
+        return 'PySpark StructType'

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -61,7 +61,7 @@ class MapOps(DataTypeOps):
 
     @property
     def pretty_name(self) -> str:
-        return 'PySpark MapType'
+        return 'maps'
 
 
 class StructOps(DataTypeOps):
@@ -71,4 +71,4 @@ class StructOps(DataTypeOps):
 
     @property
     def pretty_name(self) -> str:
-        return 'PySpark StructType'
+        return 'structs'

--- a/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
@@ -1,0 +1,199 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import decimal
+import datetime
+
+import pandas as pd
+
+from pyspark import pandas as ps
+from pyspark.pandas.config import option_context
+from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
+
+
+class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
+    @property
+    def numeric_array_psers(self):
+        return [
+            pd.Series([[1, 2, 3]]),
+            pd.Series([[0.1, 0.2, 0.3]]),
+            pd.Series([[decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(3)]])
+        ]
+
+    @property
+    def non_numeric_array_psers(self):
+        return {
+            "string": pd.Series([['x', 'y', 'z']]),
+            "date": pd.Series([
+                [datetime.date(1994, 1, 1), datetime.date(1994, 1, 2), datetime.date(1994, 1, 3)]]),
+            "bool": pd.Series([[True, True, False]])
+        }
+
+    @property
+    def numeric_array_pssers(self):
+        return [ps.from_pandas(pser) for pser in self.numeric_array_psers]
+
+    @property
+    def non_numeric_array_pssers(self):
+        pssers = {}
+
+        for k, v in self.non_numeric_array_psers.items():
+            pssers[k] = ps.from_pandas(v)
+        return pssers
+
+    @property
+    def psers(self):
+        return self.numeric_array_psers + list(self.non_numeric_array_psers.values())
+
+    @property
+    def pssers(self):
+        return self.numeric_array_pssers + list(self.non_numeric_array_pssers.values())
+
+    @property
+    def psser(self):
+        return ps.Series([[1, 2, 3]])
+
+    def test_add(self):
+        for pser, psser in zip(self.psers, self.pssers):
+            self.assert_eq(pser + pser, psser + psser)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            # Numeric array + Numeric array
+            for pser1, psser1 in zip(self.numeric_array_psers, self.numeric_array_pssers):
+                for pser2, psser2 in zip(self.numeric_array_psers, self.numeric_array_pssers):
+                    self.assert_eq((pser1 + pser2).sort_values(), (psser1 + psser2).sort_values())
+
+            # Non-numeric array + Non-numeric array
+            self.assertRaises(
+                TypeError, lambda:
+                self.non_numeric_array_pssers['string'] + self.non_numeric_array_pssers['bool']
+            )
+            self.assertRaises(
+                TypeError, lambda:
+                self.non_numeric_array_pssers['string'] + self.non_numeric_array_pssers['date']
+            )
+            self.assertRaises(
+                TypeError, lambda:
+                self.non_numeric_array_pssers['bool'] + self.non_numeric_array_pssers['date']
+            )
+
+            for data_type in self.non_numeric_array_psers.keys():
+                self.assert_eq(
+                    self.non_numeric_array_psers.get(data_type)
+                    + self.non_numeric_array_psers.get(data_type),
+                    self.non_numeric_array_pssers.get(data_type)
+                    + self.non_numeric_array_pssers.get(data_type)
+                )
+
+            # Numeric array + Non-numeric array
+            for numeric_ppser in self.numeric_array_pssers:
+                for non_numeric_ppser in self.non_numeric_array_pssers.values():
+                    self.assertRaises(TypeError, lambda: numeric_ppser + non_numeric_ppser)
+
+    def test_sub(self):
+        self.assertRaises(TypeError, lambda: self.psser - "x")
+        self.assertRaises(TypeError, lambda: self.psser - 1)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            for psser1 in self.pssers:
+                for psser2 in self.pssers:
+                    self.assertRaises(TypeError, lambda: psser1 - psser2)
+
+    def test_mul(self):
+        self.assertRaises(TypeError, lambda: self.psser * "x")
+        self.assertRaises(TypeError, lambda: self.psser * 1)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            for psser1 in self.pssers:
+                for psser2 in self.pssers:
+                    self.assertRaises(TypeError, lambda: psser1 * psser2)
+
+    def test_truediv(self):
+        self.assertRaises(TypeError, lambda: self.psser / "x")
+        self.assertRaises(TypeError, lambda: self.psser / 1)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            for psser1 in self.pssers:
+                for psser2 in self.pssers:
+                    self.assertRaises(TypeError, lambda: psser1 / psser2)
+
+    def test_floordiv(self):
+        self.assertRaises(TypeError, lambda: self.psser // "x")
+        self.assertRaises(TypeError, lambda: self.psser // 1)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            for psser1 in self.pssers:
+                for psser2 in self.pssers:
+                    self.assertRaises(TypeError, lambda: psser1 // psser2)
+
+    def test_mod(self):
+        self.assertRaises(TypeError, lambda: self.psser % "x")
+        self.assertRaises(TypeError, lambda: self.psser % 1)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            for psser1 in self.pssers:
+                for psser2 in self.pssers:
+                    self.assertRaises(TypeError, lambda: psser1 % psser2)
+
+    def test_pow(self):
+        self.assertRaises(TypeError, lambda: self.psser ** "x")
+        self.assertRaises(TypeError, lambda: self.psser ** 1)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            for psser1 in self.pssers:
+                for psser2 in self.pssers:
+                    self.assertRaises(TypeError, lambda: psser1 ** psser2)
+
+    def test_radd(self):
+        self.assertRaises(TypeError, lambda: "x" + self.psser)
+        self.assertRaises(TypeError, lambda: 1 + self.psser)
+
+    def test_rsub(self):
+        self.assertRaises(TypeError, lambda: "x" - self.psser)
+        self.assertRaises(TypeError, lambda: 1 - self.psser)
+
+    def test_rmul(self):
+        self.assertRaises(TypeError, lambda: "x" * self.psser)
+        self.assertRaises(TypeError, lambda: 2 * self.psser)
+
+    def test_rtruediv(self):
+        self.assertRaises(TypeError, lambda: "x" / self.psser)
+        self.assertRaises(TypeError, lambda: 1 / self.psser)
+
+    def test_rfloordiv(self):
+        self.assertRaises(TypeError, lambda: "x" // self.psser)
+        self.assertRaises(TypeError, lambda: 1 // self.psser)
+
+    def test_rmod(self):
+        self.assertRaises(TypeError, lambda: 1 % self.psser)
+
+    def test_rpow(self):
+        self.assertRaises(TypeError, lambda: "x" ** self.psser)
+        self.assertRaises(TypeError, lambda: 1 ** self.psser)
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.pandas.tests.data_type_ops.test_complex_ops import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The PR is proposed to introduce ArrayOps, MapOps and StructOps to handle data-type-based operations for StructType, ArrayType, and MapType separately.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
StructType, ArrayType, and MapType are not accepted by DataTypeOps now.

We should handle these complex types. Among them:

- ArrayType supports concatenation: for example, ps.Series([[1,2,3]]) + ps.Series([[4,5,6]]) should work the same as pd.Series([[1,2,3]]) + pd.Series([[4,5,6]]), as concatenation.

- StructOps will be helpful to make to/from pandas conversion data-type-based.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.

Before the change:
```py
>>> import pyspark.pandas as ps
>>> from pyspark.pandas.config import set_option
>>> set_option("compute.ops_on_diff_frames", True)
>>> ps.Series([[1, 2, 3]]) + ps.Series([[0.4, 0.5]])
Traceback (most recent call last):
...
TypeError: Type object was not understood.
>>> ps.Series([[1, 2, 3]]) + ps.Series([[4, 5]])
Traceback (most recent call last):
...
TypeError: Type object was not understood.
>>> ps.Series([[1, 2, 3]]) + ps.Series([['x']])
Traceback (most recent call last):
...
TypeError: Type object was not understood.
```

After the change:
```py
>>> import pyspark.pandas as ps
>>> from pyspark.pandas.config import set_option
>>> set_option("compute.ops_on_diff_frames", True)
>>> ps.Series([[1, 2, 3]]) + ps.Series([[0.4, 0.5]])
0    [1.0, 2.0, 3.0, 0.4, 0.5]                                                  
dtype: object
>>> ps.Series([[1, 2, 3]]) + ps.Series([[4, 5]])
0    [1, 2, 3, 4, 5]
dtype: object
>>> ps.Series([[1, 2, 3]]) + ps.Series([['x']])
Traceback (most recent call last):
...
TypeError: Concatenation can only be applied to arrays of the same type
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.

Keyword: SPARK-35337