### PR TITLE
[SPARK-35467][SPARK-35468][SPARK-35477][PYTHON] Fix disallow_untyped_defs mypy checks.

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -159,12 +159,6 @@ ignore_missing_imports = True
 [mypy-pyspark.pandas.data_type_ops.*]
 disallow_untyped_defs = False
 
-[mypy-pyspark.pandas.spark.accessors]
-disallow_untyped_defs = False
-
-[mypy-pyspark.pandas.typedef.typehints]
-disallow_untyped_defs = False
-
 [mypy-pyspark.pandas.accessors]
 disallow_untyped_defs = False
 
@@ -187,9 +181,6 @@ disallow_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-pyspark.pandas.series]
-disallow_untyped_defs = False
-
-[mypy-pyspark.pandas.utils]
 disallow_untyped_defs = False
 
 [mypy-pyspark.pandas.window]

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -136,7 +136,7 @@ def align_diff_index_ops(func, this_index_ops: "IndexOpsMixin", *args) -> "Index
                     name=this_index_ops.name,
                 )
             elif isinstance(this_index_ops, Series):
-                this = this_index_ops.reset_index()
+                this = cast(DataFrame, this_index_ops.reset_index())
                 that = [
                     cast(Series, col.to_series() if isinstance(col, Index) else col)
                     .rename(i)

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -18,7 +18,7 @@
 """
 Wrappers around spark that correspond to common pandas functions.
 """
-from typing import Any, Optional, Union, List, Tuple, Type, Sized, cast
+from typing import Any, Dict, List, Optional, Sized, Tuple, Type, Union, cast
 from collections import OrderedDict
 from collections.abc import Iterable
 from distutils.version import LooseVersion
@@ -307,7 +307,7 @@ def read_csv(
 
         if isinstance(names, str):
             sdf = reader.schema(names).csv(path)
-            column_labels = OrderedDict((col, col) for col in sdf.columns)
+            column_labels = OrderedDict((col, col) for col in sdf.columns)  # type: Dict[Any, str]
         else:
             sdf = reader.csv(path)
             if is_list_like(names):

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -18,7 +18,17 @@
 """
 Wrappers around spark that correspond to common pandas functions.
 """
-from typing import Any, Dict, List, Optional, Sized, Tuple, Type, Union, cast
+from typing import (  # noqa: F401 (SPARK-34943)
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sized,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 from collections import OrderedDict
 from collections.abc import Iterable
 from distutils.version import LooseVersion

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -21,7 +21,7 @@ Utilities to deal with types. This is mostly focused on python3.
 import datetime
 import decimal
 from inspect import getfullargspec, isclass
-from typing import Generic, List, Optional, Tuple, TypeVar, Union  # noqa: F401
+from typing import Any, Callable, Generic, List, Optional, Tuple, TypeVar, Union  # noqa: F401
 
 import numpy as np
 import pandas as pd
@@ -78,7 +78,7 @@ class SeriesType(Generic[T]):
         self.dtype = dtype
         self.spark_type = spark_type
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "SeriesType[{}]".format(self.spark_type)
 
 
@@ -96,7 +96,7 @@ class DataFrameType(object):
             ]
         )  # type: types.StructType
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "DataFrameType[{}]".format(self.spark_type)
 
 
@@ -106,16 +106,16 @@ class ScalarType(object):
         self.dtype = dtype
         self.spark_type = spark_type
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "ScalarType[{}]".format(self.spark_type)
 
 
 # The type is left unspecified or we do not know about this type.
 class UnknownType(object):
-    def __init__(self, tpe):
+    def __init__(self, tpe: Any):
         self.tpe = tpe
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "UnknownType[{}]".format(self.tpe)
 
 
@@ -262,7 +262,7 @@ def spark_type_to_pandas_dtype(
         return np.dtype(to_arrow_type(spark_type).to_pandas_dtype())
 
 
-def pandas_on_spark_type(tpe) -> Tuple[Dtype, types.DataType]:
+def pandas_on_spark_type(tpe: Union[str, type, Dtype]) -> Tuple[Dtype, types.DataType]:
     """
     Convert input into a pandas only dtype object or a numpy dtype object,
     and its corresponding Spark DataType.
@@ -322,7 +322,7 @@ def infer_pd_series_spark_type(pser: pd.Series, dtype: Dtype) -> types.DataType:
         return as_spark_type(dtype)
 
 
-def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, UnknownType]:
+def infer_return_type(f: Callable) -> Union[SeriesType, DataFrameType, ScalarType, UnknownType]:
     """
     Infer the return type from the return type annotation of the given function.
 
@@ -517,7 +517,7 @@ def infer_return_type(f) -> Union[SeriesType, DataFrameType, ScalarType, Unknown
         return ScalarType(*types)
 
 
-def _test():
+def _test() -> None:
     import doctest
     import sys
     import pyspark.pandas.typedef.typehints

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -22,7 +22,20 @@ import functools
 from collections import OrderedDict
 from contextlib import contextmanager
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TYPE_CHECKING, overload
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    TYPE_CHECKING,
+    cast,
+    no_type_check,
+    overload,
+)
 import warnings
 
 from pyspark import sql as spark
@@ -44,6 +57,7 @@ if TYPE_CHECKING:
     from pyspark.pandas.base import IndexOpsMixin  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.frame import DataFrame  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.internal import InternalFrame  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 ERROR_MESSAGE_CANNOT_COMBINE = (
@@ -90,7 +104,12 @@ def same_anchor(
     )
 
 
-def combine_frames(this, *args, how="full", preserve_order_column=False):
+def combine_frames(
+    this: "DataFrame",
+    *args: Union["DataFrame", "Series"],
+    how: str = "full",
+    preserve_order_column: bool = False
+) -> "DataFrame":
     """
     This method combines `this` DataFrame with a different `that` DataFrame or
     Series from a different DataFrame.
@@ -129,17 +148,17 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
 
     if get_option("compute.ops_on_diff_frames"):
 
-        def resolve(internal, side):
+        def resolve(internal: InternalFrame, side: str) -> InternalFrame:
             rename = lambda col: "__{}_{}".format(side, col)
             internal = internal.resolved_copy
             sdf = internal.spark_frame
             sdf = internal.spark_frame.select(
-                [
+                *[
                     scol_for(sdf, col).alias(rename(col))
                     for col in sdf.columns
                     if col not in HIDDEN_COLUMNS
-                ]
-                + list(HIDDEN_COLUMNS)
+                ],
+                *HIDDEN_COLUMNS
             )
             return internal.copy(
                 spark_frame=sdf,
@@ -216,16 +235,16 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
             order_column = []
 
         joined_df = joined_df.select(
-            merged_index_scols
-            + [
+            *merged_index_scols,
+            *(
                 scol_for(this_sdf, this_internal.spark_column_name_for(label))
                 for label in this_internal.column_labels
-            ]
-            + [
+            ),
+            *(
                 scol_for(that_sdf, that_internal.spark_column_name_for(label))
                 for label in that_internal.column_labels
-            ]
-            + order_column
+            ),
+            *order_column
         )
 
         index_spark_columns = [scol_for(joined_df, col) for col in index_column_names]
@@ -246,7 +265,7 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
 
         level = max(this_internal.column_labels_level, that_internal.column_labels_level)
 
-        def fill_label(label):
+        def fill_label(label: Optional[Tuple]) -> List:
             if label is None:
                 return ([""] * (level - 1)) + [None]
             else:
@@ -256,7 +275,7 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
             tuple(["this"] + fill_label(label)) for label in this_internal.column_labels
         ] + [tuple(["that"] + fill_label(label)) for label in that_internal.column_labels]
         column_label_names = (
-            [None] * (1 + level - this_internal.column_labels_level)
+            cast(List[Optional[Tuple]], [None]) * (1 + level - this_internal.column_labels_level)
         ) + this_internal.column_label_names
         return DataFrame(
             InternalFrame(
@@ -275,7 +294,7 @@ def combine_frames(this, *args, how="full", preserve_order_column=False):
 
 
 def align_diff_frames(
-    resolve_func,
+    resolve_func: Callable[["DataFrame", List[Tuple], List[Tuple]], Tuple["Series", Tuple]],
     this: "DataFrame",
     that: "DataFrame",
     fillna: bool = True,
@@ -385,11 +404,11 @@ def align_diff_frames(
     # Should extract columns to apply and do it in a batch in case
     # it adds new columns for example.
     if len(this_columns_to_apply) > 0 or len(that_columns_to_apply) > 0:
-        psser_set, column_labels_applied = zip(
+        psser_set, column_labels_set = zip(
             *resolve_func(combined, this_columns_to_apply, that_columns_to_apply)
         )
         columns_applied = list(psser_set)
-        column_labels_applied = list(column_labels_applied)
+        column_labels_applied = list(column_labels_set)
     else:
         columns_applied = []
         column_labels_applied = []
@@ -420,12 +439,12 @@ def align_diff_frames(
     return psdf
 
 
-def is_testing():
+def is_testing() -> bool:
     """ Indicates whether Spark is currently running tests. """
     return "SPARK_TESTING" in os.environ
 
 
-def default_session(conf=None):
+def default_session(conf: Optional[Dict[str, Any]] = None) -> spark.SparkSession:
     if conf is None:
         conf = dict()
 
@@ -443,7 +462,9 @@ def default_session(conf=None):
 
 
 @contextmanager
-def sql_conf(pairs, *, spark=None):
+def sql_conf(
+    pairs: Dict[str, Any], *, spark: Optional[spark.SparkSession] = None
+) -> Iterator[None]:
     """
     A convenient context manager to set `value` to the Spark SQL configuration `key` and
     then restores it back when it exits.
@@ -473,7 +494,7 @@ def validate_arguments_and_invoke_function(
     pandas_on_spark_func: Callable,
     pandas_func: Callable,
     input_args: Dict,
-):
+) -> Any:
     """
     Invokes a pandas function.
 
@@ -529,7 +550,8 @@ def validate_arguments_and_invoke_function(
     return pandas_func(**args)
 
 
-def lazy_property(fn):
+@no_type_check
+def lazy_property(fn: Callable[[Any], Any]) -> property:
     """
     Decorator that makes a property lazy-evaluated.
 
@@ -677,16 +699,19 @@ def is_name_like_value(
         return True
 
 
-def validate_axis(axis=0, none_axis=0):
+def validate_axis(axis: Optional[Union[int, str]] = 0, none_axis: int = 0) -> int:
     """ Check the given axis is valid. """
     # convert to numeric axis
-    axis = {None: none_axis, "index": 0, "columns": 1}.get(axis, axis)
-    if axis not in (none_axis, 0, 1):
+    axis = cast(
+        Dict[Optional[Union[int, str]], int], {None: none_axis, "index": 0, "columns": 1}
+    ).get(axis, axis)
+    if axis in (none_axis, 0, 1):
+        return cast(int, axis)
+    else:
         raise ValueError("No axis named {0}".format(axis))
-    return axis
 
 
-def validate_bool_kwarg(value, arg_name):
+def validate_bool_kwarg(value: Any, arg_name: str) -> Optional[bool]:
     """ Ensures that argument passed in arg_name is of type bool. """
     if not (isinstance(value, bool) or value is None):
         raise TypeError(
@@ -836,27 +861,43 @@ def verify_temp_column_name(
     return column_name_or_label
 
 
-def compare_null_first(left, right, comp):
+def compare_null_first(
+    left: spark.Column,
+    right: spark.Column,
+    comp: Callable[[spark.Column, spark.Column], spark.Column],
+) -> spark.Column:
     return (left.isNotNull() & right.isNotNull() & comp(left, right)) | (
         left.isNull() & right.isNotNull()
     )
 
 
-def compare_null_last(left, right, comp):
+def compare_null_last(
+    left: spark.Column,
+    right: spark.Column,
+    comp: Callable[[spark.Column, spark.Column], spark.Column],
+) -> spark.Column:
     return (left.isNotNull() & right.isNotNull() & comp(left, right)) | (
         left.isNotNull() & right.isNull()
     )
 
 
-def compare_disallow_null(left, right, comp):
+def compare_disallow_null(
+    left: spark.Column,
+    right: spark.Column,
+    comp: Callable[[spark.Column, spark.Column], spark.Column],
+) -> spark.Column:
     return left.isNotNull() & right.isNotNull() & comp(left, right)
 
 
-def compare_allow_null(left, right, comp):
+def compare_allow_null(
+    left: spark.Column,
+    right: spark.Column,
+    comp: Callable[[spark.Column, spark.Column], spark.Column],
+) -> spark.Column:
     return left.isNull() | right.isNull() | comp(left, right)
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds more type annotations in the files:

- `python/pyspark/pandas/spark/accessors.py`
- `python/pyspark/pandas/typedef/typehints.py`
- `python/pyspark/pandas/utils.py`

and fixes the mypy check failures.

### Why are the changes needed?

We should enable more `disallow_untyped_defs` mypy checks.

### Does this PR introduce _any_ user-facing change?

Yes.
This PR adds more type annotations in pandas APIs on Spark module, which can impact interaction with development tools for users.

### How was this patch tested?

The mypy check with a new configuration and existing tests should pass.
