### PR TITLE
[Minor][SQL] Change the script name for creating oracle docker image.

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -48,7 +48,7 @@ import org.apache.spark.tags.DockerTest
  *  $ git clone https://github.com/oracle/docker-images.git
  *  // Head SHA: 3e352a22618070595f823977a0fd1a3a8071a83c
  *  $ cd docker-images/OracleDatabase/SingleInstance/dockerfiles
- *  $ ./buildDockerImage.sh -v 18.4.0 -x
+ *  $ ./buildContainerImage.sh -v 18.4.0 -x
  *  $ export ORACLE_DOCKER_IMAGE_NAME=oracle/database:18.4.0-xe
  *  $ cd $SPARK_HOME
  *  $ ./build/sbt -Pdocker-integration-tests

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -43,7 +43,7 @@ import org.apache.spark.tags.DockerTest
  *  $ git clone https://github.com/oracle/docker-images.git
  *  // Head SHA: 3e352a22618070595f823977a0fd1a3a8071a83c
  *  $ cd docker-images/OracleDatabase/SingleInstance/dockerfiles
- *  $ ./buildDockerImage.sh -v 18.4.0 -x
+ *  $ ./buildContainerImage.sh -v 18.4.0 -x
  *  $ export ORACLE_DOCKER_IMAGE_NAME=oracle/database:18.4.0-xe
  *  $ cd $SPARK_HOME
  *  $ ./build/sbt -Pdocker-integration-tests


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the name in the comment in `jdbc.OracleIntegrationSuite` and `v2.OracleIntegrationSuite`.
The script is for creating oracle docker image.

### Why are the changes needed?

The name of the script is `buildContainerImage`, not `buildDockerImage` now.
- https://github.com/oracle/docker-images/commit/d918f5a4c6da9b0f294afb8650d1f6f951964262#diff-be303ab32e74192aca829e5ea259a0aec07aac23a6049120fb337ec4efa601b0

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I confirmed that I can build the image with `./buildContainerImage.sh -v 18.4.0 -x`.