### PR TITLE
[SPARK-35226][SQL][FOLLOWUP] Fix test added in SPARK-35226 for DB2KrbIntegrationSuite

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
@@ -178,19 +178,7 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
             .option("keytab", keytabFullPath)
             .option("principal", principal)
             .option("refreshKrb5Config", "true")
-            .option("query", "SELECT 1")
-            .load()
-        }
-
-        // Set the authentic krb5.conf but doesn't refresh config
-        // so this assertion is expected to fail.
-        intercept[Exception] {
-          sys.props(KRB5_CONF_PROP) = origKrb5Conf
-          spark.read.format("jdbc")
-            .option("url", jdbcUrl)
-            .option("keytab", keytabFullPath)
-            .option("principal", principal)
-            .option("query", "SELECT 1")
+            .option("query", "SELECT c0 FROM bar")
             .load()
         }
 
@@ -200,11 +188,11 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
           .option("keytab", keytabFullPath)
           .option("principal", principal)
           .option("refreshKrb5Config", "true")
-          .option("query", "SELECT 1")
+          .option("query", "SELECT c0 FROM bar")
           .load()
-        val result = df.collect().map(_.getInt(0))
+        val result = df.collect().map(_.getString(0))
         assert(result.length === 1)
-        assert(result(0) === 1)
+        assert(result(0) === "hello")
       } finally {
         sys.props(KRB5_CONF_PROP) = origKrb5Conf
       }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
@@ -178,7 +178,7 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
             .option("keytab", keytabFullPath)
             .option("principal", principal)
             .option("refreshKrb5Config", "true")
-            .option("query", "SELECT c0 FROM bar")
+            .option("dbtable", "bar")
             .load()
         }
 
@@ -188,7 +188,7 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
           .option("keytab", keytabFullPath)
           .option("principal", principal)
           .option("refreshKrb5Config", "true")
-          .option("query", "SELECT c0 FROM bar")
+          .option("dbtable", "bar")
           .load()
         val result = df.collect().map(_.getString(0))
         assert(result.length === 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes an test added in SPARK-35226 (#32344).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`SELECT 1` seems non-valid query for DB2.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
DB2KrbIntegrationSuite passes on my laptop.

I also confirmed all the KrbIntegrationSuites pass with the following command.
```
build/sbt -Phive -Phive-thriftserver -Pdocker-integration-tests "testOnly org.apache.spark.sql.jdbc.*KrbIntegrationSuite"
```