### PR TITLE
[SPARK-35490][BUILD] Update json4s to 3.7.0-M11

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/FaultToleranceTest.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/FaultToleranceTest.scala
@@ -28,7 +28,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.sys.process._
 
-import org.json4s._
 import org.json4s.jackson.JsonMethods
 
 import org.apache.spark.{SparkConf, SparkContext}

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -208,7 +208,6 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
         new File(expRoot, HistoryServerSuite.sanitizePath(name) + "_expectation.json")),
         StandardCharsets.UTF_8)
       // compare the ASTs so formatting differences don't cause failures
-      import org.json4s._
       import org.json4s.jackson.JsonMethods._
       val jsonAst = parse(clearLastUpdated(jsonOpt.get))
       val expAst = parse(exp)

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -145,10 +145,10 @@ joda-time/2.10.5//joda-time-2.10.5.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar
-json4s-ast_2.12/3.7.0-M5//json4s-ast_2.12-3.7.0-M5.jar
-json4s-core_2.12/3.7.0-M5//json4s-core_2.12-3.7.0-M5.jar
-json4s-jackson_2.12/3.7.0-M5//json4s-jackson_2.12-3.7.0-M5.jar
-json4s-scalap_2.12/3.7.0-M5//json4s-scalap_2.12-3.7.0-M5.jar
+json4s-ast_2.12/3.7.0-M11//json4s-ast_2.12-3.7.0-M11.jar
+json4s-core_2.12/3.7.0-M11//json4s-core_2.12-3.7.0-M11.jar
+json4s-jackson_2.12/3.7.0-M11//json4s-jackson_2.12-3.7.0-M11.jar
+json4s-scalap_2.12/3.7.0-M11//json4s-scalap_2.12-3.7.0-M11.jar
 jsp-api/2.1//jsp-api-2.1.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -117,10 +117,10 @@ joda-time/2.10.5//joda-time-2.10.5.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar
-json4s-ast_2.12/3.7.0-M5//json4s-ast_2.12-3.7.0-M5.jar
-json4s-core_2.12/3.7.0-M5//json4s-core_2.12-3.7.0-M5.jar
-json4s-jackson_2.12/3.7.0-M5//json4s-jackson_2.12-3.7.0-M5.jar
-json4s-scalap_2.12/3.7.0-M5//json4s-scalap_2.12-3.7.0-M5.jar
+json4s-ast_2.12/3.7.0-M11//json4s-ast_2.12-3.7.0-M11.jar
+json4s-core_2.12/3.7.0-M11//json4s-core_2.12-3.7.0-M11.jar
+json4s-jackson_2.12/3.7.0-M11//json4s-jackson_2.12-3.7.0-M11.jar
+json4s-scalap_2.12/3.7.0-M11//json4s-scalap_2.12-3.7.0-M11.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
 jul-to-slf4j/1.7.30//jul-to-slf4j-1.7.30.jar

--- a/pom.xml
+++ b/pom.xml
@@ -890,7 +890,7 @@
       <dependency>
         <groupId>org.json4s</groupId>
         <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
-        <version>3.7.0-M5</version>
+        <version>3.7.0-M11</version>
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
@@ -21,7 +21,6 @@ import java.util.UUID
 
 import scala.collection.JavaConverters._
 
-import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.Timeout


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade json4s from   3.7.0-M5  to 3.7.0-M11

Note: json4s version greater than 3.7.0-M11 is not binary compatible with Spark third party jars

### Why are the changes needed?
Multiple defect fixes and improvements  like

https://github.com/json4s/json4s/issues/750 
https://github.com/json4s/json4s/issues/554
https://github.com/json4s/json4s/issues/715

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Ran with the existing UTs
