### PR TITLE
[SPARK-34981][SQL][FOLLOWUP] Use SpecificInternalRow in ApplyFunctionExpression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ApplyFunctionExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ApplyFunctionExpression.scala
@@ -29,7 +29,7 @@ case class ApplyFunctionExpression(
   override def name: String = function.name()
   override def dataType: DataType = function.resultType()
 
-  private lazy val reusedRow = new GenericInternalRow(children.size)
+  private lazy val reusedRow = new SpecificInternalRow(function.inputTypes())
 
   /** Returns the result of evaluating this expression on a given input Row */
   override def eval(input: InternalRow): Any = {

--- a/sql/core/benchmarks/V2FunctionBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/V2FunctionBenchmark-jdk11-results.txt
@@ -1,44 +1,44 @@
 OpenJDK 64-Bit Server VM 11.0.11+9-LTS on Linux 5.4.0-1047-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = true codegen = true:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                       14079          14697         555         35.5          28.2       1.0X
-java_long_add_default                                                                 36350          38220        1620         13.8          72.7       0.4X
-java_long_add_magic                                                                   14910          15251         336         33.5          29.8       0.9X
-java_long_add_static_magic                                                            14863          14962         161         33.6          29.7       0.9X
-scala_long_add_default                                                                41715          42786        1040         12.0          83.4       0.3X
-scala_long_add_magic                                                                  15712          15775          58         31.8          31.4       0.9X
+native_long_add                                                                       14041          14263         342         35.6          28.1       1.0X
+java_long_add_default                                                                 35924          36929         872         13.9          71.8       0.4X
+java_long_add_magic                                                                   14266          14324          51         35.0          28.5       1.0X
+java_long_add_static_magic                                                            15268          15290          35         32.7          30.5       0.9X
+scala_long_add_default                                                                35174          35767         807         14.2          70.3       0.4X
+scala_long_add_magic                                                                  14441          14667         243         34.6          28.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.11+9-LTS on Linux 5.4.0-1047-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = false codegen = true:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                        13959          14048          80         35.8          27.9       1.0X
-java_long_add_default                                                                  40773          41318         580         12.3          81.5       0.3X
-java_long_add_magic                                                                    15929          16145         205         31.4          31.9       0.9X
-java_long_add_static_magic                                                             13384          13948         496         37.4          26.8       1.0X
-scala_long_add_default                                                                 37782          39099        1141         13.2          75.6       0.4X
-scala_long_add_magic                                                                   14553          14982         372         34.4          29.1       1.0X
+native_long_add                                                                        12631          12904         254         39.6          25.3       1.0X
+java_long_add_default                                                                  34026          34124         159         14.7          68.1       0.4X
+java_long_add_magic                                                                    14317          14550         280         34.9          28.6       0.9X
+java_long_add_static_magic                                                             12317          12581         240         40.6          24.6       1.0X
+scala_long_add_default                                                                 34178          34614         405         14.6          68.4       0.4X
+scala_long_add_magic                                                                   14259          14493         247         35.1          28.5       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.11+9-LTS on Linux 5.4.0-1047-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = true codegen = false:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                        31564          32912        1167         15.8          63.1       1.0X
-java_long_add_default                                                                  45392          46662        1821         11.0          90.8       0.7X
-java_long_add_magic                                                                    44650          45705        1230         11.2          89.3       0.7X
-java_long_add_static_magic                                                             46391          47033         573         10.8          92.8       0.7X
-scala_long_add_default                                                                 42915          44688        1654         11.7          85.8       0.7X
-scala_long_add_magic                                                                   45617          46073         644         11.0          91.2       0.7X
+native_long_add                                                                        27516          28663         998         18.2          55.0       1.0X
+java_long_add_default                                                                  33051          33163         183         15.1          66.1       0.8X
+java_long_add_magic                                                                    44816          45194         473         11.2          89.6       0.6X
+java_long_add_static_magic                                                             43823          44301         773         11.4          87.6       0.6X
+scala_long_add_default                                                                 36016          36041          43         13.9          72.0       0.8X
+scala_long_add_magic                                                                   45044          45219         206         11.1          90.1       0.6X
 
 OpenJDK 64-Bit Server VM 11.0.11+9-LTS on Linux 5.4.0-1047-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 scalar function (long + long) -> long, result_nullable = false codegen = false:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                         30192          30399         186         16.6          60.4       1.0X
-java_long_add_default                                                                   41940          42698         679         11.9          83.9       0.7X
-java_long_add_magic                                                                     45087          45760         628         11.1          90.2       0.7X
-java_long_add_static_magic                                                              44109          45979        1726         11.3          88.2       0.7X
-scala_long_add_default                                                                  41676          42064         375         12.0          83.4       0.7X
-scala_long_add_magic                                                                    44886          45825         858         11.1          89.8       0.7X
+native_long_add                                                                         27297          27813         855         18.3          54.6       1.0X
+java_long_add_default                                                                   34299          34302           3         14.6          68.6       0.8X
+java_long_add_magic                                                                     43979          44507         459         11.4          88.0       0.6X
+java_long_add_static_magic                                                              45129          45622         541         11.1          90.3       0.6X
+scala_long_add_default                                                                  36541          36934         387         13.7          73.1       0.7X
+scala_long_add_magic                                                                    45941          46601         635         10.9          91.9       0.6X
 

--- a/sql/core/benchmarks/V2FunctionBenchmark-results.txt
+++ b/sql/core/benchmarks/V2FunctionBenchmark-results.txt
@@ -2,43 +2,43 @@ OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Linux 5.4.0-1047-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 scalar function (long + long) -> long, result_nullable = true codegen = true:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                       14269          14469         331         35.0          28.5       1.0X
-java_long_add_default                                                                 38687          38861         198         12.9          77.4       0.4X
-java_long_add_magic                                                                   15328          15717         595         32.6          30.7       0.9X
-java_long_add_static_magic                                                            12795          12966         158         39.1          25.6       1.1X
-scala_long_add_default                                                                42538          42627          84         11.8          85.1       0.3X
-scala_long_add_magic                                                                  14953          15029          82         33.4          29.9       1.0X
+native_long_add                                                                       10886          12302        1539         45.9          21.8       1.0X
+java_long_add_default                                                                 38632          39165         466         12.9          77.3       0.3X
+java_long_add_magic                                                                   14973          15124         197         33.4          29.9       0.7X
+java_long_add_static_magic                                                            12907          13002         145         38.7          25.8       0.8X
+scala_long_add_default                                                                38344          39198        1083         13.0          76.7       0.3X
+scala_long_add_magic                                                                  14571          14706         117         34.3          29.1       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Linux 5.4.0-1047-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 scalar function (long + long) -> long, result_nullable = false codegen = true:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                        12298          12318          18         40.7          24.6       1.0X
-java_long_add_default                                                                  38181          38606         432         13.1          76.4       0.3X
-java_long_add_magic                                                                    15255          15308          58         32.8          30.5       0.8X
-java_long_add_static_magic                                                             12157          12280         117         41.1          24.3       1.0X
-scala_long_add_default                                                                 38249          38530         282         13.1          76.5       0.3X
-scala_long_add_magic                                                                   15037          15314         265         33.3          30.1       0.8X
+native_long_add                                                                        10845          10876          43         46.1          21.7       1.0X
+java_long_add_default                                                                  35638          35845         236         14.0          71.3       0.3X
+java_long_add_magic                                                                    13464          13571         107         37.1          26.9       0.8X
+java_long_add_static_magic                                                             10918          10999         111         45.8          21.8       1.0X
+scala_long_add_default                                                                 35635          36264         570         14.0          71.3       0.3X
+scala_long_add_magic                                                                   13756          14091         422         36.3          27.5       0.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Linux 5.4.0-1047-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 scalar function (long + long) -> long, result_nullable = true codegen = false:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                        37620          37724         122         13.3          75.2       1.0X
-java_long_add_default                                                                  48087          48170          73         10.4          96.2       0.8X
-java_long_add_magic                                                                    56373          56402          48          8.9         112.7       0.7X
-java_long_add_static_magic                                                             56752          57235         578          8.8         113.5       0.7X
-scala_long_add_default                                                                 48198          48350         199         10.4          96.4       0.8X
-scala_long_add_magic                                                                   57988          58093          99          8.6         116.0       0.6X
+native_long_add                                                                        33787          34676        1444         14.8          67.6       1.0X
+java_long_add_default                                                                  43411          44220        1336         11.5          86.8       0.8X
+java_long_add_magic                                                                    51949          52654         965          9.6         103.9       0.7X
+java_long_add_static_magic                                                             47779          47991         246         10.5          95.6       0.7X
+scala_long_add_default                                                                 44375          44752         518         11.3          88.7       0.8X
+scala_long_add_magic                                                                   51306          51976         580          9.7         102.6       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Linux 5.4.0-1047-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 scalar function (long + long) -> long, result_nullable = false codegen = false:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-native_long_add                                                                         34925          34976          75         14.3          69.9       1.0X
-java_long_add_default                                                                   45836          45857          33         10.9          91.7       0.8X
-java_long_add_magic                                                                     55190          55364         158          9.1         110.4       0.6X
-java_long_add_static_magic                                                              54906          54977          73          9.1         109.8       0.6X
-scala_long_add_default                                                                  46960          47204         265         10.6          93.9       0.7X
-scala_long_add_magic                                                                    54993          55016          33          9.1         110.0       0.6X
+native_long_add                                                                         34842          35556        1010         14.4          69.7       1.0X
+java_long_add_default                                                                   44147          44487         503         11.3          88.3       0.8X
+java_long_add_magic                                                                     52048          52729         665          9.6         104.1       0.7X
+java_long_add_static_magic                                                              51537          51848         271          9.7         103.1       0.7X
+scala_long_add_default                                                                  44552          44917         628         11.2          89.1       0.8X
+scala_long_add_magic                                                                    50741          50895         135          9.9         101.5       0.7X
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Use `SpecificInternalRow` instead of `GenericInternalRow` to avoid boxing / unboxing cost.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Since it doesn't know the input row schema, `GenericInternalRow` potentially need to apply boxing for input arguments. It's better to use `SpecificInternalRow` instead since we know input data types.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing tests.