### PR TITLE
[SPARK-35497][PYTHON] Enable plotly tests in pandas-on-Spark

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -215,7 +215,7 @@ jobs:
     # Ubuntu 20.04. See also SPARK-33162.
     - name: Install Python packages (Python 3.6)
       run: |
-        python3.6 -m pip install numpy 'pyarrow<3.0.0' pandas scipy xmlrunner
+        python3.6 -m pip install numpy 'pyarrow<3.0.0' pandas scipy xmlrunner plotly>=4.8
         python3.6 -m pip list
     - name: Install Conda for pip packaging test
       run: |

--- a/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
@@ -37,11 +37,10 @@ if have_plotly:
     import plotly.graph_objs as go
 
 
+@unittest.skipIf(not have_plotly, plotly_requirement_message)
 @unittest.skipIf(
-    not have_plotly or LooseVersion(pd.__version__) < "1.0.0",
-    ("" if plotly_requirement_message is None else "%s or " % plotly_requirement_message) +
-    "pandas<1.0; pandas<1.0 does not support latest plotly "
-    "and/or 'plotting.backend' option.",
+    LooseVersion(pd.__version__) < "1.0.0",
+    "pandas<1.0; pandas<1.0 does not support latest plotly and/or 'plotting.backend' option.",
 )
 class DataFramePlotPlotlyTest(PandasOnSparkTestCase, TestUtils):
     @classmethod

--- a/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
@@ -39,7 +39,8 @@ if have_plotly:
 
 @unittest.skipIf(
     not have_plotly or LooseVersion(pd.__version__) < "1.0.0",
-    plotly_requirement_message + " Or pandas<1.0; pandas<1.0 does not support latest plotly "
+    ("" if plotly_requirement_message is None else "%s or " % plotly_requirement_message) +
+    "pandas<1.0; pandas<1.0 does not support latest plotly "
     "and/or 'plotting.backend' option.",
 )
 class DataFramePlotPlotlyTest(PandasOnSparkTestCase, TestUtils):

--- a/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
@@ -39,7 +39,8 @@ if have_plotly:
 
 @unittest.skipIf(
     not have_plotly or LooseVersion(pd.__version__) < "1.0.0",
-    plotly_requirement_message + " Or pandas<1.0; pandas<1.0 does not support latest plotly "
+    ("" if plotly_requirement_message is None else "%s or " % plotly_requirement_message) +
+    "pandas<1.0; pandas<1.0 does not support latest plotly "
     "and/or 'plotting.backend' option.",
 )
 class SeriesPlotPlotlyTest(PandasOnSparkTestCase, TestUtils):

--- a/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
@@ -37,11 +37,10 @@ if have_plotly:
     import plotly.graph_objs as go
 
 
+@unittest.skipIf(not have_plotly, plotly_requirement_message)
 @unittest.skipIf(
-    not have_plotly or LooseVersion(pd.__version__) < "1.0.0",
-    ("" if plotly_requirement_message is None else "%s or " % plotly_requirement_message) +
-    "pandas<1.0; pandas<1.0 does not support latest plotly "
-    "and/or 'plotting.backend' option.",
+    LooseVersion(pd.__version__) < "1.0.0",
+    "pandas<1.0; pandas<1.0 does not support latest plotly and/or 'plotting.backend' option.",
 )
 class SeriesPlotPlotlyTest(PandasOnSparkTestCase, TestUtils):
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enables plot tests with plotly

```bash
./python/run-tests --python-executables=python3 --modules=pyspark-pandas
```

**Before**:

```
Traceback (most recent call last):
  File "/.../miniconda3/envs/python3.8/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/.../miniconda3/envs/python3.8/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/.../pyspark/pandas/tests/plot/test_frame_plot_plotly.py", line 42, in <module>
    plotly_requirement_message + " Or pandas<1.0; pandas<1.0 does not support latest plotly "
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

```

**After**:

```
...
Starting test(python3): pyspark.pandas.tests.plot.test_series_plot_plotly
...
Finished test(python3): pyspark.pandas.tests.plot.test_series_plot_plotly (23s)
...
Tests passed in 1296 seconds
```

### Why are the changes needed?

For test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

By running the tests.