### PR TITLE
[SPARK-32194][PYTHON] Use proper exception classes instead of plain Exception

### DIFF
--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -123,14 +123,14 @@ class Accumulator(object):
     def value(self):
         """Get the accumulator's value; only usable in driver program"""
         if self._deserialized:
-            raise Exception("Accumulator.value cannot be accessed inside tasks")
+            raise RuntimeError("Accumulator.value cannot be accessed inside tasks")
         return self._value
 
     @value.setter
     def value(self, value):
         """Sets the accumulator's value; only usable in driver program"""
         if self._deserialized:
-            raise Exception("Accumulator.value cannot be accessed inside tasks")
+            raise RuntimeError("Accumulator.value cannot be accessed inside tasks")
         self._value = value
 
     def add(self, term):
@@ -253,7 +253,7 @@ class _UpdateRequestHandler(SocketServer.StreamRequestHandler):
                 # we've authenticated, we can break out of the first loop now
                 return True
             else:
-                raise Exception(
+                raise ValueError(
                     "The value of the provided token to the AccumulatorServer is not correct.")
 
         # first we keep polling till we've received the authentication token

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -37,7 +37,7 @@ _broadcastRegistry = {}
 def _from_id(bid):
     from pyspark.broadcast import _broadcastRegistry
     if bid not in _broadcastRegistry:
-        raise Exception("Broadcast variable '%s' not loaded!" % bid)
+        raise RuntimeError("Broadcast variable '%s' not loaded!" % bid)
     return _broadcastRegistry[bid]
 
 
@@ -154,7 +154,7 @@ class Broadcast(object):
             Whether to block until unpersisting has completed
         """
         if self._jbroadcast is None:
-            raise Exception("Broadcast can only be unpersisted in driver")
+            raise RuntimeError("Broadcast can only be unpersisted in driver")
         self._jbroadcast.unpersist(blocking)
 
     def destroy(self, blocking=False):
@@ -173,13 +173,13 @@ class Broadcast(object):
             Whether to block until unpersisting has completed
         """
         if self._jbroadcast is None:
-            raise Exception("Broadcast can only be destroyed in driver")
+            raise RuntimeError("Broadcast can only be destroyed in driver")
         self._jbroadcast.destroy(blocking)
         os.unlink(self._path)
 
     def __reduce__(self):
         if self._jbroadcast is None:
-            raise Exception("Broadcast can only be serialized in driver")
+            raise RuntimeError("Broadcast can only be serialized in driver")
         self._pickle_registry.add(self)
         return _from_id, (self._jbroadcast.id(),)
 

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -157,7 +157,7 @@ class SparkConf(object):
     def setExecutorEnv(self, key=None, value=None, pairs=None):
         """Set an environment variable to be passed to executors."""
         if (key is not None and pairs is not None) or (key is None and pairs is None):
-            raise Exception("Either pass one key-value pair or a list of pairs")
+            raise RuntimeError("Either pass one key-value pair or a list of pairs")
         elif key is not None:
             self.set("spark.executorEnv." + key, value)
         elif pairs is not None:

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1126,7 +1126,7 @@ class SparkContext(object):
         ...     try:
         ...         sc.setJobGroup("job_to_cancel", "some description")
         ...         result = sc.parallelize(range(x)).map(map_func).collect()
-        ...     except RuntimeError as e:
+        ...     except Exception as e:
         ...         result = "Cancelled"
         ...     lock.release()
         >>> def stop_job():

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -188,9 +188,9 @@ class SparkContext(object):
 
         # Check that we have at least the required parameters
         if not self._conf.contains("spark.master"):
-            raise TypeError("A master URL must be set in your configuration")
+            raise RuntimeError("A master URL must be set in your configuration")
         if not self._conf.contains("spark.app.name"):
-            raise TypeError("An application name must be set in your configuration")
+            raise RuntimeError("An application name must be set in your configuration")
 
         # Read back our properties from the conf in case we loaded some of them from
         # the classpath or an external config file

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -188,9 +188,9 @@ class SparkContext(object):
 
         # Check that we have at least the required parameters
         if not self._conf.contains("spark.master"):
-            raise Exception("A master URL must be set in your configuration")
+            raise TypeError("A master URL must be set in your configuration")
         if not self._conf.contains("spark.app.name"):
-            raise Exception("An application name must be set in your configuration")
+            raise TypeError("An application name must be set in your configuration")
 
         # Read back our properties from the conf in case we loaded some of them from
         # the classpath or an external config file
@@ -350,7 +350,7 @@ class SparkContext(object):
 
     def __getnewargs__(self):
         # This method is called when attempting to pickle SparkContext, which is always an error:
-        raise Exception(
+        raise RuntimeError(
             "It appears that you are attempting to reference SparkContext from a broadcast "
             "variable, action, or transformation. SparkContext can only be used on the driver, "
             "not in code that it run on workers. For more information, see SPARK-5063."
@@ -1076,7 +1076,7 @@ class SparkContext(object):
         Returns a Java StorageLevel based on a pyspark.StorageLevel.
         """
         if not isinstance(storageLevel, StorageLevel):
-            raise Exception("storageLevel must be of type pyspark.StorageLevel")
+            raise TypeError("storageLevel must be of type pyspark.StorageLevel")
 
         newStorageLevel = self._jvm.org.apache.spark.storage.StorageLevel
         return newStorageLevel(storageLevel.useDisk,
@@ -1120,13 +1120,13 @@ class SparkContext(object):
         >>> lock = threading.Lock()
         >>> def map_func(x):
         ...     sleep(100)
-        ...     raise Exception("Task should have been cancelled")
+        ...     raise RuntimeError("Task should have been cancelled")
         >>> def start_job(x):
         ...     global result
         ...     try:
         ...         sc.setJobGroup("job_to_cancel", "some description")
         ...         result = sc.parallelize(range(x)).map(map_func).collect()
-        ...     except Exception as e:
+        ...     except RuntimeError as e:
         ...         result = "Cancelled"
         ...     lock.release()
         >>> def stop_job():
@@ -1274,7 +1274,7 @@ class SparkContext(object):
         Throws an exception if a SparkContext is about to be created in executors.
         """
         if TaskContext.get() is not None:
-            raise Exception("SparkContext should only be created and accessed on the driver.")
+            raise RuntimeError("SparkContext should only be created and accessed on the driver.")
 
 
 def _test():

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -105,7 +105,7 @@ def launch_gateway(conf=None, popen_kwargs=None):
                 time.sleep(0.1)
 
             if not os.path.isfile(conn_info_file):
-                raise Exception("Java gateway process exited before sending its port number")
+                raise RuntimeError("Java gateway process exited before sending its port number")
 
             with open(conn_info_file, "rb") as info:
                 gateway_port = read_int(info)
@@ -175,7 +175,7 @@ def _do_server_auth(conn, auth_secret):
     reply = UTF8Deserializer().loads(conn)
     if reply != "ok":
         conn.close()
-        raise Exception("Unexpected reply from iterator server.")
+        raise RuntimeError("Unexpected reply from iterator server.")
 
 
 def local_connect_and_auth(port, auth_secret):
@@ -211,7 +211,7 @@ def local_connect_and_auth(port, auth_secret):
             errors.append("tried to connect to %s, but an error occurred: %s" % (sa, emsg))
             sock.close()
             sock = None
-    raise Exception("could not open socket: %s" % errors)
+    raise RuntimeError("could not open socket: %s" % errors)
 
 
 def ensure_callback_server_started(gw):

--- a/python/pyspark/ml/linalg/__init__.py
+++ b/python/pyspark/ml/linalg/__init__.py
@@ -646,8 +646,8 @@ class SparseVector(Vector):
 
         if isinstance(other, np.ndarray) or isinstance(other, DenseVector):
             if isinstance(other, np.ndarray) and other.ndim != 1:
-                raise Exception("Cannot call squared_distance with %d-dimensional array" %
-                                other.ndim)
+                raise ValueError("Cannot call squared_distance with %d-dimensional array" %
+                                 other.ndim)
             if isinstance(other, DenseVector):
                 other = other.array
             sparse_ind = np.zeros(other.size, dtype=bool)

--- a/python/pyspark/mllib/__init__.py
+++ b/python/pyspark/mllib/__init__.py
@@ -27,7 +27,7 @@ import numpy
 
 ver = [int(x) for x in numpy.version.version.split('.')[:2]]
 if ver < [1, 4]:
-    raise Exception("MLlib requires NumPy 1.4+")
+    raise RuntimeError("MLlib requires NumPy 1.4+")
 
 __all__ = ['classification', 'clustering', 'feature', 'fpm', 'linalg', 'random',
            'recommendation', 'regression', 'stat', 'tree', 'util']

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -375,7 +375,7 @@ class KMeans(object):
         clusterInitialModel = []
         if initialModel is not None:
             if not isinstance(initialModel, KMeansModel):
-                raise Exception("initialModel is of "+str(type(initialModel))+". It needs "
+                raise TypeError("initialModel is of " + str(type(initialModel)) + ". It needs "
                                 "to be of <type 'KMeansModel'>")
             clusterInitialModel = [_convert_to_vector(c) for c in initialModel.clusterCenters]
         model = callMLlibFunc("trainKMeansModel", rdd.map(_convert_to_vector), k, maxIterations,
@@ -590,8 +590,8 @@ class GaussianMixture(object):
         initialModelSigma = None
         if initialModel is not None:
             if initialModel.k != k:
-                raise Exception("Mismatched cluster count, initialModel.k = %s, however k = %s"
-                                % (initialModel.k, k))
+                raise ValueError("Mismatched cluster count, initialModel.k = %s, however k = %s"
+                                 % (initialModel.k, k))
             initialModelWeights = list(initialModel.weights)
             initialModelMu = [initialModel.gaussians[i].mu for i in range(initialModel.k)]
             initialModelSigma = [initialModel.gaussians[i].sigma for i in range(initialModel.k)]

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -735,8 +735,8 @@ class SparseVector(Vector):
 
         if isinstance(other, np.ndarray) or isinstance(other, DenseVector):
             if isinstance(other, np.ndarray) and other.ndim != 1:
-                raise Exception("Cannot call squared_distance with %d-dimensional array" %
-                                other.ndim)
+                raise ValueError("Cannot call squared_distance with %d-dimensional array" %
+                                 other.ndim)
             if isinstance(other, DenseVector):
                 other = other.array
             sparse_ind = np.zeros(other.size, dtype=bool)

--- a/python/pyspark/pandas/tests/test_stats.py
+++ b/python/pyspark/pandas/tests/test_stats.py
@@ -375,14 +375,15 @@ class StatsTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(len(psdf.kurtosis(numeric_only=True)), len(pdf.kurtosis(numeric_only=True)))
         self.assert_eq(len(psdf.skew(numeric_only=True)), len(pdf.skew(numeric_only=True)))
 
-        self.assert_eq(
-            len(psdf.quantile(q=0.5, numeric_only=True)),
-            len(pdf.quantile(q=0.5, numeric_only=True)),
-        )
-        self.assert_eq(
-            len(psdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),
-            len(pdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),
-        )
+        # TODO(SPARK-35510): This fails with Python 3.9. We should fix and reenable it.
+        # self.assert_eq(
+        #     len(psdf.quantile(q=0.5, numeric_only=True)),
+        #     len(pdf.quantile(q=0.5, numeric_only=True)),
+        # )
+        # self.assert_eq(
+        #     len(psdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),
+        #     len(pdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),
+        # )
 
     def test_numeric_only_unsupported(self):
         pdf = pd.DataFrame({"i": [0, 1, 2], "b": [False, False, True], "s": ["x", "y", "z"]})

--- a/python/pyspark/pandas/tests/test_stats.py
+++ b/python/pyspark/pandas/tests/test_stats.py
@@ -375,15 +375,14 @@ class StatsTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(len(psdf.kurtosis(numeric_only=True)), len(pdf.kurtosis(numeric_only=True)))
         self.assert_eq(len(psdf.skew(numeric_only=True)), len(pdf.skew(numeric_only=True)))
 
-        # TODO(SPARK-35510): This fails with Python 3.9. We should fix and reenable it.
-        # self.assert_eq(
-        #     len(psdf.quantile(q=0.5, numeric_only=True)),
-        #     len(pdf.quantile(q=0.5, numeric_only=True)),
-        # )
-        # self.assert_eq(
-        #     len(psdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),
-        #     len(pdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),
-        # )
+        self.assert_eq(
+            len(psdf.quantile(q=0.5, numeric_only=True)),
+            len(pdf.quantile(q=0.5, numeric_only=True)),
+        )
+        self.assert_eq(
+            len(psdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),
+            len(pdf.quantile(q=[0.25, 0.5, 0.75], numeric_only=True)),
+        )
 
     def test_numeric_only_unsupported(self):
         pdf = pd.DataFrame({"i": [0, 1, 2], "b": [False, False, True], "s": ["x", "y", "z"]})

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -88,7 +88,7 @@ def portable_hash(x):
     """
 
     if 'PYTHONHASHSEED' not in os.environ:
-        raise Exception("Randomness of hash of string should be disabled via PYTHONHASHSEED")
+        raise RuntimeError("Randomness of hash of string should be disabled via PYTHONHASHSEED")
 
     if x is None:
         return 0
@@ -259,7 +259,7 @@ class RDD(object):
 
     def __getnewargs__(self):
         # This method is called when attempting to pickle an RDD, which is always an error:
-        raise Exception(
+        raise RuntimeError(
             "It appears that you are attempting to broadcast an RDD or reference an RDD from an "
             "action or transformation. RDD transformations and actions can only be invoked by the "
             "driver, not inside of other transformations; for example, "
@@ -892,8 +892,8 @@ class RDD(object):
             def check_return_code():
                 pipe.wait()
                 if checkCode and pipe.returncode:
-                    raise Exception("Pipe function `%s' exited "
-                                    "with error code %d" % (command, pipe.returncode))
+                    raise RuntimeError("Pipe function `%s' exited "
+                                       "with error code %d" % (command, pipe.returncode))
                 else:
                     for i in range(0):
                         yield i

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -276,9 +276,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         if self._schema is None:
             try:
                 self._schema = _parse_datatype_json_string(self._jdf.schema().json())
-            except AttributeError as e:
-                raise Exception(
-                    "Unable to parse datatype from schema. %s" % e)
+            except Exception as e:
+                raise ValueError(
+                    "Unable to parse datatype from schema. %s" % e) from e
         return self._schema
 
     def printSchema(self):
@@ -350,7 +350,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """
 
         if extended is not None and mode is not None:
-            raise Exception("extended and mode should not be set together.")
+            raise ValueError("extended and mode should not be set together.")
 
         # For the no argument case: df.explain()
         is_no_argument = extended is None and mode is None

--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -1179,15 +1179,15 @@ class DataStreamWriter(object):
             # 'close(error)' methods.
 
             if not hasattr(f, 'process'):
-                raise Exception("Provided object does not have a 'process' method")
+                raise AttributeError("Provided object does not have a 'process' method")
 
             if not callable(getattr(f, 'process')):
-                raise Exception("Attribute 'process' in provided object is not callable")
+                raise TypeError("Attribute 'process' in provided object is not callable")
 
             def doesMethodExist(method_name):
                 exists = hasattr(f, method_name)
                 if exists and not callable(getattr(f, method_name)):
-                    raise Exception(
+                    raise TypeError(
                         "Attribute '%s' in provided object is not callable" % method_name)
                 return exists
 
@@ -1199,7 +1199,7 @@ class DataStreamWriter(object):
                 if epoch_id:
                     epoch_id = int(epoch_id)
                 else:
-                    raise Exception("Could not get batch id from TaskContext")
+                    raise RuntimeError("Could not get batch id from TaskContext")
 
                 # Check if the data should be processed
                 should_process = True

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -246,7 +246,7 @@ class ArrowTests(ReusedSQLTestCase):
         df = self.spark.range(3).toDF("i")
 
         def raise_exception():
-            raise Exception("My error")
+            raise RuntimeError("My error")
         exception_udf = udf(raise_exception, IntegerType())
         df = df.withColumn("error", exception_udf())
         with QuietTest(self.sc):

--- a/python/pyspark/sql/tests/test_streaming.py
+++ b/python/pyspark/sql/tests/test_streaming.py
@@ -466,7 +466,7 @@ class StreamingTests(ReusedSQLTestCase):
 
         class ForeachWriter:
             def process(self, row):
-                raise Exception("test error")
+                raise RuntimeError("test error")
 
             def close(self, error):
                 tester.write_close_event(error)
@@ -557,7 +557,7 @@ class StreamingTests(ReusedSQLTestCase):
         q = None
 
         def collectBatch(df, id):
-            raise Exception("this should fail the query")
+            raise RuntimeError("this should fail the query")
 
         try:
             df = self.spark.readStream.format('text').load('python/test_support/sql/streaming')

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1577,7 +1577,7 @@ class Row(tuple):
 
     def __setattr__(self, key, value):
         if key != '__fields__':
-            raise Exception("Row is read-only")
+            raise RuntimeError("Row is read-only")
         self.__dict__[key] = value
 
     def __reduce__(self):

--- a/python/pyspark/statcounter.py
+++ b/python/pyspark/statcounter.py
@@ -56,7 +56,7 @@ class StatCounter(object):
     # Merge another StatCounter into this one, adding up the internal statistics.
     def mergeStats(self, other):
         if not isinstance(other, StatCounter):
-            raise Exception("Can only merge Statcounters!")
+            raise TypeError("Can only merge StatCounter but got %s" % type(other))
 
         if other is self:  # reference equality holds
             self.merge(copy.deepcopy(other))  # Avoid overwriting fields in a weird order

--- a/python/pyspark/streaming/context.py
+++ b/python/pyspark/streaming/context.py
@@ -139,8 +139,9 @@ class StreamingContext(object):
                 cls._activeContext = None
             elif activeJvmContextOption.get().hashCode() != activePythonContextJavaId:
                 cls._activeContext = None
-                raise Exception("JVM's active JavaStreamingContext is not the JavaStreamingContext "
-                                "backing the action Python StreamingContext. This is unexpected.")
+                raise RuntimeError(
+                    "JVM's active JavaStreamingContext is not the JavaStreamingContext "
+                    "backing the action Python StreamingContext. This is unexpected.")
         return cls._activeContext
 
     @classmethod
@@ -162,8 +163,8 @@ class StreamingContext(object):
             Function to create a new JavaStreamingContext and setup DStreams
         """
 
-        if setupFunc is None:
-            raise Exception("setupFunc cannot be None")
+        if not callable(setupFunc):
+            raise TypeError("setupFunc should be callable.")
         activeContext = cls.getActive()
         if activeContext is not None:
             return activeContext

--- a/python/pyspark/streaming/tests/test_dstream.py
+++ b/python/pyspark/streaming/tests/test_dstream.py
@@ -562,14 +562,14 @@ class CheckpointTests(unittest.TestCase):
         def check_output(n):
             while not os.listdir(outputd):
                 if self.ssc.awaitTerminationOrTimeout(0.5):
-                    raise Exception("ssc stopped")
+                    raise RuntimeError("ssc stopped")
             time.sleep(1)  # make sure mtime is larger than the previous one
             with open(os.path.join(inputd, str(n)), 'w') as f:
                 f.writelines(["%d\n" % i for i in range(10)])
 
             while True:
                 if self.ssc.awaitTerminationOrTimeout(0.5):
-                    raise Exception("ssc stopped")
+                    raise RuntimeError("ssc stopped")
                 p = os.path.join(outputd, max(os.listdir(outputd)))
                 if '_SUCCESS' not in os.listdir(p):
                     # not finished

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -185,7 +185,7 @@ class BarrierTaskContext(TaskContext):
         This API is experimental
         """
         if not isinstance(cls._taskContext, BarrierTaskContext):
-            raise Exception('It is not in a barrier stage')
+            raise RuntimeError('It is not in a barrier stage')
         return cls._taskContext
 
     @classmethod
@@ -214,8 +214,8 @@ class BarrierTaskContext(TaskContext):
         This API is experimental
         """
         if self._port is None or self._secret is None:
-            raise Exception("Not supported to call barrier() before initialize " +
-                            "BarrierTaskContext.")
+            raise RuntimeError("Not supported to call barrier() before initialize " +
+                               "BarrierTaskContext.")
         else:
             _load_from_socket(self._port, self._secret, BARRIER_FUNCTION)
 
@@ -238,8 +238,8 @@ class BarrierTaskContext(TaskContext):
         if not isinstance(message, str):
             raise TypeError("Argument `message` must be of type `str`")
         elif self._port is None or self._secret is None:
-            raise Exception("Not supported to call barrier() before initialize " +
-                            "BarrierTaskContext.")
+            raise RuntimeError("Not supported to call barrier() before initialize " +
+                               "BarrierTaskContext.")
         else:
             return _load_from_socket(self._port, self._secret, ALL_GATHER_FUNCTION, message)
 
@@ -255,8 +255,8 @@ class BarrierTaskContext(TaskContext):
         This API is experimental
         """
         if self._port is None or self._secret is None:
-            raise Exception("Not supported to call getTaskInfos() before initialize " +
-                            "BarrierTaskContext.")
+            raise RuntimeError("Not supported to call getTaskInfos() before initialize " +
+                               "BarrierTaskContext.")
         else:
             addresses = self._localProperties.get("addresses", "")
             return [BarrierTaskInfo(h.strip()) for h in addresses.split(",")]

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -169,6 +169,6 @@ def search_jar(project_relative_path, sbt_jar_name_prefix, mvn_jar_name_prefix):
     if not jars:
         return None
     elif len(jars) > 1:
-        raise Exception("Found multiple JARs: %s; please remove all but one" % (", ".join(jars)))
+        raise RuntimeError("Found multiple JARs: %s; please remove all but one" % (", ".join(jars)))
     else:
         return jars[0]

--- a/python/pyspark/tests/test_appsubmit.py
+++ b/python/pyspark/tests/test_appsubmit.py
@@ -225,7 +225,7 @@ class SparkSubmitTests(unittest.TestCase):
             |sc = SparkContext(conf = conf)
             |try:
             |    if sc._conf.get("spark.test_config") != "1":
-            |        raise Exception("Cannot find spark.test_config in SparkContext's conf.")
+            |        raise RuntimeError("Cannot find spark.test_config in SparkContext's conf.")
             |finally:
             |    sc.stop()
             """)

--- a/python/pyspark/tests/test_context.py
+++ b/python/pyspark/tests/test_context.py
@@ -201,7 +201,7 @@ class ContextTests(unittest.TestCase):
         try:
             with SparkContext() as sc:
                 self.assertNotEqual(SparkContext._active_spark_context, None)
-                raise Exception()
+                raise RuntimeError()
         except:
             pass
         self.assertEqual(SparkContext._active_spark_context, None)

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -354,10 +354,10 @@ class RDDTests(ReusedPySparkTestCase):
         bdata.destroy(blocking=True)
         try:
             self.sc.parallelize(range(1), 1).map(lambda x: len(bdata.value)).sum()
-        except Exception as e:
+        except Exception:
             pass
         else:
-            raise Exception("job should fail after destroy the broadcast")
+            raise AssertionError("job should fail after destroy the broadcast")
 
     def test_multiple_broadcasts(self):
         N = 1 << 21

--- a/python/pyspark/tests/test_serializers.py
+++ b/python/pyspark/tests/test_serializers.py
@@ -98,7 +98,7 @@ class SerializationTestCase(unittest.TestCase):
 
         class Unpicklable(object):
             def __reduce__(self):
-                raise Exception("not picklable")
+                raise RuntimeError("not picklable")
 
         global exit
         exit = Unpicklable()

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -79,7 +79,7 @@ class TaskContextTests(PySparkTestCase):
             partition_id = tc.partitionId()
             attempt_id = tc.taskAttemptId()
             if attempt_number == 0 and partition_id == 0:
-                raise Exception("Failing on first attempt")
+                raise RuntimeError("Failing on first attempt")
             else:
                 return [x, partition_id, attempt_number, attempt_id]
         result = rdd.map(fail_on_first).collect()

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -89,10 +89,10 @@ class WorkerTests(ReusedPySparkTestCase):
 
     def test_after_exception(self):
         def raise_exception(_):
-            raise Exception()
+            raise RuntimeError()
         rdd = self.sc.parallelize(range(100), 1)
         with QuietTest(self.sc):
-            self.assertRaises(Exception, lambda: rdd.foreach(raise_exception))
+            self.assertRaises(Py4JJavaError, lambda: rdd.foreach(raise_exception))
         self.assertEqual(100, rdd.map(str).count())
 
     def test_after_non_exception_error(self):
@@ -161,7 +161,7 @@ class WorkerTests(ReusedPySparkTestCase):
         # SPARK-21045: exceptions with no ascii encoding shall not hanging PySpark.
         try:
             def f():
-                raise Exception("exception with 中 and \xd6\xd0")
+                raise RuntimeError("exception with 中 and \xd6\xd0")
 
             self.sc.parallelize([1]).map(lambda x: f()).count()
         except Py4JJavaError as e:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -471,11 +471,11 @@ def main(infile, outfile):
 
         version = utf8_deserializer.loads(infile)
         if version != "%d.%d" % sys.version_info[:2]:
-            raise Exception(("Python in worker has different version %s than that in " +
-                             "driver %s, PySpark cannot run with different minor versions. " +
-                             "Please check environment variables PYSPARK_PYTHON and " +
-                             "PYSPARK_DRIVER_PYTHON are correctly set.") %
-                            ("%d.%d" % sys.version_info[:2], version))
+            raise RuntimeError(("Python in worker has different version %s than that in " +
+                                "driver %s, PySpark cannot run with different minor versions. " +
+                                "Please check environment variables PYSPARK_PYTHON and " +
+                                "PYSPARK_DRIVER_PYTHON are correctly set.") %
+                               ("%d.%d" % sys.version_info[:2], version))
 
         # read inputs only for a barrier task
         isBarrier = read_bool(infile)

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -61,7 +61,7 @@ for scala in ["2.12"]:
         SPARK_DIST_CLASSPATH = os.path.join(build_dir, "jars", "*")
         break
 else:
-    raise Exception("Cannot find assembly build directory, please build Spark first.")
+    raise RuntimeError("Cannot find assembly build directory, please build Spark first.")
 
 
 def run_individual_python_test(target_dir, test_name, pyspark_python):

--- a/sql/gen-sql-config-docs.py
+++ b/sql/gen-sql-config-docs.py
@@ -94,7 +94,7 @@ def generate_sql_configs_table_html(sql_configs, path):
                 default = config.default
 
             if default.startswith("<"):
-                raise Exception(
+                raise RuntimeError(
                     "Unhandled reference in SQL config docs. Config '{name}' "
                     "has default '{default}' that looks like an HTML tag."
                     .format(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use a proper built-in exceptions instead of the plain `Exception` in Python.

While I am here, I fixed another minor issue at `DataFrams.schema` together:

```diff
- except AttributeError as e:
-     raise Exception(
-         "Unable to parse datatype from schema. %s" % e)            
+ except Exception as e:
+     raise ValueError(
+         "Unable to parse datatype from schema. %s" % e) from e
```

Now it catches all exceptions during schema parsing, chains the exception with `ValueError`. Previously it only caught `AttributeError` that does not catch all cases.

### Why are the changes needed?

For users to expect the proper exceptions.

### Does this PR introduce _any_ user-facing change?

Yeah, the exception classes became different but should be compatible because previous exception was plain `Exception` which other exceptions inherit.

### How was this patch tested?

Existing unittests should cover,

Closes #31238