### PR TITLE
[SPARK-35505][PYTHON] Remove APIs which have been deprecated in Koalas

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -22,7 +22,6 @@ from abc import ABCMeta, abstractmethod
 from functools import wraps, partial
 from itertools import chain
 from typing import Any, Callable, Optional, Tuple, Union, cast, TYPE_CHECKING
-import warnings
 
 import numpy as np
 import pandas as pd  # noqa: F401
@@ -306,17 +305,6 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
     @abstractmethod
     def spark(self) -> SparkIndexOpsMethods:
         pass
-
-    @property
-    def spark_column(self) -> Column:
-        warnings.warn(
-            "Series.spark_column is deprecated as of Series.spark.column. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.column
-
-    spark_column.__doc__ = SparkIndexOpsMethods.column.__doc__
 
     @property
     def _dtype_op(self):

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -2298,27 +2298,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     T = property(transpose)
 
-    def apply_batch(self, func, args=(), **kwds) -> "DataFrame":
-        warnings.warn(
-            "DataFrame.apply_batch is deprecated as of DataFrame.koalas.apply_batch. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.koalas.apply_batch(func, args=args, **kwds)
-
-    apply_batch.__doc__ = PandasOnSparkFrameMethods.apply_batch.__doc__
-
-    # TODO: Remove this API.
-    def map_in_pandas(self, func) -> "DataFrame":
-        warnings.warn(
-            "DataFrame.map_in_pandas is deprecated as of DataFrame.koalas.apply_batch. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.koalas.apply_batch(func)
-
-    map_in_pandas.__doc__ = PandasOnSparkFrameMethods.apply_batch.__doc__
-
     def apply(self, func, axis=0, args=(), **kwds) -> Union["Series", "DataFrame", "Index"]:
         """
         Apply a function along an axis of the DataFrame.
@@ -2767,16 +2746,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return self._apply_series_op(
                 lambda psser: psser.koalas.transform_batch(func, *args, **kwargs)
             )
-
-    def transform_batch(self, func, *args, **kwargs) -> "DataFrame":
-        warnings.warn(
-            "DataFrame.transform_batch is deprecated as of DataFrame.koalas.transform_batch. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.koalas.transform_batch(func, *args, **kwargs)
-
-    transform_batch.__doc__ = PandasOnSparkFrameMethods.transform_batch.__doc__
 
     def pop(self, item) -> "DataFrame":
         """
@@ -4573,36 +4542,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
             return DataFrame(internal)
 
-    def cache(self) -> "CachedDataFrame":
-        warnings.warn(
-            "DataFrame.cache is deprecated as of DataFrame.spark.cache. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.cache()
-
-    cache.__doc__ = SparkFrameMethods.cache.__doc__
-
-    def persist(self, storage_level=StorageLevel.MEMORY_AND_DISK) -> "CachedDataFrame":
-        warnings.warn(
-            "DataFrame.persist is deprecated as of DataFrame.spark.persist. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.persist(storage_level)
-
-    persist.__doc__ = SparkFrameMethods.persist.__doc__
-
-    def hint(self, name: str, *parameters) -> "DataFrame":
-        warnings.warn(
-            "DataFrame.hint is deprecated as of DataFrame.spark.hint. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.hint(name, *parameters)
-
-    hint.__doc__ = SparkFrameMethods.hint.__doc__
-
     def to_table(
         self,
         name: str,
@@ -4874,17 +4813,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3   0.2   0.1
         """
         return self._internal.to_pandas_frame.copy()
-
-    # Alias to maintain backward compatibility with Spark
-    def toPandas(self) -> pd.DataFrame:
-        warnings.warn(
-            "DataFrame.toPandas is deprecated as of DataFrame.to_pandas. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.to_pandas()
-
-    toPandas.__doc__ = to_pandas.__doc__
 
     def assign(self, **kwargs) -> "DataFrame":
         """
@@ -6344,26 +6272,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 [label if len(label) > 1 else label[0] for label in self._internal.column_labels]
             ),
         )
-
-    def spark_schema(self, index_col: Optional[Union[str, List[str]]] = None) -> StructType:
-        warnings.warn(
-            "DataFrame.spark_schema is deprecated as of DataFrame.spark.schema. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.schema(index_col)
-
-    spark_schema.__doc__ = SparkFrameMethods.schema.__doc__
-
-    def print_schema(self, index_col: Optional[Union[str, List[str]]] = None) -> None:
-        warnings.warn(
-            "DataFrame.print_schema is deprecated as of DataFrame.spark.print_schema. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.print_schema(index_col)
-
-    print_schema.__doc__ = SparkFrameMethods.print_schema.__doc__
 
     def select_dtypes(self, include=None, exclude=None) -> "DataFrame":
         """
@@ -10926,16 +10834,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             return DataFrame(internal)
 
-    def explain(self, extended: Optional[bool] = None, mode: Optional[str] = None) -> None:
-        warnings.warn(
-            "DataFrame.explain is deprecated as of DataFrame.spark.explain. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.explain(extended, mode)
-
-    explain.__doc__ = SparkFrameMethods.explain.__doc__
-
     def take(self, indices, axis=0, **kwargs) -> "DataFrame":
         """
         Return the elements in the given *positional* indices along an axis.
@@ -11928,27 +11826,6 @@ class CachedDataFrame(DataFrame):
 
     # create accessor for Spark related methods.
     spark = CachedAccessor("spark", CachedSparkFrameMethods)
-
-    @property
-    def storage_level(self) -> StorageLevel:
-        warnings.warn(
-            "DataFrame.storage_level is deprecated as of DataFrame.spark.storage_level. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.storage_level
-
-    storage_level.__doc__ = CachedSparkFrameMethods.storage_level.__doc__
-
-    def unpersist(self) -> None:
-        warnings.warn(
-            "DataFrame.unpersist is deprecated as of DataFrame.spark.unpersist. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.unpersist()
-
-    unpersist.__doc__ = CachedSparkFrameMethods.unpersist.__doc__
 
 
 def _test():

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -38,7 +38,7 @@ from pandas._libs import lib
 
 from pyspark import sql as spark
 from pyspark.sql import functions as F
-from pyspark.sql.types import DataType, FractionalType, IntegralType, TimestampType
+from pyspark.sql.types import FractionalType, IntegralType, TimestampType
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.config import get_option, option_context
@@ -483,15 +483,6 @@ class Index(IndexOpsMixin):
         """
         return self._to_internal_pandas().copy()
 
-    def toPandas(self) -> pd.Index:
-        warnings.warn(
-            "Index.toPandas is deprecated as of Index.to_pandas. Please use the API instead.",
-            FutureWarning,
-        )
-        return self.to_pandas()
-
-    toPandas.__doc__ = to_pandas.__doc__
-
     def to_numpy(self, dtype: Optional[Union[str, Dtype]] = None, copy: bool = False) -> np.ndarray:
         """
         A NumPy ndarray representing the values in this Index or MultiIndex.
@@ -581,16 +572,6 @@ class Index(IndexOpsMixin):
             return np.array(list(map(lambda x: x.astype(np.int64), self.to_numpy())))
         else:
             return None
-
-    @property
-    def spark_type(self) -> DataType:
-        """ Returns the data type as defined by Spark, as a Spark DataType object."""
-        warnings.warn(
-            "Index.spark_type is deprecated as of Index.spark.data_type. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.data_type
 
     @property
     def has_duplicates(self) -> bool:

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -18,7 +18,6 @@
 from distutils.version import LooseVersion
 from functools import partial
 from typing import Any, Callable, Iterator, List, Optional, Tuple, Union, cast, no_type_check
-import warnings
 
 import pandas as pd
 from pandas.api.types import is_list_like
@@ -680,16 +679,6 @@ class MultiIndex(Index):
         # So far, we don't have any functions to change the internal state of MultiIndex except for
         # series-like operations. In that case, it creates new Index object instead of MultiIndex.
         return super().to_pandas()
-
-    def toPandas(self) -> pd.MultiIndex:
-        warnings.warn(
-            "MultiIndex.toPandas is deprecated as of MultiIndex.to_pandas. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.to_pandas()
-
-    toPandas.__doc__ = to_pandas.__doc__
 
     def nunique(self, dropna: bool = True, approx: bool = False, rsd: float = 0.05) -> int:
         raise NotImplementedError("nunique is not defined for MultiIndex")

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -22,7 +22,6 @@ import datetime
 import re
 import inspect
 import sys
-import warnings
 from collections.abc import Mapping
 from functools import partial, wraps, reduce
 from typing import Any, Generic, Iterable, List, Optional, Tuple, TypeVar, Union, cast
@@ -466,17 +465,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         [Int64Index([0, 1, 2], dtype='int64')]
         """
         return [self.index]
-
-    @property
-    def spark_type(self):
-        warnings.warn(
-            "Series.spark_type is deprecated as of Series.spark.data_type. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.spark.data_type
-
-    spark_type.__doc__ = SparkSeriesMethods.data_type.__doc__
 
     # Arithmetic Operators
     def add(self, other) -> "Series":
@@ -1017,14 +1005,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         else:
             return self.apply(arg)
 
-    def alias(self, name) -> "Series":
-        """An alias for :meth:`Series.rename`."""
-        warnings.warn(
-            "Series.alias is deprecated as of Series.rename. Please use the API instead.",
-            FutureWarning,
-        )
-        return self.rename(name)
-
     @property
     def shape(self):
         """Return a tuple of the shape of the underlying data."""
@@ -1517,16 +1497,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: dogs, dtype: float64
         """
         return self._to_internal_pandas().copy()
-
-    # Alias to maintain backward compatibility with Spark
-    def toPandas(self) -> pd.Series:
-        warnings.warn(
-            "Series.toPandas is deprecated as of Series.to_pandas. Please use the API instead.",
-            FutureWarning,
-        )
-        return self.to_pandas()
-
-    toPandas.__doc__ = to_pandas.__doc__
 
     def to_list(self) -> List:
         """
@@ -3299,16 +3269,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             return DataFrame(internal)
         else:
             return self.apply(func, args=args, **kwargs)
-
-    def transform_batch(self, func, *args, **kwargs) -> "ps.Series":
-        warnings.warn(
-            "Series.transform_batch is deprecated as of Series.koalas.transform_batch. "
-            "Please use the API instead.",
-            FutureWarning,
-        )
-        return self.koalas.transform_batch(func, *args, **kwargs)
-
-    transform_batch.__doc__ = PandasOnSparkSeriesMethods.transform_batch.__doc__
 
     def round(self, decimals=0) -> "Series":
         """


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes APIs which have been deprecated in Koalas.

### Why are the changes needed?

There are some APIs that have been deprecated in Koalas. We shouldn't have those in pandas APIs on Spark.

### Does this PR introduce _any_ user-facing change?

Yes, the APIs deprecated in Koalas will be no longer available.

### How was this patch tested?

Modified some tests which use the deprecated APIs, and the other existing tests should pass.