### PR TITLE
[SPARK-22639][SQL] Support aggregate cbo stats estimation if the group by clause involves substring

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -95,7 +95,7 @@ object EstimationUtils {
           attributeStats.contains(attr)
         case _: Literal => true
         case _ => false
-      }
+  }
 
   private def getExpressionStats(
       attribute: Attribute,

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/explain.txt
@@ -5,53 +5,53 @@ TakeOrderedAndProject (53)
       +- * HashAggregate (50)
          +- * Project (49)
             +- * SortMergeJoin Inner (48)
-               :- * Sort (18)
-               :  +- Exchange (17)
-               :     +- * Project (16)
-               :        +- * BroadcastHashJoin Inner BuildRight (15)
-               :           :- * Project (10)
-               :           :  +- * BroadcastHashJoin Inner BuildRight (9)
-               :           :     :- * Filter (3)
-               :           :     :  +- * ColumnarToRow (2)
-               :           :     :     +- Scan parquet default.store_sales (1)
-               :           :     +- BroadcastExchange (8)
-               :           :        +- * Project (7)
-               :           :           +- * Filter (6)
-               :           :              +- * ColumnarToRow (5)
-               :           :                 +- Scan parquet default.date_dim (4)
-               :           +- BroadcastExchange (14)
-               :              +- * Filter (13)
-               :                 +- * ColumnarToRow (12)
-               :                    +- Scan parquet default.store (11)
+               :- * Sort (12)
+               :  +- Exchange (11)
+               :     +- * Project (10)
+               :        +- * BroadcastHashJoin Inner BuildRight (9)
+               :           :- * Filter (3)
+               :           :  +- * ColumnarToRow (2)
+               :           :     +- Scan parquet default.store_sales (1)
+               :           +- BroadcastExchange (8)
+               :              +- * Project (7)
+               :                 +- * Filter (6)
+               :                    +- * ColumnarToRow (5)
+               :                       +- Scan parquet default.date_dim (4)
                +- * Sort (47)
                   +- Exchange (46)
-                     +- * HashAggregate (45)
-                        +- Exchange (44)
+                     +- * Project (45)
+                        +- * BroadcastHashJoin Inner BuildLeft (44)
+                           :- BroadcastExchange (16)
+                           :  +- * Filter (15)
+                           :     +- * ColumnarToRow (14)
+                           :        +- Scan parquet default.store (13)
                            +- * HashAggregate (43)
-                              +- * Project (42)
-                                 +- * BroadcastHashJoin LeftSemi BuildRight (41)
-                                    :- * Filter (21)
-                                    :  +- * ColumnarToRow (20)
-                                    :     +- Scan parquet default.customer_address (19)
-                                    +- BroadcastExchange (40)
-                                       +- * Project (39)
-                                          +- * Filter (38)
-                                             +- * HashAggregate (37)
-                                                +- Exchange (36)
+                              +- Exchange (42)
+                                 +- * HashAggregate (41)
+                                    +- * Project (40)
+                                       +- * BroadcastHashJoin LeftSemi BuildRight (39)
+                                          :- * Filter (19)
+                                          :  +- * ColumnarToRow (18)
+                                          :     +- Scan parquet default.customer_address (17)
+                                          +- BroadcastExchange (38)
+                                             +- * Project (37)
+                                                +- * Filter (36)
                                                    +- * HashAggregate (35)
-                                                      +- * Project (34)
-                                                         +- * SortMergeJoin Inner (33)
-                                                            :- * Sort (26)
-                                                            :  +- Exchange (25)
-                                                            :     +- * Filter (24)
-                                                            :        +- * ColumnarToRow (23)
-                                                            :           +- Scan parquet default.customer_address (22)
-                                                            +- * Sort (32)
-                                                               +- Exchange (31)
-                                                                  +- * Project (30)
-                                                                     +- * Filter (29)
-                                                                        +- * ColumnarToRow (28)
-                                                                           +- Scan parquet default.customer (27)
+                                                      +- Exchange (34)
+                                                         +- * HashAggregate (33)
+                                                            +- * Project (32)
+                                                               +- * SortMergeJoin Inner (31)
+                                                                  :- * Sort (24)
+                                                                  :  +- Exchange (23)
+                                                                  :     +- * Filter (22)
+                                                                  :        +- * ColumnarToRow (21)
+                                                                  :           +- Scan parquet default.customer_address (20)
+                                                                  +- * Sort (30)
+                                                                     +- Exchange (29)
+                                                                        +- * Project (28)
+                                                                           +- * Filter (27)
+                                                                              +- * ColumnarToRow (26)
+                                                                                 +- Scan parquet default.customer (25)
 
 
 (1) Scan parquet default.store_sales
@@ -62,10 +62,10 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#3), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_net_profit:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 3]
+(2) ColumnarToRow [codegen id : 2]
 Input [3]: [ss_store_sk#1, ss_net_profit#2, ss_sold_date_sk#3]
 
-(3) Filter [codegen id : 3]
+(3) Filter [codegen id : 2]
 Input [3]: [ss_store_sk#1, ss_net_profit#2, ss_sold_date_sk#3]
 Condition : isnotnull(ss_store_sk#1)
 
@@ -91,215 +91,215 @@ Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
 Input [1]: [d_date_sk#5]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#8]
 
-(9) BroadcastHashJoin [codegen id : 3]
+(9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
 Join condition: None
 
-(10) Project [codegen id : 3]
+(10) Project [codegen id : 2]
 Output [2]: [ss_store_sk#1, ss_net_profit#2]
 Input [4]: [ss_store_sk#1, ss_net_profit#2, ss_sold_date_sk#3, d_date_sk#5]
 
-(11) Scan parquet default.store
-Output [3]: [s_store_sk#9, s_store_name#10, s_zip#11]
+(11) Exchange
+Input [2]: [ss_store_sk#1, ss_net_profit#2]
+Arguments: hashpartitioning(ss_store_sk#1, 5), ENSURE_REQUIREMENTS, [id=#9]
+
+(12) Sort [codegen id : 3]
+Input [2]: [ss_store_sk#1, ss_net_profit#2]
+Arguments: [ss_store_sk#1 ASC NULLS FIRST], false, 0
+
+(13) Scan parquet default.store
+Output [3]: [s_store_sk#10, s_store_name#11, s_zip#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_zip:string>
 
-(12) ColumnarToRow [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_name#10, s_zip#11]
+(14) ColumnarToRow [codegen id : 4]
+Input [3]: [s_store_sk#10, s_store_name#11, s_zip#12]
 
-(13) Filter [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_name#10, s_zip#11]
-Condition : (isnotnull(s_store_sk#9) AND isnotnull(s_zip#11))
+(15) Filter [codegen id : 4]
+Input [3]: [s_store_sk#10, s_store_name#11, s_zip#12]
+Condition : (isnotnull(s_store_sk#10) AND isnotnull(s_zip#12))
 
-(14) BroadcastExchange
-Input [3]: [s_store_sk#9, s_store_name#10, s_zip#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+(16) BroadcastExchange
+Input [3]: [s_store_sk#10, s_store_name#11, s_zip#12]
+Arguments: HashedRelationBroadcastMode(List(substr(input[2, string, false], 1, 2)),false), [id=#13]
 
-(15) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_store_sk#1]
-Right keys [1]: [s_store_sk#9]
-Join condition: None
-
-(16) Project [codegen id : 3]
-Output [3]: [ss_net_profit#2, s_store_name#10, s_zip#11]
-Input [5]: [ss_store_sk#1, ss_net_profit#2, s_store_sk#9, s_store_name#10, s_zip#11]
-
-(17) Exchange
-Input [3]: [ss_net_profit#2, s_store_name#10, s_zip#11]
-Arguments: hashpartitioning(substr(s_zip#11, 1, 2), 5), ENSURE_REQUIREMENTS, [id=#13]
-
-(18) Sort [codegen id : 4]
-Input [3]: [ss_net_profit#2, s_store_name#10, s_zip#11]
-Arguments: [substr(s_zip#11, 1, 2) ASC NULLS FIRST], false, 0
-
-(19) Scan parquet default.customer_address
+(17) Scan parquet default.customer_address
 Output [1]: [ca_zip#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 ReadSchema: struct<ca_zip:string>
 
-(20) ColumnarToRow [codegen id : 11]
+(18) ColumnarToRow [codegen id : 11]
 Input [1]: [ca_zip#14]
 
-(21) Filter [codegen id : 11]
+(19) Filter [codegen id : 11]
 Input [1]: [ca_zip#14]
 Condition : (substr(ca_zip#14, 1, 5) INSET 10144, 10336, 10390, 10445, 10516, 10567, 11101, 11356, 11376, 11489, 11634, 11928, 12305, 13354, 13375, 13376, 13394, 13595, 13695, 13955, 14060, 14089, 14171, 14328, 14663, 14867, 14922, 15126, 15146, 15371, 15455, 15559, 15723, 15734, 15765, 15798, 15882, 16021, 16725, 16807, 17043, 17183, 17871, 17879, 17920, 18119, 18270, 18376, 18383, 18426, 18652, 18767, 18799, 18840, 18842, 18845, 18906, 19430, 19505, 19512, 19515, 19736, 19769, 19849, 20004, 20260, 20548, 21076, 21195, 21286, 21309, 21337, 21756, 22152, 22245, 22246, 22351, 22437, 22461, 22685, 22744, 22752, 22927, 23006, 23470, 23932, 23968, 24128, 24206, 24317, 24610, 24671, 24676, 24996, 25003, 25103, 25280, 25486, 25631, 25733, 25782, 25858, 25989, 26065, 26105, 26231, 26233, 26653, 26689, 26859, 27068, 27156, 27385, 27700, 28286, 28488, 28545, 28577, 28587, 28709, 28810, 28898, 28915, 29178, 29741, 29839, 30010, 30122, 30431, 30450, 30469, 30625, 30903, 31016, 31029, 31387, 31671, 31880, 32213, 32754, 33123, 33282, 33515, 33786, 34102, 34322, 34425, 35258, 35458, 35474, 35576, 35850, 35942, 36233, 36420, 36446, 36495, 36634, 37125, 37126, 37930, 38122, 38193, 38415, 38607, 38935, 39127, 39192, 39371, 39516, 39736, 39861, 39972, 40081, 40162, 40558, 40604, 41248, 41367, 41368, 41766, 41918, 42029, 42666, 42961, 43285, 43848, 43933, 44165, 44438, 45200, 45266, 45375, 45549, 45692, 45721, 45748, 46081, 46136, 46820, 47305, 47537, 47770, 48033, 48425, 48583, 49130, 49156, 49448, 50016, 50298, 50308, 50412, 51061, 51103, 51200, 51211, 51622, 51649, 51650, 51798, 51949, 52867, 53179, 53268, 53535, 53672, 54364, 54601, 54917, 55253, 55307, 55565, 56240, 56458, 56529, 56571, 56575, 56616, 56691, 56910, 57047, 57647, 57665, 57834, 57855, 58048, 58058, 58078, 58263, 58470, 58943, 59166, 59402, 60099, 60279, 60576, 61265, 61547, 61810, 61860, 62377, 62496, 62878, 62971, 63089, 63193, 63435, 63792, 63837, 63981, 64034, 64147, 64457, 64528, 64544, 65084, 65164, 66162, 66708, 66864, 67030, 67301, 67467, 67473, 67853, 67875, 67897, 68014, 68100, 68101, 68309, 68341, 68621, 68786, 68806, 68880, 68893, 68908, 69035, 69399, 69913, 69952, 70372, 70466, 70738, 71256, 71286, 71791, 71954, 72013, 72151, 72175, 72305, 72325, 72425, 72550, 72823, 73134, 73171, 73241, 73273, 73520, 73650, 74351, 75691, 76107, 76231, 76232, 76614, 76638, 76698, 77191, 77556, 77610, 77721, 78451, 78567, 78668, 78890, 79077, 79777, 79994, 81019, 81096, 81312, 81426, 82136, 82276, 82636, 83041, 83144, 83444, 83849, 83921, 83926, 83933, 84093, 84935, 85816, 86057, 86198, 86284, 86379, 87343, 87501, 87816, 88086, 88190, 88424, 88885, 89091, 89360, 90225, 90257, 90578, 91068, 91110, 91137, 91393, 92712, 94167, 94627, 94898, 94945, 94983, 96451, 96576, 96765, 96888, 96976, 97189, 97789, 98025, 98235, 98294, 98359, 98569, 99076, 99543 AND isnotnull(substr(ca_zip#14, 1, 5)))
 
-(22) Scan parquet default.customer_address
+(20) Scan parquet default.customer_address
 Output [2]: [ca_address_sk#15, ca_zip#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_zip:string>
 
-(23) ColumnarToRow [codegen id : 5]
+(21) ColumnarToRow [codegen id : 5]
 Input [2]: [ca_address_sk#15, ca_zip#16]
 
-(24) Filter [codegen id : 5]
+(22) Filter [codegen id : 5]
 Input [2]: [ca_address_sk#15, ca_zip#16]
 Condition : isnotnull(ca_address_sk#15)
 
-(25) Exchange
+(23) Exchange
 Input [2]: [ca_address_sk#15, ca_zip#16]
 Arguments: hashpartitioning(ca_address_sk#15, 5), ENSURE_REQUIREMENTS, [id=#17]
 
-(26) Sort [codegen id : 6]
+(24) Sort [codegen id : 6]
 Input [2]: [ca_address_sk#15, ca_zip#16]
 Arguments: [ca_address_sk#15 ASC NULLS FIRST], false, 0
 
-(27) Scan parquet default.customer
+(25) Scan parquet default.customer
 Output [2]: [c_current_addr_sk#18, c_preferred_cust_flag#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_preferred_cust_flag), EqualTo(c_preferred_cust_flag,Y), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_current_addr_sk:int,c_preferred_cust_flag:string>
 
-(28) ColumnarToRow [codegen id : 7]
+(26) ColumnarToRow [codegen id : 7]
 Input [2]: [c_current_addr_sk#18, c_preferred_cust_flag#19]
 
-(29) Filter [codegen id : 7]
+(27) Filter [codegen id : 7]
 Input [2]: [c_current_addr_sk#18, c_preferred_cust_flag#19]
 Condition : ((isnotnull(c_preferred_cust_flag#19) AND (c_preferred_cust_flag#19 = Y)) AND isnotnull(c_current_addr_sk#18))
 
-(30) Project [codegen id : 7]
+(28) Project [codegen id : 7]
 Output [1]: [c_current_addr_sk#18]
 Input [2]: [c_current_addr_sk#18, c_preferred_cust_flag#19]
 
-(31) Exchange
+(29) Exchange
 Input [1]: [c_current_addr_sk#18]
 Arguments: hashpartitioning(c_current_addr_sk#18, 5), ENSURE_REQUIREMENTS, [id=#20]
 
-(32) Sort [codegen id : 8]
+(30) Sort [codegen id : 8]
 Input [1]: [c_current_addr_sk#18]
 Arguments: [c_current_addr_sk#18 ASC NULLS FIRST], false, 0
 
-(33) SortMergeJoin [codegen id : 9]
+(31) SortMergeJoin [codegen id : 9]
 Left keys [1]: [ca_address_sk#15]
 Right keys [1]: [c_current_addr_sk#18]
 Join condition: None
 
-(34) Project [codegen id : 9]
+(32) Project [codegen id : 9]
 Output [1]: [ca_zip#16]
 Input [3]: [ca_address_sk#15, ca_zip#16, c_current_addr_sk#18]
 
-(35) HashAggregate [codegen id : 9]
+(33) HashAggregate [codegen id : 9]
 Input [1]: [ca_zip#16]
 Keys [1]: [ca_zip#16]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#21]
 Results [2]: [ca_zip#16, count#22]
 
-(36) Exchange
+(34) Exchange
 Input [2]: [ca_zip#16, count#22]
 Arguments: hashpartitioning(ca_zip#16, 5), ENSURE_REQUIREMENTS, [id=#23]
 
-(37) HashAggregate [codegen id : 10]
+(35) HashAggregate [codegen id : 10]
 Input [2]: [ca_zip#16, count#22]
 Keys [1]: [ca_zip#16]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#24]
 Results [2]: [substr(ca_zip#16, 1, 5) AS ca_zip#25, count(1)#24 AS count(1)#26]
 
-(38) Filter [codegen id : 10]
+(36) Filter [codegen id : 10]
 Input [2]: [ca_zip#25, count(1)#26]
 Condition : (count(1)#26 > 10)
 
-(39) Project [codegen id : 10]
+(37) Project [codegen id : 10]
 Output [1]: [ca_zip#25]
 Input [2]: [ca_zip#25, count(1)#26]
 
-(40) BroadcastExchange
+(38) BroadcastExchange
 Input [1]: [ca_zip#25]
 Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true])),false), [id=#27]
 
-(41) BroadcastHashJoin [codegen id : 11]
+(39) BroadcastHashJoin [codegen id : 11]
 Left keys [2]: [coalesce(substr(ca_zip#14, 1, 5), ), isnull(substr(ca_zip#14, 1, 5))]
 Right keys [2]: [coalesce(ca_zip#25, ), isnull(ca_zip#25)]
 Join condition: None
 
-(42) Project [codegen id : 11]
+(40) Project [codegen id : 11]
 Output [1]: [substr(ca_zip#14, 1, 5) AS ca_zip#28]
 Input [1]: [ca_zip#14]
 
-(43) HashAggregate [codegen id : 11]
+(41) HashAggregate [codegen id : 11]
 Input [1]: [ca_zip#28]
 Keys [1]: [ca_zip#28]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [ca_zip#28]
 
-(44) Exchange
+(42) Exchange
 Input [1]: [ca_zip#28]
 Arguments: hashpartitioning(ca_zip#28, 5), ENSURE_REQUIREMENTS, [id=#29]
 
-(45) HashAggregate [codegen id : 12]
+(43) HashAggregate
 Input [1]: [ca_zip#28]
 Keys [1]: [ca_zip#28]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [ca_zip#28]
 
-(46) Exchange
-Input [1]: [ca_zip#28]
-Arguments: hashpartitioning(substr(ca_zip#28, 1, 2), 5), ENSURE_REQUIREMENTS, [id=#30]
-
-(47) Sort [codegen id : 13]
-Input [1]: [ca_zip#28]
-Arguments: [substr(ca_zip#28, 1, 2) ASC NULLS FIRST], false, 0
-
-(48) SortMergeJoin [codegen id : 14]
-Left keys [1]: [substr(s_zip#11, 1, 2)]
+(44) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [substr(s_zip#12, 1, 2)]
 Right keys [1]: [substr(ca_zip#28, 1, 2)]
 Join condition: None
 
+(45) Project [codegen id : 12]
+Output [2]: [s_store_sk#10, s_store_name#11]
+Input [4]: [s_store_sk#10, s_store_name#11, s_zip#12, ca_zip#28]
+
+(46) Exchange
+Input [2]: [s_store_sk#10, s_store_name#11]
+Arguments: hashpartitioning(s_store_sk#10, 5), ENSURE_REQUIREMENTS, [id=#30]
+
+(47) Sort [codegen id : 13]
+Input [2]: [s_store_sk#10, s_store_name#11]
+Arguments: [s_store_sk#10 ASC NULLS FIRST], false, 0
+
+(48) SortMergeJoin [codegen id : 14]
+Left keys [1]: [ss_store_sk#1]
+Right keys [1]: [s_store_sk#10]
+Join condition: None
+
 (49) Project [codegen id : 14]
-Output [2]: [ss_net_profit#2, s_store_name#10]
-Input [4]: [ss_net_profit#2, s_store_name#10, s_zip#11, ca_zip#28]
+Output [2]: [ss_net_profit#2, s_store_name#11]
+Input [4]: [ss_store_sk#1, ss_net_profit#2, s_store_sk#10, s_store_name#11]
 
 (50) HashAggregate [codegen id : 14]
-Input [2]: [ss_net_profit#2, s_store_name#10]
-Keys [1]: [s_store_name#10]
+Input [2]: [ss_net_profit#2, s_store_name#11]
+Keys [1]: [s_store_name#11]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_profit#2))]
 Aggregate Attributes [1]: [sum#31]
-Results [2]: [s_store_name#10, sum#32]
+Results [2]: [s_store_name#11, sum#32]
 
 (51) Exchange
-Input [2]: [s_store_name#10, sum#32]
-Arguments: hashpartitioning(s_store_name#10, 5), ENSURE_REQUIREMENTS, [id=#33]
+Input [2]: [s_store_name#11, sum#32]
+Arguments: hashpartitioning(s_store_name#11, 5), ENSURE_REQUIREMENTS, [id=#33]
 
 (52) HashAggregate [codegen id : 15]
-Input [2]: [s_store_name#10, sum#32]
-Keys [1]: [s_store_name#10]
+Input [2]: [s_store_name#11, sum#32]
+Keys [1]: [s_store_name#11]
 Functions [1]: [sum(UnscaledValue(ss_net_profit#2))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#2))#34]
-Results [2]: [s_store_name#10, MakeDecimal(sum(UnscaledValue(ss_net_profit#2))#34,17,2) AS sum(ss_net_profit)#35]
+Results [2]: [s_store_name#11, MakeDecimal(sum(UnscaledValue(ss_net_profit#2))#34,17,2) AS sum(ss_net_profit)#35]
 
 (53) TakeOrderedAndProject
-Input [2]: [s_store_name#10, sum(ss_net_profit)#35]
-Arguments: 100, [s_store_name#10 ASC NULLS FIRST], [s_store_name#10, sum(ss_net_profit)#35]
+Input [2]: [s_store_name#11, sum(ss_net_profit)#35]
+Arguments: 100, [s_store_name#11 ASC NULLS FIRST], [s_store_name#11, sum(ss_net_profit)#35]
 
 ===== Subqueries =====
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/simplified.txt
@@ -6,85 +6,85 @@ TakeOrderedAndProject [s_store_name,sum(ss_net_profit)]
           WholeStageCodegen (14)
             HashAggregate [s_store_name,ss_net_profit] [sum,sum]
               Project [ss_net_profit,s_store_name]
-                SortMergeJoin [s_zip,ca_zip]
+                SortMergeJoin [ss_store_sk,s_store_sk]
                   InputAdapter
-                    WholeStageCodegen (4)
-                      Sort [s_zip]
+                    WholeStageCodegen (3)
+                      Sort [ss_store_sk]
                         InputAdapter
-                          Exchange [s_zip] #2
-                            WholeStageCodegen (3)
-                              Project [ss_net_profit,s_store_name,s_zip]
-                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                  Project [ss_store_sk,ss_net_profit]
-                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                      Filter [ss_store_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet default.store_sales [ss_store_sk,ss_net_profit,ss_sold_date_sk]
-                                              SubqueryBroadcast [d_date_sk] #1
-                                                ReusedExchange [d_date_sk] #3
+                          Exchange [ss_store_sk] #2
+                            WholeStageCodegen (2)
+                              Project [ss_store_sk,ss_net_profit]
+                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                  Filter [ss_store_sk]
+                                    ColumnarToRow
                                       InputAdapter
-                                        BroadcastExchange #3
-                                          WholeStageCodegen (1)
-                                            Project [d_date_sk]
-                                              Filter [d_qoy,d_year,d_date_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet default.date_dim [d_date_sk,d_year,d_qoy]
+                                        Scan parquet default.store_sales [ss_store_sk,ss_net_profit,ss_sold_date_sk]
+                                          SubqueryBroadcast [d_date_sk] #1
+                                            ReusedExchange [d_date_sk] #3
                                   InputAdapter
-                                    BroadcastExchange #4
-                                      WholeStageCodegen (2)
+                                    BroadcastExchange #3
+                                      WholeStageCodegen (1)
+                                        Project [d_date_sk]
+                                          Filter [d_qoy,d_year,d_date_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet default.date_dim [d_date_sk,d_year,d_qoy]
+                  InputAdapter
+                    WholeStageCodegen (13)
+                      Sort [s_store_sk]
+                        InputAdapter
+                          Exchange [s_store_sk] #4
+                            WholeStageCodegen (12)
+                              Project [s_store_sk,s_store_name]
+                                BroadcastHashJoin [s_zip,ca_zip]
+                                  InputAdapter
+                                    BroadcastExchange #5
+                                      WholeStageCodegen (4)
                                         Filter [s_store_sk,s_zip]
                                           ColumnarToRow
                                             InputAdapter
                                               Scan parquet default.store [s_store_sk,s_store_name,s_zip]
-                  InputAdapter
-                    WholeStageCodegen (13)
-                      Sort [ca_zip]
-                        InputAdapter
-                          Exchange [ca_zip] #5
-                            WholeStageCodegen (12)
-                              HashAggregate [ca_zip]
-                                InputAdapter
-                                  Exchange [ca_zip] #6
-                                    WholeStageCodegen (11)
-                                      HashAggregate [ca_zip]
-                                        Project [ca_zip]
-                                          BroadcastHashJoin [ca_zip,ca_zip]
-                                            Filter [ca_zip]
-                                              ColumnarToRow
+                                  HashAggregate [ca_zip]
+                                    InputAdapter
+                                      Exchange [ca_zip] #6
+                                        WholeStageCodegen (11)
+                                          HashAggregate [ca_zip]
+                                            Project [ca_zip]
+                                              BroadcastHashJoin [ca_zip,ca_zip]
+                                                Filter [ca_zip]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet default.customer_address [ca_zip]
                                                 InputAdapter
-                                                  Scan parquet default.customer_address [ca_zip]
-                                            InputAdapter
-                                              BroadcastExchange #7
-                                                WholeStageCodegen (10)
-                                                  Project [ca_zip]
-                                                    Filter [count(1)]
-                                                      HashAggregate [ca_zip,count] [count(1),ca_zip,count(1),count]
-                                                        InputAdapter
-                                                          Exchange [ca_zip] #8
-                                                            WholeStageCodegen (9)
-                                                              HashAggregate [ca_zip] [count,count]
-                                                                Project [ca_zip]
-                                                                  SortMergeJoin [ca_address_sk,c_current_addr_sk]
-                                                                    InputAdapter
-                                                                      WholeStageCodegen (6)
-                                                                        Sort [ca_address_sk]
-                                                                          InputAdapter
-                                                                            Exchange [ca_address_sk] #9
-                                                                              WholeStageCodegen (5)
-                                                                                Filter [ca_address_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.customer_address [ca_address_sk,ca_zip]
-                                                                    InputAdapter
-                                                                      WholeStageCodegen (8)
-                                                                        Sort [c_current_addr_sk]
-                                                                          InputAdapter
-                                                                            Exchange [c_current_addr_sk] #10
-                                                                              WholeStageCodegen (7)
-                                                                                Project [c_current_addr_sk]
-                                                                                  Filter [c_preferred_cust_flag,c_current_addr_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.customer [c_current_addr_sk,c_preferred_cust_flag]
+                                                  BroadcastExchange #7
+                                                    WholeStageCodegen (10)
+                                                      Project [ca_zip]
+                                                        Filter [count(1)]
+                                                          HashAggregate [ca_zip,count] [count(1),ca_zip,count(1),count]
+                                                            InputAdapter
+                                                              Exchange [ca_zip] #8
+                                                                WholeStageCodegen (9)
+                                                                  HashAggregate [ca_zip] [count,count]
+                                                                    Project [ca_zip]
+                                                                      SortMergeJoin [ca_address_sk,c_current_addr_sk]
+                                                                        InputAdapter
+                                                                          WholeStageCodegen (6)
+                                                                            Sort [ca_address_sk]
+                                                                              InputAdapter
+                                                                                Exchange [ca_address_sk] #9
+                                                                                  WholeStageCodegen (5)
+                                                                                    Filter [ca_address_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet default.customer_address [ca_address_sk,ca_zip]
+                                                                        InputAdapter
+                                                                          WholeStageCodegen (8)
+                                                                            Sort [c_current_addr_sk]
+                                                                              InputAdapter
+                                                                                Exchange [c_current_addr_sk] #10
+                                                                                  WholeStageCodegen (7)
+                                                                                    Project [c_current_addr_sk]
+                                                                                      Filter [c_preferred_cust_flag,c_current_addr_sk]
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet default.customer [c_current_addr_sk,c_preferred_cust_flag]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
If the grouping keys contains substring, Aggregate doesn't use CBO for computing stats and fall back to sizeInBytes based estimation. So we will be missing row count and col stats after that. Many TPCDS queries has substring in their group by expressions, like Query8, Query23a etc.

### Why are the changes needed?
CBO cannot estimate rowcount if the groupby clause of a query involves the expression substring. For example, we can not estimate the row count of the following query, 

**Eg: Query**
TPCDS Q8

**Before:**
(From TPCDS Q8 plan)
No rowcount
```

 +- Aggregate [ca_zip#0], [ca_zip#0], **Statistics(sizeInBytes=160.2 MiB)**
       +- Project [substr(ca_zip#94, 1, 5) AS ca_zip#0], Statistics(sizeInBytes=160.2 MiB, rowCount=6.00E+6)
```
**After:**

Rowcount exists

```
+- Aggregate [ca_zip#0], [ca_zip#0], **Statistics(sizeInBytes=241.6 KiB, rowCount=9.90E+3)**
       +- Project [substr(ca_zip#94, 1, 5) AS ca_zip#0], Statistics(sizeInBytes=143.1 MiB, rowCount=6.00E+6)

```
### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UTs, manual testing

Imapct on TPCDS Query8:
SF=1000, 8 node cluster with ExecMemory 28GB, ExecCores 4, ExecInstances 15.






<meta name="ProgId" content="Excel.Sheet">
<meta name="Generator" content="Microsoft Excel 15">
<link id="Main-File" rel="Main-File" href="file:///C:/Users/shaki/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel="File-List" href="file:///C:/Users/shaki/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Percent;
	background:#92D050;
	mso-pattern:black none;}
-->






Metrics | Before | After | Improvement
-- | -- | -- | --
minRunTime | 10.73   sec | 9.61 sec | 10.50%
ShuffleRead | 735 MB | 658 MB | 10.40%
Shuffle Write | 735 MB | 658 MB | 10.40%



















