### PR TITLE
[SPARK-34271][SQL][3.1] Use majorMinorPatchVersion for Hive version parsing

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -88,23 +88,25 @@ private[hive] object IsolatedClientLoader extends Logging {
       barrierPrefixes = barrierPrefixes)
   }
 
-  def hiveVersion(version: String): HiveVersion = version match {
-    case "12" | "0.12" | "0.12.0" => hive.v12
-    case "13" | "0.13" | "0.13.0" | "0.13.1" => hive.v13
-    case "14" | "0.14" | "0.14.0" => hive.v14
-    case "1.0" | "1.0.0" | "1.0.1" => hive.v1_0
-    case "1.1" | "1.1.0" | "1.1.1" => hive.v1_1
-    case "1.2" | "1.2.0" | "1.2.1" | "1.2.2" => hive.v1_2
-    case "2.0" | "2.0.0" | "2.0.1" => hive.v2_0
-    case "2.1" | "2.1.0" | "2.1.1" => hive.v2_1
-    case "2.2" | "2.2.0" => hive.v2_2
-    case "2.3" | "2.3.0" | "2.3.1" | "2.3.2" | "2.3.3" | "2.3.4" | "2.3.5" | "2.3.6" | "2.3.7" =>
-      hive.v2_3
-    case "3.0" | "3.0.0" => hive.v3_0
-    case "3.1" | "3.1.0" | "3.1.1" | "3.1.2" => hive.v3_1
-    case version =>
+  def hiveVersion(version: String): HiveVersion = {
+    VersionUtils.majorMinorPatchVersion(version).flatMap {
+      case (12, _, _) | (0, 12, _) => Some(hive.v12)
+      case (13, _, _) | (0, 13, _) => Some(hive.v13)
+      case (14, _, _) | (0, 14, _) => Some(hive.v14)
+      case (1, 0, _) => Some(hive.v1_0)
+      case (1, 1, _) => Some(hive.v1_1)
+      case (1, 2, _) => Some(hive.v1_2)
+      case (2, 0, _) => Some(hive.v2_0)
+      case (2, 1, _) => Some(hive.v2_1)
+      case (2, 2, _) => Some(hive.v2_2)
+      case (2, 3, _) => Some(hive.v2_3)
+      case (3, 0, _) => Some(hive.v3_0)
+      case (3, 1, _) => Some(hive.v3_1)
+      case _ => None
+    }.getOrElse {
       throw new UnsupportedOperationException(s"Unsupported Hive Metastore version ($version). " +
         s"Please set ${HiveUtils.HIVE_METASTORE_VERSION.key} with a valid version.")
+    }
   }
 
   private def downloadVersion(


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR backports SPARK-34271 (#31371).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I'm personally checking whether all the tests pass with Java 11 for thecurrent `master` and I found `HiveExternalCatalogVersionsSuite` fails.
The reason is that Spark 3.0.2 and 3.1.1 doesn't accept `2.3.8` as a hive metastore version.

`HiveExternalCatalogVersionsSuite` downloads Spark releases from https://dist.apache.org/repos/dist/release/spark/ and run test for each release. The Spark releases are `3.0.2` and `3.1.1` for the current `master` for now.
https://github.com/apache/spark/blob/e47e615c0ede9692fd3aa1098155e92e4fb50b7f/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala#L239-L259

With Java 11, the suite run with a hive metastore version which corresponds to the builtin Hive version and it's `2.3.8` for the current `master`.
https://github.com/apache/spark/blob/20750a3f9e13a2f02860859f87bbc38a18cba85e/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala#L62-L66

But `branch-3.0` and `branch-3.1` doesn't accept `2.3.8`, the suite with Java 11 fails.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing tests with CI.