### PR TITLE
[SPARK-35533][CORE] Do not drop cached rdd blocks from memory to accommodate blocks from decommissioned block manager

### DIFF
--- a/core/src/main/scala/org/apache/spark/memory/MemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/MemoryManager.scala
@@ -91,7 +91,11 @@ private[spark] abstract class MemoryManager(
    *
    * @return whether all N bytes were successfully granted.
    */
-  def acquireStorageMemory(blockId: BlockId, numBytes: Long, memoryMode: MemoryMode): Boolean
+  def acquireStorageMemory(
+      blockId: BlockId,
+      numBytes: Long,
+      memoryMode: MemoryMode,
+      canEvictBlocks: Boolean): Boolean
 
   /**
    * Acquire N bytes of memory to unroll the given block, evicting existing ones if necessary.
@@ -102,7 +106,11 @@ private[spark] abstract class MemoryManager(
    *
    * @return whether all N bytes were successfully granted.
    */
-  def acquireUnrollMemory(blockId: BlockId, numBytes: Long, memoryMode: MemoryMode): Boolean
+  def acquireUnrollMemory(
+      blockId: BlockId,
+      numBytes: Long,
+      memoryMode: MemoryMode,
+      canEvictBlocks: Boolean): Boolean
 
   /**
    * Try to acquire up to `numBytes` of execution memory for the current task and return the

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -151,7 +151,8 @@ private[spark] class UnifiedMemoryManager(
   override def acquireStorageMemory(
       blockId: BlockId,
       numBytes: Long,
-      memoryMode: MemoryMode): Boolean = synchronized {
+      memoryMode: MemoryMode,
+      canEvictBlocks: Boolean = true): Boolean = synchronized {
     assertInvariants()
     assert(numBytes >= 0)
     val (executionPool, storagePool, maxMemory) = memoryMode match {
@@ -178,14 +179,15 @@ private[spark] class UnifiedMemoryManager(
       executionPool.decrementPoolSize(memoryBorrowedFromExecution)
       storagePool.incrementPoolSize(memoryBorrowedFromExecution)
     }
-    storagePool.acquireMemory(blockId, numBytes)
+    storagePool.acquireMemory(blockId, numBytes, canEvictBlocks)
   }
 
   override def acquireUnrollMemory(
       blockId: BlockId,
       numBytes: Long,
-      memoryMode: MemoryMode): Boolean = synchronized {
-    acquireStorageMemory(blockId, numBytes, memoryMode)
+      memoryMode: MemoryMode,
+      canEvictBlocks: Boolean): Boolean = synchronized {
+    acquireStorageMemory(blockId, numBytes, memoryMode, canEvictBlocks)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockDataManager.scala
@@ -54,7 +54,8 @@ trait BlockDataManager {
       blockId: BlockId,
       data: ManagedBuffer,
       level: StorageLevel,
-      classTag: ClassTag[_]): Boolean
+      classTag: ClassTag[_],
+      isDecommissioning: Boolean): Boolean
 
   /**
    * Put the given block that will be received as a stream.
@@ -65,7 +66,8 @@ trait BlockDataManager {
   def putBlockDataAsStream(
       blockId: BlockId,
       level: StorageLevel,
-      classTag: ClassTag[_]): StreamCallbackWithID
+      classTag: ClassTag[_],
+      isDecommissioning: Boolean): StreamCallbackWithID
 
   /**
    * Release locks acquired by [[putBlockData()]] and [[getLocalBlockData()]].

--- a/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
@@ -62,7 +62,8 @@ abstract class BlockTransferService extends BlockStoreClient {
       blockId: BlockId,
       blockData: ManagedBuffer,
       level: StorageLevel,
-      classTag: ClassTag[_]): Future[Unit]
+      classTag: ClassTag[_],
+      isDecommissioning: Boolean = false): Future[Unit]
 
   /**
    * A special case of [[fetchBlocks]], as it fetches only one block and is blocking.
@@ -117,8 +118,10 @@ abstract class BlockTransferService extends BlockStoreClient {
       blockId: BlockId,
       blockData: ManagedBuffer,
       level: StorageLevel,
-      classTag: ClassTag[_]): Unit = {
-    val future = uploadBlock(hostname, port, execId, blockId, blockData, level, classTag)
+      classTag: ClassTag[_],
+      isDecommissioning: Boolean = false): Unit = {
+    val future = uploadBlock(hostname, port, execId, blockId, blockData, level, classTag,
+      isDecommissioning)
     ThreadUtils.awaitResult(future, Duration.Inf)
   }
 }

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -160,13 +160,15 @@ private[spark] class NettyBlockTransferService(
       blockId: BlockId,
       blockData: ManagedBuffer,
       level: StorageLevel,
-      classTag: ClassTag[_]): Future[Unit] = {
+      classTag: ClassTag[_],
+      isDecommissioning: Boolean): Future[Unit] = {
     val result = Promise[Unit]()
     val client = clientFactory.createClient(hostname, port)
 
     // StorageLevel and ClassTag are serialized as bytes using our JavaSerializer.
     // Everything else is encoded using our binary protocol.
-    val metadata = JavaUtils.bufferToArray(serializer.newInstance().serialize((level, classTag)))
+    val metadata = JavaUtils.bufferToArray(serializer.newInstance().serialize((level, classTag,
+    isDecommissioning)))
 
     // We always transfer shuffle blocks as a stream for simplicity with the receiving code since
     // they are always written to disk. Otherwise we check the block size.

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -678,7 +678,7 @@ private[spark] class BlockManager(
       classTag: ClassTag[_],
       isDecommissioning: Boolean): Boolean = {
     putBytes(blockId, new ChunkedByteBuffer(data.nioByteBuffer()), level,
-      isDecommissioning)(classTag)
+      isDecommissioning = isDecommissioning)(classTag)
   }
 
   override def putBlockDataAsStream(
@@ -722,7 +722,7 @@ private[spark] class BlockManager(
         channel.close()
         val blockSize = channel.getCount
         val blockStored = TempFileBasedBlockStoreUpdater(
-          blockId, level, classTag, tmpFile, blockSize, !isDecommissioning).save()
+          blockId, level, classTag, tmpFile, blockSize, canEvictBlocks = !isDecommissioning).save()
         if (!blockStored) {
           throw new Exception(s"Failure while trying to store block $blockId on $blockManagerId.")
         }
@@ -1318,7 +1318,7 @@ private[spark] class BlockManager(
     require(bytes != null, "Bytes is null")
     val blockStoreUpdater =
       ByteBufferBlockStoreUpdater(blockId, level, implicitly[ClassTag[T]], bytes, tellMaster,
-        !isDecommissioning)
+        canEvictBlocks = !isDecommissioning)
     blockStoreUpdater.save()
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -326,7 +326,8 @@ private[storage] class BlockManagerDecommissioner(
       blockToReplicate.blockId,
       blockToReplicate.replicas.toSet,
       blockToReplicate.maxReplicas,
-      maxReplicationFailures = Some(maxReplicationFailuresForDecommission))
+      maxReplicationFailures = Some(maxReplicationFailuresForDecommission),
+      isDecommissioning = true)
     if (replicatedSuccessfully) {
       logInfo(s"Block ${blockToReplicate.blockId} offloaded successfully, Removing block now")
       bm.removeBlock(blockToReplicate.blockId)

--- a/core/src/test/scala/org/apache/spark/memory/TestMemoryManager.scala
+++ b/core/src/test/scala/org/apache/spark/memory/TestMemoryManager.scala
@@ -82,7 +82,8 @@ class TestMemoryManager(conf: SparkConf)
   override def acquireStorageMemory(
       blockId: BlockId,
       numBytes: Long,
-      memoryMode: MemoryMode): Boolean = {
+      memoryMode: MemoryMode,
+      canEvictBlocks: Boolean): Boolean = {
     require(numBytes >= 0)
     true
   }
@@ -90,7 +91,8 @@ class TestMemoryManager(conf: SparkConf)
   override def acquireUnrollMemory(
       blockId: BlockId,
       numBytes: Long,
-      memoryMode: MemoryMode): Boolean = {
+      memoryMode: MemoryMode,
+      canEvictBlocks: Boolean): Boolean = {
     require(numBytes >= 0)
     true
   }

--- a/core/src/test/scala/org/apache/spark/network/BlockTransferServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/BlockTransferServiceSuite.scala
@@ -87,7 +87,8 @@ class BlockTransferServiceSuite extends SparkFunSuite with TimeLimits {
           blockId: BlockId,
           blockData: ManagedBuffer,
           level: StorageLevel,
-          classTag: ClassTag[_]): Future[Unit] = {
+          classTag: ClassTag[_],
+          canEvictBlocks: Boolean): Future[Unit] = {
         // This method is unused in this test
         throw new UnsupportedOperationException("uploadBlock")
       }

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -1656,7 +1656,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
           blockId: BlockId,
           blockData: ManagedBuffer,
           level: StorageLevel,
-          classTag: ClassTag[_]): Future[Unit] = {
+          classTag: ClassTag[_],
+          canEvictBlocks: Boolean): Future[Unit] = {
         throw new InterruptedException("Intentional interrupt")
       }
     }
@@ -2103,7 +2104,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
         blockId: BlockId,
         blockData: ManagedBuffer,
         level: StorageLevel,
-        classTag: ClassTag[_]): Future[Unit] = {
+        classTag: ClassTag[_],
+        canEvictBlocks: Boolean): Future[Unit] = {
       import scala.concurrent.ExecutionContext.Implicits.global
       Future {}
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We are adding a check for not evicting cached blocks from memory when enough memory is not available for placing a block from a decommissioned block manager.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Blocks are migrated from a decommissioned block manager for utilizing already done computations. If we drop a cached block from memory to cache another block, we unnecessarily perform memory operations without saving any computation.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added UT