### PR TITLE
[SPARK-28098][SQL]Support read hive table while LeafDir had multi-level paths

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3210,6 +3210,13 @@ object SQLConf {
     .intConf
     .createWithDefault(0)
 
+  val READ_PARTITION_WITH_SUBDIRECTORY_ENABLED =
+    buildConf("spark.sql.sources.readPartitionWithSubdirectory.enabled")
+      .doc("When set to true, Spark SQL could read the files of " +
+        " partitioned hive table from subdirectories under root path of table")
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3907,6 +3914,9 @@ class SQLConf extends Serializable with Logging {
   def decorrelateInnerQueryEnabled: Boolean = getConf(SQLConf.DECORRELATE_INNER_QUERY_ENABLED)
 
   def maxConcurrentOutputFileWriters: Int = getConf(SQLConf.MAX_CONCURRENT_OUTPUT_FILE_WRITERS)
+
+  def readPartitionWithSubdirectoryEnabled: Boolean =
+    getConf(READ_PARTITION_WITH_SUBDIRECTORY_ENABLED)
 
   /** ********************** SQLConf functionality methods ************ */
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This support could read source files of partitioned hive table with subdirectories.

### Why are the changes needed?
 While use spark engine to read a partititioned hive table with subdirectories, The source files in subdirectories couldn't
get.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
new test
