### PR TITLE
[SPARK-35540][SQL] Make config  maxShuffledHashJoinLocalMapThreshold fallback to advisoryPartitionSizeInBytes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -606,7 +606,8 @@ object SQLConf {
         "than this config, join selection prefer to use shuffled hash join instead of " +
         s"sort merge join regardless of the value of ${PREFER_SORTMERGEJOIN.key}.")
       .version("3.2.0")
-      .fallbackConf(ADVISORY_PARTITION_SIZE_IN_BYTES)
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("64MB")
 
   val SUBEXPRESSION_ELIMINATION_ENABLED =
     buildConf("spark.sql.subexpressionElimination.enabled")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -606,8 +606,7 @@ object SQLConf {
         "than this config, join selection prefer to use shuffled hash join instead of " +
         s"sort merge join regardless of the value of ${PREFER_SORTMERGEJOIN.key}.")
       .version("3.2.0")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefault(0L)
+      .fallbackConf(ADVISORY_PARTITION_SIZE_IN_BYTES)
 
   val SUBEXPRESSION_ELIMINATION_ENABLED =
     buildConf("spark.sql.subexpressionElimination.enabled")

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-join.sql.out
@@ -3024,8 +3024,8 @@ select udf(b.unique1) from
 struct<udf(unique1):int>
 -- !query output
 NULL
-NULL
 0
+NULL
 NULL
 NULL
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -739,6 +739,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
 
   test("test SortMergeJoin (with spill)") {
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1",
+      SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "0",
       SQLConf.SORT_MERGE_JOIN_EXEC_BUFFER_IN_MEMORY_THRESHOLD.key -> "0",
       SQLConf.SORT_MERGE_JOIN_EXEC_BUFFER_SPILL_THRESHOLD.key -> "1") {
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Tune `spark.sql.adaptive.maxShuffledHashJoinLocalMapThreshold` default value.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Make config `spark.sql.adaptive.maxShuffledHashJoinLocalMapThreshold` fallback to `spark.sql.adaptive.advisoryPartitionSizeInBytes` so that we can convert SMJ to SHJ in AQE by default.

tpcds sf100 perf number(seconds) with two value of `spark.sql.adaptive.maxShuffledHashJoinLocalMapThreshold`:

query|64mb|0|diff
-|-|-|-
q2|72.224|109.094|0.337965424
q11|87.811|106.552|0.175885952
q14a|269.834|298.432|0.095827525
q14b|200.496|212.351|0.05582738
q32|24.37|27.066|0.099608365
q37|31.595|36.413|0.132315382
q57|40.86|46.324|0.117951818
q69|42.891|52.873|0.188792011
q72|124.234|98.2|/


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, default value changed.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass CI.