### PR TITLE
[SPARK-33428][SQL] Match the behavior of conv function to MySQL's

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -371,7 +371,7 @@ case class Conv(numExpr: Expression, fromBaseExpr: Expression, toBaseExpr: Expre
 
   override def nullSafeEval(num: Any, fromBase: Any, toBase: Any): Any = {
     NumberConverter.convert(
-      num.asInstanceOf[UTF8String].getBytes,
+      num.asInstanceOf[UTF8String].trim().getBytes,
       fromBase.asInstanceOf[Int],
       toBase.asInstanceOf[Int])
   }
@@ -380,7 +380,7 @@ case class Conv(numExpr: Expression, fromBaseExpr: Expression, toBaseExpr: Expre
     val numconv = NumberConverter.getClass.getName.stripSuffix("$")
     nullSafeCodeGen(ctx, ev, (num, from, to) =>
       s"""
-       ${ev.value} = $numconv.convert($num.getBytes(), $from, $to);
+       ${ev.value} = $numconv.convert($num.trim().getBytes(), $from, $to);
        if (${ev.value} == null) {
          ${ev.isNull} = true;
        }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
@@ -138,7 +138,6 @@ object NumberConverter {
     }
     decode(v, Math.abs(toBase), temp)
 
-
     // Find the first non-zero digit or the last digits if all are zero.
     val firstNonZeroPos = {
       val firstNonZero = temp.indexWhere( _ != 0)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
@@ -113,27 +113,31 @@ object NumberConverter {
 
     // Copy the digits in the right side of the array
     val temp = new Array[Byte](64)
-    var i = 1
-    while (i <= n.length - first) {
-      temp(temp.length - i) = n(n.length - i)
-      i += 1
-    }
-    char2byte(fromBase, temp.length - n.length + first, temp)
-
-    // Do the conversion by going through a 64 bit integer
-    var v = encode(fromBase, temp.length - n.length + first, temp)
-    if (negative && toBase > 0) {
-      if (v < 0) {
-        v = -1
-      } else {
-        v = -v
+    if ((n.length == 65 && negative) || n.length <= 64) {
+      var i = 1
+      while (i <= n.length - first) {
+        temp(temp.length - i) = n(n.length - i)
+        i += 1
       }
+      char2byte(fromBase, temp.length - n.length + first, temp)
+
+      // Do the conversion by going through a 64 bit integer
+      var v = encode(fromBase, temp.length - n.length + first, temp)
+      if (negative && toBase > 0) {
+        if (v < 0) {
+          v = -1
+        } else {
+          v = -v
+        }
+      }
+      if (toBase < 0 && v < 0) {
+        v = -v
+        negative = true
+      }
+      decode(v, Math.abs(toBase), temp)
+    } else {
+      decode(-1, Math.abs(toBase), temp)
     }
-    if (toBase < 0 && v < 0) {
-      v = -v
-      negative = true
-    }
-    decode(v, Math.abs(toBase), temp)
 
     // Find the first non-zero digit or the last digits if all are zero.
     val firstNonZeroPos = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
@@ -113,6 +113,7 @@ object NumberConverter {
 
     // Copy the digits in the right side of the array
     val temp = new Array[Byte](64)
+    var v: Long = -1
     if ((n.length == 65 && negative) || n.length <= 64) {
       var i = 1
       while (i <= n.length - first) {
@@ -122,22 +123,21 @@ object NumberConverter {
       char2byte(fromBase, temp.length - n.length + first, temp)
 
       // Do the conversion by going through a 64 bit integer
-      var v = encode(fromBase, temp.length - n.length + first, temp)
-      if (negative && toBase > 0) {
-        if (v < 0) {
-          v = -1
-        } else {
-          v = -v
-        }
-      }
-      if (toBase < 0 && v < 0) {
-        v = -v
-        negative = true
-      }
-      decode(v, Math.abs(toBase), temp)
-    } else {
-      decode(-1, Math.abs(toBase), temp)
+      v = encode(fromBase, temp.length - n.length + first, temp)
     }
+    if (negative && toBase > 0) {
+      if (v < 0) {
+        v = -1
+      } else {
+        v = -v
+      }
+    }
+    if (toBase < 0 && v < 0) {
+      v = -v
+      negative = true
+    }
+    decode(v, Math.abs(toBase), temp)
+
 
     // Find the first non-zero digit or the last digits if all are zero.
     val firstNonZeroPos = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -203,15 +203,19 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
       df.selectExpr("""conv("9223372036854775807", 36, -16)"""), Row("-1")) // for overflow
   }
 
-  test("SPARK-33428 conv function has different behavior with mySQL's conv function") {
-    val df = Seq(("abc"), ("  abc"), ("abc  "), ("  abc  "),
-      ("aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0")).toDF("num")
+  test("SPARK-33428 conv function should trim input string") {
+    val df = Seq(("abc"), ("  abc"), ("abc  "), ("  abc  ")).toDF("num")
     checkAnswer(df.select(conv('num, 16, 10)),
-      Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748"), Row("18446744073709551615")))
-
+      Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748")))
     checkAnswer(df.select(conv('num, 16, -10)),
-      Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748"), Row("-1")))
+      Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748")))
+  }
 
+  test("SPARK-33428 conv function shouldn't raise error  input string is too big") {
+    val df = Seq((
+      "aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0")).toDF("num")
+    checkAnswer(df.select(conv('num, 16, 10)), Row("18446744073709551615"))
+    checkAnswer(df.select(conv('num, 16, -10)), Row("-1"))
   }
 
   test("floor") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -208,6 +208,10 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
       ("aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0")).toDF("num")
     checkAnswer(df.select(conv('num, 16, 10)),
       Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748"), Row("18446744073709551615")))
+
+    checkAnswer(df.select(conv('num, 16, -10)),
+      Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748"), Row("-1")))
+
   }
 
   test("floor") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -203,6 +203,13 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
       df.selectExpr("""conv("9223372036854775807", 36, -16)"""), Row("-1")) // for overflow
   }
 
+  test("SPARK-33428 conv function has different behavior with mySQL's conv function") {
+    val df = Seq(("abc"), ("  abc"), ("abc  "), ("  abc  "),
+      ("aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0")).toDF("num")
+    checkAnswer(df.select(conv('num, 16, 10)),
+      Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748"), Row("18446744073709551615")))
+  }
+
   test("floor") {
     testOneToOneMathFunction(floor, (d: Double) => math.floor(d).toLong)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -211,7 +211,7 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
       Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748")))
   }
 
-  test("SPARK-33428 conv function shouldn't raise error  input string is too big") {
+  test("SPARK-33428 conv function shouldn't raise error if input string is too big") {
     val df = Seq((
       "aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0")).toDF("num")
     checkAnswer(df.select(conv('num, 16, 10)), Row("18446744073709551615"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark conv function is from MySQL and it's better to follow the MySQL behavior. MySQL returns the max unsigned long if the input string is too big, and Spark should follow it.

However, seems Spark has different behavior in two cases:

MySQL allows leading spaces but Spark does not.
If the input string is way too long, Spark fails with ArrayIndexOutOfBoundException

This patch now help conv follow behavior in those two cases
conv allows leading spaces
conv will return the max unsigned long when the input string is way too long 

### Why are the changes needed?
fixing it to match the behavior of conv function to the (almost) only one reference of another DBMS, MySQL

### Does this PR introduce _any_ user-facing change?
Yes, as pointed out above

### How was this patch tested?
Add test