### PR TITLE
[SPARK-35059][SQL] Group exception messages in hive/execution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1596,4 +1596,13 @@ private[spark] object QueryCompilationErrors {
     new AnalysisException(
       s"the pattern '$pattern' is invalid, $message")
   }
+
+  def tableIdentifierExistsError(tableIdentifier: TableIdentifier): Throwable = {
+    new AnalysisException(s"$tableIdentifier already exists.")
+  }
+
+  def tableIdentifierNotConvertedToHadoopFsRelationError(
+      tableIdentifier: TableIdentifier): Throwable = {
+    new AnalysisException(s"$tableIdentifier should be converted to HadoopFsRelation.")
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -34,7 +34,7 @@ import org.apache.spark.memory.SparkOutOfMemoryError
 import org.apache.spark.sql.catalyst.ScalaReflection.Schema
 import org.apache.spark.sql.catalyst.WalkedTypePath
 import org.apache.spark.sql.catalyst.analysis.UnresolvedGenerator
-import org.apache.spark.sql.catalyst.catalog.CatalogDatabase
+import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogTable}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, UnevaluableAggregate}
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.{DomainJoin, LogicalPlan}
@@ -1229,5 +1229,31 @@ object QueryExecutionErrors {
 
   def parentSparkUIToAttachTabNotFoundError(): Throwable = {
     new SparkException("Parent SparkUI to attach this tab to not found!")
+  }
+
+  def inferSchemaUnsupportedForHiveError(): Throwable = {
+    new UnsupportedOperationException("inferSchema is not supported for hive data source.")
+  }
+
+  def requestedPartitionsMisMatchTableError(
+      table: CatalogTable, partition: Map[String, Option[String]]): Throwable = {
+    new SparkException(
+      s"""
+         |Requested partitioning does not match the ${table.identifier.table} table:
+         |Requested partitions: ${partition.keys.mkString(",")}
+         |Table partitions: ${table.partitionColumnNames.mkString(",")}
+       """.stripMargin)
+  }
+
+  def dynamicPartitionKeyNotAmongWrittenPartitionPathsError(key: String): Throwable = {
+    new SparkException(s"Dynamic partition key $key is not among written partition paths.")
+  }
+
+  def cannotRemovePartitionDirError(partitionPath: Path): Throwable = {
+    new RuntimeException(s"Cannot remove partition directory '$partitionPath'")
+  }
+
+  def cannotCreateStagingDirError(message: String, e: IOException): Throwable = {
+    new RuntimeException(s"Cannot create staging directory: $message", e)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1235,7 +1235,7 @@ object QueryExecutionErrors {
     new UnsupportedOperationException("inferSchema is not supported for hive data source.")
   }
 
-  def requestedPartitionsMisMatchTableError(
+  def requestedPartitionsMismatchTablePartitionsError(
       table: CatalogTable, partition: Map[String, Option[String]]): Throwable = {
     new SparkException(
       s"""

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -19,10 +19,11 @@ package org.apache.spark.sql.hive.execution
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.{AnalysisException, Row, SaveMode, SparkSession}
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.{DataWritingCommand, DDLUtils}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, InsertIntoHadoopFsRelationCommand, LogicalRelation}
@@ -46,7 +47,7 @@ trait CreateHiveTableAsSelectBase extends DataWritingCommand {
         s"Expect the table $tableIdentifier has been dropped when the save mode is Overwrite")
 
       if (mode == SaveMode.ErrorIfExists) {
-        throw new AnalysisException(s"$tableIdentifier already exists.")
+        throw QueryCompilationErrors.tableIdentifierExistsError(tableIdentifier)
       }
       if (mode == SaveMode.Ignore) {
         // Since the table already exists and the save mode is Ignore, we will just return.
@@ -162,8 +163,8 @@ case class OptimizedCreateHiveTableAsSelectCommand(
 
     val hadoopRelation = metastoreCatalog.convert(hiveTable) match {
       case LogicalRelation(t: HadoopFsRelation, _, _, _) => t
-      case _ => throw new AnalysisException(s"$tableIdentifier should be converted to " +
-        "HadoopFsRelation.")
+      case _ => throw QueryCompilationErrors.tableIdentifierNotConvertedToHadoopFsRelationError(
+        tableIdentifier)
     }
 
     InsertIntoHadoopFsRelationCommand(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveFileFormat.scala
@@ -33,6 +33,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.SPECULATION_ENABLED
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources.{FileFormat, OutputWriter, OutputWriterFactory}
 import org.apache.spark.sql.hive.{HiveInspectors, HiveTableUtil}
 import org.apache.spark.sql.hive.HiveShim.{ShimFileSinkDesc => FileSinkDesc}
@@ -56,7 +57,7 @@ class HiveFileFormat(fileSinkConf: FileSinkDesc)
       sparkSession: SparkSession,
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    throw new UnsupportedOperationException(s"inferSchema is not supported for hive data source.")
+    throw QueryExecutionErrors.inferSchemaUnsupportedForHiveError()
   }
 
   override def prepareWrite(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.CommandUtils
 import org.apache.spark.sql.hive.HiveExternalCatalog
@@ -144,10 +145,7 @@ case class InsertIntoHiveTable(
 
     // By this time, the partition map must match the table's partition columns
     if (partitionColumnNames.toSet != partition.keySet) {
-      throw new SparkException(
-        s"""Requested partitioning does not match the ${table.identifier.table} table:
-           |Requested partitions: ${partition.keys.mkString(",")}
-           |Table partitions: ${table.partitionColumnNames.mkString(",")}""".stripMargin)
+      throw QueryExecutionErrors.requestedPartitionsMisMatchTableError(table, partition)
     }
 
     // Validate partition spec if there exist any dynamic partitions
@@ -193,8 +191,8 @@ case class InsertIntoHiveTable(
 
     val partitionAttributes = partitionColumnNames.takeRight(numDynamicPartitions).map { name =>
       val attr = query.resolve(name :: Nil, sparkSession.sessionState.analyzer.resolver).getOrElse {
-        throw new AnalysisException(
-          s"Unable to resolve $name given [${query.output.map(_.name).mkString(", ")}]")
+        throw QueryCompilationErrors.cannotResolveAttributeError(
+          name, query.output.map(_.name).mkString(", "))
       }.asInstanceOf[Attribute]
       // SPARK-28054: Hive metastore is not case preserving and keeps partition columns
       // with lower cased names. Hive will validate the column names in the partition directories
@@ -235,8 +233,8 @@ case class InsertIntoHiveTable(
               case (key, None) if caseInsensitiveDpMap.contains(key) =>
                 key -> caseInsensitiveDpMap(key)
               case (key, _) =>
-                throw new SparkException(s"Dynamic partition key $key is not among " +
-                  "written partition paths.")
+                throw QueryExecutionErrors.dynamicPartitionKeyNotAmongWrittenPartitionPathsError(
+                  key)
             }
             val partitionColumnNames = table.partitionColumnNames
             val tablePath = new Path(table.location)
@@ -246,8 +244,7 @@ case class InsertIntoHiveTable(
             val fs = partitionPath.getFileSystem(hadoopConf)
             if (fs.exists(partitionPath)) {
               if (!fs.delete(partitionPath, true)) {
-                throw new RuntimeException(
-                  s"Cannot remove partition directory '$partitionPath'")
+                throw QueryExecutionErrors.cannotRemovePartitionDirError(partitionPath)
               }
             }
           }
@@ -312,8 +309,7 @@ case class InsertIntoHiveTable(
               val fs = path.getFileSystem(hadoopConf)
               if (fs.exists(path)) {
                 if (!fs.delete(path, true)) {
-                  throw new RuntimeException(
-                    s"Cannot remove partition directory '$path'")
+                  throw QueryExecutionErrors.cannotRemovePartitionDirError(path)
                 }
                 // Don't let Hive do overwrite operation since it is slower.
                 doHiveOverwrite = false

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -145,7 +145,7 @@ case class InsertIntoHiveTable(
 
     // By this time, the partition map must match the table's partition columns
     if (partitionColumnNames.toSet != partition.keySet) {
-      throw QueryExecutionErrors.requestedPartitionsMisMatchTableError(table, partition)
+      throw QueryExecutionErrors.requestedPartitionsMismatchTablePartitionsError(table, partition)
     }
 
     // Validate partition spec if there exist any dynamic partitions

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -33,6 +33,7 @@ import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.DataWritingCommand
 import org.apache.spark.sql.execution.datasources.FileFormatWriter
@@ -175,7 +176,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
       fs.deleteOnExit(dirPath)
     } catch {
       case e: IOException =>
-        throw new RuntimeException("Cannot create staging directory: " + dirPath.toString, e)
+        throw QueryExecutionErrors.cannotCreateStagingDirError(dirPath.toString, e)
     }
     dirPath
   }
@@ -246,8 +247,8 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
       fs.deleteOnExit(dir)
     } catch {
       case e: IOException =>
-        throw new RuntimeException(
-          "Cannot create staging directory '" + dir.toString + "': " + e.getMessage, e)
+        throw QueryExecutionErrors.cannotCreateStagingDirError(
+          s"'${dir.toString}': ${e.getMessage}", e)
     }
     dir
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR group exception messages in `sql/hive/src/main/scala/org/apache/spark/sql/hive/execution`.


### Why are the changes needed?
It will largely help with standardization of error messages and its maintenance.


### Does this PR introduce _any_ user-facing change?
No. Error messages remain unchanged.


### How was this patch tested?
No new tests - pass all original tests to make sure it doesn't break any existing behavior.
