### PR TITLE
[SPARK-35341][PYTHON] Introduce BooleanExtensionOps

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -399,65 +399,21 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
     __ge__ = column_op(Column.__ge__)
     __gt__ = column_op(Column.__gt__)
 
+    __invert__ = column_op(Column.__invert__)
+
     # `and`, `or`, `not` cannot be overloaded in Python,
     # so use bitwise operators as boolean operators
     def __and__(self, other) -> Union["Series", "Index"]:
-        if isinstance(self.dtype, extension_dtypes) or (
-            isinstance(other, IndexOpsMixin) and isinstance(other.dtype, extension_dtypes)
-        ):
-
-            def and_func(left, right):
-                if not isinstance(right, spark.Column):
-                    if pd.isna(right):
-                        right = F.lit(None)
-                    else:
-                        right = F.lit(right)
-                return left & right
-
-        else:
-
-            def and_func(left, right):
-                if not isinstance(right, spark.Column):
-                    if pd.isna(right):
-                        right = F.lit(None)
-                    else:
-                        right = F.lit(right)
-                scol = left & right
-                return F.when(scol.isNull(), False).otherwise(scol)
-
-        return column_op(and_func)(self, other)
+        return self._dtype_op.__and__(self, other)
 
     def __or__(self, other) -> Union["Series", "Index"]:
-        if isinstance(self.dtype, extension_dtypes) or (
-            isinstance(other, IndexOpsMixin) and isinstance(other.dtype, extension_dtypes)
-        ):
-
-            def or_func(left, right):
-                if not isinstance(right, spark.Column):
-                    if pd.isna(right):
-                        right = F.lit(None)
-                    else:
-                        right = F.lit(right)
-                return left | right
-
-        else:
-
-            def or_func(left, right):
-                if not isinstance(right, spark.Column) and pd.isna(right):
-                    return F.lit(False)
-                else:
-                    scol = left | F.lit(right)
-                    return F.when(left.isNull() | scol.isNull(), False).otherwise(scol)
-
-        return column_op(or_func)(self, other)
-
-    __invert__ = column_op(Column.__invert__)
+        return self._dtype_op.__or__(self, other)
 
     def __rand__(self, other) -> Union["Series", "Index"]:
-        return self.__and__(other)
+        return self._dtype_op.rand(self, other)
 
     def __ror__(self, other) -> Union["Series", "Index"]:
-        return self.__or__(other)
+        return self._dtype_op.ror(self, other)
 
     def __len__(self):
         return len(self._psdf)

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -88,8 +88,7 @@ class DataTypeOps(object, metaclass=ABCMeta):
 
     def __new__(cls, dtype: Dtype, spark_type: DataType):
         from pyspark.pandas.data_type_ops.binary_ops import BinaryOps
-        from pyspark.pandas.data_type_ops.boolean_ops import BooleanOps
-        from pyspark.pandas.data_type_ops.boolean_ops import BooleanExtensionOps
+        from pyspark.pandas.data_type_ops.boolean_ops import BooleanOps, BooleanExtensionOps
         from pyspark.pandas.data_type_ops.categorical_ops import CategoricalOps
         from pyspark.pandas.data_type_ops.complex_ops import ArrayOps, MapOps, StructOps
         from pyspark.pandas.data_type_ops.date_ops import DateOps

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -94,10 +94,7 @@ class DataTypeOps(object, metaclass=ABCMeta):
         from pyspark.pandas.data_type_ops.date_ops import DateOps
         from pyspark.pandas.data_type_ops.datetime_ops import DatetimeOps
         from pyspark.pandas.data_type_ops.null_ops import NullOps
-        from pyspark.pandas.data_type_ops.num_ops import (
-            IntegralOps,
-            FractionalOps,
-        )
+        from pyspark.pandas.data_type_ops.num_ops import IntegralOps, FractionalOps
         from pyspark.pandas.data_type_ops.string_ops import StringOps
         from pyspark.pandas.data_type_ops.udt_ops import UDTOps
 

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -18,13 +18,18 @@
 import numbers
 from typing import TYPE_CHECKING, Union
 
-from pyspark.pandas.base import IndexOpsMixin
+import pandas as pd
+
+from pyspark import sql as spark
+from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     is_valid_operand_for_numeric_arithmetic,
     DataTypeOps,
     transform_boolean_operand_to_numeric,
 )
+from pyspark.pandas.typedef import extension_dtypes
 from pyspark.pandas.typedef.typehints import as_spark_type
+from pyspark.sql import functions as F
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -194,3 +199,60 @@ class BooleanOps(DataTypeOps):
             raise TypeError(
                 "Modulo can not be applied to %s and the given type." % self.pretty_name
             )
+
+    def __and__(self, left, right) -> Union["Series", "Index"]:
+        if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
+            return right.__and__(left)
+        else:
+            def and_func(left, right):
+                if not isinstance(right, spark.Column):
+                    if pd.isna(right):
+                        right = F.lit(None)
+                    else:
+                        right = F.lit(right)
+                scol = left & right
+                return F.when(scol.isNull(), False).otherwise(scol)
+
+            return column_op(and_func)(left, right)
+
+    def __or__(self, left, right) -> Union["Series", "Index"]:
+        if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
+            return right.__or__(left)
+        else:
+            def or_func(left, right):
+                if not isinstance(right, spark.Column) and pd.isna(right):
+                    return F.lit(False)
+                else:
+                    scol = left | F.lit(right)
+                    return F.when(left.isNull() | scol.isNull(), False).otherwise(scol)
+
+            return column_op(or_func)(left, right)
+
+
+class BooleanExtensionOps(BooleanOps):
+    """
+    The class for binary operations of pandas-on-Spark objects with spark type BooleanType,
+    and dtype BooleanDtype.
+    """
+
+    def __and__(self, left, right) -> Union["Series", "Index"]:
+        def and_func(left, right):
+            if not isinstance(right, spark.Column):
+                if pd.isna(right):
+                    right = F.lit(None)
+                else:
+                    right = F.lit(right)
+            return left & right
+
+        return column_op(and_func)(left, right)
+
+    def __or__(self, left, right) -> Union["Series", "Index"]:
+        def or_func(left, right):
+            if not isinstance(right, spark.Column):
+                if pd.isna(right):
+                    right = F.lit(None)
+                else:
+                    right = F.lit(right)
+            return left | right
+
+        return column_op(or_func)(left, right)

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -204,6 +204,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__and__(left)
         else:
+
             def and_func(left, right):
                 if not isinstance(right, spark.Column):
                     if pd.isna(right):
@@ -219,6 +220,7 @@ class BooleanOps(DataTypeOps):
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__or__(left)
         else:
+
             def or_func(left, right):
                 if not isinstance(right, spark.Column) and pd.isna(right):
                     return F.lit(False)

--- a/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
@@ -122,6 +122,24 @@ class BinaryOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: "x" ** self.psser)
         self.assertRaises(TypeError, lambda: 1 ** self.psser)
 
+    def test_and(self):
+        self.assertRaises(TypeError, lambda: self.psser & True)
+        self.assertRaises(TypeError, lambda: self.psser & False)
+        self.assertRaises(TypeError, lambda: self.psser & self.psser)
+
+    def test_rand(self):
+        self.assertRaises(TypeError, lambda: True & self.psser)
+        self.assertRaises(TypeError, lambda: False & self.psser)
+
+    def test_or(self):
+        self.assertRaises(TypeError, lambda: self.psser | True)
+        self.assertRaises(TypeError, lambda: self.psser | False)
+        self.assertRaises(TypeError, lambda: self.psser | self.psser)
+
+    def test_ror(self):
+        self.assertRaises(TypeError, lambda: True | self.psser)
+        self.assertRaises(TypeError, lambda: False | self.psser)
+
     def test_from_to_pandas(self):
         data = [b"1", b"2", b"3"]
         pser = pd.Series(data)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -16,6 +16,7 @@
 #
 
 import datetime
+import unittest
 from distutils.version import LooseVersion
 
 import pandas as pd
@@ -24,6 +25,7 @@ import numpy as np
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
+from pyspark.pandas.typedef.typehints import extension_dtypes_available
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
 
@@ -274,6 +276,9 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(False | pser, False | psser)
 
 
+@unittest.skipIf(
+    not extension_dtypes_available, "pandas extension dtypes are not available"
+)
 class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUtils):
     @property
     def pser(self):
@@ -517,7 +522,6 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.data_type_ops.test_boolean_ops import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -300,17 +300,13 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
         pser = self.pser
         psser = self.psser
         self.assert_eq((pser + 1).astype(float), psser + 1)
-        self.assert_eq(pser + 0.1, psser + 0.1)
+        self.assert_eq((pser + 0.1).astype(float), psser + 0.1)
         self.assertRaises(TypeError, lambda: psser + psser)
         self.assertRaises(TypeError, lambda: psser + True)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
-                if pser.dtype in (np.int32, np.int64):
-                    self.assert_eq(
-                        (self.pser + pser).astype(float), (self.psser + psser).sort_index())
-                else:
-                    self.assert_eq(self.pser + pser, (self.psser + psser).sort_index())
+                self.assert_eq(self.pser + pser, (self.psser + psser).sort_index(), almost=True)
             for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser + psser)
 
@@ -318,19 +314,13 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
         pser = self.pser
         psser = self.psser
         self.assert_eq((pser - 1).astype(float), psser - 1)
-        self.assert_eq(pser - 0.1, psser - 0.1)
+        self.assert_eq((pser - 0.1).astype(float), psser - 0.1)
         self.assertRaises(TypeError, lambda: psser - psser)
         self.assertRaises(TypeError, lambda: psser - True)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
-                for pser, psser in self.numeric_pser_psser_pairs:
-                    if pser.dtype in (np.int32, np.int64):
-                        self.assert_eq(
-                            (self.pser - pser).astype(float), (self.psser - psser).sort_index())
-                    else:
-                        self.assert_eq(self.pser - pser, (self.psser - psser).sort_index())
-
+                self.assert_eq(self.pser - pser, (self.psser - psser).sort_index(), almost=True)
             for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser - psser)
 
@@ -338,33 +328,29 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
         pser = self.pser
         psser = self.psser
         self.assert_eq((pser * 1).astype(float), psser * 1)
-        self.assert_eq(pser * 0.1, psser * 0.1)
+        self.assert_eq((pser * 0.1).astype(float), psser * 0.1)
         self.assertRaises(TypeError, lambda: psser * psser)
         self.assertRaises(TypeError, lambda: psser * True)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
-                if pser.dtype in (np.int32, np.int64):
-                    self.assert_eq(
-                        (self.pser * pser).astype(float), (self.psser * psser).sort_index())
-                else:
-                    self.assert_eq(self.pser * pser, (self.psser * psser).sort_index())
-
+                self.assert_eq(self.pser * pser, (self.psser * psser).sort_index(), almost=True)
             for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser * psser)
 
     def test_truediv(self):
         pser = self.pser
         psser = self.psser
-        self.assert_eq(pser / 1, psser / 1)
-        self.assert_eq(pser / 0.1, psser / 0.1)
+        self.assert_eq((pser / 1).astype(float), psser / 1)
+        self.assert_eq((pser / 0.1).astype(float), psser / 0.1)
         self.assertRaises(TypeError, lambda: psser / psser)
         self.assertRaises(TypeError, lambda: psser / True)
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
-                self.pser / self.float_pser, (self.psser / self.float_psser).sort_index())
-
+                self.pser / self.float_pser, (self.psser / self.float_psser).sort_index(),
+                almost=True
+            )
             for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser / psser)
 
@@ -383,9 +369,9 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
-                self.pser // self.float_pser, (self.psser // self.float_psser).sort_index()
+                self.pser // self.float_pser, (self.psser // self.float_psser).sort_index(),
+                almost=True
             )
-
             for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser // psser)
 
@@ -393,18 +379,13 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
         pser = self.pser
         psser = self.psser
         self.assert_eq((pser % 1).astype(float), psser % 1)
-        self.assert_eq(pser % 0.1, psser % 0.1)
+        self.assert_eq((pser % 0.1).astype(float), psser % 0.1)
         self.assertRaises(TypeError, lambda: psser % psser)
         self.assertRaises(TypeError, lambda: psser % True)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
-                if pser.dtype in (np.int32, np.int64):
-                    self.assert_eq(
-                        (self.pser % pser).astype(float), (self.psser % psser).sort_index())
-                else:
-                    self.assert_eq(self.pser % pser, (self.psser % psser).sort_index())
-
+                self.assert_eq(self.pser % pser, (self.psser % psser).sort_index(), almost=True)
             for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser % psser)
 
@@ -413,14 +394,15 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
         psser = self.psser
         # float is always returned in pandas-on-Spark
         self.assert_eq((pser ** 1).astype("float"), psser ** 1)
-        self.assert_eq(pser ** 0.1, self.psser ** 0.1)
-        self.assert_eq(pser ** pser.astype(float), psser ** psser.astype(float))
+        self.assert_eq((pser ** 0.1).astype("float"), self.psser ** 0.1)
+        self.assert_eq((pser ** pser.astype(float)).astype("float"), psser ** psser.astype(float))
         self.assertRaises(TypeError, lambda: psser ** psser)
         self.assertRaises(TypeError, lambda: psser ** True)
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
-                self.pser ** self.float_pser, (self.psser ** self.float_psser).sort_index()
+                self.pser ** self.float_pser, (self.psser ** self.float_psser).sort_index(),
+                almost=True
             )
 
             for psser in self.non_numeric_pssers.values():
@@ -428,7 +410,7 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
 
     def test_radd(self):
         self.assert_eq((1 + self.pser).astype(float), 1 + self.psser)
-        self.assert_eq(0.1 + self.pser, 0.1 + self.psser)
+        self.assert_eq((0.1 + self.pser).astype(float), 0.1 + self.psser)
         self.assertRaises(TypeError, lambda: "x" + self.psser)
         self.assertRaises(TypeError, lambda: True + self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) + self.psser)
@@ -436,7 +418,7 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
 
     def test_rsub(self):
         self.assert_eq((1 - self.pser).astype(float), 1 - self.psser)
-        self.assert_eq(0.1 - self.pser, 0.1 - self.psser)
+        self.assert_eq((0.1 - self.pser).astype(float), 0.1 - self.psser)
         self.assertRaises(TypeError, lambda: "x" - self.psser)
         self.assertRaises(TypeError, lambda: True - self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) - self.psser)
@@ -444,23 +426,23 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
 
     def test_rmul(self):
         self.assert_eq((1 * self.pser).astype(float), 1 * self.psser)
-        self.assert_eq(0.1 * self.pser, 0.1 * self.psser)
+        self.assert_eq((0.1 * self.pser).astype(float), 0.1 * self.psser)
         self.assertRaises(TypeError, lambda: "x" * self.psser)
         self.assertRaises(TypeError, lambda: True * self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) * self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) * self.psser)
 
     def test_rtruediv(self):
-        self.assert_eq(1 / self.pser, 1 / self.psser)
-        self.assert_eq(0.1 / self.pser, 0.1 / self.psser)
+        self.assert_eq((1 / self.pser).astype(float), 1 / self.psser)
+        self.assert_eq((0.1 / self.pser).astype(float), 0.1 / self.psser)
         self.assertRaises(TypeError, lambda: "x" / self.psser)
         self.assertRaises(TypeError, lambda: True / self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) / self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) / self.psser)
 
     def test_rfloordiv(self):
-        self.assert_eq(1 // self.psser, ps.Series([1.0, np.inf, np.nan]))
-        self.assert_eq(0.1 // self.psser, ps.Series([0.0, np.inf, np.nan]))
+        self.assert_eq((1 // self.psser).astype(float), ps.Series([1.0, np.inf, np.nan]))
+        self.assert_eq((0.1 // self.psser).astype(float), ps.Series([0.0, np.inf, np.nan]))
         self.assertRaises(TypeError, lambda: "x" + self.psser)
         self.assertRaises(TypeError, lambda: True + self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) // self.psser)
@@ -468,7 +450,7 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
 
     def test_rpow(self):
         self.assert_eq(1 ** self.psser, ps.Series([1, 1, 1], dtype=float))
-        self.assert_eq(0.1 ** self.pser, 0.1 ** self.psser)
+        self.assert_eq((0.1 ** self.pser).astype(float), 0.1 ** self.psser)
         self.assertRaises(TypeError, lambda: "x" ** self.psser)
         self.assertRaises(TypeError, lambda: True ** self.psser)
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) ** self.psser)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -291,6 +291,193 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
     def other_psser(self):
         return ps.from_pandas(self.other_pser)
 
+    def test_add(self):
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq((pser + 1).astype(float), psser + 1)
+        self.assert_eq(pser + 0.1, psser + 0.1)
+        self.assertRaises(TypeError, lambda: psser + psser)
+        self.assertRaises(TypeError, lambda: psser + True)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.numeric_pser_psser_pairs:
+                if pser.dtype in (np.int32, np.int64):
+                    self.assert_eq(
+                        (self.pser + pser).astype(float), (self.psser + psser).sort_index())
+                else:
+                    self.assert_eq(self.pser + pser, (self.psser + psser).sort_index())
+            for psser in self.non_numeric_pssers.values():
+                self.assertRaises(TypeError, lambda: self.psser + psser)
+
+    def test_sub(self):
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq((pser - 1).astype(float), psser - 1)
+        self.assert_eq(pser - 0.1, psser - 0.1)
+        self.assertRaises(TypeError, lambda: psser - psser)
+        self.assertRaises(TypeError, lambda: psser - True)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.numeric_pser_psser_pairs:
+                for pser, psser in self.numeric_pser_psser_pairs:
+                    if pser.dtype in (np.int32, np.int64):
+                        self.assert_eq(
+                            (self.pser - pser).astype(float), (self.psser - psser).sort_index())
+                    else:
+                        self.assert_eq(self.pser - pser, (self.psser - psser).sort_index())
+
+            for psser in self.non_numeric_pssers.values():
+                self.assertRaises(TypeError, lambda: self.psser - psser)
+
+    def test_mul(self):
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq((pser * 1).astype(float), psser * 1)
+        self.assert_eq(pser * 0.1, psser * 0.1)
+        self.assertRaises(TypeError, lambda: psser * psser)
+        self.assertRaises(TypeError, lambda: psser * True)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.numeric_pser_psser_pairs:
+                if pser.dtype in (np.int32, np.int64):
+                    self.assert_eq(
+                        (self.pser * pser).astype(float), (self.psser * psser).sort_index())
+                else:
+                    self.assert_eq(self.pser * pser, (self.psser * psser).sort_index())
+
+            for psser in self.non_numeric_pssers.values():
+                self.assertRaises(TypeError, lambda: self.psser * psser)
+
+    def test_truediv(self):
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pser / 1, psser / 1)
+        self.assert_eq(pser / 0.1, psser / 0.1)
+        self.assertRaises(TypeError, lambda: psser / psser)
+        self.assertRaises(TypeError, lambda: psser / True)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.pser / self.float_pser, (self.psser / self.float_psser).sort_index())
+
+            for psser in self.non_numeric_pssers.values():
+                self.assertRaises(TypeError, lambda: self.psser / psser)
+
+    def test_floordiv(self):
+        pser = self.pser
+        psser = self.psser
+
+        # float is always returned in pandas-on-Spark
+        self.assert_eq((pser // 1).astype("float"), psser // 1)
+
+        # in pandas, 1 // 0.1 = 9.0; in pandas-on-Spark, 1 // 0.1 = 10.0
+        # self.assert_eq(pser // 0.1, psser // 0.1)
+
+        self.assertRaises(TypeError, lambda: psser // psser)
+        self.assertRaises(TypeError, lambda: psser // True)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.pser // self.float_pser, (self.psser // self.float_psser).sort_index()
+            )
+
+            for psser in self.non_numeric_pssers.values():
+                self.assertRaises(TypeError, lambda: self.psser // psser)
+
+    def test_mod(self):
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq((pser % 1).astype(float), psser % 1)
+        self.assert_eq(pser % 0.1, psser % 0.1)
+        self.assertRaises(TypeError, lambda: psser % psser)
+        self.assertRaises(TypeError, lambda: psser % True)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.numeric_pser_psser_pairs:
+                if pser.dtype in (np.int32, np.int64):
+                    self.assert_eq(
+                        (self.pser % pser).astype(float), (self.psser % psser).sort_index())
+                else:
+                    self.assert_eq(self.pser % pser, (self.psser % psser).sort_index())
+
+            for psser in self.non_numeric_pssers.values():
+                self.assertRaises(TypeError, lambda: self.psser % psser)
+
+    def test_pow(self):
+        pser = self.pser
+        psser = self.psser
+        # float is always returned in pandas-on-Spark
+        self.assert_eq((pser ** 1).astype("float"), psser ** 1)
+        self.assert_eq(pser ** 0.1, self.psser ** 0.1)
+        self.assert_eq(pser ** pser.astype(float), psser ** psser.astype(float))
+        self.assertRaises(TypeError, lambda: psser ** psser)
+        self.assertRaises(TypeError, lambda: psser ** True)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.pser ** self.float_pser, (self.psser ** self.float_psser).sort_index()
+            )
+
+            for psser in self.non_numeric_pssers.values():
+                self.assertRaises(TypeError, lambda: self.psser ** psser)
+
+    def test_radd(self):
+        self.assert_eq((1 + self.pser).astype(float), 1 + self.psser)
+        self.assert_eq(0.1 + self.pser, 0.1 + self.psser)
+        self.assertRaises(TypeError, lambda: "x" + self.psser)
+        self.assertRaises(TypeError, lambda: True + self.psser)
+        self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) + self.psser)
+        self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) + self.psser)
+
+    def test_rsub(self):
+        self.assert_eq((1 - self.pser).astype(float), 1 - self.psser)
+        self.assert_eq(0.1 - self.pser, 0.1 - self.psser)
+        self.assertRaises(TypeError, lambda: "x" - self.psser)
+        self.assertRaises(TypeError, lambda: True - self.psser)
+        self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) - self.psser)
+        self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) - self.psser)
+
+    def test_rmul(self):
+        self.assert_eq((1 * self.pser).astype(float), 1 * self.psser)
+        self.assert_eq(0.1 * self.pser, 0.1 * self.psser)
+        self.assertRaises(TypeError, lambda: "x" * self.psser)
+        self.assertRaises(TypeError, lambda: True * self.psser)
+        self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) * self.psser)
+        self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) * self.psser)
+
+    def test_rtruediv(self):
+        self.assert_eq(1 / self.pser, 1 / self.psser)
+        self.assert_eq(0.1 / self.pser, 0.1 / self.psser)
+        self.assertRaises(TypeError, lambda: "x" / self.psser)
+        self.assertRaises(TypeError, lambda: True / self.psser)
+        self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) / self.psser)
+        self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) / self.psser)
+
+    def test_rfloordiv(self):
+        self.assert_eq(1 // self.psser, ps.Series([1.0, np.inf, np.nan]))
+        self.assert_eq(0.1 // self.psser, ps.Series([0.0, np.inf, np.nan]))
+        self.assertRaises(TypeError, lambda: "x" + self.psser)
+        self.assertRaises(TypeError, lambda: True + self.psser)
+        self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) // self.psser)
+        self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) // self.psser)
+
+    def test_rpow(self):
+        self.assert_eq(1 ** self.psser, ps.Series([1, 1, 1], dtype=float))
+        self.assert_eq(0.1 ** self.pser, 0.1 ** self.psser)
+        self.assertRaises(TypeError, lambda: "x" ** self.psser)
+        self.assertRaises(TypeError, lambda: True ** self.psser)
+        self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) ** self.psser)
+        self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) ** self.psser)
+
+    def test_rmod(self):
+        self.assert_eq(ps.Series([0, np.nan, np.nan], dtype=float), 1 % self.psser)
+        self.assert_eq(
+            ps.Series([0.10000000000000009, np.nan, np.nan], dtype=float),
+            0.1 % self.psser,
+        )
+        self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % self.psser)
+        self.assertRaises(TypeError, lambda: True % self.psser)
+
     def test_and(self):
         pser = self.pser
         psser = self.psser

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -232,28 +232,29 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: True % self.psser)
 
     def test_and(self):
-        pser = pd.Series([True, False, None], dtype='bool')
+        pser = pd.Series([True, False, None], dtype="bool")
         psser = ps.from_pandas(pser)
         self.assert_eq(pser & True, psser & True)
         self.assert_eq(pser & False, psser & False)
         self.assert_eq(pser & pser, psser & psser)
 
-        other_pser = pd.Series([False, None, True], dtype='bool')
+        other_pser = pd.Series([False, None, True], dtype="bool")
         other_psser = ps.from_pandas(other_pser)
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(pser & other_pser, psser & other_psser)
             self.check_extension(
-                pser & other_pser.astype('boolean'), psser & other_psser.astype('boolean'))
+                pser & other_pser.astype("boolean"), psser & other_psser.astype("boolean")
+            )
             self.assert_eq(other_pser & pser, other_psser & psser)
 
     def test_rand(self):
-        pser = pd.Series([True, False, None], dtype='bool')
+        pser = pd.Series([True, False, None], dtype="bool")
         psser = ps.from_pandas(pser)
         self.assert_eq(True & pser, True & psser)
         self.assert_eq(False & pser, False & psser)
 
     def test_or(self):
-        pser = pd.Series([True, False, None], dtype='bool')
+        pser = pd.Series([True, False, None], dtype="bool")
         psser = ps.from_pandas(pser)
         self.assert_eq(pser | True, psser | True)
         self.assert_eq(pser | False, psser | False)
@@ -261,28 +262,27 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(True | pser, True | psser)
         self.assert_eq(False | pser, False | psser)
 
-        other_pser = pd.Series([False, None, True], dtype='bool')
+        other_pser = pd.Series([False, None, True], dtype="bool")
         other_psser = ps.from_pandas(other_pser)
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(pser | other_pser, psser | other_psser)
             self.check_extension(
-                pser | other_pser.astype('boolean'), psser | other_psser.astype('boolean'))
+                pser | other_pser.astype("boolean"), psser | other_psser.astype("boolean")
+            )
             self.assert_eq(other_pser | pser, other_psser | psser)
 
     def test_ror(self):
-        pser = pd.Series([True, False, None], dtype='bool')
+        pser = pd.Series([True, False, None], dtype="bool")
         psser = ps.from_pandas(pser)
         self.assert_eq(True | pser, True | psser)
         self.assert_eq(False | pser, False | psser)
 
 
-@unittest.skipIf(
-    not extension_dtypes_available, "pandas extension dtypes are not available"
-)
+@unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
 class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     @property
     def pser(self):
-        return pd.Series([True, False, None], dtype='boolean')
+        return pd.Series([True, False, None], dtype="boolean")
 
     @property
     def psser(self):
@@ -290,7 +290,7 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     @property
     def other_pser(self):
-        return pd.Series([False, None, True], dtype='boolean')
+        return pd.Series([False, None, True], dtype="boolean")
 
     @property
     def other_psser(self):
@@ -356,8 +356,9 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
-                self.pser / self.float_pser, (self.psser / self.float_psser).sort_index(),
-                almost=True
+                self.pser / self.float_pser,
+                (self.psser / self.float_psser).sort_index(),
+                almost=True,
             )
             for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser / psser)
@@ -377,8 +378,9 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
-                self.pser // self.float_pser, (self.psser // self.float_psser).sort_index(),
-                almost=True
+                self.pser // self.float_pser,
+                (self.psser // self.float_psser).sort_index(),
+                almost=True,
             )
             for psser in self.non_numeric_pssers.values():
                 self.assertRaises(TypeError, lambda: self.psser // psser)
@@ -409,8 +411,9 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
-                self.pser ** self.float_pser, (self.psser ** self.float_psser).sort_index(),
-                almost=True
+                self.pser ** self.float_pser,
+                (self.psser ** self.float_psser).sort_index(),
+                almost=True,
             )
 
             for psser in self.non_numeric_pssers.values():

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -229,6 +229,98 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % self.psser)
         self.assertRaises(TypeError, lambda: True % self.psser)
 
+    def test_and(self):
+        pser = pd.Series([True, False, None], dtype='bool')
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser & True, psser & True)
+        self.assert_eq(pser & False, psser & False)
+        self.assert_eq(pser & pser, psser & psser)
+
+        other_pser = pd.Series([False, None, True], dtype='bool')
+        other_psser = ps.from_pandas(other_pser)
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(pser & other_pser, psser & other_psser)
+            self.check_extension(
+                pser & other_pser.astype('boolean'), psser & other_psser.astype('boolean'))
+            self.assert_eq(other_pser & pser, other_psser & psser)
+
+    def test_rand(self):
+        pser = pd.Series([True, False, None], dtype='bool')
+        psser = ps.from_pandas(pser)
+        self.assert_eq(True & pser, True & psser)
+        self.assert_eq(False & pser, False & psser)
+
+    def test_or(self):
+        pser = pd.Series([True, False, None], dtype='bool')
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser | True, psser | True)
+        self.assert_eq(pser | False, psser | False)
+        self.assert_eq(pser | pser, psser | psser)
+        self.assert_eq(True | pser, True | psser)
+        self.assert_eq(False | pser, False | psser)
+
+        other_pser = pd.Series([False, None, True], dtype='bool')
+        other_psser = ps.from_pandas(other_pser)
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(pser | other_pser, psser | other_psser)
+            self.check_extension(
+                pser | other_pser.astype('boolean'), psser | other_psser.astype('boolean'))
+            self.assert_eq(other_pser | pser, other_psser | psser)
+
+    def test_ror(self):
+        pser = pd.Series([True, False, None], dtype='bool')
+        psser = ps.from_pandas(pser)
+        self.assert_eq(True | pser, True | psser)
+        self.assert_eq(False | pser, False | psser)
+
+
+class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUtils):
+    @property
+    def pser(self):
+        return pd.Series([True, False, None], dtype='boolean')
+
+    @property
+    def psser(self):
+        return ps.from_pandas(self.pser)
+
+    @property
+    def other_pser(self):
+        return pd.Series([False, None, True], dtype='boolean')
+
+    @property
+    def other_psser(self):
+        return ps.from_pandas(self.other_pser)
+
+    def test_and(self):
+        pser = self.pser
+        psser = self.psser
+        self.check_extension(pser & True, psser & True)
+        self.check_extension(pser & False, psser & False)
+        self.check_extension(pser & pser, psser & psser)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(pser & self.other_pser, psser & self.other_psser)
+            self.check_extension(self.other_pser & pser, self.other_psser & psser)
+
+    def test_rand(self):
+        self.check_extension(True & self.pser, True & self.psser)
+        self.check_extension(False & self.pser, False & self.psser)
+
+    def test_or(self):
+        pser = self.pser
+        psser = self.psser
+        self.check_extension(pser | True, psser | True)
+        self.check_extension(pser | False, psser | False)
+        self.check_extension(pser | pser, psser | psser)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(pser | self.other_pser, psser | self.other_psser)
+            self.check_extension(self.other_pser | pser, self.other_psser | psser)
+
+    def test_ror(self):
+        self.check_extension(True | self.pser, True | self.psser)
+        self.check_extension(False | self.pser, False | self.psser)
+
     def test_from_to_pandas(self):
         data = [True, True, False]
         pser = pd.Series(data)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -279,7 +279,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 @unittest.skipIf(
     not extension_dtypes_available, "pandas extension dtypes are not available"
 )
-class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUtils):
+class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     @property
     def pser(self):
         return pd.Series([True, False, None], dtype='boolean')
@@ -295,6 +295,14 @@ class BooleanExtensionOpsTest(BooleanOpsTest, PandasOnSparkTestCase, TestCasesUt
     @property
     def other_psser(self):
         return ps.from_pandas(self.other_pser)
+
+    @property
+    def float_pser(self):
+        return pd.Series([1, 2, 3], dtype=float)
+
+    @property
+    def float_psser(self):
+        return ps.from_pandas(self.float_pser)
 
     def test_add(self):
         pser = self.pser

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -115,6 +115,24 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: "x" ** self.psser)
         self.assertRaises(TypeError, lambda: 1 ** self.psser)
 
+    def test_and(self):
+        self.assertRaises(TypeError, lambda: self.psser & True)
+        self.assertRaises(TypeError, lambda: self.psser & False)
+        self.assertRaises(TypeError, lambda: self.psser & self.psser)
+
+    def test_rand(self):
+        self.assertRaises(TypeError, lambda: True & self.psser)
+        self.assertRaises(TypeError, lambda: False & self.psser)
+
+    def test_or(self):
+        self.assertRaises(TypeError, lambda: self.psser | True)
+        self.assertRaises(TypeError, lambda: self.psser | False)
+        self.assertRaises(TypeError, lambda: self.psser | self.psser)
+
+    def test_ror(self):
+        self.assertRaises(TypeError, lambda: True | self.psser)
+        self.assertRaises(TypeError, lambda: False | self.psser)
+
     def test_from_to_pandas(self):
         data = [1, "x", "y"]
         pser = pd.Series(data, dtype="category")

--- a/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
@@ -190,6 +190,24 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: "x" ** self.psser)
         self.assertRaises(TypeError, lambda: 1 ** self.psser)
 
+    def test_and(self):
+        self.assertRaises(TypeError, lambda: self.psser & True)
+        self.assertRaises(TypeError, lambda: self.psser & False)
+        self.assertRaises(TypeError, lambda: self.psser & self.psser)
+
+    def test_rand(self):
+        self.assertRaises(TypeError, lambda: True & self.psser)
+        self.assertRaises(TypeError, lambda: False & self.psser)
+
+    def test_or(self):
+        self.assertRaises(TypeError, lambda: self.psser | True)
+        self.assertRaises(TypeError, lambda: self.psser | False)
+        self.assertRaises(TypeError, lambda: self.psser | self.psser)
+
+    def test_ror(self):
+        self.assertRaises(TypeError, lambda: True | self.psser)
+        self.assertRaises(TypeError, lambda: False | self.psser)
+
     def test_from_to_pandas(self):
         for pser, psser in zip(self.psers, self.pssers):
             self.assert_eq(pser, psser.to_pandas())

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -147,6 +147,24 @@ class DateOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: 1 ** self.psser)
         self.assertRaises(TypeError, lambda: self.some_date ** self.psser)
 
+    def test_and(self):
+        self.assertRaises(TypeError, lambda: self.psser & True)
+        self.assertRaises(TypeError, lambda: self.psser & False)
+        self.assertRaises(TypeError, lambda: self.psser & self.psser)
+
+    def test_rand(self):
+        self.assertRaises(TypeError, lambda: True & self.psser)
+        self.assertRaises(TypeError, lambda: False & self.psser)
+
+    def test_or(self):
+        self.assertRaises(TypeError, lambda: self.psser | True)
+        self.assertRaises(TypeError, lambda: self.psser | False)
+        self.assertRaises(TypeError, lambda: self.psser | self.psser)
+
+    def test_ror(self):
+        self.assertRaises(TypeError, lambda: True | self.psser)
+        self.assertRaises(TypeError, lambda: False | self.psser)
+
     def test_from_to_pandas(self):
         data = [datetime.date(1994, 1, 31), datetime.date(1994, 2, 1), datetime.date(1994, 2, 2)]
         pser = pd.Series(data)

--- a/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
@@ -147,6 +147,24 @@ class DatetimeOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: 1 ** self.psser)
         self.assertRaises(TypeError, lambda: self.some_datetime ** self.psser)
 
+    def test_and(self):
+        self.assertRaises(TypeError, lambda: self.psser & True)
+        self.assertRaises(TypeError, lambda: self.psser & False)
+        self.assertRaises(TypeError, lambda: self.psser & self.psser)
+
+    def test_rand(self):
+        self.assertRaises(TypeError, lambda: True & self.psser)
+        self.assertRaises(TypeError, lambda: False & self.psser)
+
+    def test_or(self):
+        self.assertRaises(TypeError, lambda: self.psser | True)
+        self.assertRaises(TypeError, lambda: self.psser | False)
+        self.assertRaises(TypeError, lambda: self.psser | self.psser)
+
+    def test_ror(self):
+        self.assertRaises(TypeError, lambda: True | self.psser)
+        self.assertRaises(TypeError, lambda: False | self.psser)
+
     def test_from_to_pandas(self):
         data = pd.date_range("1994-1-31 10:30:15", periods=3, freq="M")
         pser = pd.Series(data)

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -254,6 +254,28 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) % psser)
 
+    def test_and(self):
+        psser = self.numeric_pssers[0]
+        self.assertRaises(TypeError, lambda: psser & True)
+        self.assertRaises(TypeError, lambda: psser & False)
+        self.assertRaises(TypeError, lambda: psser & psser)
+
+    def test_rand(self):
+        psser = self.numeric_pssers[0]
+        self.assertRaises(TypeError, lambda: True & psser)
+        self.assertRaises(TypeError, lambda: False & psser)
+
+    def test_or(self):
+        psser = self.numeric_pssers[0]
+        self.assertRaises(TypeError, lambda: psser | True)
+        self.assertRaises(TypeError, lambda: psser | False)
+        self.assertRaises(TypeError, lambda: psser | psser)
+
+    def test_ror(self):
+        psser = self.numeric_pssers[0]
+        self.assertRaises(TypeError, lambda: True | psser)
+        self.assertRaises(TypeError, lambda: False | psser)
+
     def test_from_to_pandas(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser, psser.to_pandas())

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -129,6 +129,24 @@ class StringOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: "x" ** self.psser)
         self.assertRaises(TypeError, lambda: 1 ** self.psser)
 
+    def test_and(self):
+        self.assertRaises(TypeError, lambda: self.psser & True)
+        self.assertRaises(TypeError, lambda: self.psser & False)
+        self.assertRaises(TypeError, lambda: self.psser & self.psser)
+
+    def test_rand(self):
+        self.assertRaises(TypeError, lambda: True & self.psser)
+        self.assertRaises(TypeError, lambda: False & self.psser)
+
+    def test_or(self):
+        self.assertRaises(TypeError, lambda: self.psser | True)
+        self.assertRaises(TypeError, lambda: self.psser | False)
+        self.assertRaises(TypeError, lambda: self.psser | self.psser)
+
+    def test_ror(self):
+        self.assertRaises(TypeError, lambda: True | self.psser)
+        self.assertRaises(TypeError, lambda: False | self.psser)
+
     def test_from_to_pandas(self):
         data = ["x", "y", "z"]
         pser = pd.Series(data)

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -17,11 +17,13 @@
 
 import datetime
 import decimal
+from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
 
 import pyspark.pandas as ps
+from pyspark.pandas.typedef import extension_dtypes
 
 
 class TestCasesUtils(object):
@@ -74,3 +76,10 @@ class TestCasesUtils(object):
     @property
     def pser_psser_pairs(self):
         return zip(self.psers, self.pssers)
+
+    def check_extension(self, psser, pser):
+        if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
+            self.assert_eq(psser, pser, check_exact=False)
+            self.assertTrue(isinstance(psser.dtype, extension_dtypes))
+        else:
+            self.assert_eq(psser, pser)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- Introduce BooleanExtensionOps in order to make boolean operators `and` and `or` data-type-based.
- Improve error messages for operators `and` and `or`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Boolean operators __and__, __or__, __rand__, and __ror__ should be data-type-based

BooleanExtensionDtypes processes these boolean operators differently from bool, so BooleanExtensionOps is introduced.

These boolean operators themselves are also bitwise operators, which should be able to apply to other data types classes later. However, this is not the goal of this PR.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Error messages for operators `and` and `or` are improved.
Before:
```
>>> psser = ps.Series([1, "x", "y"], dtype="category")
>>> psser | True
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: cannot resolve '(`0` OR true)' due to data type mismatch: differing types in '(`0` OR true)' (tinyint and boolean).;
'Project [unresolvedalias(CASE WHEN (isnull(0#9) OR isnull((0#9 OR true))) THEN false ELSE (0#9 OR true) END, Some(org.apache.spark.sql.Column$$Lambda$1442/1725491640@6fb8afba))]
+- Project [__index_level_0__#8L, 0#9, monotonically_increasing_id() AS __natural_order__#12L]
   +- LogicalRDD [__index_level_0__#8L, 0#9], false

```

After:
```
>>> psser = ps.Series([1, "x", "y"], dtype="category")
>>> psser | True
Traceback (most recent call last):
...
TypeError: Bitwise or can not be applied to categoricals.
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.

Keyword: SPARK-35337