### PR TITLE
[SPARK-35568][SQL] Avoid UnsupportedOperationException when enabling both AQE and DPP

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1505,6 +1505,27 @@ abstract class DynamicPartitionPruningSuiteBase
       checkAnswer(df, Row(15, 15) :: Nil)
     }
   }
+
+  test("SPARK-35568: Avoid UnsupportedOperationException when enabling both AQE and DPP") {
+    val df = sql(
+      """
+        |SELECT s.store_id, f.product_id
+        |FROM (SELECT DISTINCT * FROM fact_sk) f
+        |  JOIN (SELECT
+        |          *,
+        |          ROW_NUMBER() OVER (PARTITION BY store_id ORDER BY state_province DESC) AS rn
+        |        FROM dim_store) s
+        |   ON f.store_id = s.store_id
+        |WHERE s.country = 'DE' AND s.rn = 1
+        |""".stripMargin)
+
+    checkAnswer(df,
+      Row(3, 2) ::
+      Row(3, 2) ::
+      Row(3, 2) ::
+      Row(3, 2) :: Nil
+    )
+  }
 }
 
 class DynamicPartitionPruningSuiteAEOff extends DynamicPartitionPruningSuiteBase


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr update `doExecuteBroadcast` in `AdaptiveSparkPlanExec` to avoid `UnsupportedOperationException` when enabling both AQE and DPP.

How to reproduce this issue:
```scala
sql(
      """
        |SELECT s.store_id, f.product_id
        |FROM (SELECT DISTINCT * FROM fact_sk) f
        |  JOIN (SELECT
        |          *,
        |          ROW_NUMBER() OVER (PARTITION BY store_id ORDER BY state_province DESC) AS rn
        |        FROM dim_store) s
        |   ON f.store_id = s.store_id
        |WHERE s.country = 'DE' AND s.rn = 1
        |""".stripMargin).show
```

```
Caused by: java.lang.UnsupportedOperationException: WholeStageCodegen (3) does not implement doExecuteBroadcast
	at org.apache.spark.sql.execution.SparkPlan.doExecuteBroadcast(SparkPlan.scala:297)
	at org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec.doExecuteBroadcast(AdaptiveSparkPlanExec.scala:323)
	at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeBroadcast$1(SparkPlan.scala:192)
	at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeQuery$1(SparkPlan.scala:217)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
	at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:214)
	at org.apache.spark.sql.execution.SparkPlan.executeBroadcast(SparkPlan.scala:188)
```

### Why are the changes needed?

Fix bug.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.
