### PR TITLE
[SPARK-31168][BUILD][FOLLOWUP] Update scala-2.12 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3331,7 +3331,7 @@
          SPARK-34774 Add this property to ensure change-scala-version.sh can replace the public `scala.version`
          property correctly. 
         -->
-        <scala.version>2.12.10</scala.version>
+        <scala.version>2.12.14</scala.version>
       </properties>
       <build>
         <pluginManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of https://github.com/apache/spark/pull/32697 to update the missed part.
After SPARK-34774, we have Scala 2.12 version in `scala-2.12` profile.

### Why are the changes needed?

To be consistent.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual.

**BEFORE**
```
$ build/mvn help:evaluate -Pscala-2.12 -Dexpression=scala.version | grep "^2.12"
Using `mvn` from path: /usr/local/bin/mvn
2.12.10
```

**AFTER**
```
$ build/mvn help:evaluate -Pscala-2.12 -Dexpression=scala.version | grep "^2.12"
Using `mvn` from path: /usr/local/bin/mvn
2.12.14
```