### PR TITLE
[SPARK-35584][CORE][TESTS] Increase the timeout in FallbackStorageSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
@@ -240,7 +240,7 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
         sched.decommissionExecutor(_, ExecutorDecommissionInfo(""), false)
       }
 
-      eventually(timeout(10.seconds), interval(1.seconds)) {
+      eventually(timeout(20.seconds), interval(1.seconds)) {
         shuffle0_files.foreach { file => assert(fallbackStorage.exists(0, file)) }
         shuffle1_files.foreach { file => assert(fallbackStorage.exists(1, file)) }
       }
@@ -265,7 +265,7 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
 
         // Make it sure that fallback storage are ready
         val fallbackStorage = new FallbackStorage(sc.getConf)
-        eventually(timeout(10.seconds), interval(1.seconds)) {
+        eventually(timeout(20.seconds), interval(1.seconds)) {
           Seq(
             "shuffle_0_0_0.index", "shuffle_0_0_0.data",
             "shuffle_0_1_0.index", "shuffle_0_1_0.data").foreach { file =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
```
- Upload multi stages *** FAILED ***
{{ The code passed to eventually never returned normally. Attempted 20 times over 10.011176743 seconds. Last failure message: fallbackStorage.exists(0, file) was false. (FallbackStorageSuite.scala:243)}}
```
The error like above was raised in aarch64 randomly and also in github action test[1][2].

[1] https://github.com/apache/spark/actions/runs/489319612
[2]https://github.com/apache/spark/actions/runs/479317320

### Why are the changes needed?
timeout is too short, need to increase to let test case complete.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
build/mvn test -Dtest=none -DwildcardSuites=org.apache.spark.storage.FallbackStorageSuite -pl :spark-core_2.12