### PR TITLE
[SPARK-35589][CORE] BlockManagerMasterEndpoint should not ignore index-only shuffle file during updating

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -262,7 +262,7 @@ private[spark] class IndexShuffleBlockResolver(
         throw new FileNotFoundException("Index file is deleted already.")
       }
       if (dataFile.exists()) {
-        List((indexBlockId, indexBlockData), (dataBlockId, dataBlockData))
+        List((dataBlockId, dataBlockData), (indexBlockId, indexBlockData))
       } else {
         List((indexBlockId, indexBlockData))
       }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -574,13 +574,12 @@ class BlockManagerMasterEndpoint(
     if (blockId.isShuffle) {
       blockId match {
         case ShuffleIndexBlockId(shuffleId, mapId, _) =>
-          // We need to update this because there exists the index-only block
+          // We need to update this at index file because there exists the index-only block
           logDebug(s"Received shuffle index block update for ${shuffleId} ${mapId}, updating.")
           mapOutputTracker.updateMapOutput(shuffleId, mapId, blockManagerId)
           return true
         case ShuffleDataBlockId(shuffleId: Int, mapId: Long, reduceId: Int) =>
-          logDebug(s"Received shuffle data block update for ${shuffleId} ${mapId}, updating.")
-          mapOutputTracker.updateMapOutput(shuffleId, mapId, blockManagerId)
+          logDebug(s"Received shuffle data block update for ${shuffleId} ${mapId}, ignore.")
           return true
         case _ =>
           logDebug(s"Unexpected shuffle block type ${blockId}" +

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -574,8 +574,9 @@ class BlockManagerMasterEndpoint(
     if (blockId.isShuffle) {
       blockId match {
         case ShuffleIndexBlockId(shuffleId, mapId, _) =>
-          // Don't update the map output on just the index block
-          logDebug(s"Received shuffle index block update for ${shuffleId} ${mapId}, ignoring.")
+          // We need to update this because there exists the index-only block
+          logDebug(s"Received shuffle index block update for ${shuffleId} ${mapId}, updating.")
+          mapOutputTracker.updateMapOutput(shuffleId, mapId, blockManagerId)
           return true
         case ShuffleDataBlockId(shuffleId: Int, mapId: Long, reduceId: Int) =>
           logDebug(s"Received shuffle data block update for ${shuffleId} ${mapId}, updating.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `BlockManagerMasterEndpoint.updateBlockInfo` not to ignore index-only shuffle files.
In addition, this PR fixes `IndexShuffleBlockResolver.getMigrationBlocks` to return data files first.

### Why are the changes needed?

When [SPARK-20629](https://github.com/apache/spark/commit/a4ca355af8556e8c5948e492ef70ef0b48416dc4) introduced a worker decommission, index-only shuffle files are not considered properly.
- SPARK-33198 fixed `getMigrationBlocks` to handle index only shuffle files
- SPARK-35589 (this) aims to fix `updateBlockInfo` to handle index only shuffle files.

### Does this PR introduce _any_ user-facing change?

No. This is a bug fix.

### How was this patch tested?

Pass the CIs with the newly added test case.