### PR TITLE
[SPARK-35539][PYTHON] Restore to_koalas to keep the backward compatibility

### DIFF
--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -146,6 +146,9 @@ def _auto_patch_spark() -> None:
 
         df.DataFrame.to_pandas_on_spark = DataFrame.to_pandas_on_spark  # type: ignore
 
+        # Keep to_koalas for backward compatibility for now.
+        df.DataFrame.to_koalas = DataFrame.to_koalas  # type: ignore
+
 
 _frame_has_class_getitem = False
 _series_has_class_getitem = False

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -4548,8 +4548,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     # Keep to_koalas for backward compatibility for now.
     def to_koalas(self, index_col: Optional[Union[str, List[str]]] = None) -> "DataFrame":
         warnings.warn(
-            "DataFrame.to_koalas is deprecated as of DataFrame.to_pandas_on_spark. "
-            "Please use the API instead.",
+            "DataFrame.to_koalas is deprecated. Use DataFrame.to_pandas_on_spark instead.",
             FutureWarning,
         )
         return self.to_pandas_on_spark(index_col)

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -4545,6 +4545,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
             return DataFrame(internal)
 
+    # Keep to_koalas for backward compatibility for now.
+    def to_koalas(self, index_col: Optional[Union[str, List[str]]] = None) -> "DataFrame":
+        warnings.warn(
+            "DataFrame.to_koalas is deprecated as of DataFrame.to_pandas_on_spark. "
+            "Please use the API instead.",
+            FutureWarning,
+        )
+        return self.to_pandas_on_spark(index_col)
+
     def to_table(
         self,
         name: str,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes restoring `to_koalas` to keep the backward compatibility, with throwing deprecated warning.

### Why are the changes needed?

If we remove `to_koalas`, the existing Koalas codes that include `to_koalas` wouldn't work.


### Does this PR introduce _any_ user-facing change?

No. It's restoring the existing functionality.


### How was this patch tested?

Manually tested in local.

```shell
>>> sdf.to_koalas()
.../spark/python/pyspark/pandas/frame.py:4550: FutureWarning: DataFrame.to_koalas is deprecated as of DataFrame.to_pandas_on_spark. Please use the API instead.
  warnings.warn(
```
