### PR TITLE
[SPARK-35593][K8S][CORE] Support shuffle data recovery on the reused PVCs

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -167,15 +167,14 @@ private class ShuffleStatus(
           invalidateSerializedMapOutputStatusCache()
         case None =>
           val index = mapStatusesDeleted.indexWhere(x => x != null && x.mapId == mapId)
-          if (index >= 0) {
+          if (index >= 0 && mapStatuses(index) == null) {
             val mapStatus = mapStatusesDeleted(index)
             mapStatus.updateLocation(bmAddress)
-            assert(mapStatuses(index) == null)
             mapStatuses(index) = mapStatus
             _numAvailableMapOutputs += 1
             invalidateSerializedMapOutputStatusCache()
             mapStatusesDeleted(index) = null
-            logDebug(s"Recover ${mapStatus.mapId} ${mapStatus.location}")
+            logInfo(s"Recover ${mapStatus.mapId} ${mapStatus.location}")
           } else {
             logWarning(s"Asked to update map output ${mapId} for untracked map status.")
           }

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -174,6 +174,7 @@ private class ShuffleStatus(
             mapStatuses(index) = mapStatus
             _numAvailableMapOutputs += 1
             invalidateSerializedMapOutputStatusCache()
+            mapStatusesDeleted(index) = null
             logDebug(s"Recover ${mapStatus.mapId} ${mapStatus.location}")
           } else {
             logWarning(s"Asked to update map output ${mapId} for untracked map status.")

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -151,7 +151,6 @@ private class ShuffleStatus(
       _numAvailableMapOutputs += 1
       invalidateSerializedMapOutputStatusCache()
     }
-    mapStatusesDeleted(mapIndex) = mapStatuses(mapIndex)
     mapStatuses(mapIndex) = status
   }
 

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -90,6 +90,11 @@ private class ShuffleStatus(
   val mapStatuses = new Array[MapStatus](numPartitions)
 
   /**
+   * Keep the previous deleted MapStatus for recovery.
+   */
+  val mapStatusesDeleted = new Array[MapStatus](numPartitions)
+
+  /**
    * MergeStatus for each shuffle partition when push-based shuffle is enabled. The index of the
    * array is the shuffle partition id (reduce id). Each value in the array is the MergeStatus for
    * a shuffle partition, or null if not available. When push-based shuffle is enabled, this array
@@ -146,6 +151,7 @@ private class ShuffleStatus(
       _numAvailableMapOutputs += 1
       invalidateSerializedMapOutputStatusCache()
     }
+    mapStatusesDeleted(mapIndex) = mapStatuses(mapIndex)
     mapStatuses(mapIndex) = status
   }
 
@@ -154,14 +160,25 @@ private class ShuffleStatus(
    */
   def updateMapOutput(mapId: Long, bmAddress: BlockManagerId): Unit = withWriteLock {
     try {
-      val mapStatusOpt = mapStatuses.find(_.mapId == mapId)
+      val mapStatusOpt = mapStatuses.find(x => x != null && x.mapId == mapId)
       mapStatusOpt match {
         case Some(mapStatus) =>
           logInfo(s"Updating map output for ${mapId} to ${bmAddress}")
           mapStatus.updateLocation(bmAddress)
           invalidateSerializedMapOutputStatusCache()
         case None =>
-          logWarning(s"Asked to update map output ${mapId} for untracked map status.")
+          val index = mapStatusesDeleted.indexWhere(x => x != null && x.mapId == mapId)
+          if (index >= 0) {
+            val mapStatus = mapStatusesDeleted(index)
+            mapStatus.updateLocation(bmAddress)
+            assert(mapStatuses(index) == null)
+            mapStatuses(index) = mapStatus
+            _numAvailableMapOutputs += 1
+            invalidateSerializedMapOutputStatusCache()
+            logDebug(s"Recover ${mapStatus.mapId} ${mapStatus.location}")
+          } else {
+            logWarning(s"Asked to update map output ${mapId} for untracked map status.")
+          }
       }
     } catch {
       case e: java.lang.NullPointerException =>
@@ -178,6 +195,7 @@ private class ShuffleStatus(
     logDebug(s"Removing existing map output ${mapIndex} ${bmAddress}")
     if (mapStatuses(mapIndex) != null && mapStatuses(mapIndex).location == bmAddress) {
       _numAvailableMapOutputs -= 1
+      mapStatusesDeleted(mapIndex) = mapStatuses(mapIndex)
       mapStatuses(mapIndex) = null
       invalidateSerializedMapOutputStatusCache()
     }
@@ -234,6 +252,7 @@ private class ShuffleStatus(
     for (mapIndex <- mapStatuses.indices) {
       if (mapStatuses(mapIndex) != null && f(mapStatuses(mapIndex).location)) {
         _numAvailableMapOutputs -= 1
+        mapStatusesDeleted(mapIndex) = mapStatuses(mapIndex)
         mapStatuses(mapIndex) = null
         invalidateSerializedMapOutputStatusCache()
       }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleDataIO.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleDataIO.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.k8s.Config.KUBERNETES_DRIVER_REUSE_PVC
+import org.apache.spark.shuffle.api.{ShuffleDataIO, ShuffleDriverComponents, ShuffleExecutorComponents}
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleDriverComponents
+
+/**
+ * This should be used with ephemeral PVCs in K8s environment.
+ */
+class KubernetesLocalDiskShuffleDataIO(sparkConf: SparkConf) extends ShuffleDataIO {
+  require(sparkConf.get(KUBERNETES_DRIVER_REUSE_PVC), "Ephemeral PVCs are required")
+
+  override def driver(): ShuffleDriverComponents =
+    new LocalDiskShuffleDriverComponents()
+
+  override def executor(): ShuffleExecutorComponents =
+    new KubernetesLocalDiskShuffleExecutorComponents(sparkConf)
+}
+

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleExecutorComponents.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleExecutorComponents.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import java.io.File
+import java.util.Optional
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.{SparkConf, SparkEnv}
+import org.apache.spark.internal.Logging
+import org.apache.spark.shuffle.api.{ShuffleExecutorComponents, ShuffleMapOutputWriter, SingleSpillShuffleMapOutputWriter}
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleExecutorComponents
+import org.apache.spark.storage.{BlockId, BlockManager, StorageLevel, UnrecognizedBlockId}
+import org.apache.spark.util.Utils
+
+class KubernetesLocalDiskShuffleExecutorComponents(sparkConf: SparkConf)
+  extends ShuffleExecutorComponents with Logging {
+
+  private val delegate = new LocalDiskShuffleExecutorComponents(sparkConf)
+  private var blockManager: BlockManager = _
+
+  override def initializeExecutor(
+      appId: String, execId: String, extraConfigs: java.util.Map[String, String]): Unit = {
+    delegate.initializeExecutor(appId, execId, extraConfigs)
+    blockManager = SparkEnv.get.blockManager
+    if (sparkConf.getBoolean("spark.kubernetes.driver.reusePersistentVolumeClaim", false)) {
+      // Turn off the deletion of the shuffle data in order to reuse
+      blockManager.diskBlockManager.deleteFilesOnStop = false
+      logError("Recover shuffle data")
+      Utils.tryLogNonFatalError {
+        KubernetesLocalDiskShuffleExecutorComponents.recoverDiskStore(sparkConf, blockManager)
+      }
+    }
+  }
+
+  override def createMapOutputWriter(shuffleId: Int, mapTaskId: Long, numPartitions: Int)
+    : ShuffleMapOutputWriter = {
+    delegate.createMapOutputWriter(shuffleId, mapTaskId, numPartitions)
+  }
+
+  override def createSingleFileMapOutputWriter(shuffleId: Int, mapId: Long)
+    : Optional[SingleSpillShuffleMapOutputWriter] = {
+    delegate.createSingleFileMapOutputWriter(shuffleId, mapId)
+  }
+}
+
+object KubernetesLocalDiskShuffleExecutorComponents extends Logging {
+  /**
+   * This tries to recover shuffle data of dead executors' local dirs if exists.
+   * Since the executors are already dead, we cannot use `getHostLocalDirs`.
+   * This is enabled only when spark.kubernetes.driver.reusePersistentVolumeClaim is true.
+   */
+  def recoverDiskStore(conf: SparkConf, bm: BlockManager): Unit = {
+    // Find All files
+    val files = Utils.getConfiguredLocalDirs(conf)
+      .filter(_ != null)
+      .map(s => new File(new File(new File(s).getParent).getParent))
+      .flatMap { dir =>
+        logError(dir.toString)
+        val oldDirs = dir.listFiles().filter { f =>
+          f.isDirectory && f.getName.startsWith("spark-")
+        }
+        val files = oldDirs
+          .flatMap(_.listFiles).filter(_.isDirectory) // executor-xxx
+          .flatMap(_.listFiles).filter(_.isDirectory) // blockmgr-xxx
+          .flatMap(_.listFiles).filter(_.isDirectory) // 00
+          .flatMap(_.listFiles)
+        if (files != null) files.toSeq else Seq.empty
+      }
+
+    logInfo(s"Found ${files.size} files")
+
+    // This is not used.
+    val classTag = implicitly[ClassTag[Object]]
+    val level = StorageLevel.DISK_ONLY
+    val (indexFiles, dataFiles) = files.partition(_.getName.endsWith(".index"))
+    (dataFiles ++ indexFiles).foreach { f =>
+      try {
+        logError(f.getName)
+        val id = BlockId(f.getName)
+        val decryptedSize = f.length()
+        bm.TempFileBasedBlockStoreUpdater(id, level, classTag, f, decryptedSize).save()
+      } catch {
+        case _: UnrecognizedBlockId =>
+      }
+    }
+  }
+}
+

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleExecutorComponents.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleExecutorComponents.scala
@@ -71,7 +71,6 @@ object KubernetesLocalDiskShuffleExecutorComponents extends Logging {
       .filter(_ != null)
       .map(s => new File(new File(new File(s).getParent).getParent))
       .flatMap { dir =>
-        logError(dir.toString)
         val oldDirs = dir.listFiles().filter { f =>
           f.isDirectory && f.getName.startsWith("spark-")
         }
@@ -91,7 +90,6 @@ object KubernetesLocalDiskShuffleExecutorComponents extends Logging {
     val (indexFiles, dataFiles) = files.partition(_.getName.endsWith(".index"))
     (dataFiles ++ indexFiles).foreach { f =>
       try {
-        logError(f.getName)
         val id = BlockId(f.getName)
         val decryptedSize = f.length()
         bm.TempFileBasedBlockStoreUpdater(id, level, classTag, f, decryptedSize).save()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleExecutorComponents.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleExecutorComponents.scala
@@ -42,7 +42,6 @@ class KubernetesLocalDiskShuffleExecutorComponents(sparkConf: SparkConf)
     if (sparkConf.getBoolean("spark.kubernetes.driver.reusePersistentVolumeClaim", false)) {
       // Turn off the deletion of the shuffle data in order to reuse
       blockManager.diskBlockManager.deleteFilesOnStop = false
-      logError("Recover shuffle data")
       Utils.tryLogNonFatalError {
         KubernetesLocalDiskShuffleExecutorComponents.recoverDiskStore(sparkConf, blockManager)
       }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleDataIOSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleDataIOSuite.scala
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import scala.concurrent.duration._
+
+import org.scalatest.concurrent.Eventually.{eventually, interval, timeout}
+
+import org.apache.spark.{LocalSparkContext, MapOutputTrackerMaster, SparkConf, SparkContext, SparkFunSuite, TestUtils}
+import org.apache.spark.LocalSparkContext.withSpark
+import org.apache.spark.deploy.k8s.Config.KUBERNETES_DRIVER_REUSE_PVC
+import org.apache.spark.internal.config._
+import org.apache.spark.scheduler.cluster.StandaloneSchedulerBackend
+
+class KubernetesLocalDiskShuffleDataIOSuite extends SparkFunSuite with LocalSparkContext {
+
+  val conf = new SparkConf()
+    .setAppName("ShuffleExecutorComponentsSuite")
+    .setMaster("local-cluster[1,1,1024]")
+    .set(UI.UI_ENABLED, false)
+    .set(DYN_ALLOCATION_ENABLED, true)
+    .set(DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED, true)
+    .set(DYN_ALLOCATION_INITIAL_EXECUTORS, 1)
+    .set(DYN_ALLOCATION_MIN_EXECUTORS, 1)
+    .set(IO_ENCRYPTION_ENABLED, false)
+    .set(KUBERNETES_DRIVER_REUSE_PVC, true)
+    .set(SHUFFLE_IO_PLUGIN_CLASS, classOf[KubernetesLocalDiskShuffleDataIO].getName)
+
+  test("recompute is not blocked by the recovery") {
+    sc = new SparkContext(conf)
+    withSpark(sc) { sc =>
+      val master = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+      assert(master.shuffleStatuses.isEmpty)
+
+      val rdd = sc.parallelize(Seq((1, "one"), (2, "two"), (3, "three")), 3)
+        .groupByKey()
+      rdd.collect()
+      assert(master.shuffleStatuses.keys.toSet == Set(0))
+      val loc1 = master.shuffleStatuses(0).mapStatuses(0).location
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+
+      // Reuse the existing shuffle data
+      rdd.collect()
+      assert(master.shuffleStatuses.keys.toSet == Set(0))
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+
+      // Decommission all executors
+      val sched = sc.schedulerBackend.asInstanceOf[StandaloneSchedulerBackend]
+      sc.getExecutorIds().foreach { id =>
+        sched.killExecutor(id)
+      }
+      TestUtils.waitUntilExecutorsUp(sc, 1, 60000)
+      // Shuffle status are removed
+      eventually(timeout(60.second), interval(1.seconds)) {
+        assert(master.shuffleStatuses.keys.toSet == Set(0))
+        assert(master.shuffleStatuses(0).mapStatuses.forall(_ == null))
+      }
+
+      rdd.collect()
+      assert(master.shuffleStatuses.keys.toSet == Set(0))
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(9, 10, 11))
+    }
+  }
+
+  test("Partial recompute shuffle data") {
+    sc = new SparkContext(conf)
+    withSpark(sc) { sc =>
+      val master = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+      assert(master.shuffleStatuses.isEmpty)
+
+      val rdd = sc.parallelize(Seq((1, "one"), (2, "two"), (3, "three")), 3).groupByKey()
+      rdd.collect()
+      assert(master.shuffleStatuses.keys.toSet == Set(0))
+      val loc1 = master.shuffleStatuses(0).mapStatuses(0).location
+      assert(master.shuffleStatuses(0).mapStatuses.forall(_.location == loc1))
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+
+      // Reuse the existing shuffle data
+      rdd.collect()
+      assert(master.shuffleStatuses.keys.toSet == Set(0))
+      assert(master.shuffleStatuses(0).mapStatuses.forall(_.location == loc1))
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+
+      val rdd2 = sc.parallelize(Seq((4, "four"), (5, "five"), (6, "six"), (7, "seven")), 4)
+        .groupByKey()
+      rdd2.collect()
+      assert(master.shuffleStatuses.keys.toSet == Set(0, 1))
+      assert(master.shuffleStatuses(0).mapStatuses.forall(_.location == loc1))
+      assert(master.shuffleStatuses(1).mapStatuses.forall(_.location == loc1))
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+      assert(master.shuffleStatuses(1).mapStatuses.map(_.mapId).toSet == Set(9, 10, 11, 12))
+
+      // Decommission all executors
+      val sched = sc.schedulerBackend.asInstanceOf[StandaloneSchedulerBackend]
+      sc.getExecutorIds().foreach { id =>
+        sched.killExecutor(id)
+      }
+      TestUtils.waitUntilExecutorsUp(sc, 1, 60000)
+      // Shuffle status are removed
+      eventually(timeout(60.second), interval(1.seconds)) {
+        assert(master.shuffleStatuses.keys.toSet == Set(0, 1))
+        assert(master.shuffleStatuses(0).mapStatuses.forall(_ == null))
+        assert(master.shuffleStatuses(1).mapStatuses.forall(_ == null))
+      }
+
+      rdd.collect()
+      assert(master.shuffleStatuses.keys.toSet == Set(0, 1))
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(17, 18, 19))
+      assert(master.shuffleStatuses(1).mapStatuses.map(_.mapId).toSet == Set(9, 10, 11, 12))
+
+      rdd2.collect()
+      assert(master.shuffleStatuses(1).mapStatuses.map(_.mapId).toSet == Set(9, 10, 11, 12))
+    }
+  }
+
+  test("A new rdd and full recovery of old data") {
+    sc = new SparkContext(conf)
+    withSpark(sc) { sc =>
+      val master = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+      assert(master.shuffleStatuses.isEmpty)
+
+      val rdd = sc.parallelize(Seq((1, "one"), (2, "two"), (3, "three")), 3)
+        .groupByKey()
+      rdd.collect()
+      assert(master.shuffleStatuses.keys.toSet == Set(0))
+      val loc1 = master.shuffleStatuses(0).mapStatuses(0).location
+      assert(master.shuffleStatuses(0).mapStatuses.forall(_.location == loc1))
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+
+      // Reuse the existing shuffle data
+      rdd.collect()
+      assert(master.shuffleStatuses.keys.toSet == Set(0))
+      assert(master.shuffleStatuses(0).mapStatuses.forall(_.location == loc1))
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+
+      val rdd2 = sc.parallelize(Seq((4, "four"), (5, "five"), (6, "six"), (7, "seven")), 4)
+        .groupByKey()
+      rdd2.collect()
+      assert(master.shuffleStatuses.keys.toSet == Set(0, 1))
+      assert(master.shuffleStatuses(0).mapStatuses.forall(_.location == loc1))
+      assert(master.shuffleStatuses(1).mapStatuses.forall(_.location == loc1))
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+      assert(master.shuffleStatuses(1).mapStatuses.map(_.mapId).toSet == Set(9, 10, 11, 12))
+
+      // Decommission all executors
+      val sched = sc.schedulerBackend.asInstanceOf[StandaloneSchedulerBackend]
+      sc.getExecutorIds().foreach { id =>
+        sched.killExecutor(id)
+      }
+      TestUtils.waitUntilExecutorsUp(sc, 1, 60000)
+      // Shuffle status are removed
+      eventually(timeout(60.second), interval(1.seconds)) {
+        assert(master.shuffleStatuses.keys.toSet == Set(0, 1))
+        assert(master.shuffleStatuses(0).mapStatuses.forall(_ == null))
+        assert(master.shuffleStatuses(1).mapStatuses.forall(_ == null))
+      }
+      sc.parallelize(Seq((1, 1), (1, 2), (1, 3), (2, 1)), 2).groupByKey().collect()
+      eventually(timeout(60.second), interval(1.seconds)) {
+        assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+        assert(master.shuffleStatuses(1).mapStatuses.map(_.mapId).toSet == Set(9, 10, 11, 12))
+      }
+      rdd.count()
+      rdd2.count()
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+      assert(master.shuffleStatuses(1).mapStatuses.map(_.mapId).toSet == Set(9, 10, 11, 12))
+    }
+  }
+
+  test("Multi stages") {
+    sc = new SparkContext(conf)
+    withSpark(sc) { sc =>
+      val master = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+      assert(master.shuffleStatuses.isEmpty)
+
+      val rdd1 = sc.parallelize(1 to 10, 3)
+      val rdd2 = rdd1.map(x => (x % 2, 1))
+      val rdd3 = rdd2.reduceByKey(_ + _)
+      val rdd4 = rdd3.sortByKey()
+
+      assert(rdd4.count() === 3)
+      assert(master.shuffleStatuses.keys.toSet == Set(0, 1))
+      assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+      assert(master.shuffleStatuses(1).mapStatuses.map(_.mapId).toSet == Set(6, 7, 8))
+
+      // Kill all executors
+      val sched = sc.schedulerBackend.asInstanceOf[StandaloneSchedulerBackend]
+      sc.getExecutorIds().foreach { id =>
+        sched.killExecutor(id)
+      }
+      TestUtils.waitUntilExecutorsUp(sc, 1, 60000)
+      // Shuffle status are removed
+      eventually(timeout(10.second), interval(1.seconds)) {
+        assert(master.shuffleStatuses.keys.toSet == Set(0, 1))
+        assert(master.shuffleStatuses(0).mapStatuses.forall(_ == null))
+        assert(master.shuffleStatuses(1).mapStatuses.forall(_ == null))
+      }
+      sc.parallelize(Seq((1, 1)), 2).groupByKey().collect()
+      eventually(timeout(10.second), interval(1.seconds)) {
+        assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
+        assert(master.shuffleStatuses(1).mapStatuses.map(_.mapId).toSet == Set(6, 7, 8))
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Previously, the following two commits allow driver-owned on-demand PVC reuse.
- SPARK-35182 Support driver-owned on-demand PVC
- SPARK-35416 Support PersistentVolumeClaim Reuse

This PR aims to recover the shuffle data on those remounted PVCs. The lifecycle of PVCs are tied to the one of Spark jobs. Since this is K8s specific feature, `ShuffleDataIO` plugin is used.

### Why are the changes needed?

Although Pod is killed, we can remount PVCs and recover some data from it.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the newly added test cases.