### PR TITLE
[SPARK-35596][CORE] HighlyCompressedMapStatus should record accurately the size of skewed shuffle blocks

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1178,6 +1178,16 @@ package object config {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefault(100 * 1024 * 1024)
 
+  private[spark] val SHUFFLE_ACCURATE_SKEWED_BLOCK_THRESHOLD =
+    ConfigBuilder("spark.shuffle.accurateSkewedBlockThreshold")
+      .doc("Threshold in bytes above which the size and five times non-empty average size, " +
+        "the skewed shuffle blocks in HighlyCompressedMapStatus is accurately recorded. " +
+        "This helps to prevent OOM by avoiding underestimating skewed shuffle block size " +
+        "when fetch shuffle blocks.")
+      .version("3.2.0")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefault(350 * 1024)
+
   private[spark] val SHUFFLE_REGISTRATION_TIMEOUT =
     ConfigBuilder("spark.shuffle.registration.timeout")
       .doc("Timeout in milliseconds for registration to the external shuffle service.")

--- a/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
@@ -129,6 +129,10 @@ class MapStatusSuite extends SparkFunSuite {
     ser.newInstance().deserialize[MapStatus](buf)
   }
 
+  def compressAndDecompressSize(size: Long): Long = {
+    MapStatus.decompressSize(MapStatus.compressSize(size))
+  }
+
   test("RoaringBitmap: runOptimize succeeded") {
     val r = new RoaringBitmap
     (1 to 200000).foreach(i =>
@@ -189,6 +193,28 @@ class MapStatusSuite extends SparkFunSuite {
     withSpark(new SparkContext(conf)) { sc =>
       val count = sc.parallelize(0 until 3000, 10).repartition(2001).collect().length
       assert(count === 3000)
+    }
+  }
+
+  test("SPARK-35596: HighlyCompressedMapStatus should record accurately the size " +
+    "of skewed shuffle blocks") {
+    val sizes = Array.tabulate[Long](3000)(i => (if (i < 2990) i else i + 350 * 1024).toLong)
+    val avg = sizes.filter(_ < 3000).sum / sizes.count(i => i > 0 && i < 3000)
+    val loc = BlockManagerId("a", "b", 10)
+    val mapTaskAttemptId = 5
+    val status = MapStatus(loc, sizes, mapTaskAttemptId)
+    val status1 = compressAndDecompressMapStatus(status)
+    assert(status1.isInstanceOf[HighlyCompressedMapStatus])
+    assert(status1.location == loc)
+    assert(status1.mapId == mapTaskAttemptId)
+    assert(status1.getSizeForBlock(0) == 0)
+    for (i <- 1 until 3000) {
+      val estimate = status1.getSizeForBlock(i)
+      if (i < 2990) {
+        assert(estimate === avg)
+      } else {
+        assert(estimate === compressAndDecompressSize(sizes(i)))
+      }
     }
   }
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
HighlyCompressedMapStatus supports record accurately the size of skewed shuffle block which small than spark.shuffle.accurateBlockThreshold.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
HighlyCompressedMapStatus currently cannot record accurately the size of shuffle blocks which much greater than other block but small than `spark.shuffle.accurateBlockThreshold`, which is likely to lead OOM when fetch shuffle blocks. We have to tune some extra properties like `spark.reducer.maxReqsInFlight` to prevent it, so it is better to fix it in HighlyCompressedMapStatus.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, a new config `spark.shuffle.accurateSkewedBlockThreshold` added.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add new ut.