### PR TITLE
[SPARK-35580][SQL] Implement canonicalized method for HigherOrderFunction

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -198,12 +198,12 @@ trait HigherOrderFunction extends Expression with ExpectsInputTypes {
     val argumentMap = functions.flatMap(_.collect {
       case l: NamedLambdaVariable =>
         currExprId += 1
-        l.name -> currExprId
+        l.exprId -> currExprId
     }).toMap
 
     val cleaned = this.transformUp {
-      case l: NamedLambdaVariable if argumentMap.contains(l.name) =>
-        val newExprId = argumentMap(l.name)
+      case l: NamedLambdaVariable if argumentMap.contains(l.exprId) =>
+        val newExprId = argumentMap(l.exprId)
         NamedLambdaVariable("none", l.dataType, l.nullable, exprId = ExprId(newExprId), null)
     }
     val canonicalizedChildren = cleaned.children.map(_.canonicalized)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
@@ -135,6 +135,11 @@ class HigherOrderFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper 
     TransformValues(expr, createLambda(kt, false, vt, vcn, f)).bind(validateBinding)
   }
 
+  def mapFilter(expr: Expression, f: (Expression, Expression) => Expression): Expression = {
+    val MapType(kt, vt, vcn) = expr.dataType
+    MapFilter(expr, createLambda(kt, false, vt, vcn, f)).bind(validateBinding)
+  }
+
   test("ArrayTransform") {
     val ai0 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType, containsNull = false))
     val ai1 = Literal.create(Seq[Integer](1, null, 3), ArrayType(IntegerType, containsNull = true))
@@ -218,10 +223,6 @@ class HigherOrderFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper 
   }
 
   test("MapFilter") {
-    def mapFilter(expr: Expression, f: (Expression, Expression) => Expression): Expression = {
-      val MapType(kt, vt, vcn) = expr.dataType
-      MapFilter(expr, createLambda(kt, false, vt, vcn, f)).bind(validateBinding)
-    }
     val mii0 = Literal.create(Map(1 -> 0, 2 -> 10, 3 -> -1),
       MapType(IntegerType, IntegerType, valueContainsNull = false))
     val mii1 = Literal.create(Map(1 -> null, 2 -> 10, 3 -> null),
@@ -734,5 +735,101 @@ class HigherOrderFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper 
       Seq("[4, 6, 8]", null, null))
     checkEvaluation(zip_with(aai1, aai1, (a1, a2) => Cast(transform(a1, plusOne), StringType)),
       Seq("[2, 3, 4]", null, "[5, 6]"))
+  }
+
+  test("semanticEquals between ArrayAggregate") {
+    val ai0 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType, containsNull = false))
+    val ai1 = Literal.create(Seq[Integer](1, null, 3), ArrayType(IntegerType, containsNull = true))
+    val ai2 = Literal.create(Seq.empty[Int], ArrayType(IntegerType, containsNull = false))
+    val ain = Literal.create(null, ArrayType(IntegerType, containsNull = false))
+
+    val agg1_1 = aggregate(ai0, 0, (acc, elem) => acc + elem, acc => acc * 10)
+    val agg1_2 = aggregate(ai0, 0, (acc, elem) => acc + elem, acc => Literal(10) * acc)
+    assert(agg1_1.semanticEquals(agg1_2))
+
+    val agg2_1 = aggregate(ai1, 0, (acc, elem) => acc + coalesce(elem, 0), acc => acc * 10)
+    val agg2_2 = aggregate(ai1, 0, (acc, elem) => acc + coalesce(elem, 0), acc => Literal(10) * acc)
+    assert(agg2_1.semanticEquals(agg2_2))
+
+    val agg3_1 = aggregate(ai2, 0, (acc, elem) => acc + elem, acc => acc * 10)
+    val agg3_2 = aggregate(ai2, 0, (acc, elem) => acc + elem, acc => Literal(10) * acc)
+    assert(agg3_1.semanticEquals(agg3_2))
+
+    val agg4_1 = aggregate(ain, 0, (acc, elem) => acc + elem, acc => acc * 10)
+    val agg4_2 = aggregate(ain, 0, (acc, elem) => acc + elem, acc => Literal(10) * acc)
+    assert(agg4_1.semanticEquals(agg4_2))
+
+    assert(!agg1_1.semanticEquals(agg2_1))
+    assert(!agg1_1.semanticEquals(agg3_1))
+    assert(!agg1_1.semanticEquals(agg4_1))
+  }
+
+  test("semanticEquals between ArrayTransform") {
+    val ai0 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType, containsNull = false))
+    val ai1 = Literal.create(Seq[Integer](1, null, 3), ArrayType(IntegerType, containsNull = true))
+
+    val plusOne_1: Expression => Expression = x => x + 1
+    val plusOne_2: Expression => Expression = x => Literal(1) + x
+    val plusIndex_1: (Expression, Expression) => Expression = (x, i) => x + i
+    val plusIndex_2: (Expression, Expression) => Expression = (x, i) => i + x
+
+    val trans1_1 = transform(ai0, plusOne_1)
+    val trans1_2 = transform(ai0, plusOne_2)
+    val trans1_3 = transform(ai1, plusOne_1)
+    assert(trans1_1.semanticEquals(trans1_2))
+    assert(!trans1_1.semanticEquals(trans1_3))
+
+    val trans2_1 = transform(ai0, plusIndex_1)
+    val trans2_2 = transform(ai0, plusIndex_2)
+    val trans2_3 = transform(ai1, plusIndex_1)
+    assert(trans2_1.semanticEquals(trans2_2))
+    assert(!trans2_1.semanticEquals(trans2_3))
+
+    val trans3_1 = transform(transform(ai0, plusIndex_1), plusOne_1)
+    val trans3_2 = transform(transform(ai0, plusIndex_2), plusOne_2)
+    val trans3_3 = transform(transform(ai1, plusIndex_1), plusOne_1)
+    assert(trans3_1.semanticEquals(trans3_2))
+    assert(!trans3_1.semanticEquals(trans3_3))
+  }
+
+  test("semanticEquals between ArraySort") {
+    val a0 = Literal.create(Seq(2, 1, 3), ArrayType(IntegerType))
+
+    val typeAS = ArrayType(StructType(StructField("a", IntegerType) :: Nil))
+    val arrayStruct = Literal.create(Seq(create_row(2), create_row(1)), typeAS)
+
+    assert(arraySort(a0).semanticEquals(arraySort(a0)))
+    assert(arraySort(arrayStruct).semanticEquals(arraySort(arrayStruct)))
+
+    val sort1_1 = arraySort(a0, (left, right) => UnaryMinus(ArraySort.comparator(left, right)))
+    val sort1_2 = arraySort(a0, (right, left) => UnaryMinus(ArraySort.comparator(right, left)))
+    val sort1_3 = arraySort(a0, (right, left) => UnaryMinus(ArraySort.comparator(left, right)))
+    assert(sort1_1.semanticEquals(sort1_2))
+    assert(!sort1_1.semanticEquals(sort1_3))
+  }
+
+  test("semanticEquals between MapFilter") {
+    val mii0 = Literal.create(Map(1 -> 0, 2 -> 10, 3 -> -1),
+      MapType(IntegerType, IntegerType, valueContainsNull = false))
+    val mii1 = Literal.create(Map(1 -> null, 2 -> 10, 3 -> null),
+      MapType(IntegerType, IntegerType, valueContainsNull = true))
+
+    val kGreaterThanV1: (Expression, Expression) => Expression = (k, v) => k > v
+    val kGreaterThanV2: (Expression, Expression) => Expression = (v, k) => k < v
+    val kGreaterThanV3: (Expression, Expression) => Expression = (k, v) => k < v
+
+    val mapFilter1_1 = mapFilter(mii0, kGreaterThanV1)
+    val mapFilter1_2 = mapFilter(mii0, kGreaterThanV2)
+    val mapFilter1_3 = mapFilter(mii0, kGreaterThanV3)
+    assert(mapFilter1_1.semanticEquals(mapFilter1_2))
+    assert(!mapFilter1_1.semanticEquals(mapFilter1_3))
+
+    val valueIsNull: (Expression, Expression) => Expression = (_, v) => v.isNull
+
+    val mapFilter2_1 = mapFilter(mii0, valueIsNull)
+    val mapFilter2_2 = mapFilter(mii0, valueIsNull)
+    val mapFilter2_3 = mapFilter(mii1, valueIsNull)
+    assert(mapFilter2_1.semanticEquals(mapFilter2_2))
+    assert(!mapFilter2_1.semanticEquals(mapFilter2_3))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -1134,9 +1134,9 @@ case class HashedRelationBroadcastMode(key: Seq[Expression], isNullAware: Boolea
       sizeHint: Option[Long]): HashedRelation = {
     sizeHint match {
       case Some(numRows) =>
-        HashedRelation(rows, canonicalized.key, numRows.toInt, isNullAware = isNullAware)
+        HashedRelation(rows, key, numRows.toInt, isNullAware = isNullAware)
       case None =>
-        HashedRelation(rows, canonicalized.key, isNullAware = isNullAware)
+        HashedRelation(rows, key, isNullAware = isNullAware)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch implements `canonicalized` method for `HigherOrderFunction`. Basically it canonicalizes the name of all `NamedLambdaVariable`s and their `ExprId`. The name and `ExprId` of `NamedLambdaVariable` are unque. But to compare semantic equality between `HigherOrderFunction`, we can canonicalize them.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The default `canonicalized` method does not work for `HigherOrderFunction`. It makes subexpression elimination not work for higher functions.

Manual check gen-ed code for:
```scala
val df = Seq(Seq(1, 2, 3)).toDF("a")
df.select(transform($"a", x => x + 1), transform($"a", x => x + 1)).collect()
```

The code for `transform(input[0, array<int>, true], lambdafunction((lambda x_20#19041 + 1), lambda x_20#19041, false)),transform(input[0, array<int>, true], lambdafunction((lambda x_21#19042 + 1), lambda x_21#19042, false))`, generated by `GenerateUnsafeProjection`.

Before:

```java
/* 005 */ class SpecificUnsafeProjection extends org.apache.spark.sql.catalyst.expressions.UnsafeProjection {
...
/* 028 */   public UnsafeRow apply(InternalRow i) {                                   
...
/* 034 */     Object obj_0 = ((Expression) references[0]).eval(i);                    
...
/* 062 */     Object obj_1 = ((Expression) references[1]).eval(i);                  
...
/* 093 */ }  
```

After:
```java
/* 005 */ class SpecificUnsafeProjection extends org.apache.spark.sql.catalyst.expressions.UnsafeProjection {
...
/* 031 */   public UnsafeRow apply(InternalRow i) {
...
/* 033 */     subExpr_0(i);                                                           
...
/* 086 */   private void subExpr_0(InternalRow i) {         
/* 087 */     Object obj_0 = ((Expression) references[0]).eval(i);           
/* 088 */     boolean isNull_0 = obj_0 == null;                                       
/* 089 */     ArrayData value_0 = null;
/* 090 */     if (!isNull_0) {
/* 091 */       value_0 = (ArrayData) obj_0;
/* 092 */     }
/* 093 */     subExprIsNull_0 = isNull_0;
/* 094 */     mutableStateArray_0[0] = value_0;
/* 095 */   }
/* 096 */
/* 097 */ }
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test and manual check gen-ed code.
