### PR TITLE
[SPARK-35474] Enable disallow_untyped_defs mypy check for pyspark.pandas.indexing.

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -174,9 +174,6 @@ disallow_untyped_defs = False
 [mypy-pyspark.pandas.groupby]
 disallow_untyped_defs = False
 
-[mypy-pyspark.pandas.indexing]
-disallow_untyped_defs = False
-
 [mypy-pyspark.pandas.namespace]
 disallow_untyped_defs = False
 

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -3064,25 +3064,25 @@ class Frame(object, metaclass=ABCMeta):
 
     @property
     def at(self) -> AtIndexer:
-        return AtIndexer(self)
+        return AtIndexer(self)  # type: ignore
 
     at.__doc__ = AtIndexer.__doc__
 
     @property
     def iat(self) -> iAtIndexer:
-        return iAtIndexer(self)
+        return iAtIndexer(self)  # type: ignore
 
     iat.__doc__ = iAtIndexer.__doc__
 
     @property
     def iloc(self) -> iLocIndexer:
-        return iLocIndexer(self)
+        return iLocIndexer(self)  # type: ignore
 
     iloc.__doc__ = iLocIndexer.__doc__
 
     @property
     def loc(self) -> LocIndexer:
-        return LocIndexer(self)
+        return LocIndexer(self)  # type: ignore
 
     loc.__doc__ = LocIndexer.__doc__
 

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -628,8 +628,9 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             if cond is None:
                 cond = F.lit(True)
             if limit is not None:
-                cond = cond & (self._internal.spark_frame[cast(
-                    iLocIndexer, self)._sequence_col] < F.lit(limit))
+                cond = cond & (
+                    self._internal.spark_frame[cast(iLocIndexer, self)._sequence_col] < F.lit(limit)
+                )
 
             if isinstance(value, (Series, spark.Column)):
                 if remaining_index is not None and remaining_index == 0:
@@ -686,8 +687,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                     psdf[temp_key_col] = rows_sel
                 if isinstance(value, Series):
                     psdf[temp_value_col] = value
-                psdf = psdf.sort_values(
-                    temp_natural_order).drop(temp_natural_order)  # type: ignore
+                psdf = psdf.sort_values(temp_natural_order).drop(temp_natural_order)  # type: ignore
 
                 if isinstance(rows_sel, Series):
                     rows_sel = F.col(
@@ -713,8 +713,9 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             if cond is None:
                 cond = F.lit(True)
             if limit is not None:
-                cond = cond & (self._internal.spark_frame[cast(
-                    iLocIndexer, self)._sequence_col] < F.lit(limit))
+                cond = cond & (
+                    self._internal.spark_frame[cast(iLocIndexer, self)._sequence_col] < F.lit(limit)
+                )
 
             if isinstance(value, (Series, spark.Column)):
                 if remaining_index is not None and remaining_index == 0:
@@ -1165,10 +1166,11 @@ class LocIndexer(LocIndexerLike):
         key: Optional[Tuple],
         missing_keys: Optional[List[Tuple]],
         labels: Optional[List[Tuple]] = None,
-        recursed: int = 0
-    ) -> Tuple[List[Tuple], Optional[List[spark.Column]], List[InternalField],
-               bool, Optional[Tuple]]:
-        """ Select columns from multi-index columns. """
+        recursed: int = 0,
+    ) -> Tuple[
+        List[Tuple], Optional[List[spark.Column]], List[InternalField], bool, Optional[Tuple]
+    ]:
+        """Select columns from multi-index columns."""
         assert isinstance(key, tuple)
         if labels is None:
             labels = [(label, label) for label in self._internal.column_labels]

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -1172,7 +1172,7 @@ class LocIndexer(LocIndexerLike):
         labels: Optional[List[Tuple]] = None,
         recursed: int = 0
     ) -> Tuple[List[Tuple], Optional[List[spark.Column]], List[InternalField],
-               bool, Optional[Tuple]]:
+                bool, Optional[Tuple]]:
         """ Select columns from multi-index columns. """
         assert isinstance(key, tuple)
         if labels is None:

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -81,7 +81,7 @@ class IndexerLike(object):
     @property
     def _psdf(self) -> "DataFrame":
         if self._is_df:
-            return cast(DataFrame, self._psdf_or_psser)
+            return cast("DataFrame", self._psdf_or_psser)
         else:
             assert self._is_series
             return self._psdf_or_psser._psdf
@@ -465,7 +465,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
             if isinstance(rows_sel, Series) and not same_anchor(rows_sel, self._psdf_or_psser):
                 psdf = self._psdf_or_psser.copy()
-                temp_col = verify_temp_column_name(cast(DataFrame, psdf), "__temp_col__")
+                temp_col = verify_temp_column_name(cast("DataFrame", psdf), "__temp_col__")
 
                 psdf[temp_col] = rows_sel
                 return type(self)(psdf)[psdf[temp_col], cols_sel][list(self._psdf_or_psser.columns)]

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -634,9 +634,8 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             if isinstance(value, (Series, spark.Column)):
                 if remaining_index is not None and remaining_index == 0:
                     raise ValueError(
-                        "No axis named {} for object type {}".format(
-                            key,
-                            type(value).__name__))
+                        "No axis named {} for object type {}".format(key, type(value).__name__)
+                    )
                 if isinstance(value, Series):
                     value = value.spark.column
             else:
@@ -678,12 +677,9 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 and (isinstance(self, iLocIndexer) or not same_anchor(value, self._psdf_or_psser))
             ):
                 psdf = cast(DataFrame, self._psdf_or_psser.copy())
-                temp_natural_order = verify_temp_column_name(
-                    psdf, "__temp_natural_order__")
-                temp_key_col = verify_temp_column_name(
-                    psdf, "__temp_key_col__")
-                temp_value_col = verify_temp_column_name(
-                    psdf, "__temp_value_col__")
+                temp_natural_order = verify_temp_column_name(psdf, "__temp_natural_order__")
+                temp_key_col = verify_temp_column_name(psdf, "__temp_key_col__")
+                temp_value_col = verify_temp_column_name(psdf, "__temp_value_col__")
 
                 psdf[temp_natural_order] = F.monotonically_increasing_id()
                 if isinstance(rows_sel, Series):

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -687,7 +687,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                     psdf[temp_key_col] = rows_sel
                 if isinstance(value, Series):
                     psdf[temp_value_col] = value
-                psdf = psdf.sort_values(temp_natural_order).drop(temp_natural_order)  # type: ignore
+                psdf = psdf.sort_values(temp_natural_order).drop(temp_natural_order)
 
                 if isinstance(rows_sel, Series):
                     rows_sel = F.col(
@@ -1810,7 +1810,7 @@ class iLocIndexer(LocIndexerLike):
                         )
         super().__setitem__(key, value)
         # Update again with resolved_copy to drop extra columns.
-        self._psdf._update_internal_frame(  # type: ignore
+        self._psdf._update_internal_frame(
             self._psdf._internal.resolved_copy, requires_same_anchor=False
         )
 

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 
 
 class IndexerLike(object):
-    def __init__(self, psdf_or_psser: Union["Series", "DataFrame"]) -> None:
+    def __init__(self, psdf_or_psser: Union["Series", "DataFrame"]):
         from pyspark.pandas.frame import DataFrame
         from pyspark.pandas.series import Series
 
@@ -628,15 +628,15 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             if cond is None:
                 cond = F.lit(True)
             if limit is not None:
-                cond = cond & (
-                    self._internal.
-                    spark_frame[self._sequence_col] < F.lit(limit))  # type: ignore
+                cond = cond & (self._internal.spark_frame[cast(
+                    iLocIndexer, self)._sequence_col] < F.lit(limit))
 
             if isinstance(value, (Series, spark.Column)):
                 if remaining_index is not None and remaining_index == 0:
                     raise ValueError(
-                        "No axis named {} for object type {}".format(key, type(value).__name__)
-                    )
+                        "No axis named {} for object type {}".format(
+                            key,
+                            type(value).__name__))
                 if isinstance(value, Series):
                     value = value.spark.column
             else:
@@ -677,13 +677,13 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 isinstance(value, Series)
                 and (isinstance(self, iLocIndexer) or not same_anchor(value, self._psdf_or_psser))
             ):
-                psdf = self._psdf_or_psser.copy()
+                psdf = cast(DataFrame, self._psdf_or_psser.copy())
                 temp_natural_order = verify_temp_column_name(
-                    psdf, "__temp_natural_order__")  # type: ignore
+                    psdf, "__temp_natural_order__")
                 temp_key_col = verify_temp_column_name(
-                    psdf, "__temp_key_col__")  # type: ignore
+                    psdf, "__temp_key_col__")
                 temp_value_col = verify_temp_column_name(
-                    psdf, "__temp_value_col__")  # type: ignore
+                    psdf, "__temp_value_col__")
 
                 psdf[temp_natural_order] = F.monotonically_increasing_id()
                 if isinstance(rows_sel, Series):
@@ -717,9 +717,8 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             if cond is None:
                 cond = F.lit(True)
             if limit is not None:
-                cond = cond & (
-                    self._internal.
-                    spark_frame[self._sequence_col] < F.lit(limit))  # type: ignore
+                cond = cond & (self._internal.spark_frame[cast(
+                    iLocIndexer, self)._sequence_col] < F.lit(limit))
 
             if isinstance(value, (Series, spark.Column)):
                 if remaining_index is not None and remaining_index == 0:
@@ -1172,7 +1171,7 @@ class LocIndexer(LocIndexerLike):
         labels: Optional[List[Tuple]] = None,
         recursed: int = 0
     ) -> Tuple[List[Tuple], Optional[List[spark.Column]], List[InternalField],
-                bool, Optional[Tuple]]:
+               bool, Optional[Tuple]]:
         """ Select columns from multi-index columns. """
         assert isinstance(key, tuple)
         if labels is None:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adds more type annotations in the file:
`python/pyspark/pandas/spark/indexing.py`
and fixes the mypy check failures.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We should enable more disallow_untyped_defs mypy checks.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.
This PR adds more type annotations in pandas APIs on Spark module, which can impact interaction with development tools for users.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The mypy check with a new configuration and existing tests should pass.
`./dev/lint-python`