### PR TITLE
[SPARK-35568][SQL]  Add the BroadcastExchange after re-optimizing the physical plan to fix the UnsupportedOperationException when enabling both AQE and DPP.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
@@ -57,7 +57,8 @@ case class PlanAdaptiveDynamicPruningFilters(
 
         if (canReuseExchange) {
           exchange.setLogicalLink(adaptivePlan.executedPlan.logicalLink.get)
-          val newAdaptivePlan = adaptivePlan.copy(inputPlan = exchange)
+          val newAdaptivePlan = adaptivePlan.copy(
+            inputPlan = exchange, isSubqueryBroadcastExec = true)
 
           val broadcastValues = SubqueryBroadcastExec(
             name, index, buildKeys, newAdaptivePlan)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
@@ -57,8 +57,7 @@ case class PlanAdaptiveDynamicPruningFilters(
 
         if (canReuseExchange) {
           exchange.setLogicalLink(adaptivePlan.executedPlan.logicalLink.get)
-          val newAdaptivePlan = adaptivePlan.copy(
-            inputPlan = exchange, isSubqueryBroadcastExec = true)
+          val newAdaptivePlan = adaptivePlan.copy(inputPlan = exchange)
 
           val broadcastValues = SubqueryBroadcastExec(
             name, index, buildKeys, newAdaptivePlan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1519,12 +1519,7 @@ abstract class DynamicPartitionPruningSuiteBase
         |WHERE s.country = 'DE' AND s.rn = 1
         |""".stripMargin)
 
-    checkAnswer(df,
-      Row(3, 2) ::
-      Row(3, 2) ::
-      Row(3, 2) ::
-      Row(3, 2) :: Nil
-    )
+    checkAnswer(df, Row(3, 2) :: Row(3, 2) :: Row(3, 2) :: Row(3, 2) :: Nil)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1519,8 +1519,6 @@ abstract class DynamicPartitionPruningSuiteBase
         |WHERE s.country = 'DE' AND s.rn = 1
         |""".stripMargin)
 
-    df.show()
-
     checkAnswer(df,
       Row(3, 2) ::
         Row(3, 2) ::

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1505,6 +1505,29 @@ abstract class DynamicPartitionPruningSuiteBase
       checkAnswer(df, Row(15, 15) :: Nil)
     }
   }
+
+  test("SPARK-35568: Fix UnsupportedOperationException when enabling both AQE and DPP") {
+    val df = sql(
+      """
+        |SELECT s.store_id, f.product_id
+        |FROM (SELECT DISTINCT * FROM fact_sk) f
+        |  JOIN (SELECT
+        |          *,
+        |          ROW_NUMBER() OVER (PARTITION BY store_id ORDER BY state_province DESC) AS rn
+        |        FROM dim_store) s
+        |   ON f.store_id = s.store_id
+        |WHERE s.country = 'DE' AND s.rn = 1
+        |""".stripMargin)
+
+    df.show()
+
+    checkAnswer(df,
+      Row(3, 2) ::
+        Row(3, 2) ::
+        Row(3, 2) ::
+        Row(3, 2) :: Nil
+    )
+  }
 }
 
 class DynamicPartitionPruningSuiteAEOff extends DynamicPartitionPruningSuiteBase

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1521,9 +1521,9 @@ abstract class DynamicPartitionPruningSuiteBase
 
     checkAnswer(df,
       Row(3, 2) ::
-        Row(3, 2) ::
-        Row(3, 2) ::
-        Row(3, 2) :: Nil
+      Row(3, 2) ::
+      Row(3, 2) ::
+      Row(3, 2) :: Nil
     )
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is to fix the `UnsupportedOperationException` described in [PR#32705](https://github.com/apache/spark/pull/32705).
When AQE and DPP are turned on at the same time, because the `BroadcastExchange` included in the DPP filter is not added through `EnsureRequirement` rule, Therefore, when AQE optimizes the DPP filter, there is no way to add `BroadcastExchange` through the `EnsureRequirement` rule in `reOptimize` method, which eventually leads to the loss of `BroadcastExchange` in the final physical plan. This PR adds `BroadcastExchange` node in the `reOptimize` method if the current plan is DPP filter.
### Why are the changes needed?
bug fix

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
adding new ut
