### PR TITLE
[SPARK-34808][SQL][FOLLOWUP] Remove canPlanAsBroadcastHashJoin check in EliminateOuterJoin

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -171,17 +171,17 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
       val newJoinType = buildNewJoinType(f, j)
       if (j.joinType == newJoinType) f else Filter(condition, j.copy(joinType = newJoinType))
 
-    case a @ Aggregate(_, _, join @ Join(left, _, LeftOuter, _, _))
-        if a.isDistinct && a.references.subsetOf(AttributeSet(left.output)) =>
+    case a @ Aggregate(_, _, Join(left, _, LeftOuter, _, _))
+        if a.groupOnly && a.references.subsetOf(AttributeSet(left.output)) =>
       a.copy(child = left)
-    case a @ Aggregate(_, _, join @ Join(_, right, RightOuter, _, _))
-        if a.isDistinct && a.references.subsetOf(AttributeSet(right.output)) =>
+    case a @ Aggregate(_, _, Join(_, right, RightOuter, _, _))
+        if a.groupOnly && a.references.subsetOf(AttributeSet(right.output)) =>
       a.copy(child = right)
-    case a @ Aggregate(_, _, p @ Project(_, join @ Join(left, _, LeftOuter, _, _)))
-        if a.isDistinct && a.references.subsetOf(AttributeSet(left.output)) =>
+    case a @ Aggregate(_, _, p @ Project(_, Join(left, _, LeftOuter, _, _)))
+        if a.groupOnly && a.references.subsetOf(AttributeSet(left.output)) =>
       a.copy(child = p.copy(child = left))
-    case a @ Aggregate(_, _, p @ Project(_, join @ Join(_, right, RightOuter, _, _)))
-        if a.isDistinct && a.references.subsetOf(AttributeSet(right.output)) =>
+    case a @ Aggregate(_, _, p @ Project(_, Join(_, right, RightOuter, _, _)))
+        if a.groupOnly && a.references.subsetOf(AttributeSet(right.output)) =>
       a.copy(child = p.copy(child = right))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -132,7 +132,7 @@ object ReorderJoin extends Rule[LogicalPlan] with PredicateHelper {
  *
  * This rule should be executed before pushing down the Filter
  */
-object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper with JoinSelectionHelper {
+object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
 
   /**
    * Returns whether the expression returns null or false when all inputs are nulls.
@@ -172,20 +172,16 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper with Jo
       if (j.joinType == newJoinType) f else Filter(condition, j.copy(joinType = newJoinType))
 
     case a @ Aggregate(_, _, join @ Join(left, _, LeftOuter, _, _))
-        if a.isDistinct && a.references.subsetOf(AttributeSet(left.output)) &&
-          !canPlanAsBroadcastHashJoin(join, conf) =>
+        if a.isDistinct && a.references.subsetOf(AttributeSet(left.output)) =>
       a.copy(child = left)
     case a @ Aggregate(_, _, join @ Join(_, right, RightOuter, _, _))
-        if a.isDistinct && a.references.subsetOf(AttributeSet(right.output)) &&
-          !canPlanAsBroadcastHashJoin(join, conf) =>
+        if a.isDistinct && a.references.subsetOf(AttributeSet(right.output)) =>
       a.copy(child = right)
     case a @ Aggregate(_, _, p @ Project(_, join @ Join(left, _, LeftOuter, _, _)))
-        if a.isDistinct && a.references.subsetOf(AttributeSet(left.output)) &&
-          !canPlanAsBroadcastHashJoin(join, conf) =>
+        if a.isDistinct && a.references.subsetOf(AttributeSet(left.output)) =>
       a.copy(child = p.copy(child = left))
     case a @ Aggregate(_, _, p @ Project(_, join @ Join(_, right, RightOuter, _, _)))
-        if a.isDistinct && a.references.subsetOf(AttributeSet(right.output)) &&
-          !canPlanAsBroadcastHashJoin(join, conf) =>
+        if a.isDistinct && a.references.subsetOf(AttributeSet(right.output)) =>
       a.copy(child = p.copy(child = right))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -888,8 +888,8 @@ case class Aggregate(
   override protected def withNewChildInternal(newChild: LogicalPlan): Aggregate =
     copy(child = newChild)
 
-  // Whether this Aggregate operator is equally the Distinct operator.
-  private[sql] def isDistinct: Boolean = {
+  // Whether this Aggregate operator is group only. For example: SELECT a, a FROM t GROUP BY a
+  private[sql] def groupOnly: Boolean = {
     aggregateExpressions.forall(a => groupingExpressions.exists(g => a.semanticEquals(g)))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.{LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Distinct, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
-import org.apache.spark.sql.internal.SQLConf.{AUTO_BROADCASTJOIN_THRESHOLD, CASE_SENSITIVE, GROUP_BY_ORDINAL}
+import org.apache.spark.sql.internal.SQLConf.{CASE_SENSITIVE, GROUP_BY_ORDINAL}
 
 class AggregateOptimizeSuite extends AnalysisTest {
   val analyzer = getAnalyzer
@@ -79,34 +79,18 @@ class AggregateOptimizeSuite extends AnalysisTest {
     val x = testRelation.subquery('x)
     val y = testRelation.subquery('y)
     val query = Distinct(x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr)).select("x.b".attr))
+    val correctAnswer = x.select("x.b".attr).groupBy("x.b".attr)("x.b".attr)
 
-    Seq(-1, 10000).foreach { autoBroadcastJoinThreshold =>
-      withSQLConf(AUTO_BROADCASTJOIN_THRESHOLD.key -> s"$autoBroadcastJoinThreshold") {
-        val correctAnswer = if (autoBroadcastJoinThreshold < 0) {
-          x.select("x.b".attr).groupBy("x.b".attr)("x.b".attr)
-        } else {
-          Aggregate(query.child.output, query.child.output, query.child)
-        }
-        comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze)
-      }
-    }
+    comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze)
   }
 
   test("SPARK-34808: Remove right join if it only has distinct on right side") {
     val x = testRelation.subquery('x)
     val y = testRelation.subquery('y)
     val query = Distinct(x.join(y, RightOuter, Some("x.a".attr === "y.a".attr)).select("y.b".attr))
+    val correctAnswer = y.select("y.b".attr).groupBy("y.b".attr)("y.b".attr)
 
-    Seq(-1, 10000).foreach { autoBroadcastJoinThreshold =>
-      withSQLConf(AUTO_BROADCASTJOIN_THRESHOLD.key -> s"$autoBroadcastJoinThreshold") {
-        val correctAnswer = if (autoBroadcastJoinThreshold < 0) {
-          y.select("y.b".attr).groupBy("y.b".attr)("y.b".attr)
-        } else {
-          Aggregate(query.child.output, query.child.output, query.child)
-        }
-        comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze)
-      }
-    }
+    comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze)
   }
 
   test("SPARK-34808: Should not remove left join if select 2 join sides") {
@@ -114,37 +98,31 @@ class AggregateOptimizeSuite extends AnalysisTest {
     val y = testRelation.subquery('y)
     val query = Distinct(x.join(y, RightOuter, Some("x.a".attr === "y.a".attr))
       .select("x.b".attr, "y.c".attr))
+    val correctAnswer = Aggregate(query.child.output, query.child.output, query.child)
 
-    Seq(-1, 10000).foreach { autoBroadcastJoinThreshold =>
-      withSQLConf(AUTO_BROADCASTJOIN_THRESHOLD.key -> s"$autoBroadcastJoinThreshold") {
-        val correctAnswer = Aggregate(query.child.output, query.child.output, query.child)
-        comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze)
-      }
-    }
+    comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze)
   }
 
   test("SPARK-34808: aggregateExpressions only contains groupingExpressions") {
     val x = testRelation.subquery('x)
     val y = testRelation.subquery('y)
-    withSQLConf(AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-      comparePlans(
-        Optimize.execute(
-          Distinct(x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr))
-            .select("x.b".attr, "x.b".attr)).analyze),
-        x.select("x.b".attr, "x.b".attr).groupBy("x.b".attr)("x.b".attr, "x.b".attr).analyze)
+    comparePlans(
+      Optimize.execute(
+        Distinct(x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr))
+          .select("x.b".attr, "x.b".attr)).analyze),
+      x.select("x.b".attr, "x.b".attr).groupBy("x.b".attr)("x.b".attr, "x.b".attr).analyze)
 
-      comparePlans(
-        Optimize.execute(
-          x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr))
-            .groupBy("x.a".attr, "x.b".attr)("x.b".attr, "x.a".attr).analyze),
-        x.groupBy("x.a".attr, "x.b".attr)("x.b".attr, "x.a".attr).analyze)
-
-      comparePlans(
-        Optimize.execute(
-          x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr))
-            .groupBy("x.a".attr)("x.a".attr, Literal(1)).analyze),
+    comparePlans(
+      Optimize.execute(
         x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr))
-          .groupBy("x.a".attr)("x.a".attr, Literal(1)).analyze)
-    }
+          .groupBy("x.a".attr, "x.b".attr)("x.b".attr, "x.a".attr).analyze),
+      x.groupBy("x.a".attr, "x.b".attr)("x.b".attr, "x.a".attr).analyze)
+
+    comparePlans(
+      Optimize.execute(
+        x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr))
+          .groupBy("x.a".attr)("x.a".attr, Literal(1)).analyze),
+      x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr))
+        .groupBy("x.a".attr)("x.a".attr, Literal(1)).analyze)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes `canPlanAsBroadcastHashJoin` check in `EliminateOuterJoin.

### Why are the changes needed?

We can always removes outer join if it only has DISTINCT on streamed side.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.