### PR TITLE
[SPARK-35611][SS] Introduce the strategy on mismatched offset for start offset timestamp on Kafka data source

### DIFF
--- a/docs/structured-streaming-kafka-integration.md
+++ b/docs/structured-streaming-kafka-integration.md
@@ -369,7 +369,7 @@ The following configurations are optional:
   <td>streaming and batch</td>
   <td>The start point of timestamp when a query is started, a string specifying a starting timestamp for
   all partitions in topics being subscribed. Please refer the details on timestamp offset options below. If Kafka doesn't return the matched offset,
-  the query will fail immediately to prevent unintended read from such partition. (This is a kind of limitation as of now, and will be addressed in near future.)<p/>
+  the behavior will follow to the value of the option <code>startingOffsetsByTimestampStrategy</code><p/>
   <p/>
   Note1: <code>startingTimestamp</code> takes precedence over <code>startingOffsetsByTimestamp</code> and <code>startingOffsets</code>.<p/>
   Note2: For streaming queries, this only applies when a new query is started, and that resuming will
@@ -385,7 +385,7 @@ The following configurations are optional:
   <td>streaming and batch</td>
   <td>The start point of timestamp when a query is started, a json string specifying a starting timestamp for
   each TopicPartition. Please refer the details on timestamp offset options below. If Kafka doesn't return the matched offset,
-  the query will fail immediately to prevent unintended read from such partition. (This is a kind of limitation as of now, and will be addressed in near future.)<p/>
+  the behavior will follow to the value of the option <code>startingOffsetsByTimestampStrategy</code><p/>
   <p/>
   Note1: <code>startingOffsetsByTimestamp</code> takes precedence over <code>startingOffsets</code>.<p/>
   Note2: For streaming queries, this only applies when a new query is started, and that resuming will
@@ -523,6 +523,16 @@ The following configurations are optional:
   <td>false</td>
   <td>streaming and batch</td>
   <td>Whether to include the Kafka headers in the row.</td>
+</tr>
+<tr>
+  <td>startingOffsetsByTimestampStrategy</td>
+  <td>"error" or "latest"</td>
+  <td>"error"</td>
+  <td>streaming and batch</td>
+  <td>Defines the behavior when the starting offset by timestamp is specified (either global or per partition), and Kafka doesn't return the matched offset.<p/>
+  <p/>
+  "error": fail the query.<p/>
+  "latest": set the offset to the latest, so that further new records in the partition are being read.<p/></td>
 </tr>
 </table>
 

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaContinuousStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaContinuousStream.scala
@@ -70,10 +70,10 @@ class KafkaContinuousStream(
       case EarliestOffsetRangeLimit => KafkaSourceOffset(offsetReader.fetchEarliestOffsets())
       case LatestOffsetRangeLimit => KafkaSourceOffset(offsetReader.fetchLatestOffsets(None))
       case SpecificOffsetRangeLimit(p) => offsetReader.fetchSpecificOffsets(p, reportDataLoss)
-      case SpecificTimestampRangeLimit(p) => offsetReader.fetchSpecificTimestampBasedOffsets(p,
-        failsOnNoMatchingOffset = true)
-      case GlobalTimestampRangeLimit(ts) => offsetReader.fetchGlobalTimestampBasedOffsets(
-        ts, failsOnNoMatchingOffset = true)
+      case SpecificTimestampRangeLimit(p, strategy) =>
+        offsetReader.fetchSpecificTimestampBasedOffsets(p, isStartingOffsets = true, strategy)
+      case GlobalTimestampRangeLimit(ts, strategy) =>
+        offsetReader.fetchGlobalTimestampBasedOffsets(ts, isStartingOffsets = true, strategy)
     }
     logInfo(s"Initial offsets: $offsets")
     offsets

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -164,10 +164,12 @@ private[kafka010] class KafkaMicroBatchStream(
           KafkaSourceOffset(kafkaOffsetReader.fetchLatestOffsets(None))
         case SpecificOffsetRangeLimit(p) =>
           kafkaOffsetReader.fetchSpecificOffsets(p, reportDataLoss)
-        case SpecificTimestampRangeLimit(p) =>
-          kafkaOffsetReader.fetchSpecificTimestampBasedOffsets(p, failsOnNoMatchingOffset = true)
-        case GlobalTimestampRangeLimit(ts) =>
-          kafkaOffsetReader.fetchGlobalTimestampBasedOffsets(ts, failsOnNoMatchingOffset = true)
+        case SpecificTimestampRangeLimit(p, strategy) =>
+          kafkaOffsetReader.fetchSpecificTimestampBasedOffsets(p,
+            isStartingOffsets = true, strategy)
+        case GlobalTimestampRangeLimit(ts, strategy) =>
+          kafkaOffsetReader.fetchGlobalTimestampBasedOffsets(ts,
+            isStartingOffsets = true, strategy)
       }
       metadataLog.add(0, offsets)
       logInfo(s"Initial offsets: $offsets")

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetRangeLimit.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetRangeLimit.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.kafka010
 
 import org.apache.kafka.common.TopicPartition
 
+import org.apache.spark.sql.kafka010.KafkaSourceProvider.StrategyOnNoMatchStartingOffset
+
 /**
  * Objects that represent desired offset range limits for starting,
  * ending, and specific offsets.
@@ -47,14 +49,18 @@ private[kafka010] case class SpecificOffsetRangeLimit(
  * greater than specific timestamp.
  */
 private[kafka010] case class SpecificTimestampRangeLimit(
-    topicTimestamps: Map[TopicPartition, Long]) extends KafkaOffsetRangeLimit
+    topicTimestamps: Map[TopicPartition, Long],
+    strategyOnNoMatchingStartingOffset: StrategyOnNoMatchStartingOffset.Value)
+  extends KafkaOffsetRangeLimit
 
 /**
  * Represents the desire to bind to earliest offset which timestamp for the offset is equal or
  * greater than specific timestamp. This applies the timestamp to the all topics/partitions.
  */
 private[kafka010] case class GlobalTimestampRangeLimit(
-    timestamp: Long) extends KafkaOffsetRangeLimit
+    timestamp: Long,
+    strategyOnNoMatchingStartingOffset: StrategyOnNoMatchStartingOffset.Value)
+  extends KafkaOffsetRangeLimit
 
 private[kafka010] object KafkaOffsetRangeLimit {
   /**

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderConsumer.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderConsumer.scala
@@ -30,6 +30,7 @@ import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.ExecutorCacheTaskLocation
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.kafka010.KafkaSourceProvider.StrategyOnNoMatchStartingOffset
 import org.apache.spark.util.{UninterruptibleThread, UninterruptibleThreadRunner}
 
 /**
@@ -157,12 +158,12 @@ private[kafka010] class KafkaOffsetReaderConsumer(
       }.toMap
       case SpecificOffsetRangeLimit(partitionOffsets) =>
         validateTopicPartitions(partitions, partitionOffsets)
-      case SpecificTimestampRangeLimit(partitionTimestamps) =>
+      case SpecificTimestampRangeLimit(partitionTimestamps, strategy) =>
         fetchSpecificTimestampBasedOffsets(partitionTimestamps,
-          failsOnNoMatchingOffset = isStartingOffsets).partitionToOffsets
-      case GlobalTimestampRangeLimit(timestamp) =>
+          isStartingOffsets, strategy).partitionToOffsets
+      case GlobalTimestampRangeLimit(timestamp, strategy) =>
         fetchGlobalTimestampBasedOffsets(timestamp,
-          failsOnNoMatchingOffset = isStartingOffsets).partitionToOffsets
+          isStartingOffsets, strategy).partitionToOffsets
     }
   }
 
@@ -200,7 +201,10 @@ private[kafka010] class KafkaOffsetReaderConsumer(
 
   override def fetchSpecificTimestampBasedOffsets(
       partitionTimestamps: Map[TopicPartition, Long],
-      failsOnNoMatchingOffset: Boolean): KafkaSourceOffset = {
+      isStartingOffsets: Boolean,
+      strategyOnNoMatchStartingOffset: StrategyOnNoMatchStartingOffset.Value)
+    : KafkaSourceOffset = {
+
     val fnAssertParametersWithPartitions: ju.Set[TopicPartition] => Unit = { partitions =>
       assert(partitions.asScala == partitionTimestamps.keySet,
         "If starting/endingOffsetsByTimestamp contains specific offsets, you must specify all " +
@@ -208,27 +212,19 @@ private[kafka010] class KafkaOffsetReaderConsumer(
       logDebug(s"Partitions assigned to consumer: $partitions. Seeking to $partitionTimestamps")
     }
 
-    val fnRetrievePartitionOffsets: ju.Set[TopicPartition] => Map[TopicPartition, Long] = { _ => {
-        val converted = partitionTimestamps.map { case (tp, timestamp) =>
-          tp -> java.lang.Long.valueOf(timestamp)
-        }.asJava
+    val fnRetrievePartitionOffsets: ju.Set[TopicPartition] => Map[TopicPartition, Long] = { _ =>
+      val converted = partitionTimestamps.map { case (tp, timestamp) =>
+        tp -> java.lang.Long.valueOf(timestamp)
+      }.asJava
 
-        val offsetForTime: ju.Map[TopicPartition, OffsetAndTimestamp] =
-          consumer.offsetsForTimes(converted)
+      val offsetForTime: ju.Map[TopicPartition, OffsetAndTimestamp] =
+        consumer.offsetsForTimes(converted)
 
-        offsetForTime.asScala.map { case (tp, offsetAndTimestamp) =>
-          if (failsOnNoMatchingOffset) {
-            assert(offsetAndTimestamp != null, "No offset matched from request of " +
-              s"topic-partition $tp and timestamp ${partitionTimestamps(tp)}.")
-          }
-
-          if (offsetAndTimestamp == null) {
-            tp -> KafkaOffsetRangeLimit.LATEST
-          } else {
-            tp -> offsetAndTimestamp.offset()
-          }
-        }.toMap
-      }
+      readTimestampOffsets(
+        offsetForTime.asScala.toMap,
+        isStartingOffsets,
+        strategyOnNoMatchStartingOffset,
+        partitionTimestamps)
     }
 
     val fnAssertFetchedOffsets: Map[TopicPartition, Long] => Unit = { _ => }
@@ -239,7 +235,10 @@ private[kafka010] class KafkaOffsetReaderConsumer(
 
   override def fetchGlobalTimestampBasedOffsets(
       timestamp: Long,
-      failsOnNoMatchingOffset: Boolean): KafkaSourceOffset = {
+      isStartingOffsets: Boolean,
+      strategyOnNoMatchStartingOffset: StrategyOnNoMatchStartingOffset.Value)
+    : KafkaSourceOffset = {
+
     val fnAssertParametersWithPartitions: ju.Set[TopicPartition] => Unit = { partitions =>
       logDebug(s"Partitions assigned to consumer: $partitions. Seeking to $timestamp")
     }
@@ -250,24 +249,46 @@ private[kafka010] class KafkaOffsetReaderConsumer(
       val offsetForTime: ju.Map[TopicPartition, OffsetAndTimestamp] =
         consumer.offsetsForTimes(converted)
 
-      offsetForTime.asScala.map { case (tp, offsetAndTimestamp) =>
-        if (failsOnNoMatchingOffset) {
-          assert(offsetAndTimestamp != null, "No offset matched from request of " +
-            s"topic-partition $tp and timestamp $timestamp.")
-        }
-
-        if (offsetAndTimestamp == null) {
-          tp -> KafkaOffsetRangeLimit.LATEST
-        } else {
-          tp -> offsetAndTimestamp.offset()
-        }
-      }.toMap
+      readTimestampOffsets(
+        offsetForTime.asScala.toMap,
+        isStartingOffsets,
+        strategyOnNoMatchStartingOffset,
+        _ => timestamp)
     }
 
     val fnAssertFetchedOffsets: Map[TopicPartition, Long] => Unit = { _ => }
 
     fetchSpecificOffsets0(fnAssertParametersWithPartitions, fnRetrievePartitionOffsets,
       fnAssertFetchedOffsets)
+  }
+
+  private def readTimestampOffsets(
+      tpToOffsetMap: Map[TopicPartition, OffsetAndTimestamp],
+      isStartingOffsets: Boolean,
+      strategyOnNoMatchStartingOffset: StrategyOnNoMatchStartingOffset.Value,
+      partitionTimestampFn: TopicPartition => Long): Map[TopicPartition, Long] = {
+
+    tpToOffsetMap.map { case (tp, offsetSpec) =>
+      val offset = if (offsetSpec == null) {
+        if (isStartingOffsets) {
+          strategyOnNoMatchStartingOffset match {
+            case StrategyOnNoMatchStartingOffset.ERROR =>
+              throw new IllegalArgumentException("No offset " +
+                s"matched from request of topic-partition $tp and timestamp " +
+                s"${partitionTimestampFn(tp)}.")
+
+            case StrategyOnNoMatchStartingOffset.LATEST =>
+              KafkaOffsetRangeLimit.LATEST
+          }
+        } else {
+          KafkaOffsetRangeLimit.LATEST
+        }
+      } else {
+        offsetSpec.offset()
+      }
+
+      tp -> offset
+    }.toMap
   }
 
   private def fetchSpecificOffsets0(

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderConsumer.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderConsumer.scala
@@ -273,9 +273,12 @@ private[kafka010] class KafkaOffsetReaderConsumer(
         if (isStartingOffsets) {
           strategyOnNoMatchStartingOffset match {
             case StrategyOnNoMatchStartingOffset.ERROR =>
-              throw new IllegalArgumentException("No offset " +
+              // This is to match the old behavior - we used assert to check the condition.
+              // scalastyle:off throwerror
+              throw new AssertionError("No offset " +
                 s"matched from request of topic-partition $tp and timestamp " +
                 s"${partitionTimestampFn(tp)}.")
+              // scalastyle:on throwerror
 
             case StrategyOnNoMatchStartingOffset.LATEST =>
               KafkaOffsetRangeLimit.LATEST

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -102,10 +102,10 @@ private[kafka010] class KafkaSource(
         case EarliestOffsetRangeLimit => KafkaSourceOffset(kafkaReader.fetchEarliestOffsets())
         case LatestOffsetRangeLimit => KafkaSourceOffset(kafkaReader.fetchLatestOffsets(None))
         case SpecificOffsetRangeLimit(p) => kafkaReader.fetchSpecificOffsets(p, reportDataLoss)
-        case SpecificTimestampRangeLimit(p) =>
-          kafkaReader.fetchSpecificTimestampBasedOffsets(p, failsOnNoMatchingOffset = true)
-        case GlobalTimestampRangeLimit(ts) =>
-          kafkaReader.fetchGlobalTimestampBasedOffsets(ts, failsOnNoMatchingOffset = true)
+        case SpecificTimestampRangeLimit(p, strategy) =>
+          kafkaReader.fetchSpecificTimestampBasedOffsets(p, isStartingOffsets = true, strategy)
+        case GlobalTimestampRangeLimit(ts, strategy) =>
+          kafkaReader.fetchGlobalTimestampBasedOffsets(ts, isStartingOffsets = true, strategy)
       }
       metadataLog.add(0, offsets)
       logInfo(s"Initial offsets: $offsets")

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -538,8 +538,14 @@ private[kafka010] object KafkaSourceProvider extends Logging {
   private[kafka010] val FETCH_OFFSET_NUM_RETRY = "fetchoffset.numretries"
   private[kafka010] val FETCH_OFFSET_RETRY_INTERVAL_MS = "fetchoffset.retryintervalms"
   private[kafka010] val CONSUMER_POLL_TIMEOUT = "kafkaconsumer.polltimeoutms"
+  private[kafka010] val STARTING_OFFSETS_BY_TIMESTAMP_STRATEGY_KEY =
+    "startingoffsetsbytimestampstrategy"
   private val GROUP_ID_PREFIX = "groupidprefix"
   private[kafka010] val INCLUDE_HEADERS = "includeheaders"
+
+  private[kafka010] object StrategyOnNoMatchStartingOffset extends Enumeration {
+    val ERROR, LATEST = Value
+  }
 
   val TOPIC_OPTION_KEY = "topic"
 
@@ -581,12 +587,16 @@ private[kafka010] object KafkaSourceProvider extends Logging {
       defaultOffsets: KafkaOffsetRangeLimit): KafkaOffsetRangeLimit = {
     // The order below represents "preferences"
 
+    val strategyOnNoMatchStartingOffset = params.get(STARTING_OFFSETS_BY_TIMESTAMP_STRATEGY_KEY)
+      .map(v => StrategyOnNoMatchStartingOffset.withName(v.toUpperCase(Locale.ROOT)))
+      .getOrElse(StrategyOnNoMatchStartingOffset.ERROR)
+
     if (params.contains(globalOffsetTimestampOptionKey)) {
       // 1. global timestamp
       val tsStr = params(globalOffsetTimestampOptionKey).trim
       try {
         val ts = tsStr.toLong
-        GlobalTimestampRangeLimit(ts)
+        GlobalTimestampRangeLimit(ts, strategyOnNoMatchStartingOffset)
       } catch {
         case _: NumberFormatException =>
           throw new IllegalArgumentException(s"Expected a single long value, got $tsStr")
@@ -594,7 +604,8 @@ private[kafka010] object KafkaSourceProvider extends Logging {
     } else if (params.contains(offsetByTimestampOptionKey)) {
       // 2. timestamp per topic partition
       val json = params(offsetByTimestampOptionKey).trim
-      SpecificTimestampRangeLimit(JsonUtils.partitionTimestamps(json))
+      SpecificTimestampRangeLimit(JsonUtils.partitionTimestamps(json),
+        strategyOnNoMatchStartingOffset)
     } else {
       // 3. latest/earliest/offset
       params.get(offsetOptionKey).map(_.trim) match {

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -1143,7 +1143,6 @@ class KafkaMicroBatchV2SourceWithAdminSuite extends KafkaMicroBatchV2SourceSuite
 }
 
 class KafkaMicroBatchV1SourceSuite extends KafkaMicroBatchSourceSuiteBase {
-
   override def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set(
@@ -1511,7 +1510,7 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
       s" (failOnDataLoss: $failOnDataLoss)") {
       val topic = newTopic()
       testFromGlobalTimestamp(topic, failOnDataLoss = failOnDataLoss, addPartitions = true,
-      "subscribe" -> topic)
+        "subscribe" -> topic)
     }
 
     test(s"subscribing topic by pattern from latest offsets (failOnDataLoss: $failOnDataLoss)") {
@@ -1547,7 +1546,6 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
       s"(failOnDataLoss: $failOnDataLoss)") {
       val topicPrefix = newTopic()
       val topic = topicPrefix + "-suffix"
-
       testFromSpecificTimestamps(
         topic,
         failOnDataLoss = failOnDataLoss,
@@ -1559,7 +1557,6 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
       s"(failOnDataLoss: $failOnDataLoss)") {
       val topicPrefix = newTopic()
       val topic = topicPrefix + "-suffix"
-
       testFromGlobalTimestamp(
         topic,
         failOnDataLoss = failOnDataLoss,
@@ -1583,7 +1580,6 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
     "non-matching starting offset") {
     val topicPrefix = newTopic()
     val topic = topicPrefix + "-suffix"
-
     testFromSpecificTimestampsWithNoMatchingStartingOffset(topic,
       "subscribePattern" -> s"$topicPrefix-.*")
   }
@@ -1592,14 +1588,13 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
     "non-matching starting offset") {
     val topicPrefix = newTopic()
     val topic = topicPrefix + "-suffix"
-
     testFromGlobalTimestampWithNoMatchingStartingOffset(topic,
       "subscribePattern" -> s"$topicPrefix-.*")
   }
 
   private def testFromSpecificTimestampsWithNoMatchingStartingOffset(
-    topic: String,
-    options: (String, String)*): Unit = {
+      topic: String,
+      options: (String, String)*): Unit = {
     testUtils.createTopic(topic, partitions = 5)
 
     val firstTimestamp = System.currentTimeMillis() - 5000
@@ -1648,8 +1643,8 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
   }
 
   private def testFromGlobalTimestampWithNoMatchingStartingOffset(
-    topic: String,
-    options: (String, String)*): Unit = {
+      topic: String,
+      options: (String, String)*): Unit = {
     testUtils.createTopic(topic, partitions = 5)
 
     val firstTimestamp = System.currentTimeMillis() - 5000
@@ -1903,7 +1898,6 @@ abstract class KafkaSourceSuiteBase extends KafkaSourceTest {
     val firstTimestamp = System.currentTimeMillis() - 5000
     val secondTimestamp = firstTimestamp + 1000
     setupTestMessagesForTestOnTimestampOffsets(topic, firstTimestamp, secondTimestamp)
-
     // here we should add records in partition 4 which match with second timestamp
     // as the query will break if there's no matching records
     sendMessagesWithTimestamp(topic, Array(23, 24).map(_.toString), 4, secondTimestamp)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to introduce the strategy on mismatched offset for start offset timestamp on Kafka data source.

Please read the section `Why are the changes needed?` to understand the rationalization of the functionality.

This would be pretty much helpful for the case where there's a skew between partitions and some partitions have older records.

* AS-IS: Spark simply fails the query and end users have to deal with workarounds requiring manual steps.
* TO-BE: Spark will assign the latest offset for these partitions, so that Spark can read newer records from these partitions in further micro-batches.

To retain the existing behavior and also give some help for the proposed "TO-BE" behavior, we'd like to introduce the strategy on mismatched offset for start offset timestamp to let end users choose from them.

The strategy will be added as source option, to ensure end users set the behavior explicitly (otherwise simply "known" default value).

* New source option to be added: startingOffsetsByTimestampStrategy
* Available values: `error` (fail the query as referred as AS-IS), `latest` (set the offset to the latest as referred as TO-BE)

Doc changes are following:

![ES-106042-doc-screenshot-1](https://user-images.githubusercontent.com/1317309/120472697-2c1ba800-c3e1-11eb-884f-f28152168053.png)
![ES-106042-doc-screenshot-2](https://user-images.githubusercontent.com/1317309/120472719-33db4c80-c3e1-11eb-9851-939be8a3ddb7.png)


### Why are the changes needed?

We encountered a real-world case Spark fails the query if some of the partitions don't have matching offset by timestamp.

This is intended behavior to avoid bring unintended output for some cases like:

* timestamp 2 is presented as timestamp-offset, but the some of partitions don't have the record yet
* record with timestamp 1 comes "later" in the following micro-batch

which is possible since Kafka allows to specify the timestamp in record.

Here the unintended output we talked about was the risk of reading record with timestamp 1 in the next micro-batch despite the option specifying timestamp 2.

But for many cases end users just suppose timestamp is increasing monotonically with wall clocks are all in sync, and current behavior blocks these cases to make progress.

### Does this PR introduce _any_ user-facing change?

Yes, but not a breaking change. It's up to end users to choose the behavior which the default value is "error" (current behavior). And it's a source option (not config) so they need to explicitly set the behavior to let the functionality takes effect.

### How was this patch tested?

New UTs.