### PR TITLE
[SPARK-34859][SQL] Handle column index when using vectorized Parquet reader

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
@@ -26,8 +26,15 @@ import java.util.PrimitiveIterator;
  * Helper class to store intermediate state while reading a Parquet column chunk.
  */
 final class ParquetReadState {
+  /** A special row range used when there is no row indexes (hence all rows must be included) */
   private static final RowRange MAX_ROW_RANGE = new RowRange(Long.MIN_VALUE, Long.MAX_VALUE);
-  private static final RowRange MIN_ROW_RANGE = new RowRange(Long.MAX_VALUE, Long.MIN_VALUE);
+
+  /**
+   * A special row range used when the row indexes are present AND all the row ranges have been
+   * processed. This serves as a sentinel at the end indicating that all rows come after the last
+   * row range should be skipped.
+   */
+  private static final RowRange END_ROW_RANGE = new RowRange(Long.MAX_VALUE, Long.MIN_VALUE);
 
   /** Iterator over all row ranges, only not-null if column index is present */
   private final Iterator<RowRange> rowRanges;
@@ -133,7 +140,7 @@ final class ParquetReadState {
     if (rowRanges == null) {
       currentRange = MAX_ROW_RANGE;
     } else if (!rowRanges.hasNext()) {
-      currentRange = MIN_ROW_RANGE;
+      currentRange = END_ROW_RANGE;
     } else {
       currentRange = rowRanges.next();
     }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
@@ -69,15 +69,14 @@ final class ParquetReadState {
 
     while (rowIndexes.hasNext()) {
       long idx = rowIndexes.nextLong();
-      if (previous == Long.MIN_VALUE) {
-        currentStart = previous = idx;
+      if (currentStart == Long.MIN_VALUE) {
+        currentStart = idx;
       } else if (previous + 1 != idx) {
         RowRange range = new RowRange(currentStart, previous);
         rowRanges.add(range);
-        currentStart = previous = idx;
-      } else {
-        previous = idx;
+        currentStart = idx;
       }
+      previous = idx;
     }
 
     if (previous != Long.MIN_VALUE) {
@@ -133,12 +132,10 @@ final class ParquetReadState {
   void nextRange() {
     if (rowRanges == null) {
       currentRange = MAX_ROW_RANGE;
+    } else if (!rowRanges.hasNext()) {
+      currentRange = MIN_ROW_RANGE;
     } else {
-      if (!rowRanges.hasNext()) {
-        currentRange = MIN_ROW_RANGE;
-      } else {
-        currentRange = rowRanges.next();
-      }
+      currentRange = rowRanges.next();
     }
   }
 
@@ -146,8 +143,8 @@ final class ParquetReadState {
    * Helper struct to represent a range of row indexes `[start, end]`.
    */
   private static class RowRange {
-    long start;
-    long end;
+    final long start;
+    final long end;
 
     RowRange(long start, long end) {
       this.start = start;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
@@ -57,10 +57,15 @@ final class ParquetReadState {
     nextRange();
   }
 
+  /**
+   * Construct a list of row ranges from the given `rowIndexes`. For example, suppose the
+   * `rowIndexes` are `[0, 1, 2, 4, 5, 7, 8, 9]`, it will be converted into 3 row ranges:
+   * `[0-2], [4-5], [7-9]`.
+   */
   private Iterator<RowRange> constructRanges(PrimitiveIterator.OfLong rowIndexes) {
     List<RowRange> rowRanges = new ArrayList<>();
-    long currentStart, previous;
-    currentStart = previous = Long.MIN_VALUE;
+    long currentStart = Long.MIN_VALUE;
+    long previous = Long.MIN_VALUE;
 
     while (rowIndexes.hasNext()) {
       long idx = rowIndexes.nextLong();

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
@@ -45,7 +45,7 @@ final class ParquetReadState {
   /** Maximum definition level for the Parquet column */
   final int maxDefinitionLevel;
 
-  /** The current index overall all rows within the column chunk. This is used to check if the
+  /** The current index over all rows within the column chunk. This is used to check if the
    * current row should be skipped by comparing against the row ranges. */
   long rowId;
 
@@ -60,7 +60,7 @@ final class ParquetReadState {
 
   ParquetReadState(int maxDefinitionLevel, PrimitiveIterator.OfLong rowIndexes) {
     this.maxDefinitionLevel = maxDefinitionLevel;
-    this.rowRanges = rowIndexes == null ? null : constructRanges(rowIndexes);
+    this.rowRanges = constructRanges(rowIndexes);
     nextRange();
   }
 
@@ -70,6 +70,10 @@ final class ParquetReadState {
    * `[0-2], [4-5], [7-9]`.
    */
   private Iterator<RowRange> constructRanges(PrimitiveIterator.OfLong rowIndexes) {
+    if (rowIndexes == null) {
+      return null;
+    }
+
     List<RowRange> rowRanges = new ArrayList<>();
     long currentStart = Long.MIN_VALUE;
     long previous = Long.MIN_VALUE;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
@@ -38,7 +38,8 @@ final class ParquetReadState {
   /** Maximum definition level */
   final int maxDefinitionLevel;
 
-  /** The current row index to read */
+  /** The current index overall all rows within the column chunk. This is used to check if the
+   * current row should be skipped by comparing the index against the row ranges. */
   long rowId;
 
   /** The offset in the current batch to put the next value */

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdater.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdater.java
@@ -30,7 +30,7 @@ public interface ParquetVectorUpdater {
    * @param values destination values vector
    * @param valuesReader reader to read values from
    */
-  void updateBatch(
+  void readValues(
       int total,
       int offset,
       WritableColumnVector values,
@@ -42,7 +42,7 @@ public interface ParquetVectorUpdater {
    * @param total total number of values to skip
    * @param valuesReader reader to skip values from
    */
-  void skipBatch(int total, VectorizedValuesReader valuesReader);
+  void skipValues(int total, VectorizedValuesReader valuesReader);
 
   /**
    * Read a single value from `valuesReader` into `values`, at `offset`.
@@ -51,7 +51,7 @@ public interface ParquetVectorUpdater {
    * @param values destination value vector
    * @param valuesReader reader to read values from
    */
-  void update(int offset, WritableColumnVector values, VectorizedValuesReader valuesReader);
+  void readValue(int offset, WritableColumnVector values, VectorizedValuesReader valuesReader);
 
   /**
    * Process a batch of `total` values starting from `offset` in `values`, whose null slots

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdater.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdater.java
@@ -37,10 +37,10 @@ public interface ParquetVectorUpdater {
       VectorizedValuesReader valuesReader);
 
   /**
-   * Skip a batch of `total` from `valuesReader` into `values`, starting from `offset`.
+   * Skip a batch of `total` values from `valuesReader`.
    *
    * @param total total number of values to skip
-   * @param valuesReader reader to read values from
+   * @param valuesReader reader to skip values from
    */
   void skipBatch(int total, VectorizedValuesReader valuesReader);
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdater.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdater.java
@@ -37,6 +37,14 @@ public interface ParquetVectorUpdater {
       VectorizedValuesReader valuesReader);
 
   /**
+   * Skip a batch of `total` from `valuesReader` into `values`, starting from `offset`.
+   *
+   * @param total total number of values to skip
+   * @param valuesReader reader to read values from
+   */
+  void skipBatch(int total, VectorizedValuesReader valuesReader);
+
+  /**
    * Read a single value from `valuesReader` into `values`, at `offset`.
    *
    * @param offset offset in `values` to put the new value

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
@@ -194,6 +194,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipBooleans(total);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -222,6 +227,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipIntegers(total);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -247,6 +257,11 @@ public class ParquetVectorUpdaterFactory {
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       valuesReader.readUnsignedIntegers(total, values, offset);
+    }
+
+    @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipIntegers(total);
     }
 
     @Override
@@ -279,6 +294,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipBytes(total);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -304,6 +324,11 @@ public class ParquetVectorUpdaterFactory {
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       valuesReader.readShorts(total, values, offset);
+    }
+
+    @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipShorts(total);
     }
 
     @Override
@@ -341,6 +366,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipIntegers(total);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -368,6 +398,11 @@ public class ParquetVectorUpdaterFactory {
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       valuesReader.readLongs(total, values, offset);
+    }
+
+    @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipLongs(total);
     }
 
     @Override
@@ -401,6 +436,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipLongs(total);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -426,6 +466,11 @@ public class ParquetVectorUpdaterFactory {
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       valuesReader.readUnsignedLongs(total, values, offset);
+    }
+
+    @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipLongs(total);
     }
 
     @Override
@@ -466,6 +511,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipLongs(total);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -495,6 +545,11 @@ public class ParquetVectorUpdaterFactory {
       for (int i = 0; i < total; ++i) {
         update(offset + i, values, valuesReader);
       }
+    }
+
+    @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipLongs(total);
     }
 
     @Override
@@ -535,6 +590,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipLongs(total);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -566,6 +626,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipFloats(total);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -591,6 +656,11 @@ public class ParquetVectorUpdaterFactory {
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       valuesReader.readDoubles(total, values, offset);
+    }
+
+    @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipDoubles(total);
     }
 
     @Override
@@ -622,6 +692,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipBinary(total);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -650,6 +725,11 @@ public class ParquetVectorUpdaterFactory {
       for (int i = 0; i < total; i++) {
         update(offset + i, values, valuesReader);
       }
+    }
+
+    @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipFixedLenByteArray(total, 12);
     }
 
     @Override
@@ -692,6 +772,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipFixedLenByteArray(total, 12);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -731,6 +816,11 @@ public class ParquetVectorUpdaterFactory {
       for (int i = 0; i < total; i++) {
         update(offset + i, values, valuesReader);
       }
+    }
+
+    @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipFixedLenByteArray(total, 12);
     }
 
     @Override
@@ -778,6 +868,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipFixedLenByteArray(total, 12);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -822,6 +917,11 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipFixedLenByteArray(total, arrayLen);
+    }
+
+    @Override
     public void update(
         int offset,
         WritableColumnVector values,
@@ -856,6 +956,11 @@ public class ParquetVectorUpdaterFactory {
       for (int i = 0; i < total; i++) {
         update(offset + i, values, valuesReader);
       }
+    }
+
+    @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipFixedLenByteArray(total, arrayLen);
     }
 
     @Override
@@ -894,6 +999,11 @@ public class ParquetVectorUpdaterFactory {
       for (int i = 0; i < total; i++) {
         update(offset + i, values, valuesReader);
       }
+    }
+
+    @Override
+    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+      valuesReader.skipFixedLenByteArray(total, arrayLen);
     }
 
     @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
@@ -185,7 +185,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class BooleanUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -194,12 +194,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipBooleans(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -218,7 +218,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class IntegerUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -227,12 +227,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipIntegers(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -251,7 +251,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class UnsignedIntegerUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -260,12 +260,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipIntegers(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -285,7 +285,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class ByteUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -294,12 +294,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipBytes(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -318,7 +318,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class ShortUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -327,12 +327,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipShorts(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -357,7 +357,7 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -366,12 +366,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipIntegers(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -392,7 +392,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class LongUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -401,12 +401,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipLongs(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -425,7 +425,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class DowncastLongUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -436,12 +436,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipLongs(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -460,7 +460,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class UnsignedLongUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -469,12 +469,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipLongs(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -502,7 +502,7 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -511,12 +511,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipLongs(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -537,23 +537,23 @@ public class ParquetVectorUpdaterFactory {
 
   private static class LongAsMicrosUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       for (int i = 0; i < total; ++i) {
-        update(offset + i, values, valuesReader);
+        readValue(offset + i, values, valuesReader);
       }
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipLongs(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -579,23 +579,23 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       for (int i = 0; i < total; ++i) {
-        update(offset + i, values, valuesReader);
+        readValue(offset + i, values, valuesReader);
       }
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipLongs(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -617,7 +617,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class FloatUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -626,12 +626,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipFloats(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -650,7 +650,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class DoubleUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -659,12 +659,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipDoubles(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -683,7 +683,7 @@ public class ParquetVectorUpdaterFactory {
 
   private static class BinaryUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
@@ -692,12 +692,12 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipBinary(total);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -717,23 +717,23 @@ public class ParquetVectorUpdaterFactory {
 
   private static class BinaryToSQLTimestampUpdater implements ParquetVectorUpdater {
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       for (int i = 0; i < total; i++) {
-        update(offset + i, values, valuesReader);
+        readValue(offset + i, values, valuesReader);
       }
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipFixedLenByteArray(total, 12);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -761,23 +761,23 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       for (int i = 0; i < total; i++) {
-        update(offset + i, values, valuesReader);
+        readValue(offset + i, values, valuesReader);
       }
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipFixedLenByteArray(total, 12);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -808,23 +808,23 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       for (int i = 0; i < total; i++) {
-        update(offset + i, values, valuesReader);
+        readValue(offset + i, values, valuesReader);
       }
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipFixedLenByteArray(total, 12);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -857,23 +857,23 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       for (int i = 0; i < total; i++) {
-        update(offset + i, values, valuesReader);
+        readValue(offset + i, values, valuesReader);
       }
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipFixedLenByteArray(total, 12);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -906,23 +906,23 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       for (int i = 0; i < total; i++) {
-        update(offset + i, values, valuesReader);
+        readValue(offset + i, values, valuesReader);
       }
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipFixedLenByteArray(total, arrayLen);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -948,23 +948,23 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       for (int i = 0; i < total; i++) {
-        update(offset + i, values, valuesReader);
+        readValue(offset + i, values, valuesReader);
       }
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipFixedLenByteArray(total, arrayLen);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
@@ -991,23 +991,23 @@ public class ParquetVectorUpdaterFactory {
     }
 
     @Override
-    public void updateBatch(
+    public void readValues(
         int total,
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
       for (int i = 0; i < total; i++) {
-        update(offset + i, values, valuesReader);
+        readValue(offset + i, values, valuesReader);
       }
     }
 
     @Override
-    public void skipBatch(int total, VectorizedValuesReader valuesReader) {
+    public void skipValues(int total, VectorizedValuesReader valuesReader) {
       valuesReader.skipFixedLenByteArray(total, arrayLen);
     }
 
     @Override
-    public void update(
+    public void readValue(
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -160,18 +160,18 @@ public class VectorizedColumnReader {
       // page.
       dictionaryIds = column.reserveDictionaryIds(total);
     }
-    readState.resetForBatch(total);
+    readState.resetForNewBatch(total);
     while (readState.valuesToReadInBatch > 0) {
-      // Compute the number of values we want to read in this page.
       if (readState.valuesToReadInPage == 0) {
         int pageValueCount = readPage();
-        readState.resetForPage(pageValueCount, pageFirstRowIndex);
+        readState.resetForNewPage(pageValueCount, pageFirstRowIndex);
       }
       PrimitiveType.PrimitiveTypeName typeName =
           descriptor.getPrimitiveType().getPrimitiveTypeName();
       if (isCurrentPageDictionaryEncoded) {
         // Save starting offset in case we need to decode dictionary IDs.
         int startOffset = readState.offset;
+        // Save starting row index so we can check if we need to eagerly decode dict ids later
         long startRowId = readState.rowId;
 
         // Read and decode dictionary ids.

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -77,8 +77,7 @@ public class VectorizedColumnReader {
 
   /**
    * The index for the first row in the current page, among all rows across all pages in the
-   * column chunk for this reader. The value for this is 0 if there is no column index for the
-   * column chunk.
+   * column chunk for this reader. If there is no column index, the value is 0.
    */
   private long pageFirstRowIndex;
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
@@ -334,6 +334,7 @@ public class VectorizedParquetRecordReader extends SpecificParquetRecordReaderBa
         columns.get(i),
         types.get(i).getLogicalTypeAnnotation(),
         pages.getPageReader(columns.get(i)),
+        pages.getRowIndexes().orElse(null),
         convertTz,
         datetimeRebaseMode,
         int96RebaseMode);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -61,6 +61,14 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
     }
   }
 
+  @Override
+  public final void skipBooleans(int total) {
+    // TODO: properly vectorize this
+    for (int i = 0; i < total; i++) {
+      readBoolean();
+    }
+  }
+
   private ByteBuffer getBuffer(int length) {
     try {
       return in.slice(length).order(ByteOrder.LITTLE_ENDIAN);
@@ -82,6 +90,11 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
         c.putInt(rowId + i, buffer.getInt());
       }
     }
+  }
+
+  @Override
+  public void skipIntegers(int total) {
+    in.skip(total * 4L);
   }
 
   @Override
@@ -138,6 +151,11 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
         c.putLong(rowId + i, buffer.getLong());
       }
     }
+  }
+
+  @Override
+  public void skipLongs(int total) {
+    in.skip(total * 8L);
   }
 
   @Override
@@ -198,6 +216,11 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
   }
 
   @Override
+  public void skipFloats(int total) {
+    in.skip(total * 4L);
+  }
+
+  @Override
   public final void readDoubles(int total, WritableColumnVector c, int rowId) {
     int requiredBytes = total * 8;
     ByteBuffer buffer = getBuffer(requiredBytes);
@@ -210,6 +233,11 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
         c.putDouble(rowId + i, buffer.getDouble());
       }
     }
+  }
+
+  @Override
+  public void skipDoubles(int total) {
+    in.skip(total * 8L);
   }
 
   @Override
@@ -227,6 +255,11 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
   }
 
   @Override
+  public final void skipBytes(int total) {
+    in.skip(total * 4L);
+  }
+
+  @Override
   public final void readShorts(int total, WritableColumnVector c, int rowId) {
     int requiredBytes = total * 4;
     ByteBuffer buffer = getBuffer(requiredBytes);
@@ -234,6 +267,11 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
     for (int i = 0; i < total; i += 1) {
       c.putShort(rowId + i, (short) buffer.getInt());
     }
+  }
+
+  @Override
+  public void skipShorts(int total) {
+    in.skip(total * 4L);
   }
 
   @Override
@@ -301,6 +339,14 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
   }
 
   @Override
+  public void skipBinary(int total) {
+    for (int i = 0; i < total; i++) {
+      int len = readInteger();
+      in.skip(len);
+    }
+  }
+
+  @Override
   public final Binary readBinary(int len) {
     ByteBuffer buffer = getBuffer(len);
     if (buffer.hasArray()) {
@@ -311,5 +357,10 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
       buffer.get(bytes);
       return Binary.fromConstantByteArray(bytes);
     }
+  }
+
+  @Override
+  public void skipFixedLenByteArray(int total, int len) {
+    in.skip(total * (long) len);
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -188,11 +188,11 @@ public final class VectorizedRleValuesReader extends ValuesReader
       } else if (rowId > rangeEnd) {
         state.nextRange();
       } else {
-        // the range [rowId, rowId + n] overlaps with the current row range in state
+        // the range [rowId, rowId + n) overlaps with the current row range in state
         long start = Math.max(rangeStart, rowId);
         long end = Math.min(rangeEnd, rowId + n - 1);
 
-        // first, skip the part [rowId, start)
+        // skip the part [rowId, start)
         int toSkip = (int) (start - rowId);
         if (toSkip > 0) {
           updater.skipBatch(toSkip, valueReader);
@@ -201,7 +201,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
           leftInPage -= toSkip;
         }
 
-        // second, read the part [start, end]
+        // read the part [start, end]
         n = (int) (end - start + 1);
 
         switch (mode) {
@@ -262,11 +262,11 @@ public final class VectorizedRleValuesReader extends ValuesReader
       } else if (rowId > rangeEnd) {
         state.nextRange();
       } else {
-        // the range [rowId, rowId + n] overlaps with the current row range in state
+        // the range [rowId, rowId + n) overlaps with the current row range in state
         long start = Math.max(rangeStart, rowId);
         long end = Math.min(rangeEnd, rowId + n - 1);
 
-        // first, skip the part [rowId, start)
+        // skip the part [rowId, start)
         int toSkip = (int) (start - rowId);
         if (toSkip > 0) {
           data.skipIntegers(toSkip);
@@ -275,7 +275,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
           leftInPage -= toSkip;
         }
 
-        // second, read the part [start, end]
+        // read the part [start, end]
         n = (int) (end - start + 1);
 
         switch (mode) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -156,18 +156,12 @@ public final class VectorizedRleValuesReader extends ValuesReader
   }
 
   /**
-   * Reads `total` ints into `c` filling them in starting at `c[rowId]`. This reader
-   * reads the definition levels and then will read from `data` for the non-null values.
-   * If the value is null, c will be populated with `nullValue`. Note that `nullValue` is only
-   * necessary for readIntegers because we also use it to decode dictionaryIds and want to make
-   * sure it always has a value in range.
-   *
-   * This is a batched version of this logic:
-   *  if (this.readInt() == level) {
-   *    c[rowId] = data.readInteger();
-   *  } else {
-   *    c[rowId] = null;
-   *  }
+   * Reads a batch of values into vector `values`, using `valueReader`. The related states such
+   * as row index, offset, number of values left in the batch and page, etc, are tracked by
+   * `state`. The type-specific `updater` is used to update or skip values.
+   * <p>
+   * This reader reads the definition levels and then will read from `valueReader` for the
+   * non-null values. If the value is null, `values` will be populated with null value.
    */
   public void readBatch(
       ParquetReadState state,
@@ -175,36 +169,68 @@ public final class VectorizedRleValuesReader extends ValuesReader
       VectorizedValuesReader valueReader,
       ParquetVectorUpdater updater) throws IOException {
     int offset = state.offset;
-    int left = Math.min(state.valuesToReadInBatch, state.valuesToReadInPage);
+    long rowId = state.rowId;
+    int leftInBatch = state.valuesToReadInBatch;
+    int leftInPage = state.valuesToReadInPage;
 
-    while (left > 0) {
+    while (leftInBatch > 0 && leftInPage > 0) {
       if (this.currentCount == 0) this.readNextGroup();
-      int n = Math.min(left, this.currentCount);
+      int n = Math.min(leftInBatch, Math.min(leftInPage, this.currentCount));
 
-      switch (mode) {
-        case RLE:
-          if (currentValue == state.maxDefinitionLevel) {
-            updater.updateBatch(n, offset, values, valueReader);
-          } else {
-            values.putNulls(offset, n);
-          }
-          break;
-        case PACKED:
-          for (int i = 0; i < n; ++i) {
-            if (currentBuffer[currentBufferIdx++] == state.maxDefinitionLevel) {
-              updater.update(offset + i, values, valueReader);
+      long rangeStart = state.currentRangeStart();
+      long rangeEnd = state.currentRangeEnd();
+
+      if (rowId + n < rangeStart) {
+        updater.skipBatch(n, valueReader);
+        advance(n);
+        rowId += n;
+        leftInPage -= n;
+      } else if (rowId > rangeEnd) {
+        state.nextRange();
+      } else {
+        // the range [rowId, rowId + n] overlaps with the current row range in state
+        long start = Math.max(rangeStart, rowId);
+        long end = Math.min(rangeEnd, rowId + n - 1);
+
+        // first, skip the part [rowId, start)
+        int toSkip = (int) (start - rowId);
+        if (toSkip > 0) {
+          updater.skipBatch(toSkip, valueReader);
+          advance(toSkip);
+          rowId += toSkip;
+          leftInPage -= toSkip;
+        }
+
+        // second, read the part [start, end]
+        n = (int) (end - start + 1);
+
+        switch (mode) {
+          case RLE:
+            if (currentValue == state.maxDefinitionLevel) {
+              updater.updateBatch(n, offset, values, valueReader);
             } else {
-              values.putNull(offset + i);
+              values.putNulls(offset, n);
             }
-          }
-          break;
+            break;
+          case PACKED:
+            for (int i = 0; i < n; ++i) {
+              if (currentBuffer[currentBufferIdx++] == state.maxDefinitionLevel) {
+                updater.update(offset + i, values, valueReader);
+              } else {
+                values.putNull(offset + i);
+              }
+            }
+            break;
+        }
+        offset += n;
+        leftInBatch -= n;
+        rowId += n;
+        leftInPage -= n;
+        currentCount -= n;
       }
-      offset += n;
-      left -= n;
-      currentCount -= n;
     }
 
-    state.advanceOffset(offset);
+    state.advanceOffset(offset, rowId);
   }
 
   /**
@@ -217,36 +243,68 @@ public final class VectorizedRleValuesReader extends ValuesReader
       WritableColumnVector nulls,
       VectorizedValuesReader data) throws IOException {
     int offset = state.offset;
-    int left = Math.min(state.valuesToReadInBatch, state.valuesToReadInPage);
+    long rowId = state.rowId;
+    int leftInBatch = state.valuesToReadInBatch;
+    int leftInPage = state.valuesToReadInPage;
 
-    while (left > 0) {
+    while (leftInBatch > 0 && leftInPage > 0) {
       if (this.currentCount == 0) this.readNextGroup();
-      int n = Math.min(left, this.currentCount);
+      int n = Math.min(leftInBatch, Math.min(leftInPage, this.currentCount));
 
-      switch (mode) {
-        case RLE:
-          if (currentValue == state.maxDefinitionLevel) {
-            data.readIntegers(n, values, offset);
-          } else {
-            nulls.putNulls(offset, n);
-          }
-          break;
-        case PACKED:
-          for (int i = 0; i < n; ++i) {
-            if (currentBuffer[currentBufferIdx++] == state.maxDefinitionLevel) {
-              values.putInt(offset + i, data.readInteger());
+      long rangeStart = state.currentRangeStart();
+      long rangeEnd = state.currentRangeEnd();
+
+      if (rowId + n < rangeStart) {
+        data.skipIntegers(n);
+        advance(n);
+        rowId += n;
+        leftInPage -= n;
+      } else if (rowId > rangeEnd) {
+        state.nextRange();
+      } else {
+        // the range [rowId, rowId + n] overlaps with the current row range in state
+        long start = Math.max(rangeStart, rowId);
+        long end = Math.min(rangeEnd, rowId + n - 1);
+
+        // first, skip the part [rowId, start)
+        int toSkip = (int) (start - rowId);
+        if (toSkip > 0) {
+          data.skipIntegers(toSkip);
+          advance(toSkip);
+          rowId += toSkip;
+          leftInPage -= toSkip;
+        }
+
+        // second, read the part [start, end]
+        n = (int) (end - start + 1);
+
+        switch (mode) {
+          case RLE:
+            if (currentValue == state.maxDefinitionLevel) {
+              data.readIntegers(n, values, offset);
             } else {
-              nulls.putNull(offset + i);
+              nulls.putNulls(offset, n);
             }
-          }
-          break;
+            break;
+          case PACKED:
+            for (int i = 0; i < n; ++i) {
+              if (currentBuffer[currentBufferIdx++] == state.maxDefinitionLevel) {
+                values.putInt(offset + i, data.readInteger());
+              } else {
+                nulls.putNull(offset + i);
+              }
+            }
+            break;
+        }
+        rowId += n;
+        leftInPage -= n;
+        offset += n;
+        leftInBatch -= n;
+        currentCount -= n;
       }
-      offset += n;
-      left -= n;
-      currentCount -= n;
     }
 
-    state.advanceOffset(offset);
+    state.advanceOffset(offset, rowId);
   }
 
 
@@ -344,6 +402,68 @@ public final class VectorizedRleValuesReader extends ValuesReader
   @Override
   public Binary readBinary(int len) {
     throw new UnsupportedOperationException("only readInts is valid.");
+  }
+
+  @Override
+  public void skipIntegers(int total) {
+    for (int i = 0; i < total; i++) {
+      // TODO: optimize this
+      readInteger();
+    }
+  }
+
+  @Override
+  public void skipBooleans(int total) {
+    throw new UnsupportedOperationException("only skipIntegers is supported");
+  }
+
+  @Override
+  public void skipBytes(int total) {
+    throw new UnsupportedOperationException("only skipIntegers is supported");
+  }
+
+  @Override
+  public void skipShorts(int total) {
+    throw new UnsupportedOperationException("only skipIntegers is supported");
+  }
+
+  @Override
+  public void skipLongs(int total) {
+    throw new UnsupportedOperationException("only skipIntegers is supported");
+  }
+
+  @Override
+  public void skipFloats(int total) {
+    throw new UnsupportedOperationException("only skipIntegers is supported");
+  }
+
+  @Override
+  public void skipDoubles(int total) {
+    throw new UnsupportedOperationException("only skipIntegers is supported");
+  }
+
+  @Override
+  public void skipBinary(int total) {
+    throw new UnsupportedOperationException("only skipIntegers is supported");
+  }
+
+  @Override
+  public void skipFixedLenByteArray(int total, int len) {
+    throw new UnsupportedOperationException("only skipIntegers is supported");
+  }
+
+  /**
+   * Advance and skip the next `n` values in the current block. `n` MUST be <= `currentCount`.
+   */
+  private void advance(int n) {
+    switch (mode) {
+      case RLE:
+        break;
+      case PACKED:
+        currentBufferIdx += n;
+        break;
+    }
+    currentCount -= n;
   }
 
   /**

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -181,7 +181,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
       long rangeEnd = state.currentRangeEnd();
 
       if (rowId + n < rangeStart) {
-        updater.skipBatch(n, valueReader);
+        updater.skipValues(n, valueReader);
         advance(n);
         rowId += n;
         leftInPage -= n;
@@ -195,7 +195,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
         // skip the part [rowId, start)
         int toSkip = (int) (start - rowId);
         if (toSkip > 0) {
-          updater.skipBatch(toSkip, valueReader);
+          updater.skipValues(toSkip, valueReader);
           advance(toSkip);
           rowId += toSkip;
           leftInPage -= toSkip;
@@ -207,7 +207,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
         switch (mode) {
           case RLE:
             if (currentValue == state.maxDefinitionLevel) {
-              updater.updateBatch(n, offset, values, valueReader);
+              updater.readValues(n, offset, values, valueReader);
             } else {
               values.putNulls(offset, n);
             }
@@ -215,7 +215,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
           case PACKED:
             for (int i = 0; i < n; ++i) {
               if (currentBuffer[currentBufferIdx++] == state.maxDefinitionLevel) {
-                updater.update(offset + i, values, valueReader);
+                updater.readValue(offset + i, values, valueReader);
               } else {
                 values.putNull(offset + i);
               }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -230,7 +230,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
       }
     }
 
-    state.advanceOffset(offset, rowId);
+    state.advanceOffsetAndRowId(offset, rowId);
   }
 
   /**
@@ -304,7 +304,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
       }
     }
 
-    state.advanceOffset(offset, rowId);
+    state.advanceOffsetAndRowId(offset, rowId);
   }
 
 
@@ -417,42 +417,42 @@ public final class VectorizedRleValuesReader extends ValuesReader
 
   @Override
   public void skipBooleans(int total) {
-    throw new UnsupportedOperationException("only skipIntegers is supported");
+    throw new UnsupportedOperationException("only skipIntegers is valid");
   }
 
   @Override
   public void skipBytes(int total) {
-    throw new UnsupportedOperationException("only skipIntegers is supported");
+    throw new UnsupportedOperationException("only skipIntegers is valid");
   }
 
   @Override
   public void skipShorts(int total) {
-    throw new UnsupportedOperationException("only skipIntegers is supported");
+    throw new UnsupportedOperationException("only skipIntegers is valid");
   }
 
   @Override
   public void skipLongs(int total) {
-    throw new UnsupportedOperationException("only skipIntegers is supported");
+    throw new UnsupportedOperationException("only skipIntegers is valid");
   }
 
   @Override
   public void skipFloats(int total) {
-    throw new UnsupportedOperationException("only skipIntegers is supported");
+    throw new UnsupportedOperationException("only skipIntegers is valid");
   }
 
   @Override
   public void skipDoubles(int total) {
-    throw new UnsupportedOperationException("only skipIntegers is supported");
+    throw new UnsupportedOperationException("only skipIntegers is valid");
   }
 
   @Override
   public void skipBinary(int total) {
-    throw new UnsupportedOperationException("only skipIntegers is supported");
+    throw new UnsupportedOperationException("only skipIntegers is valid");
   }
 
   @Override
   public void skipFixedLenByteArray(int total, int len) {
-    throw new UnsupportedOperationException("only skipIntegers is supported");
+    throw new UnsupportedOperationException("only skipIntegers is valid");
   }
 
   /**

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -406,9 +406,12 @@ public final class VectorizedRleValuesReader extends ValuesReader
 
   @Override
   public void skipIntegers(int total) {
-    for (int i = 0; i < total; i++) {
-      // TODO: optimize this
-      readInteger();
+    int left = total;
+    while (left > 0) {
+      if (this.currentCount == 0) this.readNextGroup();
+      int n = Math.min(left, this.currentCount);
+      advance(n);
+      left -= n;
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedValuesReader.java
@@ -51,9 +51,9 @@ public interface VectorizedValuesReader {
   void readDoubles(int total, WritableColumnVector c, int rowId);
   void readBinary(int total, WritableColumnVector c, int rowId);
 
-  /*
-   * Skips `total` values
-   */
+   /*
+    * Skips `total` values
+    */
    void skipBooleans(int total);
    void skipBytes(int total);
    void skipShorts(int total);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedValuesReader.java
@@ -50,4 +50,17 @@ public interface VectorizedValuesReader {
   void readFloats(int total, WritableColumnVector c, int rowId);
   void readDoubles(int total, WritableColumnVector c, int rowId);
   void readBinary(int total, WritableColumnVector c, int rowId);
+
+  /*
+   * Skips `total` values
+   */
+   void skipBooleans(int total);
+   void skipBytes(int total);
+   void skipShorts(int total);
+   void skipIntegers(int total);
+   void skipLongs(int total);
+   void skipFloats(int total);
+   void skipDoubles(int total);
+   void skipBinary(int total);
+   void skipFixedLenByteArray(int total, int len);
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnIndexSuite.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.test.SharedSparkSession
+
+class ParquetColumnIndexSuite extends QueryTest with ParquetTest with SharedSparkSession {
+  import testImplicits._
+
+  /**
+   * create parquet file with two columns and unaligned pages
+   * pages will be of the following layout
+   * col_1     500       500       500       500
+   *  |---------|---------|---------|---------|
+   *  |-------|-----|-----|---|---|---|---|---|
+   * col_2   400   300   200 200 200 200 200 200
+   */
+  def checkUnalignedPages(actions: (DataFrame => DataFrame)*): Unit = {
+    withTempPath(file => {
+      val ds = spark.range(0, 2000).map(i => (i, i + ":" + "o" * (i / 100).toInt))
+      ds.coalesce(1)
+          .write
+          .option("parquet.page.size", "4096")
+          .parquet(file.getCanonicalPath)
+
+      val parquetDf = spark.read.parquet(file.getCanonicalPath)
+
+      actions.foreach{ action =>
+        checkAnswer(action(parquetDf), action(ds.toDF()))
+      }
+    })
+  }
+
+  test("reading from unaligned pages - test filters") {
+    checkUnalignedPages(
+      // single value filter
+      df => df.filter("_1 = 500"),
+      df => df.filter("_1 = 500 or _1 = 1500"),
+      df => df.filter("_1 = 500 or _1 = 501 or _1 = 1500"),
+      df => df.filter("_1 = 500 or _1 = 501 or _1 = 1000 or _1 = 1500"),
+      // range filter
+      df => df.filter("_1 >= 500 and _1 < 1000"),
+      df => df.filter("(_1 >= 500 and _1 < 1000) or (_1 >= 1500 and _1 < 1600)")
+    )
+  }
+
+  test("test reading unaligned pages - test all types") {
+    withTempPath(file => {
+      val df = spark.range(0, 2000).selectExpr(
+        "id as _1",
+        "cast(id as short) as _3",
+        "cast(id as int) as _4",
+        "cast(id as float) as _5",
+        "cast(id as double) as _6",
+        "cast(id as decimal(20,0)) as _7",
+        "cast(cast(1618161925000 + id * 1000 * 60 * 60 * 24 as timestamp) as date) as _9",
+        "cast(1618161925000 + id as timestamp) as _10"
+      )
+      df.coalesce(1)
+          .write
+          .option("parquet.page.size", "4096")
+          .parquet(file.getCanonicalPath)
+
+      val parquetDf = spark.read.parquet(file.getCanonicalPath)
+      val singleValueFilterExpr = "_1 = 500 or _1 = 1500"
+      checkAnswer(
+        parquetDf.filter(singleValueFilterExpr),
+        df.filter(singleValueFilterExpr)
+      )
+      val rangeFilterExpr = "_1 > 500 "
+      checkAnswer(
+        parquetDf.filter(rangeFilterExpr),
+        df.filter(rangeFilterExpr)
+      )
+    })
+  }
+
+  test("test reading unaligned pages - test all types (dict encode)") {
+    withTempPath(file => {
+      val df = spark.range(0, 2000).selectExpr(
+        "id as _1",
+        "cast(id % 10 as byte) as _2",
+        "cast(id % 10 as short) as _3",
+        "cast(id % 10 as int) as _4",
+        "cast(id % 10 as float) as _5",
+        "cast(id % 10 as double) as _6",
+        "cast(id % 10 as decimal(20,0)) as _7",
+        "cast(id % 2 as boolean) as _8",
+        "cast(cast(1618161925000 + (id % 10) * 1000 * 60 * 60 * 24 as timestamp) as date) as _9",
+        "cast(1618161925000 + (id % 10) as timestamp) as _10"
+      )
+      df.coalesce(1)
+          .write
+          .option("parquet.page.size", "4096")
+          .parquet(file.getCanonicalPath)
+
+      val parquetDf = spark.read.parquet(file.getCanonicalPath)
+      val singleValueFilterExpr = "_1 = 500 or _1 = 1500"
+      checkAnswer(
+        parquetDf.filter(singleValueFilterExpr),
+        df.filter(singleValueFilterExpr)
+      )
+      val rangeFilterExpr = "_1 > 500 "
+      checkAnswer(
+        parquetDf.filter(rangeFilterExpr),
+        df.filter(rangeFilterExpr)
+      )
+    })
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnIndexSuite.scala
@@ -41,7 +41,7 @@ class ParquetColumnIndexSuite extends QueryTest with ParquetTest with SharedSpar
 
       val parquetDf = spark.read.parquet(file.getCanonicalPath)
 
-      actions.foreach{ action =>
+      actions.foreach { action =>
         checkAnswer(action(parquetDf), action(ds.toDF()))
       }
     })
@@ -116,7 +116,7 @@ class ParquetColumnIndexSuite extends QueryTest with ParquetTest with SharedSpar
         parquetDf.filter(singleValueFilterExpr),
         df.filter(singleValueFilterExpr)
       )
-      val rangeFilterExpr = "_1 > 500 "
+      val rangeFilterExpr = "_1 > 500"
       checkAnswer(
         parquetDf.filter(rangeFilterExpr),
         df.filter(rangeFilterExpr)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -386,7 +386,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
       .build()
   }
 
-  test("test multiple pages with different sizes and nulls") {
+  test("SPARK-34859: test multiple pages with different sizes and nulls") {
     def makeRawParquetFile(
         path: Path,
         dictionaryEnabled: Boolean,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -368,7 +368,9 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
   private def createParquetWriter(
       schema: MessageType,
       path: Path,
-      dictionaryEnabled: Boolean = false): ParquetWriter[Group] = {
+      dictionaryEnabled: Boolean = false,
+      pageSize: Int = 1024,
+      dictionaryPageSize: Int = 1024): ParquetWriter[Group] = {
     val hadoopConf = spark.sessionState.newHadoopConf()
 
     ExampleParquetWriter
@@ -378,9 +380,75 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
       .withWriterVersion(PARQUET_1_0)
       .withCompressionCodec(GZIP)
       .withRowGroupSize(1024 * 1024)
-      .withPageSize(1024)
+      .withPageSize(pageSize)
+      .withDictionaryPageSize(dictionaryPageSize)
       .withConf(hadoopConf)
       .build()
+  }
+
+  test("test multiple pages with different sizes and nulls") {
+    def makeRawParquetFile(
+        path: Path,
+        dictionaryEnabled: Boolean,
+        n: Int,
+        pageSize: Int): Seq[Option[Int]] = {
+      val schemaStr =
+        """
+          |message root {
+          |  optional boolean _1;
+          |  optional int32   _2;
+          |  optional int64   _3;
+          |  optional float   _4;
+          |  optional double  _5;
+          |}
+        """.stripMargin
+
+      val schema = MessageTypeParser.parseMessageType(schemaStr)
+      val writer = createParquetWriter(schema, path,
+        dictionaryEnabled = dictionaryEnabled, pageSize = pageSize, dictionaryPageSize = pageSize)
+
+      val rand = scala.util.Random
+      val expected = (0 until n).map { i =>
+        if (rand.nextBoolean()) {
+          None
+        } else {
+          Some(i)
+        }
+      }
+      expected.foreach { opt =>
+        val record = new SimpleGroup(schema)
+        opt match {
+          case Some(i) =>
+            record.add(0, i % 2 == 0)
+            record.add(1, i)
+            record.add(2, i.toLong)
+            record.add(3, i.toFloat)
+            record.add(4, i.toDouble)
+          case _ =>
+        }
+        writer.write(record)
+      }
+
+      writer.close()
+      expected
+    }
+
+    Seq(true, false).foreach { dictionaryEnabled =>
+      Seq(64, 128, 89).foreach { pageSize =>
+        withTempDir { dir =>
+          val path = new Path(dir.toURI.toString, "part-r-0.parquet")
+          val expected = makeRawParquetFile(path, dictionaryEnabled, 1000, pageSize)
+          readParquetFile(path.toString) { df =>
+            checkAnswer(df, expected.map {
+              case None =>
+                Row(null, null, null, null, null)
+              case Some(i) =>
+                Row(i % 2 == 0, i, i.toLong, i.toFloat, i.toDouble)
+            })
+          }
+        }
+      }
+    }
   }
 
   test("read raw Parquet file") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Make the current vectorized Parquet reader to work with column index introduced in Parquet 1.11. In particular, this PR makes the following changes:
1. in `ParquetReadState`, track row ranges returned via `PageReadStore.getRowIndexes` as well as the first row index for each page via `DataPage.getFirstRowIndex`.
1. introduced a new API `ParquetVectorUpdater.skipValues` which skips a batch of values from a Parquet value reader. As part of the process also renamed existing `updateBatch` to `readValues`, and `update` to `readValue` to keep the method names consistent.
1. in correspondence as above, also introduced new API `VectorizedValuesReader.skipXXX` for different data types, as well as the implementations. These are useful when the reader knows that the given batch of values can be skipped, for instance, due to the batch is not covered in the row ranges generated by column index filtering.
2. changed `VectorizedRleValuesReader` to handle column index filtering. This is done by comparing the range that is going to be read next within the current RLE/PACKED block (let's call this block range), against the current row range. There are three cases:
    * if the block range is before the current row range, skip all the values in the block range
    * if the block range is after the current row range, advance the row range and repeat the steps
    * if the block range overlaps with the current row range, only read the values within the overlapping area and skip the rest.
   
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

[Parquet Column Index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) is a new feature in Parquet 1.11 which allows very efficient filtering on page level (some benchmark numbers can be found [here](https://blog.cloudera.com/speeding-up-select-queries-with-parquet-page-indexes/)), especially when data is sorted. The feature is largely implemented in parquet-mr (via classes such as `ColumnIndex` and `ColumnIndexFilter`). In Spark, the non-vectorized Parquet reader can automatically benefit from the feature after upgrading to Parquet 1.11.x, without any code change. However, the same is not true for vectorized Parquet reader since Spark chose to implement its own logic such as reading Parquet pages, handling definition levels, reading values into columnar batches, etc.

Previously, [SPARK-26345](https://issues.apache.org/jira/browse/SPARK-26345) / (#31393) updated Spark to only scan pages filtered by column index from parquet-mr side. This is done by calling `ParquetFileReader.readNextFilteredRowGroup` and `ParquetFileReader.getFilteredRecordCount` API. The implementation, however, only work for a few limited cases: in the scenario where there are multiple columns and their type width are different (e.g., `int` and `bigint`), it could return incorrect result. For this issue, please see SPARK-34859 for a detailed description.

In order to fix the above, Spark needs to leverage the API `PageReadStore.getRowIndexes` and `DataPage.getFirstRowIndex`. The former returns the indexes of all rows (note the difference between rows and values: for flat schema there is no difference between the two, but for nested schema they're different) after filtering within a Parquet row group. The latter returns the first row index within a single data page. With the combination of the two, one is able to know which rows/values should be filtered while scanning a Parquet page.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. Now the vectorized Parquet reader should work correctly with column index.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Borrowed tests from #31998 and added a few more tests.
