### PR TITLE
[SPARK-35617][INFRA] Update GitHub Action docker image to 20210602

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -152,7 +152,7 @@ jobs:
     name: "Build modules: ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20210530
+      image: dongjoon/apache-spark-github-action-image:20210602
     strategy:
       fail-fast: false
       matrix:
@@ -244,7 +244,7 @@ jobs:
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20201025
+      image: dongjoon/apache-spark-github-action-image:20210602
     env:
       HADOOP_PROFILE: hadoop3.2
       HIVE_PROFILE: hive2.3
@@ -309,7 +309,7 @@ jobs:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     container:
-      image: dongjoon/apache-spark-github-action-image:20210530
+      image: dongjoon/apache-spark-github-action-image:20210602
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update GitHub Action docker image with the following updates.
1. Add `pip` explicitly to Python 3.8/3.9
2. Add `plotly` to Python 3.8.
3. Since SPARK-35573 fixes SparkR UT failures on R 4.1.0, update SparkR job to run R 4.1.0.

### Why are the changes needed?

To improve the GitHub Action test infra and unblock #32737

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action.