### PR TITLE
[SPARK-35528][DOCS] Add more options at Data Source Options pages

### DIFF
--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -41,10 +41,10 @@ Spark SQL provides `spark.read().csv("file_name")` to read a file or directory o
 
 Data source options of CSV can be set via:
 * the `.option`/`.options` methods of
-  *  `DataFrameReader`
-  *  `DataFrameWriter`
-  *  `DataStreamReader`
-  *  `DataStreamWriter`
+  * `DataFrameReader`
+  * `DataFrameWriter`
+  * `DataStreamReader`
+  * `DataStreamWriter`
 * the built-in functions below
   * `from_csv`
   * `to_csv`

--- a/docs/sql-data-sources-json.md
+++ b/docs/sql-data-sources-json.md
@@ -99,10 +99,15 @@ SELECT * FROM jsonTable
 
 Data source options of JSON can be set via:
 * the `.option`/`.options` methods of
-  *  `DataFrameReader` 
-  *  `DataFrameWriter`
-  *  `DataStreamReader` 
-  *  `DataStreamWriter`
+  * `DataFrameReader`
+  * `DataFrameWriter`
+  * `DataStreamReader`
+  * `DataStreamWriter`
+* the built-in functions below
+  * `from_json`
+  * `to_json`
+  * `schema_of_json`
+* `OPTIONS` clause at [CREATE TABLE USING DATA_SOURCE](sql-ref-syntax-ddl-create-table-datasource.html)
 
 <table class="table">
   <tr><th><b>Property Name</b></th><th><b>Default</b></th><th><b>Meaning</b></th><th><b>Scope</b></th></tr>

--- a/docs/sql-data-sources-orc.md
+++ b/docs/sql-data-sources-orc.md
@@ -177,10 +177,11 @@ When reading from Hive metastore ORC tables and inserting to Hive metastore ORC 
 
 Data source options of ORC can be set via:
 * the `.option`/`.options` methods of
-  *  `DataFrameReader`
-  *  `DataFrameWriter`
-  *  `DataStreamReader`
-  *  `DataStreamWriter`
+  * `DataFrameReader`
+  * `DataFrameWriter`
+  * `DataStreamReader`
+  * `DataStreamWriter`
+* `OPTIONS` clause at [CREATE TABLE USING DATA_SOURCE](sql-ref-syntax-ddl-create-table-datasource.html)
 
 <table class="table">
   <tr><th><b>Property Name</b></th><th><b>Default</b></th><th><b>Meaning</b></th><th><b>Scope</b></th></tr>

--- a/docs/sql-data-sources-parquet.md
+++ b/docs/sql-data-sources-parquet.md
@@ -256,10 +256,11 @@ REFRESH TABLE my_table;
 
 Data source options of Parquet can be set via:
 * the `.option`/`.options` methods of
-  *  `DataFrameReader`
-  *  `DataFrameWriter`
-  *  `DataStreamReader`
-  *  `DataStreamWriter`
+  * `DataFrameReader`
+  * `DataFrameWriter`
+  * `DataStreamReader`
+  * `DataStreamWriter`
+* `OPTIONS` clause at [CREATE TABLE USING DATA_SOURCE](sql-ref-syntax-ddl-create-table-datasource.html)
 
 <table class="table">
   <tr><th><b>Property Name</b></th><th><b>Default</b></th><th><b>Meaning</b></th><th><b>Scope</b></th></tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes adding more methods to set data source option to `Data Source Option` page for each data source.

For example, Data Source Option page for JSON as below:

- Before
<img width="322" alt="Screen Shot 2021-06-03 at 10 51 54 AM" src="https://user-images.githubusercontent.com/44108233/120574245-eb13aa00-c459-11eb-9f81-0b356023bcb5.png">


- After
<img width="470" alt="Screen Shot 2021-06-03 at 10 52 21 AM" src="https://user-images.githubusercontent.com/44108233/120574253-ed760400-c459-11eb-9008-1f075e0b9267.png">



### Why are the changes needed?

To provide users various options when they set options for data source.


### Does this PR introduce _any_ user-facing change?

Yes, now the document provides more methods for setting options than before, as in above screen capture.


### How was this patch tested?

Manually built the docs and check one by one.

