### PR TITLE
[SPARK-35416][K8S][FOLLOWUP] Use Set instead of ArrayBuffer

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -390,8 +390,8 @@ private[spark] class ExecutorPodsAllocator(
   private def replacePVCsIfNeeded(
       pod: Pod,
       resources: Seq[HasMetadata],
-      reusablePVCs: mutable.Buffer[PersistentVolumeClaim]) = {
-    val replacedResources = mutable.ArrayBuffer[HasMetadata]()
+      reusablePVCs: mutable.Buffer[PersistentVolumeClaim]): Seq[HasMetadata] = {
+    val replacedResources = mutable.Set[HasMetadata]()
     resources.foreach {
       case pvc: PersistentVolumeClaim =>
         // Find one with the same storage class and size.
@@ -407,7 +407,7 @@ private[spark] class ExecutorPodsAllocator(
           }
           if (volume.nonEmpty) {
             val matchedPVC = reusablePVCs.remove(index)
-            replacedResources.append(pvc)
+            replacedResources.add(pvc)
             logInfo(s"Reuse PersistentVolumeClaim ${matchedPVC.getMetadata.getName}")
             volume.get.getPersistentVolumeClaim.setClaimName(matchedPVC.getMetadata.getName)
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of https://github.com/apache/spark/pull/32564 .

### Why are the changes needed?

To use Set instead of ArrayBuffer and add a return type.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.