### PR TITLE
[SPARK-35620][BUILD][PYTHON] Remove documentation build in Python linter

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -361,7 +361,7 @@ jobs:
         #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
         # Jinja2 3.0.0+ causes error when building with Sphinx.
         #   See also https://issues.apache.org/jira/browse/SPARK-35375.
-        python3.6 -m pip install flake8 'sphinx<3.1.0' numpy pydata_sphinx_theme ipython nbsphinx mypy numpydoc 'jinja2<3.0.0'
+        python3.6 -m pip install flake8 pydata_sphinx_theme mypy numpydoc 'jinja2<3.0.0'
     - name: Install R linter dependencies and SparkR
       run: |
         apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -23,8 +23,6 @@ MYPY_BUILD="mypy"
 PYCODESTYLE_BUILD="pycodestyle"
 MINIMUM_PYCODESTYLE="2.7.0"
 
-SPHINX_BUILD="sphinx-build"
-
 PYTHON_EXECUTABLE="python3"
 
 function satisfies_min_version {
@@ -187,89 +185,6 @@ flake8 checks failed."
     fi
 }
 
-function sphinx_test {
-    local SPHINX_REPORT=
-    local SPHINX_STATUS=
-
-    # Check that the documentation builds acceptably, skip check if sphinx is not installed.
-    if ! hash "$SPHINX_BUILD" 2> /dev/null; then
-        echo "The $SPHINX_BUILD command was not found. Skipping Sphinx build for now."
-        echo
-        return
-    fi
-
-    PYTHON_HAS_SPHINX=$("$PYTHON_EXECUTABLE" -c 'import importlib.util; print(importlib.util.find_spec("sphinx") is not None)')
-    if [[ "$PYTHON_HAS_SPHINX" == "False" ]]; then
-        echo "$PYTHON_EXECUTABLE does not have Sphinx installed. Skipping Sphinx build for now."
-        echo
-        return
-    fi
-
-    # TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.
-    #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
-    PYTHON_HAS_SPHINX_3_0=$("$PYTHON_EXECUTABLE" -c 'from distutils.version import LooseVersion; import sphinx; print(LooseVersion(sphinx.__version__) < LooseVersion("3.1.0"))')
-    if [[ "$PYTHON_HAS_SPHINX_3_0" == "False" ]]; then
-        echo "$PYTHON_EXECUTABLE has Sphinx 3.1+ installed but it requires lower than 3.1. Skipping Sphinx build for now."
-        echo
-        return
-    fi
-
-    # TODO(SPARK-32391): Install pydata_sphinx_theme in Jenkins machines
-    PYTHON_HAS_THEME=$("$PYTHON_EXECUTABLE" -c 'import importlib.util; print(importlib.util.find_spec("pydata_sphinx_theme") is not None)')
-    if [[ "$PYTHON_HAS_THEME" == "False" ]]; then
-        echo "$PYTHON_EXECUTABLE does not have pydata_sphinx_theme installed. Skipping Sphinx build for now."
-        echo
-        return
-    fi
-
-    # TODO(SPARK-32666): Install nbsphinx in Jenkins machines
-    PYTHON_HAS_NBSPHINX=$("$PYTHON_EXECUTABLE" -c 'import importlib.util; print(importlib.util.find_spec("nbsphinx") is not None)')
-    if [[ "$PYTHON_HAS_NBSPHINX" == "False" ]]; then
-        echo "$PYTHON_EXECUTABLE does not have nbsphinx installed. Skipping Sphinx build for now."
-        echo
-        return
-    fi
-
-    # TODO(SPARK-32666): Install ipython in Jenkins machines
-    PYTHON_HAS_IPYTHON=$("$PYTHON_EXECUTABLE" -c 'import importlib.util; print(importlib.util.find_spec("IPython") is not None)')
-    if [[ "$PYTHON_HAS_IPYTHON" == "False" ]]; then
-        echo "$PYTHON_EXECUTABLE does not have ipython installed. Skipping Sphinx build for now."
-        echo
-        return
-    fi
-
-    # TODO(SPARK-33242): Install numpydoc in Jenkins machines
-    PYTHON_HAS_NUMPYDOC=$("$PYTHON_EXECUTABLE" -c 'import importlib.util; print(importlib.util.find_spec("numpydoc") is not None)')
-    if [[ "$PYTHON_HAS_NUMPYDOC" == "False" ]]; then
-        echo "$PYTHON_EXECUTABLE does not have numpydoc installed. Skipping Sphinx build for now."
-        echo
-        return
-    fi
-
-    echo "starting $SPHINX_BUILD tests..."
-    pushd python/docs &> /dev/null
-    make clean &> /dev/null
-    # Treat warnings as errors so we stop correctly
-    SPHINX_REPORT=$( (SPHINXOPTS="-a -W" make html) 2>&1)
-    SPHINX_STATUS=$?
-
-    if [ "$SPHINX_STATUS" -ne 0 ]; then
-        echo "$SPHINX_BUILD checks failed:"
-        echo "$SPHINX_REPORT"
-        echo
-        echo "re-running make html to print full warning list:"
-        make clean &> /dev/null
-        SPHINX_REPORT=$( (SPHINXOPTS="-a" make html) 2>&1)
-        echo "$SPHINX_REPORT"
-        exit "$SPHINX_STATUS"
-    else
-        echo "$SPHINX_BUILD checks passed."
-        echo
-    fi
-
-    popd &> /dev/null
-}
-
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 SPARK_ROOT_DIR="$(dirname "${SCRIPT_DIR}")"
 
@@ -282,7 +197,6 @@ compile_python_test "$PYTHON_SOURCE"
 pycodestyle_test "$PYTHON_SOURCE"
 flake8_test
 mypy_test
-sphinx_test
 
 echo
 echo "all lint-python tests passed!"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove PySpark documentation build in linter check because:

- to speed up CI build by removing duplicate documentation build (linter and doc build)
- for https://github.com/apache/spark/pull/32726. With this PR PySpark documentation build requires a full Spark build to generate plot images in PySpark documentation. It makes less sense to require it in Python linter.
- to remove unnecessary dependency installation for Python linter in CI

### Why are the changes needed?

Python linter script includes documentation build. Because of this, we run documentation builds duplicately in CI, and requires unnecessary dependencies to be installed, and takes extra time. It would more make sense to exclude this in Python linter.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested, and it will be tested in CI.
