### PR TITLE
[SPARK-35081][DOCS] Add Data Source Option links to missing documents

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -3616,6 +3616,10 @@ def from_json(col, schema, options=None):
             the DDL-formatted string is also supported for ``schema``.
     options : dict, optional
         options to control parsing. accepts the same options as the json datasource
+        See `Data Source Option <https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option>`_
+        in the version you use.
+
+        .. # noqa
 
     Examples
     --------
@@ -3666,8 +3670,12 @@ def to_json(col, options=None):
         name of column containing a struct, an array or a map.
     options : dict, optional
         options to control converting. accepts the same options as the JSON datasource.
+        See `Data Source Option <https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option>`_
+        in the version you use.
         Additionally the function supports the `pretty` option which enables
         pretty JSON generation.
+
+        .. # noqa
 
     Examples
     --------
@@ -3753,6 +3761,10 @@ def schema_of_csv(csv, options=None):
         a CSV string or a foldable string column containing a CSV string.
     options : dict, optional
         options to control parsing. accepts the same options as the CSV datasource
+        See `Data Source Option <https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option>`_
+        in the version you use.
+
+        .. # noqa
 
     Examples
     --------
@@ -3787,6 +3799,10 @@ def to_csv(col, options=None):
         name of column containing a struct.
     options: dict, optional
         options to control converting. accepts the same options as the CSV datasource.
+        See `Data Source Option <https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option>`_
+        in the version you use.
+
+        .. # noqa
 
     Examples
     --------
@@ -4200,6 +4216,10 @@ def from_csv(col, schema, options=None):
         a string with schema in DDL format to use when parsing the CSV column.
     options : dict, optional
         options to control parsing. accepts the same options as the CSV datasource
+        See `Data Source Option <https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option>`_
+        in the version you use.
+
+        .. # noqa
 
     Examples
     --------

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -3615,7 +3615,7 @@ def from_json(col, schema, options=None):
         .. versionchanged:: 2.3
             the DDL-formatted string is also supported for ``schema``.
     options : dict, optional
-        options to control parsing. accepts the same options as the json datasource
+        options to control parsing. accepts the same options as the json datasource.
         See `Data Source Option <https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option>`_
         in the version you use.
 
@@ -3760,7 +3760,7 @@ def schema_of_csv(csv, options=None):
     csv : :class:`~pyspark.sql.Column` or str
         a CSV string or a foldable string column containing a CSV string.
     options : dict, optional
-        options to control parsing. accepts the same options as the CSV datasource
+        options to control parsing. accepts the same options as the CSV datasource.
         See `Data Source Option <https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option>`_
         in the version you use.
 
@@ -4215,7 +4215,7 @@ def from_csv(col, schema, options=None):
     schema :class:`~pyspark.sql.Column` or str
         a string with schema in DDL format to use when parsing the CSV column.
     options : dict, optional
-        options to control parsing. accepts the same options as the CSV datasource
+        options to control parsing. accepts the same options as the CSV datasource.
         See `Data Source Option <https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option>`_
         in the version you use.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes adding the missing link to Data Source Option page, for related functions such as `to_csv`, `to_json`, `from_csv`, `from_json`, `schema_of_csv`, `schema_of_json`.

- Before
<img width="797" alt="Screen Shot 2021-06-03 at 11 39 17 AM" src="https://user-images.githubusercontent.com/44108233/120578877-7b092200-c461-11eb-9e24-bd5349445c66.png">


- After
<img width="776" alt="Screen Shot 2021-06-03 at 11 59 14 AM" src="https://user-images.githubusercontent.com/44108233/120579868-29fa2d80-c463-11eb-9329-bd6c8f068f5b.png">



### Why are the changes needed?

To provide users available options in detail with the proper documentation link.


### Does this PR introduce _any_ user-facing change?

Yes, the link to Data Source Options page is added to the API documentations, as shown in the above screen capture.


### How was this patch tested?

Manually built the docs and checked one by one.
