### PR TITLE
[SPARK-35390][SQL] Handle type coercion when resolving V2 functions

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/functions/ScalarFunction.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/functions/ScalarFunction.java
@@ -39,6 +39,9 @@ import org.apache.spark.sql.types.DataType;
  * provides better performance over the default {@link #produceResult}, due to optimizations such
  * as whole-stage codegen, elimination of Java boxing, etc.
  * <p>
+ * The type parameters for the magic method <b>must match</b> those returned from
+ * {@link BoundFunction#inputTypes()}. Otherwise Spark will not be able to find the magic method.
+ * <p>
  * In addition, for stateless Java functions, users can optionally define the
  * {@link #MAGIC_METHOD_NAME} as a static method, which further avoids certain runtime costs such
  * as Java dynamic dispatch.
@@ -117,6 +120,8 @@ import org.apache.spark.sql.types.DataType;
  *   <li>{@link org.apache.spark.sql.types.DateType}: {@code int}</li>
  *   <li>{@link org.apache.spark.sql.types.TimestampType}: {@code long}</li>
  *   <li>{@link org.apache.spark.sql.types.BinaryType}: {@code byte[]}</li>
+ *   <li>{@link org.apache.spark.sql.types.CalendarIntervalType}:
+ *       {@link org.apache.spark.unsafe.types.CalendarInterval}</li>
  *   <li>{@link org.apache.spark.sql.types.DayTimeIntervalType}: {@code long}</li>
  *   <li>{@link org.apache.spark.sql.types.YearMonthIntervalType}: {@code int}</li>
  *   <li>{@link org.apache.spark.sql.types.DecimalType}:

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/functions/ScalarFunction.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/functions/ScalarFunction.java
@@ -120,8 +120,6 @@ import org.apache.spark.sql.types.DataType;
  *   <li>{@link org.apache.spark.sql.types.DateType}: {@code int}</li>
  *   <li>{@link org.apache.spark.sql.types.TimestampType}: {@code long}</li>
  *   <li>{@link org.apache.spark.sql.types.BinaryType}: {@code byte[]}</li>
- *   <li>{@link org.apache.spark.sql.types.CalendarIntervalType}:
- *       {@link org.apache.spark.unsafe.types.CalendarInterval}</li>
  *   <li>{@link org.apache.spark.sql.types.DayTimeIntervalType}: {@code long}</li>
  *   <li>{@link org.apache.spark.sql.types.YearMonthIntervalType}: {@code int}</li>
  *   <li>{@link org.apache.spark.sql.types.DecimalType}:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ApplyFunctionExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ApplyFunctionExpression.scala
@@ -20,14 +20,17 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.{AbstractDataType, DataType}
 
 case class ApplyFunctionExpression(
     function: ScalarFunction[_],
-    children: Seq[Expression]) extends Expression with UserDefinedExpression with CodegenFallback {
+    children: Seq[Expression])
+  extends Expression with UserDefinedExpression with CodegenFallback with ImplicitCastInputTypes {
+
   override def nullable: Boolean = function.isResultNullable
   override def name: String = function.name()
   override def dataType: DataType = function.resultType()
+  override def inputTypes: Seq[AbstractDataType] = function.inputTypes().toSeq
 
   private lazy val reusedRow = new SpecificInternalRow(function.inputTypes())
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -44,11 +44,16 @@ import org.apache.spark.util.Utils
 /**
  * Common base class for [[StaticInvoke]], [[Invoke]], and [[NewInstance]].
  */
-trait InvokeLike extends Expression with NonSQLExpression {
+trait InvokeLike extends Expression with NonSQLExpression with ImplicitCastInputTypes {
 
   def arguments: Seq[Expression]
 
+  def methodInputTypes: Option[Seq[DataType]]
+
   def propagateNull: Boolean
+
+  override def inputTypes: Seq[AbstractDataType] =
+    methodInputTypes.getOrElse(arguments.map(_.dataType))
 
   protected lazy val needNullCheck: Boolean = needNullCheckForIndex.contains(true)
   protected lazy val needNullCheckForIndex: Array[Boolean] =
@@ -229,6 +234,11 @@ object SerializerSupport {
  * @param dataType The expected return type of the function call
  * @param functionName The name of the method to call.
  * @param arguments An optional list of expressions to pass as arguments to the function.
+ * @param methodInputTypes An optional list of data types specifying the input types for the method
+ *                      to be invoked. It must have the same length as [[arguments]]. In case an
+ *                      input type differs from the actual argument type, Spark will try to insert
+ *                      cast before invoking the method. If not specified, Spark will assume the
+ *                      method input types are identical to the types from [[arguments]].
  * @param propagateNull When true, and any of the arguments is null, null will be returned instead
  *                      of calling the function. Also note: when this is false but any of the
  *                      arguments is of primitive type and is null, null also will be returned
@@ -241,6 +251,7 @@ case class StaticInvoke(
     dataType: DataType,
     functionName: String,
     arguments: Seq[Expression] = Nil,
+    methodInputTypes: Option[Seq[DataType]] = None,
     propagateNull: Boolean = true,
     returnNullable: Boolean = true) extends InvokeLike {
 
@@ -322,7 +333,12 @@ case class StaticInvoke(
  * @param functionName The name of the method to call.
  * @param dataType The expected return type of the function.
  * @param arguments An optional list of expressions, whose evaluation will be passed to the
-  *                 function.
+ *                 function.
+ * @param methodInputTypes An optional list of data types specifying the input types for the method
+ *                      to be invoked. It must have the same length as [[arguments]]. In case an
+ *                      input type differs from the actual argument type, Spark will try to insert
+ *                      cast before invoking the method. If not specified, Spark will assume the
+ *                      method input types are identical to the types from [[arguments]].
  * @param propagateNull When true, and any of the arguments is null, null will be returned instead
  *                      of calling the function. Also note: when this is false but any of the
  *                      arguments is of primitive type and is null, null also will be returned
@@ -335,6 +351,7 @@ case class Invoke(
     functionName: String,
     dataType: DataType,
     arguments: Seq[Expression] = Nil,
+    methodInputTypes: Option[Seq[DataType]] = None,
     propagateNull: Boolean = true,
     returnNullable : Boolean = true) extends InvokeLike {
 
@@ -342,6 +359,7 @@ case class Invoke(
 
   override def nullable: Boolean = targetObject.nullable || needNullCheck || returnNullable
   override def children: Seq[Expression] = targetObject +: arguments
+  override def inputTypes: Seq[AbstractDataType] = Seq(targetObject.dataType) ++ super.inputTypes
 
   private lazy val encodedFunctionName = ScalaReflection.encodeFieldNameToIdentifier(functionName)
 
@@ -450,7 +468,7 @@ object NewInstance {
       arguments: Seq[Expression],
       dataType: DataType,
       propagateNull: Boolean = true): NewInstance =
-    new NewInstance(cls, arguments, propagateNull, dataType, None)
+    new NewInstance(cls, arguments, methodInputTypes = None, propagateNull, dataType, None)
 }
 
 /**
@@ -459,6 +477,11 @@ object NewInstance {
  *
  * @param cls The class to construct.
  * @param arguments A list of expression to use as arguments to the constructor.
+ * @param methodInputTypes An optional list of data types specifying the input types for the method
+ *                      to be invoked. It must have the same length as [[arguments]]. In case an
+ *                      input type differs from the actual argument type, Spark will try to insert
+ *                      cast before invoking the method. If not specified, Spark will assume the
+ *                      method input types are identical to the types from [[arguments]].
  * @param propagateNull When true, if any of the arguments is null, then null will be returned
  *                      instead of trying to construct the object. Also note: when this is false
  *                      but any of the arguments is of primitive type and is null, null also will
@@ -474,6 +497,7 @@ object NewInstance {
 case class NewInstance(
     cls: Class[_],
     arguments: Seq[Expression],
+    methodInputTypes: Option[Seq[DataType]],
     propagateNull: Boolean,
     dataType: DataType,
     outerPointer: Option[() => AnyRef]) extends InvokeLike {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -48,12 +48,7 @@ trait InvokeLike extends Expression with NonSQLExpression with ImplicitCastInput
 
   def arguments: Seq[Expression]
 
-  def methodInputTypes: Option[Seq[DataType]]
-
   def propagateNull: Boolean
-
-  override def inputTypes: Seq[AbstractDataType] =
-    methodInputTypes.getOrElse(arguments.map(_.dataType))
 
   protected lazy val needNullCheck: Boolean = needNullCheckForIndex.contains(true)
   protected lazy val needNullCheckForIndex: Array[Boolean] =
@@ -234,11 +229,11 @@ object SerializerSupport {
  * @param dataType The expected return type of the function call
  * @param functionName The name of the method to call.
  * @param arguments An optional list of expressions to pass as arguments to the function.
- * @param methodInputTypes An optional list of data types specifying the input types for the method
- *                      to be invoked. It must have the same length as [[arguments]]. In case an
- *                      input type differs from the actual argument type, Spark will try to insert
- *                      cast before invoking the method. If not specified, Spark will assume the
- *                      method input types are identical to the types from [[arguments]].
+ * @param inputTypes A list of data types specifying the input types for the method to be invoked.
+ *                   If enabled, it must have the same length as [[arguments]]. In case an input
+ *                   type differs from the actual argument type, Spark will try to perform
+ *                   type coercion and insert cast whenever necessary before invoking the method.
+ *                   The above is disabled if this is empty.
  * @param propagateNull When true, and any of the arguments is null, null will be returned instead
  *                      of calling the function. Also note: when this is false but any of the
  *                      arguments is of primitive type and is null, null also will be returned
@@ -251,7 +246,7 @@ case class StaticInvoke(
     dataType: DataType,
     functionName: String,
     arguments: Seq[Expression] = Nil,
-    methodInputTypes: Option[Seq[DataType]] = None,
+    inputTypes: Seq[AbstractDataType] = Nil,
     propagateNull: Boolean = true,
     returnNullable: Boolean = true) extends InvokeLike {
 
@@ -334,11 +329,11 @@ case class StaticInvoke(
  * @param dataType The expected return type of the function.
  * @param arguments An optional list of expressions, whose evaluation will be passed to the
  *                 function.
- * @param methodInputTypes An optional list of data types specifying the input types for the method
- *                      to be invoked. It must have the same length as [[arguments]]. In case an
- *                      input type differs from the actual argument type, Spark will try to insert
- *                      cast before invoking the method. If not specified, Spark will assume the
- *                      method input types are identical to the types from [[arguments]].
+ * @param methodInputTypes A list of data types specifying the input types for the method to be
+ *                         invoked. If enabled, it must have the same length as [[arguments]]. In
+ *                         case an input type differs from the actual argument type, Spark will
+ *                         try to perform type coercion and insert cast whenever necessary before
+ *                         invoking the method. The type coercion is disabled if this is empty.
  * @param propagateNull When true, and any of the arguments is null, null will be returned instead
  *                      of calling the function. Also note: when this is false but any of the
  *                      arguments is of primitive type and is null, null also will be returned
@@ -351,7 +346,7 @@ case class Invoke(
     functionName: String,
     dataType: DataType,
     arguments: Seq[Expression] = Nil,
-    methodInputTypes: Option[Seq[DataType]] = None,
+    methodInputTypes: Seq[AbstractDataType] = Nil,
     propagateNull: Boolean = true,
     returnNullable : Boolean = true) extends InvokeLike {
 
@@ -359,7 +354,12 @@ case class Invoke(
 
   override def nullable: Boolean = targetObject.nullable || needNullCheck || returnNullable
   override def children: Seq[Expression] = targetObject +: arguments
-  override def inputTypes: Seq[AbstractDataType] = Seq(targetObject.dataType) ++ super.inputTypes
+  override def inputTypes: Seq[AbstractDataType] =
+    if (methodInputTypes.nonEmpty) {
+      Seq(targetObject.dataType) ++ methodInputTypes
+    } else {
+      Nil
+    }
 
   private lazy val encodedFunctionName = ScalaReflection.encodeFieldNameToIdentifier(functionName)
 
@@ -468,7 +468,7 @@ object NewInstance {
       arguments: Seq[Expression],
       dataType: DataType,
       propagateNull: Boolean = true): NewInstance =
-    new NewInstance(cls, arguments, methodInputTypes = None, propagateNull, dataType, None)
+    new NewInstance(cls, arguments, inputTypes = Nil, propagateNull, dataType, None)
 }
 
 /**
@@ -477,11 +477,11 @@ object NewInstance {
  *
  * @param cls The class to construct.
  * @param arguments A list of expression to use as arguments to the constructor.
- * @param methodInputTypes An optional list of data types specifying the input types for the method
- *                      to be invoked. It must have the same length as [[arguments]]. In case an
- *                      input type differs from the actual argument type, Spark will try to insert
- *                      cast before invoking the method. If not specified, Spark will assume the
- *                      method input types are identical to the types from [[arguments]].
+ * @param inputTypes A list of data types specifying the input types for the method to be invoked.
+ *                   If enabled, it must have the same length as [[arguments]]. In case an input
+ *                   type differs from the actual argument type, Spark will try to perform
+ *                   type coercion and insert cast whenever necessary before invoking the method.
+ *                   The above is disabled if this is empty.
  * @param propagateNull When true, if any of the arguments is null, then null will be returned
  *                      instead of trying to construct the object. Also note: when this is false
  *                      but any of the arguments is of primitive type and is null, null also will
@@ -497,7 +497,7 @@ object NewInstance {
 case class NewInstance(
     cls: Class[_],
     arguments: Seq[Expression],
-    methodInputTypes: Option[Seq[DataType]],
+    inputTypes: Seq[AbstractDataType],
     propagateNull: Boolean,
     dataType: DataType,
     outerPointer: Option[() => AnyRef]) extends InvokeLike {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1473,11 +1473,6 @@ private[spark] object QueryCompilationErrors {
         s"arguments but ${bound.inputTypes().length} parameters returned from 'inputTypes()'")
   }
 
-  def v2FunctionCastError(bound: BoundFunction, arg: Expression, ty: DataType): Throwable = {
-    new AnalysisException(s"Invalid bound function '${bound.name()}': cannot cast " +
-        s"actual argument type '${arg.dataType}' to expected type '$ty'")
-  }
-
   def ambiguousRelationAliasNameInNestedCTEError(name: String): Throwable = {
     new AnalysisException(s"Name $name is ambiguous in nested CTE. " +
       s"Please set ${LEGACY_CTE_PRECEDENCE_POLICY.key} to CORRECTED so that name " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.{toPrettySQL, FailFastMode, ParseMode, PermissiveMode}
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
-import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
+import org.apache.spark.sql.connector.catalog.functions.{BoundFunction, UnboundFunction}
 import org.apache.spark.sql.connector.expressions.{NamedReference, Transform}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LEGACY_CTE_PRECEDENCE_POLICY
@@ -1464,6 +1464,18 @@ private[spark] object QueryCompilationErrors {
     new AnalysisException(s"Function '${unbound.name}' cannot process " +
       s"input: (${arguments.map(_.dataType.simpleString).mkString(", ")}): " +
       unsupported.getMessage, cause = Some(unsupported))
+  }
+
+  def v2FunctionInvalidInputTypeLengthError(
+      bound: BoundFunction,
+      args: Seq[Expression]): Throwable = {
+    new AnalysisException(s"Invalid bound function '${bound.name()}: there are ${args.length} " +
+        s"arguments but ${bound.inputTypes().length} parameters returned from 'inputTypes()'")
+  }
+
+  def v2FunctionCastError(bound: BoundFunction, arg: Expression, ty: DataType): Throwable = {
+    new AnalysisException(s"Invalid bound function '${bound.name()}': cannot cast " +
+        s"actual argument type '${arg.dataType}' to expected type '$ty'")
   }
 
   def ambiguousRelationAliasNameInNestedCTEError(name: String): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -399,6 +399,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val newInst1 = NewInstance(
       cls = classOf[GenericArrayData],
       arguments = Literal.fromObject(List(1, 2, 3)) :: Nil,
+      methodInputTypes = None,
       propagateNull = false,
       dataType = ArrayType(IntegerType),
       outerPointer = None)
@@ -409,6 +410,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val newInst2 = NewInstance(
       cls = classOf[outerObj.Inner],
       arguments = Literal(1) :: Nil,
+      methodInputTypes = None,
       propagateNull = false,
       dataType = ObjectType(classOf[outerObj.Inner]),
       outerPointer = Some(() => outerObj))
@@ -418,6 +420,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val newInst3 = NewInstance(
       cls = classOf[ScroogeLikeExample],
       arguments = Literal(1) :: Nil,
+      methodInputTypes = None,
       propagateNull = false,
       dataType = ObjectType(classOf[ScroogeLikeExample]),
       outerPointer = Some(() => outerObj))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -399,7 +399,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val newInst1 = NewInstance(
       cls = classOf[GenericArrayData],
       arguments = Literal.fromObject(List(1, 2, 3)) :: Nil,
-      methodInputTypes = None,
+      inputTypes = Nil,
       propagateNull = false,
       dataType = ArrayType(IntegerType),
       outerPointer = None)
@@ -410,7 +410,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val newInst2 = NewInstance(
       cls = classOf[outerObj.Inner],
       arguments = Literal(1) :: Nil,
-      methodInputTypes = None,
+      inputTypes = Nil,
       propagateNull = false,
       dataType = ObjectType(classOf[outerObj.Inner]),
       outerPointer = Some(() => outerObj))
@@ -420,7 +420,7 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val newInst3 = NewInstance(
       cls = classOf[ScroogeLikeExample],
       arguments = Literal(1) :: Nil,
-      methodInputTypes = None,
+      inputTypes = Nil,
       propagateNull = false,
       dataType = ObjectType(classOf[ScroogeLikeExample]),
       outerPointer = Some(() => outerObj))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateMapObjectsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateMapObjectsSuite.scala
@@ -46,7 +46,7 @@ class EliminateMapObjectsSuite extends PlanTest {
     val intQuery = intInput.deserialize[Array[Int]].analyze
     val intOptimized = Optimize.execute(intQuery)
     val intExpected = DeserializeToObject(
-      Invoke(intInput.output(0), "toIntArray", intObjType, Nil, None, true, false),
+      Invoke(intInput.output(0), "toIntArray", intObjType, Nil, Nil, true, false),
       AttributeReference("obj", intObjType, true)(), intInput)
     comparePlans(intOptimized, intExpected)
 
@@ -55,7 +55,7 @@ class EliminateMapObjectsSuite extends PlanTest {
     val doubleQuery = doubleInput.deserialize[Array[Double]].analyze
     val doubleOptimized = Optimize.execute(doubleQuery)
     val doubleExpected = DeserializeToObject(
-      Invoke(doubleInput.output(0), "toDoubleArray", doubleObjType, Nil, None, true, false),
+      Invoke(doubleInput.output(0), "toDoubleArray", doubleObjType, Nil, Nil, true, false),
       AttributeReference("obj", doubleObjType, true)(), doubleInput)
     comparePlans(doubleOptimized, doubleExpected)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateMapObjectsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateMapObjectsSuite.scala
@@ -46,7 +46,7 @@ class EliminateMapObjectsSuite extends PlanTest {
     val intQuery = intInput.deserialize[Array[Int]].analyze
     val intOptimized = Optimize.execute(intQuery)
     val intExpected = DeserializeToObject(
-      Invoke(intInput.output(0), "toIntArray", intObjType, Nil, true, false),
+      Invoke(intInput.output(0), "toIntArray", intObjType, Nil, None, true, false),
       AttributeReference("obj", intObjType, true)(), intInput)
     comparePlans(intOptimized, intExpected)
 
@@ -55,7 +55,7 @@ class EliminateMapObjectsSuite extends PlanTest {
     val doubleQuery = doubleInput.deserialize[Array[Double]].analyze
     val doubleOptimized = Optimize.execute(doubleQuery)
     val doubleExpected = DeserializeToObject(
-      Invoke(doubleInput.output(0), "toDoubleArray", doubleObjType, Nil, true, false),
+      Invoke(doubleInput.output(0), "toDoubleArray", doubleObjType, Nil, None, true, false),
       AttributeReference("obj", doubleObjType, true)(), doubleInput)
     comparePlans(doubleOptimized, doubleExpected)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
@@ -21,7 +21,7 @@ import java.util
 import java.util.Collections
 
 import test.org.apache.spark.sql.connector.catalog.functions.{JavaAverage, JavaLongAdd, JavaStrLen}
-import test.org.apache.spark.sql.connector.catalog.functions.JavaLongAdd.JavaLongAddMagic
+import test.org.apache.spark.sql.connector.catalog.functions.JavaLongAdd.{JavaLongAddDefault, JavaLongAddMagic, JavaLongAddMismatchMagic, JavaLongAddStaticMagic}
 import test.org.apache.spark.sql.connector.catalog.functions.JavaStrLen._
 
 import org.apache.spark.SparkException
@@ -29,7 +29,7 @@ import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode.{FALLBACK, NO_CODEGEN}
 import org.apache.spark.sql.connector.catalog.{BasicInMemoryTableCatalog, Identifier, InMemoryCatalog, SupportsNamespaces}
-import org.apache.spark.sql.connector.catalog.functions._
+import org.apache.spark.sql.connector.catalog.functions.{AggregateFunction, _}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -215,6 +215,38 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
       .getMessage.contains("neither implement magic method nor override 'produceResult'"))
   }
 
+  test("SPARK-35390: scalar function w/ bad input types") {
+    catalog("testcat").asInstanceOf[SupportsNamespaces].createNamespace(Array("ns"), emptyProps)
+    addFunction(Identifier.of(Array("ns"), "strlen"), StrLen(StrLenBadInputTypes))
+    assert(intercept[AnalysisException](sql("SELECT testcat.ns.strlen('abc')").collect())
+        .getMessage.contains("parameters returned from 'inputTypes()'"))
+  }
+
+  test("SPARK-35390: scalar function w/ mismatch type parameters from magic method") {
+    catalog("testcat").asInstanceOf[SupportsNamespaces].createNamespace(Array("ns"), emptyProps)
+    addFunction(Identifier.of(Array("ns"), "add"), new JavaLongAdd(new JavaLongAddMismatchMagic))
+    assert(intercept[AnalysisException](sql("SELECT testcat.ns.add(1L, 2L)").collect())
+        .getMessage.contains("neither implement magic method nor override 'produceResult'"))
+  }
+
+  test("SPARK-35390: scalar function w/ type coercion") {
+    catalog("testcat").asInstanceOf[SupportsNamespaces].createNamespace(Array("ns"), emptyProps)
+    addFunction(Identifier.of(Array("ns"), "add"), new JavaLongAdd(new JavaLongAddDefault(false)))
+    addFunction(Identifier.of(Array("ns"), "add2"), new JavaLongAdd(new JavaLongAddMagic(false)))
+    addFunction(Identifier.of(Array("ns"), "add3"),
+      new JavaLongAdd(new JavaLongAddStaticMagic(false)))
+    Seq("add", "add2", "add3").foreach { name =>
+      checkAnswer(sql(s"SELECT testcat.ns.$name(42, 58)"), Row(100) :: Nil)
+      checkAnswer(sql(s"SELECT testcat.ns.$name(42L, 58)"), Row(100) :: Nil)
+      checkAnswer(sql(s"SELECT testcat.ns.$name(42, 58L)"), Row(100) :: Nil)
+
+      // can't cast date time interval to long
+      assert(intercept[AnalysisException](
+        sql(s"SELECT testcat.ns.$name(date '2021-06-01' - date '2011-06-01', 93)").collect())
+          .getMessage.contains("cannot cast"))
+    }
+  }
+
   test("SPARK-35389: magic function should handle null arguments") {
     catalog("testcat").asInstanceOf[SupportsNamespaces].createNamespace(Array("ns"), emptyProps)
     addFunction(Identifier.of(Array("ns"), "strlen"), new JavaStrLen(new JavaStrLenMagicNullSafe))
@@ -312,6 +344,27 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
     }
   }
 
+  test("SPARK-35390: aggregate function w/ type coercion") {
+    import testImplicits._
+
+    withTable("t1", "t2") {
+      addFunction(Identifier.of(Array("ns"), "avg"), UnboundDecimalAverage)
+
+      (1 to 100).toDF().write.saveAsTable("testcat.ns.t1")
+      checkAnswer(sql(s"SELECT testcat.ns.avg(value) from testcat.ns.t1"),
+        Row(BigDecimal(50.5)) :: Nil)
+
+      (1 to 100).map(BigDecimal(_)).toDF().write.saveAsTable("testcat.ns.t2")
+      checkAnswer(sql(s"SELECT testcat.ns.avg(value) from testcat.ns.t2"),
+        Row(BigDecimal(50.5)) :: Nil)
+
+      // can't cast interval to decimal
+      assert(intercept[AnalysisException](sql(s"SELECT testcat.ns.avg(*) from values" +
+          s" (date '2021-06-01' - date '2011-06-01'), (date '2000-01-01' - date '1900-01-01')"))
+          .getMessage.contains("cannot cast"))
+    }
+  }
+
   private case class StrLen(impl: BoundFunction) extends UnboundFunction {
     override def description(): String =
       """strlen: returns the length of the input string
@@ -380,6 +433,13 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
     override def inputTypes(): Array[DataType] = Array(StringType)
     override def resultType(): DataType = IntegerType
     override def name(): String = "strlen_noimpl"
+  }
+
+  // input type doesn't match arguments accepted by `UnboundFunction.bind`
+  private case object StrLenBadInputTypes extends ScalarFunction[Int] {
+    override def inputTypes(): Array[DataType] = Array(StringType, IntegerType)
+    override def resultType(): DataType = IntegerType
+    override def name(): String = "strlen_bad_input_types"
   }
 
   private case object BadBoundFunction extends BoundFunction {
@@ -464,6 +524,60 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
     }
 
     override def produceResult(state: (Long, Long)): Long = state._1 / state._2
+  }
+
+  object UnboundDecimalAverage extends UnboundFunction {
+    override def name(): String = "favg"
+
+    override def bind(inputType: StructType): BoundFunction = {
+      if (inputType.fields.length > 1) {
+        throw new UnsupportedOperationException("Too many arguments")
+      }
+
+      // put interval type here for testing purpose
+      inputType.fields(0).dataType match {
+        case _: NumericType | _: DayTimeIntervalType => DecimalAverage
+        case dataType =>
+          throw new UnsupportedOperationException(s"Unsupported input type: $dataType")
+      }
+    }
+
+    override def description(): String =
+      """iavg: produces an average using decimal division, ignoring nulls
+        |  iavg(integral) -> decimal
+        |  iavg(float) -> decimal
+        |  iavg(decimal) -> decimal""".stripMargin
+  }
+
+  object DecimalAverage extends AggregateFunction[(Decimal, Int), Decimal] {
+    val PRECISION: Int = 15
+    val SCALE: Int = 5
+
+    override def name(): String = "davg"
+    override def inputTypes(): Array[DataType] = Array(DecimalType(PRECISION, SCALE))
+    override def resultType(): DataType = DecimalType(PRECISION, SCALE)
+
+    override def newAggregationState(): (Decimal, Int) = (Decimal.ZERO, 0)
+
+    override def update(state: (Decimal, Int), input: InternalRow): (Decimal, Int) = {
+      if (input.isNullAt(0)) {
+        state
+      } else {
+        val l = input.getDecimal(0, PRECISION, SCALE)
+        state match {
+          case (_, d) if d == 0 =>
+            (l, 1)
+          case (total, count) =>
+            (total + l, count + 1)
+        }
+      }
+    }
+
+    override def merge(leftState: (Decimal, Int), rightState: (Decimal, Int)): (Decimal, Int) = {
+      (leftState._1 + rightState._1, leftState._2 + rightState._2)
+    }
+
+    override def produceResult(state: (Decimal, Int)): Decimal = state._1 / Decimal(state._2)
   }
 
   object NoImplAverage extends UnboundFunction {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
@@ -243,7 +243,7 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
       // can't cast date time interval to long
       assert(intercept[AnalysisException](
         sql(s"SELECT testcat.ns.$name(date '2021-06-01' - date '2011-06-01', 93)").collect())
-          .getMessage.contains("cannot cast"))
+          .getMessage.contains("due to data type mismatch"))
     }
   }
 
@@ -361,7 +361,7 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
       // can't cast interval to decimal
       assert(intercept[AnalysisException](sql("SELECT testcat.ns.avg(*) from values" +
           " (date '2021-06-01' - date '2011-06-01'), (date '2000-01-01' - date '1900-01-01')"))
-          .getMessage.contains("cannot cast"))
+          .getMessage.contains("due to data type mismatch"))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Handle type coercion when resolving V2 function. In particular:
- prior to evaluating function arguments, insert cast whenever the argument type doesn't match the expected input type.
- use `BoundFunction.inputTypes()` to lookup magic method for scalar function

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

For V2 functions, the actual argument types should not necessarily match those of the input types, and Spark should handle type coercion whenever it is needed.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. Now V2 function resolution should be able to handle type coercion properly.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added a few new tests.