### PR TITLE
[SPARK-35627][CORE] Decommission executors in batches to not overload network bandwidth

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2023,6 +2023,22 @@ package object config {
       .stringConf
       .createWithDefaultString("PWR")
 
+  private[spark] val EXECUTOR_DECOMMISSION_BATCH_INTERVAL =
+    ConfigBuilder("spark.executor.decommission.batchInterval")
+      .doc("Executors are decommissioned in batched to avoid overloading network bandwidth in" +
+        " migrating rdd and shuffle data. This config sets the interval between batches.")
+      .version("3.2.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(30000)
+
+  private[spark] val EXECUTOR_DECOMMISSION_BATCH_SIZE =
+    ConfigBuilder("spark.executor.decommission.batchSize")
+      .doc("Executors are decommissioned in batched to avoid overloading network bandwidth in" +
+        " migrating rdd and shuffle data. This config sets the interval between batches.")
+      .version("3.2.0")
+      .intConf
+      .createWithDefault(3)
+
   private[spark] val STAGING_DIR = ConfigBuilder("spark.yarn.stagingDir")
     .doc("Staging directory used while submitting applications.")
     .version("2.0.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2025,19 +2025,19 @@ package object config {
 
   private[spark] val EXECUTOR_DECOMMISSION_BATCH_INTERVAL =
     ConfigBuilder("spark.executor.decommission.batchInterval")
-      .doc("Executors are decommissioned in batched to avoid overloading network bandwidth in" +
+      .doc("Executors are decommissioned in batches to avoid overloading network bandwidth in" +
         " migrating rdd and shuffle data. This config sets the interval between batches.")
       .version("3.2.0")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefault(30000)
+      .createWithDefault(3000)
 
   private[spark] val EXECUTOR_DECOMMISSION_BATCH_SIZE =
     ConfigBuilder("spark.executor.decommission.batchSize")
-      .doc("Executors are decommissioned in batched to avoid overloading network bandwidth in" +
-        " migrating rdd and shuffle data. This config sets the interval between batches.")
+      .doc("Executors are decommissioned in batches to avoid overloading network bandwidth in" +
+        " migrating rdd and shuffle data. This config sets the size of a batch.")
       .version("3.2.0")
       .intConf
-      .createWithDefault(3)
+      .createWithDefault(Int.MaxValue)
 
   private[spark] val STAGING_DIR = ConfigBuilder("spark.yarn.stagingDir")
     .doc("Staging directory used while submitting applications.")

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -499,8 +499,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         periodicBatchExecutorsDecommissionThread.get.scheduleAtFixedRate(new Runnable {
           override def run(): Unit = Utils.tryLogNonFatalError {
             // check for executors decommissioning themelves.
-            val numExecutorInDecommissioning =
+            val numExecutorInDecommissioning = CoarseGrainedSchedulerBackend.this.synchronized {
               executorsPendingDecommission.size - executorsToDecommissionInBatches.size
+            }
             val executorsBatchToDecommission = executorsToDecommissionInBatches
               .take(Math.max(0, batchSize - numExecutorInDecommissioning))
             executorsBatchToDecommission.foreach { executorId =>

--- a/core/src/test/scala/org/apache/spark/scheduler/WorkerDecommissionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/WorkerDecommissionSuite.scala
@@ -86,7 +86,7 @@ class WorkerDecommissionSuite extends SparkFunSuite with LocalSparkContext {
     assert(asyncCountResult === 10)
   }
 
-  test("Verify executors are decommissioned in batches") {
+  test("SPARK-35627: Verify executors are decommissioned in batches") {
     val input = sc.parallelize(1 to 10)
     input.count()
     val sleepyRdd = input.mapPartitions{ x =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR is adding a thread which will run at scheduled interval to ask a batch of executors to start decommissioning themselves.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currenlty, each executor is asked to starts offloading rdd and shuffle blocks as soon it is decommissioned. This can overload the network bandwidth of the application.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT in progress