### PR TITLE
[SPARK-21957][SQL][FOLLOWUP] Support CURRENT_USER without tailing parentheses

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -816,8 +816,7 @@ valueExpression
     ;
 
 primaryExpression
-    : name=(CURRENT_DATE | CURRENT_TIMESTAMP)                                                  #currentDatetime
-    | CURRENT_USER                                                                             #currentUser
+    : name=(CURRENT_DATE | CURRENT_TIMESTAMP | CURRENT_USER)                                   #currentLike
     | CASE whenClause+ (ELSE elseExpression=expression)? END                                   #searchedCase
     | CASE value=expression whenClause+ (ELSE elseExpression=expression)? END                  #simpleCase
     | name=(CAST | TRY_CAST) '(' expression AS dataType ')'                                    #cast

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -817,6 +817,7 @@ valueExpression
 
 primaryExpression
     : name=(CURRENT_DATE | CURRENT_TIMESTAMP)                                                  #currentDatetime
+    | CURRENT_USER                                                                             #currentUser
     | CASE whenClause+ (ELSE elseExpression=expression)? END                                   #searchedCase
     | CASE value=expression whenClause+ (ELSE elseExpression=expression)? END                  #simpleCase
     | name=(CAST | TRY_CAST) '(' expression AS dataType ')'                                    #cast

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1652,6 +1652,7 @@ class Analyzer(override val catalogManager: CatalogManager)
   private val literalFunctions: Seq[(String, () => Expression, Expression => String)] = Seq(
     (CurrentDate().prettyName, () => CurrentDate(), toPrettySQL(_)),
     (CurrentTimestamp().prettyName, () => CurrentTimestamp(), toPrettySQL(_)),
+    (CurrentUser().prettyName, () => CurrentUser(), toPrettySQL),
     (VirtualColumn.hiveGroupingIdName, () => GroupingID(Nil), _ => VirtualColumn.hiveGroupingIdName)
   )
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1683,13 +1683,15 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
     }
   }
 
-  override def visitCurrentDatetime(ctx: CurrentDatetimeContext): Expression = withOrigin(ctx) {
+  override def visitCurrentLike(ctx: CurrentLikeContext): Expression = withOrigin(ctx) {
     if (conf.ansiEnabled) {
       ctx.name.getType match {
         case SqlBaseParser.CURRENT_DATE =>
           CurrentDate()
         case SqlBaseParser.CURRENT_TIMESTAMP =>
           CurrentTimestamp()
+        case SqlBaseParser.CURRENT_USER =>
+          CurrentUser()
       }
     } else {
       // If the parser is not in ansi mode, we should return `UnresolvedAttribute`, in case there
@@ -1698,9 +1700,6 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
     }
   }
 
-  override def visitCurrentUser(ctx: CurrentUserContext): Expression = withOrigin(ctx) {
-    if (conf.ansiEnabled) CurrentUser() else UnresolvedAttribute.quoted(ctx.CURRENT_USER().getText)
-  }
   /**
    * Create a [[Cast]] expression.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1698,6 +1698,9 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
     }
   }
 
+  override def visitCurrentUser(ctx: CurrentUserContext): Expression = withOrigin(ctx) {
+    if (conf.ansiEnabled) CurrentUser() else UnresolvedAttribute.quoted(ctx.CURRENT_USER().getText)
+  }
   /**
    * Create a [[Cast]] expression.
    */

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql
 
 import org.apache.spark.{SPARK_REVISION, SPARK_VERSION_SHORT}
+import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
@@ -42,8 +44,17 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-21957: get current_user in normal spark apps") {
-    val df = sql("select current_user()")
-    checkAnswer(df, Row(spark.sparkContext.sparkUser))
+    val user = spark.sparkContext.sparkUser
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
+      val df = sql("select current_user(), current_user")
+      checkAnswer(df, Row(user, user))
+    }
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      val df = sql("select current_user")
+      checkAnswer(df, Row(spark.sparkContext.sparkUser))
+      val e = intercept[ParseException](sql("select current_user()"))
+      assert(e.getMessage.contains("current_user"))
+    }
   }
 }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.hive.thriftserver
 import java.sql.SQLException
 import java.util.concurrent.atomic.AtomicBoolean
 
-import org.apache.hive.service.cli.HiveSQLException
+import org.apache.hive.service.cli.{HiveSQLException, OperationHandle}
 
 import org.apache.spark.TaskKilled
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
@@ -125,9 +125,23 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
     withCLIServiceClient(clientUser) { client =>
       val sessionHandle = client.openSession(clientUser, "")
       val confOverlay = new java.util.HashMap[java.lang.String, java.lang.String]
-      val opHandle = client.executeStatement(sessionHandle, sql, confOverlay)
-      val rowSet = client.fetchResults(opHandle)
-      assert(rowSet.toTRowSet.getColumns.get(0).getStringVal.getValues.get(0) === clientUser)
+      val exec: String => OperationHandle = client.executeStatement(sessionHandle, _, confOverlay)
+
+      exec(s"set ${SQLConf.ANSI_ENABLED.key}=false")
+
+      val opHandle1 = exec("select current_user(), current_user")
+      val rowSet1 = client.fetchResults(opHandle1)
+      rowSet1.toTRowSet.getColumns.forEach { col =>
+        assert(col.getStringVal.getValues.get(0) === clientUser)
+      }
+
+      exec(s"set ${SQLConf.ANSI_ENABLED.key}=true")
+      val opHandle2 = exec("select current_user")
+      assert(client.fetchResults(opHandle2).toTRowSet.getColumns.get(0)
+        .getStringVal.getValues.get(0) === clientUser)
+
+      val e = intercept[HiveSQLException](exec("select current_user()"))
+      assert(e.getMessage.contains("current_user"))
     }
   }
 }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?

A followup for 345d35ed1aa508bd2228603f94cc8aa0ad998906, in this PR we support CURRENT_USER without tailing parentheses in default mode. And for ANSI mode, we can only use CURRENT_USER without tailing parentheses because it is a reserved keyword that cannot be used as a function name

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. make it the same as current_date/current_timestamp
2. better ANSI compliance 
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no, just a followup

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new tests