### PR TITLE
[SPARK-35643][PYTHON] Fix ambiguous reference in functions.py column()

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -101,16 +101,17 @@ def lit(col):
 
 
 @since(1.3)
-def col(col_like):
+def col(col):
     """
     Returns a :class:`~pyspark.sql.Column` based on the given column name.'
     Examples
     --------
-    >>> df = spark.range(1, 10).toDF('x').withColumn('mod3', col('x') % 3)
     >>> col('x')
+    Column<'x'>
     >>> column('mod3')
+    Column<'x'>
     """
-    return _invoke_function("col", col_like)
+    return _invoke_function("col", col)
 
 
 column = col

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -108,7 +108,7 @@ def col(col):
     --------
     >>> col('x')
     Column<'x'>
-    >>> column('mod3')
+    >>> column('x')
     Column<'x'>
     """
     return _invoke_function("col", col)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -101,19 +101,19 @@ def lit(col):
 
 
 @since(1.3)
-def col(col):
+def col(col_like):
     """
     Returns a :class:`~pyspark.sql.Column` based on the given column name.'
+    Examples
+    --------
+    >>> df = spark.range(1, 10).toDF('x').withColumn('mod3', col('x') % 3)
+    >>> col('x')
+    >>> column('mod3')
     """
-    return _invoke_function("col", col)
+    return _invoke_function("col", col_like)
 
 
-@since(1.3)
-def column(col):
-    """
-    Returns a :class:`~pyspark.sql.Column` based on the given column name.'
-    """
-    return col(col)
+column = col
 
 
 @since(1.3)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In functions.py, there is a function added `def column(col)`. There is also another method in the same file `def col(col)`. This leads to some ambiguity on whether the parameter is being referred to or the function. In pyspark 3.1.2, this leads to `TypeError: 'str' object is not callable` when the function `column(col)` is called - the highest preference is given to the string variable in scope as opposed to the function `col `in the file as intended. 

This PR fixes that ambiguity by changing the variable name to `col_like`. I have filed this as an issue on JIRA here - https://issues.apache.org/jira/browse/SPARK-35643. 

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
In pyspark 3.1.2, we see `TypeError: 'str' object is not callable` when `column()` function is called. This Pr fixes that error.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
I don't believe this patch needs additional testing. 
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
