### PR TITLE
[SPARK-35599][PYTHON] Adjust `check_exact` parameter for older pd.testing

### DIFF
--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -25,6 +25,7 @@ from distutils.version import LooseVersion
 
 import pandas as pd
 from pandas.api.types import is_list_like
+from pandas.core.dtypes.common import is_numeric_dtype
 from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 
 from pyspark import pandas as ps
@@ -81,6 +82,12 @@ class PandasOnSparkTestCase(unittest.TestCase, SQLTestUtils):
                 else:
                     kwargs = dict()
 
+                if LooseVersion(pd.__version__) <= LooseVersion("1.1"):
+                    # Due to https://github.com/pandas-dev/pandas/issues/35446
+                    check_exact = check_exact \
+                        and all([is_numeric_dtype(dtype) for dtype in left.dtypes]) \
+                        and all([is_numeric_dtype(dtype) for dtype in right.dtypes])
+
                 assert_frame_equal(
                     left,
                     right,
@@ -102,7 +109,11 @@ class PandasOnSparkTestCase(unittest.TestCase, SQLTestUtils):
                     kwargs = dict(check_freq=False)
                 else:
                     kwargs = dict()
-
+                if LooseVersion(pd.__version__) <= LooseVersion("1.1"):
+                    # Due to https://github.com/pandas-dev/pandas/issues/35446
+                    check_exact = check_exact \
+                        and is_numeric_dtype(left.dtype) \
+                        and is_numeric_dtype(right.dtype)
                 assert_series_equal(
                     left,
                     right,
@@ -119,6 +130,11 @@ class PandasOnSparkTestCase(unittest.TestCase, SQLTestUtils):
                 raise AssertionError(msg) from e
         elif isinstance(left, pd.Index) and isinstance(right, pd.Index):
             try:
+                if LooseVersion(pd.__version__) <= LooseVersion("1.1"):
+                    # Due to https://github.com/pandas-dev/pandas/issues/35446
+                    check_exact = check_exact \
+                        and is_numeric_dtype(left.dtype) \
+                        and is_numeric_dtype(right.dtype)
                 assert_index_equal(left, right, check_exact=check_exact)
             except AssertionError as e:
                 msg = (

--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -82,7 +82,7 @@ class PandasOnSparkTestCase(unittest.TestCase, SQLTestUtils):
                 else:
                     kwargs = dict()
 
-                if LooseVersion(pd.__version__) <= LooseVersion("1.1"):
+                if LooseVersion(pd.__version__) < LooseVersion("1.1.1"):
                     # Due to https://github.com/pandas-dev/pandas/issues/35446
                     check_exact = check_exact \
                         and all([is_numeric_dtype(dtype) for dtype in left.dtypes]) \
@@ -109,7 +109,7 @@ class PandasOnSparkTestCase(unittest.TestCase, SQLTestUtils):
                     kwargs = dict(check_freq=False)
                 else:
                     kwargs = dict()
-                if LooseVersion(pd.__version__) <= LooseVersion("1.1"):
+                if LooseVersion(pd.__version__) < LooseVersion("1.1.1"):
                     # Due to https://github.com/pandas-dev/pandas/issues/35446
                     check_exact = check_exact \
                         and is_numeric_dtype(left.dtype) \
@@ -130,7 +130,7 @@ class PandasOnSparkTestCase(unittest.TestCase, SQLTestUtils):
                 raise AssertionError(msg) from e
         elif isinstance(left, pd.Index) and isinstance(right, pd.Index):
             try:
-                if LooseVersion(pd.__version__) <= LooseVersion("1.1"):
+                if LooseVersion(pd.__version__) < LooseVersion("1.1.1"):
                     # Due to https://github.com/pandas-dev/pandas/issues/35446
                     check_exact = check_exact \
                         and is_numeric_dtype(left.dtype) \


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adjust the `check_exact` parameter for non-numeric columns to ensure pandas-on-Spark tests passed with all pandas versions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`pd.testing` utils are utilized in pandas-on-Spark tests.
Due to https://github.com/pandas-dev/pandas/issues/35446, `check_exact=True` for non-numeric columns doesn't work for older pd.testing utils, e.g. `assert_series_equal`.  We wanted to adjust that to ensure pandas-on-Spark tests pass for all pandas versions.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing unit tests.

Keyword: SPARK-35337