### PR TITLE
[SPARK-35589][CORE][TESTS][FOLLOWUP] Remove the duplicated test coverage

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -2004,10 +2004,6 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     }
   }
 
-  test("SPARK-35589: test migration of index-only shuffle blocks during decommissioning") {
-    testShuffleBlockDecommissioning(None, true)
-  }
-
   test("test migration of shuffle blocks during decommissioning - no limit") {
     testShuffleBlockDecommissioning(None, true)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This removes the accidental duplicated test coverage.

### Why are the changes needed?

To save the test resources.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A because this is a removal of the duplicated test coverage.