### PR TITLE
[SPARK-35648][PYTHON] Refine and add dependencies needed for dev in dev/requirement.txt

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -29,6 +29,6 @@ jinja2<3.0.0
 sphinx<3.1.0
 sphinx-plotly-directive
 
-# Developement scripts
+# Development scripts
 jira
 PyGithub

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,19 +1,26 @@
-# PySpark dependencies
+# PySpark dependencies (required)
 py4j
+
+# PySpark dependencies (optional)
 numpy
 pyarrow
 pandas
 scipy
-xmlrunner
 plotly
 mlflow
 matplotlib<3.3.0
+
+# PySpark test dependencies
+xmlrunner
 
 # Linter
 mypy
 flake8
 
-# Documentation
+# Documentation (SQL)
+mkdocs
+
+# Documentation (Python)
 pydata_sphinx_theme
 ipython
 nbsphinx
@@ -21,8 +28,7 @@ numpydoc
 jinja2<3.0.0
 sphinx<3.1.0
 sphinx-plotly-directive
-mkdocs
 
-# Dev scripts
+# Developement scripts
 jira
 PyGithub

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,8 +1,28 @@
-flake8==3.5.0
-jira==2.0.0
-PyGithub==1.26.0
-sphinx
+# PySpark dependencies
+py4j
+numpy
+pyarrow
+pandas
+scipy
+xmlrunner
+plotly
+mlflow
+matplotlib<3.3.0
+
+# Linter
+mypy
+flake8
+
+# Documentation
 pydata_sphinx_theme
 ipython
 nbsphinx
 numpydoc
+jinja2<3.0.0
+sphinx<3.1.0
+sphinx-plotly-directive
+mkdocs
+
+# Dev scripts
+jira
+PyGithub


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to update `dev/requirement.txt` file.

NOTE that:
- This file isn't used anywhere in Apache Spark CI. It's just for convenience
- To minimize the overhead of maintenance, I removed all lowerbounds of dependencies, which means that using the latest versions of them should work in the clean environment (e.g., you can reinstall all of them).

### Why are the changes needed?

To note the dependencies needed for Spark dev, and for easier env setting up.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Logically derived from setup.py, and other places like CI