### PR TITLE
[SPARK-35651][DOC] Update the doc of running-on-kubernetes

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -107,10 +107,10 @@ language binding docker images.
 Example usage is
 ```bash
 # To build additional PySpark docker image
-$ ./bin/docker-image-tool.sh -r <repo> -t my-tag -p ./kubernetes/dockerfiles/spark/bindings/python/Dockerfile build
+$ ./bin/docker-image-tool.sh -r <repo> -t my-tag -p ./resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile build
 
 # To build additional SparkR docker image
-$ ./bin/docker-image-tool.sh -r <repo> -t my-tag -R ./kubernetes/dockerfiles/spark/bindings/R/Dockerfile build
+$ ./bin/docker-image-tool.sh -r <repo> -t my-tag -R ./resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile build
 ```
 
 ## Cluster Mode


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to update the command of building PySpark / SparkR docker image , which can run in the lateset version 

### Why are the changes needed?
Make the doc up-to-date

### Does this PR introduce _any_ user-facing change?
Yes, the command of building images will change  in the document

### How was this patch tested?
Manually build docs and check.