### PR TITLE
[SPARK-35601][PYTHON] Complete arithmetic operators involving bool literals, Series, and Index

### DIFF
--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -53,13 +53,13 @@ if TYPE_CHECKING:
 
 
 def is_valid_operand_for_numeric_arithmetic(
-    operand: Any, *, allow_bool_index_ops: bool = True
+    operand: Any, *, allow_bool_index_ops: bool = True, allow_bool: bool = True
 ) -> bool:
     """Check whether the `operand` is valid for arithmetic operations against numerics."""
     from pyspark.pandas.base import IndexOpsMixin
 
     if isinstance(operand, numbers.Number):
-        return True
+        return not isinstance(operand, bool) or allow_bool
     elif isinstance(operand, IndexOpsMixin):
         if isinstance(operand.dtype, CategoricalDtype):
             return False

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -52,9 +52,7 @@ if TYPE_CHECKING:
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
-def is_valid_operand_for_numeric_arithmetic(
-    operand: Any, *, allow_bool_index_ops: bool = True, allow_bool: bool = True
-) -> bool:
+def is_valid_operand_for_numeric_arithmetic(operand: Any, *, allow_bool: bool = True) -> bool:
     """Check whether the `operand` is valid for arithmetic operations against numerics."""
     from pyspark.pandas.base import IndexOpsMixin
 
@@ -65,7 +63,7 @@ def is_valid_operand_for_numeric_arithmetic(
             return False
         else:
             return isinstance(operand.spark.data_type, NumericType) or (
-                allow_bool_index_ops and isinstance(operand.spark.data_type, BooleanType)
+                allow_bool and isinstance(operand.spark.data_type, BooleanType)
             )
     else:
         return False

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -66,9 +66,7 @@ class BooleanOps(DataTypeOps):
                 return left + right
 
     def sub(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(
-            right, allow_bool_index_ops=False, allow_bool=False
-        ):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name
             )
@@ -99,9 +97,7 @@ class BooleanOps(DataTypeOps):
                 return left * right
 
     def truediv(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(
-            right, allow_bool_index_ops=False, allow_bool=False
-        ):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "True division can not be applied to %s and the given type." % self.pretty_name
             )
@@ -114,9 +110,7 @@ class BooleanOps(DataTypeOps):
             return left / right
 
     def floordiv(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(
-            right, allow_bool_index_ops=False, allow_bool=False
-        ):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Floor division can not be applied to %s and the given type." % self.pretty_name
             )
@@ -129,9 +123,7 @@ class BooleanOps(DataTypeOps):
             return left // right
 
     def mod(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(
-            right, allow_bool_index_ops=False, allow_bool=False
-        ):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Modulo can not be applied to %s and the given type." % self.pretty_name
             )
@@ -144,9 +136,7 @@ class BooleanOps(DataTypeOps):
             return left % right
 
     def pow(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(
-            right, allow_bool_index_ops=False, allow_bool=False
-        ):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name
             )

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -46,12 +46,14 @@ class BooleanOps(DataTypeOps):
         return "booleans"
 
     def add(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
             raise TypeError(
                 "Addition can not be applied to %s and the given type." % self.pretty_name
             )
 
-        if isinstance(right, numbers.Number) and not isinstance(right, bool):
+        if isinstance(right, bool):
+            return left.__or__(right)
+        elif isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left + right
         else:
@@ -60,7 +62,7 @@ class BooleanOps(DataTypeOps):
             return left + right
 
     def sub(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
             raise TypeError(
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name
             )
@@ -73,7 +75,7 @@ class BooleanOps(DataTypeOps):
             return left - right
 
     def mul(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
             raise TypeError(
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name
             )
@@ -86,7 +88,7 @@ class BooleanOps(DataTypeOps):
             return left * right
 
     def truediv(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
             raise TypeError(
                 "True division can not be applied to %s and the given type." % self.pretty_name
             )
@@ -99,7 +101,7 @@ class BooleanOps(DataTypeOps):
             return left / right
 
     def floordiv(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
             raise TypeError(
                 "Floor division can not be applied to %s and the given type." % self.pretty_name
             )
@@ -112,7 +114,7 @@ class BooleanOps(DataTypeOps):
             return left // right
 
     def mod(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
             raise TypeError(
                 "Modulo can not be applied to %s and the given type." % self.pretty_name
             )
@@ -125,7 +127,7 @@ class BooleanOps(DataTypeOps):
             return left % right
 
     def pow(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
             raise TypeError(
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name
             )

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -77,13 +77,13 @@ class BooleanOps(DataTypeOps):
             return left - right
 
     def mul(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(
-            right, allow_bool_index_ops=False, allow_bool=False
-        ):
+        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
             raise TypeError(
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name
             )
-        if isinstance(right, numbers.Number) and not isinstance(right, bool):
+        if isinstance(right, bool):
+            return left.__and__(right)
+        elif isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return left * right
         else:

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -62,7 +62,9 @@ class BooleanOps(DataTypeOps):
             return left + right
 
     def sub(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        if not is_valid_operand_for_numeric_arithmetic(
+            right, allow_bool_index_ops=False, allow_bool=False
+        ):
             raise TypeError(
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name
             )
@@ -75,7 +77,9 @@ class BooleanOps(DataTypeOps):
             return left - right
 
     def mul(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        if not is_valid_operand_for_numeric_arithmetic(
+            right, allow_bool_index_ops=False, allow_bool=False
+        ):
             raise TypeError(
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name
             )
@@ -88,7 +92,9 @@ class BooleanOps(DataTypeOps):
             return left * right
 
     def truediv(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        if not is_valid_operand_for_numeric_arithmetic(
+            right, allow_bool_index_ops=False, allow_bool=False
+        ):
             raise TypeError(
                 "True division can not be applied to %s and the given type." % self.pretty_name
             )
@@ -101,7 +107,9 @@ class BooleanOps(DataTypeOps):
             return left / right
 
     def floordiv(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        if not is_valid_operand_for_numeric_arithmetic(
+            right, allow_bool_index_ops=False, allow_bool=False
+        ):
             raise TypeError(
                 "Floor division can not be applied to %s and the given type." % self.pretty_name
             )
@@ -114,7 +122,9 @@ class BooleanOps(DataTypeOps):
             return left // right
 
     def mod(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        if not is_valid_operand_for_numeric_arithmetic(
+            right, allow_bool_index_ops=False, allow_bool=False
+        ):
             raise TypeError(
                 "Modulo can not be applied to %s and the given type." % self.pretty_name
             )
@@ -127,7 +137,9 @@ class BooleanOps(DataTypeOps):
             return left % right
 
     def pow(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        if not is_valid_operand_for_numeric_arithmetic(
+            right, allow_bool_index_ops=False, allow_bool=False
+        ):
             raise TypeError(
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name
             )

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -30,6 +30,7 @@ from pyspark.pandas.data_type_ops.base import (
 from pyspark.pandas.typedef import extension_dtypes
 from pyspark.pandas.typedef.typehints import as_spark_type
 from pyspark.sql import functions as F
+from pyspark.sql.types import BooleanType
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -46,7 +47,7 @@ class BooleanOps(DataTypeOps):
         return "booleans"
 
     def add(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError(
                 "Addition can not be applied to %s and the given type." % self.pretty_name
             )
@@ -58,8 +59,11 @@ class BooleanOps(DataTypeOps):
             return left + right
         else:
             assert isinstance(right, IndexOpsMixin)
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
-            return left + right
+            if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, BooleanType):
+                return left.__or__(right)
+            else:
+                left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+                return left + right
 
     def sub(self, left, right) -> Union["Series", "Index"]:
         if not is_valid_operand_for_numeric_arithmetic(
@@ -77,7 +81,7 @@ class BooleanOps(DataTypeOps):
             return left - right
 
     def mul(self, left, right) -> Union["Series", "Index"]:
-        if not is_valid_operand_for_numeric_arithmetic(right, allow_bool_index_ops=False):
+        if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError(
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name
             )
@@ -88,8 +92,11 @@ class BooleanOps(DataTypeOps):
             return left * right
         else:
             assert isinstance(right, IndexOpsMixin)
-            left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
-            return left * right
+            if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, BooleanType):
+                return left.__and__(right)
+            else:
+                left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
+                return left * right
 
     def truediv(self, left, right) -> Union["Series", "Index"]:
         if not is_valid_operand_for_numeric_arithmetic(

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -152,7 +152,9 @@ class BooleanOps(DataTypeOps):
             return left ** right
 
     def radd(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number) and not isinstance(right, bool):
+        if isinstance(right, bool):
+            return left.__or__(right)
+        elif isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right + left
         else:
@@ -170,7 +172,9 @@ class BooleanOps(DataTypeOps):
             )
 
     def rmul(self, left, right) -> Union["Series", "Index"]:
-        if isinstance(right, numbers.Number) and not isinstance(right, bool):
+        if isinstance(right, bool):
+            return left.__and__(right)
+        elif isinstance(right, numbers.Number):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right * left
         else:

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -109,45 +109,49 @@ class NumericOps(DataTypeOps):
     def radd(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("string addition can only be applied to string series or literals.")
-        if not isinstance(right, numbers.Number) or isinstance(right, bool):
+        if not isinstance(right, numbers.Number):
             raise TypeError("addition can not be applied to given types.")
-
+        right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__radd__)(left, right)
 
     def rsub(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("subtraction can not be applied to string series or literals.")
-        if not isinstance(right, numbers.Number) or isinstance(right, bool):
+        if not isinstance(right, numbers.Number):
             raise TypeError("subtraction can not be applied to given types.")
+        right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rsub__)(left, right)
 
     def rmul(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
-        if not isinstance(right, numbers.Number) or isinstance(right, bool):
+        if not isinstance(right, numbers.Number):
             raise TypeError("multiplication can not be applied to given types.")
+        right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rmul__)(left, right)
 
     def rpow(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("exponentiation can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number) or isinstance(right, bool):
+        if not isinstance(right, numbers.Number):
             raise TypeError("exponentiation can not be applied to given types.")
 
         def rpow_func(left, right):
             return F.when(F.lit(right == 1), right).otherwise(Column.__rpow__(left, right))
 
+        right = transform_boolean_operand_to_numeric(right)
         return column_op(rpow_func)(left, right)
 
     def rmod(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("modulo can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number) or isinstance(right, bool):
+        if not isinstance(right, numbers.Number):
             raise TypeError("modulo can not be applied to given types.")
 
         def rmod(left, right):
             return ((right % left) + left) % left
 
+        right = transform_boolean_operand_to_numeric(right)
         return column_op(rmod)(left, right)
 
 
@@ -219,7 +223,7 @@ class IntegralOps(NumericOps):
     def rtruediv(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number) or isinstance(right, bool):
+        if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
         def rtruediv(left, right):
@@ -227,12 +231,13 @@ class IntegralOps(NumericOps):
                 F.lit(right).__truediv__(left)
             )
 
+        right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rtruediv)(left, right)
 
     def rfloordiv(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number) or isinstance(right, bool):
+        if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
         def rfloordiv(left, right):
@@ -240,6 +245,7 @@ class IntegralOps(NumericOps):
                 F.floor(F.lit(right).__div__(left))
             )
 
+        right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rfloordiv)(left, right)
 
 
@@ -314,7 +320,7 @@ class FractionalOps(NumericOps):
     def rtruediv(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number) or isinstance(right, bool):
+        if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
         def rtruediv(left, right):
@@ -322,12 +328,13 @@ class FractionalOps(NumericOps):
                 F.lit(right).__truediv__(left)
             )
 
+        right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rtruediv)(left, right)
 
     def rfloordiv(self, left, right) -> Union["Series", "Index"]:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
-        if not isinstance(right, numbers.Number) or isinstance(right, bool):
+        if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
         def rfloordiv(left, right):
@@ -335,4 +342,5 @@ class FractionalOps(NumericOps):
                 F.when(F.lit(left) == np.nan, np.nan).otherwise(F.floor(F.lit(right).__div__(left)))
             )
 
+        right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rfloordiv)(left, right)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -53,7 +53,8 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser + 0.1, psser + 0.1)
         self.assert_eq(pser + pser.astype(int), psser + psser.astype(int))
         self.assertRaises(TypeError, lambda: psser + psser)
-        self.assertRaises(TypeError, lambda: psser + True)
+        self.assert_eq(pser + True, psser + True)
+        self.assert_eq(pser + False, psser + False)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -372,7 +372,7 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         if LooseVersion(pd.__version__) >= LooseVersion("1.2.2"):
             self.assert_eq(pser * True, psser * True)
             self.assert_eq(ps.Series([False, False, False], dtype="boolean"), psser * False)
-            self.asser_eq(pser * pser, psser * psser)
+            self.assert_eq(pser * pser, psser * psser)
         else:
             # Due to https://github.com/pandas-dev/pandas/issues/39410
             self.assert_eq([True, False, pd._libs.missing.NAType()], (psser * True).tolist())

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -49,6 +49,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(pser + 1, psser + 1)
             # self.assert_eq(pser + 0.1, psser + 0.1)
             self.assert_eq(pser + pser.astype(bool), psser + psser.astype(bool))
+            self.assert_eq(pser + True, psser + True)
+            self.assert_eq(pser + False, psser + False)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -61,14 +63,14 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                     pser + self.non_numeric_psers["bool"],
                 )
 
-        self.assertRaises(TypeError, lambda: self.float_psser + True)
-
     def test_sub(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser - pser, psser - psser)
             self.assert_eq(pser - 1, psser - 1)
             # self.assert_eq(pser - 0.1, psser - 0.1)
             self.assert_eq(pser - pser.astype(bool), psser - psser.astype(bool))
+            self.assert_eq(pser - True, psser - True)
+            self.assert_eq(pser - False, psser - False)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -81,12 +83,12 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                     pser - self.non_numeric_psers["bool"],
                 )
 
-        self.assertRaises(TypeError, lambda: self.float_psser - True)
-
     def test_mul(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser * pser, psser * psser)
             self.assert_eq(pser * pser.astype(bool), psser * psser.astype(bool))
+            self.assert_eq(pser * True, psser * True)
+            self.assert_eq(pser * False, psser * False)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -105,13 +107,13 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                     pser * self.non_numeric_psers["bool"],
                 )
 
-        self.assertRaises(TypeError, lambda: self.float_psser * True)
-
     def test_truediv(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             if psser.dtype in [float, int, np.int32]:
                 self.assert_eq(pser / pser, psser / psser)
                 self.assert_eq(pser / pser.astype(bool), psser / psser.astype(bool))
+                self.assert_eq(pser / True, psser / True)
+                self.assert_eq(pser / False, psser / False)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -124,13 +126,13 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.float_pser / self.non_numeric_psers["bool"],
             )
 
-        self.assertRaises(TypeError, lambda: self.float_psser / True)
-
     def test_floordiv(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             if psser.dtype == float:
                 self.assert_eq(pser // pser, psser // psser)
                 self.assert_eq(pser // pser.astype(bool), psser // psser.astype(bool))
+                self.assert_eq(pser // True, psser // True)
+                self.assert_eq(pser // False, psser // False)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -151,12 +153,17 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                     ps.Series([1.0, 2.0, np.inf]),
                 )
 
-        self.assertRaises(TypeError, lambda: self.float_psser // True)
-
     def test_mod(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser % pser, psser % psser)
             self.assert_eq(pser % pser.astype(bool), psser % psser.astype(bool))
+            self.assert_eq(pser % True, psser % True)
+            if psser.dtype in [int, np.int32]:
+                self.assert_eq(ps.Series([np.nan, np.nan, np.nan], dtype=float), psser % False)
+            else:
+                self.assert_eq(
+                    ps.Series([np.nan, np.nan, np.nan], dtype=psser.dtype), psser % False
+                )
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -169,13 +176,13 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.float_pser % self.non_numeric_psers["bool"],
             )
 
-        self.assertRaises(TypeError, lambda: self.float_psser % True)
-
     def test_pow(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             if psser.dtype == float:
                 self.assert_eq(pser ** pser, psser ** psser)
                 self.assert_eq(pser ** pser.astype(bool), psser ** psser.astype(bool))
+                self.assert_eq(pser ** True, psser ** True)
+                self.assert_eq(pser ** False, psser ** False)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -190,14 +197,13 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.float_pser ** self.non_numeric_psers["bool"],
             )
 
-        self.assertRaises(TypeError, lambda: self.float_psser ** True)
-
     def test_radd(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(1 + pser, 1 + psser)
             # self.assert_eq(0.1 + pser, 0.1 + psser)
             self.assertRaises(TypeError, lambda: "x" + psser)
-            self.assertRaises(TypeError, lambda: True + psser)
+            self.assert_eq(True + pser, True + psser)
+            self.assert_eq(False + pser, False + psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) + psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) + psser)
 
@@ -206,7 +212,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(1 - pser, 1 - psser)
             # self.assert_eq(0.1 - pser, 0.1 - psser)
             self.assertRaises(TypeError, lambda: "x" - psser)
-            self.assertRaises(TypeError, lambda: True - psser)
+            self.assert_eq(True - pser, True - psser)
+            self.assert_eq(False - pser, False - psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) - psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) - psser)
 
@@ -215,7 +222,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(1 * pser, 1 * psser)
             # self.assert_eq(0.1 * pser, 0.1 * psser)
             self.assertRaises(TypeError, lambda: "x" * psser)
-            self.assertRaises(TypeError, lambda: True * psser)
+            self.assert_eq(True * pser, True * psser)
+            self.assert_eq(False * pser, False * psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) * psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) * psser)
 
@@ -223,8 +231,9 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in self.numeric_pser_psser_pairs:
             # self.assert_eq(5 / pser, 5 / psser)
             # self.assert_eq(0.1 / pser, 0.1 / psser)
-            self.assertRaises(TypeError, lambda: "x" + psser)
-            self.assertRaises(TypeError, lambda: True + psser)
+            self.assertRaises(TypeError, lambda: "x" / psser)
+            self.assert_eq((True / pser).astype(float), True / psser, check_exact=False)
+            self.assert_eq((False / pser).astype(float), False / psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) / psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) / psser)
 
@@ -233,7 +242,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             # self.assert_eq(5 // pser, 5 // psser)
             # self.assert_eq(0.1 // pser, 0.1 // psser)
             self.assertRaises(TypeError, lambda: "x" // psser)
-            self.assertRaises(TypeError, lambda: True // psser)
+            self.assert_eq((True // pser).astype(float), True // psser)
+            self.assert_eq((False // pser).astype(float), False // psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) // psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) // psser)
 
@@ -242,7 +252,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             # self.assert_eq(1 ** pser, 1 ** psser)
             # self.assert_eq(0.1 ** pser, 0.1 ** psser)
             self.assertRaises(TypeError, lambda: "x" ** psser)
-            self.assertRaises(TypeError, lambda: True ** psser)
+            self.assert_eq((True ** pser).astype(float), True ** psser)
+            self.assert_eq((False ** pser).astype(float), False ** psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) ** psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) ** psser)
 
@@ -250,7 +261,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(1 % pser, 1 % psser)
             # self.assert_eq(0.1 % pser, 0.1 % psser)
-            self.assertRaises(TypeError, lambda: True % psser)
+            self.assert_eq(True % pser, True % psser)
+            self.assert_eq(False % pser, False % psser)
             self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) % psser)
             self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) % psser)
 
@@ -284,7 +296,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.pandas.tests.data_type_ops.test_string_ops import *  # noqa: F401
+    from pyspark.pandas.tests.data_type_ops.test_num_ops import *  # noqa: F401
 
     try:
         import xmlrunner  # type: ignore[import]

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -66,6 +66,10 @@ class TestCasesUtils(object):
         return pssers
 
     @property
+    def non_numeric_pser_psser_pairs(self):
+        return zip(self.non_numeric_psers.values(), self.non_numeric_pssers.values())
+
+    @property
     def pssers(self):
         return self.numeric_pssers + list(self.non_numeric_pssers.values())
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Completing arithmetic operators involving bool literals, Series, and Index consists of two main tasks:
- Support arithmetic operations against bool literals
- Support operators (+, *) between bool Series/Indexes.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Arithmetic operators involving bool literals, Series, and Index are incomplete now.
We ought to match pandas' behaviors.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.

Newly supported operations example:
```py
>>> ps.Series([1, 2, 3]) + True
0    2
1    3
2    4
dtype: int64
>>> ps.Series([1, 2, 3]) + False
0    1
1    2
2    3
dtype: int64
>>> ps.Series([True, False, True]) + True
0    True
1    True
2    True
dtype: bool
>>> ps.Series([True, False, True]) + False
0     True
1    False
2     True
dtype: bool
>>> ps.Series([True, False, True]) * True
0     True
1    False
2     True
dtype: bool
>>> ps.Series([True, False, True]) * False
0    False
1    False
2    False
dtype: bool
>>> ps.set_option('compute.ops_on_diff_frames', True)
>>> ps.Series([True, True, False]) + ps.Series([True, False, True])
0    True
1    True
2    True
dtype: bool
>>> ps.Series([True, True, False]) * ps.Series([True, False, True])
0     True
1    False
2    False
dtype: bool
```
Before the change, operations above are not supported, raising a TypeError such as
```py
>>> ps.Series([True, False, True]) + True
Traceback (most recent call last):
...
TypeError: Addition can not be applied to booleans and the given type.
>>> ps.Series([True, False, True]) + False
Traceback (most recent call last):
...
TypeError: Addition can not be applied to booleans and the given type.
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.

Keyword: SPARK-35337