### PR TITLE
[SPARK-35603][R][DOCS] Add data source options link for R API documentation.

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -883,15 +883,15 @@ setMethod("toJSON",
 #' Save the contents of a SparkDataFrame as a JSON file (\href{https://jsonlines.org/}{
 #' JSON Lines text format or newline-delimited JSON}). Files written out
 #' with this method can be read back in as a SparkDataFrame using read.json().
-#' You can find the JSON-specific options for writing JSON files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @param x A SparkDataFrame
 #' @param path The directory where the file is saved
 #' @param mode one of 'append', 'overwrite', 'error', 'errorifexists', 'ignore'
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
+#'            You can find the JSON-specific options for writing JSON files in
+#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#'            Data Source Option} in the version you use.
 #'
 #' @family SparkDataFrame functions
 #' @rdname write.json
@@ -917,15 +917,15 @@ setMethod("write.json",
 #'
 #' Save the contents of a SparkDataFrame as an ORC file, preserving the schema. Files written out
 #' with this method can be read back in as a SparkDataFrame using read.orc().
-#' You can find the ORC-specific options for writing ORC files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @param x A SparkDataFrame
 #' @param path The directory where the file is saved
 #' @param mode one of 'append', 'overwrite', 'error', 'errorifexists', 'ignore'
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
+#'            You can find the ORC-specific options for writing ORC files in
+#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
+#'            Data Source Option} in the version you use.
 #'
 #' @family SparkDataFrame functions
 #' @aliases write.orc,SparkDataFrame,character-method
@@ -951,15 +951,15 @@ setMethod("write.orc",
 #'
 #' Save the contents of a SparkDataFrame as a Parquet file, preserving the schema. Files written out
 #' with this method can be read back in as a SparkDataFrame using read.parquet().
-#' You can find the Parquet-specific options for writing Parquet files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @param x A SparkDataFrame
 #' @param path The directory where the file is saved
 #' @param mode one of 'append', 'overwrite', 'error', 'errorifexists', 'ignore'
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
+#'            You can find the Parquet-specific options for writing Parquet files in
+#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option}{
+#'            Data Source Option} in the version you use.
 #'
 #' @family SparkDataFrame functions
 #' @rdname write.parquet
@@ -986,15 +986,15 @@ setMethod("write.parquet",
 #' Save the content of the SparkDataFrame in a text file at the specified path.
 #' The SparkDataFrame must have only one column of string type with the name "value".
 #' Each row becomes a new line in the output file. The text files will be encoded as UTF-8.
-#' You can find the text-specific options for writing text files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @param x A SparkDataFrame
 #' @param path The directory where the file is saved
 #' @param mode one of 'append', 'overwrite', 'error', 'errorifexists', 'ignore'
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
+#'            You can find the text-specific options for writing text files in
+#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
+#'            Data Source Option} in the version you use.
 #'
 #' @family SparkDataFrame functions
 #' @aliases write.text,SparkDataFrame,character-method
@@ -3759,6 +3759,7 @@ setMethod("histogram",
 #' }
 #'
 #' @param x a SparkDataFrame.
+#' @param url JDBC database url of the form \code{jdbc:subprotocol:subname}.
 #' @param tableName the name of the table in the external database.
 #' @param mode one of 'append', 'overwrite', 'error', 'errorifexists', 'ignore'
 #'             save mode (it is 'error' by default)

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -890,7 +890,7 @@ setMethod("toJSON",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the JSON-specific options for writing JSON files in
-#'            \href{
+#'            \url{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #'
@@ -925,7 +925,7 @@ setMethod("write.json",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the ORC-specific options for writing ORC files in
-#'            \href{
+#'            \url{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #'
@@ -960,7 +960,7 @@ setMethod("write.orc",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the Parquet-specific options for writing Parquet files in
-#'            \href{
+#'            \url{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option
 #'            }{Data Source Option} in the version you use.
 #'
@@ -996,7 +996,7 @@ setMethod("write.parquet",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the text-specific options for writing text files in
-#'            \href{
+#'            \url{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #'
@@ -3748,7 +3748,7 @@ setMethod("histogram",
 #' Save the content of the SparkDataFrame to an external database table via JDBC. Additional JDBC
 #' database connection properties can be set (...)
 #' You can find the JDBC-specific option and parameter documentation for writing tables via JDBC in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option}{
+#' \url{https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option}{
 #' Data Source Option} in the version you use.
 #'
 #' Also, mode is used to specify the behavior of the save operation when

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -890,7 +890,8 @@ setMethod("toJSON",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the JSON-specific options for writing JSON files in
-#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#'            \href{
+#'            https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #'
 #' @family SparkDataFrame functions
@@ -924,7 +925,8 @@ setMethod("write.json",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the ORC-specific options for writing ORC files in
-#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
+#'            \href{
+#'            https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #'
 #' @family SparkDataFrame functions
@@ -958,8 +960,9 @@ setMethod("write.orc",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the Parquet-specific options for writing Parquet files in
-#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option}{
-#'            Data Source Option} in the version you use.
+#'            \href{
+#'            https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option
+#'            }{Data Source Option} in the version you use.
 #'
 #' @family SparkDataFrame functions
 #' @rdname write.parquet
@@ -993,7 +996,8 @@ setMethod("write.parquet",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the text-specific options for writing text files in
-#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
+#'            \href{
+#'            https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #'
 #' @family SparkDataFrame functions

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -883,6 +883,9 @@ setMethod("toJSON",
 #' Save the contents of a SparkDataFrame as a JSON file (\href{https://jsonlines.org/}{
 #' JSON Lines text format or newline-delimited JSON}). Files written out
 #' with this method can be read back in as a SparkDataFrame using read.json().
+#' You can find the JSON-specific options for writing JSON files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @param x A SparkDataFrame
 #' @param path The directory where the file is saved
@@ -914,6 +917,9 @@ setMethod("write.json",
 #'
 #' Save the contents of a SparkDataFrame as an ORC file, preserving the schema. Files written out
 #' with this method can be read back in as a SparkDataFrame using read.orc().
+#' You can find the ORC-specific options for writing ORC files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @param x A SparkDataFrame
 #' @param path The directory where the file is saved
@@ -945,6 +951,9 @@ setMethod("write.orc",
 #'
 #' Save the contents of a SparkDataFrame as a Parquet file, preserving the schema. Files written out
 #' with this method can be read back in as a SparkDataFrame using read.parquet().
+#' You can find the Parquet-specific options for writing Parquet files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @param x A SparkDataFrame
 #' @param path The directory where the file is saved
@@ -977,6 +986,9 @@ setMethod("write.parquet",
 #' Save the content of the SparkDataFrame in a text file at the specified path.
 #' The SparkDataFrame must have only one column of string type with the name "value".
 #' Each row becomes a new line in the output file. The text files will be encoded as UTF-8.
+#' You can find the text-specific options for writing text files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @param x A SparkDataFrame
 #' @param path The directory where the file is saved
@@ -3731,6 +3743,9 @@ setMethod("histogram",
 #'
 #' Save the content of the SparkDataFrame to an external database table via JDBC. Additional JDBC
 #' database connection properties can be set (...)
+#' You can find the JDBC-specific option and parameter documentation for writing tables via JDBC in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' Also, mode is used to specify the behavior of the save operation when
 #' data already exists in the data source. There are four modes:
@@ -3744,7 +3759,6 @@ setMethod("histogram",
 #' }
 #'
 #' @param x a SparkDataFrame.
-#' @param url JDBC database url of the form \code{jdbc:subprotocol:subname}.
 #' @param tableName the name of the table in the external database.
 #' @param mode one of 'append', 'overwrite', 'error', 'errorifexists', 'ignore'
 #'             save mode (it is 'error' by default)

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -378,12 +378,12 @@ setMethod("toDF", signature(x = "RDD"),
 #' ) is supported. For JSON (one record per file), set a named property \code{multiLine} to
 #' \code{TRUE}.
 #' It goes through the entire dataset once to determine the schema.
-#' You can find the JSON-specific options for reading JSON files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @param path Path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional external data source specific named properties.
+#'            You can find the JSON-specific options for reading JSON files in
+#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
 #' @rdname read.json
 #' @examples
@@ -409,12 +409,12 @@ read.json <- function(path, ...) {
 #' Create a SparkDataFrame from an ORC file.
 #'
 #' Loads an ORC file, returning the result as a SparkDataFrame.
-#' You can find the ORC-specific options for reading ORC files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @param path Path of file to read.
 #' @param ... additional external data source specific named properties.
+#'            You can find the ORC-specific options for reading ORC files in
+#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
+#'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
 #' @rdname read.orc
 #' @name read.orc
@@ -433,12 +433,12 @@ read.orc <- function(path, ...) {
 #' Create a SparkDataFrame from a Parquet file.
 #'
 #' Loads a Parquet file, returning the result as a SparkDataFrame.
-#' You can find the Parquet-specific options for reading Parquet files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @param path path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional data source specific named properties.
+#'            You can find the Parquet-specific options for reading Parquet files in
+#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option}{
+#'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
 #' @rdname read.parquet
 #' @name read.parquet
@@ -459,14 +459,14 @@ read.parquet <- function(path, ...) {
 #' Loads text files and returns a SparkDataFrame whose schema starts with
 #' a string column named "value", and followed by partitioned columns if
 #' there are any. The text files must be encoded as UTF-8.
-#' You can find the text-specific options for reading text files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' Each line in the text file is a new row in the resulting SparkDataFrame.
 #'
 #' @param path Path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional external data source specific named properties.
+#'            You can find the text-specific options for reading text files in
+#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
+#'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
 #' @rdname read.text
 #' @examples

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -624,7 +624,16 @@ loadDF <- function(path = NULL, source = NULL, schema = NULL, ...) {
 #' Don't create too many partitions in parallel on a large cluster; otherwise Spark might crash
 #' your external database systems.
 #'
+#' @param url JDBC database url of the form \code{jdbc:subprotocol:subname}
 #' @param tableName the name of the table in the external database
+#' @param partitionColumn the name of a column of numeric, date, or timestamp type
+#'                        that will be used for partitioning.
+#' @param lowerBound the minimum value of \code{partitionColumn} used to decide partition stride
+#' @param upperBound the maximum value of \code{partitionColumn} used to decide partition stride
+#' @param numPartitions the number of partitions, This, along with \code{lowerBound} (inclusive),
+#'                      \code{upperBound} (exclusive), form partition strides for generated WHERE
+#'                      clause expressions used to split the column \code{partitionColumn} evenly.
+#'                      This defaults to SparkContext.defaultParallelism when unset.
 #' @param predicates a list of conditions in the where clause; each one defines one partition
 #' @param ... additional JDBC database connection named properties.
 #' @return SparkDataFrame

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -382,7 +382,8 @@ setMethod("toDF", signature(x = "RDD"),
 #' @param path Path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional external data source specific named properties.
 #'            You can find the JSON-specific options for reading JSON files in
-#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#'            \href{
+#'            https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
 #' @rdname read.json
@@ -413,7 +414,8 @@ read.json <- function(path, ...) {
 #' @param path Path of file to read.
 #' @param ... additional external data source specific named properties.
 #'            You can find the ORC-specific options for reading ORC files in
-#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
+#'            \href{
+#'            https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
 #' @rdname read.orc
@@ -437,8 +439,9 @@ read.orc <- function(path, ...) {
 #' @param path path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional data source specific named properties.
 #'            You can find the Parquet-specific options for reading Parquet files in
-#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option}{
-#'            Data Source Option} in the version you use.
+#'            \href{
+#'            https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option
+#'            }{Data Source Option} in the version you use.
 #' @return SparkDataFrame
 #' @rdname read.parquet
 #' @name read.parquet
@@ -465,7 +468,8 @@ read.parquet <- function(path, ...) {
 #' @param path Path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional external data source specific named properties.
 #'            You can find the text-specific options for reading text files in
-#'            \href{https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
+#'            \href{
+#'            https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
 #' @rdname read.text

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -382,7 +382,7 @@ setMethod("toDF", signature(x = "RDD"),
 #' @param path Path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional external data source specific named properties.
 #'            You can find the JSON-specific options for reading JSON files in
-#'            \href{
+#'            \url{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
@@ -414,7 +414,7 @@ read.json <- function(path, ...) {
 #' @param path Path of file to read.
 #' @param ... additional external data source specific named properties.
 #'            You can find the ORC-specific options for reading ORC files in
-#'            \href{
+#'            \url{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
@@ -439,7 +439,7 @@ read.orc <- function(path, ...) {
 #' @param path path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional data source specific named properties.
 #'            You can find the Parquet-specific options for reading Parquet files in
-#'            \href{
+#'            \url{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option
 #'            }{Data Source Option} in the version you use.
 #' @return SparkDataFrame
@@ -468,7 +468,7 @@ read.parquet <- function(path, ...) {
 #' @param path Path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional external data source specific named properties.
 #'            You can find the text-specific options for reading text files in
-#'            \href{
+#'            \url{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
@@ -619,7 +619,7 @@ loadDF <- function(path = NULL, source = NULL, schema = NULL, ...) {
 #'
 #' Additional JDBC database connection properties can be set (...)
 #' You can find the JDBC-specific option and parameter documentation for reading tables via JDBC in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option}{
+#' \url{https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option}{
 #' Data Source Option} in the version you use.
 #'
 #' Only one of partitionColumn or predicates should be set. Partitions of the table will be

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -378,6 +378,9 @@ setMethod("toDF", signature(x = "RDD"),
 #' ) is supported. For JSON (one record per file), set a named property \code{multiLine} to
 #' \code{TRUE}.
 #' It goes through the entire dataset once to determine the schema.
+#' You can find the JSON-specific options for reading JSON files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @param path Path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional external data source specific named properties.
@@ -406,6 +409,9 @@ read.json <- function(path, ...) {
 #' Create a SparkDataFrame from an ORC file.
 #'
 #' Loads an ORC file, returning the result as a SparkDataFrame.
+#' You can find the ORC-specific options for reading ORC files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @param path Path of file to read.
 #' @param ... additional external data source specific named properties.
@@ -427,6 +433,9 @@ read.orc <- function(path, ...) {
 #' Create a SparkDataFrame from a Parquet file.
 #'
 #' Loads a Parquet file, returning the result as a SparkDataFrame.
+#' You can find the Parquet-specific options for reading Parquet files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @param path path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional data source specific named properties.
@@ -450,6 +459,9 @@ read.parquet <- function(path, ...) {
 #' Loads text files and returns a SparkDataFrame whose schema starts with
 #' a string column named "value", and followed by partitioned columns if
 #' there are any. The text files must be encoded as UTF-8.
+#' You can find the text-specific options for reading text files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' Each line in the text file is a new row in the resulting SparkDataFrame.
 #'
@@ -602,6 +614,9 @@ loadDF <- function(path = NULL, source = NULL, schema = NULL, ...) {
 #' Create a SparkDataFrame representing the database table accessible via JDBC URL
 #'
 #' Additional JDBC database connection properties can be set (...)
+#' You can find the JDBC-specific option and parameter documentation for reading tables via JDBC in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' Only one of partitionColumn or predicates should be set. Partitions of the table will be
 #' retrieved in parallel based on the \code{numPartitions} or by the predicates.
@@ -609,16 +624,7 @@ loadDF <- function(path = NULL, source = NULL, schema = NULL, ...) {
 #' Don't create too many partitions in parallel on a large cluster; otherwise Spark might crash
 #' your external database systems.
 #'
-#' @param url JDBC database url of the form \code{jdbc:subprotocol:subname}
 #' @param tableName the name of the table in the external database
-#' @param partitionColumn the name of a column of numeric, date, or timestamp type
-#'                        that will be used for partitioning.
-#' @param lowerBound the minimum value of \code{partitionColumn} used to decide partition stride
-#' @param upperBound the maximum value of \code{partitionColumn} used to decide partition stride
-#' @param numPartitions the number of partitions, This, along with \code{lowerBound} (inclusive),
-#'                      \code{upperBound} (exclusive), form partition strides for generated WHERE
-#'                      clause expressions used to split the column \code{partitionColumn} evenly.
-#'                      This defaults to SparkContext.defaultParallelism when unset.
 #' @param predicates a list of conditions in the where clause; each one defines one partition
 #' @param ... additional JDBC database connection named properties.
 #' @return SparkDataFrame

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -2123,6 +2123,9 @@ setMethod("to_date",
 #' \code{to_json}: Converts a column containing a \code{structType}, a \code{mapType}
 #' or an \code{arrayType} into a Column of JSON string.
 #' Resolving the Column can fail if an unsupported type is encountered.
+#' You can find the JSON-specific options for writing JSON files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @aliases to_json to_json,Column-method
@@ -2159,6 +2162,9 @@ setMethod("to_json", signature(x = "Column"),
 #' @details
 #' \code{to_csv}: Converts a column containing a \code{structType} into a Column of CSV string.
 #' Resolving the Column can fail if an unsupported type is encountered.
+#' You can find the CSV-specific options for writing CSV files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @aliases to_csv to_csv,Column-method
@@ -2640,6 +2646,9 @@ setClassUnion("characterOrstructTypeOrColumn", c("character", "structType", "Col
 #' \code{from_json}: Parses a column containing a JSON string into a Column of \code{structType}
 #' with the specified \code{schema} or array of \code{structType} if \code{as.json.array} is set
 #' to \code{TRUE}. If the string is unparseable, the Column will contain the value NA.
+#' You can find the JSON-specific options for reading JSON files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @param as.json.array indicating if input string is JSON array of objects or a single object.
@@ -2692,6 +2701,9 @@ setMethod("from_json", signature(x = "Column", schema = "characterOrstructTypeOr
 
 #' @details
 #' \code{schema_of_json}: Parses a JSON string and infers its schema in DDL format.
+#' You can find the JSON-specific options for reading JSON files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @aliases schema_of_json schema_of_json,characterOrColumn-method
@@ -2720,6 +2732,9 @@ setMethod("schema_of_json", signature(x = "characterOrColumn"),
 #' \code{from_csv}: Parses a column containing a CSV string into a Column of \code{structType}
 #' with the specified \code{schema}.
 #' If the string is unparseable, the Column will contain the value NA.
+#' You can find the CSV-specific options for reading CSV files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @aliases from_csv from_csv,Column,characterOrstructTypeOrColumn-method
@@ -2753,6 +2768,9 @@ setMethod("from_csv", signature(x = "Column", schema = "characterOrstructTypeOrC
 
 #' @details
 #' \code{schema_of_csv}: Parses a CSV string and infers its schema in DDL format.
+#' You can find the CSV-specific options for reading CSV files in
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{
+#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @aliases schema_of_csv schema_of_csv,characterOrColumn-method

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -259,7 +259,7 @@ NULL
 #'              additional named properties to control how it is converted and accepts the
 #'              same options as the JSON data source.
 #'              You can find the JSON-specific options for reading/writing JSON files in
-#'              \href{
+#'              \url{
 #'              https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
 #'              Data Source Option} in the version you use.
 #'          \item \code{to_json}: it supports the "pretty" option which enables pretty
@@ -268,7 +268,7 @@ NULL
 #'              additional named properties to control how it is converted and accepts the
 #'              same options as the CSV data source.
 #'              You can find the CSV-specific options for reading/writing CSV files in
-#'              \href{
+#'              \url{
 #'              https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{
 #'              Data Source Option} in the version you use.
 #'          \item \code{arrays_zip}, this contains additional Columns of arrays to be merged.

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -259,7 +259,8 @@ NULL
 #'              additional named properties to control how it is converted and accepts the
 #'              same options as the JSON data source.
 #'              You can find the JSON-specific options for reading/writing JSON files in
-#'              \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#'              \href{
+#'              https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
 #'              Data Source Option} in the version you use.
 #'          \item \code{to_json}: it supports the "pretty" option which enables pretty
 #'              JSON generation.
@@ -267,7 +268,8 @@ NULL
 #'              additional named properties to control how it is converted and accepts the
 #'              same options as the CSV data source.
 #'              You can find the CSV-specific options for reading/writing CSV files in
-#'              \href{https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{
+#'              \href{
+#'              https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{
 #'              Data Source Option} in the version you use.
 #'          \item \code{arrays_zip}, this contains additional Columns of arrays to be merged.
 #'          \item \code{map_concat}, this contains additional Columns of maps to be unioned.

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -258,11 +258,17 @@ NULL
 #'          \item \code{to_json}, \code{from_json} and \code{schema_of_json}: this contains
 #'              additional named properties to control how it is converted and accepts the
 #'              same options as the JSON data source.
+#'              You can find the JSON-specific options for reading/writing JSON files in
+#'              \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
+#'              Data Source Option} in the version you use.
 #'          \item \code{to_json}: it supports the "pretty" option which enables pretty
 #'              JSON generation.
 #'          \item \code{to_csv}, \code{from_csv} and \code{schema_of_csv}: this contains
 #'              additional named properties to control how it is converted and accepts the
 #'              same options as the CSV data source.
+#'              You can find the CSV-specific options for reading/writing CSV files in
+#'              \href{https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{
+#'              Data Source Option} in the version you use.
 #'          \item \code{arrays_zip}, this contains additional Columns of arrays to be merged.
 #'          \item \code{map_concat}, this contains additional Columns of maps to be unioned.
 #'          }
@@ -2123,9 +2129,6 @@ setMethod("to_date",
 #' \code{to_json}: Converts a column containing a \code{structType}, a \code{mapType}
 #' or an \code{arrayType} into a Column of JSON string.
 #' Resolving the Column can fail if an unsupported type is encountered.
-#' You can find the JSON-specific options for writing JSON files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @aliases to_json to_json,Column-method
@@ -2162,9 +2165,6 @@ setMethod("to_json", signature(x = "Column"),
 #' @details
 #' \code{to_csv}: Converts a column containing a \code{structType} into a Column of CSV string.
 #' Resolving the Column can fail if an unsupported type is encountered.
-#' You can find the CSV-specific options for writing CSV files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @aliases to_csv to_csv,Column-method
@@ -2646,9 +2646,6 @@ setClassUnion("characterOrstructTypeOrColumn", c("character", "structType", "Col
 #' \code{from_json}: Parses a column containing a JSON string into a Column of \code{structType}
 #' with the specified \code{schema} or array of \code{structType} if \code{as.json.array} is set
 #' to \code{TRUE}. If the string is unparseable, the Column will contain the value NA.
-#' You can find the JSON-specific options for reading JSON files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @param as.json.array indicating if input string is JSON array of objects or a single object.
@@ -2701,9 +2698,6 @@ setMethod("from_json", signature(x = "Column", schema = "characterOrstructTypeOr
 
 #' @details
 #' \code{schema_of_json}: Parses a JSON string and infers its schema in DDL format.
-#' You can find the JSON-specific options for reading JSON files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @aliases schema_of_json schema_of_json,characterOrColumn-method
@@ -2732,9 +2726,6 @@ setMethod("schema_of_json", signature(x = "characterOrColumn"),
 #' \code{from_csv}: Parses a column containing a CSV string into a Column of \code{structType}
 #' with the specified \code{schema}.
 #' If the string is unparseable, the Column will contain the value NA.
-#' You can find the CSV-specific options for reading CSV files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @aliases from_csv from_csv,Column,characterOrstructTypeOrColumn-method
@@ -2768,9 +2759,6 @@ setMethod("from_csv", signature(x = "Column", schema = "characterOrstructTypeOrC
 
 #' @details
 #' \code{schema_of_csv}: Parses a CSV string and infers its schema in DDL format.
-#' You can find the CSV-specific options for reading CSV files in
-#' \href{https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{
-#' Data Source Option} in the version you use.
 #'
 #' @rdname column_collection_functions
 #' @aliases schema_of_csv schema_of_csv,characterOrColumn-method

--- a/docs/sql-data-sources-jdbc.md
+++ b/docs/sql-data-sources-jdbc.md
@@ -110,7 +110,7 @@ logging into the data sources.
 
   <tr>
     <td><code>partitionColumn, lowerBound, upperBound</code></td>
-    <td>(none)</td>
+    <td><code>SparkContext.defaultParallelism</code></td>
     <td>
       These options must all be specified if any of them is specified. In addition,
       <code>numPartitions</code> must be specified. They describe how to partition the table when

--- a/docs/sql-data-sources-jdbc.md
+++ b/docs/sql-data-sources-jdbc.md
@@ -110,7 +110,7 @@ logging into the data sources.
 
   <tr>
     <td><code>partitionColumn, lowerBound, upperBound</code></td>
-    <td><code>SparkContext.defaultParallelism</code></td>
+    <td>(none)</td>
     <td>
       These options must all be specified if any of them is specified. In addition,
       <code>numPartitions</code> must be specified. They describe how to partition the table when


### PR DESCRIPTION
### What changes were proposed in this pull request?

There are options for data source are documented at Data Source Options page for every data sources.

For Python, Scala, JAVA, the link for Data Source Option page was added in each API documentation.

- Python
<img width="732" alt="Screen Shot 2021-06-07 at 12 25 45 PM" src="https://user-images.githubusercontent.com/44108233/120955187-cbe38800-c78b-11eb-9475-ccf89bbc3c95.png">

- Scala
<img width="677" alt="Screen Shot 2021-06-07 at 12 26 41 PM" src="https://user-images.githubusercontent.com/44108233/120955186-cab25b00-c78b-11eb-9fed-3f0d2024029b.png">

- JAVA
<img width="726" alt="Screen Shot 2021-06-07 at 12 27 49 PM" src="https://user-images.githubusercontent.com/44108233/120955182-c8e89780-c78b-11eb-9cf1-13e41ba35b3e.png">

However, we have no link for R documentation, so we should add the link to the R documentation as well.


### Why are the changes needed?

To provide users available options for each data source when they read/write it.


### Does this PR introduce _any_ user-facing change?

Yes, the link for Data Source Option is added to R documentation as below.

<img width="855" alt="Screen Shot 2021-06-07 at 12 29 26 PM" src="https://user-images.githubusercontent.com/44108233/120955302-064d2500-c78c-11eb-8dc3-cb22dfd5fd14.png">


### How was this patch tested?

Manually built doc and checked one by one