### PR TITLE
[SPARK-35646][PYTHON][DOCS] Relocate pandas-on-Spark API references in documentation

### DIFF
--- a/python/docs/source/reference/pyspark.pandas.rst
+++ b/python/docs/source/reference/pyspark.pandas.rst
@@ -16,20 +16,21 @@
     under the License.
 
 
-=============
-API Reference
-=============
+====================
+Pandas APIs on Spark
+====================
 
-This page lists an overview of all public PySpark modules, classes, functions and methods.
+This page gives an overview of all public pandas APIs on Spark.
 
 .. toctree::
    :maxdepth: 2
 
-   pyspark.sql
-   pyspark.pandas
-   pyspark.ss
-   pyspark.ml
-   pyspark.streaming
-   pyspark.mllib
-   pyspark
-   pyspark.resource
+   ps_io
+   ps_general_functions
+   ps_series
+   ps_frame
+   ps_indexing
+   ps_window
+   ps_groupby
+   ps_ml
+   ps_extensions


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to change from:

![Screen Shot 2021-06-07 at 1 40 47 PM](https://user-images.githubusercontent.com/6477701/120960027-fc302400-c795-11eb-96fb-73ac1d8277fe.png)

to:

![Screen Shot 2021-06-07 at 1 41 19 PM](https://user-images.githubusercontent.com/6477701/120960074-0fdb8a80-c796-11eb-87ec-69a30692fdfe.png)

### Why are the changes needed?

pandas APIs on Spark (pandas on Spark) is a package in PySpark in the end. So it has to be documented in the same level with other packages (e.g., Spark SQL).

### Does this PR introduce _any_ user-facing change?

Yes, it changes the structure of the docs. To end users, no as it's only in development branch. 

### How was this patch tested?

Manually tested as above.