### PR TITLE
[SPARK-35661][SQL] Allow deserialized off-heap memory entry

### DIFF
--- a/core/src/main/java/org/apache/spark/api/java/StorageLevels.java
+++ b/core/src/main/java/org/apache/spark/api/java/StorageLevels.java
@@ -36,7 +36,6 @@ public class StorageLevels {
   public static final StorageLevel MEMORY_AND_DISK_SER = create(true, true, false, false, 1);
   public static final StorageLevel MEMORY_AND_DISK_SER_2 = create(true, true, false, false, 2);
   public static final StorageLevel OFF_HEAP = create(true, true, true, false, 1);
-  public static final StorageLevel OFF_HEAP_ONLY_DESER = create(false, true, true, true, 1);
 
   /**
    * Create a new StorageLevel object.

--- a/core/src/main/java/org/apache/spark/api/java/StorageLevels.java
+++ b/core/src/main/java/org/apache/spark/api/java/StorageLevels.java
@@ -36,6 +36,7 @@ public class StorageLevels {
   public static final StorageLevel MEMORY_AND_DISK_SER = create(true, true, false, false, 1);
   public static final StorageLevel MEMORY_AND_DISK_SER_2 = create(true, true, false, false, 2);
   public static final StorageLevel OFF_HEAP = create(true, true, true, false, 1);
+  public static final StorageLevel OFF_HEAP_ONLY_DESER = create(false, true, true, true, 1);
 
   /**
    * Create a new StorageLevel object.

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -298,10 +298,12 @@ private[spark] class BlockManager(
 
     protected def saveToDiskStore(): Unit
 
-    private def saveDeserializedValuesToMemoryStore(inputStream: InputStream): Boolean = {
+    private def saveDeserializedValuesToMemoryStore(
+        inputStream: InputStream,
+        memoryMode: MemoryMode): Boolean = {
       try {
         val values = serializerManager.dataDeserializeStream(blockId, inputStream)(classTag)
-        memoryStore.putIteratorAsValues(blockId, values, classTag) match {
+        memoryStore.putIteratorAsValues(blockId, values, memoryMode, classTag) match {
           case Right(_) => true
           case Left(iter) =>
             // If putting deserialized values in memory failed, we will put the bytes directly
@@ -356,7 +358,7 @@ private[spark] class BlockManager(
           // Put it in memory first, even if it also has useDisk set to true;
           // We will drop it to disk later if the memory store can't hold it.
           val putSucceeded = if (level.deserialized) {
-            saveDeserializedValuesToMemoryStore(blockData().toInputStream())
+            saveDeserializedValuesToMemoryStore(blockData().toInputStream(), level.memoryMode)
           } else {
             saveSerializedValuesToMemoryStore(readToByteBuffer())
           }
@@ -1420,7 +1422,7 @@ private[spark] class BlockManager(
         // Put it in memory first, even if it also has useDisk set to true;
         // We will drop it to disk later if the memory store can't hold it.
         if (level.deserialized) {
-          memoryStore.putIteratorAsValues(blockId, iterator(), classTag) match {
+          memoryStore.putIteratorAsValues(blockId, iterator(), level.memoryMode, classTag) match {
             case Right(s) =>
               size = s
             case Left(iter) =>
@@ -1566,7 +1568,7 @@ private[spark] class BlockManager(
           // Note: if we had a means to discard the disk iterator, we would do that here.
           memoryStore.getValues(blockId).get
         } else {
-          memoryStore.putIteratorAsValues(blockId, diskIterator, classTag) match {
+          memoryStore.putIteratorAsValues(blockId, diskIterator, level.memoryMode, classTag) match {
             case Left(iter) =>
               // The memory store put() failed, so it returned the iterator back to us:
               iter

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -298,12 +298,10 @@ private[spark] class BlockManager(
 
     protected def saveToDiskStore(): Unit
 
-    private def saveDeserializedValuesToMemoryStore(
-        inputStream: InputStream,
-        memoryMode: MemoryMode): Boolean = {
+    private def saveDeserializedValuesToMemoryStore(inputStream: InputStream): Boolean = {
       try {
         val values = serializerManager.dataDeserializeStream(blockId, inputStream)(classTag)
-        memoryStore.putIteratorAsValues(blockId, values, memoryMode, classTag) match {
+        memoryStore.putIteratorAsValues(blockId, values, level.memoryMode, classTag) match {
           case Right(_) => true
           case Left(iter) =>
             // If putting deserialized values in memory failed, we will put the bytes directly
@@ -358,7 +356,7 @@ private[spark] class BlockManager(
           // Put it in memory first, even if it also has useDisk set to true;
           // We will drop it to disk later if the memory store can't hold it.
           val putSucceeded = if (level.deserialized) {
-            saveDeserializedValuesToMemoryStore(blockData().toInputStream(), level.memoryMode)
+            saveDeserializedValuesToMemoryStore(blockData().toInputStream())
           } else {
             saveSerializedValuesToMemoryStore(readToByteBuffer())
           }

--- a/core/src/main/scala/org/apache/spark/storage/StorageLevel.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageLevel.scala
@@ -59,10 +59,6 @@ class StorageLevel private(
 
   assert(replication < 40, "Replication restricted to be less than 40 for calculating hash codes")
 
-  if (useOffHeap) {
-    require(!deserialized, "Off-heap storage level does not support deserialized storage")
-  }
-
   private[spark] def memoryMode: MemoryMode = {
     if (useOffHeap) MemoryMode.OFF_HEAP
     else MemoryMode.ON_HEAP
@@ -163,6 +159,7 @@ object StorageLevel {
   val MEMORY_AND_DISK_SER = new StorageLevel(true, true, false, false)
   val MEMORY_AND_DISK_SER_2 = new StorageLevel(true, true, false, false, 2)
   val OFF_HEAP = new StorageLevel(true, true, true, false, 1)
+  val OFF_HEAP_ONLY_DESER = new StorageLevel(false, true, true, true, 1)
 
   /**
    * :: DeveloperApi ::
@@ -183,6 +180,7 @@ object StorageLevel {
     case "MEMORY_AND_DISK_SER" => MEMORY_AND_DISK_SER
     case "MEMORY_AND_DISK_SER_2" => MEMORY_AND_DISK_SER_2
     case "OFF_HEAP" => OFF_HEAP
+    case "OFF_HEAP_ONLY_DESER" => OFF_HEAP_ONLY_DESER
     case _ => throw new IllegalArgumentException(s"Invalid StorageLevel: $s")
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/StorageLevel.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageLevel.scala
@@ -159,7 +159,6 @@ object StorageLevel {
   val MEMORY_AND_DISK_SER = new StorageLevel(true, true, false, false)
   val MEMORY_AND_DISK_SER_2 = new StorageLevel(true, true, false, false, 2)
   val OFF_HEAP = new StorageLevel(true, true, true, false, 1)
-  val OFF_HEAP_ONLY_DESER = new StorageLevel(false, true, true, true, 1)
 
   /**
    * :: DeveloperApi ::
@@ -180,7 +179,6 @@ object StorageLevel {
     case "MEMORY_AND_DISK_SER" => MEMORY_AND_DISK_SER
     case "MEMORY_AND_DISK_SER_2" => MEMORY_AND_DISK_SER_2
     case "OFF_HEAP" => OFF_HEAP
-    case "OFF_HEAP_ONLY_DESER" => OFF_HEAP_ONLY_DESER
     case _ => throw new IllegalArgumentException(s"Invalid StorageLevel: $s")
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -49,8 +49,8 @@ private sealed trait MemoryEntry[T] {
 private case class DeserializedMemoryEntry[T](
     value: Array[T],
     size: Long,
+    memoryMode: MemoryMode,
     classTag: ClassTag[T]) extends MemoryEntry[T] {
-  val memoryMode: MemoryMode = MemoryMode.ON_HEAP
 }
 private case class SerializedMemoryEntry[T](
     buffer: ChunkedByteBuffer,
@@ -294,11 +294,12 @@ private[spark] class MemoryStore(
   private[storage] def putIteratorAsValues[T](
       blockId: BlockId,
       values: Iterator[T],
+      memoryMode: MemoryMode,
       classTag: ClassTag[T]): Either[PartiallyUnrolledIterator[T], Long] = {
 
-    val valuesHolder = new DeserializedValuesHolder[T](classTag)
+    val valuesHolder = new DeserializedValuesHolder[T](classTag, memoryMode)
 
-    putIterator(blockId, values, classTag, MemoryMode.ON_HEAP, valuesHolder) match {
+    putIterator(blockId, values, classTag, memoryMode, valuesHolder) match {
       case Right(storedSize) => Right(storedSize)
       case Left(unrollMemoryUsedByThisBlock) =>
         val unrolledIterator = if (valuesHolder.vector != null) {
@@ -309,7 +310,7 @@ private[spark] class MemoryStore(
 
         Left(new PartiallyUnrolledIterator(
           this,
-          MemoryMode.ON_HEAP,
+          memoryMode,
           unrollMemoryUsedByThisBlock,
           unrolled = unrolledIterator,
           rest = values))
@@ -381,7 +382,7 @@ private[spark] class MemoryStore(
       case null => None
       case e: SerializedMemoryEntry[_] =>
         throw new IllegalArgumentException("should only call getValues on deserialized blocks")
-      case DeserializedMemoryEntry(values, _, _) =>
+      case DeserializedMemoryEntry(values, _, _, _) =>
         val x = Some(values)
         x.map(_.iterator)
     }
@@ -474,7 +475,7 @@ private[spark] class MemoryStore(
             // non-blocking "tryLock" here in order to ignore blocks which are locked for reading:
             if (blockInfoManager.lockForWriting(blockId, blocking = false).isDefined) {
               selectedBlocks += blockId
-              freedMemory += pair.getValue.size
+              freedMemory += entry.size
             }
           }
         }
@@ -482,7 +483,7 @@ private[spark] class MemoryStore(
 
       def dropBlock[T](blockId: BlockId, entry: MemoryEntry[T]): Unit = {
         val data = entry match {
-          case DeserializedMemoryEntry(values, _, _) => Left(values)
+          case DeserializedMemoryEntry(values, _, _, _) => Left(values)
           case SerializedMemoryEntry(buffer, _, _) => Right(buffer)
         }
         val newEffectiveStorageLevel =
@@ -672,7 +673,9 @@ private trait ValuesHolder[T] {
 /**
  * A holder for storing the deserialized values.
  */
-private class DeserializedValuesHolder[T] (classTag: ClassTag[T]) extends ValuesHolder[T] {
+private class DeserializedValuesHolder[T](
+    classTag: ClassTag[T],
+    memoryMode: MemoryMode) extends ValuesHolder[T] {
   // Underlying vector for unrolling the block
   var vector = new SizeTrackingVector[T]()(classTag)
   var arrayValues: Array[T] = null
@@ -693,7 +696,7 @@ private class DeserializedValuesHolder[T] (classTag: ClassTag[T]) extends Values
     override val preciseSize: Long = SizeEstimator.estimate(arrayValues)
 
     override def build(): MemoryEntry[T] =
-      DeserializedMemoryEntry[T](arrayValues, preciseSize, classTag)
+      DeserializedMemoryEntry[T](arrayValues, preciseSize, memoryMode, classTag)
   }
 }
 
@@ -706,6 +709,7 @@ private class SerializedValuesHolder[T](
     classTag: ClassTag[T],
     memoryMode: MemoryMode,
     serializerManager: SerializerManager) extends ValuesHolder[T] {
+
   val allocator = memoryMode match {
     case MemoryMode.ON_HEAP => ByteBuffer.allocate _
     case MemoryMode.OFF_HEAP => Platform.allocateDirectBuffer _

--- a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala
@@ -709,7 +709,6 @@ private class SerializedValuesHolder[T](
     classTag: ClassTag[T],
     memoryMode: MemoryMode,
     serializerManager: SerializerManager) extends ValuesHolder[T] {
-
   val allocator = memoryMode match {
     case MemoryMode.ON_HEAP => ByteBuffer.allocate _
     case MemoryMode.OFF_HEAP => Platform.allocateDirectBuffer _

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -44,7 +44,7 @@ import org.apache.spark.executor.DataReadMethod
 import org.apache.spark.internal.config
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Tests._
-import org.apache.spark.memory.UnifiedMemoryManager
+import org.apache.spark.memory.{MemoryMode, UnifiedMemoryManager}
 import org.apache.spark.network.{BlockDataManager, BlockTransferService, TransportContext}
 import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer, NioManagedBuffer}
 import org.apache.spark.network.client.{RpcResponseCallback, TransportClient}
@@ -1538,7 +1538,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
 
     // Unroll with not enough space. This should succeed but kick out b1 in the process.
     // Memory store should contain b2 and b3, while disk store should contain only b1
-    val result3 = memoryStore.putIteratorAsValues("b3", smallIterator, ClassTag.Any)
+    val result3 = memoryStore.putIteratorAsValues("b3", smallIterator, MemoryMode.ON_HEAP,
+      ClassTag.Any)
     assert(result3.isRight)
     assert(!memoryStore.contains("b1"))
     assert(memoryStore.contains("b2"))
@@ -1554,7 +1555,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     // the block may be stored to disk. During the unrolling process, block "b2" should be kicked
     // out, so the memory store should contain only b3, while the disk store should contain
     // b1, b2 and b4.
-    val result4 = memoryStore.putIteratorAsValues("b4", bigIterator, ClassTag.Any)
+    val result4 = memoryStore.putIteratorAsValues("b4", bigIterator, MemoryMode.ON_HEAP,
+      ClassTag.Any)
     assert(result4.isLeft)
     assert(!memoryStore.contains("b1"))
     assert(!memoryStore.contains("b2"))

--- a/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
@@ -277,7 +277,7 @@ class MemoryStoreSuite
     // Size the values so the sequence of block drops matches the one in the on-heap test. The
     // values are different since the sizes here are exact, vs. being estimated for on-heap.
     testPutIteratorAsValues(() => OffHeapValue(110), () => OffHeapValue(1500),
-      StorageLevel.OFF_HEAP_ONLY_DESER)
+      StorageLevel(false, true, useOffHeap = true, deserialized = true, 1))
   }
 
   test("safely unroll blocks through putIteratorAsBytes") {

--- a/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
@@ -33,6 +33,8 @@ import org.apache.spark.storage.memory.{BlockEvictionHandler, MemoryStore, Parti
 import org.apache.spark.util._
 import org.apache.spark.util.io.ChunkedByteBuffer
 
+case class OffHeapValue(override val estimatedSize: Long) extends KnownSizeEstimation
+
 class MemoryStoreSuite
   extends SparkFunSuite
   with PrivateMethodTester
@@ -41,6 +43,9 @@ class MemoryStoreSuite
 
   val conf: SparkConf = new SparkConf(false)
     .set(STORAGE_UNROLL_MEMORY_THRESHOLD, 512L)
+    .set(MEMORY_OFFHEAP_ENABLED, true)
+    .set(MEMORY_OFFHEAP_SIZE, 12000L)
+    .set(MEMORY_STORAGE_FRACTION, 0.5)
 
   // Reuse a serializer across tests to avoid creating a new thread-local buffer on each test
   val serializer = new KryoSerializer(
@@ -156,7 +161,7 @@ class MemoryStoreSuite
       assert(blockInfoManager.lockNewBlockForWriting(
         blockId,
         new BlockInfo(StorageLevel.MEMORY_ONLY, classTag, tellMaster = false)))
-      val res = memoryStore.putIteratorAsValues(blockId, iter, classTag)
+      val res = memoryStore.putIteratorAsValues(blockId, iter, MemoryMode.ON_HEAP, classTag)
       blockInfoManager.unlock(blockId)
       res
     }
@@ -196,10 +201,13 @@ class MemoryStoreSuite
     assert(memoryStore.currentUnrollMemoryForThisTask === 0)
   }
 
-  test("safely unroll blocks through putIteratorAsValues") {
+  def testPutIteratorAsValues[T](
+      smallListValue: () => T,
+      bigListValue: () => T,
+      storageLevel: StorageLevel): Unit = {
     val (memoryStore, blockInfoManager) = makeMemoryStore(12000)
-    val smallList = List.fill(40)(new Array[Byte](100))
-    val bigList = List.fill(40)(new Array[Byte](1000))
+    val smallList = List.fill(40)(smallListValue())
+    val bigList = List.fill(40)(bigListValue())
     def smallIterator: Iterator[Any] = smallList.iterator.asInstanceOf[Iterator[Any]]
     def bigIterator: Iterator[Any] = bigList.iterator.asInstanceOf[Iterator[Any]]
     assert(memoryStore.currentUnrollMemoryForThisTask === 0)
@@ -210,8 +218,8 @@ class MemoryStoreSuite
         classTag: ClassTag[T]): Either[PartiallyUnrolledIterator[T], Long] = {
       assert(blockInfoManager.lockNewBlockForWriting(
         blockId,
-        new BlockInfo(StorageLevel.MEMORY_ONLY, classTag, tellMaster = false)))
-      val res = memoryStore.putIteratorAsValues(blockId, iter, classTag)
+        new BlockInfo(storageLevel, classTag, tellMaster = false)))
+      val res = memoryStore.putIteratorAsValues(blockId, iter, storageLevel.memoryMode, classTag)
       blockInfoManager.unlock(blockId)
       res
     }
@@ -258,6 +266,18 @@ class MemoryStoreSuite
     assert(memoryStore.currentUnrollMemoryForThisTask > 0) // we returned an iterator
     result4.left.get.close()
     assert(memoryStore.currentUnrollMemoryForThisTask === 0) // close released the unroll memory
+  }
+
+  test("safely unroll blocks through putIteratorAsValues") {
+    testPutIteratorAsValues(() => new Array[Byte](100), () => new Array[Byte](1000),
+      StorageLevel.MEMORY_ONLY)
+  }
+
+  test("safely unroll blocks through putIteratorAsValues off-heap") {
+    // Size the values so the sequence of block drops matches the one in the on-heap test. The
+    // values are different since the sizes here are exact, vs. being estimated for on-heap.
+    testPutIteratorAsValues(() => OffHeapValue(110), () => OffHeapValue(1500),
+      StorageLevel.OFF_HEAP_ONLY_DESER)
   }
 
   test("safely unroll blocks through putIteratorAsBytes") {
@@ -376,7 +396,7 @@ class MemoryStoreSuite
     def putIteratorAsValues(
         blockId: BlockId,
         iter: Iterator[Any]): Either[PartiallyUnrolledIterator[Any], Long] = {
-       memoryStore.putIteratorAsValues(blockId, iter, ClassTag.Any)
+       memoryStore.putIteratorAsValues(blockId, iter, MemoryMode.ON_HEAP, ClassTag.Any)
     }
 
     // All unroll memory used is released because putIterator did not return an iterator
@@ -556,7 +576,7 @@ class MemoryStoreSuite
         blockId: BlockId,
         iter: Iterator[T],
         classTag: ClassTag[T]): Either[PartiallyUnrolledIterator[T], Long] = {
-      memoryStore.putIteratorAsValues(blockId, iter, classTag)
+      memoryStore.putIteratorAsValues(blockId, iter, MemoryMode.ON_HEAP, classTag)
     }
 
     // Unroll with plenty of space. This should succeed and cache both blocks.
@@ -582,7 +602,7 @@ class MemoryStoreSuite
         blockId: BlockId,
         iter: Iterator[T],
         classTag: ClassTag[T]): Either[PartiallyUnrolledIterator[T], Long] = {
-      memoryStore.putIteratorAsValues(blockId, iter, classTag)
+      memoryStore.putIteratorAsValues(blockId, iter, MemoryMode.ON_HEAP, classTag)
     }
 
     // Unroll with plenty of space. This should succeed and cache both blocks.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/32534

#32534 proposed a use case to use `DeserializedMemoryEntry` to store off-heap data, and let Spark release the memory via the `AutoCloseable` interface. However, there is one more problem: `DeserializedMemoryEntry` always reports its size as on-heap size, which is inaccurate. If the Spark cluster is configured with small on-heap size and large off-heap size, this will trigger a lot of spilling.

This PR makes `DeserializedMemoryEntry` truly support off-heap data. Now the caller side can cache off-heap data with a new storage level `OFF_HEAP_ONLY_DESER`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
correct the memory counting for off-heap data.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
updated test