### PR TITLE
[SPARK-26867][YARN] Spark Support of YARN Placement Constraint

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/LocalityPreferredSchedulingRequestContainerPlacementStrategy.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/LocalityPreferredSchedulingRequestContainerPlacementStrategy.scala
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn
+
+import scala.collection.mutable
+import scala.collection.mutable.{ArrayBuffer, HashMap, Set}
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.yarn.api.records.{ContainerId, SchedulingRequest}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.resource.ResourceProfile
+
+
+/**
+ * This strategy is calculating the optimal locality preferences of YARN containers by considering
+ * the node ratio of pending tasks, number of required cores/containers and locality of current
+ * existing and pending allocated containers. The target of this algorithm is to maximize the number
+ * of tasks that would run locally.
+ *
+ * Consider a situation in which we have 20 tasks that require (host1, host2, host3)
+ * and 10 tasks that require (host1, host2, host4), besides each container has 2 cores
+ * and cpus per task is 1, so the required container number is 15,
+ * and host ratio is (host1: 30, host2: 30, host3: 20, host4: 10).
+ *
+ * 1. If the requested container number (18) is more than the required container number (15):
+ *
+ * requests for 5 containers with nodes: (host1, host2, host3, host4)
+ * requests for 5 containers with nodes: (host1, host2, host3)
+ * requests for 5 containers with nodes: (host1, host2)
+ * requests for 3 containers with no locality preferences.
+ *
+ * The placement ratio is 3 : 3 : 2 : 1, and set the additional containers with no locality
+ * preferences.
+ *
+ * 2. If requested container number (10) is less than or equal to the required container number
+ * (15):
+ *
+ * requests for 4 containers with nodes: (host1, host2, host3, host4)
+ * requests for 3 containers with nodes: (host1, host2, host3)
+ * requests for 3 containers with nodes: (host1, host2)
+ *
+ * The placement ratio is 10 : 10 : 7 : 4, close to expected ratio (3 : 3 : 2 : 1)
+ *
+ * 3. If containers exist but none of them can match the requested localities,
+ * follow the method of 1 and 2.
+ *
+ * 4. If containers exist and some of them can match the requested localities.
+ * For example if we have 1 container on each node (host1: 1, host2: 1: host3: 1, host4: 1),
+ * and the expected containers on each node would be (host1: 5, host2: 5, host3: 4, host4: 2),
+ * so the newly requested containers on each node would be updated to (host1: 4, host2: 4,
+ * host3: 3, host4: 1), 12 containers by total.
+ *
+ *   4.1 If requested container number (18) is more than newly required containers (12). Follow
+ *   method 1 with an updated ratio 4 : 4 : 3 : 1.
+ *
+ *   4.2 If request container number (10) is less than newly required containers (12). Follow
+ *   method 2 with an updated ratio 4 : 4 : 3 : 1.
+ *
+ * 5. If containers exist and existing localities can fully cover the requested localities.
+ * For example if we have 5 containers on each node (host1: 5, host2: 5, host3: 5, host4: 5),
+ * which could cover the current requested localities. This algorithm will allocate all the
+ * requested containers with no localities.
+ */
+private[yarn] class LocalityPreferredSchedulingRequestContainerPlacementStrategy(
+    val sparkConf: SparkConf,
+    val yarnConf: Configuration,
+    resolver: SparkRackResolver) {
+
+  /**
+   * Calculate each container's node locality and rack locality
+   * @param numContainer number of containers to calculate
+   * @param numLocalityAwareTasks number of locality required tasks
+   * @param hostToLocalTaskCount a map to store the preferred hostname and possible task
+   *                             numbers running on it, used as hints for container allocation
+   * @param allocatedHostToContainersMap host to allocated containers map, used to calculate the
+   *                                     expected locality preference by considering the existing
+   *                                     containers
+   * @param localityMatchedPendingAllocations A sequence of pending container request which
+   *                                          matches the localities of current required tasks.
+   * @param rp The ResourceProfile associated with this container.
+   * @return node localities and rack localities, each locality is an array of string,
+   *         the length of localities is the same as number of containers
+   */
+  def localityOfRequestedContainers(
+      numContainer: Int,
+      numLocalityAwareTasks: Int,
+      hostToLocalTaskCount: Map[String, Int],
+      allocatedHostToContainersMap: HashMap[String, Set[ContainerId]],
+      localityMatchedPendingAllocations: Seq[SchedulingRequest],
+      schedulingRequestToNodes: mutable.HashMap[Long, Array[String]],
+      rp: ResourceProfile
+    ): Array[ContainerLocalityPreferences] = {
+    val updatedHostToContainerCount = expectedHostToContainerCount(
+      numLocalityAwareTasks, hostToLocalTaskCount, allocatedHostToContainersMap,
+        localityMatchedPendingAllocations, schedulingRequestToNodes, rp)
+    val updatedLocalityAwareContainerNum = updatedHostToContainerCount.values.sum
+
+    // The number of containers to allocate, divided into two groups, one with preferred locality,
+    // and the other without locality preference.
+    val requiredLocalityFreeContainerNum =
+      math.max(0, numContainer - updatedLocalityAwareContainerNum)
+    val requiredLocalityAwareContainerNum = numContainer - requiredLocalityFreeContainerNum
+
+    val containerLocalityPreferences = ArrayBuffer[ContainerLocalityPreferences]()
+    if (requiredLocalityFreeContainerNum > 0) {
+      for (i <- 0 until requiredLocalityFreeContainerNum) {
+        containerLocalityPreferences += ContainerLocalityPreferences(
+          null.asInstanceOf[Array[String]], null.asInstanceOf[Array[String]])
+      }
+    }
+
+    if (requiredLocalityAwareContainerNum > 0) {
+      val largestRatio = updatedHostToContainerCount.values.max
+      // Round the ratio of preferred locality to the number of locality required container
+      // number, which is used for locality preferred host calculating.
+      var preferredLocalityRatio = updatedHostToContainerCount.map { case(k, ratio) =>
+        val adjustedRatio = ratio.toDouble * requiredLocalityAwareContainerNum / largestRatio
+        (k, adjustedRatio.ceil.toInt)
+      }
+
+      for (i <- 0 until requiredLocalityAwareContainerNum) {
+        // Only filter out the ratio which is larger than 0, which means the current host can
+        // still be allocated with new container request.
+        val hosts = preferredLocalityRatio.filter(_._2 > 0).keys.toArray
+        val racks = resolver.resolve(hosts).map(_.getNetworkLocation)
+          .filter(_ != null).toSet
+        containerLocalityPreferences += ContainerLocalityPreferences(hosts, racks.toArray)
+
+        // Minus 1 each time when the host is used. When the current ratio is 0,
+        // which means all the required ratio is satisfied, this host will not be allocated again.
+        preferredLocalityRatio = preferredLocalityRatio.map { case (k, v) => (k, v - 1) }
+      }
+    }
+
+    containerLocalityPreferences.toArray
+  }
+
+  /**
+   * Calculate the number of executors needed to satisfy the given number of pending tasks for
+   * the ResourceProfile.
+   */
+  private def numExecutorsPending(
+      numTasksPending: Int,
+      rp: ResourceProfile): Int = {
+    val tasksPerExec = rp.maxTasksPerExecutor(sparkConf)
+    math.ceil(numTasksPending / tasksPerExec.toDouble).toInt
+  }
+
+  /**
+   * Calculate the expected host to number of containers by considering with allocated containers.
+   * @param localityAwareTasks number of locality aware tasks
+   * @param hostToLocalTaskCount a map to store the preferred hostname and possible task
+   *                             numbers running on it, used as hints for container allocation
+   * @param allocatedHostToContainersMap host to allocated containers map, used to calculate the
+   *                                     expected locality preference by considering the existing
+   *                                     containers
+   * @param localityMatchedPendingAllocations A sequence of pending container request which
+   *                                          matches the localities of current required tasks.
+   * @return a map with hostname as key and required number of containers on this host as value
+   */
+  private def expectedHostToContainerCount(
+      localityAwareTasks: Int,
+      hostToLocalTaskCount: Map[String, Int],
+      allocatedHostToContainersMap: HashMap[String, Set[ContainerId]],
+      localityMatchedPendingAllocations: Seq[SchedulingRequest],
+      schedulingRequestToNodes: mutable.HashMap[Long, Array[String]],
+      rp: ResourceProfile
+    ): Map[String, Int] = {
+    val totalLocalTaskNum = hostToLocalTaskCount.values.sum
+    val pendingHostToContainersMap =
+      pendingHostToContainerCount(localityMatchedPendingAllocations, schedulingRequestToNodes)
+
+    hostToLocalTaskCount.map { case (host, count) =>
+      val expectedCount =
+        count.toDouble * numExecutorsPending(localityAwareTasks, rp) / totalLocalTaskNum
+      // Take the locality of pending containers into consideration
+      val existedCount = allocatedHostToContainersMap.get(host).map(_.size).getOrElse(0) +
+        pendingHostToContainersMap.getOrElse(host, 0.0)
+
+      // If existing container can not fully satisfy the expected number of container,
+      // the required container number is expected count minus existed count. Otherwise the
+      // required container number is 0.
+      (host, math.max(0, (expectedCount - existedCount).ceil.toInt))
+    }
+  }
+
+  /**
+   * According to the locality ratio and number of container requests, calculate the host to
+   * possible number of containers for pending allocated containers.
+   *
+   * If current locality ratio of hosts is: Host1 : Host2 : Host3 = 20 : 20 : 10,
+   * and pending container requests is 3, so the possible number of containers on
+   * Host1 : Host2 : Host3 will be 1.2 : 1.2 : 0.6.
+   * @param localityMatchedPendingAllocations A sequence of pending container request which
+   *                                          matches the localities of current required tasks.
+   * @return a Map with hostname as key and possible number of containers on this host as value
+   */
+  private def pendingHostToContainerCount(
+      localityMatchedPendingAllocations: Seq[SchedulingRequest],
+      schedulingRequestToNodes: mutable.HashMap[Long, Array[String]]): Map[String, Double] = {
+    val pendingHostToContainerCount = new HashMap[String, Int]()
+    localityMatchedPendingAllocations.foreach { cr =>
+      schedulingRequestToNodes(cr.getAllocationRequestId).foreach { n =>
+        val count = pendingHostToContainerCount.getOrElse(n, 0) + 1
+        pendingHostToContainerCount(n) = count
+      }
+    }
+
+    val possibleTotalContainerNum = pendingHostToContainerCount.values.sum
+    val localityMatchedPendingNum = localityMatchedPendingAllocations.size.toDouble
+    pendingHostToContainerCount.map { case (k, v) =>
+      (k, v * localityMatchedPendingNum / possibleTotalContainerNum)
+    }.toMap
+  }
+}

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -95,7 +95,7 @@ private[yarn] class YarnAllocator(
   private val numExecutorsStartingPerResourceProfileId = new HashMap[Int, AtomicInteger]
 
   @GuardedBy("this")
-  private val targetNumExecutorsPerResourceProfileId = new mutable.HashMap[Int, Int]
+  protected val targetNumExecutorsPerResourceProfileId = new mutable.HashMap[Int, Int]
 
   // Executor loss reason requests that are pending - maps from executor ID for inquiry to a
   // list of requesters that should be responded to once we find out why the given executor
@@ -131,7 +131,7 @@ private[yarn] class YarnAllocator(
   // A map of ResourceProfile id to a map of preferred hostname and possible
   // task numbers running on it.
   @GuardedBy("this")
-  private var hostToLocalTaskCountPerResourceProfileId: Map[Int, Map[String, Int]] =
+  protected var hostToLocalTaskCountPerResourceProfileId: Map[Int, Map[String, Int]] =
     Map(DEFAULT_RESOURCE_PROFILE_ID -> Map.empty)
 
   // ResourceProfile Id to number of tasks that have locality preferences in active stages
@@ -228,30 +228,30 @@ private[yarn] class YarnAllocator(
   // always finishes a stage before starting a later one and if we have 2 running in parallel
   // the priority doesn't matter.
   // We are using the ResourceProfile id as the priority.
-  private def getContainerPriority(rpId: Int): Priority = {
+  protected def getContainerPriority(rpId: Int): Priority = {
     Priority.newInstance(rpId)
   }
 
   // The ResourceProfile id is the priority
-  private def getResourceProfileIdFromPriority(priority: Priority): Int = {
+  protected def getResourceProfileIdFromPriority(priority: Priority): Int = {
     priority.getPriority()
   }
 
-  private def getOrUpdateAllocatedHostToContainersMapForRPId(
+  protected def getOrUpdateAllocatedHostToContainersMapForRPId(
       rpId: Int): HashMap[String, collection.mutable.Set[ContainerId]] = synchronized {
     allocatedHostToContainersMapPerRPId.getOrElseUpdate(rpId,
       new HashMap[String, mutable.Set[ContainerId]]())
   }
 
-  private def getOrUpdateRunningExecutorForRPId(rpId: Int): mutable.Set[String] = synchronized {
+  protected def getOrUpdateRunningExecutorForRPId(rpId: Int): mutable.Set[String] = synchronized {
     runningExecutorsPerResourceProfileId.getOrElseUpdate(rpId, mutable.HashSet[String]())
   }
 
-  private def getOrUpdateNumExecutorsStartingForRPId(rpId: Int): AtomicInteger = synchronized {
+  protected def getOrUpdateNumExecutorsStartingForRPId(rpId: Int): AtomicInteger = synchronized {
     numExecutorsStartingPerResourceProfileId.getOrElseUpdate(rpId, new AtomicInteger(0))
   }
 
-  private def getOrUpdateTargetNumExecutorsForRPId(rpId: Int): Int = synchronized {
+  protected def getOrUpdateTargetNumExecutorsForRPId(rpId: Int): Int = synchronized {
     targetNumExecutorsPerResourceProfileId.getOrElseUpdate(rpId,
       SchedulerBackendUtils.getInitialTargetExecutorNumber(sparkConf))
   }
@@ -643,7 +643,7 @@ private[yarn] class YarnAllocator(
    * @param containersToUse list of containers that will be used
    * @param remaining list of containers that will not be used
    */
-  private def matchContainerToRequest(
+  protected def matchContainerToRequest(
       allocatedContainer: Container,
       location: String,
       containersToUse: ArrayBuffer[Container],

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -83,8 +83,13 @@ private[spark] class YarnRMClient extends Logging {
       securityMgr: SecurityManager,
       localResources: Map[String, LocalResource]): YarnAllocator = {
     require(registered, "Must register AM before creating allocator.")
-    new YarnAllocator(driverUrl, driverRef, conf, sparkConf, amClient, appAttemptId, securityMgr,
-      localResources, SparkRackResolver.get(conf))
+    if (sparkConf.get(SCHEDULING_REQUEST_ENABLED)) {
+      new YarnSchedulingRequestAllocator(driverUrl, driverRef, conf, sparkConf, amClient,
+        appAttemptId, securityMgr, localResources, SparkRackResolver.get(conf))
+    } else {
+      new YarnAllocator(driverUrl, driverRef, conf, sparkConf, amClient, appAttemptId, securityMgr,
+        localResources, SparkRackResolver.get(conf))
+    }
   }
 
   /**

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSchedulingRequestAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSchedulingRequestAllocator.scala
@@ -76,7 +76,7 @@ private[yarn] class YarnSchedulingRequestAllocator(
     new LocalityPreferredSchedulingRequestContainerPlacementStrategy(sparkConf, conf, resolver)
   private[yarn] val nodeAttributes = sparkConf.get(NODE_ATTRIBUTE)
     .map(PlacementConstraintParser.parseExpression)
-  private[yarn] val delayedOrIntervalMiliseconds = sparkConf.get(DELAYED_OR_INTERVAL)
+  private[yarn] val delayedOrIntervalMilliseconds = sparkConf.get(DELAYED_OR_INTERVAL)
 
   private[yarn] val outstandingSchedRequests: JMap[JSet[String], JList[SchedulingRequest]] = {
     val field = classOf[AMRMClientImpl[ContainerRequest]]
@@ -232,8 +232,8 @@ private[yarn] class YarnSchedulingRequestAllocator(
 
     val locality = (nodesLocality, racksLocality) match {
       case (Some(nodes), Some(racks)) => Some(delayedOr(
-        timedClockConstraint(nodes, delayedOrIntervalMiliseconds, TimeUnit.MILLISECONDS),
-        timedClockConstraint(racks, delayedOrIntervalMiliseconds * 2, TimeUnit.MILLISECONDS)))
+        timedClockConstraint(nodes, delayedOrIntervalMilliseconds, TimeUnit.MILLISECONDS),
+        timedClockConstraint(racks, delayedOrIntervalMilliseconds * 2, TimeUnit.MILLISECONDS)))
       case (Some(nodes), None) => Some(nodes)
       case (None, Some(racks)) => Some(racks)
       case _ => None

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSchedulingRequestAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSchedulingRequestAllocator.scala
@@ -1,0 +1,390 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn
+
+import java.util.{List => JList, Map => JMap, Set => JSet}
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.hadoop.yarn.api.records._
+import org.apache.hadoop.yarn.api.resource.PlacementConstraints._
+import org.apache.hadoop.yarn.client.api.AMRMClient
+import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest
+import org.apache.hadoop.yarn.client.api.impl.AMRMClientImpl
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.hadoop.yarn.util.constraint.PlacementConstraintParser
+
+import org.apache.spark.{SecurityManager, SparkConf}
+import org.apache.spark.deploy.yarn.config._
+import org.apache.spark.internal.Logging
+import org.apache.spark.rpc.RpcEndpointRef
+import org.apache.spark.util.{Clock, SystemClock}
+
+
+/**
+ * YarnSchedulingRequestAllocator is charged with requesting containers from the
+ * YARN ResourceManager using Placement Constraint and deciding what to do with
+ * containers when YARN fulfills these requests.
+ *
+ * This class makes use of YARN's AMRMClient APIs. We interact with the AMRMClient in three ways:
+ * * Making our resource needs known, which updates local bookkeeping about containers requested.
+ * * Calling "allocate", which syncs our local container requests with the RM, and returns any
+ *   containers that YARN has granted to us.  This also functions as a heartbeat.
+ * * Processing the containers granted to us to possibly launch executors inside of them.
+ *
+ * The public methods of this class are thread-safe.  All methods that mutate state are
+ * synchronized.
+ */
+private[yarn] class YarnSchedulingRequestAllocator(
+    driverUrl: String,
+    driverRef: RpcEndpointRef,
+    conf: YarnConfiguration,
+    sparkConf: SparkConf,
+    amClient: AMRMClient[ContainerRequest],
+    appAttemptId: ApplicationAttemptId,
+    securityMgr: SecurityManager,
+    localResources: Map[String, LocalResource],
+    resolver: SparkRackResolver,
+    clock: Clock = new SystemClock)
+  extends YarnAllocator(driverUrl, driverRef, conf, sparkConf, amClient,
+    appAttemptId, securityMgr, localResources, resolver, clock) with Logging {
+
+  private[yarn] lazy val nextAllocationRequestId = new AtomicLong(0)
+  private[yarn] val allocationRequestIdToNodes = new mutable.HashMap[Long, Array[String]]
+  private[yarn] val allocationRequestIdToRacks = new mutable.HashMap[Long, Array[String]]
+  // A container placement strategy based on pending tasks' locality preference
+  private[yarn] val schedulingRequestContainerPlacementStrategy =
+    new LocalityPreferredSchedulingRequestContainerPlacementStrategy(sparkConf, conf, resolver)
+  private[yarn] val nodeAttributes = sparkConf.get(NODE_ATTRIBUTE)
+    .map(PlacementConstraintParser.parseExpression)
+
+  private def outstandingSchedRequests: JMap[JSet[String], JList[SchedulingRequest]] = {
+    val field = classOf[AMRMClientImpl[ContainerRequest]]
+      .getDeclaredField("outstandingSchedRequests")
+    field.setAccessible(true)
+    val outstandingSchedRequests =
+      field.get(amClient.asInstanceOf[AMRMClientImpl[ContainerRequest]])
+        .asInstanceOf[JMap[JSet[String], JList[SchedulingRequest]]]
+    // For pass UT, since mock AMRMClientImpl use reflection will got null.
+    Option(outstandingSchedRequests)
+      .getOrElse(Map.empty[JSet[String], JList[SchedulingRequest]].asJava)
+  }
+
+  /**
+   * A sequence of pending container requests that have not yet been fulfilled.
+   * ResourceProfile id -> pendingAllocate container request
+   */
+  def getPendingSchedAllocate: Map[Int, Seq[SchedulingRequest]] = {
+    outstandingSchedRequests.asScala.values.flatMap(_.asScala.map { request =>
+      request.getPriority.getPriority -> request
+    }).groupBy(_._1).mapValues(_.map(_._2).toSet.toSeq)
+  }
+
+  override def getNumContainersPendingAllocate: Int = synchronized {
+    getPendingSchedAllocate.values.flatten.size
+  }
+
+  /**
+   * Update the set of SchedulingRequest that we will sync with the RM based on the number of
+   * executors we have currently running and our target number of executors for each
+   * ResourceProfile.
+   *
+   * Visible for testing.
+   */
+  override def updateResourceRequests(): Unit = synchronized {
+    val pendingAllocatePerResourceProfileId = getPendingSchedAllocate
+
+    // Here we lack pending size for each profile
+    val missingPerProfile = targetNumExecutorsPerResourceProfileId.map { case (rpId, targetNum) =>
+      val starting = getOrUpdateNumExecutorsStartingForRPId(rpId).get
+      val pending = pendingAllocatePerResourceProfileId.getOrElse(rpId, Seq.empty).size
+      val running = getOrUpdateRunningExecutorForRPId(rpId).size
+      logDebug(s"Updating resource requests for ResourceProfile id: $rpId, target: " +
+        s"$targetNum, pending: $pending, running: $running, executorsStarting: $starting")
+      (rpId, targetNum - pending - running - starting)
+    }.toMap
+
+    missingPerProfile.foreach { case (rpId, missing) =>
+      val hostToLocalTaskCount =
+        hostToLocalTaskCountPerResourceProfileId.getOrElse(rpId, Map.empty)
+      val pendingAllocate = pendingAllocatePerResourceProfileId.getOrElse(rpId, Seq.empty)
+      val numPendingAllocate = pendingAllocate.size
+      // Split the pending container request into three groups: locality matched list, locality
+      // unmatched list and non-locality list. Take the locality matched container request into
+      // consideration of container placement, treat as allocated containers.
+      // For locality unmatched and locality free container requests, cancel these container
+      // requests, since required locality preference has been changed, recalculating using
+      // container placement strategy.
+      val (localRequests, staleRequests, anyHostRequests) =
+      splitPendingSchedulingRequestAllocationsByLocality(hostToLocalTaskCount, pendingAllocate)
+
+      if (missing > 0) {
+        val resource = rpIdToYarnResource.get(rpId)
+        if (log.isInfoEnabled()) {
+          var requestContainerMessage = s"Will request $missing executor container(s) for " +
+            s" ResourceProfile Id: $rpId, each with " +
+            s"${resource.getVirtualCores} core(s) and " +
+            s"${resource.getMemory} MB memory."
+          if (ResourceRequestHelper.isYarnResourceTypesAvailable() &&
+            ResourceRequestHelper.isYarnCustomResourcesNonEmpty(resource)) {
+            requestContainerMessage ++= s" with custom resources: " + resource.toString
+          }
+          logInfo(requestContainerMessage)
+        }
+
+        // cancel "stale" requests for locations that are no longer needed
+        staleRequests.foreach { stale =>
+          removeFromOutstandingSchedulingRequests(stale)
+        }
+        val cancelledContainers = staleRequests.size
+        if (cancelledContainers > 0) {
+          logInfo(s"Canceled $cancelledContainers container request(s) (locality no longer needed)")
+        }
+
+        // consider the number of new containers and cancelled stale containers available
+        val availableContainers = missing + cancelledContainers
+
+        // to maximize locality, include requests with no locality preference
+        // that can be cancelled
+        val potentialContainers = availableContainers + anyHostRequests.size
+
+        val allocatedHostToContainer = getOrUpdateAllocatedHostToContainersMapForRPId(rpId)
+        val numLocalityAwareTasks = numLocalityAwareTasksPerResourceProfileId.getOrElse(rpId, 0)
+        val containerLocalityPreferences =
+          schedulingRequestContainerPlacementStrategy.localityOfRequestedContainers(
+            potentialContainers, numLocalityAwareTasks, hostToLocalTaskCount,
+            allocatedHostToContainer, localRequests, allocationRequestIdToNodes,
+            rpIdToResourceProfile(rpId))
+
+        val newLocalityRequests = new mutable.ArrayBuffer[SchedulingRequest]
+        containerLocalityPreferences.foreach {
+          case ContainerLocalityPreferences(nodes, racks) if nodes != null =>
+            newLocalityRequests += createSchedulingRequest(resource, nodes, racks, rpId)
+          case _ =>
+        }
+
+        if (availableContainers >= newLocalityRequests.size) {
+          // more containers are available than needed for locality, fill in requests for any host
+          for (i <- 0 until (availableContainers - newLocalityRequests.size)) {
+            newLocalityRequests += createSchedulingRequest(resource, rpId = rpId)
+          }
+        } else {
+          val numToCancel = newLocalityRequests.size - availableContainers
+          // cancel some requests without locality preferences to schedule more local containers
+          anyHostRequests.slice(0, numToCancel).foreach { nonLocal =>
+            removeFromOutstandingSchedulingRequests(nonLocal)
+          }
+          if (numToCancel > 0) {
+            logInfo(s"Canceled $numToCancel unlocalized container requests to " +
+              s"resubmit with locality")
+          }
+        }
+        amClient.addSchedulingRequests(newLocalityRequests.asJava)
+      } else if (numPendingAllocate > 0 && missing < 0) {
+        val numToCancel = math.min(numPendingAllocate, -missing)
+        logInfo(s"Canceling requests for $numToCancel executor container(s) to have a new " +
+          s"desired total ${getOrUpdateTargetNumExecutorsForRPId(rpId)} executors.")
+        // cancel pending allocate requests by taking locality preference into account
+        val cancelRequests = (staleRequests ++ anyHostRequests ++ localRequests).take(numToCancel)
+        cancelRequests.foreach(removeFromOutstandingSchedulingRequests)
+      }
+    }
+  }
+
+  def createSchedulingRequest(
+      resource: Resource,
+      nodes: Array[String] = Array.empty,
+      racks: Array[String] = Array.empty,
+      rpId: Int): SchedulingRequest = {
+    val allocationRequestId = nextAllocationRequestId.getAndIncrement()
+    val nodesLocality = if (nodes.nonEmpty) {
+      allocationRequestIdToNodes.put(allocationRequestId, nodes)
+      Some(targetIn(NODE, PlacementTargets.nodeAttribute("host", nodes: _*)))
+    } else {
+      None
+    }
+    val racksLocality = if (racks.nonEmpty) {
+      allocationRequestIdToRacks.put(allocationRequestId, racks)
+      Some(targetIn(RACK, PlacementTargets.nodeAttribute("rack", racks: _*)))
+    } else {
+      None
+    }
+
+    val locality = (nodesLocality, racksLocality) match {
+      case (Some(nodes), Some(racks)) => Some(and(nodes, racks))
+      case (Some(nodes), None) => Some(nodes)
+      case (None, Some(racks)) => Some(racks)
+      case _ => None
+    }
+
+    val expression = (nodeAttributes, locality) match {
+      case (Some(attributes), Some(locality)) => Some(and(attributes, locality))
+      case (Some(attribute), None) => Some(attribute)
+      case (None, Some(locality)) => Some(locality)
+      case _ => None
+    }
+
+    val schedulingRequestBuilder = SchedulingRequest.newBuilder()
+      // Use default and same as construct ContainerRequest.
+      .executionType(ExecutionTypeRequest.newInstance)
+      // When constructing ContainerRequest use default 0L
+      .allocationRequestId(allocationRequestId)
+      // priority same as rpId, use this to make which container belong to which rpId.
+      // and mark each container's status.
+      .priority(getContainerPriority(rpId))
+      .allocationTags(Set("SPARK").asJava)
+      .resourceSizing(ResourceSizing.newInstance(resource))
+
+    expression.foreach { placementConstraint =>
+      schedulingRequestBuilder.placementConstraintExpression(placementConstraint.build())
+    }
+
+    schedulingRequestBuilder.build()
+  }
+
+  /**
+   * Looks for locality message of each allocation request id. If matches, means YARN have
+   * fullfilled this AllocationRequestId's request, remove it from allocationRequestIdToNodes and
+   * allocationRequestIdToRacks. Places the matched container into
+   * containersToUse or remaining.
+   *
+   * @param allocatedContainer container that was given to us by YARN
+   * @param location resource name, either a node, rack, or *
+   * @param containersToUse list of containers that will be used
+   * @param remaining list of containers that will not be used
+   */
+  override def matchContainerToRequest(
+      allocatedContainer: Container,
+      location: String,
+      containersToUse: ArrayBuffer[Container],
+      remaining: ArrayBuffer[Container]): Unit = {
+    // Match on the exact resource we requested so there shouldn't be a mismatch,
+    // we are relying on YARN to return a container with resources no less then we requested.
+    // If we change this, or starting validating the container, be sure the logic covers SPARK-6050.
+    val rpId = getResourceProfileIdFromPriority(allocatedContainer.getPriority)
+    val resourceForRP = rpIdToYarnResource.get(rpId)
+
+    logDebug(s"Calling amClient.getMatchingRequests with parameters: " +
+      s"priority: ${allocatedContainer.getPriority}, " +
+      s"location: $location, resource: $resourceForRP")
+
+    if (matchContainerToRequestLocality(allocatedContainer.getAllocationRequestId, location)) {
+      // Add this method for test, since outstanding request has been removed
+      // when container allocated to AMRMClient.
+      removeFromOutstandingSchedulingRequests(allocatedContainer)
+      containersToUse += allocatedContainer
+    } else {
+      remaining += allocatedContainer
+    }
+  }
+
+  def matchContainerToRequestLocality(requestId: Long, location: String): Boolean = {
+    if (allocationRequestIdToNodes.contains(requestId) ||
+      allocationRequestIdToRacks.contains(requestId)) {
+      val requestNodes = allocationRequestIdToNodes.getOrElse(requestId, Array.empty)
+      val requestRacks = allocationRequestIdToRacks.getOrElse(requestId, Array.empty)
+      if (requestNodes.contains(location) || requestRacks.contains(location)) {
+        allocationRequestIdToNodes.remove(requestId)
+        allocationRequestIdToRacks.remove(requestId)
+        true
+      } else {
+        false
+      }
+    } else {
+      true
+    }
+  }
+
+  private def splitPendingSchedulingRequestAllocationsByLocality(
+      hostToLocalTaskCount: Map[String, Int],
+      pendingAllocations: Seq[SchedulingRequest]
+  ): (Seq[SchedulingRequest], Seq[SchedulingRequest], Seq[SchedulingRequest]) = {
+    val localityMatched = ArrayBuffer[SchedulingRequest]()
+    val localityUnMatched = ArrayBuffer[SchedulingRequest]()
+    val localityFree = ArrayBuffer[SchedulingRequest]()
+
+    val preferredHosts = hostToLocalTaskCount.keySet
+    pendingAllocations.foreach { cr =>
+      val nodes = allocationRequestIdToNodes.getOrElse(cr.getAllocationRequestId, Array.empty)
+      if (nodes.isEmpty) {
+        localityFree += cr
+      } else if (nodes.toSet.intersect(preferredHosts).nonEmpty) {
+        localityMatched += cr
+      } else {
+        localityUnMatched += cr
+      }
+    }
+
+    (localityMatched.toSeq, localityUnMatched.toSeq, localityFree.toSeq)
+  }
+
+  def removeFromOutstandingSchedulingRequests(request: SchedulingRequest): Unit = {
+    if (request != null) {
+      if (request.getAllocationTags != null && !request.getAllocationTags.isEmpty) {
+        val schedReqs: JList[SchedulingRequest] =
+          outstandingSchedRequests.get(request.getAllocationTags)
+        if (schedReqs != null && !schedReqs.isEmpty) {
+          val iter: java.util.Iterator[SchedulingRequest] = schedReqs.iterator
+          while (iter.hasNext) {
+            val schedReq: SchedulingRequest = iter.next
+            if (schedReq.getPriority == request.getPriority &&
+              schedReq.getAllocationRequestId == request.getAllocationRequestId) {
+              var numAllocations: Int = schedReq.getResourceSizing.getNumAllocations
+              numAllocations -= 1
+              if (numAllocations == 0) {
+                iter.remove()
+              } else {
+                schedReq.getResourceSizing.setNumAllocations(numAllocations)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def removeFromOutstandingSchedulingRequests(request: Container): Unit = {
+    if (request != null) {
+      if (request.getAllocationTags != null && !request.getAllocationTags.isEmpty) {
+        val schedReqs: JList[SchedulingRequest] =
+          outstandingSchedRequests.get(request.getAllocationTags)
+        if (schedReqs != null && !schedReqs.isEmpty) {
+          val iter: java.util.Iterator[SchedulingRequest] = schedReqs.iterator
+          while (iter.hasNext) {
+            val schedReq: SchedulingRequest = iter.next
+            if (schedReq.getPriority == request.getPriority &&
+              schedReq.getAllocationRequestId == request.getAllocationRequestId) {
+              var numAllocations: Int = schedReq.getResourceSizing.getNumAllocations
+              numAllocations -= 1
+              if (numAllocations == 0) {
+                iter.remove()
+              } else {
+                schedReq.getResourceSizing.setNumAllocations(numAllocations)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSchedulingRequestAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSchedulingRequestAllocator.scala
@@ -76,7 +76,7 @@ private[yarn] class YarnSchedulingRequestAllocator(
   private[yarn] val nodeAttributes = sparkConf.get(NODE_ATTRIBUTE)
     .map(PlacementConstraintParser.parseExpression)
 
-  private def outstandingSchedRequests: JMap[JSet[String], JList[SchedulingRequest]] = {
+  private[yarn] val outstandingSchedRequests: JMap[JSet[String], JList[SchedulingRequest]] = {
     val field = classOf[AMRMClientImpl[ContainerRequest]]
       .getDeclaredField("outstandingSchedRequests")
     field.setAccessible(true)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSchedulingRequestAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSchedulingRequestAllocator.scala
@@ -243,12 +243,8 @@ private[yarn] class YarnSchedulingRequestAllocator(
     }
 
     val schedulingRequestBuilder = SchedulingRequest.newBuilder()
-      // Use default and same as construct ContainerRequest.
       .executionType(ExecutionTypeRequest.newInstance)
-      // When constructing ContainerRequest use default 0L
       .allocationRequestId(allocationRequestId)
-      // priority same as rpId, use this to make which container belong to which rpId.
-      // and mark each container's status.
       .priority(getContainerPriority(rpId))
       .allocationTags(Set("SPARK").asJava)
       .resourceSizing(ResourceSizing.newInstance(resource))

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -40,6 +40,12 @@ package object config extends Logging {
       .stringConf
       .createOptional
 
+  private[spark] val DELAYED_OR_INTERVAL =
+    ConfigBuilder("spark.yarn.executor.localityDelayedOrInterval")
+      .doc("Interval between YARN allocate container to fullfill delayed_or constraint.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(3000)
+
   private[spark] val APPLICATION_TAGS = ConfigBuilder("spark.yarn.tags")
     .doc("Comma-separated list of strings to pass through as YARN application tags appearing " +
       "in YARN Application Reports, which can be used for filtering when querying YARN.")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -27,6 +27,18 @@ import org.apache.spark.network.util.ByteUnit
 package object config extends Logging {
 
   /* Common app configuration. */
+  private[spark] val SCHEDULING_REQUEST_ENABLED =
+    ConfigBuilder("spark.yarn.schedulingRequestEnabled")
+      .doc("If true, use YARN Placement Constraint when request container resources")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val NODE_ATTRIBUTE =
+    ConfigBuilder("spark.yarn.executor.nodeAttributes")
+      .doc("Required node attributes when request container, if no container can fullfills" +
+        "node attributes we required, we can't allocate container.")
+      .stringConf
+      .createOptional
 
   private[spark] val APPLICATION_TAGS = ConfigBuilder("spark.yarn.tags")
     .doc("Comma-separated list of strings to pass through as YARN application tags appearing " +

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ContainerImpl.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ContainerImpl.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.deploy.yarn
+
+import java.util
+
+import org.apache.hadoop.yarn.api.records.{Container, ContainerId, ExecutionType, NodeId, Priority, Resource, Token}
+
+class ContainerImpl(var containerId: ContainerId,
+  var nodeId: NodeId,
+  var nodeHttpAddress: String,
+  var resource: Resource,
+  var priority: Priority,
+  var containerToken: Token,
+  var executionType: ExecutionType,
+  var allocationRequestId: Long,
+  var allocationTags: util.Set[String]) extends Container {
+
+  override def getId: ContainerId = containerId
+
+  override def setId(containerId: ContainerId): Unit = this.containerId = containerId
+
+  override def getNodeId: NodeId = nodeId
+
+  override def setNodeId(nodeId: NodeId): Unit = this.nodeId = nodeId
+
+  override def getNodeHttpAddress: String = nodeHttpAddress
+
+  override def setNodeHttpAddress(s: String): Unit = this.nodeHttpAddress = s
+
+  override def getResource: Resource = resource
+
+  override def setResource(resource: Resource): Unit = this.resource = resource
+
+  override def getPriority: Priority = priority
+
+  override def setPriority(priority: Priority): Unit = this.priority = priority
+
+  override def getContainerToken: Token = containerToken
+
+  override def setContainerToken(token: Token): Unit = this.containerToken = token
+
+  override def getExecutionType: ExecutionType = executionType
+
+  override def setExecutionType(executionType: ExecutionType): Unit =
+    this.executionType = executionType
+
+  override def getAllocationRequestId: Long = allocationRequestId
+
+  override def setAllocationRequestId(allocationRequestID: Long): Unit =
+    this.allocationRequestId = allocationRequestID
+
+  override def getAllocationTags: util.Set[String] = allocationTags
+
+  override def setAllocationTags(allocationTags: util.Set[String]): Unit =
+    this.allocationTags = allocationTags
+
+  override def compareTo(other: Container): Int = {
+    if (this.getId.compareTo(other.getId) == 0) {
+      if (this.getNodeId.compareTo(other.getNodeId) == 0) {
+        this.getResource.compareTo(other.getResource)
+      } else {
+        this.getNodeId.compareTo(other.getNodeId)
+      }
+    } else {
+      this.getId.compareTo(other.getId)
+    }
+  }
+
+  override def toString: String = s"ContainerImpl($containerId, $nodeId, $nodeHttpAddress, " +
+    s"$resource, $priority, $containerToken, $executionType, $allocationRequestId, " +
+    s"$allocationTags)"
+}
+

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSchedulingRequestAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSchedulingRequestAllocatorSuite.scala
@@ -1,0 +1,797 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn
+
+import java.util.Collections
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import org.apache.hadoop.yarn.api.records._
+import org.apache.hadoop.yarn.api.records.impl.pb.SchedulingRequestPBImpl
+import org.apache.hadoop.yarn.api.resource.PlacementConstraint
+import org.apache.hadoop.yarn.api.resource.PlacementConstraints._
+import org.apache.hadoop.yarn.client.api.AMRMClient
+import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest
+import org.apache.hadoop.yarn.client.api.impl.AMRMClientImpl
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.hadoop.yarn.util.constraint.PlacementConstraintParser
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers._
+
+import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.yarn.ResourceRequestHelper._
+import org.apache.spark.deploy.yarn.config._
+import org.apache.spark.internal.config._
+import org.apache.spark.resource.{ExecutorResourceRequests, ResourceProfile, TaskResourceRequests}
+import org.apache.spark.resource.ResourceUtils.{AMOUNT, GPU}
+import org.apache.spark.resource.TestResourceIDs._
+import org.apache.spark.rpc.RpcEndpointRef
+import org.apache.spark.scheduler.SplitInfo
+import org.apache.spark.util.ManualClock
+
+
+class YarnSchedulingRequestAllocatorSuite
+  extends SparkFunSuite with Matchers with BeforeAndAfterEach {
+  val conf = new YarnConfiguration()
+  val sparkConf = new SparkConf()
+  sparkConf.set(DRIVER_HOST_ADDRESS, "localhost")
+  sparkConf.set(DRIVER_PORT, 4040)
+  sparkConf.set(SPARK_JARS, Seq("notarealjar.jar"))
+  sparkConf.set("spark.yarn.launchContainers", "false")
+  sparkConf.set(SCHEDULING_REQUEST_ENABLED, true)
+
+  val appAttemptId = ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 0), 0)
+
+  // Resource returned by YARN.  YARN can give larger containers than requested, so give 6 cores
+  // instead of the 5 requested and 3 GB instead of the 2 requested.
+  val containerResource = Resource.newInstance(3072, 6)
+
+  var rmClient: AMRMClient[ContainerRequest] = _
+
+  var clock: ManualClock = _
+
+  var containerNum = 0
+
+  // priority has to be 0 to match default profile id
+  val RM_REQUEST_PRIORITY = Priority.newInstance(0)
+  val defaultRPId = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID
+  var defaultRP = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    rmClient = AMRMClient.createAMRMClient()
+    rmClient.init(conf)
+    rmClient.start()
+    clock = new ManualClock()
+  }
+
+  override def afterEach(): Unit = {
+    try {
+      rmClient.stop()
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  class MockSplitInfo(host: String) extends SplitInfo(null, host, null, 1, null) {
+    override def hashCode(): Int = 0
+    override def equals(other: Any): Boolean = false
+  }
+
+  def createAllocator(
+      maxExecutors: Int = 5,
+      rmClient: AMRMClient[ContainerRequest] = rmClient,
+      additionalConfigs: Map[String, String] = Map()):
+  (YarnSchedulingRequestAllocator, SparkConf) = {
+    val args = Array(
+      "--jar", "somejar.jar",
+      "--class", "SomeClass")
+    val sparkConfClone = sparkConf.clone()
+    sparkConfClone
+      .set(EXECUTOR_INSTANCES, maxExecutors)
+      .set(EXECUTOR_CORES, 5)
+      .set(EXECUTOR_MEMORY, 2048L)
+
+    for ((name, value) <- additionalConfigs) {
+      sparkConfClone.set(name, value)
+    }
+    // different spark confs means we need to reinit the default profile
+    ResourceProfile.clearDefaultProfile()
+    defaultRP = ResourceProfile.getOrCreateDefaultProfile(sparkConfClone)
+
+    val allocator = new YarnSchedulingRequestAllocator(
+      "not used",
+      mock(classOf[RpcEndpointRef]),
+      conf,
+      sparkConfClone,
+      rmClient,
+      appAttemptId,
+      new SecurityManager(sparkConf),
+      Map(),
+      new MockResolver(),
+      clock)
+    (allocator, sparkConfClone)
+  }
+
+  def createContainer(
+      host: String,
+      allocationRequestId: Long = 0,
+      allocationTags: Set[String] = Set("SPARK"),
+      containerNumber: Int = containerNum,
+      resource: Resource = containerResource,
+      priority: Priority = RM_REQUEST_PRIORITY): Container = {
+    val  containerId: ContainerId = ContainerId.newContainerId(appAttemptId, containerNum)
+    containerNum += 1
+    val nodeId = NodeId.newInstance(host, 1000)
+    new ContainerImpl(containerId, nodeId, "", resource, priority, null,
+      ExecutionType.GUARANTEED, allocationRequestId, allocationTags.asJava)
+  }
+
+  def createContainers(
+      hosts: Seq[String],
+      allocationRequestIds: Seq[Int],
+      containerIds: Seq[Int]): Seq[Container] = {
+    hosts.zip(allocationRequestIds.zip(containerIds)).map{ case (host, ids) =>
+      createContainer(host, allocationRequestId = ids._1, containerNumber = ids._2)
+    }
+  }
+
+  def createContainerStatus(
+      containerId: ContainerId,
+      exitStatus: Int,
+      containerState: ContainerState = ContainerState.COMPLETE,
+      diagnostics: String = "diagnostics"): ContainerStatus = {
+    ContainerStatus.newInstance(containerId, containerState, diagnostics, exitStatus)
+  }
+
+
+  test("single container allocated") {
+    // request a single container and receive it
+    val (handler, _) = createAllocator(1)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be(0)
+    handler.getNumContainersPendingAllocate should be(1)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(1)
+
+    val container = createContainer("host1", 0)
+    handler.handleAllocatedContainers(Array(container))
+
+    handler.getNumExecutorsRunning should be (1)
+    handler.allocatedContainerToHostMap.get(container.getId).get should be ("host1")
+    val hostTocontainer = handler.allocatedHostToContainersMapPerRPId(defaultRPId)
+    hostTocontainer.get("host1").get should contain(container.getId)
+
+    handler.getPendingSchedAllocate
+      .getOrElse(container.getPriority.getPriority, Seq.empty).size should be (0)
+  }
+
+  test("single container allocated with ResourceProfile") {
+    assume(isYarnResourceTypesAvailable())
+    val yarnResources = Seq(YARN_GPU_RESOURCE_CONFIG)
+    ResourceRequestTestHelper.initializeResourceTypes(yarnResources)
+    // create default profile so we get a different id to test below
+    val defaultRProf = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
+    val execReq = new ExecutorResourceRequests().resource("gpu", 6)
+    val taskReq = new TaskResourceRequests().resource("gpu", 1)
+    val rprof = new ResourceProfile(execReq.requests, taskReq.requests)
+    // request a single container and receive it
+    val (handler, _) = createAllocator(0)
+
+    val resourceProfileToTotalExecs = mutable.HashMap(defaultRProf -> 0, rprof -> 1)
+    val numLocalityAwareTasksPerResourceProfileId = mutable.HashMap(rprof.id -> 0)
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map.empty, Set.empty)
+
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (1)
+    handler.getPendingSchedAllocate
+      .getOrElse(rprof.id, Seq.empty).size should be(1)
+
+    val container = createContainer("host1", 0, priority = Priority.newInstance(rprof.id))
+    handler.handleAllocatedContainers(Array(container))
+
+    handler.getNumExecutorsRunning should be (1)
+    handler.allocatedContainerToHostMap.get(container.getId).get should be ("host1")
+    val hostTocontainer = handler.allocatedHostToContainersMapPerRPId(rprof.id)
+    hostTocontainer.get("host1").get should contain(container.getId)
+
+    handler.getPendingSchedAllocate
+      .getOrElse(container.getPriority.getPriority, Seq.empty).size should be(0)
+
+    ResourceProfile.reInitDefaultProfile(sparkConf)
+  }
+
+  test("multiple containers allocated with ResourceProfiles") {
+    assume(isYarnResourceTypesAvailable())
+    val yarnResources = Seq(YARN_GPU_RESOURCE_CONFIG, YARN_FPGA_RESOURCE_CONFIG)
+    ResourceRequestTestHelper.initializeResourceTypes(yarnResources)
+    // create default profile so we get a different id to test below
+    val defaultRProf = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
+    val execReq = new ExecutorResourceRequests().resource("gpu", 6)
+    val taskReq = new TaskResourceRequests().resource("gpu", 1)
+    val rprof = new ResourceProfile(execReq.requests, taskReq.requests)
+
+    val execReq2 = new ExecutorResourceRequests().memory("8g").resource("fpga", 2)
+    val taskReq2 = new TaskResourceRequests().resource("fpga", 1)
+    val rprof2 = new ResourceProfile(execReq2.requests, taskReq2.requests)
+
+
+    // request a single container and receive it
+    val (handler, _) = createAllocator(1)
+    val resourceProfileToTotalExecs = mutable.HashMap(defaultRProf -> 0, rprof -> 1, rprof2 -> 2)
+    val numLocalityAwareTasksPerResourceProfileId = mutable.HashMap(rprof.id -> 0, rprof2.id -> 0)
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map.empty, Set.empty)
+
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (3)
+    handler.getPendingSchedAllocate
+      .getOrElse(defaultRProf.id, Seq.empty).size should be(0)
+    handler.getPendingSchedAllocate
+      .getOrElse(rprof.id, Seq.empty).size should be(1)
+    handler.getPendingSchedAllocate
+      .getOrElse(rprof2.id, Seq.empty).size should be(2)
+
+    val containerResourcerp2 = Resource.newInstance(10240, 5)
+
+    val container = createContainer("host1", 0,
+      priority = Priority.newInstance(rprof.id))
+    val container2 = createContainer("host2", 1,
+      resource = containerResourcerp2,
+      priority = Priority.newInstance(rprof2.id))
+    val container3 = createContainer("host3", 2,
+      resource = containerResourcerp2,
+      priority = Priority.newInstance(rprof2.id))
+    handler.handleAllocatedContainers(Array(container, container2, container3))
+
+    handler.getNumExecutorsRunning should be (3)
+    handler.allocatedContainerToHostMap.get(container.getId).get should be ("host1")
+    handler.allocatedContainerToHostMap.get(container2.getId).get should be ("host2")
+    handler.allocatedContainerToHostMap.get(container3.getId).get should be ("host3")
+
+    val hostTocontainer = handler.allocatedHostToContainersMapPerRPId(rprof.id)
+    hostTocontainer.get("host1").get should contain(container.getId)
+    val hostTocontainer2 = handler.allocatedHostToContainersMapPerRPId(rprof2.id)
+    hostTocontainer2.get("host2").get should contain(container2.getId)
+    hostTocontainer2.get("host3").get should contain(container3.getId)
+
+    handler.getPendingSchedAllocate
+      .getOrElse(container.getPriority.getPriority, Seq.empty).size should be(0)
+
+    ResourceProfile.reInitDefaultProfile(sparkConf)
+  }
+
+  // java.lang.ClassCastException: scala.collection.convert.Wrappers$MutableBufferWrapper
+  // cannot be cast to org.apache.hadoop.yarn.api.records.impl.pb.SchedulingRequestPBImpl
+  ignore("custom resource requested from yarn") {
+    assume(isYarnResourceTypesAvailable())
+    ResourceRequestTestHelper.initializeResourceTypes(List("gpu"))
+
+    val mockAmClient = mock(classOf[AMRMClientImpl[ContainerRequest]])
+    val (handler, _) = createAllocator(1, mockAmClient,
+      Map(s"${YARN_EXECUTOR_RESOURCE_TYPES_PREFIX}${GPU}.${AMOUNT}" -> "2G"))
+
+    handler.updateResourceRequests()
+    val defaultResource = handler.rpIdToYarnResource.get(defaultRPId)
+    val container = createContainer("host1", 0, resource = defaultResource)
+    handler.handleAllocatedContainers(Array(container))
+
+    // get amount of memory and vcores from resource, so effectively skipping their validation
+    val expectedResources = Resource.newInstance(defaultResource.getMemory(),
+      defaultResource.getVirtualCores)
+    setResourceRequests(Map("gpu" -> "2G"), expectedResources)
+    val captor = ArgumentCaptor.forClass(classOf[SchedulingRequestPBImpl])
+
+    verify(mockAmClient).addSchedulingRequests(
+      Seq(captor.capture(): SchedulingRequest).asJavaCollection)
+    val containerRequest: SchedulingRequestPBImpl = captor.getValue
+    assert(containerRequest.getResourceSizing.getResources === expectedResources)
+  }
+
+  test("custom spark resource mapped to yarn resource configs") {
+    assume(isYarnResourceTypesAvailable())
+    val yarnMadeupResource = "yarn.io/madeup"
+    val yarnResources = Seq(YARN_GPU_RESOURCE_CONFIG, YARN_FPGA_RESOURCE_CONFIG, yarnMadeupResource)
+    ResourceRequestTestHelper.initializeResourceTypes(yarnResources)
+    val mockAmClient = mock(classOf[AMRMClientImpl[ContainerRequest]])
+    val madeupConfigName = s"${YARN_EXECUTOR_RESOURCE_TYPES_PREFIX}${yarnMadeupResource}.${AMOUNT}"
+    val sparkResources =
+      Map(EXECUTOR_GPU_ID.amountConf -> "3",
+        EXECUTOR_FPGA_ID.amountConf -> "2",
+        madeupConfigName -> "5")
+    val (handler, _) = createAllocator(1, mockAmClient, sparkResources)
+
+    handler.updateResourceRequests()
+    val defaultResource = handler.rpIdToYarnResource.get(defaultRPId)
+    val yarnRInfo = ResourceRequestTestHelper.getResources(defaultResource)
+    val allResourceInfo = yarnRInfo.map( rInfo => (rInfo.name -> rInfo.value) ).toMap
+    assert(allResourceInfo.get(YARN_GPU_RESOURCE_CONFIG).nonEmpty)
+    assert(allResourceInfo.get(YARN_GPU_RESOURCE_CONFIG).get === 3)
+    assert(allResourceInfo.get(YARN_FPGA_RESOURCE_CONFIG).nonEmpty)
+    assert(allResourceInfo.get(YARN_FPGA_RESOURCE_CONFIG).get === 2)
+    assert(allResourceInfo.get(yarnMadeupResource).nonEmpty)
+    assert(allResourceInfo.get(yarnMadeupResource).get === 5)
+  }
+
+  test("container should not be created if requested number if met") {
+    // request a single container and receive it
+    val (handler, _) = createAllocator(1)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (1)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(1)
+
+    val container = createContainer("host1", 0)
+    handler.handleAllocatedContainers(Array(container))
+
+    handler.getNumExecutorsRunning should be (1)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(0)
+    handler.allocatedContainerToHostMap.get(container.getId).get should be ("host1")
+    val hostTocontainer = handler.allocatedHostToContainersMapPerRPId(defaultRPId)
+    hostTocontainer.get("host1").get should contain(container.getId)
+
+    val container2 = createContainer("host2", 1)
+    handler.handleAllocatedContainers(Array(container2))
+    handler.getNumExecutorsRunning should be (1)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(0)
+  }
+
+  test("some containers allocated") {
+    // request a few containers and receive some of them
+    val (handler, _) = createAllocator(4)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (4)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(4)
+
+    val container1 = createContainer("host1", 0)
+    val container2 = createContainer("host1", 1)
+    val container3 = createContainer("host2", 2)
+    handler.handleAllocatedContainers(Array(container1, container2, container3))
+
+    handler.getNumExecutorsRunning should be (3)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(1)
+    handler.allocatedContainerToHostMap.get(container1.getId).get should be ("host1")
+    handler.allocatedContainerToHostMap.get(container2.getId).get should be ("host1")
+    handler.allocatedContainerToHostMap.get(container3.getId).get should be ("host2")
+    val hostTocontainer = handler.allocatedHostToContainersMapPerRPId(defaultRPId)
+    hostTocontainer.get("host1").get should contain(container1.getId)
+    hostTocontainer.get("host1").get should contain (container2.getId)
+    hostTocontainer.get("host2").get should contain (container3.getId)
+  }
+
+  test("receive more containers than requested") {
+    val (handler, _) = createAllocator(2)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (2)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(2)
+
+    val container1 = createContainer("host1", 0)
+    val container2 = createContainer("host2", 1)
+    val container3 = createContainer("host4", 2)
+    handler.handleAllocatedContainers(Array(container1, container2, container3))
+
+    handler.getNumExecutorsRunning should be (2)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(0)
+    handler.allocatedContainerToHostMap.get(container1.getId).get should be ("host1")
+    handler.allocatedContainerToHostMap.get(container2.getId).get should be ("host2")
+    handler.allocatedContainerToHostMap.contains(container3.getId) should be (false)
+    val hostTocontainer = handler.allocatedHostToContainersMapPerRPId(defaultRPId)
+    hostTocontainer.get("host1").get should contain(container1.getId)
+    hostTocontainer.get("host2").get should contain (container2.getId)
+    hostTocontainer.contains("host4") should be (false)
+  }
+
+  test("decrease total requested executors") {
+    val (handler, _) = createAllocator(4)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (4)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(4)
+
+    val resourceProfileToTotalExecs = mutable.HashMap(defaultRP -> 3)
+    val numLocalityAwareTasksPerResourceProfileId = mutable.HashMap(defaultRPId -> 0)
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map.empty, Set.empty)
+    handler.updateResourceRequests()
+    handler.getNumContainersPendingAllocate should be (3)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(3)
+
+    val container = createContainer("host1", 0)
+    handler.handleAllocatedContainers(Array(container))
+
+    handler.getNumExecutorsRunning should be (1)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(3)
+    handler.allocatedContainerToHostMap.get(container.getId).get should be ("host1")
+    val hostTocontainer = handler.allocatedHostToContainersMapPerRPId(defaultRPId)
+    hostTocontainer.get("host1").get should contain(container.getId)
+
+    resourceProfileToTotalExecs(defaultRP) = 2
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map.empty, Set.empty)
+    handler.updateResourceRequests()
+    handler.getNumContainersPendingAllocate should be (1)
+    handler.getPendingSchedAllocate
+      .getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty).size should be(1)
+  }
+
+  test("decrease total requested executors to less than currently running") {
+    val (handler, _) = createAllocator(4)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (4)
+
+    val resourceProfileToTotalExecs = mutable.HashMap(defaultRP -> 3)
+    val numLocalityAwareTasksPerResourceProfileId = mutable.HashMap(defaultRPId -> 0)
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map.empty, Set.empty)
+    handler.updateResourceRequests()
+    handler.getNumContainersPendingAllocate should be (3)
+
+    val container1 = createContainer("host1", 0)
+    val container2 = createContainer("host2", 1)
+    handler.handleAllocatedContainers(Array(container1, container2))
+
+    handler.getNumExecutorsRunning should be (2)
+
+    resourceProfileToTotalExecs(defaultRP) = 1
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map.empty, Set.empty)
+    handler.updateResourceRequests()
+    handler.getNumContainersPendingAllocate should be (0)
+    handler.getNumExecutorsRunning should be (2)
+  }
+
+  test("kill executors") {
+    val (handler, _) = createAllocator(4)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (4)
+
+    val container1 = createContainer("host1", 0)
+    val container2 = createContainer("host2", 1)
+    handler.handleAllocatedContainers(Array(container1, container2))
+
+    val resourceProfileToTotalExecs = mutable.HashMap(defaultRP -> 1)
+    val numLocalityAwareTasksPerResourceProfileId = mutable.HashMap(defaultRPId -> 0)
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map.empty, Set.empty)
+    handler.executorIdToContainer.keys.foreach { id => handler.killExecutor(id ) }
+
+    val statuses = Seq(container1, container2).map { c =>
+      ContainerStatus.newInstance(c.getId(), ContainerState.COMPLETE, "Finished", 0)
+    }
+    handler.updateResourceRequests()
+    handler.processCompletedContainers(statuses)
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (1)
+  }
+
+  test("kill same executor multiple times") {
+    val (handler, _) = createAllocator(2)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (2)
+
+    val container1 = createContainer("host1", 0)
+    val container2 = createContainer("host2", 1)
+    handler.handleAllocatedContainers(Array(container1, container2))
+    handler.getNumExecutorsRunning should be (2)
+    handler.getNumContainersPendingAllocate should be (0)
+
+    val executorToKill = handler.executorIdToContainer.keys.head
+    handler.killExecutor(executorToKill)
+    handler.getNumExecutorsRunning should be (1)
+    handler.killExecutor(executorToKill)
+    handler.killExecutor(executorToKill)
+    handler.killExecutor(executorToKill)
+    handler.getNumExecutorsRunning should be (1)
+    val resourceProfileToTotalExecs = mutable.HashMap(defaultRP -> 2)
+    val numLocalityAwareTasksPerResourceProfileId = mutable.HashMap(defaultRPId -> 0)
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map.empty, Set.empty)
+    handler.updateResourceRequests()
+    handler.getNumContainersPendingAllocate should be (1)
+  }
+
+  // Ignore this since in SchedulingRequest, we need to use AllocationRequestId
+  // but in UT, we can't construct ContainerPBImpl.
+  test("process same completed container multiple times") {
+    val (handler, _) = createAllocator(2)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (2)
+
+    val container1 = createContainer("host1", 0)
+    val container2 = createContainer("host2", 1)
+    handler.handleAllocatedContainers(Array(container1, container2))
+    handler.getNumExecutorsRunning should be (2)
+    handler.getNumContainersPendingAllocate should be (0)
+
+    val statuses = Seq(container1, container1, container2).map { c =>
+      ContainerStatus.newInstance(c.getId(), ContainerState.COMPLETE, "Finished", 0)
+    }
+    handler.processCompletedContainers(statuses)
+    handler.getNumExecutorsRunning should be (0)
+
+  }
+
+  // Ignore this since in SchedulingRequest, we need to use AllocationRequestId
+  // but in UT, we can't construct ContainerPBImpl.
+  test("lost executor removed from backend") {
+    val (handler, _) = createAllocator(4)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (4)
+
+    val container1 = createContainer("host1", 0)
+    val container2 = createContainer("host2", 1)
+    handler.handleAllocatedContainers(Array(container1, container2))
+
+    val resourceProfileToTotalExecs = mutable.HashMap(defaultRP -> 2)
+    val numLocalityAwareTasksPerResourceProfileId = mutable.HashMap(defaultRPId -> 0)
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map(), Set.empty)
+
+    val statuses = Seq(container1, container2).map { c =>
+      ContainerStatus.newInstance(c.getId(), ContainerState.COMPLETE, "Failed", -1)
+    }
+    handler.updateResourceRequests()
+    handler.processCompletedContainers(statuses)
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (2)
+    handler.getNumExecutorsFailed should be (2)
+    handler.getNumUnexpectedContainerRelease should be (2)
+  }
+
+  test("excluded nodes reflected in amClient requests") {
+    // Internally we track the set of excluded nodes, but yarn wants us to send *changes*
+    // to it. Note the YARN api uses the term blacklist for excluded nodes.
+    // This makes sure we are sending the right updates.
+    val mockAmClient = mock(classOf[AMRMClientImpl[ContainerRequest]])
+    val (handler, _) = createAllocator(4, mockAmClient)
+    val resourceProfileToTotalExecs = mutable.HashMap(defaultRP -> 1)
+    val numLocalityAwareTasksPerResourceProfileId = mutable.HashMap(defaultRPId -> 0)
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map(), Set("hostA"))
+    verify(mockAmClient).updateBlacklist(Seq("hostA").asJava, Seq[String]().asJava)
+
+    val excludedNodes = Set(
+      "hostA",
+      "hostB"
+    )
+
+    resourceProfileToTotalExecs(defaultRP) = 2
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map(), excludedNodes)
+    verify(mockAmClient).updateBlacklist(Seq("hostB").asJava, Seq[String]().asJava)
+    resourceProfileToTotalExecs(defaultRP) = 3
+    handler.requestTotalExecutorsWithPreferredLocalities(resourceProfileToTotalExecs.toMap,
+      numLocalityAwareTasksPerResourceProfileId.toMap, Map(), Set.empty)
+    verify(mockAmClient).updateBlacklist(Seq[String]().asJava, Seq("hostA", "hostB").asJava)
+  }
+
+  test("window based failure executor counting") {
+    sparkConf.set(EXECUTOR_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS, 100 * 1000L)
+    val (handler, _) = createAllocator(4)
+
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumContainersPendingAllocate should be (4)
+
+    val containers = Seq(
+      createContainer("host1", 0),
+      createContainer("host2", 1),
+      createContainer("host3", 2),
+      createContainer("host4", 3)
+    )
+    handler.handleAllocatedContainers(containers)
+
+    val failedStatuses = containers.map { c =>
+      ContainerStatus.newInstance(c.getId, ContainerState.COMPLETE, "Failed", -1)
+    }
+
+    handler.getNumExecutorsFailed should be (0)
+
+    clock.advance(100 * 1000L)
+    handler.processCompletedContainers(failedStatuses.slice(0, 1))
+    handler.getNumExecutorsFailed should be (1)
+
+    clock.advance(101 * 1000L)
+    handler.getNumExecutorsFailed should be (0)
+
+    handler.processCompletedContainers(failedStatuses.slice(1, 3))
+    handler.getNumExecutorsFailed should be (2)
+
+    clock.advance(50 * 1000L)
+    handler.processCompletedContainers(failedStatuses.slice(3, 4))
+    handler.getNumExecutorsFailed should be (3)
+
+    clock.advance(51 * 1000L)
+    handler.getNumExecutorsFailed should be (1)
+
+    clock.advance(50 * 1000L)
+    handler.getNumExecutorsFailed should be (0)
+  }
+
+  test("SPARK-26269: YarnAllocator should have same excludeOnFailure behaviour with YARN") {
+    val rmClientSpy = spy(rmClient)
+    val maxExecutors = 11
+
+    val (handler, _) = createAllocator(
+      maxExecutors,
+      rmClientSpy,
+      Map(
+        YARN_EXECUTOR_LAUNCH_EXCLUDE_ON_FAILURE_ENABLED.key -> "true",
+        MAX_FAILED_EXEC_PER_NODE.key -> "0"))
+    handler.updateResourceRequests()
+
+    val hosts = (0 until maxExecutors).map(i => s"host$i")
+    val ids = 0 to maxExecutors
+    val containers = createContainers(hosts, ids, ids)
+
+    val nonExcludedStatuses = Seq(
+      ContainerExitStatus.SUCCESS,
+      ContainerExitStatus.PREEMPTED,
+      ContainerExitStatus.KILLED_EXCEEDED_VMEM,
+      ContainerExitStatus.KILLED_EXCEEDED_PMEM,
+      ContainerExitStatus.KILLED_BY_RESOURCEMANAGER,
+      ContainerExitStatus.KILLED_BY_APPMASTER,
+      ContainerExitStatus.KILLED_AFTER_APP_COMPLETION,
+      ContainerExitStatus.ABORTED,
+      ContainerExitStatus.DISKS_FAILED)
+
+    val nonExcludedContainerStatuses = nonExcludedStatuses.zipWithIndex.map {
+      case (exitStatus, idx) => createContainerStatus(containers(idx).getId, exitStatus)
+    }
+
+    val EXCLUDED_EXIT_CODE = 1
+    val excludedStatuses = Seq(ContainerExitStatus.INVALID, EXCLUDED_EXIT_CODE)
+
+    val excludedContainerStatuses = excludedStatuses.zip(9 until maxExecutors).map {
+      case (exitStatus, idx) => createContainerStatus(containers(idx).getId, exitStatus)
+    }
+
+    handler.handleAllocatedContainers(containers.slice(0, 9))
+    handler.processCompletedContainers(nonExcludedContainerStatuses)
+    verify(rmClientSpy, never())
+      .updateBlacklist(hosts.slice(0, 9).asJava, Collections.emptyList())
+
+    handler.handleAllocatedContainers(containers.slice(9, 11))
+    handler.processCompletedContainers(excludedContainerStatuses)
+    verify(rmClientSpy)
+      .updateBlacklist(hosts.slice(9, 10).asJava, Collections.emptyList())
+    verify(rmClientSpy)
+      .updateBlacklist(hosts.slice(10, 11).asJava, Collections.emptyList())
+  }
+
+  test("SPDI-10313: Support configuration of node attribute") {
+    // request a single container and receive it
+    val (handler, _) = createAllocator(1,
+      additionalConfigs = Map(
+        NODE_ATTRIBUTE.key -> "and(python!=3:java=1.8)"))
+    handler.updateResourceRequests()
+    handler.getNumExecutorsRunning should be(0)
+    handler.getNumContainersPendingAllocate should be(1)
+
+    val requests =
+      handler.getPendingSchedAllocate.getOrElse(RM_REQUEST_PRIORITY.getPriority, Seq.empty)
+    requests.size should be(1)
+    requests.head.getPlacementConstraint.getConstraintExpr should be(and(targetNodeAttribute(NODE,
+      NodeAttributeOpCode.NE,
+      PlacementTargets.nodeAttribute("python", "3")),
+      targetNodeAttribute(NODE,
+        NodeAttributeOpCode.EQ,
+        PlacementTargets.nodeAttribute("java", "1.8"))))
+  }
+
+  test("SPARK-28577#YarnAllocator.resource.memory should include offHeapSize " +
+    "when offHeapEnabled is true.") {
+    val originalOffHeapEnabled = sparkConf.get(MEMORY_OFFHEAP_ENABLED)
+    val originalOffHeapSize = sparkConf.get(MEMORY_OFFHEAP_SIZE)
+    val executorMemory = sparkConf.get(EXECUTOR_MEMORY).toInt
+    val offHeapMemoryInMB = 1024L
+    val offHeapMemoryInByte = offHeapMemoryInMB * 1024 * 1024
+    try {
+      sparkConf.set(MEMORY_OFFHEAP_ENABLED, true)
+      sparkConf.set(MEMORY_OFFHEAP_SIZE, offHeapMemoryInByte)
+      val (handler, _) = createAllocator(maxExecutors = 1,
+        additionalConfigs = Map(EXECUTOR_MEMORY.key -> executorMemory.toString))
+      val defaultResource = handler.rpIdToYarnResource.get(defaultRPId)
+      val memory = defaultResource.getMemory
+      assert(memory ==
+        executorMemory + offHeapMemoryInMB + ResourceProfile.MEMORY_OVERHEAD_MIN_MIB)
+    } finally {
+      sparkConf.set(MEMORY_OFFHEAP_ENABLED, originalOffHeapEnabled)
+      sparkConf.set(MEMORY_OFFHEAP_SIZE, originalOffHeapSize)
+    }
+  }
+
+  test("SPDI-10313: Test PlacementConstraintParser") {
+    checkPlacementConstraintParser(
+      "python=3",
+      targetNodeAttribute(NODE, NodeAttributeOpCode.EQ,
+        PlacementTargets.nodeAttribute("python", "3"))
+    )
+    checkPlacementConstraintParser(
+      "python!=3",
+      targetNodeAttribute(NODE, NodeAttributeOpCode.NE,
+        PlacementTargets.nodeAttribute("python", "3"))
+    )
+    checkPlacementConstraintParser(
+      "and(python=3:java!=1.8)",
+      and(targetNodeAttribute(NODE, NodeAttributeOpCode.EQ,
+        PlacementTargets.nodeAttribute("python", "3")),
+        targetNodeAttribute(NODE, NodeAttributeOpCode.NE,
+          PlacementTargets.nodeAttribute("java", "1.8"))
+      )
+    )
+    checkPlacementConstraintParser(
+      "in,node,host=[host2]",
+      targetIn(NODE, PlacementTargets.nodeAttribute("host", Array("host2"): _*))
+    )
+    checkPlacementConstraintParser(
+      "in,node,host=[host1:host2]",
+      targetIn(NODE, PlacementTargets.nodeAttribute("host", Array("host1", "host2"): _*))
+    )
+    checkPlacementConstraintParser(
+      "notin,node,rack=[rack1:rack2]",
+     targetNotIn(NODE, PlacementTargets.nodeAttribute("rack", Array("rack1", "rack2"): _*))
+    )
+    checkPlacementConstraintParser(
+      "AND(IN,RACK,hbase=[hb]:NOTIN,NODE,zk=[zk])",
+      and(targetIn(RACK, PlacementTargets.nodeAttribute("hbase", "hb")),
+        targetNotIn(NODE, PlacementTargets.nodeAttribute("zk", "zk")))
+    )
+    checkPlacementConstraintParser(
+      "and(python!=3:java=1.8)",
+      and(targetNodeAttribute(NODE,
+        NodeAttributeOpCode.NE,
+        PlacementTargets.nodeAttribute("python", "3")),
+        targetNodeAttribute(NODE,
+          NodeAttributeOpCode.EQ,
+          PlacementTargets.nodeAttribute("java", "1.8")))
+    )
+  }
+
+  def checkPlacementConstraintParser(
+    expression: String,
+    placementConstraint: PlacementConstraint.AbstractConstraint): Unit = {
+    assert(PlacementConstraintParser.parseExpression(expression).toString ==
+      placementConstraint.toString)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support YARN Placement Constraint, In this pr:

- Add `LocalityPreferredSchedulingRequestContainerPlacementStrategy` for compute locality for SchedulingRequest
- Add `ContainerImpl` for UT, since the interface Container's common API can't support `setAllocationRequestId` and `getAllocationRequestId`
- Add `YarnSchedulingRequestAllocator ` as the implement of allocator when use Placement Constraint.

### Why are the changes needed?
Spark can allow users to configure the Placement Constraint so that users will have more control on where the executors will get placed. For example:

1. Spark job wants to be run on machines where Python version is x or Java version is y (Node Attributes)
2. Spark job needs / does not need executors to be placed on machine where Hbase RegionServer / Zookeeper / Or any other Service is running. (Affinity / Anti Affinity)
3. Spark job wants no more than 2 of it's executors on same node (Cardinality)
4. Spark Job A executors wants / does not want to be run on where Spark Job / Any Other Job B containers runs (Application_Tag NameSpace)


### Does this PR introduce _any_ user-facing change?
Use can set `spark.yarn.schedulingRequestEnabled` to use YARN placement constraint and set `spark.yarn.executor.nodeAttributes` to set constraint.

### How was this patch tested?
Added UT and manuel tested this in yarn cluser:

**set node attribute**
```
/usr/share/yarn-3/bin/yarn nodeattributes -attributestonodes -attributes attr1
Hostname Attribute-value  rm.yarn.io/attr1 :ip-xxxx              1

/usr/share/yarn-3/bin/yarn nodeattributes -attributestonodes -attributes attr2
Hostname Attribute-value  rm.yarn.io/attr2 :ip-xxx
spark command

export SPARK_CONF_DIR=/tmp/spark-conf-3.1.1
export SPARK_HOME=/tmp/spark-3.1.1
/tmp/spark-3.1.1/bin/spark-sql --queue infra \
--executor-memory 1g --executor-cores 1  \
--conf spark.yarn.schedulingRequestEnabled=true  \
--conf spark.executor.instances=1 \
--conf spark.dynamicAllocation.enabled=true \
--conf spark.dynamicAllocation.initialExecutors=1 \
--conf spark.dynamicAllocation.maxExecutors=2 \
--conf spark.dynamicAllocation.minExecutors=0    \
--conf spark.dynamicAllocation.executorIdleTimeout=10s \
--conf spark.yarn.executor.nodeAttribute='attr1=1'
```
Under dynamic allocation, can work as expect, all allocated container is under NM `ip-xxx`,
if we set node attribute as `attr1=2`, we can't allocate any executor container.

