### PR TITLE
[SPARK-35666][ML]  gemv skip array shape checking

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HingeBlockAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HingeBlockAggregator.scala
@@ -58,12 +58,6 @@ private[ml] class HingeBlockAggregator(
       s"got type ${bcCoefficients.value.getClass}.)")
   }
 
-  @transient private lazy val linear = if (fitIntercept) {
-    new DenseVector(coefficientsArray.take(numFeatures))
-  } else {
-    new DenseVector(coefficientsArray)
-  }
-
   // pre-computed margin of an empty vector.
   // with this variable as an offset, for a sparse vector, we only need to
   // deal with non-zero values in prediction.
@@ -91,14 +85,13 @@ private[ml] class HingeBlockAggregator(
     if (block.weightIter.forall(_ == 0)) return this
     val size = block.size
 
-    // vec/arr here represents margins
-    val vec = new DenseVector(Array.ofDim[Double](size))
-    val arr = vec.values
+    // arr here represents margins
+    val arr = Array.ofDim[Double](size)
     if (fitIntercept) java.util.Arrays.fill(arr, marginOffset)
-    BLAS.gemv(1.0, block.matrix, linear, 1.0, vec)
+    BLAS.gemv(1.0, block.matrix, coefficientsArray, 1.0, arr)
 
     // in-place convert margins to multiplier
-    // then, vec/arr represents multiplier
+    // then, arr represents multiplier
     var localLossSum = 0.0
     var localWeightSum = 0.0
     var multiplierSum = 0.0
@@ -128,24 +121,7 @@ private[ml] class HingeBlockAggregator(
     if (arr.forall(_ == 0)) return this
 
     // update the linear part of gradientSumArray
-    block.matrix match {
-      case dm: DenseMatrix =>
-        BLAS.nativeBLAS.dgemv("N", dm.numCols, dm.numRows, 1.0, dm.values, dm.numCols,
-          vec.values, 1, 1.0, gradientSumArray, 1)
-
-      case sm: SparseMatrix if fitIntercept =>
-        val linearGradSumVec = new DenseVector(Array.ofDim[Double](numFeatures))
-        BLAS.gemv(1.0, sm.transpose, vec, 0.0, linearGradSumVec)
-        BLAS.javaBLAS.daxpy(numFeatures, 1.0, linearGradSumVec.values, 1,
-          gradientSumArray, 1)
-
-      case sm: SparseMatrix if !fitIntercept =>
-        val gradSumVec = new DenseVector(gradientSumArray)
-        BLAS.gemv(1.0, sm.transpose, vec, 1.0, gradSumVec)
-
-      case m =>
-        throw new IllegalArgumentException(s"Unknown matrix type ${m.getClass}.")
-    }
+    BLAS.gemv(1.0, block.matrix.transpose, arr, 1.0, gradientSumArray)
 
     if (fitIntercept) {
       // above update of the linear part of gradientSumArray does NOT take the centering


### PR DESCRIPTION
### What changes were proposed in this pull request?
In existing impls, it is common case that the vector/matrix need to be sliced/copied just due to shape match.
which makes the logic complex and introduce extra costing of slicing & copying.


### Why are the changes needed?
1, avoid slicing and copying due to shape checking;
2, simpify the usages;


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existing testsuites