### PR TITLE
[WIP][SPARK-35677][Core][SQL] Support dynamic range of executor numbers for dynamic allocation

### DIFF
--- a/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
+++ b/core/src/main/java/org/apache/spark/SparkFirehoseListener.java
@@ -216,6 +216,11 @@ public class SparkFirehoseListener implements SparkListenerInterface {
   }
 
   @Override
+  public void onExecutorAllocatorRangeUpdate(SparkListenerExecutorAllocatorRangeUpdate event) {
+    onEvent(event);
+  }
+
+  @Override
   public void onOtherEvent(SparkListenerEvent event) {
     onEvent(event);
   }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -582,6 +582,7 @@ package object config {
     ConfigBuilder("spark.dynamicAllocation.minExecutors")
       .version("1.2.0")
       .intConf
+      .checkValue(_ >= 0, "Lowest executor number must >= 0")
       .createWithDefault(0)
 
   private[spark] val DYN_ALLOCATION_INITIAL_EXECUTORS =
@@ -593,12 +594,14 @@ package object config {
     ConfigBuilder("spark.dynamicAllocation.maxExecutors")
       .version("1.2.0")
       .intConf
+      .checkValue(_ > 0, "Lowest executor number must > 0 ")
       .createWithDefault(Int.MaxValue)
 
   private[spark] val DYN_ALLOCATION_EXECUTOR_ALLOCATION_RATIO =
     ConfigBuilder("spark.dynamicAllocation.executorAllocationRatio")
       .version("2.4.0")
       .doubleConf
+      .checkValue(r => r > 0 && r <= 1.0, "The ratio must be > 0 and <= 1.0")
       .createWithDefault(1.0)
 
   private[spark] val DYN_ALLOCATION_CACHED_EXECUTOR_IDLE_TIMEOUT =
@@ -631,7 +634,9 @@ package object config {
   private[spark] val DYN_ALLOCATION_SCHEDULER_BACKLOG_TIMEOUT =
     ConfigBuilder("spark.dynamicAllocation.schedulerBacklogTimeout")
       .version("1.2.0")
-      .timeConf(TimeUnit.SECONDS).createWithDefault(1)
+      .timeConf(TimeUnit.SECONDS)
+      .checkValue(_ > 0, "Timeout must be > 0!")
+      .createWithDefault(1)
 
   private[spark] val DYN_ALLOCATION_SUSTAINED_SCHEDULER_BACKLOG_TIMEOUT =
     ConfigBuilder("spark.dynamicAllocation.sustainedSchedulerBacklogTimeout")

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -286,6 +286,11 @@ case class SparkListenerLogStart(sparkVersion: String) extends SparkListenerEven
 case class SparkListenerResourceProfileAdded(resourceProfile: ResourceProfile)
   extends SparkListenerEvent
 
+@DeveloperApi
+@Since("3.2.0")
+case class SparkListenerExecutorAllocatorRangeUpdate(
+    lower: Option[Int] = None, upper: Option[Int] = None) extends SparkListenerEvent
+
 /**
  * Interface for listening to events from the Spark scheduler. Most applications should probably
  * extend SparkListener or SparkFirehoseListener directly, rather than implementing this class.
@@ -483,6 +488,8 @@ private[spark] trait SparkListenerInterface {
    * Called when a Resource Profile is added to the manager.
    */
   def onResourceProfileAdded(event: SparkListenerResourceProfileAdded): Unit
+
+  def onExecutorAllocatorRangeUpdate(event: SparkListenerExecutorAllocatorRangeUpdate): Unit
 }
 
 
@@ -576,4 +583,7 @@ abstract class SparkListener extends SparkListenerInterface {
   override def onOtherEvent(event: SparkListenerEvent): Unit = { }
 
   override def onResourceProfileAdded(event: SparkListenerResourceProfileAdded): Unit = { }
+
+  override def onExecutorAllocatorRangeUpdate(
+      event: SparkListenerExecutorAllocatorRangeUpdate): Unit = { }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
@@ -97,6 +97,8 @@ private[spark] trait SparkListenerBus
         listener.onUnschedulableTaskSetRemoved(unschedulableTaskSetRemoved)
       case resourceProfileAdded: SparkListenerResourceProfileAdded =>
         listener.onResourceProfileAdded(resourceProfileAdded)
+      case executorRange: SparkListenerExecutorAllocatorRangeUpdate =>
+        listener.onExecutorAllocatorRangeUpdate(executorRange)
       case _ => listener.onOtherEvent(event)
     }
   }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1693,7 +1693,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(numExecutorsTargetForDefaultProfileId(manager) === 1)
   }
 
-  test("update ") {
+  test("SPARK-35677: update range for dynamic allocation") {
     val manager = createManager(createConf(2, 5, 3), clock = clock)
     assert(getExecutorRange(manager) === (2, 5))
     onChangeExecutorRange() // unchanged

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -90,12 +90,12 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
 
   test("verify min/max executors") {
     // Min < 0
-    intercept[SparkException] {
+    intercept[IllegalArgumentException] {
       createManager(createConf().set(config.DYN_ALLOCATION_MIN_EXECUTORS, -1))
     }
 
     // Max < 0
-    intercept[SparkException] {
+    intercept[IllegalArgumentException] {
       createManager(createConf().set(config.DYN_ALLOCATION_MAX_EXECUTORS, -1))
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?

Currently, Spark allows users to set scalability within a Spark application using dynamic allocation. `spark.dynamicAllocation.minExecutors` & `spark.dynamicAllocation.maxExecutors` are used for scaling up and down. Within an application，Spark tactfully use them to request executors from cluster manager according to the real-time workload. Once set, the range is fixed through the whole application lifecycle. This is not very convenient for long-running application when the range should be changeable for some cases, such as:
1. the cluster manager itself or the queue will scale up and down, which looks very likely to happen in modern cloud platforms
2. the application is long-running, but the timeliness, priority, e.t.c are not only determined by the workload of the application, but also by the traffic across the cluster manager or just different moments
3. e.t.c.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

make the dynamic allocation for long term Spark applications

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Configs below are changeable:

spark.dynamicAllocation.maxExecutors 
spark.dynamicAllocation.minExecutors 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new tests