### PR TITLE
[SPARK-35685][SQL] Prompt recreating the view when there is an incompatible schema issue

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1705,12 +1705,13 @@ class Analyzer(override val catalogManager: CatalogManager)
           assert(ordinal >= 0 && ordinal < attrCandidates.length)
           attrCandidates(ordinal)
 
-        case GetViewColumnByNameAndOrdinal(viewName, colName, ordinal, expectedNumCandidates) =>
+        case GetViewColumnByNameAndOrdinal(
+            viewName, colName, ordinal, expectedNumCandidates, viewDDL) =>
           val attrCandidates = getAttrCandidates()
           val matched = attrCandidates.filter(a => resolver(a.name, colName))
           if (matched.length != expectedNumCandidates) {
             throw QueryCompilationErrors.incompatibleViewSchemaChange(
-              viewName, colName, expectedNumCandidates, matched)
+              viewName, colName, expectedNumCandidates, matched, viewDDL)
           }
           matched(ordinal)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -605,7 +605,8 @@ case class GetViewColumnByNameAndOrdinal(
     viewName: String,
     colName: String,
     ordinal: Int,
-    expectedNumCandidates: Int)
+    expectedNumCandidates: Int,
+    viewDDL: String)
   extends LeafExpression with Unevaluable with NonSQLExpression {
   override def dataType: DataType = throw new UnresolvedException("dataType")
   override def nullable: Boolean = throw new UnresolvedException("nullable")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -613,6 +613,7 @@ case class GetViewColumnByNameAndOrdinal(
   override def dataType: DataType = throw new UnresolvedException("dataType")
   override def nullable: Boolean = throw new UnresolvedException("nullable")
   override lazy val resolved = false
+  override def stringArgs: Iterator[Any] = super.stringArgs.toSeq.dropRight(1).toIterator
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -606,7 +606,9 @@ case class GetViewColumnByNameAndOrdinal(
     colName: String,
     ordinal: Int,
     expectedNumCandidates: Int,
-    viewDDL: String)
+    // viewDDL is used to help user fix incompatible schema issue for permanent views
+    // it will be None for temp views.
+    viewDDL: Option[String])
   extends LeafExpression with Unevaluable with NonSQLExpression {
   override def dataType: DataType = throw new UnresolvedException("dataType")
   override def nullable: Boolean = throw new UnresolvedException("nullable")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -846,6 +846,12 @@ class SessionCatalog(
     case None => fromCatalogTable(viewInfo.tableMeta, isTempView = true)
   }
 
+  private def buildViewDDL(metadata: CatalogTable): String = {
+    val viewName = metadata.identifier.toString
+    val viewText = metadata.viewText.get
+    s"ALTER VIEW $viewName AS $viewText"
+  }
+
   private def fromCatalogTable(metadata: CatalogTable, isTempView: Boolean): View = {
     val viewText = metadata.viewText.getOrElse {
       throw new IllegalStateException("Invalid view without text.")
@@ -880,17 +886,15 @@ class SessionCatalog(
     }
     val nameToCounts = viewColumnNames.groupBy(normalizeColName).mapValues(_.length)
     val nameToCurrentOrdinal = scala.collection.mutable.HashMap.empty[String, Int]
+    val viewDDL = buildViewDDL(metadata)
 
     val projectList = viewColumnNames.zip(metadata.schema).map { case (name, field) =>
       val normalizedName = normalizeColName(name)
       val count = nameToCounts(normalizedName)
-      val col = if (count > 1) {
-        val ordinal = nameToCurrentOrdinal.getOrElse(normalizedName, 0)
-        nameToCurrentOrdinal(normalizedName) = ordinal + 1
-        GetViewColumnByNameAndOrdinal(metadata.identifier.toString, name, ordinal, count)
-      } else {
-        UnresolvedAttribute.quoted(name)
-      }
+      val ordinal = nameToCurrentOrdinal.getOrElse(normalizedName, 0)
+      nameToCurrentOrdinal(normalizedName) = ordinal + 1
+      val col = GetViewColumnByNameAndOrdinal(
+        metadata.identifier.toString, name, ordinal, count, viewDDL)
       Alias(UpCast(col, field.dataType), field.name)(explicitMetadata = Some(field.metadata))
     }
     View(desc = metadata, isTempView = isTempView, child = Project(projectList, parsedPlan))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1290,10 +1290,12 @@ private[spark] object QueryCompilationErrors {
       viewName: String,
       colName: String,
       expectedNum: Int,
-      actualCols: Seq[Attribute]): Throwable = {
+      actualCols: Seq[Attribute],
+      viewDDL: String): Throwable = {
     new AnalysisException(s"The SQL query of view $viewName has an incompatible schema change " +
       s"and column $colName cannot be resolved. Expected $expectedNum columns named $colName but " +
-      s"got ${actualCols.map(_.name).mkString("[", ",", "]")}")
+      s"got ${actualCols.map(_.name).mkString("[", ",", "]")}\nPlease try to recreate the view " +
+      s"to fix this by running: ${viewDDL}")
   }
 
   def numberOfPartitionsNotAllowedWithUnspecifiedDistributionError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1291,11 +1291,11 @@ private[spark] object QueryCompilationErrors {
       colName: String,
       expectedNum: Int,
       actualCols: Seq[Attribute],
-      viewDDL: String): Throwable = {
+      viewDDL: Option[String]): Throwable = {
     new AnalysisException(s"The SQL query of view $viewName has an incompatible schema change " +
       s"and column $colName cannot be resolved. Expected $expectedNum columns named $colName but " +
-      s"got ${actualCols.map(_.name).mkString("[", ",", "]")}\nPlease try to recreate the view " +
-      s"to fix this by running: ${viewDDL}")
+      s"got ${actualCols.map(_.name).mkString("[", ",", "]")}" +
+      viewDDL.map(s => s"\nPlease try to re-create the view by running: $s").getOrElse(""))
   }
 
   def numberOfPartitionsNotAllowedWithUnspecifiedDistributionError(): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -635,7 +635,9 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
   private def getViewPlan(metadata: CatalogTable): LogicalPlan = {
     import org.apache.spark.sql.catalyst.dsl.expressions._
     val projectList = metadata.schema.map { field =>
-      UpCast(field.name.attr, field.dataType).as(field.name)
+      UpCast(
+        GetViewColumnByNameAndOrdinal(metadata.identifier.toString, field.name, 0, 1, None),
+        field.dataType).as(field.name)
     }
     Project(projectList, CatalystSqlParser.parsePlan(metadata.viewText.get))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.internal.SQLConf._
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 class SimpleSQLViewSuite extends SQLViewSuite with SharedSparkSession
 
@@ -907,6 +908,29 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
           sql("SELECT * FROM v1").collect()
         }.getMessage
         assert(e.contains("divide by zero"))
+      }
+    }
+  }
+
+  test("SPARK-35685: Prompt recreating view message for schema mismatch") {
+    withTable("t") {
+      sql("CREATE TABLE t USING json AS SELECT 1 AS col_i")
+      val catalog = spark.sessionState.catalog
+      withView("test_view") {
+        sql("CREATE VIEW test_view AS SELECT * FROM t")
+        val meta = catalog.getTableRawMetadata(TableIdentifier("test_view", Some("default")))
+        // simulate a view meta with incompatible schema change
+        val newProp = meta.properties
+          .mapValues(_.replace("col_i", "col_j"))
+        val newSchema = StructType(Seq(StructField("col_j", IntegerType)))
+        catalog.alterTable(meta.copy(properties = newProp, schema = newSchema))
+        val e = intercept[AnalysisException] {
+          sql(s"SELECT * FROM test_view")
+        }
+        assert(e.getMessage.contains("re-create the view by running: CREATE OR REPLACE"))
+        val ddl = e.getMessage.split(": ").last
+        sql(ddl)
+        checkAnswer(sql("select * FROM test_view"), Row(1))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -921,7 +921,7 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
         val meta = catalog.getTableRawMetadata(TableIdentifier("test_view", Some("default")))
         // simulate a view meta with incompatible schema change
         val newProp = meta.properties
-          .mapValues(_.replace("col_i", "col_j"))
+          .mapValues(_.replace("col_i", "col_j")).toMap
         val newSchema = StructType(Seq(StructField("col_j", IntegerType)))
         catalog.alterTable(meta.copy(properties = newProp, schema = newSchema))
         val e = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -363,13 +363,8 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
 
             // One less duplicated column if caseSensitive=false.
             sql("CREATE OR REPLACE VIEW v1 AS SELECT 1 a, 2 b")
-            if (caseSensitive) {
-              val e = intercept[AnalysisException](spark.table(viewName2).collect())
-              assert(e.message.contains("cannot resolve 'COL'"))
-            } else {
-              val e = intercept[AnalysisException](spark.table(viewName2).collect())
-              assert(e.message.contains("incompatible schema change"))
-            }
+            val e = intercept[AnalysisException](spark.table(viewName2).collect())
+            assert(e.message.contains("incompatible schema change"))
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -375,20 +375,6 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
       }
     }
   }
-
-  test("SPARK-35685: Prompt recreating view message") {
-    withTable("t") {
-      sql("CREATE TABLE t(i INT, j INT) USING json")
-      val viewName = createView("v", "SELECT * FROM t")
-      withView(viewName) {
-        sql("SELECT * FROM v").show()
-        sql("DROP TABLE t")
-        sql("CREATE TABLE t(a INT, b INT) USING json")
-        sql("ALTER VIEW `v`  AS SELECT * FROM t")
-        sql("SELECT * FROM v").show()
-      }
-    }
-  }
 }
 
 class LocalTempViewTestSuite extends SQLViewTestSuite with SharedSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -375,6 +375,20 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
       }
     }
   }
+
+  test("SPARK-35685: Prompt recreating view message") {
+    withTable("t") {
+      sql("CREATE TABLE t(i INT, j INT) USING json")
+      val viewName = createView("v", "SELECT * FROM t")
+      withView(viewName) {
+        sql("SELECT * FROM v").show()
+        sql("DROP TABLE t")
+        sql("CREATE TABLE t(a INT, b INT) USING json")
+        sql("ALTER VIEW `v`  AS SELECT * FROM t")
+        sql("SELECT * FROM v").show()
+      }
+    }
+  }
 }
 
 class LocalTempViewTestSuite extends SQLViewTestSuite with SharedSparkSession {


### PR DESCRIPTION
### What changes were proposed in this pull request?
If the user creates a view in 2.4 and reads it in 3.1/3.2, there will be an incompatible schema issue.
So this PR adds a view ddl in the error message to prompt the user recreating the view to fix the
incompatible issue.
For example:
```sql
-- create view in 2.4
CREATE TABLE IF NOT EXISTS t USING parquet AS SELECT '1' as a, '20210420' as b"
CREATE OR REPLACE VIEW v AS SELECT CAST(t.a AS INT), to_date(t.b, 'yyyyMMdd') FROM t
-- select view in master
SELECT * FROM v
```
Then we will get below error:
```
cannot resolve '`to_date(spark_catalog.default.t.b, 'yyyyMMdd')`' given input columns: [a, to_date(b, yyyyMMdd)];
```


### Why are the changes needed?
Improve the error message


### Does this PR introduce _any_ user-facing change?
Yes, the error message will change


### How was this patch tested?
newly added test case
