### PR TITLE
[SPARK-35591][PYTHON][DOCS] Rename "Koalas" to "pandas API on Spark" in the documents

### DIFF
--- a/python/docs/source/development/ps_contributing.rst
+++ b/python/docs/source/development/ps_contributing.rst
@@ -17,9 +17,9 @@ The largest amount of work consists simply of implementing the pandas API using 
 
 3. Improve the project's documentation.
 
-4. Write blog posts or tutorial articles evangelizing Koalas and help new users learn Koalas.
+4. Write blog posts or tutorial articles evangelizing pandas APIs on Spark and help new users learn pandas APIs on Spark.
 
-5. Give a talk about Koalas at your local meetup or a conference.
+5. Give a talk about pandas APIs on Spark at your local meetup or a conference.
 
 
 Step-by-step Guide For Code Contributions
@@ -48,7 +48,7 @@ Environment Setup
 Conda
 -----
 
-If you are using Conda, the Koalas installation and development environment are as follows.
+If you are using Conda, the pandas APIs on Spark installation and development environment are as follows.
 
 .. code-block:: bash
 
@@ -79,7 +79,7 @@ With Python 3.6+, pip can be used as below to install and set up the development
 Running Tests
 =============
 
-There is a script `./dev/pytest` which is exactly same as `pytest` but with some default settings to run Koalas tests easily.
+There is a script `./dev/pytest` which is exactly same as `pytest` but with some default settings to run the tests easily.
 
 To run all the tests, similar to our CI pipeline:
 
@@ -131,13 +131,13 @@ We follow `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ with one exceptio
 Doctest Conventions
 ===================
 
-When writing doctests, usually the doctests in pandas are converted into Koalas to make sure the same codes work in Koalas.
+When writing doctests, usually the doctests in pandas are converted into pandas APIs on Spark to make sure the same codes work in pandas APIs on Spark.
 In general, doctests should be grouped logically by separating a newline.
 
 For instance, the first block is for the statements for preparation, the second block is for using the function with a specific argument,
 and third block is for another argument. As a example, please refer `DataFrame.rsub <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.rsub.html#pandas.DataFrame.rsub>`_ in pandas.
 
-These blocks should be consistently separated in Koalas, and more doctests should be added if the coverage of the doctests or the number of examples to show is not enough even though they are different from pandas'.
+These blocks should be consistently separated in pandas-on-Spark doctests, and more doctests should be added if the coverage of the doctests or the number of examples to show is not enough even though they are different from pandas'.
 
 Release Guide
 =============
@@ -176,7 +176,7 @@ Only project maintainers can do the following to publish a release.
       # for release
       python3 -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/koalas-$package_version-py3-none-any.whl dist/koalas-$package_version.tar.gz
 
-5. Verify the uploaded package can be installed and executed. One unofficial tip is to run the doctests of Koalas within a Python interpreter after installing it.
+5. Verify the uploaded package can be installed and executed. One unofficial tip is to run the doctests of pandas APIs on Spark within a Python interpreter after installing it.
 
   .. code-block:: python
 

--- a/python/docs/source/development/ps_design.rst
+++ b/python/docs/source/development/ps_design.rst
@@ -4,40 +4,40 @@ Design Principles
 
 .. currentmodule:: pyspark.pandas
 
-This section outlines design principles guiding the Koalas project.
+This section outlines design principles guiding the pandas APIs on Spark.
 
 Be Pythonic
 -----------
 
-Koalas targets Python data scientists. We want to stick to the convention that users are already familiar with as much as possible. Here are some examples:
+Pandas APIs on Spark target Python data scientists. We want to stick to the convention that users are already familiar with as much as possible. Here are some examples:
 
-- Function names and parameters use snake_case, rather than CamelCase. This is different from PySpark's design. For example, Koalas has `to_pandas()`, whereas PySpark has `toPandas()` for converting a DataFrame into a pandas DataFrame. In limited cases, to maintain compatibility with Spark, we also provide Spark's variant as an alias.
+- Function names and parameters use snake_case, rather than CamelCase. This is different from PySpark's design. For example, pandas APIs on Spark have `to_pandas()`, whereas PySpark has `toPandas()` for converting a DataFrame into a pandas DataFrame. In limited cases, to maintain compatibility with Spark, we also provide Spark's variant as an alias.
 
-- Koalas respects to the largest extent the conventions of the Python numerical ecosystem, and allows the use of NumPy types, etc. that can be supported by Spark.
+- Pandas APIs on Spark respect to the largest extent the conventions of the Python numerical ecosystem, and allows the use of NumPy types, etc. that can be supported by Spark.
 
-- Koalas docs' style and infrastructure simply follow rest of the PyData projects'.
+- pandas-on-Spark docs' style and infrastructure simply follow rest of the PyData projects'.
 
 Unify small data (pandas) API and big data (Spark) API, but pandas first
 ------------------------------------------------------------------------
 
-The Koalas DataFrame is meant to provide the best of pandas and Spark under a single API, with easy and clear conversions between each API when necessary. When Spark and pandas have similar APIs with subtle differences, the principle is to honor the contract of the pandas API first.
+The pandas-on-Spark DataFrame is meant to provide the best of pandas and Spark under a single API, with easy and clear conversions between each API when necessary. When Spark and pandas have similar APIs with subtle differences, the principle is to honor the contract of the pandas API first.
 
 There are different classes of functions:
 
  1. Functions that are found in both Spark and pandas under the same name (`count`, `dtypes`, `head`). The return value is the same as the return type in pandas (and not Spark's).
     
- 2. Functions that are found in Spark but that have a clear equivalent in pandas, e.g. `alias` and `rename`. These functions will be implemented as the alias of the pandas function, but should be marked that they are aliases of the same functions. They are provided so that existing users of PySpark can get the benefits of Koalas without having to adapt their code.
+ 2. Functions that are found in Spark but that have a clear equivalent in pandas, e.g. `alias` and `rename`. These functions will be implemented as the alias of the pandas function, but should be marked that they are aliases of the same functions. They are provided so that existing users of PySpark can get the benefits of pandas APIs on Spark without having to adapt their code.
  
- 3. Functions that are only found in pandas. When these functions are appropriate for distributed datasets, they should become available in Koalas.
+ 3. Functions that are only found in pandas. When these functions are appropriate for distributed datasets, they should become available in pandas APIs on Spark.
  
- 4. Functions that are only found in Spark that are essential to controlling the distributed nature of the computations, e.g. `cache`. These functions should be available in Koalas.
+ 4. Functions that are only found in Spark that are essential to controlling the distributed nature of the computations, e.g. `cache`. These functions should be available in pandas APIs on Spark.
 
-We are still debating whether data transformation functions only available in Spark should be added to Koalas, e.g. `select`. We would love to hear your feedback on that.
+We are still debating whether data transformation functions only available in Spark should be added to pandas APIs on Spark, e.g. `select`. We would love to hear your feedback on that.
 
-Return Koalas data structure for big data, and pandas data structure for small data
------------------------------------------------------------------------------------
+Return pandas-on-Spark data structure for big data, and pandas data structure for small data
+--------------------------------------------------------------------------------------------
 
-Often developers face the question whether a particular function should return a Koalas DataFrame/Series, or a pandas DataFrame/Series. The principle is: if the returned object can be large, use a Koalas DataFrame/Series. If the data is bound to be small, use a pandas DataFrame/Series. For example, `DataFrame.dtypes` return a pandas Series, because the number of columns in a DataFrame is bounded and small, whereas `DataFrame.head()` or `Series.unique()` returns a Koalas DataFrame/Series, because the resulting object can be large.
+Often developers face the question whether a particular function should return a pandas-on-Spark DataFrame/Series, or a pandas DataFrame/Series. The principle is: if the returned object can be large, use a pandas-on-Spark DataFrame/Series. If the data is bound to be small, use a pandas DataFrame/Series. For example, `DataFrame.dtypes` return a pandas Series, because the number of columns in a DataFrame is bounded and small, whereas `DataFrame.head()` or `Series.unique()` returns a pandas-on-Spark DataFrame/Series, because the resulting object can be large.
 
 Provide discoverable APIs for common data science tasks
 -------------------------------------------------------
@@ -46,19 +46,19 @@ At the risk of overgeneralization, there are two API design approaches: the firs
 
 One example is value count (count by some key column), one of the most common operations in data science. pandas `DataFrame.value_count` returns the result in sorted order, which in 90% of the cases is what users prefer when exploring data, whereas Spark's does not sort, which is more desirable when building data pipelines, as users can accomplish the pandas behavior by adding an explicit `orderBy`.
 
-Similar to pandas, Koalas should also lean more towards the former, providing discoverable APIs for common data science tasks. In most cases, this principle is well taken care of by simply implementing pandas' APIs. However, there will be circumstances in which pandas' APIs don't address a specific need, e.g. plotting for big data.
+Similar to pandas, pandas APIs on Spark should also lean more towards the former, providing discoverable APIs for common data science tasks. In most cases, this principle is well taken care of by simply implementing pandas' APIs. However, there will be circumstances in which pandas' APIs don't address a specific need, e.g. plotting for big data.
 
 Provide well documented APIs, with examples
 -------------------------------------------
 
 All functions and parameters should be documented. Most functions should be documented with examples, because those are the easiest to understand than a blob of text explaining what the function does.
 
-A recommended way to add documentation is to start with the docstring of the corresponding function in PySpark or pandas, and adapt it for Koalas. If you are adding a new function, also add it to the API reference doc index page in `docs/source/reference` directory. The examples in docstring also improve our test coverage.
+A recommended way to add documentation is to start with the docstring of the corresponding function in PySpark or pandas, and adapt it for pandas APIs on Spark. If you are adding a new function, also add it to the API reference doc index page in `docs/source/reference` directory. The examples in docstring also improve our test coverage.
 
 Guardrails to prevent users from shooting themselves in the foot
 ----------------------------------------------------------------
 
-Certain operations in pandas are prohibitively expensive as data scales, and we don't want to give users the illusion that they can rely on such operations in Koalas. That is to say, methods implemented in Koalas should be safe to perform by default on large datasets. As a result, the following capabilities are not implemented in Koalas:
+Certain operations in pandas are prohibitively expensive as data scales, and we don't want to give users the illusion that they can rely on such operations in pandas APIs on Spark. That is to say, methods implemented in pandas APIs on Spark should be safe to perform by default on large datasets. As a result, the following capabilities are not implemented in pandas APIs on Spark:
 
 1. Capabilities that are fundamentally not parallelizable: e.g. imperatively looping over each element
 2. Capabilities that require materializing the entire working set in a single node's memory. This is why we do not implement `pandas.DataFrame.to_xarray <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_xarray.html>`_. Another example is the `_repr_html_` call caps the total number of records shown to a maximum of 1000, to prevent users from blowing up their driver node simply by typing the name of the DataFrame in a notebook.
@@ -66,20 +66,20 @@ Certain operations in pandas are prohibitively expensive as data scales, and we 
 A few exceptions, however, exist. One common pattern with "big data science" is that while the initial dataset is large, the working set becomes smaller as the analysis goes deeper. For example, data scientists often perform aggregation on datasets and want to then convert the aggregated dataset to some local data structure. To help data scientists, we offer the following:
 
 - :func:`DataFrame.to_pandas`: returns a pandas DataFrame, koalas only
-- :func:`DataFrame.to_numpy`: returns a numpy array, works with both pandas and Koalas
+- :func:`DataFrame.to_numpy`: returns a numpy array, works with both pandas and pandas APIs on Spark
 
 Note that it is clear from the names that these functions return some local data structure that would require materializing data in a single node's memory. For these functions, we also explicitly document them with a warning note that the resulting data structure must be small.
 
 Be a lean API layer and move fast
 ---------------------------------
 
-Koalas is designed as an API overlay layer on top of Spark. The project should be lightweight, and most functions should be implemented as wrappers
-around Spark or pandas - the Koalas library is designed to be used only in the Spark's driver side in general.
-Koalas does not accept heavyweight implementations, e.g. execution engine changes.
+Pandas APIs on Spark are designed as an API overlay layer on top of Spark. The project should be lightweight, and most functions should be implemented as wrappers
+around Spark or pandas - the pandas-on-Spark library is designed to be used only in the Spark's driver side in general.
+Pandas APIs on Spark do not accept heavyweight implementations, e.g. execution engine changes.
 
 This approach enables us to move fast. For the considerable future, we aim to be making monthly releases. If we find a critical bug, we will be making a new release as soon as the bug fix is available.
 
 High test coverage
 ------------------
 
-Koalas should be well tested. The project tracks its test coverage with over 90% across the entire codebase, and close to 100% for critical parts. Pull requests will not be accepted unless they have close to 100% statement coverage from the codecov report.
+Pandas APIs on Spark should be well tested. The project tracks its test coverage with over 90% across the entire codebase, and close to 100% for critical parts. Pull requests will not be accepted unless they have close to 100% statement coverage from the codecov report.

--- a/python/docs/source/getting_started/ps_install.rst
+++ b/python/docs/source/getting_started/ps_install.rst
@@ -2,9 +2,9 @@
 Installation
 ============
 
-Koalas requires PySpark so please make sure your PySpark is available.
+Pandas APIs on Spark require PySpark so please make sure your PySpark is available.
 
-To install Koalas, you can use:
+To install pandas APIs on Spark, you can use:
 
 - `Conda <https://anaconda.org/conda-forge/koalas>`__
 - `PyPI <https://pypi.org/project/koalas>`__
@@ -24,13 +24,13 @@ Python version support
 Officially Python 3.5 to 3.8.
 
 .. note::
-   Koalas support for Python 3.5 is deprecated and will be dropped in the future release.
-   At that point, existing Python 3.5 workflows that use Koalas will continue to work without
-   modification, but Python 3.5 users will no longer get access to the latest Koalas features
+   Pandas APIs on Spark support for Python 3.5 is deprecated and will be dropped in the future release.
+   At that point, existing Python 3.5 workflows that use pandas APIs on Spark will continue to work without
+   modification, but Python 3.5 users will no longer get access to the latest pandas-on-Spark features
    and bugfixes. We recommend that you upgrade to Python 3.6 or newer.
 
-Installing Koalas
------------------
+Installing pandas APIs on Spark
+-------------------------------
 
 Installing with Conda
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -47,12 +47,12 @@ To put your self inside this environment run::
 
     conda activate koalas-dev-env
 
-The final step required is to install Koalas. This can be done with the
+The final step required is to install pandas APIs on Spark. This can be done with the
 following command::
 
     conda install -c conda-forge koalas
 
-To install a specific Koalas version::
+To install a specific version of pandas APIs on Spark::
 
     conda install -c conda-forge koalas=1.3.0
 
@@ -60,7 +60,7 @@ To install a specific Koalas version::
 Installing from PyPI
 ~~~~~~~~~~~~~~~~~~~~
 
-Koalas can be installed via pip from
+Pandas APIs on Spark can be installed via pip from
 `PyPI <https://pypi.org/project/koalas>`__::
 
     pip install koalas

--- a/python/docs/source/reference/pyspark.pandas/extensions.rst
+++ b/python/docs/source/reference/pyspark.pandas/extensions.rst
@@ -8,9 +8,9 @@ Extensions
 Accessors
 ---------
 
-Accessors can be written and registered with Koalas Dataframes, Series, and
+Accessors can be written and registered with pandas-on-Spark Dataframes, Series, and
 Index objects. Accessors allow developers to extend the functionality of
-Koalas objects seamlessly by writing arbitrary classes and methods which are
+pandas-on-Spark objects seamlessly by writing arbitrary classes and methods which are
 then wrapped in one of the following decorators.
 
 .. autosummary::

--- a/python/docs/source/reference/pyspark.pandas/frame.rst
+++ b/python/docs/source/reference/pyspark.pandas/frame.rst
@@ -314,9 +314,9 @@ specific plotting methods of the form ``DataFrame.plot.<kind>``.
    DataFrame.hist
    DataFrame.kde
 
-Koalas-specific
----------------
-``DataFrame.pandas_on_spark`` provides Koalas-specific features that exists only in Koalas.
+Pandas-on-Spark specific
+------------------------
+``DataFrame.pandas_on_spark`` provides pandas-on-Spark specific features that exists only in pandas APIs on Spark.
 These can be accessed by ``DataFrame.pandas_on_spark.<function/property>``.
 
 .. autosummary::

--- a/python/docs/source/reference/pyspark.pandas/ml.rst
+++ b/python/docs/source/reference/pyspark.pandas/ml.rst
@@ -8,7 +8,7 @@ Machine Learning utilities
 MLflow
 ------
 
-Arbitrary MLflow models can be used with Koalas Dataframes,
+Arbitrary MLflow models can be used with pandas-on-Spark Dataframes,
 provided they implement the 'pyfunc' flavor. This is the case
 for most frameworks supported by MLflow (scikit-learn, pytorch,
 tensorflow, ...). See comprehensive examples in

--- a/python/docs/source/reference/pyspark.pandas/series.rst
+++ b/python/docs/source/reference/pyspark.pandas/series.rst
@@ -258,7 +258,7 @@ in Spark. These can be accessed by ``Series.spark.<function/property>``.
 Accessors
 ---------
 
-Koalas provides dtype-specific methods under various accessors.
+Pandas APIs on Spark provide dtype-specific methods under various accessors.
 These are separate namespaces within :class:`Series` that only apply
 to specific data types.
 
@@ -442,9 +442,9 @@ Serialization / IO / Conversion
    Series.to_excel
    Series.to_frame
 
-Koalas-specific
----------------
-``Series.pandas_on_spark`` provides Koalas-specific features that exists only in Koalas.
+Pandas-on-Spark specific
+------------------------
+``Series.pandas_on_spark`` provides pandas-on-Spark specific features that exists only in pandas APIs on Spark.
 These can be accessed by ``Series.pandas_on_spark.<function/property>``.
 
 .. autosummary::

--- a/python/docs/source/user_guide/pandas_on_spark/best_practices.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/best_practices.rst
@@ -5,15 +5,15 @@ Best Practices
 Leverage PySpark APIs
 ---------------------
 
-Koalas uses Spark under the hood; therefore, many features and performance optimization are available
-in Koalas as well. Leverage and combine those cutting-edge features with Koalas.
+Pandas APIs on Spark use Spark under the hood; therefore, many features and performance optimization are available
+in pandas APIs on Spark as well. Leverage and combine those cutting-edge features with pandas APIs on Spark.
 
-Existing Spark context and Spark sessions are used out of the box in Koalas. If you already have your own
-configured Spark context or sessions running, Koalas uses them.
+Existing Spark context and Spark sessions are used out of the box in pandas APIs on Spark. If you already have your own
+configured Spark context or sessions running, pandas APIs on Spark use them.
 
 If there is no Spark context or session running in your environment (e.g., ordinary Python interpreter),
 such configurations can be set to ``SparkContext`` and/or ``SparkSession``.
-Once Spark context and/or session is created, Koalas can use this context and/or session automatically.
+Once Spark context and/or session is created, pandas APIs on Spark can use this context and/or session automatically.
 For example, if you want to configure the executor memory in Spark, you can do as below:
 
 .. code-block:: python
@@ -21,7 +21,7 @@ For example, if you want to configure the executor memory in Spark, you can do a
    from pyspark import SparkConf, SparkContext
    conf = SparkConf()
    conf.set('spark.executor.memory', '2g')
-   # Koalas automatically uses this Spark context with the configurations set.
+   # Pandas APIs on Spark automatically use this Spark context with the configurations set.
    SparkContext(conf=conf)
 
    import pyspark.pandas as ks
@@ -33,15 +33,15 @@ it can be set into Spark session as below:
 .. code-block:: python
 
    from pyspark.sql import SparkSession
-   builder = SparkSession.builder.appName("Koalas")
+   builder = SparkSession.builder.appName("pandas-on-spark")
    builder = builder.config("spark.sql.execution.arrow.enabled", "true")
-   # Koalas automatically uses this Spark session with the configurations set.
+   # Pandas APIs on Spark automatically use this Spark session with the configurations set.
    builder.getOrCreate()
 
    import pyspark.pandas as ks
    ...
 
-All Spark features such as history server, web UI and deployment modes can be used as are with Koalas.
+All Spark features such as history server, web UI and deployment modes can be used as are with pandas APIs on Spark.
 If you are interested in performance tuning, please see also `Tuning Spark <https://spark.apache.org/docs/latest/tuning.html>`_.
 
 
@@ -49,7 +49,7 @@ Check execution plans
 ---------------------
 
 Expensive operations can be predicted by leveraging PySpark API `DataFrame.spark.explain()`
-before the actual computation since Koalas is based on lazy execution. For example, see below.
+before the actual computation since pandas APIs on Spark are based on lazy execution. For example, see below.
 
 .. code-block:: python
 
@@ -65,14 +65,14 @@ before the actual computation since Koalas is based on lazy execution. For examp
 Whenever you are not sure about such cases, you can check the actual execution plans and
 foresee the expensive cases.
 
-Even though Koalas tries its best to optimize and reduce such shuffle operations by leveraging Spark
+Even though pandas APIs on Spark try its best to optimize and reduce such shuffle operations by leveraging Spark
 optimizers, it is best to avoid shuffling in the application side whenever possible.
 
 
 Use checkpoint
 --------------
 
-After a bunch of operations on Koalas objects, the underlying Spark planner can slow down due to the huge and complex plan.
+After a bunch of operations on pandas APIs on Spark objects, the underlying Spark planner can slow down due to the huge and complex plan.
 If the Spark plan becomes huge or it takes the planning long time, ``DataFrame.spark.checkpoint()``
 or ``DataFrame.spark.local_checkpoint()`` would be helpful.
 
@@ -157,14 +157,14 @@ as it is less expensive because data can be distributed and computed for each gr
 Avoid reserved column names
 ---------------------------
 
-Columns with leading ``__`` and trailing ``__`` are reserved in Koalas. To handle internal behaviors for, such as, index,
-Koalas uses some internal columns. Therefore, it is discouraged to use such column names and not guaranteed to work.
+Columns with leading ``__`` and trailing ``__`` are reserved in pandas APIs on Spark. To handle internal behaviors for, such as, index,
+pandas APIs on Spark use some internal columns. Therefore, it is discouraged to use such column names and not guaranteed to work.
 
 
 Do not use duplicated column names
 ----------------------------------
 
-It is disallowed to use duplicated column names because Spark SQL does not allow this in general. Koalas inherits
+It is disallowed to use duplicated column names because Spark SQL does not allow this in general. Pandas APIs on Spark inherit
 this behavior. For instance, see below:
 
 .. code-block:: python
@@ -175,7 +175,7 @@ this behavior. For instance, see below:
    ...
    Reference 'a' is ambiguous, could be: a, a.;
 
-Additionally, it is strongly discouraged to use case sensitive column names. Koalas disallows it by default.
+Additionally, it is strongly discouraged to use case sensitive column names. Pandas APIs on Spark disallow it by default.
 
 .. code-block:: python
 
@@ -189,7 +189,7 @@ However, you can turn on ``spark.sql.caseSensitive`` in Spark configuration to e
 .. code-block:: python
 
    >>> from pyspark.sql import SparkSession
-   >>> builder = SparkSession.builder.appName("Koalas")
+   >>> builder = SparkSession.builder.appName("pandas-on-spark")
    >>> builder = builder.config("spark.sql.caseSensitive", "true")
    >>> builder.getOrCreate()
 
@@ -201,11 +201,11 @@ However, you can turn on ``spark.sql.caseSensitive`` in Spark configuration to e
    1  2  4
 
 
-Specify the index column in conversion from Spark DataFrame to Koalas DataFrame
--------------------------------------------------------------------------------
+Specify the index column in conversion from Spark DataFrame to pandas-on-Spark DataFrame
+----------------------------------------------------------------------------------------
 
-When Koalas Dataframe is converted from Spark DataFrame, it loses the index information, which results in using
-the default index in Koalas DataFrame. The default index is inefficient in general comparing to explicitly specifying
+When pandas APIs on Spark Dataframe are converted from Spark DataFrame, it loses the index information, which results in using
+the default index in pandas APIs on Spark DataFrame. The default index is inefficient in general comparing to explicitly specifying
 the index column. Specify the index column whenever possible.
 
 See  `working with PySpark <pandas_pyspark.rst#pyspark>`_
@@ -214,8 +214,8 @@ See  `working with PySpark <pandas_pyspark.rst#pyspark>`_
 Use ``distributed`` or ``distributed-sequence`` default index
 -------------------------------------------------------------
 
-One common issue when Koalas users face is the slow performance by default index. Koalas attaches
-a default index when the index is unknown, for example, Spark DataFrame is directly converted to Koalas DataFrame.
+One common issue when pandas-on-Spark users face is the slow performance by default index. Pandas APIs on Spark attache
+a default index when the index is unknown, for example, Spark DataFrame is directly converted to pandas-on-Spark DataFrame.
 
 This default index is ``sequence`` which requires the computation on single partition which is discouraged. If you plan
 to handle large data in production, make it distributed by configuring the default index to ``distributed`` or
@@ -227,19 +227,19 @@ See `Default Index Type <options.rst#default-index-type>`_ for more details abou
 Reduce the operations on different DataFrame/Series
 ---------------------------------------------------
 
-Koalas disallows the operations on different DataFrames (or Series) by default to prevent expensive operations.
+Pandas APIs on Spark disallow the operations on different DataFrames (or Series) by default to prevent expensive operations.
 It internally performs a join operation which can be expensive in general, which is discouraged. Whenever possible,
 this operation should be avoided.
 
 See `Operations on different DataFrames <options.rst#operations-on-different-dataframes>`_ for more details.
 
 
-Use Koalas APIs directly whenever possible
-------------------------------------------
+Use pandas APIs on Spark directly whenever possible
+---------------------------------------------------
 
-Although Koalas has most of the pandas-equivalent APIs, there are several APIs not implemented yet or explicitly unsupported.
+Although pandas APIs on Spark have most of the pandas-equivalent APIs, there are several APIs not implemented yet or explicitly unsupported.
 
-As an example, Koalas does not implement ``__iter__()`` to prevent users from collecting all data into the client (driver) side from the whole cluster.
+As an example, pandas APIs on Spark do not implement ``__iter__()`` to prevent users from collecting all data into the client (driver) side from the whole cluster.
 Unfortunately, many external APIs such as Python built-in functions such as min, max, sum, etc. require the given argument to be iterable.
 In case of pandas, it works properly out of the box as below:
 
@@ -254,9 +254,9 @@ In case of pandas, it works properly out of the box as below:
    6
 
 pandas dataset lives in the single machine, and is naturally iterable locally within the same machine.
-However, Koalas dataset lives across multiple machines, and they are computed in a distributed manner.
+However, pandas-on-Spark dataset lives across multiple machines, and they are computed in a distributed manner.
 It is difficult to be locally iterable and it is very likely users collect the entire data into the client side without knowing it.
-Therefore, it is best to stick to using Koalas APIs.
+Therefore, it is best to stick to using pandas-on-Spark APIs.
 The examples above can be converted as below:
 
 .. code-block:: python
@@ -291,8 +291,8 @@ Therefore, it works seamlessly in pandas as below:
    Helsinki    144.0
    dtype: float64
 
-However, for Koalas it does not work as the same reason above.
-The example above can be also changed to directly using Koalas APIs as below:
+However, for pandas APIs on Spark it do not work as the same reason above.
+The example above can be also changed to directly using pandas-on-Spark APIs as below:
 
 .. code-block:: python
 

--- a/python/docs/source/user_guide/pandas_on_spark/from_to_dbms.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/from_to_dbms.rst
@@ -4,8 +4,8 @@ From/to other DBMSes
 .. currentmodule:: pyspark.pandas
 
 
-The APIs interacting with other DBMSes in Koalas are slightly different from the ones in pandas
-because Koalas leverages JDBC APIs in PySpark to read and write from/to other DBMSes.
+The APIs interacting with other DBMSes in pandas APIs on Spark are slightly different from the ones in pandas
+because pandas APIs on Spark leverage JDBC APIs in PySpark to read and write from/to other DBMSes.
 
 The APIs to read/write from/to external DBMSes are as follows:
 
@@ -18,7 +18,7 @@ The APIs to read/write from/to external DBMSes are as follows:
 ..
     TODO: we should implement and document `DataFrame.to_sql`.
 
-Koalas needs a canonical JDBC URL for ``con``, and is able to take extra keyword arguments for `the options in PySpark JDBC APIs <https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html>`_:
+pandas-on-Spark needs a canonical JDBC URL for ``con``, and is able to take extra keyword arguments for `the options in PySpark JDBC APIs <https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html>`_:
 
 .. code-block:: python
 
@@ -30,7 +30,7 @@ Reading and writing DataFrames
 
 In the example below, you will read and write a table in SQLite.
 
-Firstly, create the ``example`` database as below via Python's SQLite library. This will be read to Koalas later:
+Firstly, create the ``example`` database as below via Python's SQLite library. This will be read to pandas-on-Spark later:
 
 .. code-block:: python
 
@@ -48,13 +48,13 @@ Firstly, create the ``example`` database as below via Python's SQLite library. T
     con.commit()
     con.close()
 
-Koalas requires a JDBC driver to read so it requires the driver for your particular database to be on the Spark's classpath. For SQLite JDBC driver, you can download it, for example, as below:
+Pandas APIs on Spark require a JDBC driver to read so it requires the driver for your particular database to be on the Spark's classpath. For SQLite JDBC driver, you can download it, for example, as below:
 
 .. code-block:: bash
 
     curl -O https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.34.0/sqlite-jdbc-3.34.0.jar
 
-After that, you should add it into your Spark session first. Once you add them, Koalas will automatically detect the Spark session and leverage it.
+After that, you should add it into your Spark session first. Once you add them, pandas APIs on Spark will automatically detect the Spark session and leverage it.
 
 .. code-block:: python
 

--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -3,7 +3,7 @@ Options and settings
 ====================
 .. currentmodule:: pyspark.pandas
 
-Koalas has an options system that lets you customize some aspects of its behaviour,
+Pandas APIs on Spark have an options system that lets you customize some aspects of its behaviour,
 display-related options being those the user is most likely to adjust.
 
 Options have a full "dotted-style", case-insensitive name (e.g. ``display.max_rows``).
@@ -92,7 +92,7 @@ are restored automatically when you exit the `with` block:
 Operations on different DataFrames
 ----------------------------------
 
-Koalas disallows the operations on different DataFrames (or Series) by default to prevent expensive
+Pandas APIs on Spark disallow the operations on different DataFrames (or Series) by default to prevent expensive
 operations. It internally performs a join operation which can be expensive in general.
 
 This can be enabled by setting `compute.ops_on_diff_frames` to `True` to allow such cases.
@@ -134,9 +134,9 @@ See the examples below.
 Default Index type
 ------------------
 
-In Koalas, the default index is used in several cases, for instance,
-when Spark DataFrame is converted into Koalas DataFrame. In this case, internally Koalas attaches a
-default index into Koalas DataFrame.
+In pandas APIs on Spark, the default index is used in several cases, for instance,
+when Spark DataFrame is converted into pandas-on-Spark DataFrame. In this case, internally pandas APIs on Spark attache a
+default index into pandas-on-Spark DataFrame.
 
 There are several types of the default index that can be configured by `compute.default_index_type` as below:
 
@@ -230,21 +230,23 @@ Available options
 =============================== ============== =====================================================
 Option                          Default        Description
 =============================== ============== =====================================================
-display.max_rows                1000           This sets the maximum number of rows Koalas should
-                                               output when printing out various output. For example,
-                                               this value determines the number of rows to be shown
-                                               at the repr() in a dataframe. Set `None` to unlimit
-                                               the input length. Default is 1000.
+display.max_rows                1000           This sets the maximum number of rows pandas-on-Spark
+                                               should output when printing out various output. For
+                                               example, this value determines the number of rows to
+                                               be shown at the repr() in a dataframe. Set `None` to
+                                               unlimit the input length. Default is 1000.
 compute.max_rows                1000           'compute.max_rows' sets the limit of the current
-                                               Koalas DataFrame. Set `None` to unlimit the input
-                                               length. When the limit is set, it is executed by the
-                                               shortcut by collecting the data into the driver, and
-                                               then using the pandas API. If the limit is unset, the
-                                               operation is executed by PySpark. Default is 1000.
+                                               pandas-on-Spark DataFrame. Set `None` to unlimit the
+                                               input length. When the limit is set, it is executed
+                                               by the shortcut by collecting the data into the
+                                               driver, and then using the pandas API. If the limit
+                                               is unset, the operation is executed by PySpark.
+                                               Default is 1000.
 compute.shortcut_limit          1000           'compute.shortcut_limit' sets the limit for a
                                                shortcut. It computes specified number of rows and
                                                use its schema. When the dataframe length is larger
-                                               than this limit, Koalas uses PySpark to compute.
+                                               than this limit, pandas-on-Spark uses PySpark to
+                                               compute.
 compute.ops_on_diff_frames      False          This determines whether or not to operate between two
                                                different dataframes. For example, 'combine_frames'
                                                function internally performs a join operation which
@@ -254,12 +256,12 @@ compute.ops_on_diff_frames      False          This determines whether or not to
 compute.default_index_type      'sequence'     This sets the default index type: sequence,
                                                distributed and distributed-sequence.
 compute.ordered_head            False          'compute.ordered_head' sets whether or not to operate
-                                               head with natural ordering. Koalas does not guarantee
-                                               the row ordering so `head` could return some rows
-                                               from distributed partitions. If
-                                               'compute.ordered_head' is set to True, Koalas
-                                               performs natural ordering beforehand, but it will
-                                               cause a performance overhead.
+                                               head with natural ordering. pandas-on-Spark does not
+                                               guarantee the row ordering so `head` could return
+                                               some rows from distributed partitions. If
+                                               'compute.ordered_head' is set to True, pandas-on-
+                                               Spark performs natural ordering beforehand, but it
+                                               will cause a performance overhead.
 plotting.max_rows               1000           'plotting.max_rows' sets the visual limit on top-n-
                                                based plots such as `plot.bar` and `plot.pie`. If it
                                                is set to 1000, the first 1000 data points will be

--- a/python/docs/source/user_guide/pandas_on_spark/pandas_pyspark.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/pandas_pyspark.rst
@@ -5,16 +5,16 @@ From/to pandas and PySpark DataFrames
 .. currentmodule:: pyspark.pandas
 
 Users from pandas and/or PySpark face API compatibility issue sometimes when they
-work with Koalas. Since Koalas does not target 100% compatibility of both pandas and
+work with pandas APIs on Spark. Since pandas APIs on Spark do not target 100% compatibility of both pandas and
 PySpark, users need to do some workaround to port their pandas and/or PySpark codes or
-get familiar with Koalas in this case. This page aims to describe it.
+get familiar with pandas APIs on Spark in this case. This page aims to describe it.
 
 
 pandas
 ------
 
 pandas users can access to full pandas APIs by calling :func:`DataFrame.to_pandas`.
-Koalas DataFrame and pandas DataFrame are similar. However, the former is distributed
+pandas-on-Spark DataFrame and pandas DataFrame are similar. However, the former is distributed
 and the latter is in a single machine. When converting to each other, the data is
 transferred between multiple machines and the single client machine.
 
@@ -39,7 +39,7 @@ as below:
           [8],
           [9]])
 
-pandas DataFrame can be a Koalas DataFrame easily as below:
+pandas DataFrame can be a pandas-on-Spark DataFrame easily as below:
 
 .. code-block:: python
 
@@ -56,15 +56,15 @@ pandas DataFrame can be a Koalas DataFrame easily as below:
    8   8
    9   9
 
-Note that converting Koalas DataFrame to pandas requires to collect all the data into the client machine; therefore,
-if possible, it is recommended to use Koalas or PySpark APIs instead.
+Note that converting pandas-on-Spark DataFrame to pandas requires to collect all the data into the client machine; therefore,
+if possible, it is recommended to use pandas APIs on Spark or PySpark APIs instead.
 
 
 PySpark
 -------
 
 PySpark users can access to full PySpark APIs by calling :func:`DataFrame.to_spark`.
-Koalas DataFrame and Spark DataFrame are virtually interchangeable.
+pandas-on-Spark DataFrame and Spark DataFrame are virtually interchangeable.
 
 For example, if you need to call ``spark_df.filter(...)`` of Spark DataFrame, you can do
 as below:
@@ -85,7 +85,7 @@ as below:
    |  9|
    +---+
 
-Spark DataFrame can be a Koalas DataFrame easily as below:
+Spark DataFrame can be a pandas-on-Spark DataFrame easily as below:
 
 .. code-block:: python
 
@@ -96,13 +96,13 @@ Spark DataFrame can be a Koalas DataFrame easily as below:
    2   8
    3   9
 
-However, note that it requires to create new default index in case Koalas DataFrame is created from
+However, note that it requires to create new default index in case pandas-on-Spark DataFrame is created from
 Spark DataFrame. See `Default Index Type <options.rst#default-index-type>`_. In order to avoid this overhead, specify the column
 to use as an index when possible.
 
 .. code-block:: python
 
-   >>> # Create a Koalas DataFrame with an explicit index.
+   >>> # Create a pandas-on-Spark DataFrame with an explicit index.
    ... kdf = ks.DataFrame({'id': range(10)}, index=range(10))
    >>> # Keep the explicit index.
    ... sdf = kdf.to_spark(index_col='index')

--- a/python/docs/source/user_guide/pandas_on_spark/transform_apply.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/transform_apply.rst
@@ -6,7 +6,7 @@ Transform and apply a function
 
 .. currentmodule:: pyspark.pandas
 
-There are many APIs that allow users to apply a function against Koalas DataFrame such as
+There are many APIs that allow users to apply a function against pandas-on-Spark DataFrame such as
 :func:`DataFrame.transform`, :func:`DataFrame.apply`, :func:`DataFrame.koalas.transform_batch`,
 :func:`DataFrame.koalas.apply_batch`, :func:`Series.koalas.transform_batch`, etc. Each has a distinct
 purpose and works differently internally. This section describes the differences among
@@ -34,7 +34,7 @@ to return the same length of the input and the latter does not require this. See
    ...
    >>> kdf.apply(pandas_plus)
 
-In this case, each function takes a pandas Series, and Koalas computes the functions in a distributed manner as below.
+In this case, each function takes a pandas Series, and pandas APIs on Spark compute the functions in a distributed manner as below.
 
 .. image:: https://user-images.githubusercontent.com/6477701/80076790-a1cf0680-8587-11ea-8b08-8dc694071ba0.png
   :alt: transform and apply
@@ -66,7 +66,7 @@ Please refer the API documentations.
 -----------------------------------------------------
 
 In :func:`DataFrame.koalas.transform_batch`, :func:`DataFrame.koalas.apply_batch`, :func:`Series.koalas.transform_batch`, etc., the ``batch``
-postfix means each chunk in Koalas DataFrame or Series. The APIs slice the Koalas DataFrame or Series, and
+postfix means each chunk in pandas-on-Spark DataFrame or Series. The APIs slice the pandas-on-Spark DataFrame or Series, and
 then applies the given function with pandas DataFrame or Series as input and output. See the examples below:
 
 .. code-block:: python
@@ -85,8 +85,8 @@ then applies the given function with pandas DataFrame or Series as input and out
    ...
    >>> kdf.koalas.apply_batch(pandas_plus)
 
-The functions in both examples take a pandas DataFrame as a chunk of Koalas DataFrame, and output a pandas DataFrame.
-Koalas combines the pandas DataFrames as a Koalas DataFrame.
+The functions in both examples take a pandas DataFrame as a chunk of pandas-on-Spark DataFrame, and output a pandas DataFrame.
+Pandas APIs on Spark combine the pandas DataFrames as a pandas-on-Spark DataFrame.
 
 Note that :func:`DataFrame.koalas.transform_batch` has the length restriction - the length of input and output should be
 the same whereas :func:`DataFrame.koalas.apply_batch` does not.  However, it is important to know that
@@ -101,7 +101,7 @@ treated that it belongs to a new different DataFrame. See also
   :width: 650
 
 In case of :func:`Series.koalas.transform_batch`, it is also similar with :func:`DataFrame.koalas.transform_batch`; however, it takes
-a pandas Series as a chunk of Koalas Series.
+a pandas Series as a chunk of pandas-on-Spark Series.
 
 .. code-block:: python
 
@@ -111,7 +111,7 @@ a pandas Series as a chunk of Koalas Series.
    ...
    >>> kdf.a.koalas.transform_batch(pandas_plus)
 
-Under the hood, each batch of Koalas Series is split to multiple pandas Series, and each function computes on that as below:
+Under the hood, each batch of pandas-on-Spark Series is split to multiple pandas Series, and each function computes on that as below:
 
 .. image:: https://user-images.githubusercontent.com/6477701/80076795-a3003380-8587-11ea-8b73-186e4047f8c0.png
   :alt: koalas.transform_batch in Series

--- a/python/docs/source/user_guide/pandas_on_spark/typehints.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/typehints.rst
@@ -1,36 +1,36 @@
-====================
-Type Hints In Koalas
-====================
+==================================
+Type Hints in Pandas APIs on Spark
+==================================
 
 .. currentmodule:: pyspark.pandas
 
-Koalas, by default, infers the schema by taking some top records from the output,
-in particular, when you use APIs that allow users to apply a function against Koalas DataFrame
+Pandas APIs on Spark, by default, infers the schema by taking some top records from the output,
+in particular, when you use APIs that allow users to apply a function against pandas-on-Spark DataFrame
 such as :func:`DataFrame.transform`, :func:`DataFrame.apply`, :func:`DataFrame.koalas.apply_batch`,
 :func:`DataFrame.koalas.apply_batch`, :func:`Series.koalas.apply_batch`, etc.
 
 However, this is potentially expensive. If there are several expensive operations such as a shuffle
-in the upstream of the execution plan, Koalas will end up with executing the Spark job twice, once
+in the upstream of the execution plan, pandas APIs on Spark will end up with executing the Spark job twice, once
 for schema inference, and once for processing actual data with the schema.
 
-To avoid the consequences, Koalas has its own type hinting style to specify the schema to avoid
-schema inference. Koalas understands the type hints specified in the return type and converts it
+To avoid the consequences, pandas APIs on Spark have its own type hinting style to specify the schema to avoid
+schema inference. Pandas APIs on Spark understand the type hints specified in the return type and converts it
 as a Spark schema for pandas UDFs used internally. The way of type hinting has been evolved over
 the time.
 
 In this chapter, it covers the recommended way and the supported ways in details.
 
 .. note::
-    The variadic generics support is experimental and unstable in Koalas.
+    The variadic generics support is experimental and unstable in pandas APIs on Spark.
     The way of typing can change between minor releases without a warning.
     See also `PEP 646 <https://www.python.org/dev/peps/pep-0646/>`_ for variadic generics in Python.
 
 
-Koalas DataFrame and Pandas DataFrame
--------------------------------------
+pandas-on-Spark DataFrame and Pandas DataFrame
+----------------------------------------------
 
-In the early Koalas version, it was introduced to specify a type hint in the function in order to use
-it as a Spark schema. As an example, you can specify the return type hint as below by using Koalas
+In the early pandas-on-Spark version, it was introduced to specify a type hint in the function in order to use
+it as a Spark schema. As an example, you can specify the return type hint as below by using pandas-on-Spark
 :class:`DataFrame`.
 
 .. code-block:: python
@@ -42,10 +42,10 @@ it as a Spark schema. As an example, you can specify the return type hint as bel
     >>> df = ks.DataFrame({'A': ['a', 'a', 'b'], 'B': [1, 2, 3], 'C': [4, 6, 5]})
     >>> df.groupby('A').apply(pandas_div)
 
-The function ``pandas_div`` actually takes and outputs a pandas DataFrame instead of Koalas :class:`DataFrame`.
-However, Koalas has to force to set the mismatched type hints.
+The function ``pandas_div`` actually takes and outputs a pandas DataFrame instead of pandas-on-Spark :class:`DataFrame`.
+However, pandas APIs on Spark have to force to set the mismatched type hints.
 
-From Koalas 1.0 with Python 3.7+, now you can specify the type hints by using pandas instances.
+From pandas-on-Spark 1.0 with Python 3.7+, now you can specify the type hints by using pandas instances.
 
 .. code-block:: python
 
@@ -66,16 +66,16 @@ Likewise, pandas Series can be also used as a type hints:
     >>> df = ks.DataFrame([[4, 9]] * 3, columns=['A', 'B'])
     >>> df.apply(sqrt, axis=0)
 
-Currently, both Koalas and pandas instances can be used to specify the type hints; however, Koalas
+Currently, both pandas APIs on Spark and pandas instances can be used to specify the type hints; however, pandas-on-Spark
 plans to move gradually towards using pandas instances only as the stability becomes proven.
 
 
 Type Hinting with Names
 -----------------------
 
-In Koalas 1.0, the new style of type hinting was introduced to overcome the limitations in the existing type
+In pandas-on-Spark 1.0, the new style of type hinting was introduced to overcome the limitations in the existing type
 hinting especially for DataFrame. When you use a DataFrame as the return type hint, for example,
-``DataFrame[int, int]``, there is no way to specify the names of each Series. In the old way, Koalas just generates
+``DataFrame[int, int]``, there is no way to specify the names of each Series. In the old way, pandas APIs on Spark just generate
 the column names as ``c#`` and this easily leads users to lose or forgot the Series mappings. See the example below:
 
 .. code-block:: python
@@ -95,7 +95,7 @@ the column names as ``c#`` and this easily leads users to lose or forgot the Ser
     3   3   4
     4   4   5
 
-The new style of type hinting in Koalas is similar with the regular Python type hints in variables. The Series name
+The new style of type hinting in pandas APIs on Spark are similar with the regular Python type hints in variables. The Series name
 is specified as a string, and the type is specified after a colon. The following example shows a simple case with
 the Series names, ``id`` and ``A``, and ``int`` types respectively.
 
@@ -116,7 +116,7 @@ the Series names, ``id`` and ``A``, and ``int`` types respectively.
     3   3   4
     4   4   5
 
-In addition, Koalas also dynamically supports ``dtype`` instance and the column index in pandas so that users can
+In addition, pandas APIs on Spark also dynamically support ``dtype`` instance and the column index in pandas so that users can
 programmatically generate the return type and schema.
 
 .. code-block:: python
@@ -126,7 +126,7 @@ programmatically generate the return type and schema.
     ...
     >>> kdf.koalas.apply_batch(transform)
 
-Likewise, ``dtype`` instances from pandas DataFrame can be used alone and let Koalas generate column names.
+Likewise, ``dtype`` instances from pandas DataFrame can be used alone and let pandas APIs on Spark generate column names.
 
 .. code-block:: python
 

--- a/python/docs/source/user_guide/pandas_on_spark/types.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/types.rst
@@ -1,18 +1,18 @@
-======================
-Type Support In Koalas
-======================
+====================================
+Type Support in Pandas APIs on Spark
+====================================
 
 .. currentmodule:: pyspark.pandas
 
-In this chapter, we will briefly show you how data types change when converting Koalas DataFrame from/to PySpark DataFrame or pandas DataFrame.
+In this chapter, we will briefly show you how data types change when converting pandas-on-Spark DataFrame from/to PySpark DataFrame or pandas DataFrame.
 
 
-Type casting between PySpark and Koalas
----------------------------------------
+Type casting between PySpark and pandas APIs on Spark
+-----------------------------------------------------
 
-When converting a Koalas DataFrame from/to PySpark DataFrame, the data types are automatically casted to the appropriate type.
+When converting a pandas-on-Spark DataFrame from/to PySpark DataFrame, the data types are automatically casted to the appropriate type.
 
-The example below shows how data types are casted from PySpark DataFrame to Koalas DataFrame.
+The example below shows how data types are casted from PySpark DataFrame to pandas-on-Spark DataFrame.
 
 .. code-block:: python
 
@@ -25,10 +25,10 @@ The example below shows how data types are casted from PySpark DataFrame to Koal
     >>> sdf
     DataFrame[tinyint: tinyint, decimal: decimal(10,0), float: float, double: double, integer: int, long: bigint, short: smallint, timestamp: timestamp, string: string, boolean: boolean, date: date]
 
-    # 3. Convert PySpark DataFrame to Koalas DataFrame
+    # 3. Convert PySpark DataFrame to pandas-on-Spark DataFrame
     >>> kdf = sdf.to_koalas()
 
-    # 4. Check the Koalas data types
+    # 4. Check the pandas-on-Spark data types
     >>> kdf.dtypes
     tinyint                int8
     decimal              object
@@ -44,11 +44,11 @@ The example below shows how data types are casted from PySpark DataFrame to Koal
     dtype: object
 
 
-The example below shows how data types are casted from Koalas DataFrame to PySpark DataFrame.
+The example below shows how data types are casted from pandas-on-Spark DataFrame to PySpark DataFrame.
 
 .. code-block:: python
 
-    # 1. Create a Koalas DataFrame
+    # 1. Create a pandas-on-Spark DataFrame
     >>> kdf = ks.DataFrame({"int8": [1], "bool": [True], "float32": [1.0], "float64": [1.0], "int32": [1], "int64": [1], "int16": [1], "datetime": [datetime.datetime(2020, 10, 27)], "object_string": ["1"], "object_decimal": [decimal.Decimal("1.1")], "object_date": [datetime.date(2020, 10, 27)]})
 
     # 2. Type casting by using `astype`
@@ -57,7 +57,7 @@ The example below shows how data types are casted from Koalas DataFrame to PySpa
     >>> kdf['int32'] = kdf['int32'].astype('int32')
     >>> kdf['float32'] = kdf['float32'].astype('float32')
 
-    # 3. Check the Koalas data types
+    # 3. Check the pandas-on-Spark data types
     >>> kdf.dtypes
     int8                        int8
     bool                        bool
@@ -72,7 +72,7 @@ The example below shows how data types are casted from Koalas DataFrame to PySpa
     object_date               object
     dtype: object
 
-    # 4. Convert Koalas DataFrame to PySpark DataFrame
+    # 4. Convert pandas-on-Spark DataFrame to PySpark DataFrame
     >>> sdf = kdf.to_spark()
 
     # 5. Check the PySpark data types
@@ -80,14 +80,14 @@ The example below shows how data types are casted from Koalas DataFrame to PySpa
     DataFrame[int8: tinyint, bool: boolean, float32: float, float64: double, int32: int, int64: bigint, int16: smallint, datetime: timestamp, object_string: string, object_decimal: decimal(2,1), object_date: date]
 
 
-Type casting between pandas and Koalas
---------------------------------------
+Type casting between pandas and pandas APIs on Spark
+----------------------------------------------------
 
-When converting Koalas DataFrame to pandas DataFrame, and the data types are basically same as pandas.
+When converting pandas-on-Spark DataFrame to pandas DataFrame, and the data types are basically same as pandas.
 
 .. code-block:: python
 
-    # Convert Koalas DataFrame to pandas DataFrame
+    # Convert pandas-on-Spark DataFrame to pandas DataFrame
     >>> pdf = kdf.to_pandas()
 
     # Check the pandas data types
@@ -110,7 +110,7 @@ However, there are several data types only provided by pandas.
 
 .. code-block:: python
 
-    # pd.Catrgorical type is not supported in Koalas yet.
+    # pd.Catrgorical type is not supported in pandas APIs on Spark yet.
     >>> ks.Series([pd.Categorical([1, 2, 3])])
     Traceback (most recent call last):
     ...
@@ -118,14 +118,14 @@ However, there are several data types only provided by pandas.
     Categories (3, int64): [1, 2, 3] with type Categorical: did not recognize Python value type when inferring an Arrow data type
 
 
-These kind of pandas specific data types below are not currently supported in Koalas but planned to be supported.
+These kind of pandas specific data types below are not currently supported in pandas APIs on Spark but planned to be supported.
 
 * pd.Timedelta
 * pd.Categorical
 * pd.CategoricalDtype
 
 
-The pandas specific data types below are not planned to be supported in Koalas yet.
+The pandas specific data types below are not planned to be supported in pandas APIs on Spark yet.
 
 * pd.SparseDtype
 * pd.DatetimeTZDtype
@@ -137,7 +137,7 @@ The pandas specific data types below are not planned to be supported in Koalas y
 Internal type mapping
 ---------------------
 
-The table below shows which NumPy data types are matched to which PySpark data types internally in Koalas.
+The table below shows which NumPy data types are matched to which PySpark data types internally in pandas APIs on Spark.
 
 ============= =======================
 NumPy         PySpark
@@ -162,7 +162,7 @@ np.ndarray    ArrayType(StringType())
 ============= =======================
 
 
-The table below shows which Python data types are matched to which PySpark data types internally in Koalas.
+The table below shows which Python data types are matched to which PySpark data types internally in pandas APIs on Spark.
 
 ================= ===================
 Python            PySpark
@@ -177,7 +177,7 @@ datetime.date     DateType
 decimal.Decimal   DecimalType(38, 18)
 ================= ===================
 
-For decimal type, Koalas uses Spark's system default precision and scale.
+For decimal type, pandas APIs on Spark use Spark's system default precision and scale.
 
 You can check this mapping by using `as_spark_type` function.
 
@@ -204,13 +204,13 @@ You can also check the underlying PySpark data type of `Series` or schema of `Da
     >>> ks.Series([0.3, 0.1, 0.8]).spark.data_type
     DoubleType
 
-    >>> ks.Series(["welcome", "to", "Koalas"]).spark.data_type
+    >>> ks.Series(["welcome", "to", "pandas-on-Spark"]).spark.data_type
     StringType
 
     >>> ks.Series([[False, True, False]]).spark.data_type
     ArrayType(BooleanType,true)
 
-    >>> ks.DataFrame({"d": [0.3, 0.1, 0.8], "s": ["welcome", "to", "Koalas"], "b": [False, True, False]}).spark.print_schema()
+    >>> ks.DataFrame({"d": [0.3, 0.1, 0.8], "s": ["welcome", "to", "pandas-on-Spark"], "b": [False, True, False]}).spark.print_schema()
     root
      |-- d: double (nullable = false)
      |-- s: string (nullable = false)
@@ -218,7 +218,7 @@ You can also check the underlying PySpark data type of `Series` or schema of `Da
 
 .. note::
 
-    Koalas currently does not support multiple types of data in single column.
+    Pandas APIs on Spark currently do not support multiple types of data in single column.
 
     .. code-block:: python
     


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes the change the name "Koalas" to the "Pandas APIs on Spark" in the documents.


### Why are the changes needed?

Since we don't use the name "Koalas" anymore.

We should use "Pandas APIs on Spark" instead.


### Does this PR introduce _any_ user-facing change?

Yes, the name "Koalas" is renamed to "Pandas APIs on Spark" in the documents.


### How was this patch tested?

Manually built the docs and checked one by one.
