### PR TITLE
[SPARK-35679][SQL] instantToMicros overflow

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -385,12 +385,13 @@ object DateTimeUtils {
    * microseconds where microsecond 0 is 1970-01-01 00:00:00Z.
    */
   def instantToMicros(instant: Instant): Long = {
-    if (instant.getEpochSecond < 0) {
-      val us = Math.multiplyExact(instant.getEpochSecond + 1, MICROS_PER_SECOND)
+    val secs = instant.getEpochSecond
+    if (secs == Math.floorDiv(Long.MinValue, MICROS_PER_SECOND)) {
+      val us = Math.multiplyExact(secs + 1, MICROS_PER_SECOND)
       val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano) - MICROS_PER_SECOND)
       result
     } else {
-      val us = Math.multiplyExact(instant.getEpochSecond, MICROS_PER_SECOND)
+      val us = Math.multiplyExact(secs, MICROS_PER_SECOND)
       val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano))
       result
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -379,10 +379,8 @@ object DateTimeUtils {
     }
   }
   // See issue SPARK-35679
-  // LongMinValueDividedByMicroPerSecond is equal to
-  // Math.floorDiv(Long.MinValue, MICROS_PER_SECOND)
-  // which is -9223372036855L
-  private final val LongMinValueDividedByMicroPerSecond = -9223372036855L
+  // min second cause overflow in instant to micro
+  private val MIN_SECONDS = Math.floorDiv(Long.MinValue, MICROS_PER_SECOND)
 
   /**
    * Gets the number of microseconds since the epoch of 1970-01-01 00:00:00Z from the given
@@ -391,7 +389,7 @@ object DateTimeUtils {
    */
   def instantToMicros(instant: Instant): Long = {
     val secs = instant.getEpochSecond
-    if (secs == LongMinValueDividedByMicroPerSecond) {
+    if (secs == MIN_SECONDS) {
       val us = Math.multiplyExact(secs + 1, MICROS_PER_SECOND)
       Math.addExact(us, NANOSECONDS.toMicros(instant.getNano) - MICROS_PER_SECOND)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -378,6 +378,11 @@ object DateTimeUtils {
       throw QueryExecutionErrors.cannotCastUTF8StringToDataTypeError(s, TimestampType)
     }
   }
+  // See issue SPARK-35679
+  // LongMinValueDividedByMicroPerSecond is equal to
+  // Math.floorDiv(Long.MinValue, MICROS_PER_SECOND)
+  // which is -9223372036855L
+  private final val LongMinValueDividedByMicroPerSecond = -9223372036855L
 
   /**
    * Gets the number of microseconds since the epoch of 1970-01-01 00:00:00Z from the given
@@ -386,9 +391,7 @@ object DateTimeUtils {
    */
   def instantToMicros(instant: Instant): Long = {
     val secs = instant.getEpochSecond
-    // See issue SPARK-35679
-    // Math.floorDiv(Long.MinValue, MICROS_PER_SECOND) is equal to -9223372036855L
-    if (secs == -9223372036855L) {
+    if (secs == LongMinValueDividedByMicroPerSecond) {
       val us = Math.multiplyExact(secs + 1, MICROS_PER_SECOND)
       Math.addExact(us, NANOSECONDS.toMicros(instant.getNano) - MICROS_PER_SECOND)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -387,7 +387,7 @@ object DateTimeUtils {
   def instantToMicros(instant: Instant): Long = {
     if (instant.getEpochSecond < 0) {
       val us = Math.multiplyExact(instant.getEpochSecond + 1, MICROS_PER_SECOND)
-      val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano - NANOS_PER_SECOND))
+      val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano) - MICROS_PER_SECOND)
       result
     } else {
       val us = Math.multiplyExact(instant.getEpochSecond, MICROS_PER_SECOND)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -385,9 +385,15 @@ object DateTimeUtils {
    * microseconds where microsecond 0 is 1970-01-01 00:00:00Z.
    */
   def instantToMicros(instant: Instant): Long = {
-    val us = Math.multiplyExact(instant.getEpochSecond, MICROS_PER_SECOND)
-    val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano))
-    result
+    if (Math.floorDiv(Long.MinValue, MICROS_PER_SECOND) == instant.getEpochSecond) {
+      val us = Math.multiplyExact(instant.getEpochSecond + 1, MICROS_PER_SECOND)
+      val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano - NANOS_PER_SECOND))
+      result
+    } else {
+      val us = Math.multiplyExact(instant.getEpochSecond, MICROS_PER_SECOND)
+      val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano))
+      result
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -385,7 +385,7 @@ object DateTimeUtils {
    * microseconds where microsecond 0 is 1970-01-01 00:00:00Z.
    */
   def instantToMicros(instant: Instant): Long = {
-    if (Math.floorDiv(Long.MinValue, MICROS_PER_SECOND) == instant.getEpochSecond) {
+    if (instant.getEpochSecond < 0) {
       val us = Math.multiplyExact(instant.getEpochSecond + 1, MICROS_PER_SECOND)
       val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano - NANOS_PER_SECOND))
       result

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -386,14 +386,14 @@ object DateTimeUtils {
    */
   def instantToMicros(instant: Instant): Long = {
     val secs = instant.getEpochSecond
-    if (secs == Math.floorDiv(Long.MinValue, MICROS_PER_SECOND)) {
+    // See issue SPARK-35679
+    // Math.floorDiv(Long.MinValue, MICROS_PER_SECOND) is equal to -9223372036855L
+    if (secs == -9223372036855L) {
       val us = Math.multiplyExact(secs + 1, MICROS_PER_SECOND)
-      val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano) - MICROS_PER_SECOND)
-      result
+      Math.addExact(us, NANOSECONDS.toMicros(instant.getNano) - MICROS_PER_SECOND)
     } else {
       val us = Math.multiplyExact(secs, MICROS_PER_SECOND)
-      val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano))
-      result
+      Math.addExact(us, NANOSECONDS.toMicros(instant.getNano))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -821,7 +821,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     }
   }
 
-  test("SPARK-35679: handled overflow error raised by instantToMicros") {
+  test("SPARK-35679: instantToMicros should be able to return microseconds of Long.MinValue") {
     assert(instantToMicros(microsToInstant(Long.MaxValue)) === Long.MaxValue)
     assert(instantToMicros(microsToInstant(Long.MinValue)) === Long.MinValue)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -820,4 +820,9 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       }
     }
   }
+
+  test("SPARK-35679: handled overflow error raised by instantToMicros") {
+    assert(instantToMicros(microsToInstant(Long.MaxValue)) === Long.MaxValue)
+    assert(instantToMicros(microsToInstant(Long.MinValue)) === Long.MinValue)
+  }
 }


### PR DESCRIPTION
### Why are the changes needed?
With Long.minValue cast to an instant, secs will be floored in function microsToInstant and cause overflow when multiply with Micros_per_second 

```
def microsToInstant(micros: Long): Instant = {
  val secs = Math.floorDiv(micros, MICROS_PER_SECOND)
  // Unfolded Math.floorMod(us, MICROS_PER_SECOND) to reuse the result of
  // the above calculation of `secs` via `floorDiv`.
  val mos = micros - secs * MICROS_PER_SECOND  <- it will overflow here
  Instant.ofEpochSecond(secs, mos * NANOS_PER_MICROS)
}
```

But the overflow is acceptable because it won't produce any change to the result

However, when convert the instant back to micro value, it will raise Overflow Error

```
def instantToMicros(instant: Instant): Long = {
  val us = Math.multiplyExact(instant.getEpochSecond, MICROS_PER_SECOND) <- It overflow here
  val result = Math.addExact(us, NANOSECONDS.toMicros(instant.getNano))
  result
}
```

Code to reproduce this error
```
instantToMicros(microToInstant(Long.MinValue))
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test added
