### PR TITLE
[SPARK-35697][SQL][TESTS] Test TimestampWithoutTZType as ordered and atomic type

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -140,6 +140,19 @@ object RandomDataGenerator {
     StructType(fields.toSeq)
   }
 
+  private def uniformMicrosRand(rand: Random): Long = {
+    var milliseconds = rand.nextLong() % 253402329599999L
+    // -62135740800000L is the number of milliseconds before January 1, 1970, 00:00:00 GMT
+    // for "0001-01-01 00:00:00.000000". We need to find a
+    // number that is greater or equals to this number as a valid timestamp value.
+    while (milliseconds < -62135740800000L) {
+      // 253402329599999L is the number of milliseconds since
+      // January 1, 1970, 00:00:00 GMT for "9999-12-31 23:59:59.999999".
+      milliseconds = rand.nextLong() % 253402329599999L
+    }
+    milliseconds * MICROS_PER_MILLIS
+  }
+
   /**
    * Returns a function which generates random values for the given `DataType`, or `None` if no
    * random data generator is defined for that data type. The generated values will use an external
@@ -216,18 +229,6 @@ object RandomDataGenerator {
             specialDates.map(java.sql.Date.valueOf))
         }
       case TimestampType =>
-        def uniformMicrosRand(rand: Random): Long = {
-          var milliseconds = rand.nextLong() % 253402329599999L
-          // -62135740800000L is the number of milliseconds before January 1, 1970, 00:00:00 GMT
-          // for "0001-01-01 00:00:00.000000". We need to find a
-          // number that is greater or equals to this number as a valid timestamp value.
-          while (milliseconds < -62135740800000L) {
-            // 253402329599999L is the number of milliseconds since
-            // January 1, 1970, 00:00:00 GMT for "9999-12-31 23:59:59.999999".
-            milliseconds = rand.nextLong() % 253402329599999L
-          }
-          milliseconds * MICROS_PER_MILLIS
-        }
         val specialTs = Seq(
           "0001-01-01 00:00:00", // the fist timestamp of Common Era
           "1582-10-15 23:59:59", // the cutover date from Julian to Gregorian calendar
@@ -267,6 +268,7 @@ object RandomDataGenerator {
             getRandomTimestamp,
             specialTs.map(java.sql.Timestamp.valueOf))
         }
+      case TimestampWithoutTZType =>
       case CalendarIntervalType => Some(() => {
         val months = rand.nextInt(1000)
         val days = rand.nextInt(10000)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -153,6 +153,13 @@ object RandomDataGenerator {
     milliseconds * MICROS_PER_MILLIS
   }
 
+  private val specialTs = Seq(
+    "0001-01-01 00:00:00", // the fist timestamp of Common Era
+    "1582-10-15 23:59:59", // the cutover date from Julian to Gregorian calendar
+    "1970-01-01 00:00:00", // the epoch timestamp
+    "9999-12-31 23:59:59"  // the last supported timestamp according to SQL standard
+  )
+
   /**
    * Returns a function which generates random values for the given `DataType`, or `None` if no
    * random data generator is defined for that data type. The generated values will use an external
@@ -229,12 +236,6 @@ object RandomDataGenerator {
             specialDates.map(java.sql.Date.valueOf))
         }
       case TimestampType =>
-        val specialTs = Seq(
-          "0001-01-01 00:00:00", // the fist timestamp of Common Era
-          "1582-10-15 23:59:59", // the cutover date from Julian to Gregorian calendar
-          "1970-01-01 00:00:00", // the epoch timestamp
-          "9999-12-31 23:59:59"  // the last supported timestamp according to SQL standard
-        )
         def getRandomTimestamp(rand: Random): java.sql.Timestamp = {
           // DateTimeUtils.toJavaTimestamp takes microsecond.
           val ts = DateTimeUtils.toJavaTimestamp(uniformMicrosRand(rand))
@@ -269,6 +270,13 @@ object RandomDataGenerator {
             specialTs.map(java.sql.Timestamp.valueOf))
         }
       case TimestampWithoutTZType =>
+        randomNumeric[LocalDateTime](
+          rand,
+          (rand: Random) => {
+            DateTimeUtils.microsToLocalDateTime(uniformMicrosRand(rand))
+          },
+          specialTs.map { s => LocalDateTime.parse(s.replace(" ", "T")) }
+        )
       case CalendarIntervalType => Some(() => {
         val months = rand.nextInt(1000)
         val days = rand.nextInt(10000)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -63,7 +63,10 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       checkNullCast(from, to)
     }
 
-    atomicTypes.foreach(dt => checkNullCast(NullType, dt))
+    (atomicTypes -- Set(
+      // TODO(SPARK-35698): Support casting timestamp without time zone to strings.
+      TimestampWithoutTZType
+    )).foreach(dt => checkNullCast(NullType, dt))
     atomicTypes.foreach(dt => checkNullCast(dt, StringType))
     checkNullCast(StringType, BinaryType)
     checkNullCast(StringType, BooleanType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
@@ -24,7 +24,8 @@ import java.util.concurrent.TimeUnit
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.Assertions._
 
-import org.apache.spark.sql.catalyst.util.DateTimeConstants.MILLIS_PER_DAY
+import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_MILLIS, MILLIS_PER_DAY}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 
@@ -122,7 +123,7 @@ object LiteralGenerator {
       yield Literal.create(new Date(day * MILLIS_PER_DAY), DateType)
   }
 
-  lazy val timestampLiteralGen: Gen[Literal] = {
+  private def millisGen = {
     // Catalyst's Timestamp type stores number of microseconds since epoch in
     // a variable of Long type. To prevent arithmetic overflow of Long on
     // conversion from milliseconds to microseconds, the range of random milliseconds
@@ -130,8 +131,18 @@ object LiteralGenerator {
     // Valid range for TimestampType is [0001-01-01T00:00:00.000000Z, 9999-12-31T23:59:59.999999Z]
     val minMillis = Instant.parse("0001-01-01T00:00:00.000000Z").toEpochMilli
     val maxMillis = Instant.parse("9999-12-31T23:59:59.999999Z").toEpochMilli
-    for { millis <- Gen.choose(minMillis, maxMillis) }
+    Gen.choose(minMillis, maxMillis)
+  }
+
+  lazy val timestampLiteralGen: Gen[Literal] = {
+    for { millis <- millisGen }
       yield Literal.create(new Timestamp(millis), TimestampType)
+  }
+
+  lazy val timestampWithoutTZLiteralGen: Gen[Literal] = {
+    for { millis <- millisGen }
+      yield Literal.create(
+        DateTimeUtils.microsToLocalDateTime(millis * MICROS_PER_MILLIS), TimestampWithoutTZType)
   }
 
   // Valid range for DateType and TimestampType is [0001-01-01, 9999-12-31]
@@ -186,6 +197,7 @@ object LiteralGenerator {
       case FloatType => floatLiteralGen
       case DateType => dateLiteralGen
       case TimestampType => timestampLiteralGen
+      case TimestampWithoutTZType => timestampWithoutTZLiteralGen
       case BooleanType => booleanLiteralGen
       case StringType => stringLiteralGen
       case BinaryType => binaryLiteralGen

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
@@ -63,6 +63,7 @@ object DataTypeTestUtils {
   val ordered: Set[DataType] = numericTypeWithoutDecimal ++ Set(
     BooleanType,
     TimestampType,
+    TimestampWithoutTZType,
     DateType,
     StringType,
     BinaryType,
@@ -83,6 +84,7 @@ object DataTypeTestUtils {
     DateType,
     StringType,
     TimestampType,
+    TimestampWithoutTZType,
     DayTimeIntervalType,
     YearMonthIntervalType
   )


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `TimestampWithoutTZType` to `DataTypeTestUtils.ordered`/`atomicTypes`, and implement values generation of those types in `LiteralGenerator`/`RandomDataGenerator`. In this way, the types will be tested automatically in:
1. ArithmeticExpressionSuite:
    - "function least"
    - "function greatest"
2. PredicateSuite
    - "BinaryComparison consistency check"
    - "AND, OR, EqualTo, EqualNullSafe consistency check"
3. ConditionalExpressionSuite
    - "if"
4. RandomDataGeneratorSuite
    - "Basic types"
5. CastSuite
    - "null cast"
    - "up-cast"
    - "SPARK-27671: cast from nested null type in struct"
6. OrderingSuite
    - "GenerateOrdering with TimestampWithoutTZType"
7. PredicateSuite
    - "IN with different types"
8. UnsafeRowSuite
    - "calling get(ordinal, datatype) on null columns"
9. SortSuite
    - "sorting on TimestampWithoutTZType ..."

### Why are the changes needed?
To improve test coverage.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
By running the affected test suites.