### PR TITLE
[SPARK-35691][CORE] addFile/addJar/addDirectory should put CanonicalFile

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/RpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcEnv.scala
@@ -187,7 +187,8 @@ private[spark] trait RpcEnvFileServer {
 
   /** Validates and normalizes the base URI for directories. */
   protected def validateDirectoryUri(baseUri: String): String = {
-    val fixedBaseUri = "/" + baseUri.stripPrefix("/").stripSuffix("/")
+    val baseCanonicalUri = new File(baseUri).getCanonicalPath
+    val fixedBaseUri = "/" + baseCanonicalUri.stripPrefix("/").stripSuffix("/")
     require(fixedBaseUri != "/files" && fixedBaseUri != "/jars",
       "Directory URI cannot be /files nor /jars.")
     fixedBaseUri

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyStreamManager.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyStreamManager.scala
@@ -66,7 +66,7 @@ private[netty] class NettyStreamManager(rpcEnv: NettyRpcEnv)
   }
 
   override def addFile(file: File): String = {
-    val existingPath = files.putIfAbsent(file.getName, file)
+    val existingPath = files.putIfAbsent(file.getName, file.getCanonicalFile)
     require(existingPath == null || existingPath == file,
       s"File ${file.getName} was already registered with a different path " +
         s"(old path = $existingPath, new path = $file")
@@ -74,7 +74,7 @@ private[netty] class NettyStreamManager(rpcEnv: NettyRpcEnv)
   }
 
   override def addJar(file: File): String = {
-    val existingPath = jars.putIfAbsent(file.getName, file)
+    val existingPath = jars.putIfAbsent(file.getName, file.getCanonicalFile)
     require(existingPath == null || existingPath == file,
       s"File ${file.getName} was already registered with a different path " +
         s"(old path = $existingPath, new path = $file")
@@ -83,7 +83,7 @@ private[netty] class NettyStreamManager(rpcEnv: NettyRpcEnv)
 
   override def addDirectory(baseUri: String, path: File): String = {
     val fixedBaseUri = validateDirectoryUri(baseUri)
-    require(dirs.putIfAbsent(fixedBaseUri.stripPrefix("/"), path) == null,
+    require(dirs.putIfAbsent(fixedBaseUri.stripPrefix("/"), path.getCanonicalFile) == null,
       s"URI '$fixedBaseUri' already registered.")
     s"${rpcEnv.address.toSparkURL}$fixedBaseUri"
   }

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyStreamManager.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyStreamManager.scala
@@ -66,16 +66,18 @@ private[netty] class NettyStreamManager(rpcEnv: NettyRpcEnv)
   }
 
   override def addFile(file: File): String = {
-    val existingPath = files.putIfAbsent(file.getName, file.getCanonicalFile)
-    require(existingPath == null || existingPath == file,
+    val canonicalFile = file.getCanonicalFile
+    val existingPath = files.putIfAbsent(file.getName, canonicalFile)
+    require(existingPath == null || existingPath == canonicalFile,
       s"File ${file.getName} was already registered with a different path " +
         s"(old path = $existingPath, new path = $file")
     s"${rpcEnv.address.toSparkURL}/files/${Utils.encodeFileNameToURIRawPath(file.getName())}"
   }
 
   override def addJar(file: File): String = {
-    val existingPath = jars.putIfAbsent(file.getName, file.getCanonicalFile)
-    require(existingPath == null || existingPath == file,
+    val canonicalFile = file.getCanonicalFile
+    val existingPath = jars.putIfAbsent(file.getName, canonicalFile)
+    require(existingPath == null || existingPath == canonicalFile,
       s"File ${file.getName} was already registered with a different path " +
         s"(old path = $existingPath, new path = $file")
     s"${rpcEnv.address.toSparkURL}/jars/${Utils.encodeFileNameToURIRawPath(file.getName())}"

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2051,7 +2051,7 @@ private[spark] object Utils extends Logging {
     } catch {
       case e: URISyntaxException =>
     }
-    new File(path).getAbsoluteFile().toURI()
+    new File(path).getCanonicalFile().toURI()
   }
 
   /** Resolve a comma-separated list of paths. */

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -21,8 +21,10 @@ import java.io.File
 import java.net.{MalformedURLException, URI}
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.{CountDownLatch, Semaphore, TimeUnit}
+
 import scala.concurrent.duration._
 import scala.io.Source
+
 import com.google.common.io.Files
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -33,6 +35,7 @@ import org.json4s.{DefaultFormats, Extraction}
 import org.junit.Assert.{assertEquals, assertFalse}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.must.Matchers._
+
 import org.apache.spark.TestUtils._
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Tests._

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1289,7 +1289,8 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
   test("SPARK-35691: addFile/addJar/addDirectory should put CanonicalFile") {
     withTempDir { dir =>
       try {
-        sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
+        sc = new SparkContext(
+          new SparkConf().setAppName("test").setMaster("local-cluster[3, 1, 1024]"))
 
         val sep = File.separator
         val tmpCanonicalDir = Utils.createTempDir(dir.getAbsolutePath + sep + "test space")
@@ -1297,14 +1298,16 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
         val tmpJar = File.createTempFile("test", ".jar", tmpAbsoluteDir)
         val tmpFile = File.createTempFile("test", ".txt", tmpAbsoluteDir)
 
-        assert(tmpJar.getAbsolutePath != tmpJar.getCanonicalPath)
-        assert(tmpFile.getAbsolutePath != tmpFile.getCanonicalPath)
+        // Check those files are not canonical
+        assert(tmpCanonicalDir.getAbsolutePath !== tmpCanonicalDir.getCanonicalPath)
+        assert(tmpJar.getAbsolutePath !== tmpJar.getCanonicalPath)
+        assert(tmpFile.getAbsolutePath !== tmpFile.getCanonicalPath)
 
         sc.addJar(tmpJar.getAbsolutePath)
         sc.addFile(tmpFile.getAbsolutePath)
 
-        assert(sc.listJars().size == 1)
-        assert(sc.listFiles().size == 1)
+        assert(sc.listJars().size === 1)
+        assert(sc.listFiles().size === 1)
         assert(sc.listJars().head.contains(tmpJar.getName))
         assert(sc.listFiles().head.contains(tmpFile.getName))
         assert(!sc.listJars().head.contains("." + sep))

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1298,8 +1298,8 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
         val tmpJar = File.createTempFile("test", ".jar", tmpAbsoluteDir)
         val tmpFile = File.createTempFile("test", ".txt", tmpAbsoluteDir)
 
-        // Check those files are not canonical
-        assert(tmpCanonicalDir.getAbsolutePath !== tmpCanonicalDir.getCanonicalPath)
+        // Check those files and directory are not canonical
+        assert(tmpAbsoluteDir.getAbsolutePath !== tmpAbsoluteDir.getCanonicalPath)
         assert(tmpJar.getAbsolutePath !== tmpJar.getCanonicalPath)
         assert(tmpFile.getAbsolutePath !== tmpFile.getCanonicalPath)
 

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1289,16 +1289,17 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
   test("SPARK-35691: addFile/addJar/addDirectory should put CanonicalFile") {
     withTempDir { dir =>
       try {
+        sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
+
         val sep = File.separator
         val tmpCanonicalDir = Utils.createTempDir(dir.getAbsolutePath + sep + "test space")
         val tmpAbsoluteDir = new File(tmpCanonicalDir.getAbsolutePath + sep + '.' + sep)
         val tmpJar = File.createTempFile("test", ".jar", tmpAbsoluteDir)
         val tmpFile = File.createTempFile("test", ".txt", tmpAbsoluteDir)
 
-        assert(tmpJar.getAbsolutePath == tmpJar.getCanonicalPath)
-        assert(tmpFile.getAbsolutePath == tmpFile.getCanonicalPath)
+        assert(tmpJar.getAbsolutePath != tmpJar.getCanonicalPath)
+        assert(tmpFile.getAbsolutePath != tmpFile.getCanonicalPath)
 
-        sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
         sc.addJar(tmpJar.getAbsolutePath)
         sc.addFile(tmpFile.getAbsolutePath)
 

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -901,6 +901,15 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
           }
         }
 
+        // Try registering directories that have different
+        // absolute path but have same canonical path
+        intercept[IllegalArgumentException] {
+          env.fileServer.addDirectory("/dir1/././", dir1)
+        }
+        intercept[IllegalArgumentException] {
+          env.fileServer.addDirectory("/dir2/../dir2/", dir2)
+        }
+
         val hc = SparkHadoopUtil.get.conf
 
         val files = Seq(

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -893,12 +893,12 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
 
         val file1Uri = env.fileServer.addFile(file1)
         val file2Uri = env.fileServer.addFile(file2)
-        assert(file1Uri == file2Uri)
+        assert(file1Uri === file2Uri)
         val fileWithSpecialCharsUri = env.fileServer.addFile(fileWithSpecialChars)
         val emptyUri = env.fileServer.addFile(empty)
         val jar1Uri = env.fileServer.addJar(jar1)
         val jar2Uri = env.fileServer.addJar(jar2)
-        assert(jar1Uri == jar2Uri)
+        assert(jar1Uri === jar2Uri)
         val dir1Uri = env.fileServer.addDirectory("/dir1", dir1)
         val dir2Uri = env.fileServer.addDirectory("/dir2", dir2)
         // Try registering directories with invalid names.

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -868,14 +868,18 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
       withTempDir { destDir =>
         val conf = new SparkConf()
 
-        val file = new File(tempDir, "file")
-        Files.write(UUID.randomUUID().toString(), file, UTF_8)
+        val file1 = new File(tempDir, "file")
+        Files.write(UUID.randomUUID().toString(), file1, UTF_8)
+        val file2 = new File(tempDir, "/./././file")
+        Files.write(UUID.randomUUID().toString(), file2, UTF_8)
         val fileWithSpecialChars = new File(tempDir, "file name")
         Files.write(UUID.randomUUID().toString(), fileWithSpecialChars, UTF_8)
         val empty = new File(tempDir, "empty")
         Files.write("", empty, UTF_8);
-        val jar = new File(tempDir, "jar")
-        Files.write(UUID.randomUUID().toString(), jar, UTF_8)
+        val jar1 = new File(tempDir, "jar1")
+        Files.write(UUID.randomUUID().toString(), jar1, UTF_8)
+        val jar2 = new File(tempDir, "/./././jar1")
+        Files.write(UUID.randomUUID().toString(), jar2, UTF_8)
 
         val dir1 = new File(tempDir, "dir1")
         assert(dir1.mkdir())
@@ -887,13 +891,16 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
         val subFile2 = new File(dir2, "file2")
         Files.write(UUID.randomUUID().toString(), subFile2, UTF_8)
 
-        val fileUri = env.fileServer.addFile(file)
+        val file1Uri = env.fileServer.addFile(file1)
+        val file2Uri = env.fileServer.addFile(file2)
+        assert(file1Uri == file2Uri)
         val fileWithSpecialCharsUri = env.fileServer.addFile(fileWithSpecialChars)
         val emptyUri = env.fileServer.addFile(empty)
-        val jarUri = env.fileServer.addJar(jar)
+        val jar1Uri = env.fileServer.addJar(jar1)
+        val jar2Uri = env.fileServer.addJar(jar2)
+        assert(jar1Uri == jar2Uri)
         val dir1Uri = env.fileServer.addDirectory("/dir1", dir1)
         val dir2Uri = env.fileServer.addDirectory("/dir2", dir2)
-
         // Try registering directories with invalid names.
         Seq("/files", "/jars").foreach { uri =>
           intercept[IllegalArgumentException] {
@@ -913,10 +920,10 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
         val hc = SparkHadoopUtil.get.conf
 
         val files = Seq(
-          (file, fileUri),
+          (file1, file1Uri),
           (fileWithSpecialChars, fileWithSpecialCharsUri),
           (empty, emptyUri),
-          (jar, jarUri),
+          (jar1, jar1Uri),
           (subFile1, dir1Uri + "/file1"),
           (subFile2, dir2Uri + "/file2"))
         files.foreach { case (f, uri) =>

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -868,18 +868,14 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
       withTempDir { destDir =>
         val conf = new SparkConf()
 
-        val file1 = new File(tempDir, "file")
-        Files.write(UUID.randomUUID().toString(), file1, UTF_8)
-        val file2 = new File(tempDir, "/./././file")
-        Files.write(UUID.randomUUID().toString(), file2, UTF_8)
+        val file = new File(tempDir, "file")
+        Files.write(UUID.randomUUID().toString(), file, UTF_8)
         val fileWithSpecialChars = new File(tempDir, "file name")
         Files.write(UUID.randomUUID().toString(), fileWithSpecialChars, UTF_8)
         val empty = new File(tempDir, "empty")
         Files.write("", empty, UTF_8);
-        val jar1 = new File(tempDir, "jar1")
-        Files.write(UUID.randomUUID().toString(), jar1, UTF_8)
-        val jar2 = new File(tempDir, "/./././jar1")
-        Files.write(UUID.randomUUID().toString(), jar2, UTF_8)
+        val jar = new File(tempDir, "jar")
+        Files.write(UUID.randomUUID().toString(), jar, UTF_8)
 
         val dir1 = new File(tempDir, "dir1")
         assert(dir1.mkdir())
@@ -891,16 +887,13 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
         val subFile2 = new File(dir2, "file2")
         Files.write(UUID.randomUUID().toString(), subFile2, UTF_8)
 
-        val file1Uri = env.fileServer.addFile(file1)
-        val file2Uri = env.fileServer.addFile(file2)
-        assert(file1Uri === file2Uri)
+        val fileUri = env.fileServer.addFile(file)
         val fileWithSpecialCharsUri = env.fileServer.addFile(fileWithSpecialChars)
         val emptyUri = env.fileServer.addFile(empty)
-        val jar1Uri = env.fileServer.addJar(jar1)
-        val jar2Uri = env.fileServer.addJar(jar2)
-        assert(jar1Uri === jar2Uri)
+        val jarUri = env.fileServer.addJar(jar)
         val dir1Uri = env.fileServer.addDirectory("/dir1", dir1)
         val dir2Uri = env.fileServer.addDirectory("/dir2", dir2)
+
         // Try registering directories with invalid names.
         Seq("/files", "/jars").foreach { uri =>
           intercept[IllegalArgumentException] {
@@ -920,10 +913,10 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
         val hc = SparkHadoopUtil.get.conf
 
         val files = Seq(
-          (file1, file1Uri),
+          (file, fileUri),
           (fileWithSpecialChars, fileWithSpecialCharsUri),
           (empty, emptyUri),
-          (jar1, jar1Uri),
+          (jar, jarUri),
           (subFile1, dir1Uri + "/file1"),
           (subFile2, dir2Uri + "/file2"))
         files.foreach { case (f, uri) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`addFile/addJar/addDirectory` should put CanonicalFile

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I met the error below.
 

21/06/07 00:06:57 ERROR SparkContext: Failed to add file:/home/runner/work/spark/spark/./core/target/scala-2.12/spark-
core_2.12-3.2.0-SNAPSHOT-tests.jar to Spark environment    
java.lang.IllegalArgumentException: requirement failed: File spark-core_2.12-3.2.0-SNAPSHOT-tests.jar was already registered with a different path (old path = /home/runner/work/spark/spark/core/target/scala-2.12/spark-core_2.12-3.2.0-SNAPSHOT-tests.jar, new path = /home/runner/work/spark/spark/./core/target/scala-2.12/spark-core_2.12-3.2.0-SNAPSHOT-tests.jar But actually, /home/runner/work/spark/spark/./core/target/scala-2.12/spark-core_2.12-3.2.0-SNAPSHOT-tests.jar* and * /*home/runner/work/spark/spark/core/target/scala-2.12/spark-core_2.12-3.2.0-SNAPSHOT-tests.jar are the same*.

But actually, `/home/runner/work/spark/spark/./core/target/scala-2.12/spark-core_2.12-3.2.0-SNAPSHOT-tests.jar`and `/home/runner/work/spark/spark/core/target/scala-2.12/spark-core_2.12-3.2.0-SNAPSHOT-tests.jar` are the same.

I think we should put the Canonical File in ConcurrentHashMap.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass the CIs.