### PR TITLE
[SPARK-35616][PYTHON] Make `astype` method data-type-based

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -29,14 +29,9 @@ from pandas.api.types import is_list_like, CategoricalDtype
 from pyspark import sql as spark
 from pyspark.sql import functions as F, Window, Column
 from pyspark.sql.types import (
-    BooleanType,
-    DateType,
     DoubleType,
     FloatType,
     LongType,
-    NumericType,
-    StringType,
-    TimestampType,
 )
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
@@ -52,7 +47,6 @@ from pyspark.pandas.spark.accessors import SparkIndexOpsMethods
 from pyspark.pandas.typedef import (
     Dtype,
     extension_dtypes,
-    pandas_on_spark_type,
 )
 from pyspark.pandas.utils import (
     combine_frames,
@@ -802,103 +796,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         >>> ser.rename("a").to_frame().set_index("a").index.astype('int64')
         Int64Index([1, 2], dtype='int64', name='a')
         """
-        dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
-
-        if isinstance(self.dtype, CategoricalDtype):
-            if isinstance(dtype, CategoricalDtype) and dtype.categories is None:
-                return cast(Union[ps.Index, ps.Series], self).copy()
-
-            categories = self.dtype.categories
-            if len(categories) == 0:
-                scol = F.lit(None)
-            else:
-                kvs = chain(
-                    *[(F.lit(code), F.lit(category)) for code, category in enumerate(categories)]
-                )
-                map_scol = F.create_map(*kvs)
-                scol = map_scol.getItem(self.spark.column)
-            return self._with_new_scol(
-                scol.alias(self._internal.data_spark_column_names[0])
-            ).astype(dtype)
-        elif isinstance(dtype, CategoricalDtype):
-            if dtype.categories is None:
-                codes, uniques = self.factorize()
-                return codes._with_new_scol(
-                    codes.spark.column,
-                    field=codes._internal.data_fields[0].copy(
-                        dtype=CategoricalDtype(categories=uniques)
-                    ),
-                )
-            else:
-                categories = dtype.categories
-                if len(categories) == 0:
-                    scol = F.lit(-1)
-                else:
-                    kvs = chain(
-                        *[
-                            (F.lit(category), F.lit(code))
-                            for code, category in enumerate(categories)
-                        ]
-                    )
-                    map_scol = F.create_map(*kvs)
-
-                    scol = F.coalesce(map_scol.getItem(self.spark.column), F.lit(-1))
-                return self._with_new_scol(
-                    scol.cast(spark_type).alias(self._internal.data_fields[0].name),
-                    field=self._internal.data_fields[0].copy(
-                        dtype=dtype, spark_type=spark_type, nullable=False
-                    ),
-                )
-
-        if isinstance(spark_type, BooleanType):
-            if isinstance(dtype, extension_dtypes):
-                scol = self.spark.column.cast(spark_type)
-            else:
-                if isinstance(self.spark.data_type, StringType):
-                    scol = F.when(self.spark.column.isNull(), F.lit(False)).otherwise(
-                        F.length(self.spark.column) > 0
-                    )
-                elif isinstance(self.spark.data_type, (FloatType, DoubleType)):
-                    scol = F.when(
-                        self.spark.column.isNull() | F.isnan(self.spark.column), F.lit(True)
-                    ).otherwise(self.spark.column.cast(spark_type))
-                else:
-                    scol = F.when(self.spark.column.isNull(), F.lit(False)).otherwise(
-                        self.spark.column.cast(spark_type)
-                    )
-        elif isinstance(spark_type, StringType):
-            if isinstance(dtype, extension_dtypes):
-                if isinstance(self.spark.data_type, BooleanType):
-                    scol = F.when(
-                        self.spark.column.isNotNull(),
-                        F.when(self.spark.column, "True").otherwise("False"),
-                    )
-                elif isinstance(self.spark.data_type, TimestampType):
-                    # seems like a pandas' bug?
-                    scol = F.when(self.spark.column.isNull(), str(pd.NaT)).otherwise(
-                        self.spark.column.cast(spark_type)
-                    )
-                else:
-                    scol = self.spark.column.cast(spark_type)
-            else:
-                if isinstance(self.spark.data_type, NumericType):
-                    null_str = str(np.nan)
-                elif isinstance(self.spark.data_type, (DateType, TimestampType)):
-                    null_str = str(pd.NaT)
-                else:
-                    null_str = str(None)
-                if isinstance(self.spark.data_type, BooleanType):
-                    casted = F.when(self.spark.column, "True").otherwise("False")
-                else:
-                    casted = self.spark.column.cast(spark_type)
-                scol = F.when(self.spark.column.isNull(), null_str).otherwise(casted)
-        else:
-            scol = self.spark.column.cast(spark_type)
-        return self._with_new_scol(
-            scol.alias(self._internal.data_spark_column_names[0]), field=InternalField(dtype=dtype)
-        )
+        return self._dtype_op.astype(self, dtype)
 
     def isin(self, values) -> Union["Series", "Index"]:
         """

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -93,7 +93,7 @@ def transform_boolean_operand_to_numeric(
 
 def _as_categorical_type(
     index_ops: Union["Series", "Index"], dtype: CategoricalDtype, spark_type: types.DataType
-):
+) -> Union["Index", "Series"]:
     """Cast `index_ops` to categorical dtype, given `dtype` and `spark_type`."""
     assert isinstance(dtype, CategoricalDtype)
     if dtype.categories is None:

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -139,6 +139,28 @@ def _as_bool_type(
     )
 
 
+def _as_string_type(
+    index_ops: Union["Series", "Index"],
+    dtype: Union[str, type, Dtype],
+    *,
+    null_str: str = str(None)
+) -> Union["Index", "Series"]:
+    """
+    Cast `index_ops` to StringType Spark type, given `dtype` and
+    `null_str` representing null Spark column."""
+    from pyspark.pandas.internal import InternalField
+
+    if isinstance(dtype, extension_dtypes):
+        scol = index_ops.spark.column.cast(StringType())
+    else:
+        casted = index_ops.spark.column.cast(StringType())
+        scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+    return index_ops._with_new_scol(
+        scol.alias(index_ops._internal.data_spark_column_names[0]),
+        field=InternalField(dtype=dtype),
+    )
+
+
 class DataTypeOps(object, metaclass=ABCMeta):
     """The base class for binary operations of pandas-on-Spark objects (of different data types)."""
 

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -51,7 +51,6 @@ if extension_object_dtypes_available:
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.base import IndexOpsMixin
 
 
 def is_valid_operand_for_numeric_arithmetic(operand: Any, *, allow_bool: bool = True) -> bool:

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -206,3 +206,8 @@ class DataTypeOps(object, metaclass=ABCMeta):
     def prepare(self, col: pd.Series) -> pd.Series:
         """Prepare column when from_pandas."""
         return col.replace({np.nan: None})
+
+    def astype(
+        self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
+    ) -> Union["Index", "Series"]:
+        raise TypeError("astype can not be applied to %s." % self.pretty_name)

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -93,7 +93,7 @@ def transform_boolean_operand_to_numeric(
 
 
 def _as_categorical_type(
-    index_ops: "IndexOpsMixin", dtype: CategoricalDtype, spark_type: types.DataType
+    index_ops: Union["Series", "Index"], dtype: CategoricalDtype, spark_type: types.DataType
 ):
     """Cast `index_ops` to categorical dtype, given `dtype` and `spark_type`."""
     assert isinstance(dtype, CategoricalDtype)

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -41,7 +41,6 @@ from pyspark.sql.types import (
     TimestampType,
     UserDefinedType,
 )
-import pyspark.sql.types as types
 from pyspark.pandas.typedef import Dtype, extension_dtypes
 from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
 
@@ -71,7 +70,7 @@ def is_valid_operand_for_numeric_arithmetic(operand: Any, *, allow_bool: bool = 
 
 
 def transform_boolean_operand_to_numeric(
-    operand: Any, spark_type: Optional[types.DataType] = None
+    operand: Any, spark_type: Optional[DataType] = None
 ) -> Any:
     """Transform boolean operand to numeric.
 
@@ -92,7 +91,7 @@ def transform_boolean_operand_to_numeric(
 
 
 def _as_categorical_type(
-    index_ops: Union["Series", "Index"], dtype: CategoricalDtype, spark_type: types.DataType
+    index_ops: Union["Series", "Index"], dtype: CategoricalDtype, spark_type: DataType
 ) -> Union["Index", "Series"]:
     """Cast `index_ops` to categorical dtype, given `dtype` and `spark_type`."""
     assert isinstance(dtype, CategoricalDtype)
@@ -162,7 +161,7 @@ def _as_string_type(
 
 
 def _as_other_type(
-    index_ops: Union["Series", "Index"], dtype: Union[str, type, Dtype], spark_type: types.DataType
+    index_ops: Union["Series", "Index"], dtype: Union[str, type, Dtype], spark_type: DataType
 ) -> Union["Index", "Series"]:
     """Cast `index_ops` to a `dtype` (`spark_type`) that needs no pre-processing.
 

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Union
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
+from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_bool_type, _as_categorical_type
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 from pyspark.sql import functions as F
@@ -68,13 +68,9 @@ class BinaryOps(DataTypeOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
 
-        if isinstance(spark_type, BooleanType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
-                    index_ops.spark.column.cast(spark_type)
-                )
+        elif isinstance(spark_type, BooleanType):
+            return _as_bool_type(index_ops, dtype)
+
         elif isinstance(spark_type, StringType):
             if isinstance(dtype, extension_dtypes):
                 scol = index_ops.spark.column.cast(spark_type)

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -15,12 +15,17 @@
 # limitations under the License.
 #
 
+from itertools import chain
 from typing import TYPE_CHECKING, Union
 
-from pyspark.sql import functions as F
-from pyspark.sql.types import BinaryType
+from pandas.api.types import CategoricalDtype
+
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.internal import InternalField
+from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
+from pyspark.sql import functions as F
+from pyspark.sql.types import BinaryType, BooleanType, StringType
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -53,3 +58,61 @@ class BinaryOps(DataTypeOps):
             raise TypeError(
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name
             )
+
+    def astype(
+        self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
+    ) -> Union["Index", "Series"]:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+        if not spark_type:
+            raise ValueError("Type {} not understood".format(dtype))
+
+        if isinstance(dtype, CategoricalDtype):
+            if dtype.categories is None:
+                codes, uniques = index_ops.factorize()
+                return codes._with_new_scol(
+                    codes.spark.column,
+                    field=codes._internal.data_fields[0].copy(
+                        dtype=CategoricalDtype(categories=uniques)
+                    ),
+                )
+            else:
+                categories = dtype.categories
+                if len(categories) == 0:
+                    scol = F.lit(-1)
+                else:
+                    kvs = chain(
+                        *[
+                            (F.lit(category), F.lit(code))
+                            for code, category in enumerate(categories)
+                        ]
+                    )
+                    map_scol = F.create_map(*kvs)
+
+                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
+                return index_ops._with_new_scol(
+                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
+                    field=index_ops._internal.data_fields[0].copy(
+                        dtype=dtype, spark_type=spark_type, nullable=False
+                    ),
+                )
+
+        if isinstance(spark_type, BooleanType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
+                    index_ops.spark.column.cast(spark_type)
+                )
+        elif isinstance(spark_type, StringType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                null_str = str(None)
+                casted = index_ops.spark.column.cast(spark_type)
+                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+        else:
+            scol = index_ops.spark.column.cast(spark_type)
+        return index_ops._with_new_scol(
+            scol.alias(index_ops._internal.data_spark_column_names[0]),
+            field=InternalField(dtype=dtype),
+        )

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -67,8 +67,6 @@ class BinaryOps(DataTypeOps):
         self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
     ) -> Union["Index", "Series"]:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -20,9 +20,14 @@ from typing import TYPE_CHECKING, Union
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_bool_type, _as_categorical_type
+from pyspark.pandas.data_type_ops.base import (
+    DataTypeOps,
+    _as_bool_type,
+    _as_categorical_type,
+    _as_string_type,
+)
 from pyspark.pandas.internal import InternalField
-from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.types import BinaryType, BooleanType, StringType
 
@@ -72,12 +77,7 @@ class BinaryOps(DataTypeOps):
             return _as_bool_type(index_ops, dtype)
 
         elif isinstance(spark_type, StringType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                null_str = str(None)
-                casted = index_ops.spark.column.cast(spark_type)
-                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+            return _as_string_type(index_ops, dtype)
         else:
             scol = index_ops.spark.column.cast(spark_type)
         return index_ops._with_new_scol(

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -24,9 +24,9 @@ from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     _as_bool_type,
     _as_categorical_type,
+    _as_other_type,
     _as_string_type,
 )
-from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.types import BinaryType, BooleanType, StringType
@@ -72,15 +72,9 @@ class BinaryOps(DataTypeOps):
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
-
         elif isinstance(spark_type, BooleanType):
             return _as_bool_type(index_ops, dtype)
-
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype)
         else:
-            scol = index_ops.spark.column.cast(spark_type)
-        return index_ops._with_new_scol(
-            scol.alias(index_ops._internal.data_spark_column_names[0]),
-            field=InternalField(dtype=dtype),
-        )
+            return _as_other_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -15,13 +15,12 @@
 # limitations under the License.
 #
 
-from itertools import chain
 from typing import TYPE_CHECKING, Union
 
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 from pyspark.sql import functions as F
@@ -67,34 +66,7 @@ class BinaryOps(DataTypeOps):
             raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
-            if dtype.categories is None:
-                codes, uniques = index_ops.factorize()
-                return codes._with_new_scol(
-                    codes.spark.column,
-                    field=codes._internal.data_fields[0].copy(
-                        dtype=CategoricalDtype(categories=uniques)
-                    ),
-                )
-            else:
-                categories = dtype.categories
-                if len(categories) == 0:
-                    scol = F.lit(-1)
-                else:
-                    kvs = chain(
-                        *[
-                            (F.lit(category), F.lit(code))
-                            for code, category in enumerate(categories)
-                        ]
-                    )
-                    map_scol = F.create_map(*kvs)
-
-                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
-                return index_ops._with_new_scol(
-                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
-                    field=index_ops._internal.data_fields[0].copy(
-                        dtype=dtype, spark_type=spark_type, nullable=False
-                    ),
-                )
+            return _as_categorical_type(index_ops, dtype, spark_type)
 
         if isinstance(spark_type, BooleanType):
             if isinstance(dtype, extension_dtypes):

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -27,6 +27,7 @@ from pyspark.pandas.data_type_ops.base import (
     is_valid_operand_for_numeric_arithmetic,
     DataTypeOps,
     transform_boolean_operand_to_numeric,
+    _as_bool_type,
     _as_categorical_type,
 )
 from pyspark.pandas.internal import InternalField
@@ -258,13 +259,8 @@ class BooleanOps(DataTypeOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
 
-        if isinstance(spark_type, BooleanType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
-                    index_ops.spark.column.cast(spark_type)
-                )
+        elif isinstance(spark_type, BooleanType):
+            return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
             if isinstance(dtype, extension_dtypes):
                 scol = F.when(

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -29,6 +29,7 @@ from pyspark.pandas.data_type_ops.base import (
     transform_boolean_operand_to_numeric,
     _as_bool_type,
     _as_categorical_type,
+    _as_other_type,
 )
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
@@ -258,7 +259,6 @@ class BooleanOps(DataTypeOps):
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
-
         elif isinstance(spark_type, BooleanType):
             return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
@@ -271,12 +271,12 @@ class BooleanOps(DataTypeOps):
                 null_str = str(None)
                 casted = F.when(index_ops.spark.column, "True").otherwise("False")
                 scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+            return index_ops._with_new_scol(
+                scol.alias(index_ops._internal.data_spark_column_names[0]),
+                field=InternalField(dtype=dtype),
+            )
         else:
-            scol = index_ops.spark.column.cast(spark_type)
-        return index_ops._with_new_scol(
-            scol.alias(index_ops._internal.data_spark_column_names[0]),
-            field=InternalField(dtype=dtype),
-        )
+            return _as_other_type(index_ops, dtype, spark_type)
 
 
 class BooleanExtensionOps(BooleanOps):

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -16,9 +16,11 @@
 #
 
 import numbers
+from itertools import chain
 from typing import TYPE_CHECKING, Union
 
 import pandas as pd
+from pandas.api.types import CategoricalDtype
 
 from pyspark import sql as spark
 from pyspark.pandas.base import column_op, IndexOpsMixin
@@ -27,10 +29,11 @@ from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     transform_boolean_operand_to_numeric,
 )
-from pyspark.pandas.typedef import extension_dtypes
+from pyspark.pandas.internal import InternalField
+from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 from pyspark.pandas.typedef.typehints import as_spark_type
 from pyspark.sql import functions as F
-from pyspark.sql.types import BooleanType
+from pyspark.sql.types import BooleanType, StringType
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -244,6 +247,67 @@ class BooleanOps(DataTypeOps):
                     return F.when(left.isNull() | scol.isNull(), False).otherwise(scol)
 
             return column_op(or_func)(left, right)
+
+    def astype(
+        self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
+    ) -> Union["Index", "Series"]:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+        if not spark_type:
+            raise ValueError("Type {} not understood".format(dtype))
+
+        if isinstance(dtype, CategoricalDtype):
+            if dtype.categories is None:
+                codes, uniques = index_ops.factorize()
+                return codes._with_new_scol(
+                    codes.spark.column,
+                    field=codes._internal.data_fields[0].copy(
+                        dtype=CategoricalDtype(categories=uniques)
+                    ),
+                )
+            else:
+                categories = dtype.categories
+                if len(categories) == 0:
+                    scol = F.lit(-1)
+                else:
+                    kvs = chain(
+                        *[
+                            (F.lit(category), F.lit(code))
+                            for code, category in enumerate(categories)
+                        ]
+                    )
+                    map_scol = F.create_map(*kvs)
+
+                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
+                return index_ops._with_new_scol(
+                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
+                    field=index_ops._internal.data_fields[0].copy(
+                        dtype=dtype, spark_type=spark_type, nullable=False
+                    ),
+                )
+
+        if isinstance(spark_type, BooleanType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
+                    index_ops.spark.column.cast(spark_type)
+                )
+        elif isinstance(spark_type, StringType):
+            if isinstance(dtype, extension_dtypes):
+                scol = F.when(
+                    index_ops.spark.column.isNotNull(),
+                    F.when(index_ops.spark.column, "True").otherwise("False"),
+                )
+            else:
+                null_str = str(None)
+                casted = F.when(index_ops.spark.column, "True").otherwise("False")
+                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+        else:
+            scol = index_ops.spark.column.cast(spark_type)
+        return index_ops._with_new_scol(
+            scol.alias(index_ops._internal.data_spark_column_names[0]),
+            field=InternalField(dtype=dtype),
+        )
 
 
 class BooleanExtensionOps(BooleanOps):

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -16,7 +16,6 @@
 #
 
 import numbers
-from itertools import chain
 from typing import TYPE_CHECKING, Union
 
 import pandas as pd
@@ -28,6 +27,7 @@ from pyspark.pandas.data_type_ops.base import (
     is_valid_operand_for_numeric_arithmetic,
     DataTypeOps,
     transform_boolean_operand_to_numeric,
+    _as_categorical_type,
 )
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
@@ -256,34 +256,7 @@ class BooleanOps(DataTypeOps):
             raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
-            if dtype.categories is None:
-                codes, uniques = index_ops.factorize()
-                return codes._with_new_scol(
-                    codes.spark.column,
-                    field=codes._internal.data_fields[0].copy(
-                        dtype=CategoricalDtype(categories=uniques)
-                    ),
-                )
-            else:
-                categories = dtype.categories
-                if len(categories) == 0:
-                    scol = F.lit(-1)
-                else:
-                    kvs = chain(
-                        *[
-                            (F.lit(category), F.lit(code))
-                            for code, category in enumerate(categories)
-                        ]
-                    )
-                    map_scol = F.create_map(*kvs)
-
-                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
-                return index_ops._with_new_scol(
-                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
-                    field=index_ops._internal.data_fields[0].copy(
-                        dtype=dtype, spark_type=spark_type, nullable=False
-                    ),
-                )
+            return _as_categorical_type(index_ops, dtype, spark_type)
 
         if isinstance(spark_type, BooleanType):
             if isinstance(dtype, extension_dtypes):

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -254,8 +254,6 @@ class BooleanOps(DataTypeOps):
         self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
     ) -> Union["Index", "Series"]:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -73,4 +73,4 @@ class CategoricalOps(DataTypeOps):
         return index_ops._with_new_scol(
             scol.alias(index_ops._internal.data_spark_column_names[0]),
             field=InternalField(dtype=dtype),
-        )
+        ).astype(dtype)

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -71,6 +71,5 @@ class CategoricalOps(DataTypeOps):
             map_scol = F.create_map(*kvs)
             scol = map_scol.getItem(index_ops.spark.column)
         return index_ops._with_new_scol(
-            scol.alias(index_ops._internal.data_spark_column_names[0]),
-            field=InternalField(dtype=dtype),
+            scol.alias(index_ops._internal.data_spark_column_names[0])
         ).astype(dtype)

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -59,7 +59,7 @@ class CategoricalOps(DataTypeOps):
             raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype) and dtype.categories is None:
-            return cast(Union[ps.Index, ps.Series], self).copy()
+            return cast(Union[ps.Index, ps.Series], index_ops).copy()
 
         categories = index_ops.dtype.categories
         if len(categories) == 0:

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -23,7 +23,6 @@ from pandas.api.types import CategoricalDtype
 
 import pyspark.pandas as ps
 from pyspark.pandas.data_type_ops.base import DataTypeOps
-from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql import functions as F
 

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -15,9 +15,21 @@
 # limitations under the License.
 #
 
-import pandas as pd
+from itertools import chain
+from typing import cast, TYPE_CHECKING, Union
 
+import pandas as pd
+from pandas.api.types import CategoricalDtype
+
+import pyspark.pandas as ps
 from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.internal import InternalField
+from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
+from pyspark.sql import functions as F
+
+if TYPE_CHECKING:
+    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class CategoricalOps(DataTypeOps):
@@ -38,3 +50,27 @@ class CategoricalOps(DataTypeOps):
     def prepare(self, col: pd.Series) -> pd.Series:
         """Prepare column when from_pandas."""
         return col.cat.codes
+
+    def astype(
+        self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
+    ) -> Union["Index", "Series"]:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+        if not spark_type:
+            raise ValueError("Type {} not understood".format(dtype))
+
+        if isinstance(dtype, CategoricalDtype) and dtype.categories is None:
+            return cast(Union[ps.Index, ps.Series], self).copy()
+
+        categories = index_ops.dtype.categories
+        if len(categories) == 0:
+            scol = F.lit(None)
+        else:
+            kvs = chain(
+                *[(F.lit(code), F.lit(category)) for code, category in enumerate(categories)]
+            )
+            map_scol = F.create_map(*kvs)
+            scol = map_scol.getItem(index_ops.spark.column)
+        return index_ops._with_new_scol(
+            scol.alias(index_ops._internal.data_spark_column_names[0]),
+            field=InternalField(dtype=dtype),
+        )

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -54,8 +54,6 @@ class CategoricalOps(DataTypeOps):
         self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
     ) -> Union["Index", "Series"]:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype) and dtype.categories is None:
             return cast(Union[ps.Index, ps.Series], index_ops).copy()

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -15,13 +15,12 @@
 # limitations under the License.
 #
 
-from itertools import chain
 from typing import TYPE_CHECKING, Union
 
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 from pyspark.sql import functions as F
@@ -69,34 +68,7 @@ class ArrayOps(DataTypeOps):
             raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
-            if dtype.categories is None:
-                codes, uniques = index_ops.factorize()
-                return codes._with_new_scol(
-                    codes.spark.column,
-                    field=codes._internal.data_fields[0].copy(
-                        dtype=CategoricalDtype(categories=uniques)
-                    ),
-                )
-            else:
-                categories = dtype.categories
-                if len(categories) == 0:
-                    scol = F.lit(-1)
-                else:
-                    kvs = chain(
-                        *[
-                            (F.lit(category), F.lit(code))
-                            for code, category in enumerate(categories)
-                        ]
-                    )
-                    map_scol = F.create_map(*kvs)
-
-                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
-                return index_ops._with_new_scol(
-                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
-                    field=index_ops._internal.data_fields[0].copy(
-                        dtype=dtype, spark_type=spark_type, nullable=False
-                    ),
-                )
+            return _as_categorical_type(index_ops, dtype, spark_type)
 
         if isinstance(spark_type, BooleanType):
             if isinstance(dtype, extension_dtypes):

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -24,9 +24,9 @@ from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     _as_bool_type,
     _as_categorical_type,
+    _as_other_type,
     _as_string_type,
 )
-from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.types import ArrayType, BooleanType, NumericType, StringType
@@ -74,17 +74,12 @@ class ArrayOps(DataTypeOps):
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
-
         elif isinstance(spark_type, BooleanType):
             return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype)
         else:
-            scol = index_ops.spark.column.cast(spark_type)
-        return index_ops._with_new_scol(
-            scol.alias(index_ops._internal.data_spark_column_names[0]),
-            field=InternalField(dtype=dtype),
-        )
+            return _as_other_type(index_ops, dtype, spark_type)
 
 
 class MapOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -20,9 +20,14 @@ from typing import TYPE_CHECKING, Union
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_bool_type, _as_categorical_type
+from pyspark.pandas.data_type_ops.base import (
+    DataTypeOps,
+    _as_bool_type,
+    _as_categorical_type,
+    _as_string_type,
+)
 from pyspark.pandas.internal import InternalField
-from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.types import ArrayType, BooleanType, NumericType, StringType
 
@@ -73,12 +78,7 @@ class ArrayOps(DataTypeOps):
         elif isinstance(spark_type, BooleanType):
             return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                null_str = str(None)
-                casted = index_ops.spark.column.cast(spark_type)
-                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+            return _as_string_type(index_ops, dtype)
         else:
             scol = index_ops.spark.column.cast(spark_type)
         return index_ops._with_new_scol(

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Union
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
+from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_bool_type, _as_categorical_type
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 from pyspark.sql import functions as F
@@ -70,13 +70,8 @@ class ArrayOps(DataTypeOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
 
-        if isinstance(spark_type, BooleanType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
-                    index_ops.spark.column.cast(spark_type)
-                )
+        elif isinstance(spark_type, BooleanType):
+            return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
             if isinstance(dtype, extension_dtypes):
                 scol = index_ops.spark.column.cast(spark_type)

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -15,12 +15,17 @@
 # limitations under the License.
 #
 
+from itertools import chain
 from typing import TYPE_CHECKING, Union
+
+from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.internal import InternalField
+from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 from pyspark.sql import functions as F
-from pyspark.sql.types import ArrayType, NumericType
+from pyspark.sql.types import ArrayType, BooleanType, NumericType, StringType
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -55,6 +60,64 @@ class ArrayOps(DataTypeOps):
             )
 
         return column_op(F.concat)(left, right)
+
+    def astype(
+        self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
+    ) -> Union["Index", "Series"]:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+        if not spark_type:
+            raise ValueError("Type {} not understood".format(dtype))
+
+        if isinstance(dtype, CategoricalDtype):
+            if dtype.categories is None:
+                codes, uniques = index_ops.factorize()
+                return codes._with_new_scol(
+                    codes.spark.column,
+                    field=codes._internal.data_fields[0].copy(
+                        dtype=CategoricalDtype(categories=uniques)
+                    ),
+                )
+            else:
+                categories = dtype.categories
+                if len(categories) == 0:
+                    scol = F.lit(-1)
+                else:
+                    kvs = chain(
+                        *[
+                            (F.lit(category), F.lit(code))
+                            for code, category in enumerate(categories)
+                        ]
+                    )
+                    map_scol = F.create_map(*kvs)
+
+                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
+                return index_ops._with_new_scol(
+                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
+                    field=index_ops._internal.data_fields[0].copy(
+                        dtype=dtype, spark_type=spark_type, nullable=False
+                    ),
+                )
+
+        if isinstance(spark_type, BooleanType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
+                    index_ops.spark.column.cast(spark_type)
+                )
+        elif isinstance(spark_type, StringType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                null_str = str(None)
+                casted = index_ops.spark.column.cast(spark_type)
+                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+        else:
+            scol = index_ops.spark.column.cast(spark_type)
+        return index_ops._with_new_scol(
+            scol.alias(index_ops._internal.data_spark_column_names[0]),
+            field=InternalField(dtype=dtype),
+        )
 
 
 class MapOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -69,8 +69,6 @@ class ArrayOps(DataTypeOps):
         self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
     ) -> Union["Index", "Series"]:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -17,13 +17,19 @@
 
 import datetime
 import warnings
+from itertools import chain
 from typing import TYPE_CHECKING, Union
 
+import pandas as pd
+from pandas.api.types import CategoricalDtype
+
 from pyspark.sql import functions as F
-from pyspark.sql.types import DateType
+from pyspark.sql.types import BooleanType, DateType, StringType
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.internal import InternalField
+from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -69,3 +75,61 @@ class DateOps(DataTypeOps):
             return -column_op(F.datediff)(left, F.lit(right)).astype("long")
         else:
             raise TypeError("date subtraction can only be applied to date series.")
+
+    def astype(
+        self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
+    ) -> Union["Index", "Series"]:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+        if not spark_type:
+            raise ValueError("Type {} not understood".format(dtype))
+
+        if isinstance(dtype, CategoricalDtype):
+            if dtype.categories is None:
+                codes, uniques = index_ops.factorize()
+                return codes._with_new_scol(
+                    codes.spark.column,
+                    field=codes._internal.data_fields[0].copy(
+                        dtype=CategoricalDtype(categories=uniques)
+                    ),
+                )
+            else:
+                categories = dtype.categories
+                if len(categories) == 0:
+                    scol = F.lit(-1)
+                else:
+                    kvs = chain(
+                        *[
+                            (F.lit(category), F.lit(code))
+                            for code, category in enumerate(categories)
+                        ]
+                    )
+                    map_scol = F.create_map(*kvs)
+
+                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
+                return index_ops._with_new_scol(
+                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
+                    field=index_ops._internal.data_fields[0].copy(
+                        dtype=dtype, spark_type=spark_type, nullable=False
+                    ),
+                )
+
+        if isinstance(spark_type, BooleanType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
+                    index_ops.spark.column.cast(spark_type)
+                )
+        elif isinstance(spark_type, StringType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                null_str = str(pd.NaT)
+                casted = index_ops.spark.column.cast(spark_type)
+                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+        else:
+            scol = index_ops.spark.column.cast(spark_type)
+        return index_ops._with_new_scol(
+            scol.alias(index_ops._internal.data_spark_column_names[0]),
+            field=InternalField(dtype=dtype),
+        )

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -30,9 +30,9 @@ from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     _as_bool_type,
     _as_categorical_type,
+    _as_other_type,
     _as_string_type,
 )
-from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 
 if TYPE_CHECKING:
@@ -89,14 +89,9 @@ class DateOps(DataTypeOps):
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
-
         elif isinstance(spark_type, BooleanType):
             return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype, null_str=str(pd.NaT))
         else:
-            scol = index_ops.spark.column.cast(spark_type)
-        return index_ops._with_new_scol(
-            scol.alias(index_ops._internal.data_spark_column_names[0]),
-            field=InternalField(dtype=dtype),
-        )
+            return _as_other_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -17,7 +17,6 @@
 
 import datetime
 import warnings
-from itertools import chain
 from typing import TYPE_CHECKING, Union
 
 import pandas as pd
@@ -27,7 +26,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, DateType, StringType
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 
@@ -84,34 +83,7 @@ class DateOps(DataTypeOps):
             raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
-            if dtype.categories is None:
-                codes, uniques = index_ops.factorize()
-                return codes._with_new_scol(
-                    codes.spark.column,
-                    field=codes._internal.data_fields[0].copy(
-                        dtype=CategoricalDtype(categories=uniques)
-                    ),
-                )
-            else:
-                categories = dtype.categories
-                if len(categories) == 0:
-                    scol = F.lit(-1)
-                else:
-                    kvs = chain(
-                        *[
-                            (F.lit(category), F.lit(code))
-                            for code, category in enumerate(categories)
-                        ]
-                    )
-                    map_scol = F.create_map(*kvs)
-
-                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
-                return index_ops._with_new_scol(
-                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
-                    field=index_ops._internal.data_fields[0].copy(
-                        dtype=dtype, spark_type=spark_type, nullable=False
-                    ),
-                )
+            return _as_categorical_type(index_ops, dtype, spark_type)
 
         if isinstance(spark_type, BooleanType):
             if isinstance(dtype, extension_dtypes):

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -84,8 +84,6 @@ class DateOps(DataTypeOps):
         self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
     ) -> Union["Index", "Series"]:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -26,7 +26,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, DateType, StringType
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
+from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_bool_type, _as_categorical_type
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 
@@ -85,13 +85,8 @@ class DateOps(DataTypeOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
 
-        if isinstance(spark_type, BooleanType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
-                    index_ops.spark.column.cast(spark_type)
-                )
+        elif isinstance(spark_type, BooleanType):
+            return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
             if isinstance(dtype, extension_dtypes):
                 scol = index_ops.spark.column.cast(spark_type)

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -92,8 +92,6 @@ class DatetimeOps(DataTypeOps):
         self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
     ) -> Union["Index", "Series"]:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -17,14 +17,19 @@
 
 import datetime
 import warnings
+from itertools import chain
 from typing import TYPE_CHECKING, Union
 
+import pandas as pd
+from pandas.api.types import CategoricalDtype
+
 from pyspark.sql import functions as F
-from pyspark.sql.types import TimestampType
+from pyspark.sql.types import BooleanType, StringType, TimestampType
 
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import DataTypeOps
-from pyspark.pandas.typedef import as_spark_type
+from pyspark.pandas.internal import InternalField
+from pyspark.pandas.typedef import as_spark_type, Dtype, extension_dtypes, pandas_on_spark_type
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -78,3 +83,64 @@ class DatetimeOps(DataTypeOps):
     def prepare(self, col):
         """Prepare column when from_pandas."""
         return col
+
+    def astype(
+        self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
+    ) -> Union["Index", "Series"]:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+        if not spark_type:
+            raise ValueError("Type {} not understood".format(dtype))
+
+        if isinstance(dtype, CategoricalDtype):
+            if dtype.categories is None:
+                codes, uniques = index_ops.factorize()
+                return codes._with_new_scol(
+                    codes.spark.column,
+                    field=codes._internal.data_fields[0].copy(
+                        dtype=CategoricalDtype(categories=uniques)
+                    ),
+                )
+            else:
+                categories = dtype.categories
+                if len(categories) == 0:
+                    scol = F.lit(-1)
+                else:
+                    kvs = chain(
+                        *[
+                            (F.lit(category), F.lit(code))
+                            for code, category in enumerate(categories)
+                        ]
+                    )
+                    map_scol = F.create_map(*kvs)
+
+                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
+                return index_ops._with_new_scol(
+                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
+                    field=index_ops._internal.data_fields[0].copy(
+                        dtype=dtype, spark_type=spark_type, nullable=False
+                    ),
+                )
+
+        if isinstance(spark_type, BooleanType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
+                    index_ops.spark.column.cast(spark_type)
+                )
+        elif isinstance(spark_type, StringType):
+            if isinstance(dtype, extension_dtypes):
+                # seems like a pandas' bug?
+                scol = F.when(index_ops.spark.column.isNull(), str(pd.NaT)).otherwise(
+                    index_ops.spark.column.cast(spark_type)
+                )
+            else:
+                null_str = str(pd.NaT)
+                casted = index_ops.spark.column.cast(spark_type)
+                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+        else:
+            scol = index_ops.spark.column.cast(spark_type)
+        return index_ops._with_new_scol(
+            scol.alias(index_ops._internal.data_spark_column_names[0]),
+            field=InternalField(dtype=dtype),
+        )

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -26,7 +26,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, StringType, TimestampType
 
 from pyspark.pandas.base import IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
+from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_bool_type, _as_categorical_type
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import as_spark_type, Dtype, extension_dtypes, pandas_on_spark_type
 
@@ -93,13 +93,8 @@ class DatetimeOps(DataTypeOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
 
-        if isinstance(spark_type, BooleanType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
-                    index_ops.spark.column.cast(spark_type)
-                )
+        elif isinstance(spark_type, BooleanType):
+            return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
             if isinstance(dtype, extension_dtypes):
                 # seems like a pandas' bug?

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -15,7 +15,20 @@
 # limitations under the License.
 #
 
+from itertools import chain
+from typing import TYPE_CHECKING, Union
+
+from pandas.api.types import CategoricalDtype
+
 from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.internal import InternalField
+from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
+from pyspark.sql import functions as F
+from pyspark.sql.types import BooleanType, StringType
+
+if TYPE_CHECKING:
+    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class NullOps(DataTypeOps):
@@ -26,3 +39,61 @@ class NullOps(DataTypeOps):
     @property
     def pretty_name(self) -> str:
         return "nulls"
+
+    def astype(
+        self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
+    ) -> Union["Index", "Series"]:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+        if not spark_type:
+            raise ValueError("Type {} not understood".format(dtype))
+
+        if isinstance(dtype, CategoricalDtype):
+            if dtype.categories is None:
+                codes, uniques = index_ops.factorize()
+                return codes._with_new_scol(
+                    codes.spark.column,
+                    field=codes._internal.data_fields[0].copy(
+                        dtype=CategoricalDtype(categories=uniques)
+                    ),
+                )
+            else:
+                categories = dtype.categories
+                if len(categories) == 0:
+                    scol = F.lit(-1)
+                else:
+                    kvs = chain(
+                        *[
+                            (F.lit(category), F.lit(code))
+                            for code, category in enumerate(categories)
+                        ]
+                    )
+                    map_scol = F.create_map(*kvs)
+
+                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
+                return index_ops._with_new_scol(
+                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
+                    field=index_ops._internal.data_fields[0].copy(
+                        dtype=dtype, spark_type=spark_type, nullable=False
+                    ),
+                )
+
+        if isinstance(spark_type, BooleanType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
+                    index_ops.spark.column.cast(spark_type)
+                )
+        elif isinstance(spark_type, StringType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                null_str = str(None)
+                casted = index_ops.spark.column.cast(spark_type)
+                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+        else:
+            scol = index_ops.spark.column.cast(spark_type)
+        return index_ops._with_new_scol(
+            scol.alias(index_ops._internal.data_spark_column_names[0]),
+            field=InternalField(dtype=dtype),
+        )

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -47,8 +47,6 @@ class NullOps(DataTypeOps):
         self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
     ) -> Union["Index", "Series"]:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -23,9 +23,9 @@ from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     _as_bool_type,
     _as_categorical_type,
+    _as_other_type,
     _as_string_type,
 )
-from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql.types import BooleanType, StringType
 
@@ -52,14 +52,9 @@ class NullOps(DataTypeOps):
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
-
         elif isinstance(spark_type, BooleanType):
             return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype)
         else:
-            scol = index_ops.spark.column.cast(spark_type)
-        return index_ops._with_new_scol(
-            scol.alias(index_ops._internal.data_spark_column_names[0]),
-            field=InternalField(dtype=dtype),
-        )
+            return _as_other_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -19,10 +19,14 @@ from typing import TYPE_CHECKING, Union
 
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_bool_type, _as_categorical_type
+from pyspark.pandas.data_type_ops.base import (
+    DataTypeOps,
+    _as_bool_type,
+    _as_categorical_type,
+    _as_string_type,
+)
 from pyspark.pandas.internal import InternalField
-from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
-from pyspark.sql import functions as F
+from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql.types import BooleanType, StringType
 
 if TYPE_CHECKING:
@@ -52,12 +56,7 @@ class NullOps(DataTypeOps):
         elif isinstance(spark_type, BooleanType):
             return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                null_str = str(None)
-                casted = index_ops.spark.column.cast(spark_type)
-                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+            return _as_string_type(index_ops, dtype)
         else:
             scol = index_ops.spark.column.cast(spark_type)
         return index_ops._with_new_scol(

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Union
 
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
+from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_bool_type, _as_categorical_type
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 from pyspark.sql import functions as F
@@ -49,13 +49,8 @@ class NullOps(DataTypeOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
 
-        if isinstance(spark_type, BooleanType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
-                    index_ops.spark.column.cast(spark_type)
-                )
+        elif isinstance(spark_type, BooleanType):
+            return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
             if isinstance(dtype, extension_dtypes):
                 scol = index_ops.spark.column.cast(spark_type)

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -15,12 +15,11 @@
 # limitations under the License.
 #
 
-from itertools import chain
 from typing import TYPE_CHECKING, Union
 
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 from pyspark.sql import functions as F
@@ -48,34 +47,7 @@ class NullOps(DataTypeOps):
             raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
-            if dtype.categories is None:
-                codes, uniques = index_ops.factorize()
-                return codes._with_new_scol(
-                    codes.spark.column,
-                    field=codes._internal.data_fields[0].copy(
-                        dtype=CategoricalDtype(categories=uniques)
-                    ),
-                )
-            else:
-                categories = dtype.categories
-                if len(categories) == 0:
-                    scol = F.lit(-1)
-                else:
-                    kvs = chain(
-                        *[
-                            (F.lit(category), F.lit(code))
-                            for code, category in enumerate(categories)
-                        ]
-                    )
-                    map_scol = F.create_map(*kvs)
-
-                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
-                return index_ops._with_new_scol(
-                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
-                    field=index_ops._internal.data_fields[0].copy(
-                        dtype=dtype, spark_type=spark_type, nullable=False
-                    ),
-                )
+            return _as_categorical_type(index_ops, dtype, spark_type)
 
         if isinstance(spark_type, BooleanType):
             if isinstance(dtype, extension_dtypes):

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -16,7 +16,6 @@
 #
 
 import numbers
-from itertools import chain
 from typing import TYPE_CHECKING, Union
 
 import numpy as np
@@ -27,6 +26,7 @@ from pyspark.pandas.data_type_ops.base import (
     is_valid_operand_for_numeric_arithmetic,
     DataTypeOps,
     transform_boolean_operand_to_numeric,
+    _as_categorical_type,
 )
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.spark import functions as SF
@@ -261,34 +261,7 @@ class IntegralOps(NumericOps):
             raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
-            if dtype.categories is None:
-                codes, uniques = index_ops.factorize()
-                return codes._with_new_scol(
-                    codes.spark.column,
-                    field=codes._internal.data_fields[0].copy(
-                        dtype=CategoricalDtype(categories=uniques)
-                    ),
-                )
-            else:
-                categories = dtype.categories
-                if len(categories) == 0:
-                    scol = F.lit(-1)
-                else:
-                    kvs = chain(
-                        *[
-                            (F.lit(category), F.lit(code))
-                            for code, category in enumerate(categories)
-                        ]
-                    )
-                    map_scol = F.create_map(*kvs)
-
-                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
-                return index_ops._with_new_scol(
-                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
-                    field=index_ops._internal.data_fields[0].copy(
-                        dtype=dtype, spark_type=spark_type, nullable=False
-                    ),
-                )
+            return _as_categorical_type(index_ops, dtype, spark_type)
 
         if isinstance(spark_type, BooleanType):
             if isinstance(dtype, extension_dtypes):
@@ -416,34 +389,7 @@ class FractionalOps(NumericOps):
             raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
-            if dtype.categories is None:
-                codes, uniques = index_ops.factorize()
-                return codes._with_new_scol(
-                    codes.spark.column,
-                    field=codes._internal.data_fields[0].copy(
-                        dtype=CategoricalDtype(categories=uniques)
-                    ),
-                )
-            else:
-                categories = dtype.categories
-                if len(categories) == 0:
-                    scol = F.lit(-1)
-                else:
-                    kvs = chain(
-                        *[
-                            (F.lit(category), F.lit(code))
-                            for code, category in enumerate(categories)
-                        ]
-                    )
-                    map_scol = F.create_map(*kvs)
-
-                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
-                return index_ops._with_new_scol(
-                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
-                    field=index_ops._internal.data_fields[0].copy(
-                        dtype=dtype, spark_type=spark_type, nullable=False
-                    ),
-                )
+            return _as_categorical_type(index_ops, dtype, spark_type)
 
         if isinstance(spark_type, BooleanType):
             if isinstance(dtype, extension_dtypes):

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -28,6 +28,7 @@ from pyspark.pandas.data_type_ops.base import (
     transform_boolean_operand_to_numeric,
     _as_bool_type,
     _as_categorical_type,
+    _as_string_type,
 )
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.spark import functions as SF
@@ -267,12 +268,7 @@ class IntegralOps(NumericOps):
         elif isinstance(spark_type, BooleanType):
             return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                null_str = str(np.nan)
-                casted = index_ops.spark.column.cast(spark_type)
-                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+            return _as_string_type(index_ops, dtype, null_str=str(np.nan))
         else:
             scol = index_ops.spark.column.cast(spark_type)
         return index_ops._with_new_scol(
@@ -401,12 +397,7 @@ class FractionalOps(NumericOps):
                         index_ops.spark.column.cast(spark_type)
                     )
         elif isinstance(spark_type, StringType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                null_str = str(np.nan)
-                casted = index_ops.spark.column.cast(spark_type)
-                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+            return _as_string_type(index_ops, dtype, null_str=str(np.nan))
         else:
             scol = index_ops.spark.column.cast(spark_type)
         return index_ops._with_new_scol(

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -260,8 +260,6 @@ class IntegralOps(NumericOps):
         self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
     ) -> Union["Index", "Series"]:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
@@ -373,8 +371,6 @@ class FractionalOps(NumericOps):
         self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
     ) -> Union["Index", "Series"]:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -26,6 +26,7 @@ from pyspark.pandas.data_type_ops.base import (
     is_valid_operand_for_numeric_arithmetic,
     DataTypeOps,
     transform_boolean_operand_to_numeric,
+    _as_bool_type,
     _as_categorical_type,
 )
 from pyspark.pandas.internal import InternalField
@@ -263,13 +264,8 @@ class IntegralOps(NumericOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
 
-        if isinstance(spark_type, BooleanType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
-                    index_ops.spark.column.cast(spark_type)
-                )
+        elif isinstance(spark_type, BooleanType):
+            return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
             if isinstance(dtype, extension_dtypes):
                 scol = index_ops.spark.column.cast(spark_type)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -28,6 +28,7 @@ from pyspark.pandas.data_type_ops.base import (
     transform_boolean_operand_to_numeric,
     _as_bool_type,
     _as_categorical_type,
+    _as_other_type,
     _as_string_type,
 )
 from pyspark.pandas.internal import InternalField
@@ -264,17 +265,12 @@ class IntegralOps(NumericOps):
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
-
         elif isinstance(spark_type, BooleanType):
             return _as_bool_type(index_ops, dtype)
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype, null_str=str(np.nan))
         else:
-            scol = index_ops.spark.column.cast(spark_type)
-        return index_ops._with_new_scol(
-            scol.alias(index_ops._internal.data_spark_column_names[0]),
-            field=InternalField(dtype=dtype),
-        )
+            return _as_other_type(index_ops, dtype, spark_type)
 
 
 class FractionalOps(NumericOps):
@@ -382,8 +378,7 @@ class FractionalOps(NumericOps):
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
-
-        if isinstance(spark_type, BooleanType):
+        elif isinstance(spark_type, BooleanType):
             if isinstance(dtype, extension_dtypes):
                 scol = index_ops.spark.column.cast(spark_type)
             else:
@@ -396,11 +391,11 @@ class FractionalOps(NumericOps):
                     scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
                         index_ops.spark.column.cast(spark_type)
                     )
+            return index_ops._with_new_scol(
+                scol.alias(index_ops._internal.data_spark_column_names[0]),
+                field=InternalField(dtype=dtype),
+            )
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype, null_str=str(np.nan))
         else:
-            scol = index_ops.spark.column.cast(spark_type)
-        return index_ops._with_new_scol(
-            scol.alias(index_ops._internal.data_spark_column_names[0]),
-            field=InternalField(dtype=dtype),
-        )
+            return _as_other_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-from itertools import chain
 from typing import TYPE_CHECKING, Union
 
 from pandas.api.types import CategoricalDtype
@@ -24,7 +23,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import IntegralType, StringType
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
@@ -115,34 +114,7 @@ class StringOps(DataTypeOps):
             raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
-            if dtype.categories is None:
-                codes, uniques = index_ops.factorize()
-                return codes._with_new_scol(
-                    codes.spark.column,
-                    field=codes._internal.data_fields[0].copy(
-                        dtype=CategoricalDtype(categories=uniques)
-                    ),
-                )
-            else:
-                categories = dtype.categories
-                if len(categories) == 0:
-                    scol = F.lit(-1)
-                else:
-                    kvs = chain(
-                        *[
-                            (F.lit(category), F.lit(code))
-                            for code, category in enumerate(categories)
-                        ]
-                    )
-                    map_scol = F.create_map(*kvs)
-
-                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
-                return index_ops._with_new_scol(
-                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
-                    field=index_ops._internal.data_fields[0].copy(
-                        dtype=dtype, spark_type=spark_type, nullable=False
-                    ),
-                )
+            return _as_categorical_type(index_ops, dtype, spark_type)
 
         if isinstance(spark_type, BooleanType):
             if isinstance(dtype, extension_dtypes):

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+from itertools import chain
 from typing import TYPE_CHECKING, Union
 
 from pandas.api.types import CategoricalDtype
@@ -24,7 +25,10 @@ from pyspark.sql.types import IntegralType, StringType
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.internal import InternalField
 from pyspark.pandas.spark import functions as SF
+from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
+from pyspark.sql.types import BooleanType
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -102,3 +106,61 @@ class StringOps(DataTypeOps):
 
     def rmod(self, left, right):
         raise TypeError("modulo can not be applied on string series or literals.")
+
+    def astype(
+        self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
+    ) -> Union["Index", "Series"]:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+        if not spark_type:
+            raise ValueError("Type {} not understood".format(dtype))
+
+        if isinstance(dtype, CategoricalDtype):
+            if dtype.categories is None:
+                codes, uniques = index_ops.factorize()
+                return codes._with_new_scol(
+                    codes.spark.column,
+                    field=codes._internal.data_fields[0].copy(
+                        dtype=CategoricalDtype(categories=uniques)
+                    ),
+                )
+            else:
+                categories = dtype.categories
+                if len(categories) == 0:
+                    scol = F.lit(-1)
+                else:
+                    kvs = chain(
+                        *[
+                            (F.lit(category), F.lit(code))
+                            for code, category in enumerate(categories)
+                        ]
+                    )
+                    map_scol = F.create_map(*kvs)
+
+                    scol = F.coalesce(map_scol.getItem(index_ops.spark.column), F.lit(-1))
+                return index_ops._with_new_scol(
+                    scol.cast(spark_type).alias(index_ops._internal.data_fields[0].name),
+                    field=index_ops._internal.data_fields[0].copy(
+                        dtype=dtype, spark_type=spark_type, nullable=False
+                    ),
+                )
+
+        if isinstance(spark_type, BooleanType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
+                    F.length(index_ops.spark.column) > 0
+                )
+        elif isinstance(spark_type, StringType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                null_str = str(None)
+                casted = index_ops.spark.column.cast(spark_type)
+                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+        else:
+            scol = index_ops.spark.column.cast(spark_type)
+        return index_ops._with_new_scol(
+            scol.alias(index_ops._internal.data_spark_column_names[0]),
+            field=InternalField(dtype=dtype),
+        )

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -115,8 +115,6 @@ class StringOps(DataTypeOps):
         self, index_ops: Union["Index", "Series"], dtype: Union[str, type, Dtype]
     ) -> Union["Index", "Series"]:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if not spark_type:
-            raise ValueError("Type {} not understood".format(dtype))
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -23,7 +23,11 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import IntegralType, StringType
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas.data_type_ops.base import DataTypeOps, _as_categorical_type
+from pyspark.pandas.data_type_ops.base import (
+    DataTypeOps,
+    _as_categorical_type,
+    _as_string_type,
+)
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
@@ -124,12 +128,7 @@ class StringOps(DataTypeOps):
                     F.length(index_ops.spark.column) > 0
                 )
         elif isinstance(spark_type, StringType):
-            if isinstance(dtype, extension_dtypes):
-                scol = index_ops.spark.column.cast(spark_type)
-            else:
-                null_str = str(None)
-                casted = index_ops.spark.column.cast(spark_type)
-                scol = F.when(index_ops.spark.column.isNull(), null_str).otherwise(casted)
+            return _as_string_type(index_ops, dtype)
         else:
             scol = index_ops.spark.column.cast(spark_type)
         return index_ops._with_new_scol(

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -26,6 +26,7 @@ from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     _as_categorical_type,
+    _as_other_type,
     _as_string_type,
 )
 from pyspark.pandas.internal import InternalField
@@ -127,11 +128,11 @@ class StringOps(DataTypeOps):
                 scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(
                     F.length(index_ops.spark.column) > 0
                 )
+            return index_ops._with_new_scol(
+                scol.alias(index_ops._internal.data_spark_column_names[0]),
+                field=InternalField(dtype=dtype),
+            )
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype)
         else:
-            scol = index_ops.spark.column.cast(spark_type)
-        return index_ops._with_new_scol(
-            scol.alias(index_ops._internal.data_spark_column_names[0]),
-            field=InternalField(dtype=dtype),
-        )
+            return _as_other_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
@@ -147,6 +147,9 @@ class BinaryOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser, psser.to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
+    def test_astype(self):
+        self.assert_eq(self.pser.astype("category"), self.psser.astype("category"))
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
@@ -16,6 +16,7 @@
 #
 
 import pandas as pd
+from pandas.api.types import CategoricalDtype
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
@@ -152,7 +153,7 @@ class BinaryOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         psser = self.psser
         self.assert_eq(pd.Series(["1", "2", "3"]), psser.astype(str))
         self.assert_eq(pser.astype("category"), psser.astype("category"))
-        cat_type = pd.api.types.CategoricalDtype(categories=[b"2", b"3", b"1"])
+        cat_type = CategoricalDtype(categories=[b"2", b"3", b"1"])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
@@ -148,7 +148,12 @@ class BinaryOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_astype(self):
-        self.assert_eq(self.pser.astype("category"), self.psser.astype("category"))
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pd.Series(["1", "2", "3"]), psser.astype(str))
+        self.assert_eq(pser.astype("category"), psser.astype("category"))
+        cat_type = pd.api.types.CategoricalDtype(categories=[b"2", b"3", b"1"])
+        self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -287,6 +287,9 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(True | pser, True | psser)
         self.assert_eq(False | pser, False | psser)
 
+    def test_astype(self):
+        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+
 
 @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
 class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
@@ -577,6 +580,9 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         psser = ps.Series(data)
         self.assert_eq(pser, psser.to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
+
+    def test_astype(self):
+        self.assert_eq(["True", "False", "None"], self.psser.astype(str).tolist())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -288,7 +288,19 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(False | pser, False | psser)
 
     def test_astype(self):
-        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pser.astype(int), psser.astype(int))
+        self.assert_eq(pser.astype(float), psser.astype(float))
+        self.assert_eq(pser.astype(np.float32), psser.astype(np.float32))
+        self.assert_eq(pser.astype(np.int32), psser.astype(np.int32))
+        self.assert_eq(pser.astype(np.int16), psser.astype(np.int16))
+        self.assert_eq(pser.astype(np.int8), psser.astype(np.int8))
+        self.assert_eq(pser.astype(str), psser.astype(str))
+        self.assert_eq(pser.astype(bool), psser.astype(bool))
+        self.assert_eq(pser.astype("category"), psser.astype("category"))
+        cat_type = pd.api.types.CategoricalDtype(categories=[False, True])
+        self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
 @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
@@ -582,7 +594,12 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_astype(self):
+        pser = self.pser
+        psser = self.psser
         self.assert_eq(["True", "False", "None"], self.psser.astype(str).tolist())
+        self.assert_eq(pser.astype("category"), psser.astype("category"))
+        cat_type = pd.api.types.CategoricalDtype(categories=[False, True])
+        self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -21,6 +21,7 @@ from distutils.version import LooseVersion
 
 import pandas as pd
 import numpy as np
+from pandas.api.types import CategoricalDtype
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
@@ -299,7 +300,7 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser.astype(str), psser.astype(str))
         self.assert_eq(pser.astype(bool), psser.astype(bool))
         self.assert_eq(pser.astype("category"), psser.astype("category"))
-        cat_type = pd.api.types.CategoricalDtype(categories=[False, True])
+        cat_type = CategoricalDtype(categories=[False, True])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
@@ -598,7 +599,7 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         psser = self.psser
         self.assert_eq(["True", "False", "None"], self.psser.astype(str).tolist())
         self.assert_eq(pser.astype("category"), psser.astype("category"))
-        cat_type = pd.api.types.CategoricalDtype(categories=[False, True])
+        cat_type = CategoricalDtype(categories=[False, True])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -19,6 +19,7 @@ from distutils.version import LooseVersion
 
 import pandas as pd
 import numpy as np
+from pandas.api.types import CategoricalDtype
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
@@ -156,7 +157,7 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser.astype(str), psser.astype(str))
         self.assert_eq(pser.astype(bool), psser.astype(bool))
         self.assert_eq(pser.astype("category"), psser.astype("category"))
-        cat_type = pd.api.types.CategoricalDtype(categories=[3, 1, 2])
+        cat_type = CategoricalDtype(categories=[3, 1, 2])
         if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
             self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
         else:

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -15,7 +15,10 @@
 # limitations under the License.
 #
 
+from distutils.version import LooseVersion
+
 import pandas as pd
+import numpy as np
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
@@ -141,7 +144,23 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_astype(self):
-        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+        data = [1, 2, 3]
+        pser = pd.Series(data, dtype="category")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser.astype(int), psser.astype(int))
+        self.assert_eq(pser.astype(float), psser.astype(float))
+        self.assert_eq(pser.astype(np.float32), psser.astype(np.float32))
+        self.assert_eq(pser.astype(np.int32), psser.astype(np.int32))
+        self.assert_eq(pser.astype(np.int16), psser.astype(np.int16))
+        self.assert_eq(pser.astype(np.int8), psser.astype(np.int8))
+        self.assert_eq(pser.astype(str), psser.astype(str))
+        self.assert_eq(pser.astype(bool), psser.astype(bool))
+        self.assert_eq(pser.astype("category"), psser.astype("category"))
+        cat_type = pd.api.types.CategoricalDtype(categories=[3, 1, 2])
+        if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
+            self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
+        else:
+            self.assert_eq(pd.Series(data).astype(cat_type), psser.astype(cat_type))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -140,6 +140,9 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser, psser.to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
+    def test_astype(self):
+        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
@@ -66,8 +66,12 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         return self.numeric_array_pssers + list(self.non_numeric_array_pssers.values())
 
     @property
+    def pser(self):
+        return pd.Series([[1, 2, 3]])
+
+    @property
     def psser(self):
-        return ps.Series([[1, 2, 3]])
+        return ps.from_pandas(self.pser)
 
     def test_add(self):
         for pser, psser in zip(self.psers, self.pssers):
@@ -212,6 +216,9 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in zip(self.psers, self.pssers):
             self.assert_eq(pser, psser.to_pandas())
             self.assert_eq(ps.from_pandas(pser), psser)
+
+    def test_astype(self):
+        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -18,6 +18,7 @@
 import datetime
 
 import pandas as pd
+from pandas.api.types import CategoricalDtype
 
 from pyspark.sql.types import DateType
 
@@ -177,7 +178,7 @@ class DateOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         psser = self.psser
         self.assert_eq(pser.astype(str), psser.astype(str))
         self.assert_eq(pd.Series([None, None, None]), psser.astype(bool))
-        cat_type = pd.api.types.CategoricalDtype(categories=["a", "b", "c"])
+        cat_type = CategoricalDtype(categories=["a", "b", "c"])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -172,6 +172,9 @@ class DateOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser, psser.to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
+    def test_astype(self):
+        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -173,7 +173,12 @@ class DateOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_astype(self):
-        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pser.astype(str), psser.astype(str))
+        self.assert_eq(pd.Series([None, None, None]), psser.astype(bool))
+        cat_type = pd.api.types.CategoricalDtype(categories=["a", "b", "c"])
+        self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
@@ -173,7 +173,12 @@ class DatetimeOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_astype(self):
-        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pser.astype(str), psser.astype(str))
+        self.assert_eq(pser.astype("category"), psser.astype("category"))
+        cat_type = pd.api.types.CategoricalDtype(categories=["a", "b", "c"])
+        self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
@@ -19,6 +19,7 @@ import datetime
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import CategoricalDtype
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
@@ -177,7 +178,7 @@ class DatetimeOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         psser = self.psser
         self.assert_eq(pser.astype(str), psser.astype(str))
         self.assert_eq(pser.astype("category"), psser.astype("category"))
-        cat_type = pd.api.types.CategoricalDtype(categories=["a", "b", "c"])
+        cat_type = CategoricalDtype(categories=["a", "b", "c"])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
@@ -172,6 +172,9 @@ class DatetimeOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser, psser.to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
+    def test_astype(self):
+        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
@@ -122,6 +122,9 @@ class NullOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser, psser.to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
+    def test_astype(self):
+        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
@@ -16,6 +16,7 @@
 #
 
 import pandas as pd
+from pandas.api.types import CategoricalDtype
 
 import pyspark.pandas as ps
 from pyspark.pandas.config import option_context
@@ -128,7 +129,7 @@ class NullOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser.astype(str), psser.astype(str))
         self.assert_eq(pser.astype(bool), psser.astype(bool))
         self.assert_eq(pser.astype("category"), psser.astype("category"))
-        cat_type = pd.api.types.CategoricalDtype(categories=[1, 2, 3])
+        cat_type = CategoricalDtype(categories=[1, 2, 3])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
@@ -123,7 +123,13 @@ class NullOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_astype(self):
-        self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+        pser = self.pser
+        psser = self.psser
+        self.assert_eq(pser.astype(str), psser.astype(str))
+        self.assert_eq(pser.astype(bool), psser.astype(bool))
+        self.assert_eq(pser.astype("category"), psser.astype("category"))
+        cat_type = pd.api.types.CategoricalDtype(categories=[1, 2, 3])
+        self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -20,6 +20,7 @@ from distutils.version import LooseVersion
 
 import pandas as pd
 import numpy as np
+from pandas.api.types import CategoricalDtype
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
@@ -304,7 +305,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(pser.astype(str), psser.astype(str))
             self.assert_eq(pser.astype(bool), psser.astype(bool))
             self.assert_eq(pser.astype("category"), psser.astype("category"))
-            cat_type = pd.api.types.CategoricalDtype(categories=[2, 1, 3])
+            cat_type = CategoricalDtype(categories=[2, 1, 3])
             self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -293,6 +293,10 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(pser, psser.to_pandas())
             self.assert_eq(ps.from_pandas(pser), psser)
 
+    def test_astype(self):
+        for pser, psser in self.numeric_pser_psser_pairs:
+            self.assert_eq(pser.astype(int), psser.astype(int))
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -296,6 +296,16 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def test_astype(self):
         for pser, psser in self.numeric_pser_psser_pairs:
             self.assert_eq(pser.astype(int), psser.astype(int))
+            self.assert_eq(pser.astype(float), psser.astype(float))
+            self.assert_eq(pser.astype(np.float32), psser.astype(np.float32))
+            self.assert_eq(pser.astype(np.int32), psser.astype(np.int32))
+            self.assert_eq(pser.astype(np.int16), psser.astype(np.int16))
+            self.assert_eq(pser.astype(np.int8), psser.astype(np.int8))
+            self.assert_eq(pser.astype(str), psser.astype(str))
+            self.assert_eq(pser.astype(bool), psser.astype(bool))
+            self.assert_eq(pser.astype("category"), psser.astype("category"))
+            cat_type = pd.api.types.CategoricalDtype(categories=[2, 1, 3])
+            self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -17,6 +17,7 @@
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import CategoricalDtype
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
@@ -166,7 +167,7 @@ class StringOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser.astype(str), psser.astype(str))
         self.assert_eq(pser.astype(bool), psser.astype(bool))
         self.assert_eq(pser.astype("category"), psser.astype("category"))
-        cat_type = pd.api.types.CategoricalDtype(categories=["3", "1", "2"])
+        cat_type = CategoricalDtype(categories=["3", "1", "2"])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -154,6 +154,9 @@ class StringOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser, psser.to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
+    def test_astype(self):
+        self.assert_eq(self.pser.astype("category"), self.psser.astype("category"))
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -155,7 +155,19 @@ class StringOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_astype(self):
-        self.assert_eq(self.pser.astype("category"), self.psser.astype("category"))
+        pser = pd.Series(["1", "2", "3"])
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser.astype(int), psser.astype(int))
+        self.assert_eq(pser.astype(float), psser.astype(float))
+        self.assert_eq(pser.astype(np.float32), psser.astype(np.float32))
+        self.assert_eq(pser.astype(np.int32), psser.astype(np.int32))
+        self.assert_eq(pser.astype(np.int16), psser.astype(np.int16))
+        self.assert_eq(pser.astype(np.int8), psser.astype(np.int8))
+        self.assert_eq(pser.astype(str), psser.astype(str))
+        self.assert_eq(pser.astype(bool), psser.astype(bool))
+        self.assert_eq(pser.astype("category"), psser.astype("category"))
+        cat_type = pd.api.types.CategoricalDtype(categories=["3", "1", "2"])
+        self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -172,7 +172,7 @@ class StringOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.pandas.tests.data_type_ops.test_num_ops import *  # noqa: F401
+    from pyspark.pandas.tests.data_type_ops.test_string_ops import *  # noqa: F401
 
     try:
         import xmlrunner  # type: ignore[import]

--- a/python/pyspark/pandas/tests/data_type_ops/test_udt_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_udt_ops.py
@@ -125,6 +125,9 @@ class UDTOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser, psser.to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
+    def test_astype(self):
+        self.assertRaises(TypeError, lambda: self.psser.astype(str))
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Make `astype` method data-type-based.

**Non-goal: Match pandas' `astype` TypeErrors.**
Currently, `astype` throws TypeError error messages only when the destination type is not recognized. However, for some destination types that don't make sense to the specific type of  Series/Index, for example, `numeric Series/Index → bytes`, we don't have proper TypeError error messages.
Since the goal of the PR is refactoring mainly, the above issue might be resolved later if needed.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There are many type checks in the `astype` method. Since `DataTypeOps` and its subclasses are introduced, we should refactor `astype` to make it data-type-based. In this way, code is cleaner, more maintainable, and more flexible.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.

Keyword: SPARK-35337