### PR TITLE
[SPARK-35683][PYTHON] Fix Index.difference to avoid collect 'other' to driver side

### DIFF
--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -1992,7 +1992,11 @@ class Index(IndexOpsMixin):
         """
         from pyspark.pandas.indexes.multi import MultiIndex
 
-        if isinstance(other, Index) and not isinstance(self, type(other)):
+        # Check if the `self` and `other` have different index types.
+        # 1. `self` is Index, `other` is MultiIndex
+        # 2. `self` is MultiIndex, `other` is Index
+        is_index_types_different = isinstance(other, Index) and not isinstance(self, type(other))
+        if is_index_types_different:
             if isinstance(self, MultiIndex):
                 # In case `self` is MultiIndex and `other` is Index,
                 # return MultiIndex without its names.
@@ -2002,7 +2006,7 @@ class Index(IndexOpsMixin):
                 # return Index without its name.
                 return self.rename(None)
 
-        if not is_list_like(other):
+        if not isinstance(other, (Index, Series, tuple, list, set, dict)):
             raise TypeError("Input must be Index or array-like")
         if not isinstance(sort, (type(None), type(True))):
             raise ValueError(
@@ -2010,11 +2014,12 @@ class Index(IndexOpsMixin):
                     sort
                 )
             )
-        # Handling MultiIndex when `other` is list-like objects.
+        # Handling MultiIndex when `other` is not MultiIndex.
         if isinstance(self, MultiIndex) and not isinstance(other, MultiIndex):
-            if isinstance(other, (list, set, dict)) and all(
+            is_other_list_of_tuples = isinstance(other, (list, set, dict)) and all(
                 [isinstance(item, tuple) for item in other]
-            ):
+            )
+            if is_other_list_of_tuples:
                 other = MultiIndex.from_tuples(other)
             elif isinstance(other, Series):
                 other = Index(other)

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -1295,10 +1295,14 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
         pidx2 = pd.Index([3, 4, 5, 6], name="koalas")
         psidx1 = ps.from_pandas(pidx1)
         psidx2 = ps.from_pandas(pidx2)
+        # Series
+        pser = pd.Series([3, 4, 5, 6], name="koalas")
+        psser = ps.from_pandas(pser)
 
         self.assert_eq(
             psidx1.difference(psidx2).sort_values(), pidx1.difference(pidx2).sort_values()
         )
+        self.assert_eq(psidx1.difference(psser).sort_values(), pidx1.difference(pser).sort_values())
         self.assert_eq(
             psidx1.difference([3, 4, 5, 6]).sort_values(),
             pidx1.difference([3, 4, 5, 6]).sort_values(),
@@ -1333,30 +1337,37 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
             psidx1.difference(psidx2, sort=1)
 
         # MultiIndex
-        pidx1 = pd.MultiIndex.from_tuples(
+        pmidx1 = pd.MultiIndex.from_tuples(
             [("a", "x", 1), ("b", "y", 2), ("c", "z", 3)], names=["hello", "koalas", "world"]
         )
-        pidx2 = pd.MultiIndex.from_tuples(
+        pmidx2 = pd.MultiIndex.from_tuples(
             [("a", "x", 1), ("b", "z", 2), ("k", "z", 3)], names=["hello", "koalas", "world"]
         )
-        psidx1 = ps.from_pandas(pidx1)
-        psidx2 = ps.from_pandas(pidx2)
+        psmidx1 = ps.from_pandas(pmidx1)
+        psmidx2 = ps.from_pandas(pmidx2)
 
         self.assert_eq(
-            psidx1.difference(psidx2).sort_values(), pidx1.difference(pidx2).sort_values()
+            psmidx1.difference(psmidx2).sort_values(), pmidx1.difference(pmidx2).sort_values()
         )
         self.assert_eq(
-            psidx1.difference({("a", "x", 1)}).sort_values(),
-            pidx1.difference({("a", "x", 1)}).sort_values(),
+            psmidx1.difference(psidx1).sort_values(), pmidx1.difference(pidx1).sort_values()
         )
         self.assert_eq(
-            psidx1.difference({("a", "x", 1): [1, 2, 3]}).sort_values(),
-            pidx1.difference({("a", "x", 1): [1, 2, 3]}).sort_values(),
+            psidx1.difference(psmidx1).sort_values(), pidx1.difference(pmidx1).sort_values()
+        )
+        self.assert_eq(psidx1.difference(psser).sort_values(), pidx1.difference(pser).sort_values())
+        self.assert_eq(
+            psmidx1.difference({("a", "x", 1)}).sort_values(),
+            pmidx1.difference({("a", "x", 1)}).sort_values(),
+        )
+        self.assert_eq(
+            psmidx1.difference({("a", "x", 1): [1, 2, 3]}).sort_values(),
+            pmidx1.difference({("a", "x", 1): [1, 2, 3]}).sort_values(),
         )
 
         # Exceptions for MultiIndex
         with self.assertRaisesRegex(TypeError, "other must be a MultiIndex or a list of tuples"):
-            psidx1.difference(["b", "z", "2"])
+            psmidx1.difference(["b", "z", "2"])
 
     def test_repeat(self):
         pidx = pd.Index(["a", "b", "c"])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fix the wrong behavior of `Index.difference` in pandas APIs on Spark, based on the comment https://github.com/databricks/koalas/pull/1325#discussion_r647889901 and https://github.com/databricks/koalas/pull/1325#discussion_r647890007
- it couldn't handle the case properly when `self` is `Index` or `MultiIndex` and `other` is `MultiIndex` or `Index`.
```python
>>> midx1 = ps.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'z', 2), ('k', 'z', 3)])
>>> idx1 = ps.Index([1, 2, 3])
>>> midx1 = ps.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'z', 2), ('k', 'z', 3)])
>>> midx1.difference(idx1)
pyspark.pandas.exceptions.PandasNotImplementedError: The method `pd.Index.__iter__()` is not implemented. If you want to collect your data as an NumPy array, use 'to_numpy()' instead.
```
- it's collecting the all data into the driver side when the other is list-like objects, especially when the `other` is distributed object such as Series which is very dangerous.

And added the related test cases.

### Why are the changes needed?

To correct the incompatible behavior with pandas, and to prevent the case which potentially cause the OOM easily.

```python
>>> midx1 = ps.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'z', 2), ('k', 'z', 3)])
>>> idx1 = ps.Index([1, 2, 3])
>>> midx1 = ps.MultiIndex.from_tuples([('a', 'x', 1), ('b', 'z', 2), ('k', 'z', 3)])
>>> midx1.difference(idx1)
MultiIndex([('a', 'x', 1),
            ('b', 'z', 2),
            ('k', 'z', 3)],
           )
```

And now it only using the for loop when the `other` is only the case `list`, `set` or `dict`.


### Does this PR introduce _any_ user-facing change?

Yes, the previous bug is fixed as described in the above code examples.


### How was this patch tested?

Manually tested with linter and unittest in local, and it might be passed on CI.
