### PR TITLE
[SPARK-35707][ML] optimize sparse GEMM by skipping bound checking

### DIFF
--- a/mllib-local/src/main/scala/org/apache/spark/ml/linalg/BLAS.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/linalg/BLAS.scala
@@ -480,7 +480,7 @@ private[spark] object BLAS extends Serializable {
             val indEnd = AcolPtrs(rowCounterForA + 1)
             var sum = 0.0
             while (i < indEnd) {
-              sum += Avals(i) * B(ArowIndices(i), colCounterForB)
+              sum += Avals(i) * Bvals(colCounterForB + nB * ArowIndices(i))
               i += 1
             }
             val Cindex = Cstart + rowCounterForA
@@ -522,7 +522,7 @@ private[spark] object BLAS extends Serializable {
           while (colCounterForA < kA) {
             var i = AcolPtrs(colCounterForA)
             val indEnd = AcolPtrs(colCounterForA + 1)
-            val Bval = B(colCounterForA, colCounterForB) * alpha
+            val Bval = Bvals(colCounterForB + nB * colCounterForA) * alpha
             while (i < indEnd) {
               Cvals(Cstart + ArowIndices(i)) += Avals(i) * Bval
               i += 1

--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/BLASSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/BLASSuite.scala
@@ -302,6 +302,32 @@ class BLASSuite extends SparkMLFunSuite {
 
   }
 
+  test("sparse gemm") {
+    val rng = new scala.util.Random(0)
+    val m = 1e3.toInt
+    val n = 1e3.toInt
+    val k = 1e3.toInt
+    val alpha = rng.nextDouble
+    val beta = rng.nextDouble
+
+    val a = Array.tabulate(m * k) { _ =>
+      if (rng.nextDouble < 0.9) 0.0 else rng.nextDouble
+    }
+    val A = Matrices.dense(m, k, a).toSparse
+
+    val B = Matrices.dense(k, n, Array.fill(k * n)(rng.nextDouble)).toDense
+
+    val C = Matrices.dense(m, n, Array.fill(k * n)(rng.nextDouble)).toDense
+
+    val tic1 = System.nanoTime
+    Iterator.range(0, 1000).foreach { i => BLAS.gemm(alpha, A, B, beta, C) }
+    val toc1 = System.nanoTime
+
+    // scalastyle:off println
+    println(f"new sparse gemm duration: ${(toc1 - tic1) * 1e-9}%.3f")
+    // scalastyle:on println
+  }
+
   test("gemv") {
 
     val dA =

--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/BLASSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/BLASSuite.scala
@@ -302,32 +302,6 @@ class BLASSuite extends SparkMLFunSuite {
 
   }
 
-  test("sparse gemm") {
-    val rng = new scala.util.Random(0)
-    val m = 1e3.toInt
-    val n = 1e3.toInt
-    val k = 1e3.toInt
-    val alpha = rng.nextDouble
-    val beta = rng.nextDouble
-
-    val a = Array.tabulate(m * k) { _ =>
-      if (rng.nextDouble < 0.9) 0.0 else rng.nextDouble
-    }
-    val A = Matrices.dense(m, k, a).toSparse
-
-    val B = Matrices.dense(k, n, Array.fill(k * n)(rng.nextDouble)).toDense
-
-    val C = Matrices.dense(m, n, Array.fill(k * n)(rng.nextDouble)).toDense
-
-    val tic1 = System.nanoTime
-    Iterator.range(0, 1000).foreach { i => BLAS.gemm(alpha, A, B, beta, C) }
-    val toc1 = System.nanoTime
-
-    // scalastyle:off println
-    println(f"new sparse gemm duration: ${(toc1 - tic1) * 1e-9}%.3f")
-    // scalastyle:on println
-  }
-
   test("gemv") {
 
     val dA =

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -462,7 +462,7 @@ private[spark] object BLAS extends Serializable with Logging {
             val indEnd = AcolPtrs(rowCounterForA + 1)
             var sum = 0.0
             while (i < indEnd) {
-              sum += Avals(i) * B(ArowIndices(i), colCounterForB)
+              sum += Avals(i) * Bvals(colCounterForB + nB * ArowIndices(i))
               i += 1
             }
             val Cindex = Cstart + rowCounterForA
@@ -504,7 +504,7 @@ private[spark] object BLAS extends Serializable with Logging {
           while (colCounterForA < kA) {
             var i = AcolPtrs(colCounterForA)
             val indEnd = AcolPtrs(colCounterForA + 1)
-            val Bval = B(colCounterForA, colCounterForB) * alpha
+            val Bval = Bvals(colCounterForB + nB * colCounterForA) * alpha
             while (i < indEnd) {
               Cvals(Cstart + ArowIndices(i)) += Avals(i) * Bval
               i += 1


### PR DESCRIPTION
### What changes were proposed in this pull request?
Sparse gemm use mothod `DenseMatrix.apply` to access the values, which can be optimized by skipping checking the bound and `isTransposed`

```
  override def apply(i: Int, j: Int): Double = values(index(i, j))

  private[ml] def index(i: Int, j: Int): Int = {
    require(i >= 0 && i < numRows, s"Expected 0 <= i < $numRows, got i = $i.")
    require(j >= 0 && j < numCols, s"Expected 0 <= j < $numCols, got j = $j.")
    if (!isTransposed) i + numRows * j else j + numCols * i
  }

```


### Why are the changes needed?
to improve performance, about 15% faster in the designed case


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing testsuite and additional performance test
