### PR TITLE
[SPARK-35706][SQL] Consider making the ':' in STRUCT data type definition optional

### DIFF
--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -194,7 +194,7 @@ The following table shows the type names as well as aliases used in Spark SQL pa
 |**DecimalType**|DECIMAL, DEC, NUMERIC|
 |**CalendarIntervalType**|INTERVAL|
 |**ArrayType**|ARRAY\<element_type>|
-|**StructType**|STRUCT<field1_name field1_type, field2_name field2_type, ...>|
+|**StructType**|STRUCT<field1_name: field1_type, field2_name: field2_type, ...><br/> **Note:** ':' is optional.|
 |**MapType**|MAP<key_type, value_type>|
 
 </div>

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -194,7 +194,7 @@ The following table shows the type names as well as aliases used in Spark SQL pa
 |**DecimalType**|DECIMAL, DEC, NUMERIC|
 |**CalendarIntervalType**|INTERVAL|
 |**ArrayType**|ARRAY\<element_type>|
-|**StructType**|STRUCT<field1_name: field1_type, field2_name: field2_type, ...>|
+|**StructType**|STRUCT<field1_name field1_type, field2_name field2_type, ...>|
 |**MapType**|MAP<key_type, value_type>|
 
 </div>

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -930,7 +930,7 @@ complexColTypeList
     ;
 
 complexColType
-    : identifier ':' dataType (NOT NULL)? commentSpec?
+    : identifier ':'? dataType (NOT NULL)? commentSpec?
     ;
 
 whenClause

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DataTypeParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DataTypeParserSuite.scala
@@ -119,11 +119,16 @@ class DataTypeParserSuite extends SparkFunSuite {
   )
   // Empty struct.
   checkDataType("strUCt<>", StructType(Nil))
+  // struct data type definition without ":"
+  checkDataType("struct<x int, y string>",
+    StructType(
+      StructField("x", IntegerType, true) ::
+      StructField("y", StringType, true) :: Nil)
+  )
 
   unsupported("it is not a data type")
   unsupported("struct<x+y: int, 1.1:timestamp>")
   unsupported("struct<x: int")
-  unsupported("struct<x int, y string>")
 
   test("Do not print empty parentheses for no params") {
     assert(intercept("unknown").getMessage.contains("unknown is not supported"))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -97,6 +97,12 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
     assert(StructType.fromDDL(nestedStruct.toDDL) == nestedStruct)
   }
 
+  test("SPARK-35706: make the ':' in STRUCT data type definition optional") {
+    val ddl = "`a` STRUCT<`b` STRUCT<`c` STRING COMMENT 'Deep Nested comment'> " +
+      "COMMENT 'Nested comment'> COMMENT 'comment'"
+    assert(StructType.fromDDL(ddl) == nestedStruct)
+  }
+
   private val structWithEmptyString = new StructType()
     .add(StructField("a b", StringType).withComment("comment"))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The STRUCT type syntax is defined like this:

STRUCT(fieldNmae: fileType [NOT NULL][COMMENT stringLiteral][,.....])

So the field list is nearly the same as a column list

if we could make ':' optional it would be so much cleaner an less proprietary


### Why are the changes needed?
ease of use


### Does this PR introduce _any_ user-facing change?
Yes, you can use Struct type list is nearly the same as a column list


### How was this patch tested?
unit tests
