### PR TITLE
[SPARK-35709][DOCS] Remove the reference to third party Nomad integration project

### DIFF
--- a/docs/cluster-overview.md
+++ b/docs/cluster-overview.md
@@ -70,9 +70,6 @@ The system currently supports several cluster managers:
 * [Kubernetes](running-on-kubernetes.html) -- an open-source system for automating deployment, scaling,
   and management of containerized applications.
 
-A third-party project (not supported by the Spark project) exists to add support for
-[Nomad](https://github.com/hashicorp/nomad-spark) as a cluster manager.
-
 # Submitting Applications
 
 Applications can be submitted to a cluster of any type using the `spark-submit` script.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR updates documentation by removing reference to [hashicorp/nomad-spark](https://github.com/hashicorp/nomad-spark) which has been deprecated in April 2020, and will not be developed any longer.

### Why are the changes needed?
To keep the documentation updated and remove confusion for potential users being interested in running with Nomad.

### Does this PR introduce _any_ user-facing change?
Yes. A change to the documentation. 

### How was this patch tested?
Generated to documentation, and checked everything is alright in the output. 
