### PR TITLE
[SPARK-35713]Bug fix for thread leak in JobCancellationSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/JobCancellationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/JobCancellationSuite.scala
@@ -234,7 +234,7 @@ class JobCancellationSuite extends SparkFunSuite with Matchers with BeforeAndAft
     val jobA = Future {
       sc.setJobGroup("jobA", "this is a job to be cancelled", interruptOnCancel = true)
       sc.parallelize(1 to 10000, 2).map { i =>
-        while (true) { }
+        while (true) { Thread.sleep(100) }
       }.count()
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bug fix for thread leak in JobCancellationSuite UT

### Why are the changes needed?

When we call Thread.interrupt() method, that thread's interrupt status will be set but it may not really interrupt.
So when spark task runs in an infinite loop, spark context may fail to interrupt the task thread, and resulting in thread leak. 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Test case "task reaper kills JVM if killed tasks keep running for too long" in JobCancellationSuite
