### PR TITLE
[SPARK-35718][SQL] Support casting of Date to timestamp without time zone type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -70,6 +70,8 @@ object Cast {
     case (_: NumericType, TimestampType) => true
     case (TimestampWithoutTZType, TimestampType) => true
 
+    case (DateType, TimestampWithoutTZType) => true
+
     case (StringType, DateType) => true
     case (TimestampType, DateType) => true
     case (TimestampWithoutTZType, DateType) => true
@@ -315,6 +317,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   // The brackets that are used in casting structs and maps to strings
   private val (leftBracket, rightBracket) = if (legacyCastToStr) ("[", "]") else ("{", "}")
 
+  // THe class name of `DateTimeUtils`
+  protected def dateTimeUtilsCls: String = DateTimeUtils.getClass.getName.stripSuffix("$")
+
   // UDFToString
   private[this] def castToString(from: DataType): Any => Any = from match {
     case CalendarIntervalType =>
@@ -503,6 +508,11 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     // TimestampWritable.floatToTimestamp
     case FloatType =>
       buildCast[Float](_, f => doubleToTimestamp(f.toDouble))
+  }
+
+  private[this] def castToTimestampWithoutTZ(from: DataType): Any => Any = from match {
+    case DateType =>
+      buildCast[Int](_, d => daysToMicros(d, ZoneOffset.UTC))
   }
 
   private[this] def decimalToTimestamp(d: Decimal): Long = {
@@ -856,6 +866,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
         case DateType => castToDate(from)
         case decimal: DecimalType => castToDecimal(from, decimal)
         case TimestampType => castToTimestamp(from)
+        case TimestampWithoutTZType => castToTimestampWithoutTZ(from)
         case CalendarIntervalType => castToInterval(from)
         case DayTimeIntervalType => castToDayTimeInterval(from)
         case YearMonthIntervalType => castToYearMonthInterval(from)
@@ -916,6 +927,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case DateType => castToDateCode(from, ctx)
     case decimal: DecimalType => castToDecimalCode(from, decimal, ctx)
     case TimestampType => castToTimestampCode(from, ctx)
+    case TimestampWithoutTZType => castToTimestampWithoutTZCode(from)
     case CalendarIntervalType => castToIntervalCode(from)
     case DayTimeIntervalType => castToDayTimeIntervalCode(from)
     case YearMonthIntervalType => castToYearMonthIntervalCode(from)
@@ -1209,9 +1221,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
             org.apache.spark.sql.catalyst.util.DateTimeUtils.microsToDays($c, $zid);"""
       case TimestampWithoutTZType =>
         (c, evPrim, evNull) =>
-          // scalastyle:off line.size.limit
-          code"$evPrim = org.apache.spark.sql.catalyst.util.DateTimeUtils.microsToDays($c, java.time.ZoneOffset.UTC);"
-          // scalastyle:on line.size.limit
+          code"$evPrim = $dateTimeUtilsCls.microsToDays($c, java.time.ZoneOffset.UTC);"
       case _ =>
         (c, evPrim, evNull) => code"$evNull = true;"
     }
@@ -1369,6 +1379,12 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
             $evPrim = (long)((double)$c * $MICROS_PER_SECOND);
           }
         """
+  }
+
+  private[this] def castToTimestampWithoutTZCode(from: DataType): CastFunction = from match {
+    case DateType =>
+      (c, evPrim, evNull) =>
+        code"$evPrim = $dateTimeUtilsCls.daysToMicros($c, java.time.ZoneOffset.UTC);"
   }
 
   private[this] def castToIntervalCode(from: DataType): CastFunction = from match {
@@ -1954,6 +1970,8 @@ object AnsiCast {
     case (StringType, TimestampType) => true
     case (DateType, TimestampType) => true
     case (TimestampWithoutTZType, TimestampType) => true
+
+    case (DateType, TimestampWithoutTZType) => true
 
     case (StringType, _: CalendarIntervalType) => true
     case (StringType, DayTimeIntervalType) => true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -317,7 +317,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   // The brackets that are used in casting structs and maps to strings
   private val (leftBracket, rightBracket) = if (legacyCastToStr) ("[", "]") else ("{", "}")
 
-  // THe class name of `DateTimeUtils`
+  // The class name of `DateTimeUtils`
   protected def dateTimeUtilsCls: String = DateTimeUtils.getClass.getName.stripSuffix("$")
 
   // UDFToString

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1267,6 +1267,15 @@ abstract class AnsiCastSuiteBase extends CastSuiteBase {
       checkEvaluation(cast(dt, DateType), LocalDate.parse(s.split("T")(0)))
     }
   }
+
+  test("SPARK-35718: cast date type to timestamp without timezone") {
+    specialTs.foreach { s =>
+      val inputDate = LocalDate.parse(s.split("T")(0))
+      // The hour/minute/second of the expect result should be 0
+      val expectedTs = LocalDateTime.parse(s.split("T")(0) + "T00:00:00")
+      checkEvaluation(cast(inputDate, TimestampWithoutTZType), expectedTs)
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Extend the Cast expression and support DateType in casting to TimestampWithoutTZType.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To conform the ANSI SQL standard which requires to support such casting.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the new timestamp type is not released yet.



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test