### PR TITLE
[SPARK-35722][CORE] wait until something does get queued.

### DIFF
--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -188,7 +188,7 @@ private[spark] class ContextCleaner(
   private def keepCleaning(): Unit = Utils.tryOrStopSparkContext(sc) {
     while (!stopped) {
       try {
-        val reference = Option(referenceQueue.remove(ContextCleaner.REF_QUEUE_POLL_TIMEOUT))
+        val reference = Option(referenceQueue.remove())
           .map(_.asInstanceOf[CleanupTaskWeakReference])
         // Synchronize here to avoid being interrupted on stop()
         synchronized {
@@ -299,10 +299,6 @@ private[spark] class ContextCleaner(
 
   private def broadcastManager = sc.env.broadcastManager
   private def mapOutputTrackerMaster = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
-}
-
-private object ContextCleaner {
-  private val REF_QUEUE_POLL_TIMEOUT = 100
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, we continue the loop after wait timeout when `ContextCleaner` cleanUp if the queue is empty, It is an ineffective loop because the queue is empty.

In the PR, it prevent ineffective loop, if the queue is empty, we wait until something does get queued instead of ineffective loop after wait timeout .

### Why are the changes needed?
avoid inefeective loop

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Exist test
