### PR TITLE
[SPARK-35689][SS][3.0] Add log warn when keyWithIndexToValue returns null value

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManagerSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.streaming.state
 
+import java.sql.Timestamp
 import java.util.UUID
 
 import org.apache.hadoop.conf.Configuration
@@ -30,6 +31,7 @@ import org.apache.spark.sql.execution.streaming.StatefulOperatorStateInfo
 import org.apache.spark.sql.execution.streaming.StreamingSymmetricHashJoinHelper.LeftSide
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter {
 
@@ -41,6 +43,28 @@ class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter 
   SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
     test(s"StreamingJoinStateManager V${version} - all operations") {
       testAllOperations(version)
+    }
+  }
+
+  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
+    test(s"SPARK-35689: StreamingJoinStateManager V${version} - " +
+      "printable key of keyWithIndexToValue") {
+
+      val keyExprs = Seq[Expression](
+        Literal(false),
+        Literal(10.0),
+        Literal("string"),
+        Literal(Timestamp.valueOf("2021-6-8 10:25:50")))
+      val keyGen = UnsafeProjection.create(keyExprs.map(_.dataType).toArray)
+
+      withJoinStateManager(inputValueAttribs, keyExprs, version) { manager =>
+        val currentKey = keyGen.apply(new GenericInternalRow(Array[Any](
+          false, 10.0, UTF8String.fromString("string"),
+          Timestamp.valueOf("2021-6-8 10:25:50").getTime)))
+
+        val projectedRow = manager.getInternalRowOfKeyWithIndex(currentKey)
+        assert(s"$projectedRow" == "[false,10.0,string,1623173150000]")
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch adds log warn when `keyWithIndexToValue` returns null value in `SymmetricHashJoinStateManager`.

This is the backport of #32828 to branch-3.0.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Once we get null from state store in SymmetricHashJoinStateManager, it is better to add meaningful logging for the case. It is better for debugging.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing tests.
