### PR TITLE
[SPARK-35734][SQL] Format day-time intervals using type fields

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -1041,7 +1041,7 @@ object IntervalUtils {
             case DayTimeIntervalType.SECOND =>
               formatBuilder.append(s"$leadSecZero$secStr' ")
           }
-          formatBuilder.append(s"$from TO $to").toString.format(formatArgs: _*)
+          formatBuilder.append(s"$from TO $to").toString.format(formatArgs.toSeq: _*)
         }
       case HIVE_STYLE =>
         val seconds = secondsWithFraction / MICROS_PER_SECOND

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -21,6 +21,7 @@ import java.time.{Duration, Period}
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
+import scala.collection.mutable
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
@@ -28,7 +29,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils.millisToMicros
 import org.apache.spark.sql.catalyst.util.IntervalStringStyles.{ANSI_STYLE, HIVE_STYLE, IntervalStyle}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.Decimal
+import org.apache.spark.sql.types.{DayTimeIntervalType, Decimal}
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 // The style of textual representation of intervals
@@ -960,18 +961,31 @@ object IntervalUtils {
   def toDayTimeIntervalString(
       micros: Long,
       style: IntervalStyle,
-      // TODO(SPARK-35734): Format day-time intervals using type fields
       startField: Byte,
       endField: Byte): String = {
     var sign = ""
     var rest = micros
+    val from = DayTimeIntervalType.fieldToString(startField).toUpperCase
+    val to = DayTimeIntervalType.fieldToString(endField).toUpperCase
     if (micros < 0) {
       if (micros == Long.MinValue) {
         // Especial handling of minimum `Long` value because negate op overflows `Long`.
         // seconds = 106751991 * (24 * 60 * 60) + 4 * 60 * 60 + 54 = 9223372036854
         // microseconds = -9223372036854000000L-775808 == Long.MinValue
         val minIntervalString = style match {
-          case ANSI_STYLE => "INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND"
+          case ANSI_STYLE =>
+            val baseStr = "-106751991 04:00:54.775808"
+            val fromPos = startField match {
+              case DayTimeIntervalType.DAY => 0
+              case DayTimeIntervalType.HOUR => 11
+              case DayTimeIntervalType.MINUTE => 14
+            }
+            val toPos = endField match {
+              case DayTimeIntervalType.HOUR => 13
+              case DayTimeIntervalType.MINUTE => 16
+              case DayTimeIntervalType.SECOND => baseStr.length
+            }
+            s"INTERVAL '${baseStr.substring(fromPos, toPos)}' $from TO $to"
           case HIVE_STYLE => "-106751991 04:00:54.775808000"
         }
         return minIntervalString
@@ -992,7 +1006,31 @@ object IntervalUtils {
         val secStr = java.math.BigDecimal.valueOf(secondsWithFraction, 6)
           .stripTrailingZeros()
           .toPlainString()
-        f"INTERVAL '$sign$days $hours%02d:$minutes%02d:$leadSecZero$secStr' DAY TO SECOND"
+        val formatBuilder = new StringBuilder("INTERVAL '")
+        val formatArgs = new mutable.ArrayBuffer[Long]
+        if (startField <= DayTimeIntervalType.DAY && DayTimeIntervalType.DAY < endField) {
+          formatBuilder.append(s"$sign$days ")
+        }
+        if (startField <= DayTimeIntervalType.HOUR && DayTimeIntervalType.HOUR < endField) {
+          formatBuilder.append("%02d:")
+          formatArgs.append(hours)
+        }
+        if (startField <= DayTimeIntervalType.MINUTE && DayTimeIntervalType.MINUTE < endField) {
+          formatBuilder.append("%02d:")
+          formatArgs.append(minutes)
+        }
+        endField match {
+          case DayTimeIntervalType.HOUR =>
+            formatBuilder.append("%02d' ")
+            formatArgs.append(hours)
+          case DayTimeIntervalType.MINUTE =>
+            formatBuilder.append("%02d' ")
+            formatArgs.append(minutes)
+          case DayTimeIntervalType.SECOND =>
+            formatBuilder.append(s"$leadSecZero$secStr' ")
+        }
+
+        formatBuilder.append(s"$from TO $to").toString().format(formatArgs: _*)
       case HIVE_STYLE =>
         val seconds = secondsWithFraction / MICROS_PER_SECOND
         val nanos = (secondsWithFraction % MICROS_PER_SECOND) * NANOS_PER_MICROS

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -534,4 +534,53 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
       assert(toDayTimeIntervalString(micros, HIVE_STYLE, DAY, SECOND) === hiveIntervalStr)
     }
   }
+
+  test("SPARK-35734: Format day-time intervals using type fields") {
+    import DayTimeIntervalType._
+    Seq(
+      0L ->
+        ("INTERVAL '0 00:00:00' DAY TO SECOND",
+          "INTERVAL '0 00:00' DAY TO MINUTE",
+          "INTERVAL '0 00' DAY TO HOUR",
+          "INTERVAL '00:00:00' HOUR TO SECOND",
+          "INTERVAL '00:00' HOUR TO MINUTE",
+          "INTERVAL '00:00' MINUTE TO SECOND"),
+      -1L ->
+        ("INTERVAL '-0 00:00:00.000001' DAY TO SECOND",
+          "INTERVAL '-0 00:00' DAY TO MINUTE",
+          "INTERVAL '-0 00' DAY TO HOUR",
+          "INTERVAL '00:00:00.000001' HOUR TO SECOND",
+          "INTERVAL '00:00' HOUR TO MINUTE",
+          "INTERVAL '00:00.000001' MINUTE TO SECOND"),
+      10 * MICROS_PER_MILLIS ->
+        ("INTERVAL '0 00:00:00.01' DAY TO SECOND",
+          "INTERVAL '0 00:00' DAY TO MINUTE",
+          "INTERVAL '0 00' DAY TO HOUR",
+          "INTERVAL '00:00:00.01' HOUR TO SECOND",
+          "INTERVAL '00:00' HOUR TO MINUTE",
+          "INTERVAL '00:00.01' MINUTE TO SECOND"),
+      (-123 * MICROS_PER_DAY - 3 * MICROS_PER_SECOND) ->
+        ("INTERVAL '-123 00:00:03' DAY TO SECOND",
+          "INTERVAL '-123 00:00' DAY TO MINUTE",
+          "INTERVAL '-123 00' DAY TO HOUR",
+          "INTERVAL '00:00:03' HOUR TO SECOND",
+          "INTERVAL '00:00' HOUR TO MINUTE",
+          "INTERVAL '00:03' MINUTE TO SECOND"),
+      Long.MinValue ->
+        ("INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND",
+          "INTERVAL '-106751991 04:00' DAY TO MINUTE",
+          "INTERVAL '-106751991 04' DAY TO HOUR",
+          "INTERVAL '04:00:54.775808' HOUR TO SECOND",
+          "INTERVAL '04:00' HOUR TO MINUTE",
+          "INTERVAL '00:54.775808' MINUTE TO SECOND")
+    ).foreach {
+      case (micros, (dayToSec, dayToMinute, dayToHour, hourToSec, hourToMinute, minuteToSec)) =>
+        assert(toDayTimeIntervalString(micros, ANSI_STYLE, DAY, SECOND) === dayToSec)
+        assert(toDayTimeIntervalString(micros, ANSI_STYLE, DAY, MINUTE) === dayToMinute)
+        assert(toDayTimeIntervalString(micros, ANSI_STYLE, DAY, HOUR) === dayToHour)
+        assert(toDayTimeIntervalString(micros, ANSI_STYLE, HOUR, SECOND) === hourToSec)
+        assert(toDayTimeIntervalString(micros, ANSI_STYLE, HOUR, MINUTE) === hourToMinute)
+        assert(toDayTimeIntervalString(micros, ANSI_STYLE, MINUTE, SECOND) === minuteToSec)
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -544,43 +544,78 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
           "INTERVAL '0 00' DAY TO HOUR",
           "INTERVAL '00:00:00' HOUR TO SECOND",
           "INTERVAL '00:00' HOUR TO MINUTE",
-          "INTERVAL '00:00' MINUTE TO SECOND"),
+          "INTERVAL '00:00' MINUTE TO SECOND",
+          "INTERVAL '0' DAY",
+          "INTERVAL '00' HOUR",
+          "INTERVAL '00' MINUTE",
+          "INTERVAL '00' SECOND"),
       -1L ->
         ("INTERVAL '-0 00:00:00.000001' DAY TO SECOND",
           "INTERVAL '-0 00:00' DAY TO MINUTE",
           "INTERVAL '-0 00' DAY TO HOUR",
           "INTERVAL '00:00:00.000001' HOUR TO SECOND",
           "INTERVAL '00:00' HOUR TO MINUTE",
-          "INTERVAL '00:00.000001' MINUTE TO SECOND"),
+          "INTERVAL '00:00.000001' MINUTE TO SECOND",
+          "INTERVAL '-0' DAY",
+          "INTERVAL '00' HOUR",
+          "INTERVAL '00' MINUTE",
+          "INTERVAL '00.000001' SECOND"),
       10 * MICROS_PER_MILLIS ->
         ("INTERVAL '0 00:00:00.01' DAY TO SECOND",
           "INTERVAL '0 00:00' DAY TO MINUTE",
           "INTERVAL '0 00' DAY TO HOUR",
           "INTERVAL '00:00:00.01' HOUR TO SECOND",
           "INTERVAL '00:00' HOUR TO MINUTE",
-          "INTERVAL '00:00.01' MINUTE TO SECOND"),
+          "INTERVAL '00:00.01' MINUTE TO SECOND",
+          "INTERVAL '0' DAY",
+          "INTERVAL '00' HOUR",
+          "INTERVAL '00' MINUTE",
+          "INTERVAL '00.01' SECOND"),
       (-123 * MICROS_PER_DAY - 3 * MICROS_PER_SECOND) ->
         ("INTERVAL '-123 00:00:03' DAY TO SECOND",
           "INTERVAL '-123 00:00' DAY TO MINUTE",
           "INTERVAL '-123 00' DAY TO HOUR",
           "INTERVAL '00:00:03' HOUR TO SECOND",
           "INTERVAL '00:00' HOUR TO MINUTE",
-          "INTERVAL '00:03' MINUTE TO SECOND"),
+          "INTERVAL '00:03' MINUTE TO SECOND",
+          "INTERVAL '-123' DAY",
+          "INTERVAL '00' HOUR",
+          "INTERVAL '00' MINUTE",
+          "INTERVAL '03' SECOND"),
       Long.MinValue ->
         ("INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND",
           "INTERVAL '-106751991 04:00' DAY TO MINUTE",
           "INTERVAL '-106751991 04' DAY TO HOUR",
           "INTERVAL '04:00:54.775808' HOUR TO SECOND",
           "INTERVAL '04:00' HOUR TO MINUTE",
-          "INTERVAL '00:54.775808' MINUTE TO SECOND")
+          "INTERVAL '00:54.775808' MINUTE TO SECOND",
+          "INTERVAL '-106751991' DAY",
+          "INTERVAL '04' HOUR",
+          "INTERVAL '00' MINUTE",
+          "INTERVAL '54.775808' SECOND")
     ).foreach {
-      case (micros, (dayToSec, dayToMinute, dayToHour, hourToSec, hourToMinute, minuteToSec)) =>
+      case (
+        micros, (
+          dayToSec,
+          dayToMinute,
+          dayToHour,
+          hourToSec,
+          hourToMinute,
+          minuteToSec,
+          day,
+          hour,
+          minute,
+          sec)) =>
         assert(toDayTimeIntervalString(micros, ANSI_STYLE, DAY, SECOND) === dayToSec)
         assert(toDayTimeIntervalString(micros, ANSI_STYLE, DAY, MINUTE) === dayToMinute)
         assert(toDayTimeIntervalString(micros, ANSI_STYLE, DAY, HOUR) === dayToHour)
         assert(toDayTimeIntervalString(micros, ANSI_STYLE, HOUR, SECOND) === hourToSec)
         assert(toDayTimeIntervalString(micros, ANSI_STYLE, HOUR, MINUTE) === hourToMinute)
         assert(toDayTimeIntervalString(micros, ANSI_STYLE, MINUTE, SECOND) === minuteToSec)
+        assert(toDayTimeIntervalString(micros, ANSI_STYLE, DAY, DAY) === day)
+        assert(toDayTimeIntervalString(micros, ANSI_STYLE, HOUR, HOUR) === hour)
+        assert(toDayTimeIntervalString(micros, ANSI_STYLE, MINUTE, MINUTE) === minute)
+        assert(toDayTimeIntervalString(micros, ANSI_STYLE, SECOND, SECOND) === sec)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR add a feature which formats day-time interval to strings using the start and end fields of `DayTimeIntervalType`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, they are ignored, and any `DayTimeIntervalType` is formatted as `INTERVAL DAY TO SECOND.`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. The format of day-time intervals is determined the start and end fields.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New test.