### PR TITLE
[SPARK-35736][SQL] Parse any day-time interval types in SQL

### DIFF
--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -300,6 +300,7 @@ Below is a list of all the keywords in Spark SQL.
 |GROUP|reserved|non-reserved|reserved|
 |GROUPING|non-reserved|non-reserved|reserved|
 |HAVING|reserved|non-reserved|reserved|
+|HOUR|non-reserved|non-reserved|non-reserved|
 |IF|non-reserved|non-reserved|not a keyword|
 |IGNORE|non-reserved|non-reserved|non-reserved|
 |IMPORT|non-reserved|non-reserved|non-reserved|
@@ -336,6 +337,7 @@ Below is a list of all the keywords in Spark SQL.
 |MAP|non-reserved|non-reserved|non-reserved|
 |MATCHED|non-reserved|non-reserved|non-reserved|
 |MERGE|non-reserved|non-reserved|non-reserved|
+|MINUTE|non-reserved|non-reserved|non-reserved|
 |MINUS|non-reserved|strict-non-reserved|non-reserved|
 |MONTH|non-reserved|non-reserved|non-reserved|
 |MSCK|non-reserved|non-reserved|non-reserved|

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -905,7 +905,8 @@ dataType
     | complex=MAP '<' dataType ',' dataType '>'                 #complexDataType
     | complex=STRUCT ('<' complexColTypeList? '>' | NEQ)        #complexDataType
     | INTERVAL YEAR TO MONTH                                    #yearMonthIntervalDataType
-    | INTERVAL DAY TO SECOND                                    #dayTimeIntervalDataType
+    | INTERVAL from=(DAY | HOUR | MINUTE | SECOND)
+      (TO to=(HOUR | MINUTE | SECOND))?                         #dayTimeIntervalDataType
     | identifier ('(' INTEGER_VALUE (',' INTEGER_VALUE)* ')')?  #primitiveDataType
     ;
 
@@ -1110,6 +1111,7 @@ ansiNonReserved
     | FUNCTIONS
     | GLOBAL
     | GROUPING
+    | HOUR
     | IF
     | IGNORE
     | IMPORT
@@ -1137,6 +1139,7 @@ ansiNonReserved
     | MAP
     | MATCHED
     | MERGE
+    | MINUTE
     | MONTH
     | MSCK
     | NAMESPACE
@@ -1358,6 +1361,7 @@ nonReserved
     | GROUP
     | GROUPING
     | HAVING
+    | HOUR
     | IF
     | IGNORE
     | IMPORT
@@ -1389,6 +1393,7 @@ nonReserved
     | MAP
     | MATCHED
     | MERGE
+    | MINUTE
     | MONTH
     | MSCK
     | NAMESPACE
@@ -1612,6 +1617,7 @@ GRANT: 'GRANT';
 GROUP: 'GROUP';
 GROUPING: 'GROUPING';
 HAVING: 'HAVING';
+HOUR: 'HOUR';
 IF: 'IF';
 IGNORE: 'IGNORE';
 IMPORT: 'IMPORT';
@@ -1648,6 +1654,7 @@ MACRO: 'MACRO';
 MAP: 'MAP';
 MATCHED: 'MATCHED';
 MERGE: 'MERGE';
+MINUTE: 'MINUTE';
 MONTH: 'MONTH';
 MSCK: 'MSCK';
 NAMESPACE: 'NAMESPACE';

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2514,19 +2514,15 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
   }
 
   override def visitDayTimeIntervalDataType(ctx: DayTimeIntervalDataTypeContext): DataType = {
-    def strToFieldIndex(str: String): Byte = str match {
-      case "day" => 0
-      case "hour" => 1
-      case "minute" => 2
-      case "second" => 3
-    }
-    val from = strToFieldIndex(ctx.from.getText.toLowerCase(Locale.ROOT))
-    val to = if (ctx.to != null ) {
+    val strToFieldIndex =
+      DayTimeIntervalType.dayTimeFields.map(i => DayTimeIntervalType.fieldToString(i) -> i).toMap
+    val start = strToFieldIndex(ctx.from.getText.toLowerCase(Locale.ROOT))
+    val end = if (ctx.to != null ) {
       strToFieldIndex(ctx.to.getText.toLowerCase(Locale.ROOT))
     } else {
-      from
+      start
     }
-    DayTimeIntervalType(from, to)
+    DayTimeIntervalType(start, end)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2514,8 +2514,19 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
   }
 
   override def visitDayTimeIntervalDataType(ctx: DayTimeIntervalDataTypeContext): DataType = {
-    // TODO(SPARK-35736): Parse any day-time interval types in SQL
-    DayTimeIntervalType()
+    def strToFieldIndex(str: String): Byte = str match {
+      case "day" => 0
+      case "hour" => 1
+      case "minute" => 2
+      case "second" => 3
+    }
+    val from = strToFieldIndex(ctx.from.getText.toLowerCase(Locale.ROOT))
+    val to = if (ctx.to != null ) {
+      strToFieldIndex(ctx.to.getText.toLowerCase(Locale.ROOT))
+    } else {
+      from
+    }
+    DayTimeIntervalType(from, to)
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -258,6 +258,15 @@ class DataTypeSuite extends SparkFunSuite {
 
   checkDataTypeFromDDL(YearMonthIntervalType)
   checkDataTypeFromDDL(DayTimeIntervalType())
+  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.MINUTE))
+  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.HOUR))
+  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.DAY))
+  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.SECOND))
+  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.MINUTE))
+  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.HOUR))
+  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.MINUTE, DayTimeIntervalType.SECOND))
+  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.MINUTE, DayTimeIntervalType.MINUTE))
+  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.SECOND, DayTimeIntervalType.SECOND))
 
   val metadata = new MetadataBuilder()
     .putString("name", "age")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -257,16 +257,7 @@ class DataTypeSuite extends SparkFunSuite {
   checkDataTypeFromDDL(VarcharType(11))
 
   checkDataTypeFromDDL(YearMonthIntervalType)
-  checkDataTypeFromDDL(DayTimeIntervalType())
-  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.MINUTE))
-  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.HOUR))
-  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.DAY))
-  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.SECOND))
-  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.MINUTE))
-  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.HOUR))
-  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.MINUTE, DayTimeIntervalType.SECOND))
-  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.MINUTE, DayTimeIntervalType.MINUTE))
-  checkDataTypeFromDDL(DayTimeIntervalType(DayTimeIntervalType.SECOND, DayTimeIntervalType.SECOND))
+  dayTimeIntervalTypes.foreach(checkDataTypeFromDDL)
 
   val metadata = new MetadataBuilder()
     .putString("name", "age")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adda a feature which allow the parser parse any day-time interval types in SQL.

### Why are the changes needed?
To comply with ANSI standard, we additionally need to support the following types.

* INTERVAL DAY
* INTERVAL DAY TO HOUR
* INTERVAL DAY TO MINUTE
* INTERVAL HOUR
* INTERVAL HOUR TO MINUTE
* INTERVAL HOUR TO SECOND
* INTERVAL MINUTE
* INTERVAL MINUTE TO SECOND
* INTERVAL SECOND

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New tests.