### PR TITLE
[SPARK-35748][SS][SQL] Fix StreamingJoinHelper to be able to handle day-time interval

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/StreamingJoinHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/StreamingJoinHelper.scala
@@ -266,6 +266,9 @@ object StreamingJoinHelper extends PredicateHelper with Logging {
                 Literal(calendarInterval.days * MICROS_PER_DAY.toDouble +
                   calendarInterval.microseconds.toDouble)
               }
+            case _: DayTimeIntervalType =>
+              // Unbox and then cast
+              Literal(lit.value.asInstanceOf[Long].toDouble)
             case DoubleType =>
               Multiply(lit, Literal(1000000.0))
             case _: NumericType =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/StreamingJoinHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/StreamingJoinHelperSuite.scala
@@ -86,6 +86,18 @@ class StreamingJoinHelperSuite extends AnalysisTest {
     assert(watermarkFrom("rightTime - interval 1 second < leftTime - interval 3 second")
       === Some(12000))
 
+    assert(watermarkFrom("leftTime > rightTime + interval '0 00:00:01' day to second")
+      === Some(11000))
+    assert(watermarkFrom("leftTime + interval '00:00:02' hour to second > rightTime ")
+      === Some(8000))
+    assert(watermarkFrom("leftTime > rightTime - interval '00:03' minute to second")
+      === Some(7000))
+    assert(watermarkFrom("rightTime < leftTime - interval '1 20:30:40' day to second")
+      === Some(160250000))
+    assert(watermarkFrom(
+      "rightTime - interval 1 second < leftTime - interval '20:15:32' hour to second")
+      === Some(72941000))
+
     // Test with casted long type + constants on either side of equation
     // Note: long type and constants commute, so more combinations to test.
     // -- Constants on the right


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes `StreamingJoinHelper` to be able to handle day-time interval.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In the current master, `StreamingJoinHelper.getStateValueWatermark` can't handle conditions which contain day-time interval literals.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New assertions added to `StreamingJoinHlelperSuite`.