### PR TITLE
[SPARK-35614][PYTHON] Make the conversion to pandas data-type-based for ExtensionDtypes

### DIFF
--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -43,10 +43,20 @@ from pyspark.sql.types import (
     UserDefinedType,
 )
 from pyspark.pandas.typedef import Dtype, extension_dtypes
-from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
+from pyspark.pandas.typedef.typehints import (
+    extension_dtypes_available,
+    extension_float_dtypes_available,
+    extension_object_dtypes_available,
+)
+
+if extension_dtypes_available:
+    from pandas import Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype
+
+if extension_float_dtypes_available:
+    from pandas import Float32Dtype, Float64Dtype
 
 if extension_object_dtypes_available:
-    from pandas import BooleanDtype
+    from pandas import BooleanDtype, StringDtype
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
@@ -195,8 +205,14 @@ class DataTypeOps(object, metaclass=ABCMeta):
         from pyspark.pandas.data_type_ops.date_ops import DateOps
         from pyspark.pandas.data_type_ops.datetime_ops import DatetimeOps
         from pyspark.pandas.data_type_ops.null_ops import NullOps
-        from pyspark.pandas.data_type_ops.num_ops import IntegralOps, FractionalOps, DecimalOps
-        from pyspark.pandas.data_type_ops.string_ops import StringOps
+        from pyspark.pandas.data_type_ops.num_ops import (
+            DecimalOps,
+            FractionalExtensionOps,
+            FractionalOps,
+            IntegralExtensionOps,
+            IntegralOps,
+        )
+        from pyspark.pandas.data_type_ops.string_ops import StringOps, StringExtensionOps
         from pyspark.pandas.data_type_ops.udt_ops import UDTOps
 
         if isinstance(dtype, CategoricalDtype):
@@ -204,11 +220,25 @@ class DataTypeOps(object, metaclass=ABCMeta):
         elif isinstance(spark_type, DecimalType):
             return object.__new__(DecimalOps)
         elif isinstance(spark_type, FractionalType):
-            return object.__new__(FractionalOps)
+            if extension_float_dtypes_available and type(dtype) in [Float32Dtype, Float64Dtype]:
+                return object.__new__(FractionalExtensionOps)
+            else:
+                return object.__new__(FractionalOps)
         elif isinstance(spark_type, IntegralType):
-            return object.__new__(IntegralOps)
+            if extension_dtypes_available and type(dtype) in [
+                Int8Dtype,
+                Int16Dtype,
+                Int32Dtype,
+                Int64Dtype,
+            ]:
+                return object.__new__(IntegralExtensionOps)
+            else:
+                return object.__new__(IntegralOps)
         elif isinstance(spark_type, StringType):
-            return object.__new__(StringOps)
+            if extension_object_dtypes_available and isinstance(dtype, StringDtype):
+                return object.__new__(StringExtensionOps)
+            else:
+                return object.__new__(StringOps)
         elif isinstance(spark_type, BooleanType):
             if extension_object_dtypes_available and isinstance(dtype, BooleanDtype):
                 return object.__new__(BooleanExtensionOps)

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -304,3 +304,7 @@ class BooleanExtensionOps(BooleanOps):
             return left | right
 
         return column_op(or_func)(left, right)
+
+    def restore(self, col: pd.Series) -> pd.Series:
+        """Restore column when to_pandas."""
+        return col.astype(self.dtype)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -19,6 +19,7 @@ import numbers
 from typing import TYPE_CHECKING, Union
 
 import numpy as np
+import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op
@@ -414,3 +415,31 @@ class DecimalOps(FractionalOps):
 
     def isnull(self, index_ops: Union["Index", "Series"]) -> Union["Series", "Index"]:
         return index_ops._with_new_scol(index_ops.spark.column.isNull())
+
+
+class IntegralExtensionOps(IntegralOps):
+    """
+    The class for binary operations of pandas-on-Spark objects with one of the
+    - spark types:
+        LongType, IntegerType, ByteType and ShortType
+    - dtypes:
+        Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype
+    """
+
+    def restore(self, col: pd.Series) -> pd.Series:
+        """Restore column when to_pandas."""
+        return col.astype(self.dtype)
+
+
+class FractionalExtensionOps(FractionalOps):
+    """
+    The class for binary operations of pandas-on-Spark objects with one of the
+    - spark types:
+        FloatType, DoubleType and DecimalType
+    - dtypes:
+        Float32Dtype, Float64Dtype
+    """
+
+    def restore(self, col: pd.Series) -> pd.Series:
+        """Restore column when to_pandas."""
+        return col.astype(self.dtype)

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -17,6 +17,7 @@
 
 from typing import TYPE_CHECKING, Union
 
+import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 from pyspark.sql import functions as F
@@ -134,3 +135,14 @@ class StringOps(DataTypeOps):
             return _as_string_type(index_ops, dtype)
         else:
             return _as_other_type(index_ops, dtype, spark_type)
+
+
+class StringExtensionOps(StringOps):
+    """
+    The class for binary operations of pandas-on-Spark objects with spark type StringType,
+    and dtype StringDtype.
+    """
+
+    def restore(self, col: pd.Series) -> pd.Series:
+        """Restore column when to_pandas."""
+        return col.astype(self.dtype)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -341,17 +341,10 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq((pser + 1).astype(float), psser + 1)
         self.assert_eq((pser + 0.1).astype(float), psser + 0.1)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.2"):
-            # In pandas, NA | True is NA, whereas NA | True is True in pandas-on-Spark
-            self.assert_eq(ps.Series([True, True, True], dtype="boolean"), psser + True)
-
-            self.assert_eq(pser + False, psser + False)
-            self.assert_eq(pser + pser, psser + psser)
-        else:
-            # Due to https://github.com/pandas-dev/pandas/issues/39410
-            self.assert_eq(ps.Series([True, True, True]), (psser + True).astype(bool))
-            self.assert_eq([True, False, pd._libs.missing.NAType()], (psser + False).tolist())
-            self.assert_eq([True, False, pd._libs.missing.NAType()], (psser + psser).tolist())
+        # In pandas, NA | True is NA, whereas NA | True is True in pandas-on-Spark
+        self.check_extension(ps.Series([True, True, True], dtype="boolean"), psser + True)
+        self.check_extension(pser + False, psser + False)
+        self.check_extension(pser + pser, psser + psser)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -361,13 +354,7 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                     self.assertRaises(TypeError, lambda: self.psser + psser)
             bool_pser = pd.Series([False, False, False])
             bool_psser = ps.from_pandas(bool_pser)
-            if LooseVersion(pd.__version__) >= LooseVersion("1.2.2"):
-                self.assert_eq(self.pser + bool_pser, self.psser + bool_psser)
-            else:
-                # Due to https://github.com/pandas-dev/pandas/issues/39410
-                self.assert_eq(
-                    [True, False, pd._libs.missing.NAType()], (self.psser + bool_psser).tolist()
-                )
+            self.check_extension(self.pser + bool_pser, self.psser + bool_psser)
 
     def test_sub(self):
         pser = self.pser
@@ -390,15 +377,9 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq((pser * 0.1).astype(float), psser * 0.1)
 
         # In pandas, NA & False is NA, whereas NA & False is False in pandas-on-Spark
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.2"):
-            self.assert_eq(pser * True, psser * True)
-            self.assert_eq(ps.Series([False, False, False], dtype="boolean"), psser * False)
-            self.assert_eq(pser * pser, psser * psser)
-        else:
-            # Due to https://github.com/pandas-dev/pandas/issues/39410
-            self.assert_eq([True, False, pd._libs.missing.NAType()], (psser * True).tolist())
-            self.assert_eq(ps.Series([False, False, False]), (psser * False).astype(bool))
-            self.assert_eq([True, False, pd._libs.missing.NAType()], (psser * psser).tolist())
+        self.check_extension(pser * True, psser * True)
+        self.check_extension(ps.Series([False, False, False], dtype="boolean"), psser * False)
+        self.check_extension(pser * pser, psser * psser)
 
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
@@ -408,13 +389,7 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                     self.assertRaises(TypeError, lambda: self.psser * psser)
             bool_pser = pd.Series([True, True, True])
             bool_psser = ps.from_pandas(bool_pser)
-            if LooseVersion(pd.__version__) >= LooseVersion("1.2.2"):
-                self.assert_eq(self.pser * bool_pser, self.psser * bool_psser)
-            else:
-                # Due to https://github.com/pandas-dev/pandas/issues/39410
-                self.assert_eq(
-                    [True, False, pd._libs.missing.NAType()], (self.psser * bool_psser).tolist()
-                )
+            self.check_extension(self.pser * bool_pser, self.psser * bool_psser)
 
     def test_truediv(self):
         pser = self.pser
@@ -495,12 +470,8 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: "x" + self.psser)
 
         # In pandas, NA | True is NA, whereas NA | True is True in pandas-on-Spark
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.2"):
-            self.assert_eq(ps.Series([True, True, True], dtype="boolean"), True + self.psser)
-            self.assert_eq(False + self.pser, False + self.psser)
-        else:
-            # Due to https://github.com/pandas-dev/pandas/issues/39410
-            self.assert_eq(ps.Series([True, True, True]), (True + self.psser).astype(bool))
+        self.check_extension(ps.Series([True, True, True], dtype="boolean"), True + self.psser)
+        self.check_extension(False + self.pser, False + self.psser)
 
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) + self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) + self.psser)
@@ -519,12 +490,8 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: "x" * self.psser)
 
         # In pandas, NA & False is NA, whereas NA & False is False in pandas-on-Spark
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.2"):
-            self.assert_eq(True * self.pser, True * self.psser)
-            self.assert_eq(ps.Series([False, False, False], dtype="boolean"), False * self.psser)
-        else:
-            # Due to https://github.com/pandas-dev/pandas/issues/39410
-            self.assert_eq(ps.Series([False, False, False]), (False * self.psser).astype(bool))
+        self.check_extension(True * self.pser, True * self.psser)
+        self.check_extension(ps.Series([False, False, False], dtype="boolean"), False * self.psser)
 
         self.assertRaises(TypeError, lambda: datetime.date(1994, 1, 1) * self.psser)
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) * self.psser)
@@ -596,8 +563,8 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         data = [True, True, False, None]
         pser = pd.Series(data, dtype="boolean")
         psser = ps.Series(data, dtype="boolean")
-        self.assert_eq(pser, psser.to_pandas())
-        self.assert_eq(ps.from_pandas(pser), psser)
+        self.check_extension(pser, psser.to_pandas())
+        self.check_extension(ps.from_pandas(pser), psser)
 
     def test_isnull(self):
         self.assert_eq(self.pser.isnull(), self.psser.isnull())

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -26,7 +26,7 @@ from pandas.api.types import CategoricalDtype
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
-from pyspark.pandas.typedef.typehints import extension_dtypes_available
+from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
 from pyspark.sql.types import BooleanType
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
@@ -307,7 +307,9 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
-@unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
+@unittest.skipIf(
+    not extension_object_dtypes_available, "pandas extension object dtypes are not available"
+)
 class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     @property
     def pser(self):
@@ -591,9 +593,9 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.check_extension(False | self.pser, False | self.psser)
 
     def test_from_to_pandas(self):
-        data = [True, True, False]
-        pser = pd.Series(data)
-        psser = ps.Series(data)
+        data = [True, True, False, None]
+        pser = pd.Series(data, dtype="boolean")
+        psser = ps.Series(data, dtype="boolean")
         self.assert_eq(pser, psser.to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -16,6 +16,7 @@
 #
 
 import datetime
+import unittest
 from distutils.version import LooseVersion
 
 import pandas as pd
@@ -25,6 +26,10 @@ from pandas.api.types import CategoricalDtype
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
+from pyspark.pandas.typedef.typehints import (
+    extension_dtypes_available,
+    extension_float_dtypes_available,
+)
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
 
@@ -313,8 +318,33 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
+@unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
+class IntegralExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
+    def test_from_to_pandas(self):
+        data = [1, 2, 3, None]
+        dtypes = ["Int8", "Int16", "Int32", "Int64"]
+        for dtype in dtypes:
+            pser = pd.Series(data, dtype=dtype)
+            psser = ps.Series(data, dtype=dtype)
+            self.check_extension(pser, psser.to_pandas())
+            self.check_extension(ps.from_pandas(pser), psser)
+
+
+@unittest.skipIf(
+    not extension_float_dtypes_available, "pandas extension float dtypes are not available"
+)
+class FractionalExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
+    def test_from_to_pandas(self):
+        data = [0.1, 0.2, 0.3, None]
+        dtypes = ["Float32", "Float64"]
+        for dtype in dtypes:
+            pser = pd.Series(data, dtype=dtype)
+            psser = ps.Series(data, dtype=dtype)
+            self.check_extension(pser, psser.to_pandas())
+            self.check_extension(ps.from_pandas(pser), psser)
+
+
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.data_type_ops.test_num_ops import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+import unittest
+
 import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -22,6 +24,7 @@ from pandas.api.types import CategoricalDtype
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
+from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
 
@@ -174,8 +177,19 @@ class StringOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
 
+@unittest.skipIf(
+    not extension_object_dtypes_available, "pandas extension object dtypes are not available"
+)
+class StringExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
+    def test_from_to_pandas(self):
+        data = ["x", "y", "z", None]
+        pser = pd.Series(data, dtype="string")
+        psser = ps.Series(data, dtype="string")
+        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(ps.from_pandas(pser), psser)
+
+
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.data_type_ops.test_string_ops import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -83,9 +83,9 @@ class TestCasesUtils(object):
 
     def check_extension(self, psser, pser):
         """
-        Compare `psser` and `pser` of ExtensionDtypes.
+        Compare `psser` and `pser` of numeric ExtensionDtypes.
 
-        This utility is to adjust an issue for comparing ExtensionDtypes objects in specific
+        This utility is to adjust an issue for comparing numeric ExtensionDtypes in specific
         pandas versions. Please refer to https://github.com/pandas-dev/pandas/issues/39410.
         """
         if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -82,6 +82,12 @@ class TestCasesUtils(object):
         return zip(self.psers, self.pssers)
 
     def check_extension(self, psser, pser):
+        """
+        Compare `psser` and `pser` of ExtensionDtypes.
+
+        This utility is to adjust an issue for comparing ExtensionDtypes objects in specific
+        pandas versions. Please refer to https://github.com/pandas-dev/pandas/issues/39410.
+        """
         if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
             self.assert_eq(psser, pser, check_exact=False)
             self.assertTrue(isinstance(psser.dtype, extension_dtypes))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We propose to
- introduce the Ops class for ExtensionDtypes: `IntegralExtensionOps`, `FractionalExtensionOps`, `StringExtensionOps`
- make the "conversion to pandas" data-type-based for ExtensionDtypes

Non-goal: same arithmetic operation of ExtensionDtypes have different result dtypes between pandas and pandas API on Spark. That should be adjusted in a separated PR if needed.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The conversion to pandas includes logic for checking ExtensionDtypes data types and behaving accordingly.
That makes code hard to change or maintain.

Since we have DataTypeOps defined, we are able to dispatch the specific conversion logic to the `ExtensionOps` classes.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.

Keyword: SPARK-35337