### PR TITLE
[SPARK-35761][PYTHON] Use type-annotation based pandas_udf or avoid specifying udf types to suppress warnings

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -23,11 +23,10 @@ from abc import ABCMeta, abstractmethod
 import sys
 import inspect
 from collections import OrderedDict, namedtuple
-from collections.abc import Callable
 from distutils.version import LooseVersion
 from functools import partial
 from itertools import product
-from typing import Any, List, Set, Tuple, Union, cast
+from typing import Any, Callable, List, Set, Tuple, Union, cast
 
 import pandas as pd
 from pandas.api.types import is_hashable, is_list_like

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -32,7 +32,7 @@ from typing import Any, List, Set, Tuple, Union, cast
 import pandas as pd
 from pandas.api.types import is_hashable, is_list_like
 
-from pyspark.sql import Column, Window, functions as F
+from pyspark.sql import Column, DataFrame as SparkDataFrame, Window, functions as F
 from pyspark.sql.types import (  # noqa: F401
     DataType,
     FloatType,
@@ -42,7 +42,6 @@ from pyspark.sql.types import (  # noqa: F401
     StructType,
     StringType,
 )
-from pyspark.sql.functions import PandasUDFType, pandas_udf
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.typedef import infer_return_type, DataFrameType, ScalarType, SeriesType
@@ -1175,9 +1174,7 @@ class GroupBy(object, metaclass=ABCMeta):
             data_fields = [
                 field.normalize_spark_type() for field in psdf_from_pandas._internal.data_fields
             ]
-            return_schema = StructType(
-                [field.struct_field for field in index_fields + data_fields]
-            )  # type: DataType
+            return_schema = StructType([field.struct_field for field in index_fields + data_fields])
         else:
             return_type = infer_return_type(func)
             if not is_series_groupby and isinstance(return_type, SeriesType):
@@ -1375,14 +1372,24 @@ class GroupBy(object, metaclass=ABCMeta):
         return DataFrame(psdf._internal.resolved_copy), groupkey_labels, groupkey_names
 
     @staticmethod
-    def _spark_group_map_apply(psdf, func, groupkeys_scols, return_schema, retain_index):
+    def _spark_group_map_apply(
+        psdf: DataFrame,
+        func: Callable[[pd.DataFrame], pd.DataFrame],
+        groupkeys_scols: List[Column],
+        return_schema: StructType,
+        retain_index: bool,
+    ) -> SparkDataFrame:
         output_func = GroupBy._make_pandas_df_builder_func(psdf, func, return_schema, retain_index)
-        grouped_map_func = pandas_udf(return_schema, PandasUDFType.GROUPED_MAP)(output_func)
         sdf = psdf._internal.spark_frame.drop(*HIDDEN_COLUMNS)
-        return sdf.groupby(*groupkeys_scols).apply(grouped_map_func)
+        return sdf.groupby(*groupkeys_scols).applyInPandas(output_func, return_schema)
 
     @staticmethod
-    def _make_pandas_df_builder_func(psdf, func, return_schema, retain_index):
+    def _make_pandas_df_builder_func(
+        psdf: DataFrame,
+        func: Callable[[pd.DataFrame], pd.DataFrame],
+        return_schema: StructType,
+        retain_index: bool,
+    ) -> Callable[[pd.DataFrame], pd.DataFrame]:
         """
         Creates a function that can be used inside the pandas UDF. This function can construct
         the same pandas DataFrame as if the pandas-on-Spark DataFrame is collected to driver side.
@@ -1390,7 +1397,7 @@ class GroupBy(object, metaclass=ABCMeta):
         """
         arguments_for_restore_index = psdf._internal.arguments_for_restore_index
 
-        def rename_output(pdf):
+        def rename_output(pdf: pd.DataFrame) -> pd.DataFrame:
             pdf = InternalFrame.restore_index(pdf.copy(), **arguments_for_restore_index)
 
             pdf = func(pdf)
@@ -2161,7 +2168,7 @@ class GroupBy(object, metaclass=ABCMeta):
                 as_nullable_spark_type(
                     psdf_from_pandas._internal.spark_frame.drop(*HIDDEN_COLUMNS).schema
                 )
-            )  # type: DataType
+            )
             if len(pdf) <= limit:
                 return psdf_from_pandas
 

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -29,7 +29,7 @@ from pandas.api.types import CategoricalDtype  # noqa: F401
 from pyspark import sql as spark
 from pyspark._globals import _NoValue, _NoValueType
 from pyspark.sql import functions as F, Window
-from pyspark.sql.functions import PandasUDFType, pandas_udf
+from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import (  # noqa: F401
     BooleanType,
     DataType,
@@ -1008,7 +1008,7 @@ class InternalFrame(object):
         sums = dict(zip(map(lambda count: count[0], sorted_counts), cumulative_counts))
 
         # 3. Attach offset for each partition.
-        @pandas_udf(LongType(), PandasUDFType.SCALAR)
+        @pandas_udf(returnType=LongType())  # type: ignore
         def offset(id: pd.Series) -> pd.Series:
             current_partition_offset = sums[id.iloc[0]]
             return pd.Series(current_partition_offset).repeat(len(id))

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -47,7 +47,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from pyspark import sql as spark
 from pyspark.sql import functions as F
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import (
     ByteType,
     ShortType,
@@ -763,8 +763,8 @@ def read_parquet(
         # Try to read pandas metadata
 
         @no_type_check
-        @pandas_udf("index_col array<string>, index_names array<string>", PandasUDFType.SCALAR)
-        def read_index_metadata(pser):
+        @pandas_udf("index_col array<string>, index_names array<string>")
+        def read_index_metadata(pser: pd.Series) -> pd.DataFrame:
             binary = pser.iloc[0]
             metadata = pq.ParquetFile(pa.BufferReader(binary)).metadata.metadata
             if b"pandas" in metadata:

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, TYPE_CHECKING, no_type_check
 
 import numpy as np
 from pyspark.sql import functions as F, Column
-from pyspark.sql.pandas.functions import pandas_udf, PandasUDFType
+from pyspark.sql.pandas.functions import pandas_udf
 from pyspark.sql.types import DoubleType, LongType, BooleanType
 
 if TYPE_CHECKING:
@@ -31,11 +31,11 @@ unary_np_spark_mappings = OrderedDict(
         "abs": F.abs,
         "absolute": F.abs,
         "arccos": F.acos,
-        "arccosh": pandas_udf(lambda s: np.arccosh(s), DoubleType(), PandasUDFType.SCALAR),
+        "arccosh": pandas_udf(lambda s: np.arccosh(s), DoubleType()),  # type: ignore
         "arcsin": F.asin,
-        "arcsinh": pandas_udf(lambda s: np.arcsinh(s), DoubleType(), PandasUDFType.SCALAR),
+        "arcsinh": pandas_udf(lambda s: np.arcsinh(s), DoubleType()),  # type: ignore
         "arctan": F.atan,
-        "arctanh": pandas_udf(lambda s: np.arctanh(s), DoubleType(), PandasUDFType.SCALAR),
+        "arctanh": pandas_udf(lambda s: np.arctanh(s), DoubleType()),  # type: ignore
         "bitwise_not": F.bitwiseNOT,
         "cbrt": F.cbrt,
         "ceil": F.ceil,
@@ -43,17 +43,17 @@ unary_np_spark_mappings = OrderedDict(
         "conj": lambda _: NotImplemented,
         "conjugate": lambda _: NotImplemented,  # It requires complex type
         "cos": F.cos,
-        "cosh": pandas_udf(lambda s: np.cosh(s), DoubleType(), PandasUDFType.SCALAR),
-        "deg2rad": pandas_udf(lambda s: np.deg2rad(s), DoubleType(), PandasUDFType.SCALAR),
+        "cosh": pandas_udf(lambda s: np.cosh(s), DoubleType()),  # type: ignore
+        "deg2rad": pandas_udf(lambda s: np.deg2rad(s), DoubleType()),  # type: ignore
         "degrees": F.degrees,
         "exp": F.exp,
-        "exp2": pandas_udf(lambda s: np.exp2(s), DoubleType(), PandasUDFType.SCALAR),
+        "exp2": pandas_udf(lambda s: np.exp2(s), DoubleType()),  # type: ignore
         "expm1": F.expm1,
-        "fabs": pandas_udf(lambda s: np.fabs(s), DoubleType(), PandasUDFType.SCALAR),
+        "fabs": pandas_udf(lambda s: np.fabs(s), DoubleType()),  # type: ignore
         "floor": F.floor,
         "frexp": lambda _: NotImplemented,  # 'frexp' output lengths become different
         # and it cannot be supported via pandas UDF.
-        "invert": pandas_udf(lambda s: np.invert(s), DoubleType(), PandasUDFType.SCALAR),
+        "invert": pandas_udf(lambda s: np.invert(s), DoubleType()),  # type: ignore
         "isfinite": lambda c: c != float("inf"),
         "isinf": lambda c: c == float("inf"),
         "isnan": F.isnan,
@@ -61,25 +61,25 @@ unary_np_spark_mappings = OrderedDict(
         "log": F.log,
         "log10": F.log10,
         "log1p": F.log1p,
-        "log2": pandas_udf(lambda s: np.log2(s), DoubleType(), PandasUDFType.SCALAR),
+        "log2": pandas_udf(lambda s: np.log2(s), DoubleType()),  # type: ignore
         "logical_not": lambda c: ~(c.cast(BooleanType())),
         "matmul": lambda _: NotImplemented,  # Can return a NumPy array in pandas.
         "negative": lambda c: c * -1,
         "positive": lambda c: c,
-        "rad2deg": pandas_udf(lambda s: np.rad2deg(s), DoubleType(), PandasUDFType.SCALAR),
+        "rad2deg": pandas_udf(lambda s: np.rad2deg(s), DoubleType()),  # type: ignore
         "radians": F.radians,
-        "reciprocal": pandas_udf(lambda s: np.reciprocal(s), DoubleType(), PandasUDFType.SCALAR),
-        "rint": pandas_udf(lambda s: np.rint(s), DoubleType(), PandasUDFType.SCALAR),
+        "reciprocal": pandas_udf(lambda s: np.reciprocal(s), DoubleType()),  # type: ignore
+        "rint": pandas_udf(lambda s: np.rint(s), DoubleType()),  # type: ignore
         "sign": lambda c: F.when(c == 0, 0).when(c < 0, -1).otherwise(1),
         "signbit": lambda c: F.when(c < 0, True).otherwise(False),
         "sin": F.sin,
-        "sinh": pandas_udf(lambda s: np.sinh(s), DoubleType(), PandasUDFType.SCALAR),
-        "spacing": pandas_udf(lambda s: np.spacing(s), DoubleType(), PandasUDFType.SCALAR),
+        "sinh": pandas_udf(lambda s: np.sinh(s), DoubleType()),  # type: ignore
+        "spacing": pandas_udf(lambda s: np.spacing(s), DoubleType()),  # type: ignore
         "sqrt": F.sqrt,
-        "square": pandas_udf(lambda s: np.square(s), DoubleType(), PandasUDFType.SCALAR),
+        "square": pandas_udf(lambda s: np.square(s), DoubleType()),  # type: ignore
         "tan": F.tan,
-        "tanh": pandas_udf(lambda s: np.tanh(s), DoubleType(), PandasUDFType.SCALAR),
-        "trunc": pandas_udf(lambda s: np.trunc(s), DoubleType(), PandasUDFType.SCALAR),
+        "tanh": pandas_udf(lambda s: np.tanh(s), DoubleType()),  # type: ignore
+        "trunc": pandas_udf(lambda s: np.trunc(s), DoubleType()),  # type: ignore
     }
 )
 
@@ -89,33 +89,25 @@ binary_np_spark_mappings = OrderedDict(
         "bitwise_and": lambda c1, c2: c1.bitwiseAND(c2),
         "bitwise_or": lambda c1, c2: c1.bitwiseOR(c2),
         "bitwise_xor": lambda c1, c2: c1.bitwiseXOR(c2),
-        "copysign": pandas_udf(
-            lambda s1, s2: np.copysign(s1, s2), DoubleType(), PandasUDFType.SCALAR
+        "copysign": pandas_udf(lambda s1, s2: np.copysign(s1, s2), DoubleType()),  # type: ignore
+        "float_power": pandas_udf(  # type: ignore
+            lambda s1, s2: np.float_power(s1, s2), DoubleType()
         ),
-        "float_power": pandas_udf(
-            lambda s1, s2: np.float_power(s1, s2), DoubleType(), PandasUDFType.SCALAR
+        "floor_divide": pandas_udf(  # type: ignore
+            lambda s1, s2: np.floor_divide(s1, s2), DoubleType()
         ),
-        "floor_divide": pandas_udf(
-            lambda s1, s2: np.floor_divide(s1, s2), DoubleType(), PandasUDFType.SCALAR
-        ),
-        "fmax": pandas_udf(lambda s1, s2: np.fmax(s1, s2), DoubleType(), PandasUDFType.SCALAR),
-        "fmin": pandas_udf(lambda s1, s2: np.fmin(s1, s2), DoubleType(), PandasUDFType.SCALAR),
-        "fmod": pandas_udf(lambda s1, s2: np.fmod(s1, s2), DoubleType(), PandasUDFType.SCALAR),
-        "gcd": pandas_udf(lambda s1, s2: np.gcd(s1, s2), DoubleType(), PandasUDFType.SCALAR),
-        "heaviside": pandas_udf(
-            lambda s1, s2: np.heaviside(s1, s2), DoubleType(), PandasUDFType.SCALAR
-        ),
+        "fmax": pandas_udf(lambda s1, s2: np.fmax(s1, s2), DoubleType()),  # type: ignore
+        "fmin": pandas_udf(lambda s1, s2: np.fmin(s1, s2), DoubleType()),  # type: ignore
+        "fmod": pandas_udf(lambda s1, s2: np.fmod(s1, s2), DoubleType()),  # type: ignore
+        "gcd": pandas_udf(lambda s1, s2: np.gcd(s1, s2), DoubleType()),  # type: ignore
+        "heaviside": pandas_udf(lambda s1, s2: np.heaviside(s1, s2), DoubleType()),  # type: ignore
         "hypot": F.hypot,
-        "lcm": pandas_udf(lambda s1, s2: np.lcm(s1, s2), DoubleType(), PandasUDFType.SCALAR),
-        "ldexp": pandas_udf(lambda s1, s2: np.ldexp(s1, s2), DoubleType(), PandasUDFType.SCALAR),
-        "left_shift": pandas_udf(
-            lambda s1, s2: np.left_shift(s1, s2), LongType(), PandasUDFType.SCALAR
-        ),
-        "logaddexp": pandas_udf(
-            lambda s1, s2: np.logaddexp(s1, s2), DoubleType(), PandasUDFType.SCALAR
-        ),
-        "logaddexp2": pandas_udf(
-            lambda s1, s2: np.logaddexp2(s1, s2), DoubleType(), PandasUDFType.SCALAR
+        "lcm": pandas_udf(lambda s1, s2: np.lcm(s1, s2), DoubleType()),  # type: ignore
+        "ldexp": pandas_udf(lambda s1, s2: np.ldexp(s1, s2), DoubleType()),  # type: ignore
+        "left_shift": pandas_udf(lambda s1, s2: np.left_shift(s1, s2), LongType()),  # type: ignore
+        "logaddexp": pandas_udf(lambda s1, s2: np.logaddexp(s1, s2), DoubleType()),  # type: ignore
+        "logaddexp2": pandas_udf(  # type: ignore
+            lambda s1, s2: np.logaddexp2(s1, s2), DoubleType()
         ),
         "logical_and": lambda c1, c2: c1.cast(BooleanType()) & c2.cast(BooleanType()),
         "logical_or": lambda c1, c2: c1.cast(BooleanType()) | c2.cast(BooleanType()),
@@ -126,12 +118,10 @@ binary_np_spark_mappings = OrderedDict(
         ),
         "maximum": F.greatest,
         "minimum": F.least,
-        "modf": pandas_udf(lambda s1, s2: np.modf(s1, s2), DoubleType(), PandasUDFType.SCALAR),
-        "nextafter": pandas_udf(
-            lambda s1, s2: np.nextafter(s1, s2), DoubleType(), PandasUDFType.SCALAR
-        ),
-        "right_shift": pandas_udf(
-            lambda s1, s2: np.right_shift(s1, s2), LongType(), PandasUDFType.SCALAR
+        "modf": pandas_udf(lambda s1, s2: np.modf(s1, s2), DoubleType()),  # type: ignore
+        "nextafter": pandas_udf(lambda s1, s2: np.nextafter(s1, s2), DoubleType()),  # type: ignore
+        "right_shift": pandas_udf(  # type: ignore
+            lambda s1, s2: np.right_shift(s1, s2), LongType()
         ),
     }
 )

--- a/python/pyspark/pandas/strings.py
+++ b/python/pyspark/pandas/strings.py
@@ -32,9 +32,10 @@ from typing import (
 
 import numpy as np
 
+import pandas as pd
 from pyspark.sql.types import StringType, BinaryType, ArrayType, LongType, MapType
 from pyspark.sql import functions as F
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import pandas_udf
 
 from pyspark.pandas.spark import functions as SF
 
@@ -1182,11 +1183,10 @@ class StringMethods(object):
         dtype: object
         """
         # type hint does not support to specify array type yet.
-        pudf = pandas_udf(
-            lambda s, *_: s.str.findall(pat, flags),
-            returnType=ArrayType(StringType(), containsNull=True),
-            functionType=PandasUDFType.SCALAR,
-        )
+        @pandas_udf(returnType=ArrayType(StringType(), containsNull=True))  # type: ignore
+        def pudf(s: pd.Series) -> pd.Series:
+            return s.str.findall(pat, flags)
+
         return self._data._with_new_scol(scol=pudf(self._data.spark.column))
 
     def index(self, sub: str, start: int = 0, end: Optional[int] = None) -> "ps.Series":
@@ -2054,11 +2054,11 @@ class StringMethods(object):
 
         # type hint does not support to specify array type yet.
         return_type = ArrayType(StringType(), containsNull=True)
-        pudf = pandas_udf(
-            lambda s, *_: s.str.split(pat, n),
-            returnType=return_type,
-            functionType=PandasUDFType.SCALAR,
-        )
+
+        @pandas_udf(returnType=return_type)  # type: ignore
+        def pudf(s: pd.Series) -> pd.Series:
+            return s.str.split(pat, n)
+
         psser = self._data._with_new_scol(
             pudf(self._data.spark.column).alias(self._data._internal.data_spark_column_names[0]),
             field=self._data._internal.data_fields[0].copy(spark_type=return_type, nullable=True),
@@ -2201,11 +2201,11 @@ class StringMethods(object):
 
         # type hint does not support to specify array type yet.
         return_type = ArrayType(StringType(), containsNull=True)
-        pudf = pandas_udf(
-            lambda s, *_: s.str.rsplit(pat, n),
-            returnType=return_type,
-            functionType=PandasUDFType.SCALAR,
-        )
+
+        @pandas_udf(returnType=return_type)  # type: ignore
+        def pudf(s: pd.Series) -> pd.Series:
+            return s.str.rsplit(pat, n)
+
         psser = self._data._with_new_scol(
             pudf(self._data.spark.column).alias(self._data._internal.data_spark_column_names[0]),
             field=self._data._internal.data_fields[0].copy(spark_type=return_type, nullable=True),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modify the `pandas_udf` usage to use type-annotation based pandas_udf or avoid specifying udf types to suppress warnings.

### Why are the changes needed?

The usage of `pandas_udf` in pandas-on-Spark is outdated and shows warnings.
We should use type-annotation based `pandas_udf` or avoid specifying udf types.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.