### PR TITLE
[SPARK-35770][SQL] Parse YearMonthIntervalType from JSON

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -175,7 +175,8 @@ object DataType {
       // TODO(SPARK-35732): Parse DayTimeIntervalType from JSON
       DayTimeIntervalType(),
       YearMonthIntervalType(YEAR, YEAR),
-      YearMonthIntervalType(MONTH, MONTH), YearMonthIntervalType(YEAR, MONTH),
+      YearMonthIntervalType(MONTH, MONTH),
+      YearMonthIntervalType(YEAR, MONTH),
       TimestampWithoutTZType)
       .map(t => t.typeName -> t).toMap
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy.{ANSI, STRICT}
+import org.apache.spark.sql.types.YearMonthIntervalType._
 import org.apache.spark.util.Utils
 
 /**
@@ -173,8 +174,9 @@ object DataType {
       DoubleType, FloatType, ShortType, ByteType, StringType, CalendarIntervalType,
       // TODO(SPARK-35732): Parse DayTimeIntervalType from JSON
       DayTimeIntervalType(),
-      // TODO(SPARK-35770): Parse YearMonthIntervalType from JSON
-      YearMonthIntervalType(), TimestampWithoutTZType)
+      YearMonthIntervalType(YEAR, YEAR),
+      YearMonthIntervalType(MONTH, MONTH), YearMonthIntervalType(YEAR, MONTH),
+      TimestampWithoutTZType)
       .map(t => t.typeName -> t).toMap
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -256,6 +256,9 @@ class DataTypeSuite extends SparkFunSuite {
   checkDataTypeFromJson(VarcharType(10))
   checkDataTypeFromDDL(VarcharType(11))
 
+
+  yearMonthIntervalTypes.foreach(checkDataTypeFromJson)
+
   yearMonthIntervalTypes.foreach(checkDataTypeFromDDL)
   dayTimeIntervalTypes.foreach(checkDataTypeFromDDL)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Parse YearMonthIntervalType from JSON.

### Why are the changes needed?
This will allow to store year-month intervals as table columns into Hive external catalog.

### Does this PR introduce _any_ user-facing change?
People can store year-month interval types as json string.

### How was this patch tested?
Added UT.