### PR TITLE
[SPARK-33898][SQL] Support SHOW CREATE TABLE In V2

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -934,8 +934,8 @@ private[spark] object QueryCompilationErrors {
     notSupportedForV2TablesError("LOAD DATA")
   }
 
-  def showCreateTableNotSupportedForV2TablesError(): Throwable = {
-    notSupportedForV2TablesError("SHOW CREATE TABLE")
+  def showCreateTableAsSerdeNotSupportedForV2TablesError(): Throwable = {
+    notSupportedForV2TablesError("SHOW CREATE TABLE AS SERDE")
   }
 
   def showColumnsNotSupportedForV2TablesError(): Throwable = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -377,8 +377,11 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
     case LoadData(_: ResolvedTable, _, _, _, _) =>
       throw QueryCompilationErrors.loadDataNotSupportedForV2TablesError()
 
-    case ShowCreateTable(_: ResolvedTable, _, _) =>
-      throw QueryCompilationErrors.showCreateTableNotSupportedForV2TablesError()
+    case ShowCreateTable(rt: ResolvedTable, asSerde, output) =>
+      if (asSerde) {
+        throw QueryCompilationErrors.showCreateTableAsSerdeNotSupportedForV2TablesError()
+      }
+      ShowCreateTableExec(output, rt.table) :: Nil
 
     case TruncateTable(r: ResolvedTable) =>
       TruncateTableExec(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.util.escapeSingleQuotedString
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Table, TableCatalog}
+import org.apache.spark.sql.execution.LeafExecNode
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * Physical plan node for show create table.
+ */
+case class ShowCreateTableExec(
+    output: Seq[Attribute],
+    table: Table) extends V2CommandExec with LeafExecNode {
+  override protected def run(): Seq[InternalRow] = {
+    val builder = StringBuilder.newBuilder
+    // it is used to generate Spark DDL for given table. include Hive Serde table
+    showCreateTable(table, builder)
+    Seq(InternalRow(UTF8String.fromString(builder.toString)))
+  }
+
+  private def showCreateTable(table: Table, builder: StringBuilder): Unit = {
+    import scala.collection.JavaConverters._
+    builder ++= s"CREATE TABLE ${table.name()} "
+
+    showTableDataColumns(table, builder)
+    showTableUsing(table, builder)
+
+    val tableOptions = table.properties.asScala
+      .filterKeys(_.startsWith(TableCatalog.OPTION_PREFIX)).map {
+      case (k, v) => k.drop(TableCatalog.OPTION_PREFIX.length) -> v
+    }.toMap
+    showTableOptions(builder, tableOptions)
+    showTablePartitioning(table, builder)
+    showTableComment(table, builder)
+    showTableLocation(table, builder)
+    showTableProperties(table, builder, tableOptions)
+  }
+
+  private def showTableDataColumns(table: Table, builder: StringBuilder): Unit = {
+    val columns = table.schema().fields.map(_.toDDL)
+    builder ++= concatByMultiLines(columns)
+  }
+
+  private def showTableUsing(table: Table, builder: StringBuilder): Unit = {
+    Option(table.properties.get(TableCatalog.PROP_PROVIDER))
+      .map("USING " + escapeSingleQuotedString(_) + "\n")
+      .foreach(builder.append)
+  }
+
+  private def showTableOptions(
+      builder: StringBuilder,
+      tableOptions: Map[String, String]): Unit = {
+    if (tableOptions.nonEmpty) {
+      val props = tableOptions.map { case (key, value) =>
+        s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
+      }
+      builder ++= "OPTIONS"
+      builder ++= concatByMultiLines(props)
+    }
+  }
+
+  private def showTablePartitioning(table: Table, builder: StringBuilder): Unit = {
+    if (!table.partitioning.isEmpty) {
+      val transforms = new mutable.ArrayBuffer[String]
+      table.partitioning.foreach(t => transforms += t.describe())
+      builder ++= s"PARTITIONED BY ${transforms.mkString("(", ", ", ")")}\n"
+    }
+  }
+
+  private def showTableLocation(table: Table, builder: StringBuilder): Unit = {
+    Option(table.properties.get(TableCatalog.PROP_LOCATION))
+      .map("LOCATION '" + escapeSingleQuotedString(_) + "'\n")
+      .foreach(builder.append)
+  }
+
+  private def showTableProperties(
+      table: Table,
+      builder: StringBuilder,
+      tableOptions: Map[String, String]): Unit = {
+    import scala.collection.JavaConverters._
+
+    val showProps = table.properties.asScala
+      .filterKeys(key => !CatalogV2Util.TABLE_RESERVED_PROPERTIES.contains(key)
+        && !key.startsWith(TableCatalog.OPTION_PREFIX)
+        && !tableOptions.contains(key))
+    if (showProps.nonEmpty) {
+      val props = showProps.map {
+        case (key, value) =>
+          s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
+      }
+
+      builder ++= "TBLPROPERTIES"
+      builder ++= concatByMultiLines(props)
+    }
+  }
+
+  private def showTableComment(table: Table, builder: StringBuilder): Unit = {
+    Option(table.properties.get(TableCatalog.PROP_COMMENT))
+      .map("COMMENT '" + escapeSingleQuotedString(_) + "'\n")
+      .foreach(builder.append)
+  }
+
+  private def concatByMultiLines(iter: Iterable[String]): String = {
+    iter.mkString("(\n  ", ",\n  ", ")\n")
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
-import scala.collection.mutable
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -34,13 +35,11 @@ case class ShowCreateTableExec(
     table: Table) extends V2CommandExec with LeafExecNode {
   override protected def run(): Seq[InternalRow] = {
     val builder = StringBuilder.newBuilder
-    // it is used to generate Spark DDL for given table. include Hive Serde table
     showCreateTable(table, builder)
     Seq(InternalRow(UTF8String.fromString(builder.toString)))
   }
 
   private def showCreateTable(table: Table, builder: StringBuilder): Unit = {
-    import scala.collection.JavaConverters._
     builder ++= s"CREATE TABLE ${table.name()} "
 
     showTableDataColumns(table, builder)
@@ -82,7 +81,7 @@ case class ShowCreateTableExec(
 
   private def showTablePartitioning(table: Table, builder: StringBuilder): Unit = {
     if (!table.partitioning.isEmpty) {
-      val transforms = new mutable.ArrayBuffer[String]
+      val transforms = new ArrayBuffer[String]
       table.partitioning.foreach(t => transforms += t.describe())
       builder ++= s"PARTITIONED BY ${transforms.mkString("(", ", ", ")")}\n"
     }
@@ -98,7 +97,7 @@ case class ShowCreateTableExec(
       table: Table,
       builder: StringBuilder,
       tableOptions: Map[String, String]): Unit = {
-    import scala.collection.JavaConverters._
+
 
     val showProps = table.properties.asScala
       .filterKeys(key => !CatalogV2Util.TABLE_RESERVED_PROPERTIES.contains(key)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1975,22 +1975,24 @@ class DataSourceV2SQLSuite
   test("SPARK-33898: SHOW CREATE TABLE") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {
-      spark.sql(s"""|CREATE TABLE $t (
-                    |  a bigint,
-                    |  b bigint,
-                    |  c bigint,
-                    |  `extra col` ARRAY<INT>,
-                    |  `<another>` STRUCT<x: INT, y: ARRAY<BOOLEAN>>
-                    |)
-                    |USING foo
-                    |OPTIONS (
-                    |  from = 0,
-                    |  to = 1)
-                    |COMMENT 'This is a comment'
-                    |TBLPROPERTIES ('prop1' = '1')
-                    |PARTITIONED BY (a)
-                    |LOCATION '/tmp'
-                 """.stripMargin)
+      sql(
+        s"""
+           |CREATE TABLE $t (
+           |  a bigint,
+           |  b bigint,
+           |  c bigint,
+           |  `extra col` ARRAY<INT>,
+           |  `<another>` STRUCT<x: INT, y: ARRAY<BOOLEAN>>
+           |)
+           |USING foo
+           |OPTIONS (
+           |  from = 0,
+           |  to = 1)
+           |COMMENT 'This is a comment'
+           |TBLPROPERTIES ('prop1' = '1')
+           |PARTITIONED BY (a)
+           |LOCATION '/tmp'
+        """.stripMargin)
       val showDDL = getShowCreateDDL(s"SHOW CREATE TABLE $t")
       assert(showDDL === Array(
         "CREATE TABLE testcat.ns1.ns2.tbl (",
@@ -2015,10 +2017,12 @@ class DataSourceV2SQLSuite
   test("SPARK-33898: SHOW CREATE TABLE WITH AS SELECT") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {
-      spark.sql(s"""|CREATE TABLE $t
-                    |USING foo
-                    |AS SELECT 1 AS a, "foo" AS b
-                 """.stripMargin)
+      sql(
+        s"""
+           |CREATE TABLE $t
+           |USING foo
+           |AS SELECT 1 AS a, "foo" AS b
+         """.stripMargin)
       val showDDL = getShowCreateDDL(s"SHOW CREATE TABLE $t")
       assert(showDDL === Array(
         "CREATE TABLE testcat.ns1.ns2.tbl (",
@@ -2032,18 +2036,17 @@ class DataSourceV2SQLSuite
   test("SPARK-33898: SHOW CREATE TABLE PARTITIONED BY Transforms") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {
-      val createSql =
+      sql(
         s"""
-            |CREATE TABLE $t (a INT, b STRING, ts TIMESTAMP) USING foo
-            |PARTITIONED BY (
-            |    a,
-            |    bucket(16, b),
-            |    years(ts),
-            |    months(ts),
-            |    days(ts),
-            |    hours(ts))
-         """.stripMargin
-      spark.sql(createSql)
+           |CREATE TABLE $t (a INT, b STRING, ts TIMESTAMP) USING foo
+           |PARTITIONED BY (
+           |    a,
+           |    bucket(16, b),
+           |    years(ts),
+           |    months(ts),
+           |    days(ts),
+           |    hours(ts))
+         """.stripMargin)
       val showDDL = getShowCreateDDL(s"SHOW CREATE TABLE $t")
       assert(showDDL === Array(
         "CREATE TABLE testcat.ns1.ns2.tbl (",
@@ -2923,11 +2926,7 @@ class DataSourceV2SQLSuite
   }
 
   private def getShowCreateDDL(showCreateTableSql: String): Array[String] = {
-    sql(showCreateTableSql)
-      .head()
-      .getString(0)
-      .split("\n")
-      .map(_.trim)
+    sql(showCreateTableSql).head().getString(0).split("\n").map(_.trim)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1961,12 +1961,98 @@ class DataSourceV2SQLSuite
     }
   }
 
-  test("SHOW CREATE TABLE") {
+  test("SPARK-33898: SHOW CREATE TABLE AS SERDE") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {
       spark.sql(s"CREATE TABLE $t (id bigint, data string) USING foo")
-      testNotSupportedV2Command("SHOW CREATE TABLE", t)
-      testNotSupportedV2Command("SHOW CREATE TABLE", s"$t AS SERDE")
+      val e = intercept[AnalysisException] {
+        sql(s"SHOW CREATE TABLE $t AS SERDE")
+      }
+      assert(e.message.contains(s"SHOW CREATE TABLE AS SERDE is not supported for v2 tables."))
+    }
+  }
+
+  test("SPARK-33898: SHOW CREATE TABLE") {
+    val t = "testcat.ns1.ns2.tbl"
+    withTable(t) {
+      spark.sql(s"""|CREATE TABLE $t (
+                    |  a bigint,
+                    |  b bigint,
+                    |  c bigint,
+                    |  `extra col` ARRAY<INT>,
+                    |  `<another>` STRUCT<x: INT, y: ARRAY<BOOLEAN>>
+                    |)
+                    |USING foo
+                    |OPTIONS (
+                    |  from = 0,
+                    |  to = 1)
+                    |COMMENT 'This is a comment'
+                    |TBLPROPERTIES ('prop1' = '1')
+                    |PARTITIONED BY (a)
+                    |LOCATION '/tmp'
+                 """.stripMargin)
+      val showDDL = getShowCreateDDL(s"SHOW CREATE TABLE $t")
+      assert(showDDL === Array(
+        "CREATE TABLE testcat.ns1.ns2.tbl (",
+        "`a` BIGINT,",
+        "`b` BIGINT,",
+        "`c` BIGINT,",
+        "`extra col` ARRAY<INT>,",
+        "`<another>` STRUCT<`x`: INT, `y`: ARRAY<BOOLEAN>>)",
+        "USING foo",
+        "OPTIONS(",
+        "'from' = '0',",
+        "'to' = '1')",
+        "PARTITIONED BY (a)",
+        "COMMENT 'This is a comment'",
+        "LOCATION '/tmp'",
+        "TBLPROPERTIES(",
+        "'prop1' = '1')"
+      ))
+    }
+  }
+
+  test("SPARK-33898: SHOW CREATE TABLE WITH AS SELECT") {
+    val t = "testcat.ns1.ns2.tbl"
+    withTable(t) {
+      spark.sql(s"""|CREATE TABLE $t
+                    |USING foo
+                    |AS SELECT 1 AS a, "foo" AS b
+                 """.stripMargin)
+      val showDDL = getShowCreateDDL(s"SHOW CREATE TABLE $t")
+      assert(showDDL === Array(
+        "CREATE TABLE testcat.ns1.ns2.tbl (",
+        "`a` INT,",
+        "`b` STRING)",
+        "USING foo"
+      ))
+    }
+  }
+
+  test("SPARK-33898: SHOW CREATE TABLE PARTITIONED BY Transforms") {
+    val t = "testcat.ns1.ns2.tbl"
+    withTable(t) {
+      val createSql =
+        s"""
+            |CREATE TABLE $t (a INT, b STRING, ts TIMESTAMP) USING foo
+            |PARTITIONED BY (
+            |    a,
+            |    bucket(16, b),
+            |    years(ts),
+            |    months(ts),
+            |    days(ts),
+            |    hours(ts))
+         """.stripMargin
+      spark.sql(createSql)
+      val showDDL = getShowCreateDDL(s"SHOW CREATE TABLE $t")
+      assert(showDDL === Array(
+        "CREATE TABLE testcat.ns1.ns2.tbl (",
+        "`a` INT,",
+        "`b` STRING,",
+        "`ts` TIMESTAMP)",
+        "USING foo",
+        "PARTITIONED BY (a, bucket(16, b), years(ts), months(ts), days(ts), hours(ts))"
+      ))
     }
   }
 
@@ -2834,6 +2920,14 @@ class DataSourceV2SQLSuite
       sql(sqlStatement)
     }.getMessage
     assert(errMsg.contains(expectedError))
+  }
+
+  private def getShowCreateDDL(showCreateTableSql: String): Array[String] = {
+    sql(showCreateTableSql)
+      .head()
+      .getString(0)
+      .split("\n")
+      .map(_.trim)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Implement V2 execution node `ShowCreateTableExec` similar to V1 `ShowCreateTableCommand`
2. No support `SHOW CREATE TABLE XXX AS SERDE`

### Why are the changes needed?
[SPARK-33898](https://issues.apache.org/jira/browse/SPARK-33898)

### Does this PR introduce _any_ user-facing change?
Yes. Support the user to execute `SHOW CREATE TABLE` command in V2 table

### How was this patch tested?
Add two UT tests
1. ./dev/scalastyle
2. run test DataSourceV2SQLSuite
