### PR TITLE
[SPARK-35786][SQL] Add a new operator to rebalance the query output if AQE is enabled

### DIFF
--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -228,6 +228,8 @@ The "REPARTITION_BY_RANGE" hint must have column names and a partition number is
     SELECT /*+ REPARTITION */ * FROM t
     SELECT /*+ REPARTITION_BY_RANGE(c) */ * FROM t
     SELECT /*+ REPARTITION_BY_RANGE(3, c) */ * FROM t
+    SELECT /*+ ADAPTIVE_REPARTITION */ * FROM t
+    SELECT /*+ ADAPTIVE_REPARTITION(c) */ * FROM t
 
 For more details please refer to the documentation of [Partitioning Hints](sql-ref-syntax-qry-select-hints.html#partitioning-hints).
 

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -228,8 +228,8 @@ The "REPARTITION_BY_RANGE" hint must have column names and a partition number is
     SELECT /*+ REPARTITION */ * FROM t
     SELECT /*+ REPARTITION_BY_RANGE(c) */ * FROM t
     SELECT /*+ REPARTITION_BY_RANGE(3, c) */ * FROM t
-    SELECT /*+ ADAPTIVE_REPARTITION */ * FROM t
-    SELECT /*+ ADAPTIVE_REPARTITION(c) */ * FROM t
+    SELECT /*+ REPARTITION_BY_AQE */ * FROM t
+    SELECT /*+ REPARTITION_BY_AQE(c) */ * FROM t
 
 For more details please refer to the documentation of [Partitioning Hints](sql-ref-syntax-qry-select-hints.html#partitioning-hints).
 

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -228,8 +228,8 @@ The "REPARTITION_BY_RANGE" hint must have column names and a partition number is
     SELECT /*+ REPARTITION */ * FROM t
     SELECT /*+ REPARTITION_BY_RANGE(c) */ * FROM t
     SELECT /*+ REPARTITION_BY_RANGE(3, c) */ * FROM t
-    SELECT /*+ REPARTITION_BY_AQE */ * FROM t
-    SELECT /*+ REPARTITION_BY_AQE(c) */ * FROM t
+    SELECT /*+ REBALANCE_PARTITIONS */ * FROM t
+    SELECT /*+ REBALANCE_PARTITIONS(c) */ * FROM t
 
 For more details please refer to the documentation of [Partitioning Hints](sql-ref-syntax-qry-select-hints.html#partitioning-hints).
 

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -228,8 +228,8 @@ The "REPARTITION_BY_RANGE" hint must have column names and a partition number is
     SELECT /*+ REPARTITION */ * FROM t
     SELECT /*+ REPARTITION_BY_RANGE(c) */ * FROM t
     SELECT /*+ REPARTITION_BY_RANGE(3, c) */ * FROM t
-    SELECT /*+ REBALANCE_PARTITIONS */ * FROM t
-    SELECT /*+ REBALANCE_PARTITIONS(c) */ * FROM t
+    SELECT /*+ REBALANCE */ * FROM t
+    SELECT /*+ REBALANCE(c) */ * FROM t
 
 For more details please refer to the documentation of [Partitioning Hints](sql-ref-syntax-qry-select-hints.html#partitioning-hints).
 

--- a/docs/sql-ref-syntax-qry-select-hints.md
+++ b/docs/sql-ref-syntax-qry-select-hints.md
@@ -51,9 +51,9 @@ specified, multiple nodes are inserted into the logical plan, but the leftmost h
 
   The `REPARTITION_BY_RANGE` hint can be used to repartition to the specified number of partitions using the specified partitioning expressions. It takes column names and an optional partition number as parameters.
 
-* **REPARTITION_BY_AQE**
+* **REBALANCE_PARTITIONS**
 
-  The `REPARTITION_BY_AQE` hint can be used to repartition to the specified partitioning expressions. It takes column names or none as parameters.
+  The `REBALANCE_PARTITIONS` hint can be used to repartition to the specified partitioning expressions. It takes column names or none as parameters.
 
 #### Examples
 
@@ -70,9 +70,9 @@ SELECT /*+ REPARTITION_BY_RANGE(c) */ * FROM t;
 
 SELECT /*+ REPARTITION_BY_RANGE(3, c) */ * FROM t;
 
-SELECT /*+ REPARTITION_BY_AQE */ * FROM t;
+SELECT /*+ REBALANCE_PARTITIONS */ * FROM t;
 
-SELECT /*+ REPARTITION_BY_AQE(c) */ * FROM t;
+SELECT /*+ REBALANCE_PARTITIONS(c) */ * FROM t;
 
 -- multiple partitioning hints
 EXPLAIN EXTENDED SELECT /*+ REPARTITION(100), COALESCE(500), REPARTITION_BY_RANGE(3, c) */ * FROM t;

--- a/docs/sql-ref-syntax-qry-select-hints.md
+++ b/docs/sql-ref-syntax-qry-select-hints.md
@@ -51,9 +51,9 @@ specified, multiple nodes are inserted into the logical plan, but the leftmost h
 
   The `REPARTITION_BY_RANGE` hint can be used to repartition to the specified number of partitions using the specified partitioning expressions. It takes column names and an optional partition number as parameters.
 
-* **REBALANCE_PARTITIONS**
+* **REBALANCE**
 
-  The `REBALANCE_PARTITIONS` hint can be used to rebalance the query result output partitions, so that every partition is of a reasonable size (not too small and not too big). It can take column names as parameters, and try its best to partition the query result by these columns. This is a best-effort: if there are skews, Spark will split the skewed partitions, to make these partitions not too big. This hint is useful when you need to write the result of this query to a table, to avoid too small/big files. This hint is ignored if AQE is not enabled.
+  The `REBALANCE` hint can be used to rebalance the query result output partitions, so that every partition is of a reasonable size (not too small and not too big). It can take column names as parameters, and try its best to partition the query result by these columns. This is a best-effort: if there are skews, Spark will split the skewed partitions, to make these partitions not too big. This hint is useful when you need to write the result of this query to a table, to avoid too small/big files. This hint is ignored if AQE is not enabled.
 
 #### Examples
 
@@ -70,9 +70,9 @@ SELECT /*+ REPARTITION_BY_RANGE(c) */ * FROM t;
 
 SELECT /*+ REPARTITION_BY_RANGE(3, c) */ * FROM t;
 
-SELECT /*+ REBALANCE_PARTITIONS */ * FROM t;
+SELECT /*+ REBALANCE */ * FROM t;
 
-SELECT /*+ REBALANCE_PARTITIONS(c) */ * FROM t;
+SELECT /*+ REBALANCE(c) */ * FROM t;
 
 -- multiple partitioning hints
 EXPLAIN EXTENDED SELECT /*+ REPARTITION(100), COALESCE(500), REPARTITION_BY_RANGE(3, c) */ * FROM t;

--- a/docs/sql-ref-syntax-qry-select-hints.md
+++ b/docs/sql-ref-syntax-qry-select-hints.md
@@ -51,6 +51,10 @@ specified, multiple nodes are inserted into the logical plan, but the leftmost h
 
   The `REPARTITION_BY_RANGE` hint can be used to repartition to the specified number of partitions using the specified partitioning expressions. It takes column names and an optional partition number as parameters.
 
+* **REPARTITION_BY_AQE**
+
+  The `REPARTITION_BY_AQE` hint can be used to repartition to the specified partitioning expressions. It takes column names or none as parameters.
+
 #### Examples
 
 ```sql
@@ -65,6 +69,10 @@ SELECT /*+ REPARTITION(3, c) */ * FROM t;
 SELECT /*+ REPARTITION_BY_RANGE(c) */ * FROM t;
 
 SELECT /*+ REPARTITION_BY_RANGE(3, c) */ * FROM t;
+
+SELECT /*+ REPARTITION_BY_AQE */ * FROM t;
+
+SELECT /*+ REPARTITION_BY_AQE(c) */ * FROM t;
 
 -- multiple partitioning hints
 EXPLAIN EXTENDED SELECT /*+ REPARTITION(100), COALESCE(500), REPARTITION_BY_RANGE(3, c) */ * FROM t;

--- a/docs/sql-ref-syntax-qry-select-hints.md
+++ b/docs/sql-ref-syntax-qry-select-hints.md
@@ -53,12 +53,7 @@ specified, multiple nodes are inserted into the logical plan, but the leftmost h
 
 * **REBALANCE_PARTITIONS**
 
-  The `REBALANCE_PARTITIONS` hint can be used to rebalance the query result output partitions, so that
-  every partition is of a reasonable size (not too small and not too big). It can take column names as
-  parameters, and try its best to partition the query result by these columns. This is a best-effort: if
-  there are skews, Spark will split the skewed partitions, to make these partitions not too big. This
-  hint is useful when you need to write the result of this query to a table, to avoid too small/big files.
-  This hint is ignored if AQE is not enabled.
+  The `REBALANCE_PARTITIONS` hint can be used to rebalance the query result output partitions, so that every partition is of a reasonable size (not too small and not too big). It can take column names as parameters, and try its best to partition the query result by these columns. This is a best-effort: if there are skews, Spark will split the skewed partitions, to make these partitions not too big. This hint is useful when you need to write the result of this query to a table, to avoid too small/big files. This hint is ignored if AQE is not enabled.
 
 #### Examples
 

--- a/docs/sql-ref-syntax-qry-select-hints.md
+++ b/docs/sql-ref-syntax-qry-select-hints.md
@@ -53,7 +53,12 @@ specified, multiple nodes are inserted into the logical plan, but the leftmost h
 
 * **REBALANCE_PARTITIONS**
 
-  The `REBALANCE_PARTITIONS` hint can be used to repartition to the specified partitioning expressions. It takes column names or none as parameters.
+  The `REBALANCE_PARTITIONS` hint can be used to rebalance the query result output partitions, so that
+  every partition is of a reasonable size (not too small and not too big). It can take column names as
+  parameters, and try its best to partition the query result by these columns. This is a best-effort: if
+  there are skews, Spark will split the skewed partitions, to make these partitions not too big. This
+  hint is useful when you need to write the result of this query to a table, to avoid too small/big files.
+  This hint is ignored if AQE is not enabled.
 
 #### Examples
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -176,7 +176,7 @@ object ResolveHints {
   object ResolveCoalesceHints extends Rule[LogicalPlan] {
 
     val COALESCE_HINT_NAMES: Set[String] =
-      Set("COALESCE", "REPARTITION", "REPARTITION_BY_RANGE", "ADAPTIVE_REPARTITION")
+      Set("COALESCE", "REPARTITION", "REPARTITION_BY_RANGE", "REPARTITION_BY_AQE")
 
     /**
      * This function handles hints for "COALESCE" and "REPARTITION".
@@ -188,7 +188,7 @@ object ResolveHints {
       val hintName = hint.name.toUpperCase(Locale.ROOT)
 
       def createRepartitionByExpression(
-          numPartitions: Option[Int], partitionExprs: Seq[Any]): RepartitionOperation = {
+          numPartitions: Option[Int], partitionExprs: Seq[Any]): LogicalPlan = {
         val sortOrders = partitionExprs.filter(_.isInstanceOf[SortOrder])
         if (sortOrders.nonEmpty) {
           throw QueryCompilationErrors.invalidRepartitionExpressionsError(sortOrders)
@@ -265,7 +265,7 @@ object ResolveHints {
             createRepartition(shuffle = false, hint)
           case "REPARTITION_BY_RANGE" =>
             createRepartitionByRange(hint)
-          case "ADAPTIVE_REPARTITION" =>
+          case "REPARTITION_BY_AQE" =>
             createRepartition(shuffle = true, hint, true)
           case _ => hint
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -176,7 +176,7 @@ object ResolveHints {
   object ResolveCoalesceHints extends Rule[LogicalPlan] {
 
     val COALESCE_HINT_NAMES: Set[String] =
-      Set("COALESCE", "REPARTITION", "REPARTITION_BY_RANGE", "REBALANCE_PARTITIONS")
+      Set("COALESCE", "REPARTITION", "REPARTITION_BY_RANGE", "REBALANCE")
 
     /**
      * This function handles hints for "COALESCE" and "REPARTITION".
@@ -270,7 +270,7 @@ object ResolveHints {
             createRepartition(shuffle = false, hint)
           case "REPARTITION_BY_RANGE" =>
             createRepartitionByRange(hint)
-          case "REBALANCE_PARTITIONS" if conf.adaptiveExecutionEnabled =>
+          case "REBALANCE" if conf.adaptiveExecutionEnabled =>
             createRebalance(hint)
           case _ => hint
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -176,7 +176,7 @@ object ResolveHints {
   object ResolveCoalesceHints extends Rule[LogicalPlan] {
 
     val COALESCE_HINT_NAMES: Set[String] =
-      Set("COALESCE", "REPARTITION", "REPARTITION_BY_RANGE", "REPARTITION_BY_AQE")
+      Set("COALESCE", "REPARTITION", "REPARTITION_BY_RANGE", "REBALANCE_PARTITIONS")
 
     /**
      * This function handles hints for "COALESCE" and "REPARTITION".
@@ -198,7 +198,7 @@ object ResolveHints {
           throw QueryCompilationErrors.invalidHintParameterError(hintName, invalidParams)
         }
         if (adaptive) {
-          AdaptiveRepartition(partitionExprs.map(_.asInstanceOf[Expression]), hint.child)
+          RebalancePartitions(partitionExprs.map(_.asInstanceOf[Expression]), hint.child)
         } else {
           RepartitionByExpression(
             partitionExprs.map(_.asInstanceOf[Expression]), hint.child, numPartitions)
@@ -265,7 +265,7 @@ object ResolveHints {
             createRepartition(shuffle = false, hint)
           case "REPARTITION_BY_RANGE" =>
             createRepartitionByRange(hint)
-          case "REPARTITION_BY_AQE" =>
+          case "REBALANCE_PARTITIONS" =>
             createRepartition(shuffle = true, hint, true)
           case _ => hint
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -252,10 +252,6 @@ object ResolveHints {
     private def createRebalance(hint: UnresolvedHint): LogicalPlan = {
       hint.parameters match {
         case partitionExprs @ Seq(_*) =>
-          val sortOrders = partitionExprs.filter(_.isInstanceOf[SortOrder])
-          if (sortOrders.nonEmpty) {
-            throw QueryCompilationErrors.invalidRepartitionExpressionsError(sortOrders)
-          }
           val invalidParams = partitionExprs.filter(!_.isInstanceOf[UnresolvedAttribute])
           if (invalidParams.nonEmpty) {
             val hintName = hint.name.toUpperCase(Locale.ROOT)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -265,7 +265,7 @@ object ResolveHints {
             createRepartition(shuffle = false, hint)
           case "REPARTITION_BY_RANGE" =>
             createRepartitionByRange(hint)
-          case "REBALANCE_PARTITIONS" =>
+          case "REBALANCE_PARTITIONS" if conf.adaptiveExecutionEnabled =>
             createRepartition(shuffle = true, hint, true)
           case _ => hint
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1357,11 +1357,13 @@ object RepartitionByExpression {
  */
 case class AdaptiveRepartition(
     partitionExpressions: Seq[Expression],
-    child: LogicalPlan) extends RepartitionOperation {
-  override def shuffle: Boolean = true
-  override def numPartitions: Int = conf.numShufflePartitions
+    child: LogicalPlan) extends UnaryNode {
+  override def maxRows: Option[Long] = child.maxRows
+  override def output: Seq[Attribute] = child.output
 
-  override lazy val partitioning: Partitioning = if (partitionExpressions.nonEmpty) {
+  lazy val numPartitions: Int = conf.numShufflePartitions
+
+  def partitioning: Partitioning = if (partitionExpressions.nonEmpty) {
     HashPartitioning(partitionExpressions, numPartitions)
   } else {
     RoundRobinPartitioning(numPartitions)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1366,10 +1366,10 @@ case class RebalancePartitions(
   override def maxRows: Option[Long] = child.maxRows
   override def output: Seq[Attribute] = child.output
 
-  def partitioning: Partitioning = if (partitionExpressions.nonEmpty) {
-    HashPartitioning(partitionExpressions, conf.numShufflePartitions)
-  } else {
+  def partitioning: Partitioning = if (partitionExpressions.isEmpty) {
     RoundRobinPartitioning(conf.numShufflePartitions)
+  } else {
+    HashPartitioning(partitionExpressions, conf.numShufflePartitions)
   }
 
   override protected def withNewChildInternal(newChild: LogicalPlan): RebalancePartitions =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1355,7 +1355,7 @@ object RepartitionByExpression {
  * This operator does not guarantee the output partitioning, because the partition number will be
  * optimized by AQE.
  */
-case class AdaptiveRepartition(
+case class RebalancePartitions(
     partitionExpressions: Seq[Expression],
     child: LogicalPlan) extends UnaryNode {
   override def maxRows: Option[Long] = child.maxRows
@@ -1369,7 +1369,7 @@ case class AdaptiveRepartition(
     RoundRobinPartitioning(numPartitions)
   }
 
-  override protected def withNewChildInternal(newChild: LogicalPlan): AdaptiveRepartition =
+  override protected def withNewChildInternal(newChild: LogicalPlan): RebalancePartitions =
     copy(child = newChild)
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1352,13 +1352,13 @@ object RepartitionByExpression {
 }
 
 /**
- * This operator used to rebalance the query result output partitions, so that every partition
- * is of a reasonable size (not too small and not too big). It can take column names as parameters,
- * and try its best to partition the query result by these columns. If there are skews, Spark will
- * split the skewed partitions, to make these partitions not too big. This operator is useful when
- * you need to write the result of this query to a table, to avoid too small/big files.
+ * This operator is used to rebalance the output partitions of the given `child`, so that every
+ * partition is of a reasonable size (not too small and not too big). It also try its best to
+ * partition the child output by `partitionExpressions`. If there are skews, Spark will split the
+ * skewed partitions, to make these partitions not too big. This operator is useful when you need
+ * to write the result of `child` to a table, to avoid too small/big files.
  *
- * Note that, only AQE is enabled does the operator make sense.
+ * Note that, this operator only makes sense when AQE is enabled.
  */
 case class RebalancePartitions(
     partitionExpressions: Seq[Expression],

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -295,4 +295,18 @@ class ResolveHintsSuite extends AnalysisTest {
         caseSensitive = true)
     }
   }
+
+  test("SPARK-35786: Support optimize repartition by expression in AQE") {
+    checkAnalysisWithoutViewWrapper(
+      UnresolvedHint("ADAPTIVE_REPARTITION", Seq(UnresolvedAttribute("a")), table("TaBlE")),
+      AdaptiveRepartition(Seq(AttributeReference("a", IntegerType)()), testRelation))
+
+    checkAnalysisWithoutViewWrapper(
+      UnresolvedHint("ADAPTIVE_REPARTITION", Seq.empty, table("TaBlE")),
+      AdaptiveRepartition(Seq.empty, testRelation))
+
+    assertAnalysisError(
+      UnresolvedHint("ADAPTIVE_REPARTITION", Seq(Literal(1)), table("TaBlE")),
+      Seq("Hint parameter should include columns"))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -298,15 +298,15 @@ class ResolveHintsSuite extends AnalysisTest {
 
   test("SPARK-35786: Support optimize repartition by expression in AQE") {
     checkAnalysisWithoutViewWrapper(
-      UnresolvedHint("REPARTITION_BY_AQE", Seq(UnresolvedAttribute("a")), table("TaBlE")),
-      AdaptiveRepartition(Seq(AttributeReference("a", IntegerType)()), testRelation))
+      UnresolvedHint("REBALANCE_PARTITIONS", Seq(UnresolvedAttribute("a")), table("TaBlE")),
+      RebalancePartitions(Seq(AttributeReference("a", IntegerType)()), testRelation))
 
     checkAnalysisWithoutViewWrapper(
-      UnresolvedHint("REPARTITION_BY_AQE", Seq.empty, table("TaBlE")),
-      AdaptiveRepartition(Seq.empty, testRelation))
+      UnresolvedHint("REBALANCE_PARTITIONS", Seq.empty, table("TaBlE")),
+      RebalancePartitions(Seq.empty, testRelation))
 
     assertAnalysisError(
-      UnresolvedHint("REPARTITION_BY_AQE", Seq(Literal(1)), table("TaBlE")),
+      UnresolvedHint("REBALANCE_PARTITIONS", Seq(Literal(1)), table("TaBlE")),
       Seq("Hint parameter should include columns"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -298,15 +298,15 @@ class ResolveHintsSuite extends AnalysisTest {
 
   test("SPARK-35786: Support optimize repartition by expression in AQE") {
     checkAnalysisWithoutViewWrapper(
-      UnresolvedHint("ADAPTIVE_REPARTITION", Seq(UnresolvedAttribute("a")), table("TaBlE")),
+      UnresolvedHint("REPARTITION_BY_AQE", Seq(UnresolvedAttribute("a")), table("TaBlE")),
       AdaptiveRepartition(Seq(AttributeReference("a", IntegerType)()), testRelation))
 
     checkAnalysisWithoutViewWrapper(
-      UnresolvedHint("ADAPTIVE_REPARTITION", Seq.empty, table("TaBlE")),
+      UnresolvedHint("REPARTITION_BY_AQE", Seq.empty, table("TaBlE")),
       AdaptiveRepartition(Seq.empty, testRelation))
 
     assertAnalysisError(
-      UnresolvedHint("ADAPTIVE_REPARTITION", Seq(Literal(1)), table("TaBlE")),
+      UnresolvedHint("REPARTITION_BY_AQE", Seq(Literal(1)), table("TaBlE")),
       Seq("Hint parameter should include columns"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -299,25 +299,25 @@ class ResolveHintsSuite extends AnalysisTest {
 
   test("SPARK-35786: Support optimize repartition by expression in AQE") {
     checkAnalysisWithoutViewWrapper(
-      UnresolvedHint("REBALANCE_PARTITIONS", Seq(UnresolvedAttribute("a")), table("TaBlE")),
+      UnresolvedHint("REBALANCE", Seq(UnresolvedAttribute("a")), table("TaBlE")),
       RebalancePartitions(Seq(AttributeReference("a", IntegerType)()), testRelation))
 
     checkAnalysisWithoutViewWrapper(
-      UnresolvedHint("REBALANCE_PARTITIONS", Seq.empty, table("TaBlE")),
+      UnresolvedHint("REBALANCE", Seq.empty, table("TaBlE")),
       RebalancePartitions(Seq.empty, testRelation))
 
     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
       checkAnalysisWithoutViewWrapper(
-        UnresolvedHint("REBALANCE_PARTITIONS", Seq(UnresolvedAttribute("a")), table("TaBlE")),
+        UnresolvedHint("REBALANCE", Seq(UnresolvedAttribute("a")), table("TaBlE")),
         testRelation)
 
       checkAnalysisWithoutViewWrapper(
-        UnresolvedHint("REBALANCE_PARTITIONS", Seq.empty, table("TaBlE")),
+        UnresolvedHint("REBALANCE", Seq.empty, table("TaBlE")),
         testRelation)
     }
 
     assertAnalysisError(
-      UnresolvedHint("REBALANCE_PARTITIONS", Seq(Literal(1)), table("TaBlE")),
+      UnresolvedHint("REBALANCE", Seq(Literal(1)), table("TaBlE")),
       Seq("Hint parameter should include columns"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference,
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.IntegerType
 
 class ResolveHintsSuite extends AnalysisTest {
@@ -304,6 +305,16 @@ class ResolveHintsSuite extends AnalysisTest {
     checkAnalysisWithoutViewWrapper(
       UnresolvedHint("REBALANCE_PARTITIONS", Seq.empty, table("TaBlE")),
       RebalancePartitions(Seq.empty, testRelation))
+
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      checkAnalysisWithoutViewWrapper(
+        UnresolvedHint("REBALANCE_PARTITIONS", Seq(UnresolvedAttribute("a")), table("TaBlE")),
+        testRelation)
+
+      checkAnalysisWithoutViewWrapper(
+        UnresolvedHint("REBALANCE_PARTITIONS", Seq.empty, table("TaBlE")),
+        testRelation)
+    }
 
     assertAnalysisError(
       UnresolvedHint("REBALANCE_PARTITIONS", Seq(Literal(1)), table("TaBlE")),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors
 import org.apache.spark.sql.execution.aggregate.AggUtils
 import org.apache.spark.sql.execution.columnar.{InMemoryRelation, InMemoryTableScanExec}
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.exchange.{REPARTITION_BY_COL, REPARTITION_BY_NONE, REPARTITION_BY_NUM, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.exchange.{ADAPTIVE_REPARTITION, REPARTITION_BY_COL, REPARTITION_BY_NONE, REPARTITION_BY_NUM, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.python._
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.sources.MemoryPlan
@@ -722,6 +722,9 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
           REPARTITION_BY_NUM
         }
         exchange.ShuffleExchangeExec(r.partitioning, planLater(r.child), shuffleOrigin) :: Nil
+      case r: logical.AdaptiveRepartition =>
+        exchange.ShuffleExchangeExec(
+          r.partitioning, planLater(r.child), ADAPTIVE_REPARTITION) :: Nil
       case ExternalRDD(outputObjAttr, rdd) => ExternalRDDScanExec(outputObjAttr, rdd) :: Nil
       case r: LogicalRDD =>
         RDDScanExec(r.output, r.rdd, "ExistingRDD", r.outputPartitioning, r.outputOrdering) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors
 import org.apache.spark.sql.execution.aggregate.AggUtils
 import org.apache.spark.sql.execution.columnar.{InMemoryRelation, InMemoryTableScanExec}
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.exchange.{ADAPTIVE_REPARTITION, REPARTITION_BY_COL, REPARTITION_BY_NONE, REPARTITION_BY_NUM, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.exchange.{REPARTITION_BY_AQE, REPARTITION_BY_COL, REPARTITION_BY_NONE, REPARTITION_BY_NUM, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.python._
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.sources.MemoryPlan
@@ -724,7 +724,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         exchange.ShuffleExchangeExec(r.partitioning, planLater(r.child), shuffleOrigin) :: Nil
       case r: logical.AdaptiveRepartition =>
         exchange.ShuffleExchangeExec(
-          r.partitioning, planLater(r.child), ADAPTIVE_REPARTITION) :: Nil
+          r.partitioning, planLater(r.child), REPARTITION_BY_AQE) :: Nil
       case ExternalRDD(outputObjAttr, rdd) => ExternalRDDScanExec(outputObjAttr, rdd) :: Nil
       case r: LogicalRDD =>
         RDDScanExec(r.output, r.rdd, "ExistingRDD", r.outputPartitioning, r.outputOrdering) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors
 import org.apache.spark.sql.execution.aggregate.AggUtils
 import org.apache.spark.sql.execution.columnar.{InMemoryRelation, InMemoryTableScanExec}
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.exchange.{REBALANCE_PARTITIONS_BY_COL, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_COL, REPARTITION_BY_NONE, REPARTITION_BY_NUM, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.exchange.{REBALANCE_PARTITIONS_BY_COL, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_COL, REPARTITION_BY_NUM, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.python._
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.sources.MemoryPlan
@@ -715,7 +715,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.RangeExec(r) :: Nil
       case r: logical.RepartitionByExpression =>
         val shuffleOrigin = if (r.partitionExpressions.isEmpty && r.optNumPartitions.isEmpty) {
-          REPARTITION_BY_NONE
+          REBALANCE_PARTITIONS_BY_NONE
         } else if (r.optNumPartitions.isEmpty) {
           REPARTITION_BY_COL
         } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors
 import org.apache.spark.sql.execution.aggregate.AggUtils
 import org.apache.spark.sql.execution.columnar.{InMemoryRelation, InMemoryTableScanExec}
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.exchange.{REPARTITION_BY_AQE, REPARTITION_BY_COL, REPARTITION_BY_NONE, REPARTITION_BY_NUM, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.exchange.{REBALANCE_PARTITIONS, REPARTITION_BY_COL, REPARTITION_BY_NONE, REPARTITION_BY_NUM, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.python._
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.sources.MemoryPlan
@@ -722,9 +722,9 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
           REPARTITION_BY_NUM
         }
         exchange.ShuffleExchangeExec(r.partitioning, planLater(r.child), shuffleOrigin) :: Nil
-      case r: logical.AdaptiveRepartition =>
+      case r: logical.RebalancePartitions =>
         exchange.ShuffleExchangeExec(
-          r.partitioning, planLater(r.child), REPARTITION_BY_AQE) :: Nil
+          r.partitioning, planLater(r.child), REBALANCE_PARTITIONS) :: Nil
       case ExternalRDD(outputObjAttr, rdd) => ExternalRDDScanExec(outputObjAttr, rdd) :: Nil
       case r: LogicalRDD =>
         RDDScanExec(r.output, r.rdd, "ExistingRDD", r.outputPartitioning, r.outputOrdering) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Strategy, execution}
+import org.apache.spark.sql.{execution, Strategy}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions._

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan}
-import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ADAPTIVE_REPARTITION, ENSURE_REQUIREMENTS, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -30,7 +30,7 @@ import org.apache.spark.sql.internal.SQLConf
 case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_COL, REPARTITION_BY_NONE)
+    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, REPARTITION_BY_COL, ADAPTIVE_REPARTITION)
 
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.coalesceShufflePartitionsEnabled) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan}
-import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REPARTITION_BY_AQE, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -30,7 +30,7 @@ import org.apache.spark.sql.internal.SQLConf
 case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, REPARTITION_BY_COL, REPARTITION_BY_AQE)
+    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, REPARTITION_BY_COL, REBALANCE_PARTITIONS)
 
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.coalesceShufflePartitionsEnabled) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan}
-import org.apache.spark.sql.execution.exchange.{REPARTITION_BY_AQE, ENSURE_REQUIREMENTS, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REPARTITION_BY_AQE, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.internal.SQLConf
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.internal.SQLConf
 case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_COL,
+    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_COL, REBALANCE_PARTITIONS_BY_NONE,
       REBALANCE_PARTITIONS_BY_COL)
 
   override def apply(plan: SparkPlan): SparkPlan = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan}
-import org.apache.spark.sql.execution.exchange.{ADAPTIVE_REPARTITION, ENSURE_REQUIREMENTS, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{REPARTITION_BY_AQE, ENSURE_REQUIREMENTS, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -30,7 +30,7 @@ import org.apache.spark.sql.internal.SQLConf
 case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, REPARTITION_BY_COL, ADAPTIVE_REPARTITION)
+    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, REPARTITION_BY_COL, REPARTITION_BY_AQE)
 
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.coalesceShufflePartitionsEnabled) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan}
-import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_COL, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -30,7 +30,7 @@ import org.apache.spark.sql.internal.SQLConf
 case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, REPARTITION_BY_COL, REBALANCE_PARTITIONS)
+    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, REPARTITION_BY_COL, REBALANCE_PARTITIONS_BY_COL)
 
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.coalesceShufflePartitionsEnabled) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan}
-import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_COL, REPARTITION_BY_COL, REPARTITION_BY_NONE, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_COL, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_COL, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -30,7 +30,8 @@ import org.apache.spark.sql.internal.SQLConf
 case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, REPARTITION_BY_COL, REBALANCE_PARTITIONS_BY_COL)
+    Seq(ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_COL,
+      REBALANCE_PARTITIONS_BY_COL)
 
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.coalesceShufflePartitionsEnabled) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.exchange.{ADAPTIVE_REPARTITION, ENSURE_REQUIREMENTS, EnsureRequirements, REPARTITION_BY_NONE, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, EnsureRequirements, REPARTITION_BY_NONE, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
 import org.apache.spark.sql.internal.SQLConf
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, EnsureRequirements, REPARTITION_BY_NONE, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ADAPTIVE_REPARTITION, ENSURE_REQUIREMENTS, EnsureRequirements, REPARTITION_BY_NONE, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
 import org.apache.spark.sql.internal.SQLConf
 
@@ -36,7 +36,7 @@ import org.apache.spark.sql.internal.SQLConf
 object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE)
+    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, ADAPTIVE_REPARTITION)
 
   private val ensureRequirements = EnsureRequirements
 
@@ -144,7 +144,7 @@ object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
       s.shuffle.shuffleOrigin match {
         case ENSURE_REQUIREMENTS =>
           s.mapStats.isDefined && partitionSpecs.nonEmpty && supportLocalReader(s.shuffle)
-        case REPARTITION_BY_NONE =>
+        case REPARTITION_BY_NONE | ADAPTIVE_REPARTITION =>
           // Use LocalShuffleReader only when we can't CoalesceShufflePartitions
           s.mapStats.exists(_.bytesByPartitionId.length == partitionSpecs.size) &&
             partitionSpecs.nonEmpty && supportLocalReader(s.shuffle)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.internal.SQLConf
 object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, ADAPTIVE_REPARTITION)
+    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE)
 
   private val ensureRequirements = EnsureRequirements
 
@@ -144,7 +144,7 @@ object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
       s.shuffle.shuffleOrigin match {
         case ENSURE_REQUIREMENTS =>
           s.mapStats.isDefined && partitionSpecs.nonEmpty && supportLocalReader(s.shuffle)
-        case REPARTITION_BY_NONE | ADAPTIVE_REPARTITION =>
+        case REPARTITION_BY_NONE =>
           // Use LocalShuffleReader only when we can't CoalesceShufflePartitions
           s.mapStats.exists(_.bytesByPartitionId.length == partitionSpecs.size) &&
             partitionSpecs.nonEmpty && supportLocalReader(s.shuffle)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, EnsureRequirements, REPARTITION_BY_NONE, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, EnsureRequirements, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_NONE, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
 import org.apache.spark.sql.internal.SQLConf
 
@@ -36,7 +36,7 @@ import org.apache.spark.sql.internal.SQLConf
 object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE)
+    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, REBALANCE_PARTITIONS_BY_NONE)
 
   private val ensureRequirements = EnsureRequirements
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, EnsureRequirements, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_NONE, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, EnsureRequirements, REBALANCE_PARTITIONS_BY_NONE, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
 import org.apache.spark.sql.internal.SQLConf
 
@@ -36,7 +36,7 @@ import org.apache.spark.sql.internal.SQLConf
 object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NONE, REBALANCE_PARTITIONS_BY_NONE)
+    Seq(ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_NONE)
 
   private val ensureRequirements = EnsureRequirements
 
@@ -144,7 +144,7 @@ object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
       s.shuffle.shuffleOrigin match {
         case ENSURE_REQUIREMENTS =>
           s.mapStats.isDefined && partitionSpecs.nonEmpty && supportLocalReader(s.shuffle)
-        case REPARTITION_BY_NONE =>
+        case REBALANCE_PARTITIONS_BY_NONE =>
           // Use LocalShuffleReader only when we can't CoalesceShufflePartitions
           s.mapStats.exists(_.bytesByPartitionId.length == partitionSpecs.size) &&
             partitionSpecs.nonEmpty && supportLocalReader(s.shuffle)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -97,6 +97,10 @@ case object REPARTITION_BY_NUM extends ShuffleOrigin
 // reader.
 case object REPARTITION_BY_NONE extends ShuffleOrigin
 
+// Indicates that the shuffle operator was not guaranteed the output partitioning so Spark
+// can try to optimize the partition number in AQE framework.
+case object ADAPTIVE_REPARTITION extends ShuffleOrigin
+
 /**
  * Performs a shuffle that will result in the desired partitioning.
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -92,16 +92,16 @@ case object REPARTITION_BY_COL extends ShuffleOrigin
 // a certain partition number. Spark can't optimize it.
 case object REPARTITION_BY_NUM extends ShuffleOrigin
 
-// Indicates that the shuffle operator was added by the user-specified repartition operator. Spark
-// will try to rebalance partitions that make per-partition size not too small and not too big,
-// if can not rebalance partitions then use the local shuffle reader.
+// Indicates that the rebalance operator was added by the user-specified repartition operator.
+// Spark will try to rebalance partitions that make per-partition size not too small and not
+// too big. Local shuffle reader will be used if possible to reduce network traffic.
 case object REBALANCE_PARTITIONS_BY_NONE extends ShuffleOrigin
 
 // Indicates that the shuffle operator was added by the user-specified repartition operator with
 // columns. Spark will try to rebalance partitions that make per-partition size not too small and
 // not too big.
-// Different from `REBALANCE_PARTITIONS_BY_NONE`, this operator also try its best to partition the
-// child output by some columns.
+// Different from `REBALANCE_PARTITIONS_BY_NONE`, local shuffle reader cannot be used for it as
+// the output needs to be partitioned by the given columns.
 case object REBALANCE_PARTITIONS_BY_COL extends ShuffleOrigin
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -99,7 +99,7 @@ case object REPARTITION_BY_NONE extends ShuffleOrigin
 
 // Indicates that the shuffle operator was not guaranteed the output partitioning so Spark
 // can try to optimize the partition number in AQE framework.
-case object ADAPTIVE_REPARTITION extends ShuffleOrigin
+case object REPARTITION_BY_AQE extends ShuffleOrigin
 
 /**
  * Performs a shuffle that will result in the desired partitioning.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -97,9 +97,14 @@ case object REPARTITION_BY_NUM extends ShuffleOrigin
 // reader.
 case object REPARTITION_BY_NONE extends ShuffleOrigin
 
-// Indicates that the shuffle operator was not guaranteed the output partitioning so Spark
-// can try to optimize the partition number in AQE framework.
-case object REBALANCE_PARTITIONS extends ShuffleOrigin
+// Indicates that the shuffle operator was added by the user-specified repartition operator. Spark
+// can still optimize it via changing shuffle partition number, as data partitioning won't change.
+case object REBALANCE_PARTITIONS_BY_COL extends ShuffleOrigin
+
+// Indicates that the shuffle operator was added by the user-specified repartition operator. Spark
+// firstly tries to coalesce partitions, if it cannot be coalesced, then use the local shuffle
+// reader.
+case object REBALANCE_PARTITIONS_BY_NONE extends ShuffleOrigin
 
 /**
  * Performs a shuffle that will result in the desired partitioning.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -97,8 +97,8 @@ case object REPARTITION_BY_NUM extends ShuffleOrigin
 // reader.
 case object REBALANCE_PARTITIONS_BY_NONE extends ShuffleOrigin
 
-// Indicates that the shuffle operator was added by the user-specified repartition operator. Spark
-// can still optimize it via changing shuffle partition number, as data partitioning won't change.
+// Indicates that the shuffle operator was not guaranteed the output partitioning so Spark
+// can try to optimize the partition number in AQE framework.
 case object REBALANCE_PARTITIONS_BY_COL extends ShuffleOrigin
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -99,7 +99,7 @@ case object REPARTITION_BY_NONE extends ShuffleOrigin
 
 // Indicates that the shuffle operator was not guaranteed the output partitioning so Spark
 // can try to optimize the partition number in AQE framework.
-case object REPARTITION_BY_AQE extends ShuffleOrigin
+case object REBALANCE_PARTITIONS extends ShuffleOrigin
 
 /**
  * Performs a shuffle that will result in the desired partitioning.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -95,16 +95,11 @@ case object REPARTITION_BY_NUM extends ShuffleOrigin
 // Indicates that the shuffle operator was added by the user-specified repartition operator. Spark
 // firstly tries to coalesce partitions, if it cannot be coalesced, then use the local shuffle
 // reader.
-case object REPARTITION_BY_NONE extends ShuffleOrigin
+case object REBALANCE_PARTITIONS_BY_NONE extends ShuffleOrigin
 
 // Indicates that the shuffle operator was added by the user-specified repartition operator. Spark
 // can still optimize it via changing shuffle partition number, as data partitioning won't change.
 case object REBALANCE_PARTITIONS_BY_COL extends ShuffleOrigin
-
-// Indicates that the shuffle operator was added by the user-specified repartition operator. Spark
-// firstly tries to coalesce partitions, if it cannot be coalesced, then use the local shuffle
-// reader.
-case object REBALANCE_PARTITIONS_BY_NONE extends ShuffleOrigin
 
 /**
  * Performs a shuffle that will result in the desired partitioning.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -93,12 +93,15 @@ case object REPARTITION_BY_COL extends ShuffleOrigin
 case object REPARTITION_BY_NUM extends ShuffleOrigin
 
 // Indicates that the shuffle operator was added by the user-specified repartition operator. Spark
-// firstly tries to coalesce partitions, if it cannot be coalesced, then use the local shuffle
-// reader.
+// will try to rebalance partitions that make per-partition size not too small and not too big,
+// if can not rebalance partitions then use the local shuffle reader.
 case object REBALANCE_PARTITIONS_BY_NONE extends ShuffleOrigin
 
-// Indicates that the shuffle operator was not guaranteed the output partitioning so Spark
-// can try to optimize the partition number in AQE framework.
+// Indicates that the shuffle operator was added by the user-specified repartition operator with
+// columns. Spark will try to rebalance partitions that make per-partition size not too small and
+// not too big.
+// Different from `REBALANCE_PARTITIONS_BY_NONE`, this operator also try its best to partition the
+// child output by some columns.
 case object REBALANCE_PARTITIONS_BY_COL extends ShuffleOrigin
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -92,12 +92,12 @@ case object REPARTITION_BY_COL extends ShuffleOrigin
 // a certain partition number. Spark can't optimize it.
 case object REPARTITION_BY_NUM extends ShuffleOrigin
 
-// Indicates that the rebalance operator was added by the user-specified repartition operator.
+// Indicates that the shuffle operator was added by the user-specified rebalance operator.
 // Spark will try to rebalance partitions that make per-partition size not too small and not
 // too big. Local shuffle reader will be used if possible to reduce network traffic.
 case object REBALANCE_PARTITIONS_BY_NONE extends ShuffleOrigin
 
-// Indicates that the shuffle operator was added by the user-specified repartition operator with
+// Indicates that the shuffle operator was added by the user-specified rebalance operator with
 // columns. Spark will try to rebalance partitions that make per-partition size not too small and
 // not too big.
 // Different from `REBALANCE_PARTITIONS_BY_NONE`, local shuffle reader cannot be used for it as

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1807,20 +1807,17 @@ class AdaptiveQueryExecSuite
 
   test("SPARK-35650: Use local shuffle reader if can not coalesce number of partitions") {
     withSQLConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "2") {
-      Seq("REPARTITION", "ADAPTIVE_REPARTITION", "ADAPTIVE_REPARTITION(key)")
-        .foreach { repartition =>
-          val query = s"SELECT /*+ $repartition */ * FROM testData"
-          val (_, adaptivePlan) = runAdaptiveAndVerifyResult(query)
-          collect(adaptivePlan) {
-            case r: CustomShuffleReaderExec => r
-          } match {
-            case Seq(customShuffleReader) =>
-              assert(customShuffleReader.partitionSpecs.size === 4)
-              assert(customShuffleReader.isLocalReader)
-            case _ =>
-              fail("There should be a CustomShuffleReaderExec")
-          }
-        }
+      val query = "SELECT /*+ REPARTITION */ * FROM testData"
+      val (_, adaptivePlan) = runAdaptiveAndVerifyResult(query)
+      collect(adaptivePlan) {
+        case r: CustomShuffleReaderExec => r
+      } match {
+        case Seq(customShuffleReader) =>
+          assert(customShuffleReader.partitionSpecs.size === 4)
+          assert(customShuffleReader.isLocalReader)
+        case _ =>
+          fail("There should be a CustomShuffleReaderExec")
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1788,7 +1788,7 @@ class AdaptiveQueryExecSuite
 
   test("SPARK-35650: Coalesce number of partitions by AEQ") {
     withSQLConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1") {
-      Seq("REPARTITION", "REBALANCE_PARTITIONS", "REBALANCE_PARTITIONS(key)")
+      Seq("REPARTITION", "REBALANCE_PARTITIONS(key)")
         .foreach {repartition =>
           val query = s"SELECT /*+ $repartition */ * FROM testData"
           val (_, adaptivePlan) = runAdaptiveAndVerifyResult(query)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1788,7 +1788,7 @@ class AdaptiveQueryExecSuite
 
   test("SPARK-35650: Coalesce number of partitions by AEQ") {
     withSQLConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1") {
-      Seq("REPARTITION", "ADAPTIVE_REPARTITION", "ADAPTIVE_REPARTITION(key)")
+      Seq("REPARTITION", "REPARTITION_BY_AQE", "REPARTITION_BY_AQE(key)")
         .foreach {repartition =>
           val query = s"SELECT /*+ $repartition */ * FROM testData"
           val (_, adaptivePlan) = runAdaptiveAndVerifyResult(query)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1788,7 +1788,7 @@ class AdaptiveQueryExecSuite
 
   test("SPARK-35650: Coalesce number of partitions by AEQ") {
     withSQLConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1") {
-      Seq("REPARTITION", "REPARTITION_BY_AQE", "REPARTITION_BY_AQE(key)")
+      Seq("REPARTITION", "REBALANCE_PARTITIONS", "REBALANCE_PARTITIONS(key)")
         .foreach {repartition =>
           val query = s"SELECT /*+ $repartition */ * FROM testData"
           val (_, adaptivePlan) = runAdaptiveAndVerifyResult(query)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1788,7 +1788,7 @@ class AdaptiveQueryExecSuite
 
   test("SPARK-35650: Coalesce number of partitions by AEQ") {
     withSQLConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1") {
-      Seq("REPARTITION", "REBALANCE_PARTITIONS(key)")
+      Seq("REPARTITION", "REBALANCE(key)")
         .foreach {repartition =>
           val query = s"SELECT /*+ $repartition */ * FROM testData"
           val (_, adaptivePlan) = runAdaptiveAndVerifyResult(query)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
* Add a new repartition operator `RebalanceRepartition`.
* Support a new hint `REBALANCE`

After this patch, user can run this query:
```sql
SELECT /*+ REBALANCE(c) */ * FROM t
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Add a new hint to distingush if we can optimize it safely.

This new hint can let AQE optimize with `CustomShuffleReaderExec` safely. Currently, AQE can only coalesce shuffle partitions but can not expand shuffle partitions due to the semantics of output partitioning.
Let's say we have a query:
```sql
SELECT /*+ REPARTITION(col) */ * FROM t
```
AQE can not expand the shuffle partitions even if `col` is skewed because expanding shuffle partitions will break the hashed output paritioning of `RepartitionByExpression`. But if the query is use`REPARTITION_BY_AQE`, AQE can optimize it without considering the semantics of output partitioning.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, a new hint.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add test.