### PR TITLE
[SPARK-35720][SQL] Support casting of String to timestamp without time zone type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -248,8 +248,7 @@ object DateTimeUtils {
    * @return timestamp segments, time zone id and whether the input is just time without a date. If
    *         the input string can't be parsed as timestamp, the result timestamp segments are empty.
    */
-  private def parseTimestampString(
-      s: UTF8String): (Array[Int], Option[String], Boolean) = {
+  private def parseTimestampString(s: UTF8String): (Array[Int], Option[String], Boolean) = {
     if (s == null) {
       return (Array.empty, None, false)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -30,7 +30,7 @@ import sun.util.calendar.ZoneInfo
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.RebaseDateTime._
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.types.{DateType, Decimal, TimestampType}
+import org.apache.spark.sql.types.{DateType, Decimal, TimestampType, TimestampWithoutTZType}
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 /**
@@ -219,7 +219,8 @@ object DateTimeUtils {
   def cleanLegacyTimestampStr(s: UTF8String): UTF8String = s.replace(gmtUtf8, UTF8String.EMPTY_UTF8)
 
   /**
-   * Trims and parses a given UTF8 timestamp string to the corresponding a corresponding [[Long]]
+   * Trims and parses a given UTF8 timestamp string to the corresponding timestamp segments,
+   * time zone id and whether it is just time without a date.
    * value. The return type is [[Option]] in order to distinguish between 0L and null. The following
    * formats are allowed:
    *
@@ -243,10 +244,14 @@ object DateTimeUtils {
    *     - +|-hh:mm:ss
    *     - +|-hhmmss
    *  - Region-based zone IDs in the form `area/city`, such as `Europe/Paris`
+   *
+   * @return timestamp segments, time zone id and whether the input is just time without a date. If
+   *         the input string can't be parsed as timestamp, the result timestamp segments are empty.
    */
-  def stringToTimestamp(s: UTF8String, timeZoneId: ZoneId): Option[Long] = {
+  private def parseTimestampString(
+      s: UTF8String): (Array[Int], Option[String], Boolean) = {
     if (s == null) {
-      return None
+      return (Array.empty, None, false)
     }
     var tz: Option[String] = None
     val segments: Array[Int] = Array[Int](1, 1, 1, 0, 0, 0, 0, 0, 0)
@@ -267,7 +272,7 @@ object DateTimeUtils {
           if (b == '-') {
             if (i == 0 && j != 4) {
               // year should have exact four digits
-              return None
+              return (Array.empty, None, false)
             }
             segments(i) = currentSegmentValue
             currentSegmentValue = 0
@@ -278,7 +283,7 @@ object DateTimeUtils {
             currentSegmentValue = 0
             i = 4
           } else {
-            return None
+            return (Array.empty, None, false)
           }
         } else if (i == 2) {
           if (b == ' ' || b == 'T') {
@@ -286,7 +291,7 @@ object DateTimeUtils {
             currentSegmentValue = 0
             i += 1
           } else {
-            return None
+            return (Array.empty, None, false)
           }
         } else if (i == 3 || i == 4) {
           if (b == ':') {
@@ -294,7 +299,7 @@ object DateTimeUtils {
             currentSegmentValue = 0
             i += 1
           } else {
-            return None
+            return (Array.empty, None, false)
           }
         } else if (i == 5 || i == 6) {
           if (b == '-' || b == '+') {
@@ -322,7 +327,7 @@ object DateTimeUtils {
             currentSegmentValue = 0
             i += 1
           } else {
-            return None
+            return (Array.empty, None, false)
           }
         }
       } else {
@@ -337,7 +342,7 @@ object DateTimeUtils {
     segments(i) = currentSegmentValue
     if (!justTime && i == 0 && j != 4) {
       // year should have exact four digits
-      return None
+      return (Array.empty, None, false)
     }
 
     while (digitsMilli < 6) {
@@ -349,6 +354,40 @@ object DateTimeUtils {
     while (digitsMilli > 6) {
       segments(6) /= 10
       digitsMilli -= 1
+    }
+    (segments, tz, justTime)
+  }
+
+  /**
+   * Trims and parses a given UTF8 timestamp string to the corresponding a corresponding [[Long]]
+   * value. The return type is [[Option]] in order to distinguish between 0L and null. The following
+   * formats are allowed:
+   *
+   * `yyyy`
+   * `yyyy-[m]m`
+   * `yyyy-[m]m-[d]d`
+   * `yyyy-[m]m-[d]d `
+   * `yyyy-[m]m-[d]d [h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
+   * `yyyy-[m]m-[d]dT[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
+   * `[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
+   * `T[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
+   *
+   * where `zone_id` should have one of the forms:
+   *   - Z - Zulu time zone UTC+0
+   *   - +|-[h]h:[m]m
+   *   - A short id, see https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#SHORT_IDS
+   *   - An id with one of the prefixes UTC+, UTC-, GMT+, GMT-, UT+ or UT-,
+   *     and a suffix in the formats:
+   *     - +|-h[h]
+   *     - +|-hh[:]mm
+   *     - +|-hh:mm:ss
+   *     - +|-hhmmss
+   *  - Region-based zone IDs in the form `area/city`, such as `Europe/Paris`
+   */
+  def stringToTimestamp(s: UTF8String, timeZoneId: ZoneId): Option[Long] = {
+    val (segments, tz, justTime) = parseTimestampString(s)
+    if (segments.isEmpty) {
+      return None
     }
     try {
       val zoneId = tz match {
@@ -378,6 +417,60 @@ object DateTimeUtils {
       throw QueryExecutionErrors.cannotCastUTF8StringToDataTypeError(s, TimestampType)
     }
   }
+
+  /**
+   * Trims and parses a given UTF8 string to a corresponding [[Long]] value which representing the
+   * number of microseconds since the epoch. The result is independent of time zones,
+   * which means that zone ID in the input string will be ignored.
+   * The return type is [[Option]] in order to distinguish between 0L and null. The following
+   * formats are allowed:
+   *
+   * `yyyy`
+   * `yyyy-[m]m`
+   * `yyyy-[m]m-[d]d`
+   * `yyyy-[m]m-[d]d `
+   * `yyyy-[m]m-[d]d [h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
+   * `yyyy-[m]m-[d]dT[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
+   *
+   * where `zone_id` should have one of the forms:
+   *   - Z - Zulu time zone UTC+0
+   *   - +|-[h]h:[m]m
+   *   - A short id, see https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#SHORT_IDS
+   *   - An id with one of the prefixes UTC+, UTC-, GMT+, GMT-, UT+ or UT-,
+   *     and a suffix in the formats:
+   *     - +|-h[h]
+   *     - +|-hh[:]mm
+   *     - +|-hh:mm:ss
+   *     - +|-hhmmss
+   *  - Region-based zone IDs in the form `area/city`, such as `Europe/Paris`
+   *
+   * Note: The input string has to contains year/month/day fields, otherwise Spark can't determine
+   *       the value of timestamp without time zone.
+   */
+  def stringToTimestampWithoutTimeZone(s: UTF8String): Option[Long] = {
+    val (segments, _, justTime) = parseTimestampString(s)
+    // If the input string can't be parsed as a timestamp, or it contains only the time part of a
+    // timestamp and we can't determine its date, return None.
+    if (segments.isEmpty || justTime) {
+      return None
+    }
+    try {
+      val nanoseconds = MICROSECONDS.toNanos(segments(6))
+      val localTime = LocalTime.of(segments(3), segments(4), segments(5), nanoseconds.toInt)
+      val localDate = LocalDate.of(segments(0), segments(1), segments(2))
+      val localDateTime = LocalDateTime.of(localDate, localTime)
+      Some(localDateTimeToMicros(localDateTime))
+    } catch {
+      case NonFatal(_) => None
+    }
+  }
+
+  def stringToTimestampWithoutTimeZoneAnsi(s: UTF8String): Long = {
+    stringToTimestampWithoutTimeZone(s).getOrElse {
+      throw QueryExecutionErrors.cannotCastUTF8StringToDataTypeError(s, TimestampWithoutTZType)
+    }
+  }
+
   // See issue SPARK-35679
   // min second cause overflow in instant to micro
   private val MIN_SECONDS = Math.floorDiv(Long.MinValue, MICROS_PER_SECOND)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -356,6 +356,7 @@ object DateTimeUtils {
       segments(6) /= 10
       digitsMilli -= 1
     }
+    // This step also validates time zone part
     val zoneId = tz match {
       case None => timeZoneId
       case Some("+") => Some(ZoneOffset.ofHoursMinutes(segments(7), segments(8)))
@@ -452,6 +453,8 @@ object DateTimeUtils {
   def stringToTimestampWithoutTimeZone(s: UTF8String): Option[Long] = {
     try {
       val (segments, _, justTime) = parseTimestampString(s, None)
+      // If the input string can't be parsed as a timestamp, or it contains only the time part of a
+      // timestamp and we can't determine its date, return None.
       if (segments.isEmpty || justTime) {
         return None
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
@@ -403,7 +403,12 @@ abstract class AnsiCastSuiteBase extends CastSuiteBase {
   }
 
   test("SPARK-35720: cast invalid string input to timestamp without time zone") {
-    Seq("00:00:00", "a", "123", "a2021-06-17", "2021-06-17abc").foreach { invalidInput =>
+    Seq("00:00:00",
+      "a",
+      "123",
+      "a2021-06-17",
+      "2021-06-17abc",
+      "2021-06-17 00:00:00ABC").foreach { invalidInput =>
       checkExceptionInExpression[DateTimeException](
         cast(invalidInput, TimestampWithoutTZType),
         s"Cannot cast $invalidInput to TimestampWithoutTZType")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
@@ -401,6 +401,14 @@ abstract class AnsiCastSuiteBase extends CastSuiteBase {
     checkExceptionInExpression[ArithmeticException](
       cast(cast(Literal("2147483648"), FloatType), IntegerType), "overflow")
   }
+
+  test("SPARK-35720: cast invalid string input to timestamp without time zone") {
+    Seq("00:00:00", "a", "123", "a2021-06-17", "2021-06-17abc").foreach { invalidInput =>
+      checkExceptionInExpression[DateTimeException](
+        cast(invalidInput, TimestampWithoutTZType),
+        s"Cannot cast $invalidInput to TimestampWithoutTZType")
+    }
+  }
 }
 
 /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -651,4 +651,10 @@ class CastSuite extends CastSuiteBase {
         checkEvaluation(cast(cast(interval, StringType), YearMonthIntervalType()), period)
       }
   }
+
+  test("SPARK-35720: cast invalid string input to timestamp without time zone") {
+    Seq("00:00:00", "a", "123", "a2021-06-17", "2021-06-17abc").foreach { invalidInput =>
+      checkEvaluation(cast(invalidInput, TimestampWithoutTZType), null)
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -653,7 +653,12 @@ class CastSuite extends CastSuiteBase {
   }
 
   test("SPARK-35720: cast invalid string input to timestamp without time zone") {
-    Seq("00:00:00", "a", "123", "a2021-06-17", "2021-06-17abc").foreach { invalidInput =>
+    Seq("00:00:00",
+      "a",
+      "123",
+      "a2021-06-17",
+      "2021-06-17abc",
+      "2021-06-17 00:00:00ABC").foreach { invalidInput =>
       checkEvaluation(cast(invalidInput, TimestampWithoutTZType), null)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -939,9 +939,9 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       // The result is independent of timezone
       outstandingZoneIds.foreach { zoneId =>
         checkEvaluation(cast(s + zoneId.toString, TimestampWithoutTZType), expectedTs)
-        val tsWithNanoSeconds = s + ".123456"
-        val expectedTsWithNanoSeconds = LocalDateTime.parse(tsWithNanoSeconds)
-        checkEvaluation(cast(tsWithNanoSeconds + zoneId.toString, TimestampWithoutTZType),
+        val tsWithMicros = s + ".123456"
+        val expectedTsWithNanoSeconds = LocalDateTime.parse(tsWithMicros)
+        checkEvaluation(cast(tsWithMicros + zoneId.toString, TimestampWithoutTZType),
           expectedTsWithNanoSeconds)
       }
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -929,4 +929,24 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       verifyCastFailure(cast(timestampWithoutTZLiteral, numericType), Some(errorMsg))
     }
   }
+
+  test("SPARK-35720: cast string to timestamp without timezone") {
+    specialTs.foreach { s =>
+      val expectedTs = LocalDateTime.parse(s)
+      checkEvaluation(cast(s, TimestampWithoutTZType), expectedTs)
+      // Trim spaces before casting
+      checkEvaluation(cast("  " + s + "   ", TimestampWithoutTZType), expectedTs)
+      // The result is independent of timezone
+      outstandingZoneIds.foreach { zoneId =>
+        checkEvaluation(cast(s + zoneId.toString, TimestampWithoutTZType), expectedTs)
+        val tsWithNanoSeconds = s + ".123456"
+        val expectedTsWithNanoSeconds = LocalDateTime.parse(tsWithNanoSeconds)
+        checkEvaluation(cast(tsWithNanoSeconds + zoneId.toString, TimestampWithoutTZType),
+          expectedTsWithNanoSeconds)
+      }
+    }
+    // The input string can contain date only
+    checkEvaluation(cast("2021-06-17", TimestampWithoutTZType),
+      LocalDateTime.of(2021, 6, 17, 0, 0))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Extend the Cast expression and support StringType in casting to TimestampWithoutTZType.

Closes #32898

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To conform the ANSI SQL standard which requires to support such casting.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the new timestamp type is not released yet.



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test