### PR TITLE
[SPARK-35769][SQL] Truncate java.time.Period by fields of year-month interval type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.YearMonthIntervalType._
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
@@ -77,8 +78,7 @@ object CatalystTypeConverters {
       case DoubleType => DoubleConverter
       // TODO(SPARK-35726): Truncate java.time.Duration by fields of day-time interval type
       case _: DayTimeIntervalType => DurationConverter
-      // TODO(SPARK-35769): Truncate java.time.Period by fields of year-month interval type
-      case _: YearMonthIntervalType => PeriodConverter
+      case YearMonthIntervalType(startField, endField) => PeriodConverter(startField, endField)
       case dataType: DataType => IdentityConverter(dataType)
     }
     converter.asInstanceOf[CatalystTypeConverter[Any, Any, Any]]
@@ -444,9 +444,10 @@ object CatalystTypeConverters {
       IntervalUtils.microsToDuration(row.getLong(column))
   }
 
-  private object PeriodConverter extends CatalystTypeConverter[Period, Period, Any] {
+  private case class PeriodConverter(startField: Byte, endField: Byte)
+      extends CatalystTypeConverter[Period, Period, Any] {
     override def toCatalystImpl(scalaValue: Period): Int = {
-      IntervalUtils.periodToMonths(scalaValue)
+      IntervalUtils.periodToMonths(scalaValue, startField, endField)
     }
     override def toScala(catalystValue: Any): Period = {
       if (catalystValue == null) null
@@ -523,7 +524,7 @@ object CatalystTypeConverters {
         (key: Any) => convertToCatalyst(key),
         (value: Any) => convertToCatalyst(value))
     case d: Duration => DurationConverter.toCatalyst(d)
-    case p: Period => PeriodConverter.toCatalyst(p)
+    case p: Period => PeriodConverter(YEAR, MONTH).toCatalyst(p)
     case other => other
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -447,7 +447,7 @@ object CatalystTypeConverters {
   private case class PeriodConverter(startField: Byte, endField: Byte)
       extends CatalystTypeConverter[Period, Period, Any] {
     override def toCatalystImpl(scalaValue: Period): Int = {
-      IntervalUtils.periodToMonths(scalaValue, startField, endField)
+      IntervalUtils.periodToMonths(scalaValue, endField)
     }
     override def toScala(catalystValue: Any): Period = {
       if (catalystValue == null) null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -78,7 +78,7 @@ object CatalystTypeConverters {
       case DoubleType => DoubleConverter
       // TODO(SPARK-35726): Truncate java.time.Duration by fields of day-time interval type
       case _: DayTimeIntervalType => DurationConverter
-      case YearMonthIntervalType(startField, endField) => PeriodConverter(startField, endField)
+      case YearMonthIntervalType(_, endField) => PeriodConverter(endField)
       case dataType: DataType => IdentityConverter(dataType)
     }
     converter.asInstanceOf[CatalystTypeConverter[Any, Any, Any]]
@@ -444,7 +444,7 @@ object CatalystTypeConverters {
       IntervalUtils.microsToDuration(row.getLong(column))
   }
 
-  private case class PeriodConverter(startField: Byte, endField: Byte)
+  private case class PeriodConverter(endField: Byte)
       extends CatalystTypeConverter[Period, Period, Any] {
     override def toCatalystImpl(scalaValue: Period): Int = {
       IntervalUtils.periodToMonths(scalaValue, endField)
@@ -524,7 +524,7 @@ object CatalystTypeConverters {
         (key: Any) => convertToCatalyst(key),
         (value: Any) => convertToCatalyst(value))
     case d: Duration => DurationConverter.toCatalyst(d)
-    case p: Period => PeriodConverter(YEAR, MONTH).toCatalyst(p)
+    case p: Period => PeriodConverter(MONTH).toCatalyst(p)
     case other => other
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -928,13 +928,13 @@ object IntervalUtils {
       period: Period,
       startField: Byte = YearMonthIntervalType.YEAR,
       endField: Byte = YearMonthIntervalType.MONTH): Int = {
+    val monthsInYears = Math.multiplyExact(period.getYears, MONTHS_PER_YEAR)
+    val months = Math.addExact(monthsInYears, period.getMonths)
     (startField, endField) match {
       case (YearMonthIntervalType.YEAR, YearMonthIntervalType.YEAR) =>
-        Math.multiplyExact(period.getYears, MONTHS_PER_YEAR)
-      case (YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH) =>
-        val monthsInYears = Math.multiplyExact(period.getYears, MONTHS_PER_YEAR)
-        Math.addExact(monthsInYears, period.getMonths)
-      case (YearMonthIntervalType.MONTH, YearMonthIntervalType.MONTH) => period.getMonths
+        Math.multiplyExact(Math.floorDiv(months, MONTHS_PER_YEAR), MONTHS_PER_YEAR)
+      case (YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH) => months
+      case (YearMonthIntervalType.MONTH, YearMonthIntervalType.MONTH) => months
       case _ =>
         throw QueryCompilationErrors.invalidDayTimeIntervalType(
           YearMonthIntervalType.fieldToString(startField),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -932,7 +932,7 @@ object IntervalUtils {
     val monthsInYears = Math.multiplyExact(period.getYears, MONTHS_PER_YEAR)
     val months = Math.addExact(monthsInYears, period.getMonths)
     if (endField == YearMonthIntervalType.YEAR) {
-      Math.multiplyExact(Math.floorDiv(months, MONTHS_PER_YEAR), MONTHS_PER_YEAR)
+      months - months % MONTHS_PER_YEAR
     } else {
       months
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -925,10 +925,10 @@ object IntervalUtils {
    * @throws ArithmeticException If numeric overflow occurs
    */
   def periodToMonths(period: Period): Int = {
-    periodToMonths(period, YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH)
+    periodToMonths(period, YearMonthIntervalType.MONTH)
   }
 
-  def periodToMonths(period: Period, startField: Byte, endField: Byte): Int = {
+  def periodToMonths(period: Period, endField: Byte): Int = {
     val monthsInYears = Math.multiplyExact(period.getYears, MONTHS_PER_YEAR)
     val months = Math.addExact(monthsInYears, period.getMonths)
     if (endField == YearMonthIntervalType.YEAR) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -914,6 +914,10 @@ object IntervalUtils {
    */
   def microsToDuration(micros: Long): Duration = Duration.of(micros, ChronoUnit.MICROS)
 
+  def periodToMonths(period: Period): Int = {
+    periodToMonths(period, YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH)
+  }
+
   /**
    * Gets the total number of months in this period.
    * <p>
@@ -924,10 +928,7 @@ object IntervalUtils {
    * @return The total number of months in the period, may be negative
    * @throws ArithmeticException If numeric overflow occurs
    */
-  def periodToMonths(
-      period: Period,
-      startField: Byte = YearMonthIntervalType.YEAR,
-      endField: Byte = YearMonthIntervalType.MONTH): Int = {
+  def periodToMonths(period: Period, startField: Byte, endField: Byte): Int = {
     val monthsInYears = Math.multiplyExact(period.getYears, MONTHS_PER_YEAR)
     val months = Math.addExact(monthsInYears, period.getMonths)
     (startField, endField) match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -914,10 +914,6 @@ object IntervalUtils {
    */
   def microsToDuration(micros: Long): Duration = Duration.of(micros, ChronoUnit.MICROS)
 
-  def periodToMonths(period: Period): Int = {
-    periodToMonths(period, YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH)
-  }
-
   /**
    * Gets the total number of months in this period.
    * <p>
@@ -928,6 +924,10 @@ object IntervalUtils {
    * @return The total number of months in the period, may be negative
    * @throws ArithmeticException If numeric overflow occurs
    */
+  def periodToMonths(period: Period): Int = {
+    periodToMonths(period, YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH)
+  }
+
   def periodToMonths(period: Period, startField: Byte, endField: Byte): Int = {
     val monthsInYears = Math.multiplyExact(period.getYears, MONTHS_PER_YEAR)
     val months = Math.addExact(monthsInYears, period.getMonths)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_MILLIS, 
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.YearMonthIntervalType.YEAR
 import org.apache.spark.unsafe.types.CalendarInterval
 /**
  * Random data generators for Spark SQL DataTypes. These generators do not generate uniformly random
@@ -284,7 +285,10 @@ object RandomDataGenerator {
         new CalendarInterval(months, days, ns)
       })
       case _: DayTimeIntervalType => Some(() => Duration.of(rand.nextLong(), ChronoUnit.MICROS))
-      case _: YearMonthIntervalType => Some(() => Period.ofMonths(rand.nextInt()).normalized())
+      case YearMonthIntervalType(_, YEAR) =>
+        val period = Period.ofMonths(rand.nextInt()).normalized()
+        Some(() => Period.ofYears(period.getYears).normalized())
+      case YearMonthIntervalType(_, _) => Some(() => Period.ofMonths(rand.nextInt()).normalized())
       case DecimalType.Fixed(precision, scale) => Some(
         () => BigDecimal.apply(
           rand.nextLong() % math.pow(10, precision).toLong,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable
 import scala.util.{Random, Try}
 
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
-import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_MILLIS, MILLIS_PER_DAY}
+import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -286,7 +286,7 @@ object RandomDataGenerator {
       })
       case _: DayTimeIntervalType => Some(() => Duration.of(rand.nextLong(), ChronoUnit.MICROS))
       case YearMonthIntervalType(_, YEAR) =>
-        Some(() => Period.ofYears(rand.nextInt() / 12).normalized())
+        Some(() => Period.ofYears(rand.nextInt() / MONTHS_PER_YEAR).normalized())
       case YearMonthIntervalType(_, _) => Some(() => Period.ofMonths(rand.nextInt()).normalized())
       case DecimalType.Fixed(precision, scale) => Some(
         () => BigDecimal.apply(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -286,8 +286,7 @@ object RandomDataGenerator {
       })
       case _: DayTimeIntervalType => Some(() => Duration.of(rand.nextLong(), ChronoUnit.MICROS))
       case YearMonthIntervalType(_, YEAR) =>
-        val period = Period.ofMonths(rand.nextInt()).normalized()
-        Some(() => Period.ofYears(period.getYears).normalized())
+        Some(() => Period.ofYears(rand.nextInt() / 12).normalized())
       case YearMonthIntervalType(_, _) => Some(() => Period.ofMonths(rand.nextInt()).normalized())
       case DecimalType.Fixed(precision, scale) => Some(
         () => BigDecimal.apply(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGeneratorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGeneratorSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql
 
 import java.nio.ByteBuffer
+import java.time.Period
 import java.util.Arrays
 
 import scala.util.Random
@@ -28,6 +29,7 @@ import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, yearMonthIntervalTypes}
+import org.apache.spark.sql.types.YearMonthIntervalType.YEAR
 
 /**
  * Tests of [[RandomDataGenerator]].
@@ -154,7 +156,15 @@ class RandomDataGeneratorSuite extends SparkFunSuite with SQLHelper {
         val data = generator.apply()
         val catalyst = toCatalyst(data)
         val convertedBack = toScala(catalyst)
-        assert(data == convertedBack)
+        dt match {
+          case YearMonthIntervalType(_, YEAR) =>
+            assert(Period.ofYears(data.asInstanceOf[Period].normalized().getYears).normalized()
+              == convertedBack)
+          case YearMonthIntervalType(_, _) =>
+            assert(data == convertedBack)
+          case _ =>
+            assert(data == convertedBack)
+        }
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGeneratorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGeneratorSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql
 
 import java.nio.ByteBuffer
-import java.time.Period
 import java.util.Arrays
 
 import scala.util.Random
@@ -29,7 +28,6 @@ import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, yearMonthIntervalTypes}
-import org.apache.spark.sql.types.YearMonthIntervalType.YEAR
 
 /**
  * Tests of [[RandomDataGenerator]].
@@ -156,15 +154,7 @@ class RandomDataGeneratorSuite extends SparkFunSuite with SQLHelper {
         val data = generator.apply()
         val catalyst = toCatalyst(data)
         val convertedBack = toScala(catalyst)
-        dt match {
-          case YearMonthIntervalType(_, YEAR) =>
-            assert(Period.ofYears(data.asInstanceOf[Period].normalized().getYears).normalized()
-              == convertedBack)
-          case YearMonthIntervalType(_, _) =>
-            assert(data == convertedBack)
-          case _ =>
-            assert(data == convertedBack)
-        }
+        assert(data == convertedBack)
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.util.{DateTimeConstants, DateTimeUtils, GenericArrayData, IntervalUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.YearMonthIntervalType._
 import org.apache.spark.unsafe.types.UTF8String
 
 class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
@@ -307,6 +308,15 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
       IntervalUtils.periodToMonths(Period.of(Int.MaxValue, Int.MaxValue, Int.MaxValue))
     }.getMessage
     assert(errMsg.contains("integer overflow"))
+  }
+
+  test("SPARK-35769: Truncate java.time.Period by fields of year-month interval type") {
+    Seq(YearMonthIntervalType(YEAR, YEAR) -> 12,
+      YearMonthIntervalType(YEAR, MONTH) -> 13,
+      YearMonthIntervalType(MONTH, MONTH) -> 1)
+      .foreach { case (ym, value) =>
+        assert(CatalystTypeConverters.createToCatalystConverter(ym)(Period.of(1, 1, 0)) == value)
+      }
   }
 
   test("SPARK-34615: converting YearMonthIntervalType to java.time.Period") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -313,7 +313,7 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
   test("SPARK-35769: Truncate java.time.Period by fields of year-month interval type") {
     Seq(YearMonthIntervalType(YEAR, YEAR) -> 12,
       YearMonthIntervalType(YEAR, MONTH) -> 13,
-      YearMonthIntervalType(MONTH, MONTH) -> 1)
+      YearMonthIntervalType(MONTH, MONTH) -> 13)
       .foreach { case (ym, value) =>
         assert(CatalystTypeConverters.createToCatalystConverter(ym)(Period.of(1, 1, 0)) == value)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support truncate java.time.Period by fields of year-month interval type

### Why are the changes needed?
To follow the SQL standard and respect the field restriction of the target year-month type.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT
