### PR TITLE
[SPARK-35726][SQL] Truncate java.time.Duration by fields of day-time interval type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -523,7 +523,7 @@ object CatalystTypeConverters {
         map,
         (key: Any) => convertToCatalyst(key),
         (value: Any) => convertToCatalyst(value))
-    case d: Duration => DurationConverter(DAY, SECOND).toCatalyst(d)
+    case d: Duration => DurationConverter(SECOND).toCatalyst(d)
     case p: Period => PeriodConverter.toCatalyst(p)
     case other => other
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DayTimeIntervalType._
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
@@ -75,8 +76,7 @@ object CatalystTypeConverters {
       case LongType => LongConverter
       case FloatType => FloatConverter
       case DoubleType => DoubleConverter
-      // TODO(SPARK-35726): Truncate java.time.Duration by fields of day-time interval type
-      case _: DayTimeIntervalType => DurationConverter
+      case DayTimeIntervalType(startField, endField) => DurationConverter(startField, endField)
       // TODO(SPARK-35769): Truncate java.time.Period by fields of year-month interval type
       case _: YearMonthIntervalType => PeriodConverter
       case dataType: DataType => IdentityConverter(dataType)
@@ -432,9 +432,10 @@ object CatalystTypeConverters {
     override def toScalaImpl(row: InternalRow, column: Int): Double = row.getDouble(column)
   }
 
-  private object DurationConverter extends CatalystTypeConverter[Duration, Duration, Any] {
+  private case class DurationConverter(startField: Byte, endField: Byte)
+      extends CatalystTypeConverter[Duration, Duration, Any] {
     override def toCatalystImpl(scalaValue: Duration): Long = {
-      IntervalUtils.durationToMicros(scalaValue)
+      IntervalUtils.durationToMicros(scalaValue, startField, endField)
     }
     override def toScala(catalystValue: Any): Duration = {
       if (catalystValue == null) null
@@ -522,7 +523,7 @@ object CatalystTypeConverters {
         map,
         (key: Any) => convertToCatalyst(key),
         (value: Any) => convertToCatalyst(value))
-    case d: Duration => DurationConverter.toCatalyst(d)
+    case d: Duration => DurationConverter(DAY, SECOND).toCatalyst(d)
     case p: Period => PeriodConverter.toCatalyst(p)
     case other => other
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -76,7 +76,7 @@ object CatalystTypeConverters {
       case LongType => LongConverter
       case FloatType => FloatConverter
       case DoubleType => DoubleConverter
-      case DayTimeIntervalType(endField) => DurationConverter(startField, endField)
+      case DayTimeIntervalType(_, endField) => DurationConverter(endField)
       // TODO(SPARK-35769): Truncate java.time.Period by fields of year-month interval type
       case _: YearMonthIntervalType => PeriodConverter
       case dataType: DataType => IdentityConverter(dataType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -435,7 +435,7 @@ object CatalystTypeConverters {
   private case class DurationConverter(startField: Byte, endField: Byte)
       extends CatalystTypeConverter[Duration, Duration, Any] {
     override def toCatalystImpl(scalaValue: Duration): Long = {
-      IntervalUtils.durationToMicros(scalaValue, startField, endField)
+      IntervalUtils.durationToMicros(scalaValue, endField)
     }
     override def toScala(catalystValue: Any): Duration = {
       if (catalystValue == null) null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -76,7 +76,7 @@ object CatalystTypeConverters {
       case LongType => LongConverter
       case FloatType => FloatConverter
       case DoubleType => DoubleConverter
-      case DayTimeIntervalType(startField, endField) => DurationConverter(startField, endField)
+      case DayTimeIntervalType(endField) => DurationConverter(startField, endField)
       // TODO(SPARK-35769): Truncate java.time.Period by fields of year-month interval type
       case _: YearMonthIntervalType => PeriodConverter
       case dataType: DataType => IdentityConverter(dataType)
@@ -432,7 +432,7 @@ object CatalystTypeConverters {
     override def toScalaImpl(row: InternalRow, column: Int): Double = row.getDouble(column)
   }
 
-  private case class DurationConverter(startField: Byte, endField: Byte)
+  private case class DurationConverter(endField: Byte)
       extends CatalystTypeConverter[Duration, Duration, Any] {
     override def toCatalystImpl(scalaValue: Duration): Long = {
       IntervalUtils.durationToMicros(scalaValue, endField)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -891,6 +891,10 @@ object IntervalUtils {
    * @return The total length of the duration in microseconds
    * @throws ArithmeticException If numeric overflow occurs
    */
+  def durationToMicros(duration: Duration): Long = {
+    durationToMicros(duration, DayTimeIntervalType.DAY, DayTimeIntervalType.SECOND)
+  }
+
   def durationToMicros(
       duration: Duration,
       startField: Byte = DayTimeIntervalType.DAY,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -895,10 +895,7 @@ object IntervalUtils {
     durationToMicros(duration, DayTimeIntervalType.DAY, DayTimeIntervalType.SECOND)
   }
 
-  def durationToMicros(
-      duration: Duration,
-      startField: Byte = DayTimeIntervalType.DAY,
-      endField: Byte = DayTimeIntervalType.SECOND): Long = {
+  def durationToMicros(duration: Duration, startField: Byte, endField: Byte): Long = {
 
     def secondsToMicros(seconds: Long): Long = {
       if (seconds == minDurationSeconds) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -922,7 +922,6 @@ object IntervalUtils {
     val seconds = duration.getSeconds
     (startField, endField) match {
       case (DayTimeIntervalType.DAY, DayTimeIntervalType.DAY) =>
-        println(Math.floorDiv(seconds, SECONDS_PER_DAY))
         secondsToMicros(extractEqualConstant(seconds, SECONDS_PER_DAY))
       case (DayTimeIntervalType.DAY, DayTimeIntervalType.HOUR) =>
         secondsToMicros(extractEqualConstant(seconds, SECONDS_PER_HOUR))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -896,31 +896,24 @@ object IntervalUtils {
   }
 
   def durationToMicros(duration: Duration, endField: Byte): Long = {
-
-    def secondsToMicros(seconds: Long): Long = {
-      if (seconds == minDurationSeconds) {
-        val microsInSeconds = (minDurationSeconds + 1) * MICROS_PER_SECOND
-        val nanoAdjustment = duration.getNano
-        assert(0 <= nanoAdjustment && nanoAdjustment < NANOS_PER_SECOND,
-          "Duration.getNano() must return the adjustment to the seconds field " +
-            "in the range from 0 to 999999999 nanoseconds, inclusive.")
-        Math.addExact(microsInSeconds, (nanoAdjustment - NANOS_PER_SECOND) / NANOS_PER_MICROS)
-      } else {
-        val microsInSeconds = Math.multiplyExact(seconds, MICROS_PER_SECOND)
-        Math.addExact(microsInSeconds, duration.getNano / NANOS_PER_MICROS)
-      }
+    val seconds = duration.getSeconds
+    val micros = if (seconds == minDurationSeconds) {
+      val microsInSeconds = (minDurationSeconds + 1) * MICROS_PER_SECOND
+      val nanoAdjustment = duration.getNano
+      assert(0 <= nanoAdjustment && nanoAdjustment < NANOS_PER_SECOND,
+        "Duration.getNano() must return the adjustment to the seconds field " +
+          "in the range from 0 to 999999999 nanoseconds, inclusive.")
+      Math.addExact(microsInSeconds, (nanoAdjustment - NANOS_PER_SECOND) / NANOS_PER_MICROS)
+    } else {
+      val microsInSeconds = Math.multiplyExact(seconds, MICROS_PER_SECOND)
+      Math.addExact(microsInSeconds, duration.getNano / NANOS_PER_MICROS)
     }
 
-    val seconds = duration.getSeconds
     endField match {
-      case DayTimeIntervalType.DAY =>
-        secondsToMicros(seconds - seconds % SECONDS_PER_DAY)
-      case DayTimeIntervalType.HOUR =>
-        secondsToMicros(seconds - seconds % SECONDS_PER_HOUR)
-      case DayTimeIntervalType.MINUTE =>
-        secondsToMicros(seconds - seconds % SECONDS_PER_MINUTE)
-      case DayTimeIntervalType.SECOND =>
-        secondsToMicros(seconds)
+      case DayTimeIntervalType.DAY => micros - micros % MICROS_PER_DAY
+      case DayTimeIntervalType.HOUR => micros - micros % MICROS_PER_HOUR
+      case DayTimeIntervalType.MINUTE => micros - micros % MICROS_PER_MINUTE
+      case DayTimeIntervalType.SECOND => micros
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -915,35 +915,16 @@ object IntervalUtils {
       Math.multiplyExact(Math.floorDiv(seconds, constant), constant)
     }
 
-    def subtractEqualOrGreatThanConstant(seconds: Long, constant: Long): Long = {
-      Math.subtractExact(seconds, extractEqualConstant(seconds, constant))
-    }
-
     val seconds = duration.getSeconds
-    (startField, endField) match {
-      case (DayTimeIntervalType.DAY, DayTimeIntervalType.DAY) =>
+    endField match {
+      case DayTimeIntervalType.DAY =>
         secondsToMicros(extractEqualConstant(seconds, SECONDS_PER_DAY))
-      case (DayTimeIntervalType.DAY, DayTimeIntervalType.HOUR) =>
+      case DayTimeIntervalType.HOUR =>
         secondsToMicros(extractEqualConstant(seconds, SECONDS_PER_HOUR))
-      case (DayTimeIntervalType.DAY, DayTimeIntervalType.MINUTE) =>
+      case DayTimeIntervalType.MINUTE =>
         secondsToMicros(extractEqualConstant(seconds, SECONDS_PER_MINUTE))
-      case (DayTimeIntervalType.DAY, DayTimeIntervalType.SECOND) =>
+      case DayTimeIntervalType.SECOND =>
         secondsToMicros(seconds)
-      case (DayTimeIntervalType.HOUR, DayTimeIntervalType.HOUR) =>
-        val subtractGreatThanHours = subtractEqualOrGreatThanConstant(seconds, SECONDS_PER_DAY)
-        secondsToMicros(extractEqualConstant(subtractGreatThanHours, SECONDS_PER_HOUR))
-      case (DayTimeIntervalType.HOUR, DayTimeIntervalType.MINUTE) =>
-        val subtractGreatThanHours = subtractEqualOrGreatThanConstant(seconds, SECONDS_PER_DAY)
-        secondsToMicros(extractEqualConstant(subtractGreatThanHours, SECONDS_PER_MINUTE))
-      case (DayTimeIntervalType.HOUR, DayTimeIntervalType.SECOND) =>
-        secondsToMicros(subtractEqualOrGreatThanConstant(seconds, SECONDS_PER_DAY))
-      case (DayTimeIntervalType.MINUTE, DayTimeIntervalType.MINUTE) =>
-        val subtractGreatThanHours = subtractEqualOrGreatThanConstant(seconds, SECONDS_PER_HOUR)
-        secondsToMicros(extractEqualConstant(subtractGreatThanHours, SECONDS_PER_MINUTE))
-      case (DayTimeIntervalType.MINUTE, DayTimeIntervalType.SECOND) =>
-        secondsToMicros(subtractEqualOrGreatThanConstant(seconds, SECONDS_PER_HOUR))
-      case (DayTimeIntervalType.SECOND, DayTimeIntervalType.SECOND) =>
-        secondsToMicros(subtractEqualOrGreatThanConstant(seconds, SECONDS_PER_MINUTE))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -911,18 +911,14 @@ object IntervalUtils {
       }
     }
 
-    def extractEqualConstant(seconds: Long, constant: Long): Long = {
-      Math.multiplyExact(Math.floorDiv(seconds, constant), constant)
-    }
-
     val seconds = duration.getSeconds
     endField match {
       case DayTimeIntervalType.DAY =>
-        secondsToMicros(extractEqualConstant(seconds, SECONDS_PER_DAY))
+        secondsToMicros(seconds - seconds % SECONDS_PER_DAY)
       case DayTimeIntervalType.HOUR =>
-        secondsToMicros(extractEqualConstant(seconds, SECONDS_PER_HOUR))
+        secondsToMicros(seconds - seconds % SECONDS_PER_HOUR)
       case DayTimeIntervalType.MINUTE =>
-        secondsToMicros(extractEqualConstant(seconds, SECONDS_PER_MINUTE))
+        secondsToMicros(seconds - seconds % SECONDS_PER_MINUTE)
       case DayTimeIntervalType.SECOND =>
         secondsToMicros(seconds)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -892,10 +892,10 @@ object IntervalUtils {
    * @throws ArithmeticException If numeric overflow occurs
    */
   def durationToMicros(duration: Duration): Long = {
-    durationToMicros(duration, DayTimeIntervalType.DAY, DayTimeIntervalType.SECOND)
+    durationToMicros(duration, DayTimeIntervalType.SECOND)
   }
 
-  def durationToMicros(duration: Duration, startField: Byte, endField: Byte): Long = {
+  def durationToMicros(duration: Duration, endField: Byte): Long = {
 
     def secondsToMicros(seconds: Long): Long = {
       if (seconds == minDurationSeconds) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -26,10 +26,11 @@ import scala.collection.mutable
 import scala.util.{Random, Try}
 
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
-import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_MILLIS, MILLIS_PER_DAY}
+import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DayTimeIntervalType._
 import org.apache.spark.unsafe.types.CalendarInterval
 /**
  * Random data generators for Spark SQL DataTypes. These generators do not generate uniformly random
@@ -283,7 +284,17 @@ object RandomDataGenerator {
         val ns = rand.nextLong()
         new CalendarInterval(months, days, ns)
       })
-      case _: DayTimeIntervalType => Some(() => Duration.of(rand.nextLong(), ChronoUnit.MICROS))
+      case DayTimeIntervalType(_, DAY) =>
+        val mircoSeconds = rand.nextLong()
+        Some(() => Duration.of(mircoSeconds - mircoSeconds % MICROS_PER_DAY, ChronoUnit.MICROS))
+      case DayTimeIntervalType(_, HOUR) =>
+        val mircoSeconds = rand.nextLong()
+        Some(() => Duration.of(mircoSeconds - mircoSeconds % MICROS_PER_HOUR, ChronoUnit.MICROS))
+      case DayTimeIntervalType(_, MINUTE) =>
+        val mircoSeconds = rand.nextLong()
+        Some(() => Duration.of(mircoSeconds - mircoSeconds % MICROS_PER_MINUTE, ChronoUnit.MICROS))
+      case DayTimeIntervalType(_, SECOND) =>
+        Some(() => Duration.of(rand.nextLong(), ChronoUnit.MICROS))
       case _: YearMonthIntervalType => Some(() => Period.ofMonths(rand.nextInt()).normalized())
       case DecimalType.Fixed(precision, scale) => Some(
         () => BigDecimal.apply(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -276,20 +276,21 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
   }
 
   test("SPARK-35726: Truncate java.time.Duration by fields of day-time interval type") {
-    val duration = Duration.ofSeconds(90061)
-    Seq(DayTimeIntervalType(DAY, DAY) -> 86400000000L,
-      DayTimeIntervalType(DAY, HOUR) -> 90000000000L,
-      DayTimeIntervalType(DAY, MINUTE) -> 90060000000L,
-      DayTimeIntervalType(DAY, SECOND) -> 90061000000L,
-      DayTimeIntervalType(HOUR, HOUR) -> 90000000000L,
-      DayTimeIntervalType(HOUR, MINUTE) -> 90060000000L,
-      DayTimeIntervalType(HOUR, SECOND) -> 90061000000L,
-      DayTimeIntervalType(MINUTE, MINUTE) -> 90060000000L,
-      DayTimeIntervalType(MINUTE, SECOND) -> 90061000000L,
-      DayTimeIntervalType(SECOND, SECOND) -> 90061000000L)
-      .foreach { case (dt, value) =>
-        assert(CatalystTypeConverters.createToCatalystConverter(dt)(duration) == value)
-        assert(CatalystTypeConverters.createToCatalystConverter(dt)(duration.negated()) == -value)
+    val duration = Duration.ofSeconds(90061, 1000000023)
+    Seq((DayTimeIntervalType(DAY, DAY), 86400000000L, -86400000000L),
+      (DayTimeIntervalType(DAY, HOUR), 90000000000L, -90000000000L),
+      (DayTimeIntervalType(DAY, MINUTE), 90060000000L, -90060000000L),
+      (DayTimeIntervalType(DAY, SECOND), 90062000000L, -90062000001L),
+      (DayTimeIntervalType(HOUR, HOUR), 90000000000L, -90000000000L),
+      (DayTimeIntervalType(HOUR, MINUTE), 90060000000L, -90060000000L),
+      (DayTimeIntervalType(HOUR, SECOND), 90062000000L, -90062000001L),
+      (DayTimeIntervalType(MINUTE, MINUTE), 90060000000L, -90060000000L),
+      (DayTimeIntervalType(MINUTE, SECOND), 90062000000L, -90062000001L),
+      (DayTimeIntervalType(SECOND, SECOND), 90062000000L, -90062000001L))
+      .foreach { case (dt, positive, negative) =>
+        assert(CatalystTypeConverters.createToCatalystConverter(dt)(duration) == positive)
+        assert(
+          CatalystTypeConverters.createToCatalystConverter(dt)(duration.negated()) == negative)
       }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -294,7 +294,6 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
       }
   }
 
-
   test("SPARK-34605: converting DayTimeIntervalType to java.time.Duration") {
     Seq(
       0L,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -288,6 +288,7 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
       DayTimeIntervalType(SECOND, SECOND) -> 90061000000L)
       .foreach { case (dt, value) =>
         assert(CatalystTypeConverters.createToCatalystConverter(dt)(duration) == value)
+        assert(CatalystTypeConverters.createToCatalystConverter(dt)(duration.negated()) == -value)
       }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -280,12 +280,12 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
       DayTimeIntervalType(DAY, HOUR) -> 90000000000L,
       DayTimeIntervalType(DAY, MINUTE) -> 90060000000L,
       DayTimeIntervalType(DAY, SECOND) -> 90061000000L,
-      DayTimeIntervalType(HOUR, HOUR) -> 3600000000L,
-      DayTimeIntervalType(HOUR, MINUTE) -> 3660000000L,
-      DayTimeIntervalType(HOUR, SECOND) -> 3661000000L,
-      DayTimeIntervalType(MINUTE, MINUTE) -> 60000000L,
-      DayTimeIntervalType(MINUTE, SECOND) -> 61000000L,
-      DayTimeIntervalType(SECOND, SECOND) -> 1000000L)
+      DayTimeIntervalType(HOUR, HOUR) -> 90000000000L,
+      DayTimeIntervalType(HOUR, MINUTE) -> 90060000000L,
+      DayTimeIntervalType(HOUR, SECOND) -> 90061000000L,
+      DayTimeIntervalType(MINUTE, MINUTE) -> 90060000000L,
+      DayTimeIntervalType(MINUTE, SECOND) -> 90061000000L,
+      DayTimeIntervalType(SECOND, SECOND) -> 90061000000L)
       .foreach { case (dt, value) =>
         assert(CatalystTypeConverters.createToCatalystConverter(dt)(duration) == value)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support truncate java.time.Duration by fields of day-time interval type.

### Why are the changes needed?
To respect fields of the target day-time interval types.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UT
