### PR TITLE
[MINOR] Add GitHub Action build status badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ and Structured Streaming for stream processing.
 
 <https://spark.apache.org/>
 
+[![GitHub Action Build](https://github.com/apache/spark/actions/workflows/build_and_test.yml/badge.svg?branch=master)](https://github.com/apache/spark/actions/workflows/build_and_test.yml?query=branch%3Amaster)
 [![Jenkins Build](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-3.2/badge/icon)](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-3.2)
 [![AppVeyor Build](https://img.shields.io/appveyor/ci/ApacheSoftwareFoundation/spark/master.svg?style=plastic&logo=appveyor)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark)
 [![PySpark Coverage](https://img.shields.io/badge/dynamic/xml.svg?label=pyspark%20coverage&url=https%3A%2F%2Fspark-test.github.io%2Fpyspark-coverage-site&query=%2Fhtml%2Fbody%2Fdiv%5B1%5D%2Fdiv%2Fh1%2Fspan&colorB=brightgreen&style=plastic)](https://spark-test.github.io/pyspark-coverage-site)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add GitHub Action build status badge to README.md.

### Why are the changes needed?
This will improve the visibility of the build status. 
- https://github.com/williamhyun/spark/tree/badge#apache-spark


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
N/A