### PR TITLE
[SPARK-35469][PYTHON] Fix disallow_untyped_defs mypy checks.

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -159,9 +159,6 @@ ignore_missing_imports = True
 [mypy-pyspark.pandas.data_type_ops.*]
 disallow_untyped_defs = False
 
-[mypy-pyspark.pandas.accessors]
-disallow_untyped_defs = False
-
 [mypy-pyspark.pandas.base]
 disallow_untyped_defs = False
 

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -18,14 +18,15 @@
 pandas-on-Spark specific features.
 """
 import inspect
-from typing import Any, Optional, Tuple, Union, TYPE_CHECKING, cast
-import types
+from typing import Any, Callable, Optional, Tuple, Union, TYPE_CHECKING, cast
+from types import FunctionType
 
 import numpy as np  # noqa: F401
 import pandas as pd
+
 from pyspark.sql import functions as F
 from pyspark.sql.functions import pandas_udf
-from pyspark.sql.types import LongType, StructField, StructType
+from pyspark.sql.types import DataType, LongType, StructField, StructType
 
 from pyspark.pandas.internal import (
     InternalField,
@@ -45,6 +46,7 @@ from pyspark.pandas.utils import (
 if TYPE_CHECKING:
     from pyspark.pandas.frame import DataFrame  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
+    from pyspark.sql._typing import UserDefinedFunctionLike
 
 
 class PandasOnSparkFrameMethods(object):
@@ -201,7 +203,9 @@ class PandasOnSparkFrameMethods(object):
             ).resolved_copy
         )
 
-    def apply_batch(self, func, args=(), **kwds) -> "DataFrame":
+    def apply_batch(
+        self, func: Callable[..., Union[pd.DataFrame, pd.Series]], args: Tuple = (), **kwds: Any
+    ) -> "DataFrame":
         """
         Apply a function that takes pandas DataFrame and outputs pandas DataFrame. The pandas
         DataFrame given to the function is of a batch used internally.
@@ -338,7 +342,7 @@ class PandasOnSparkFrameMethods(object):
         from pyspark.pandas.frame import DataFrame
         from pyspark import pandas as ps
 
-        if not isinstance(func, types.FunctionType):
+        if not isinstance(func, FunctionType):
             assert callable(func), "the first argument should be a callable function."
             f = func
             func = lambda *args, **kwargs: f(*args, **kwargs)
@@ -409,7 +413,9 @@ class PandasOnSparkFrameMethods(object):
 
         return DataFrame(internal)
 
-    def transform_batch(self, func, *args, **kwargs) -> Union["DataFrame", "Series"]:
+    def transform_batch(
+        self, func: Callable[..., Union[pd.DataFrame, pd.Series]], *args: Any, **kwargs: Any
+    ) -> Union["DataFrame", "Series"]:
         """
         Transform chunks with a function that takes pandas DataFrame and outputs pandas DataFrame.
         The pandas DataFrame given to the function is of a batch used internally. The length of
@@ -560,12 +566,14 @@ class PandasOnSparkFrameMethods(object):
         def apply_func(pdf: pd.DataFrame) -> pd.DataFrame:
             return func(pdf).to_frame()
 
-        def pandas_series_func(f, return_type):
+        def pandas_series_func(
+            f: Callable[[pd.DataFrame], pd.DataFrame], return_type: DataType
+        ) -> "UserDefinedFunctionLike":
             ff = f
 
-            @pandas_udf(returnType=return_type)
-            def udf(*series: pd.Series) -> pd.Series:
-                return first_series(ff(*series))
+            @pandas_udf(returnType=return_type)  # type: ignore
+            def udf(pdf: pd.DataFrame) -> pd.Series:
+                return first_series(ff(pdf))
 
             return udf
 
@@ -706,7 +714,9 @@ class PandasOnSparkSeriesMethods(object):
     def __init__(self, series: "Series"):
         self._psser = series
 
-    def transform_batch(self, func, *args, **kwargs) -> "Series":
+    def transform_batch(
+        self, func: Callable[..., pd.Series], *args: Any, **kwargs: Any
+    ) -> "Series":
         """
         Transform the data with the function that takes pandas Series and outputs pandas Series.
         The pandas Series given to the function is of a batch used internally.
@@ -831,12 +841,14 @@ class PandasOnSparkSeriesMethods(object):
 
         return self._transform_batch(lambda c: func(c, *args, **kwargs), return_type)
 
-    def _transform_batch(self, func, return_type: Optional[Union[SeriesType, ScalarType]]):
+    def _transform_batch(
+        self, func: Callable[..., pd.Series], return_type: Optional[Union[SeriesType, ScalarType]]
+    ) -> "Series":
         from pyspark.pandas.groupby import GroupBy
         from pyspark.pandas.series import Series, first_series
         from pyspark import pandas as ps
 
-        if not isinstance(func, types.FunctionType):
+        if not isinstance(func, FunctionType):
             f = func
             func = lambda *args, **kwargs: f(*args, **kwargs)
 
@@ -865,14 +877,14 @@ class PandasOnSparkSeriesMethods(object):
         psdf = self._psser.to_frame()
         columns = psdf._internal.spark_column_names
 
-        def pandas_concat(series):
+        def pandas_concat(*series: pd.Series) -> pd.DataFrame:
             # The input can only be a DataFrame for struct from Spark 3.0.
             # This works around to make the input as a frame. See SPARK-27240
             pdf = pd.concat(series, axis=1)
             pdf.columns = columns
             return pdf
 
-        def apply_func(pdf):
+        def apply_func(pdf: pd.DataFrame) -> pd.DataFrame:
             return func(first_series(pdf)).to_frame()
 
         return_schema = StructType([StructField(SPARK_DEFAULT_SERIES_NAME, field.spark_type)])
@@ -882,14 +894,14 @@ class PandasOnSparkSeriesMethods(object):
 
         @pandas_udf(returnType=field.spark_type)  # type: ignore
         def pudf(*series: pd.Series) -> pd.Series:
-            return first_series(output_func(pandas_concat(series)))
+            return first_series(output_func(pandas_concat(*series)))
 
         return self._psser._with_new_scol(
             scol=pudf(*psdf._internal.spark_columns).alias(field.name), field=field
         )
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import sys

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -204,7 +204,7 @@ class PandasOnSparkFrameMethods(object):
         )
 
     def apply_batch(
-        self, func: Callable[..., Union[pd.DataFrame, pd.Series]], args: Tuple = (), **kwds: Any
+        self, func: Callable[..., pd.DataFrame], args: Tuple = (), **kwds: Any
     ) -> "DataFrame":
         """
         Apply a function that takes pandas DataFrame and outputs pandas DataFrame. The pandas


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds more type annotations in the file `python/pyspark/pandas/accessors.py` and fixes the mypy check failures.

### Why are the changes needed?

We should enable more disallow_untyped_defs mypy checks.

### Does this PR introduce _any_ user-facing change?

Yes.
This PR adds more type annotations in pandas APIs on Spark module, which can impact interaction with development tools for users.

### How was this patch tested?

The mypy check with a new configuration and existing tests should pass.