### PR TITLE
[SPARK-35472][PYTHON] Fix disallow_untyped_defs mypy checks for pyspark.pandas.generic

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -168,9 +168,6 @@ disallow_untyped_defs = False
 [mypy-pyspark.pandas.frame]
 disallow_untyped_defs = False
 
-[mypy-pyspark.pandas.generic]
-disallow_untyped_defs = False
-
 [mypy-pyspark.pandas.groupby]
 disallow_untyped_defs = False
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -628,7 +628,14 @@ class DataFrame(Frame, Generic[T]):
         """
         return [self.index, self.columns]
 
-    def _reduce_for_stat_function(self, sfun, name, axis=None, numeric_only=True, **kwargs):
+    def _reduce_for_stat_function(
+        self,
+        sfun: Union[Callable[[Column], Column], Callable[[Column, DataType], Column]],
+        name: str,
+        axis: Optional[Union[int, str]] = None,
+        numeric_only: bool = True,
+        **kwargs: Any
+    ) -> "Series":
         """
         Applies sfun to each column and returns a pd.Series where the number of rows equal the
         number of columns.
@@ -665,11 +672,13 @@ class DataFrame(Frame, Generic[T]):
                 if keep_column:
                     if num_args == 1:
                         # Only pass in the column if sfun accepts only one arg
-                        scol = sfun(spark_column)
+                        scol = cast(Callable[[Column], Column], sfun)(spark_column)
                     else:  # must be 2
                         assert num_args == 2
                         # Pass in both the column and its data type if sfun accepts two args
-                        scol = sfun(spark_column, spark_type)
+                        scol = cast(Callable[[Column, DataType], Column], sfun)(
+                            spark_column, spark_type
+                        )
 
                     if min_count > 0:
                         scol = F.when(
@@ -703,8 +712,8 @@ class DataFrame(Frame, Generic[T]):
             if len(pdf) <= limit:
                 return Series(pser)
 
-            @pandas_udf(returnType=as_spark_type(pser.dtype.type))
-            def calculate_columns_axis(*cols):
+            @pandas_udf(returnType=as_spark_type(pser.dtype.type))  # type: ignore
+            def calculate_columns_axis(*cols: pd.Series) -> pd.Series:
                 return getattr(pd.concat(cols, axis=1), name)(
                     axis=axis, numeric_only=numeric_only, **kwargs
                 )

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -20,19 +20,32 @@ A base class of DataFrame/Column to behave similar to pandas DataFrame/Series.
 """
 from abc import ABCMeta, abstractmethod
 from collections import Counter
-from collections.abc import Iterable
 from distutils.version import LooseVersion
 from functools import reduce
-from typing import Any, List, Optional, Tuple, Union, TYPE_CHECKING, cast
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    IO,
+    List,
+    Optional,
+    NoReturn,
+    Tuple,
+    TypeVar,
+    Union,
+    TYPE_CHECKING,
+    cast,
+)
 import warnings
 
 import numpy as np  # noqa: F401
 import pandas as pd
 from pandas.api.types import is_list_like
 
-from pyspark.sql import functions as F
+from pyspark.sql import Column, functions as F
 from pyspark.sql.types import (
     BooleanType,
+    DataType,
     DoubleType,
     FloatType,
     IntegralType,
@@ -43,7 +56,7 @@ from pyspark.sql.types import (
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from pyspark.pandas.internal import InternalFrame
-from pyspark.pandas.typedef import Scalar, spark_type_to_pandas_dtype
+from pyspark.pandas.typedef import Dtype, Scalar, spark_type_to_pandas_dtype
 from pyspark.pandas.utils import (
     is_name_like_tuple,
     is_name_like_value,
@@ -58,8 +71,13 @@ from pyspark.pandas.window import Rolling, Expanding
 
 if TYPE_CHECKING:
     from pyspark.pandas.frame import DataFrame  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.indexes.base import Index  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.groupby import DataFrameGroupBy, SeriesGroupBy  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
+
+
+T = TypeVar("T", bound="Frame")
+bool_type = bool
 
 
 class Frame(object, metaclass=ABCMeta):
@@ -68,7 +86,7 @@ class Frame(object, metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def __getitem__(self, key):
+    def __getitem__(self, key: Any) -> Any:
         pass
 
     @property
@@ -77,41 +95,50 @@ class Frame(object, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def _apply_series_op(self, op, should_resolve: bool = False):
+    def _apply_series_op(
+        self: T, op: Callable[["Series"], "Series"], should_resolve: bool = False
+    ) -> T:
         pass
 
     @abstractmethod
-    def _reduce_for_stat_function(self, sfun, name, axis=None, numeric_only=True, **kwargs):
+    def _reduce_for_stat_function(
+        self,
+        sfun: Union[Callable[[Column], Column], Callable[[Column, DataType], Column]],
+        name: str,
+        axis: Optional[Union[int, str]] = None,
+        numeric_only: bool = True,
+        **kwargs: Any
+    ) -> Union["Series", Scalar]:
         pass
 
     @property
     @abstractmethod
-    def dtypes(self):
+    def dtypes(self) -> Union[pd.Series, Dtype]:
         pass
 
     @abstractmethod
-    def to_pandas(self):
+    def to_pandas(self) -> Union[pd.DataFrame, pd.Series]:
         pass
 
     @property
     @abstractmethod
-    def index(self):
+    def index(self) -> "Index":
         pass
 
     @abstractmethod
-    def copy(self):
+    def copy(self: T) -> T:
         pass
 
     @abstractmethod
-    def _to_internal_pandas(self):
+    def _to_internal_pandas(self) -> Union[pd.DataFrame, pd.Series]:
         pass
 
     @abstractmethod
-    def head(self, n: int = 5):
+    def head(self: T, n: int = 5) -> T:
         pass
 
     # TODO: add 'axis' parameter
-    def cummin(self, skipna: bool = True) -> Union["Series", "DataFrame"]:
+    def cummin(self: T, skipna: bool = True) -> T:
         """
         Return cumulative minimum over a DataFrame or Series axis.
 
@@ -171,7 +198,7 @@ class Frame(object, metaclass=ABCMeta):
         return self._apply_series_op(lambda psser: psser._cum(F.min, skipna), should_resolve=True)
 
     # TODO: add 'axis' parameter
-    def cummax(self, skipna: bool = True) -> Union["Series", "DataFrame"]:
+    def cummax(self: T, skipna: bool = True) -> T:
         """
         Return cumulative maximum over a DataFrame or Series axis.
 
@@ -232,7 +259,7 @@ class Frame(object, metaclass=ABCMeta):
         return self._apply_series_op(lambda psser: psser._cum(F.max, skipna), should_resolve=True)
 
     # TODO: add 'axis' parameter
-    def cumsum(self, skipna: bool = True) -> Union["Series", "DataFrame"]:
+    def cumsum(self: T, skipna: bool = True) -> T:
         """
         Return cumulative sum over a DataFrame or Series axis.
 
@@ -295,7 +322,7 @@ class Frame(object, metaclass=ABCMeta):
     # TODO: add 'axis' parameter
     # TODO: use pandas_udf to support negative values and other options later
     #  other window except unbounded ones is supported as of Spark 3.0.
-    def cumprod(self, skipna: bool = True) -> Union["Series", "DataFrame"]:
+    def cumprod(self: T, skipna: bool = True) -> T:
         """
         Return cumulative product over a DataFrame or Series axis.
 
@@ -409,7 +436,7 @@ class Frame(object, metaclass=ABCMeta):
             dtypes = list(self.dtypes)
         return pd.Series(dict(Counter([d.name for d in dtypes])))
 
-    def pipe(self, func, *args, **kwargs) -> Any:
+    def pipe(self: T, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
         r"""
         Apply func(self, \*args, \*\*kwargs).
 
@@ -604,19 +631,19 @@ class Frame(object, metaclass=ABCMeta):
 
     def to_csv(
         self,
-        path=None,
-        sep=",",
-        na_rep="",
-        columns=None,
-        header=True,
-        quotechar='"',
-        date_format=None,
-        escapechar=None,
-        num_files=None,
+        path: Optional[str] = None,
+        sep: str = ",",
+        na_rep: str = "",
+        columns: Optional[List[Union[Any, Tuple]]] = None,
+        header: bool = True,
+        quotechar: str = '"',
+        date_format: Optional[str] = None,
+        escapechar: Optional[str] = None,
+        num_files: Optional[int] = None,
         mode: str = "overwrite",
         partition_cols: Optional[Union[str, List[str]]] = None,
         index_col: Optional[Union[str, List[str]]] = None,
-        **options
+        **options: Any
     ) -> Optional[str]:
         r"""
         Write object to a comma-separated values (csv) file.
@@ -839,15 +866,15 @@ class Frame(object, metaclass=ABCMeta):
 
     def to_json(
         self,
-        path=None,
-        compression="uncompressed",
-        num_files=None,
+        path: Optional[str] = None,
+        compression: str = "uncompressed",
+        num_files: Optional[int] = None,
         mode: str = "overwrite",
-        orient="records",
-        lines=True,
+        orient: str = "records",
+        lines: bool = True,
         partition_cols: Optional[Union[str, List[str]]] = None,
         index_col: Optional[Union[str, List[str]]] = None,
-        **options
+        **options: Any
     ) -> Optional[str]:
         """
         Convert the object to a JSON string.
@@ -970,22 +997,22 @@ class Frame(object, metaclass=ABCMeta):
 
     def to_excel(
         self,
-        excel_writer,
-        sheet_name="Sheet1",
-        na_rep="",
-        float_format=None,
-        columns=None,
-        header=True,
-        index=True,
-        index_label=None,
-        startrow=0,
-        startcol=0,
-        engine=None,
-        merge_cells=True,
-        encoding=None,
-        inf_rep="inf",
-        verbose=True,
-        freeze_panes=None,
+        excel_writer: Union[str, pd.ExcelWriter],
+        sheet_name: str = "Sheet1",
+        na_rep: str = "",
+        float_format: Optional[str] = None,
+        columns: Optional[Union[str, List[str]]] = None,
+        header: bool = True,
+        index: bool = True,
+        index_label: Optional[Union[str, List[str]]] = None,
+        startrow: int = 0,
+        startcol: int = 0,
+        engine: Optional[str] = None,
+        merge_cells: bool = True,
+        encoding: Optional[str] = None,
+        inf_rep: str = "inf",
+        verbose: bool = True,
+        freeze_panes: Optional[Tuple[int, int]] = None,
     ) -> None:
         """
         Write object to an Excel sheet.
@@ -1148,7 +1175,7 @@ class Frame(object, metaclass=ABCMeta):
         if numeric_only is None and axis == 0:
             numeric_only = True
 
-        def mean(spark_column, spark_type):
+        def mean(spark_column: Column, spark_type: DataType) -> Column:
             if isinstance(spark_type, BooleanType):
                 spark_column = spark_column.cast(LongType())
             elif not isinstance(spark_type, NumericType):
@@ -1233,7 +1260,7 @@ class Frame(object, metaclass=ABCMeta):
         elif numeric_only is True and axis == 1:
             numeric_only = None
 
-        def sum(spark_column, spark_type):
+        def sum(spark_column: Column, spark_type: DataType) -> Column:
             if isinstance(spark_type, BooleanType):
                 spark_column = spark_column.cast(LongType())
             elif not isinstance(spark_type, NumericType):
@@ -1317,7 +1344,7 @@ class Frame(object, metaclass=ABCMeta):
         elif numeric_only is True and axis == 1:
             numeric_only = None
 
-        def prod(spark_column, spark_type):
+        def prod(spark_column: Column, spark_type: DataType) -> Column:
             if isinstance(spark_type, BooleanType):
                 scol = F.min(F.coalesce(spark_column, F.lit(True))).cast(LongType())
             elif isinstance(spark_type, NumericType):
@@ -1388,7 +1415,7 @@ class Frame(object, metaclass=ABCMeta):
         if numeric_only is None and axis == 0:
             numeric_only = True
 
-        def skew(spark_column, spark_type):
+        def skew(spark_column: Column, spark_type: DataType) -> Column:
             if isinstance(spark_type, BooleanType):
                 spark_column = spark_column.cast(LongType())
             elif not isinstance(spark_type, NumericType):
@@ -1445,7 +1472,7 @@ class Frame(object, metaclass=ABCMeta):
         if numeric_only is None and axis == 0:
             numeric_only = True
 
-        def kurtosis(spark_column, spark_type):
+        def kurtosis(spark_column: Column, spark_type: DataType) -> Column:
             if isinstance(spark_type, BooleanType):
                 spark_column = spark_column.cast(LongType())
             elif not isinstance(spark_type, NumericType):
@@ -1707,7 +1734,7 @@ class Frame(object, metaclass=ABCMeta):
         if numeric_only is None and axis == 0:
             numeric_only = True
 
-        def std(spark_column, spark_type):
+        def std(spark_column: Column, spark_type: DataType) -> Column:
             if isinstance(spark_type, BooleanType):
                 spark_column = spark_column.cast(LongType())
             elif not isinstance(spark_type, NumericType):
@@ -1786,7 +1813,7 @@ class Frame(object, metaclass=ABCMeta):
         if numeric_only is None and axis == 0:
             numeric_only = True
 
-        def var(spark_column, spark_type):
+        def var(spark_column: Column, spark_type: DataType) -> Column:
             if isinstance(spark_type, BooleanType):
                 spark_column = spark_column.cast(LongType())
             elif not isinstance(spark_type, NumericType):
@@ -1899,7 +1926,7 @@ class Frame(object, metaclass=ABCMeta):
                 "accuracy must be an integer; however, got [%s]" % type(accuracy).__name__
             )
 
-        def median(spark_column, spark_type):
+        def median(spark_column: Column, spark_type: DataType) -> Column:
             if isinstance(spark_type, (BooleanType, NumericType)):
                 return F.percentile_approx(spark_column.cast(DoubleType()), 0.5, accuracy)
             else:
@@ -1981,7 +2008,7 @@ class Frame(object, metaclass=ABCMeta):
         if numeric_only is None and axis == 0:
             numeric_only = True
 
-        def std(spark_column, spark_type):
+        def std(spark_column: Column, spark_type: DataType) -> Column:
             if isinstance(spark_type, BooleanType):
                 spark_column = spark_column.cast(LongType())
             elif not isinstance(spark_type, NumericType):
@@ -1995,7 +2022,7 @@ class Frame(object, metaclass=ABCMeta):
             else:
                 return F.stddev_samp(spark_column)
 
-        def sem(spark_column, spark_type):
+        def sem(spark_column: Column, spark_type: DataType) -> Column:
             return std(spark_column, spark_type) / pow(
                 Frame._count_expr(spark_column, spark_type), 0.5
             )
@@ -2032,7 +2059,7 @@ class Frame(object, metaclass=ABCMeta):
         else:
             return len(self) * num_columns  # type: ignore
 
-    def abs(self) -> Union["DataFrame", "Series"]:
+    def abs(self: T) -> T:
         """
         Return a Series/DataFrame with absolute numeric value of each element.
 
@@ -2069,7 +2096,7 @@ class Frame(object, metaclass=ABCMeta):
         3  7  40   50
         """
 
-        def abs(psser):
+        def abs(psser: "Series") -> "Series":
             if isinstance(psser.spark.data_type, BooleanType):
                 return psser
             elif isinstance(psser.spark.data_type, NumericType):
@@ -2087,7 +2114,11 @@ class Frame(object, metaclass=ABCMeta):
     # TODO: by argument only support the grouping name and as_index only for now. Documentation
     # should be updated when it's supported.
     def groupby(
-        self, by, axis=0, as_index: bool = True, dropna: bool = True
+        self,
+        by: Union[Any, Tuple, Series, List[Union[Any, Tuple, Series]]],
+        axis: Union[int, str] = 0,
+        as_index: bool = True,
+        dropna: bool = True,
     ) -> Union["DataFrameGroupBy", "SeriesGroupBy"]:
         """
         Group DataFrame or Series using a Series of columns.
@@ -2173,17 +2204,17 @@ class Frame(object, metaclass=ABCMeta):
         if isinstance(by, ps.DataFrame):
             raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by).__name__))
         elif isinstance(by, ps.Series):
-            by = [by]
+            new_by = [by]  # type: List[Union[Tuple, ps.Series]]
         elif is_name_like_tuple(by):
             if isinstance(self, ps.Series):
                 raise KeyError(by)
-            by = [by]
+            new_by = [cast(Tuple, by)]
         elif is_name_like_value(by):
             if isinstance(self, ps.Series):
                 raise KeyError(by)
-            by = [(by,)]
+            new_by = [(by,)]
         elif is_list_like(by):
-            new_by = []  # type: List[Union[Tuple, ps.Series]]
+            new_by = []
             for key in by:
                 if isinstance(key, ps.DataFrame):
                     raise ValueError(
@@ -2203,19 +2234,18 @@ class Frame(object, metaclass=ABCMeta):
                     raise ValueError(
                         "Grouper for '{}' not 1-dimensional".format(type(key).__name__)
                     )
-            by = new_by
         else:
             raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by).__name__))
-        if not len(by):
+        if not len(new_by):
             raise ValueError("No group keys passed!")
         axis = validate_axis(axis)
         if axis != 0:
             raise NotImplementedError('axis should be either 0 or "index" currently.')
 
         if isinstance(self, ps.DataFrame):
-            return DataFrameGroupBy._build(self, by, as_index=as_index, dropna=dropna)
+            return DataFrameGroupBy._build(self, new_by, as_index=as_index, dropna=dropna)
         elif isinstance(self, ps.Series):
-            return SeriesGroupBy._build(self, by, as_index=as_index, dropna=dropna)
+            return SeriesGroupBy._build(self, new_by, as_index=as_index, dropna=dropna)
         else:
             raise TypeError(
                 "Constructor expects DataFrame or Series; however, " "got [%s]" % (self,)
@@ -2477,7 +2507,7 @@ class Frame(object, metaclass=ABCMeta):
             return tuple(last_valid_row)
 
     # TODO: 'center', 'win_type', 'on', 'axis' parameter should be implemented.
-    def rolling(self, window, min_periods=None) -> Rolling:
+    def rolling(self, window: int, min_periods: Optional[int] = None) -> Rolling:
         """
         Provide rolling transformations.
 
@@ -2506,7 +2536,7 @@ class Frame(object, metaclass=ABCMeta):
 
     # TODO: 'center' and 'axis' parameter should be implemented.
     #   'axis' implementation, refer https://github.com/pyspark.pandas/pull/607
-    def expanding(self, min_periods=1) -> Expanding:
+    def expanding(self, min_periods: int = 1) -> Expanding:
         """
         Provide expanding transformations.
 
@@ -2526,7 +2556,7 @@ class Frame(object, metaclass=ABCMeta):
         """
         return Expanding(self, min_periods=min_periods)
 
-    def get(self, key, default=None) -> Any:
+    def get(self, key: Any, default: Optional[Any] = None) -> Any:
         """
         Get item from object for given key (DataFrame column, Panel slice,
         etc.). Returns default value if not found.
@@ -2577,7 +2607,9 @@ class Frame(object, metaclass=ABCMeta):
         except (KeyError, ValueError, IndexError):
             return default
 
-    def squeeze(self, axis=None) -> Union[Scalar, "DataFrame", "Series"]:
+    def squeeze(
+        self, axis: Optional[Union[int, str]] = None
+    ) -> Union[Scalar, "DataFrame", "Series"]:
         """
         Squeeze 1 dimensional axis objects into scalars.
 
@@ -2710,7 +2742,11 @@ class Frame(object, metaclass=ABCMeta):
             return cast(Union[Scalar, ps.Series], self_top_two[0] if has_single_value else self)
 
     def truncate(
-        self, before=None, after=None, axis=None, copy=True
+        self,
+        before: Optional[Any] = None,
+        after: Optional[Any] = None,
+        axis: Optional[Union[int, str]] = None,
+        copy: bool_type = True,
     ) -> Union["DataFrame", "Series"]:
         """
         Truncate a Series or DataFrame before and after some index value.
@@ -2850,7 +2886,9 @@ class Frame(object, metaclass=ABCMeta):
 
         return cast(Union[ps.DataFrame, ps.Series], result.copy() if copy else result)
 
-    def to_markdown(self, buf=None, mode=None) -> str:
+    def to_markdown(
+        self, buf: Optional[Union[IO[str], str]] = None, mode: Optional[str] = None
+    ) -> str:
         """
         Print Series or DataFrame in Markdown-friendly format.
 
@@ -2911,11 +2949,23 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     @abstractmethod
-    def fillna(self, value=None, method=None, axis=None, inplace=False, limit=None):
+    def fillna(
+        self: T,
+        value: Optional[Any] = None,
+        method: Optional[str] = None,
+        axis: Optional[Union[int, str]] = None,
+        inplace: bool_type = False,
+        limit: Optional[int] = None,
+    ) -> T:
         pass
 
     # TODO: add 'downcast' when value parameter exists
-    def bfill(self, axis=None, inplace=False, limit=None) -> Union["DataFrame", "Series"]:
+    def bfill(
+        self: T,
+        axis: Optional[Union[int, str]] = None,
+        inplace: bool_type = False,
+        limit: Optional[int] = None,
+    ) -> T:
         """
         Synonym for `DataFrame.fillna()` or `Series.fillna()` with ``method=`bfill```.
 
@@ -2989,7 +3039,12 @@ class Frame(object, metaclass=ABCMeta):
     backfill = bfill
 
     # TODO: add 'downcast' when value parameter exists
-    def ffill(self, axis=None, inplace=False, limit=None) -> Union["DataFrame", "Series"]:
+    def ffill(
+        self: T,
+        axis: Optional[Union[int, str]] = None,
+        inplace: bool_type = False,
+        limit: Optional[int] = None,
+    ) -> T:
         """
         Synonym for `DataFrame.fillna()` or `Series.fillna()` with ``method=`ffill```.
 
@@ -3086,14 +3141,17 @@ class Frame(object, metaclass=ABCMeta):
 
     loc.__doc__ = LocIndexer.__doc__
 
-    def __bool__(self):
+    def __bool__(self) -> NoReturn:
         raise ValueError(
             "The truth value of a {0} is ambiguous. "
             "Use a.empty, a.bool(), a.item(), a.any() or a.all().".format(self.__class__.__name__)
         )
 
+    def __len__(self) -> int:
+        pass
+
     @staticmethod
-    def _count_expr(spark_column, spark_type):
+    def _count_expr(spark_column: Column, spark_type: DataType) -> Column:
         # Special handle floating point types because Spark's count treats nan as a valid value,
         # whereas pandas count doesn't include nan.
         if isinstance(spark_type, (FloatType, DoubleType)):
@@ -3102,7 +3160,7 @@ class Frame(object, metaclass=ABCMeta):
             return F.count(spark_column)
 
 
-def _test():
+def _test() -> None:
     import os
     import doctest
     import shutil

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -436,7 +436,7 @@ class Frame(object, metaclass=ABCMeta):
             dtypes = list(self.dtypes)
         return pd.Series(dict(Counter([d.name for d in dtypes])))
 
-    def pipe(self: T, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    def pipe(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         r"""
         Apply func(self, \*args, \*\*kwargs).
 

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -76,7 +76,7 @@ if TYPE_CHECKING:
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
-T = TypeVar("T", bound="Frame")
+T_Frame = TypeVar("T_Frame", bound="Frame")
 bool_type = bool
 
 
@@ -96,8 +96,8 @@ class Frame(object, metaclass=ABCMeta):
 
     @abstractmethod
     def _apply_series_op(
-        self: T, op: Callable[["Series"], "Series"], should_resolve: bool = False
-    ) -> T:
+        self: T_Frame, op: Callable[["Series"], "Series"], should_resolve: bool = False
+    ) -> T_Frame:
         pass
 
     @abstractmethod
@@ -126,7 +126,7 @@ class Frame(object, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def copy(self: T) -> T:
+    def copy(self: T_Frame) -> T_Frame:
         pass
 
     @abstractmethod
@@ -134,11 +134,11 @@ class Frame(object, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def head(self: T, n: int = 5) -> T:
+    def head(self: T_Frame, n: int = 5) -> T_Frame:
         pass
 
     # TODO: add 'axis' parameter
-    def cummin(self: T, skipna: bool = True) -> T:
+    def cummin(self: T_Frame, skipna: bool = True) -> T_Frame:
         """
         Return cumulative minimum over a DataFrame or Series axis.
 
@@ -198,7 +198,7 @@ class Frame(object, metaclass=ABCMeta):
         return self._apply_series_op(lambda psser: psser._cum(F.min, skipna), should_resolve=True)
 
     # TODO: add 'axis' parameter
-    def cummax(self: T, skipna: bool = True) -> T:
+    def cummax(self: T_Frame, skipna: bool = True) -> T_Frame:
         """
         Return cumulative maximum over a DataFrame or Series axis.
 
@@ -259,7 +259,7 @@ class Frame(object, metaclass=ABCMeta):
         return self._apply_series_op(lambda psser: psser._cum(F.max, skipna), should_resolve=True)
 
     # TODO: add 'axis' parameter
-    def cumsum(self: T, skipna: bool = True) -> T:
+    def cumsum(self: T_Frame, skipna: bool = True) -> T_Frame:
         """
         Return cumulative sum over a DataFrame or Series axis.
 
@@ -322,7 +322,7 @@ class Frame(object, metaclass=ABCMeta):
     # TODO: add 'axis' parameter
     # TODO: use pandas_udf to support negative values and other options later
     #  other window except unbounded ones is supported as of Spark 3.0.
-    def cumprod(self: T, skipna: bool = True) -> T:
+    def cumprod(self: T_Frame, skipna: bool = True) -> T_Frame:
         """
         Return cumulative product over a DataFrame or Series axis.
 
@@ -2059,7 +2059,7 @@ class Frame(object, metaclass=ABCMeta):
         else:
             return len(self) * num_columns  # type: ignore
 
-    def abs(self: T) -> T:
+    def abs(self: T_Frame) -> T_Frame:
         """
         Return a Series/DataFrame with absolute numeric value of each element.
 
@@ -2952,22 +2952,22 @@ class Frame(object, metaclass=ABCMeta):
 
     @abstractmethod
     def fillna(
-        self: T,
+        self: T_Frame,
         value: Optional[Any] = None,
         method: Optional[str] = None,
         axis: Optional[Union[int, str]] = None,
         inplace: bool_type = False,
         limit: Optional[int] = None,
-    ) -> T:
+    ) -> T_Frame:
         pass
 
     # TODO: add 'downcast' when value parameter exists
     def bfill(
-        self: T,
+        self: T_Frame,
         axis: Optional[Union[int, str]] = None,
         inplace: bool_type = False,
         limit: Optional[int] = None,
-    ) -> T:
+    ) -> T_Frame:
         """
         Synonym for `DataFrame.fillna()` or `Series.fillna()` with ``method=`bfill```.
 
@@ -3042,11 +3042,11 @@ class Frame(object, metaclass=ABCMeta):
 
     # TODO: add 'downcast' when value parameter exists
     def ffill(
-        self: T,
+        self: T_Frame,
         axis: Optional[Union[int, str]] = None,
         inplace: bool_type = False,
         limit: Optional[int] = None,
-    ) -> T:
+    ) -> T_Frame:
         """
         Synonym for `DataFrame.fillna()` or `Series.fillna()` with ``method=`ffill```.
 

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2115,7 +2115,7 @@ class Frame(object, metaclass=ABCMeta):
     # should be updated when it's supported.
     def groupby(
         self,
-        by: Union[Any, Tuple, Series, List[Union[Any, Tuple, Series]]],
+        by: Union[Any, Tuple, "Series", List[Union[Any, Tuple, "Series"]]],
         axis: Union[int, str] = 0,
         as_index: bool = True,
         dropna: bool = True,
@@ -2739,7 +2739,7 @@ class Frame(object, metaclass=ABCMeta):
             # The case of Series is simple.
             # If Series has only a single value, just return it as a scalar.
             # Otherwise, there is no change.
-            self_top_two = self.head(2)
+            self_top_two = cast("Series", self).head(2)
             has_single_value = len(self_top_two) == 1
             return cast(Union[Scalar, ps.Series], self_top_two[0] if has_single_value else self)
 
@@ -3148,9 +3148,6 @@ class Frame(object, metaclass=ABCMeta):
             "The truth value of a {0} is ambiguous. "
             "Use a.empty, a.bool(), a.item(), a.any() or a.all().".format(self.__class__.__name__)
         )
-
-    def __len__(self) -> int:
-        pass
 
     @staticmethod
     def _count_expr(spark_column: Column, spark_type: DataType) -> Column:

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -24,7 +24,7 @@ import inspect
 import sys
 from collections.abc import Mapping
 from functools import partial, wraps, reduce
-from typing import Any, Generic, Iterable, List, Optional, Tuple, TypeVar, Union, cast
+from typing import Any, Callable, Generic, Iterable, List, Optional, Tuple, TypeVar, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -37,6 +37,7 @@ from pyspark import sql as spark
 from pyspark.sql import functions as F, Column
 from pyspark.sql.types import (
     BooleanType,
+    DataType,
     DoubleType,
     FloatType,
     IntegerType,
@@ -87,6 +88,7 @@ from pyspark.pandas.strings import StringMethods
 from pyspark.pandas.typedef import (
     infer_return_type,
     spark_type_to_pandas_dtype,
+    Dtype,
     ScalarType,
     Scalar,
     SeriesType,
@@ -449,7 +451,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     spark = CachedAccessor("spark", SparkSeriesMethods)
 
     @property
-    def dtypes(self) -> np.dtype:
+    def dtypes(self) -> Dtype:
         """Return the dtype object of the underlying data.
 
         >>> s = ps.Series(list('abc'))
@@ -6082,7 +6084,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         else:
             return psser
 
-    def _reduce_for_stat_function(self, sfun, name, axis=None, numeric_only=None, **kwargs):
+    def _reduce_for_stat_function(
+        self,
+        sfun: Union[Callable[[Column], Column], Callable[[Column, DataType], Column]],
+        name: str_type,
+        axis: Optional[Union[int, str_type]] = None,
+        numeric_only: bool = True,
+        **kwargs: Any
+    ) -> Scalar:
         """
         Applies sfun to the column and returns a scalar
 
@@ -6104,11 +6113,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         if num_args == 1:
             # Only pass in the column if sfun accepts only one arg
-            scol = sfun(spark_column)
+            scol = cast(Callable[[Column], Column], sfun)(spark_column)
         else:  # must be 2
             assert num_args == 2
             # Pass in both the column and its data type if sfun accepts two args
-            scol = sfun(spark_column, spark_type)
+            scol = cast(Callable[[Column, DataType], Column], sfun)(spark_column, spark_type)
 
         min_count = kwargs.get("min_count", 0)
         if min_count > 0:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds more type annotations in the file `python/pyspark/pandas/generic.py` and fixes the mypy check failures.

### Why are the changes needed?

We should enable more disallow_untyped_defs mypy checks.

### Does this PR introduce _any_ user-facing change?

Yes.
This PR adds more type annotations in pandas APIs on Spark module, which can impact interaction with development tools for users.

### How was this patch tested?

The mypy check with a new configuration and existing tests should pass.