### PR TITLE
[SPARK-35378][SQL][FOLLOWUP] isLocal should consider CommandResult

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -597,7 +597,8 @@ class Dataset[T] private[sql](
    * @group basic
    * @since 1.6.0
    */
-  def isLocal: Boolean = logicalPlan.isInstanceOf[LocalRelation]
+  def isLocal: Boolean = logicalPlan.isInstanceOf[LocalRelation] ||
+    logicalPlan.isInstanceOf[CommandResult]
 
   /**
    * Returns true if the `Dataset` is empty.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2909,12 +2909,10 @@ class DataFrameSuite extends QueryTest
   }
 
   test("isLocal should consider CommandResult and LocalRelation") {
-    withTable("t1") {
-      val df = sql("CREATE TABLE t USING PARQUET AS SELECT 1 as a")
-      assert(df.isLocal)
-    }
-    val df = (1 to 10).toDF()
-    assert(df.isLocal)
+    val df1 = sql("SHOW TABLES")
+    assert(df1.isLocal)
+    val df2 = (1 to 10).toDF()
+    assert(df2.isLocal)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2907,6 +2907,15 @@ class DataFrameSuite extends QueryTest
       }
     }
   }
+
+  test("isLocal should consider CommandResult and LocalRelation") {
+    withTable("t1") {
+      val df = sql("CREATE TABLE t USING PARQUET AS SELECT 1 as a")
+      assert(df.isLocal)
+    }
+    val df = (1 to 10).toDF()
+    assert(df.isLocal)
+  }
 }
 
 case class GroupByKey(a: Int, b: Int)


### PR DESCRIPTION
### What changes were proposed in this pull request?
#32513 added the case class `CommandResult` so as we can eagerly execute command locally. But we forgot to update 
`isLocal` of `Dataset`.

### Why are the changes needed?
`Dataset.isLocal` should consider `CommandResult`.


### Does this PR introduce _any_ user-facing change?
Yes. If the SQL plan is `CommandResult`, `Dataset.isLocal` must return true.


### How was this patch tested?
No test.
