### PR TITLE
[SPARK-35756][SQL] unionByName supports struct having same col names but different sequence

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnion.scala
@@ -107,6 +107,15 @@ object ResolveUnion extends Rule[LogicalPlan] {
             // in `foundAttr`.
             aliased += foundAttr
             Alias(addFields(foundAttr, target), foundAttr.name)()
+          case (source: StructType, target: StructType)
+            if !allowMissingCol && !source.sameType(target) &&
+              target.toAttributes.map(x => x.name).sorted
+                == source.toAttributes.map(x => x.name).sorted =>
+            // Having an output with same name, but different struct type.
+            // We will sort columns in the struct expression to make sure two sides of
+            // union have consistent schema.
+            aliased += foundAttr
+            Alias(addFields(foundAttr, target), foundAttr.name)()
           case _ =>
             // We don't need/try to add missing fields if:
             // 1. The attributes of left and right side are the same struct type

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnion.scala
@@ -108,9 +108,7 @@ object ResolveUnion extends Rule[LogicalPlan] {
             aliased += foundAttr
             Alias(addFields(foundAttr, target), foundAttr.name)()
           case (source: StructType, target: StructType)
-            if !allowMissingCol && !source.sameType(target) &&
-              target.toAttributes.map(attr => attr.name).sorted
-                == source.toAttributes.map(x => x.name).sorted =>
+            if !allowMissingCol && !source.sameType(target) =>
             // Having an output with same name, but different struct type.
             // We will sort columns in the struct expression to make sure two sides of
             // union have consistent schema.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnion.scala
@@ -58,13 +58,15 @@ object ResolveUnion extends Rule[LogicalPlan] {
           addFields(extractedValue, expectedType, allowMissing)
         case (Some(cf), _) =>
           ExtractValue(col, Literal(cf.name), resolver)
-        // for allowMissingCol allow the null values
-        case (None, expectedType) if allowMissing =>
-          Literal(null, expectedType)
-        // for allowMissingCol as false throw exception for missing col
-        case (_, _) if !allowMissing =>
-          throw QueryCompilationErrors.noSuchStructFieldInGivenFieldsError(
-            expectedField.name, colType.fields)
+        case (None, expectedType) =>
+          if (allowMissing) {
+            // for allowMissingCol allow the null values
+            Literal(null, expectedType)
+          } else {
+            // for allowMissingCol as false throw exception for missing col
+            throw QueryCompilationErrors.noSuchStructFieldInGivenFieldsError(
+              expectedField.name, colType.fields)
+          }
       }
       newStructFields ++= Literal(expectedField.name) :: newExpression :: Nil
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnion.scala
@@ -115,7 +115,7 @@ object ResolveUnion extends Rule[LogicalPlan] {
             // We will sort columns in the struct expression to make sure two sides of
             // union have consistent schema.
             aliased += foundAttr
-            Alias(addFields(foundAttr, target), foundAttr.name)()
+            Alias(sortStructFields(foundAttr), foundAttr.name)()
           case _ =>
             // We don't need/try to add missing fields if:
             // 1. The attributes of left and right side are the same struct type

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -925,12 +925,15 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-35756: unionByName support struct having same col names but different sequence") {
     // struct having same col names but different sequence
-    var df1 = Seq((1, Struct1(1, 2))).toDF("a", "b")
-    var df2 = Seq((1, Struct2(1, 2))).toDF("a", "b")
+    var df1 = Seq(("d1", Struct1(1, 2))).toDF("a", "b")
+    var df2 = Seq(("d2", Struct2(1, 2))).toDF("a", "b")
     var unionDF = df1.unionByName(df2)
-    var expected = Row(1, Row(1, 2)) :: Row(1, Row(2, 1)) :: Nil
-    val schema = "`a` INT,`b` STRUCT<`c1`: INT, `c2`: INT>"
-    assert(unionDF.schema.toDDL === schema)
+    var expected = Row("d1", Row(1, 2)) :: Row("d2", Row(2, 1)) :: Nil
+    val schema = StructType(Seq(StructField("a", StringType),
+      StructField("b", StructType(Seq(StructField("c1", IntegerType),
+        StructField("c2", IntegerType))))))
+
+    assert(unionDF.schema === schema)
     checkAnswer(unionDF, expected)
 
     // nested struct, inner struct having different col name

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -924,6 +924,7 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-35756: unionByName support struct having same col names but different sequence") {
+    // struct having same col names but different sequence
     var df1 = Seq((1, Struct1(1, 2))).toDF("a", "b")
     var df2 = Seq((1, Struct2(1, 2))).toDF("a", "b")
     var unionDF = df1.unionByName(df2)
@@ -951,6 +952,17 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
 
     unionDF = df1.unionByName(df2)
     checkAnswer(unionDF, expected)
+
+    // sorting of sequence based on the lower case
+    df1 = Seq((1, Struct1(1, 2))).toDF("a", "b")
+    df2 = Seq((1, Struct2a(1, 2))).toDF("a", "b")
+    expected = Row(1, Row(1, 2, 5)) :: Row(1, Row(2, 1, 5)) :: Nil
+
+    unionDF = df1.unionByName(df2)
+    checkAnswer(unionDF, expected)
+
+    unionDF = df1.unionByName(df2, true)
+    checkAnswer(unionDF, expected)
   }
 }
 
@@ -966,6 +978,7 @@ case class UnionClass3(a: Int, b: Long)
 case class UnionClass4(A: Int, b: Long)
 case class Struct1(c1: Int, c2: Int)
 case class Struct2(c2: Int, c1: Int)
+case class Struct2a(C2: Int, c1: Int)
 case class Struct3(c3: Int)
 case class Struct3a(C3: Int)
 case class Struct4(c4: Int)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -926,8 +926,8 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
   test("SPARK-35756: unionByName support struct having same col names but different sequence") {
     var df1 = Seq((1, Struct1(1, 2))).toDF("a", "b")
     var df2 = Seq((1, Struct2(1, 2))).toDF("a", "b")
-    val unionDF = df1.unionByName(df2)
-    val expected = Row(1, Row(1, 2)) :: Row(1, Row(2, 1)) :: Nil
+    var unionDF = df1.unionByName(df2)
+    var expected = Row(1, Row(1, 2)) :: Row(1, Row(2, 1)) :: Nil
     val schema = "`a` INT,`b` STRUCT<`c1`: INT, `c2`: INT>"
     assert(unionDF.schema.toDDL === schema)
     checkAnswer(unionDF, expected)
@@ -942,6 +942,15 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
       "Union can only be performed on tables with the compatible column types." +
         " struct<c1:int,c2:int,c3:struct<c4:int>> <> struct<c1:int,c2:int,c3:struct<c3:int>>" +
         " at the third column of the second table"))
+
+    // diff Case sensitive attributes names and diff sequence scenario for unionByName
+    df1 = Seq((1, 2, UnionClass1d(1, 2, Struct3(1)))).toDF("a", "b", "c")
+    df2 = Seq((1, 2, UnionClass1f(1, 2, Struct3a(1)))).toDF("a", "b", "c")
+    expected =
+      Row(1, 2, Row(1, 2, Row(1, 5))) :: Row(1, 2, Row(2, 1, Row(1, 5))) :: Nil
+
+    unionDF = df1.unionByName(df2)
+    checkAnswer(unionDF, expected)
   }
 }
 
@@ -950,6 +959,7 @@ case class UnionClass1b(a: Int, b: Long, nested: UnionClass3)
 case class UnionClass1c(a: Int, b: Long, nested: UnionClass4)
 case class UnionClass1d(c1: Int, c2: Int, c3: Struct3)
 case class UnionClass1e(c2: Int, c1: Int, c3: Struct4)
+case class UnionClass1f(c2: Int, c1: Int, c3: Struct3a)
 
 case class UnionClass2(a: Int, c: String)
 case class UnionClass3(a: Int, b: Long)
@@ -957,4 +967,5 @@ case class UnionClass4(A: Int, b: Long)
 case class Struct1(c1: Int, c2: Int)
 case class Struct2(c2: Int, c1: Int)
 case class Struct3(c3: Int)
+case class Struct3a(C3: Int)
 case class Struct4(c4: Int)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -922,6 +922,16 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-35756: unionByName support struct having same col names but different sequence") {
+    val df1 = Seq((1, Struct1(1, 2))).toDF("a", "b")
+    val df2 = Seq((1, Struct2(1, 2))).toDF("a", "b")
+    val unionDF = df1.unionByName(df2)
+    val expected = Row(1, Row(1, 2)) :: Row(1, Row(2, 1)) :: Nil
+    val schema = "`a` INT,`b` STRUCT<`c1`: INT, `c2`: INT>"
+    assert(unionDF.schema.toDDL === schema)
+    checkAnswer(unionDF, expected)
+  }
 }
 
 case class UnionClass1a(a: Int, b: Long, nested: UnionClass2)
@@ -931,3 +941,5 @@ case class UnionClass1c(a: Int, b: Long, nested: UnionClass4)
 case class UnionClass2(a: Int, c: String)
 case class UnionClass3(a: Int, b: Long)
 case class UnionClass4(A: Int, b: Long)
+case class Struct1(c1: Int, c2: Int)
+case class Struct2(c2: Int, c1: Int)


### PR DESCRIPTION
### What changes were proposed in this pull request?

unionByName does not supports struct having same col names but different sequence
```
val df1 = Seq((1, Struct1(1, 2))).toDF("a", "b")
val df2 = Seq((1, Struct2(1, 2))).toDF("a", "b")
val unionDF = df1.unionByName(df2)
```
it gives the exception 

`org.apache.spark.sql.AnalysisException: Union can only be performed on tables with the compatible column types. struct<c2:int,c1:int> <> struct<c1:int,c2:int> at the second column of the second table; 'Union false, false :- LocalRelation [_1#38, _2#39] +- LocalRelation _1#45, _2#46`

In this case the col names are same so this unionByName should have the support to check within in the Struct if col names are same it should not throw this exception and works. 

after fix we are getting the result

```
val unionDF = df1.unionByName(df2)
scala>  unionDF.show
+---+------+                                                                    
|  a|     b|
+---+------+
|  1|{1, 2}|
|  1|{2, 1}|
+---+------+

```


### Why are the changes needed?
As per unionByName functionality based on name, does the union. In the case of struct this scenario was missing where all the columns  names are same but sequence is different,  so added this functionality.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added the unit test and also done the testing through spark shell
