### PR TITLE
[SPARK-36009][GRAPHX] Add missing GraphX classes to registerKryoClasses util method

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphXUtils.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphXUtils.scala
@@ -35,6 +35,8 @@ object GraphXUtils {
       classOf[Edge[Object]],
       classOf[(VertexId, Object)],
       classOf[EdgePartition[Object, Object]],
+      classOf[ShippableVertexPartition],
+      classOf[RoutingTablePartition],
       classOf[BitSet],
       classOf[VertexIdToIndexMap],
       classOf[VertexAttributeBlock[Object]],

--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphXUtils.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphXUtils.scala
@@ -35,7 +35,7 @@ object GraphXUtils {
       classOf[Edge[Object]],
       classOf[(VertexId, Object)],
       classOf[EdgePartition[Object, Object]],
-      classOf[ShippableVertexPartition],
+      classOf[ShippableVertexPartition[Object]],
       classOf[RoutingTablePartition],
       classOf[BitSet],
       classOf[VertexIdToIndexMap],


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `ShippableVertexPartition` and `RoutingTablePartition` to the classes registered with Kryo in `GraphXUtils.registerKryoClasses`.

### Why are the changes needed?
`VertexRDDImpl` uses an `RDD[ShippableVertexPartition[VD]]` however, `GraphXUtils.registerKryoClasses` does not register `ShippableVertexPartition`. This means when running with `spark.kryo.registrationRequired` set to `true`, we get a "Class is not registered" exception. This is an issue as it prevents other unregistered classes from being discovered using `spark.kryo.registrationRequired` as the first unregistered class found halts the whole job. It also potentially decreases the serialised size of the RDD when using Kryo.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested manually by running with `spark.kryo.registrationRequired` set to `true` and verifying no "Class is not registered" exception was thrown.
