### PR TITLE
[SPARK-35820][SQL] Support Cast between different field DayTimeIntervalType

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -666,12 +666,7 @@ class CastSuite extends CastSuiteBase {
   }
 
   test("SPARK-35820: Support cast DayTimeIntervalType in different fields") {
-    val ymPositive = Literal.create(
-      Duration.ofSeconds(12345678L, 123456789),
-      DayTimeIntervalType(DAY, SECOND))
-    val ymNegative = Literal.create(
-      Duration.ofSeconds(-12345678L, -123456789),
-      DayTimeIntervalType(DAY, SECOND))
+    val ym = Duration.ofSeconds(12345678L, 123456789)
     Seq((DayTimeIntervalType(DAY, DAY), 12268800000000L, -12268800000000L),
       (DayTimeIntervalType(DAY, HOUR), 12344400000000L, -12344400000000L),
       (DayTimeIntervalType(DAY, MINUTE), 12345660000000L, -12345660000000L),
@@ -683,8 +678,9 @@ class CastSuite extends CastSuiteBase {
       (DayTimeIntervalType(MINUTE, SECOND), 12345678123456L, -12345678123457L),
       (DayTimeIntervalType(SECOND, SECOND), 12345678123456L, -12345678123457L))
       .foreach { case (dt, positive, negative) =>
-        checkEvaluation(cast(ymPositive, dt), positive)
-        checkEvaluation(cast(ymNegative, dt), negative)
+        checkEvaluation(cast(Literal.create(ym, DayTimeIntervalType(DAY, SECOND)), dt), positive)
+        checkEvaluation(
+          cast(Literal.create(ym.negated(), DayTimeIntervalType(DAY, SECOND)), dt), negative)
       }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -666,7 +666,7 @@ class CastSuite extends CastSuiteBase {
   }
 
   test("SPARK-35820: Support cast DayTimeIntervalType in different fields") {
-    val ym = Duration.ofSeconds(12345678L, 123456789)
+    val dt = Duration.ofSeconds(12345678L, 123456789)
     Seq((DayTimeIntervalType(DAY, DAY), 12268800000000L, -12268800000000L),
       (DayTimeIntervalType(DAY, HOUR), 12344400000000L, -12344400000000L),
       (DayTimeIntervalType(DAY, MINUTE), 12345660000000L, -12345660000000L),
@@ -678,9 +678,9 @@ class CastSuite extends CastSuiteBase {
       (DayTimeIntervalType(MINUTE, SECOND), 12345678123456L, -12345678123457L),
       (DayTimeIntervalType(SECOND, SECOND), 12345678123456L, -12345678123457L))
       .foreach { case (dt, positive, negative) =>
-        checkEvaluation(cast(Literal.create(ym, DayTimeIntervalType(DAY, SECOND)), dt), positive)
+        checkEvaluation(cast(Literal.create(dt, DayTimeIntervalType(DAY, SECOND)), dt), positive)
         checkEvaluation(
-          cast(Literal.create(ym.negated(), DayTimeIntervalType(DAY, SECOND)), dt), negative)
+          cast(Literal.create(dt.negated(), DayTimeIntervalType(DAY, SECOND)), dt), negative)
       }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -666,7 +666,7 @@ class CastSuite extends CastSuiteBase {
   }
 
   test("SPARK-35820: Support cast DayTimeIntervalType in different fields") {
-    val dt = Duration.ofSeconds(12345678L, 123456789)
+    val duration = Duration.ofSeconds(12345678L, 123456789)
     Seq((DayTimeIntervalType(DAY, DAY), 12268800000000L, -12268800000000L),
       (DayTimeIntervalType(DAY, HOUR), 12344400000000L, -12344400000000L),
       (DayTimeIntervalType(DAY, MINUTE), 12345660000000L, -12345660000000L),
@@ -678,9 +678,10 @@ class CastSuite extends CastSuiteBase {
       (DayTimeIntervalType(MINUTE, SECOND), 12345678123456L, -12345678123457L),
       (DayTimeIntervalType(SECOND, SECOND), 12345678123456L, -12345678123457L))
       .foreach { case (dt, positive, negative) =>
-        checkEvaluation(cast(Literal.create(dt, DayTimeIntervalType(DAY, SECOND)), dt), positive)
         checkEvaluation(
-          cast(Literal.create(dt.negated(), DayTimeIntervalType(DAY, SECOND)), dt), negative)
+          cast(Literal.create(duration, DayTimeIntervalType(DAY, SECOND)), dt), positive)
+        checkEvaluation(
+          cast(Literal.create(duration.negated(), DayTimeIntervalType(DAY, SECOND)), dt), negative)
       }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Support Cast between different field DayTimeIntervalType


### Why are the changes needed?
Make user convenient to get different field DayTimeIntervalType


### Does this PR introduce _any_ user-facing change?
User can call cast DayTimeIntervalType(DAY, SECOND) to DayTimeIntervalType(DAY, MINUTE) etc


### How was this patch tested?
Added UT