### PR TITLE
[SPARK-35688][SQL]Subexpressions should be lazy evaluation in GeneratePredicate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
@@ -38,8 +38,9 @@ object GeneratePredicate extends CodeGenerator[Expression, BasePredicate] {
     val ctx = newCodeGenContext()
 
     // Do sub-expression elimination for predicates.
-    val eval = ctx.generateExpressions(Seq(predicate), useSubexprElimination).head
-    val evalSubexpr = ctx.subexprFunctionsCode
+    val eval =
+      ctx.generateExpressions(Seq(predicate), useSubexprElimination, useSubexprElimination).head
+    val subExprReset = ctx.subexprResetFunctionCode
 
     val codeBody = s"""
       public SpecificPredicate generate(Object[] references) {
@@ -60,9 +61,10 @@ object GeneratePredicate extends CodeGenerator[Expression, BasePredicate] {
         }
 
         public boolean eval(InternalRow ${ctx.INPUT_ROW}) {
-          $evalSubexpr
           ${eval.code}
-          return !${eval.isNull} && ${eval.value};
+          boolean result = !${eval.isNull} && ${eval.value};
+          $subExprReset;
+          return result;
         }
 
         ${ctx.declareAddedFunctions()}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -286,8 +286,9 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
   def createCode(
       ctx: CodegenContext,
       expressions: Seq[Expression],
-      useSubexprElimination: Boolean = false): ExprCode = {
-    val exprEvals = ctx.generateExpressions(expressions, useSubexprElimination)
+      useSubexprElimination: Boolean = false,
+      lazyEvaluation: Boolean = false): ExprCode = {
+    val exprEvals = ctx.generateExpressions(expressions, useSubexprElimination, lazyEvaluation)
     val exprSchemas = expressions.map(e => Schema(e.dataType, e.nullable))
 
     val numVarLenFields = exprSchemas.count {
@@ -323,19 +324,21 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
 
   def generate(
       expressions: Seq[Expression],
-      subexpressionEliminationEnabled: Boolean): UnsafeProjection = {
-    create(canonicalize(expressions), subexpressionEliminationEnabled)
+      subexpressionEliminationEnabled: Boolean,
+      lazyEvaluation: Boolean = false): UnsafeProjection = {
+    create(canonicalize(expressions), subexpressionEliminationEnabled, lazyEvaluation)
   }
 
   protected def create(references: Seq[Expression]): UnsafeProjection = {
-    create(references, subexpressionEliminationEnabled = false)
+    create(references, subexpressionEliminationEnabled = false, lazyEvaluation = false)
   }
 
   private def create(
       expressions: Seq[Expression],
-      subexpressionEliminationEnabled: Boolean): UnsafeProjection = {
+      subexpressionEliminationEnabled: Boolean,
+      lazyEvaluation: Boolean): UnsafeProjection = {
     val ctx = newCodeGenContext()
-    val eval = createCode(ctx, expressions, subexpressionEliminationEnabled)
+    val eval = createCode(ctx, expressions, subexpressionEliminationEnabled, false)
 
     val codeBody =
       s"""

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -535,8 +535,10 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
         Add(BoundReference(colIndex, DoubleType, true),
           BoundReference(numOfExprs + colIndex, DoubleType, true))))
     // these should not fail to compile due to 64K limit
-    GenerateUnsafeProjection.generate(exprs, true)
-    GenerateMutableProjection.generate(exprs, true)
+    GenerateUnsafeProjection.generate(exprs, true, false)
+    GenerateMutableProjection.generate(exprs, true, false)
+    GenerateUnsafeProjection.generate(exprs, true, true)
+    GenerateMutableProjection.generate(exprs, true, true)
   }
 
   test("SPARK-32624: Use CodeGenerator.typeName() to fix byte[] compile issue") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2914,9 +2914,8 @@ class DataFrameSuite extends QueryTest
         ("true", "false"),
         ("false", "true"),
         ("false", "false"),
-        ("true", "true"),
+        ("true", "true")
       ).foreach { case (subExprEliminationEnabled, codegenEnabled) =>
-
         withSQLConf(
           SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> subExprEliminationEnabled,
           SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> codegenEnabled,

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2909,7 +2909,7 @@ class DataFrameSuite extends QueryTest
   }
 
   test("SPARK-35688: subexpressions should be lazy evaluation in GeneratePredicate") {
-    withTempPath(dir => {
+    withTempPath { dir =>
       Seq(
         ("true", "false"),
         ("false", "true"),
@@ -2935,7 +2935,7 @@ class DataFrameSuite extends QueryTest
           )
         }
       }
-    })
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently the subexpression elimination in GeneraterPredicate is eager execution, add lazy evaluation mode for subexpression elimination. Fix error when the subexression elimination is inside a condition branch and the subexression depends on the other conditions.
For instance:
```sql
-- c1 as type of array
-- +-------------------------------+
-- |c1                             |
-- +-------------------------------+
-- |[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]|
-- |[1, 2, 3, 4, 5]                |
-- +-------------------------------+
set spark.sql.ansi.enabled = true;
set spark.sql.codegen.wholeStage = false;

select * from table_name where size(c1) > 5 and (element_at(c1, 7) = 8 or element_at(c1, 7) = 7);
```
In this case, `element_at` depends on condition `size(c1) > 5`, before this pr, an exception will throw when we disable codegen.


As the lazy evaluation is expensive (we need to extract a variable and check the subexpr is initialized or not before we use the subexpr), we keep subexpression eager execution in `GenerateUnsafeProjection/GenerateMutableProjection`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix bug when subexpression elimination enabled.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Exsiting test and new test.