### PR TITLE
[SPARK-35827][SQL] Show proper error message when update column types to year-month/day-time interval

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -533,7 +533,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
                   case u: UserDefinedType[_] =>
                     alter.failAnalysis(s"Cannot update ${table.name} field $fieldName type: " +
                       s"update a UserDefinedType[${u.sql}] by updating its fields")
-                  case _: CalendarIntervalType =>
+                  case _: CalendarIntervalType | _: YearMonthIntervalType |
+                       _: DayTimeIntervalType =>
                     alter.failAnalysis(s"Cannot update ${table.name} field $fieldName to " +
                       s"interval type")
                   case _ =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
@@ -403,8 +403,24 @@ trait AlterTableTests extends SharedSparkSession {
     val t = s"${catalogAndNamespace}table_name"
     withTable(t) {
       sql(s"CREATE TABLE $t (id int) USING $v2Format")
-      val e = intercept[AnalysisException](sql(s"ALTER TABLE $t ALTER COLUMN id TYPE interval"))
-      assert(e.getMessage.contains("id to interval type"))
+      Seq(
+        "interval",
+        "interval year",
+        "interval month",
+        "interval year to month",
+        "interval day",
+        "interval hour",
+        "interval minute",
+        "interval second",
+        "interval day to second",
+        "interval day to minute",
+        "interval day to hour",
+        "interval hour to second",
+        "interval hour to minute",
+        "interval minute to second").foreach { case dtype =>
+        val e = intercept[AnalysisException](sql(s"ALTER TABLE $t ALTER COLUMN id TYPE $dtype"))
+        assert(e.getMessage.contains("id to interval type"))
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
@@ -403,22 +403,12 @@ trait AlterTableTests extends SharedSparkSession {
     val t = s"${catalogAndNamespace}table_name"
     withTable(t) {
       sql(s"CREATE TABLE $t (id int) USING $v2Format")
-      Seq(
-        "interval",
-        "interval year",
-        "interval month",
-        "interval year to month",
-        "interval day",
-        "interval hour",
-        "interval minute",
-        "interval second",
-        "interval day to second",
-        "interval day to minute",
-        "interval day to hour",
-        "interval hour to second",
-        "interval hour to minute",
-        "interval minute to second").foreach { case dtype =>
-        val e = intercept[AnalysisException](sql(s"ALTER TABLE $t ALTER COLUMN id TYPE $dtype"))
+      (DataTypeTestUtils.dayTimeIntervalTypes ++ DataTypeTestUtils.yearMonthIntervalTypes).map {
+        case d: DayTimeIntervalType => d.typeName
+        case y: YearMonthIntervalType => y.typeName
+      }.foreach { case dtype =>
+        val e = intercept[AnalysisException](
+          sql(s"ALTER TABLE $t ALTER COLUMN id TYPE $dtype"))
         assert(e.getMessage.contains("id to interval type"))
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
@@ -403,14 +403,13 @@ trait AlterTableTests extends SharedSparkSession {
     val t = s"${catalogAndNamespace}table_name"
     withTable(t) {
       sql(s"CREATE TABLE $t (id int) USING $v2Format")
-      (DataTypeTestUtils.dayTimeIntervalTypes ++ DataTypeTestUtils.yearMonthIntervalTypes).map {
-        case d: DayTimeIntervalType => d.typeName
-        case y: YearMonthIntervalType => y.typeName
-      }.foreach { case dtype =>
-        val e = intercept[AnalysisException](
-          sql(s"ALTER TABLE $t ALTER COLUMN id TYPE $dtype"))
-        assert(e.getMessage.contains("id to interval type"))
-      }
+      (DataTypeTestUtils.dayTimeIntervalTypes ++ DataTypeTestUtils.yearMonthIntervalTypes)
+        .foreach {
+          case d: DataType => d.typeName
+            val e = intercept[AnalysisException](
+              sql(s"ALTER TABLE $t ALTER COLUMN id TYPE ${d.typeName}"))
+            assert(e.getMessage.contains("id to interval type"))
+        }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes error message shown when changing a column type to year-month/day-time interval type is attempted.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's for consistent behavior.
Updating column types to interval types are prohibited for V2 source tables.
So, if we attempt to update the type of a column to the conventional interval type, an error message like `Error in query: Cannot update <table> field <column> to interval type;`.

But, for year-month/day-time interval types, another error message like `Error in query: Cannot update <table> field <column>:<type> cannot be cast to interval year;`.

You can reproduce with the following procedure.
```
$ bin/spark-sql
spark-sql> SET spark.sql.catalog.mycatalog=<a catalog implementation class>;
spark-sql> CREATE TABLE mycatalog.t1(c1 int) USING <V2 datasource implementation class>;
spark-sql> ALTER TABLE mycatalog.t1 ALTER COLUMN c1 TYPE interval year to month;
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Modified an existing test.