### PR TITLE
[SPARK-35726][SPARK-35769][SQL][FOLLOWUP] Call periodToMonths and durationToMicros in HiveResult should add endField

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -118,9 +118,11 @@ object HiveResult {
         s""""${t.name}":${toHiveString((v, t.dataType), true, formatters)}"""
       }.mkString("{", ",", "}")
     case (period: Period, YearMonthIntervalType(startField, endField)) =>
-      toYearMonthIntervalString(periodToMonths(period), HIVE_STYLE, startField, endField)
+      toYearMonthIntervalString(
+        periodToMonths(period, endField), HIVE_STYLE, startField, endField)
     case (duration: Duration, DayTimeIntervalType(startField, endField)) =>
-      toDayTimeIntervalString(durationToMicros(duration), HIVE_STYLE, startField, endField)
+      toDayTimeIntervalString(
+        durationToMicros(duration, endField), HIVE_STYLE, startField, endField)
     case (other, _: UserDefinedType[_]) => other.toString
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -119,10 +119,16 @@ object HiveResult {
       }.mkString("{", ",", "}")
     case (period: Period, YearMonthIntervalType(startField, endField)) =>
       toYearMonthIntervalString(
-        periodToMonths(period, endField), HIVE_STYLE, startField, endField)
+        periodToMonths(period, endField),
+        HIVE_STYLE,
+        startField,
+        endField)
     case (duration: Duration, DayTimeIntervalType(startField, endField)) =>
       toDayTimeIntervalString(
-        durationToMicros(duration, endField), HIVE_STYLE, startField, endField)
+        durationToMicros(duration, endField),
+        HIVE_STYLE,
+        startField,
+        endField)
     case (other, _: UserDefinedType[_]) => other.toString
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When we call periodToMonths and durationToMicros  with certain type field, we should pass endField parameter.

### Why are the changes needed?
When we call periodToMonths and durationToMicros  with certain type field, we should pass endField parameter.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existed UT
