### PR TITLE
[SPARK-35832][CORE][ML][K8S][TESTS] Add LocalRootDirsTest trait

### DIFF
--- a/core/src/test/scala/org/apache/spark/LocalRootDirsTest.scala
+++ b/core/src/test/scala/org/apache/spark/LocalRootDirsTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import java.io.File
+import java.util.UUID
+
+import org.apache.spark.util.Utils
+
+
+trait LocalRootDirsTest extends SparkFunSuite with LocalSparkContext {
+
+  val conf = new SparkConf(loadDefaults = false)
+
+  protected var tempDir: File = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // Once 'spark.local.dir' is set, it is cached. Unless this is manually cleared
+    // before/after a test, it could return the same directory even if this property
+    // is configured.
+    Utils.clearLocalRootDirs()
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    tempDir = Utils.createTempDir(namePrefix = "local")
+    conf.set("spark.local.dir",
+      tempDir.getAbsolutePath + File.separator + UUID.randomUUID().toString)
+  }
+
+  override def afterEach(): Unit = {
+    try {
+      Utils.deleteRecursively(tempDir)
+      Utils.clearLocalRootDirs()
+    } finally {
+      super.afterEach()
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -39,9 +39,7 @@ import org.apache.spark.shuffle.ShuffleWriter
 import org.apache.spark.storage.{ShuffleBlockId, ShuffleDataBlockId, ShuffleIndexBlockId}
 import org.apache.spark.util.MutablePair
 
-abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkContext {
-
-  val conf = new SparkConf(loadDefaults = false)
+abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalRootDirsTest {
 
   // Ensure that the DAGScheduler doesn't retry stages whose fetches fail, so that we accurately
   // test that the shuffle works (rather than retrying until all blocks are local to one Executor).

--- a/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SortShuffleSuite.scala
@@ -26,40 +26,17 @@ import org.apache.commons.io.filefilter.TrueFileFilter
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers._
 
-import org.apache.spark.internal.config
+import org.apache.spark.internal.config.SHUFFLE_MANAGER
 import org.apache.spark.rdd.ShuffledRDD
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.shuffle.sort.SortShuffleManager
-import org.apache.spark.util.Utils
 
 class SortShuffleSuite extends ShuffleSuite with BeforeAndAfterAll {
 
   // This test suite should run all tests in ShuffleSuite with sort-based shuffle.
-
-  private var tempDir: File = _
-
   override def beforeAll(): Unit = {
     super.beforeAll()
-    // Once 'spark.local.dir' is set, it is cached. Unless this is manually cleared
-    // before/after a test, it could return the same directory even if this property
-    // is configured.
-    Utils.clearLocalRootDirs()
-    conf.set(config.SHUFFLE_MANAGER, "sort")
-  }
-
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    tempDir = Utils.createTempDir()
-    conf.set("spark.local.dir", tempDir.getAbsolutePath)
-  }
-
-  override def afterEach(): Unit = {
-    try {
-      Utils.deleteRecursively(tempDir)
-      Utils.clearLocalRootDirs()
-    } finally {
-      super.afterEach()
-    }
+    conf.set(SHUFFLE_MANAGER, "sort")
   }
 
   test("SortShuffleManager properly cleans up files for shuffles that use the serialized path") {

--- a/core/src/test/scala/org/apache/spark/rdd/RDDCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDCleanerSuite.scala
@@ -23,25 +23,12 @@ import scala.collection.JavaConverters._
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter.TrueFileFilter
-import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark._
 import org.apache.spark.util.Utils
 
 
-class RDDCleanerSuite extends SparkFunSuite with BeforeAndAfterEach {
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    // Once `Utils.getOrCreateLocalRootDirs` is called, it is cached in `Utils.localRootDirs`.
-    // Unless this is manually cleared before and after a test, it returns the same directory
-    // set before even if 'spark.local.dir' is configured afterwards.
-    Utils.clearLocalRootDirs()
-  }
-
-  override def afterEach(): Unit = {
-    Utils.clearLocalRootDirs()
-    super.afterEach()
-  }
+class RDDCleanerSuite extends SparkFunSuite with LocalRootDirsTest {
 
   test("RDD shuffle cleanup standalone") {
     val conf = new SparkConf()

--- a/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/LocalDirsSuite.scala
@@ -19,23 +19,13 @@ package org.apache.spark.storage
 
 import java.io.{File, IOException}
 
-import org.scalatest.BeforeAndAfter
-
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.{LocalRootDirsTest, SparkConf, SparkFunSuite}
 import org.apache.spark.util.{SparkConfWithEnv, Utils}
 
 /**
  * Tests for the spark.local.dir and SPARK_LOCAL_DIRS configuration options.
  */
-class LocalDirsSuite extends SparkFunSuite with BeforeAndAfter {
-
-  before {
-    Utils.clearLocalRootDirs()
-  }
-
-  after {
-    Utils.clearLocalRootDirs()
-  }
+class LocalDirsSuite extends SparkFunSuite with LocalRootDirsTest {
 
   private def assumeNonExistentAndNotCreatable(f: File): Unit = {
     try {

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -26,7 +26,6 @@ import scala.collection.mutable.{ArrayBuffer, WrappedArray}
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter.TrueFileFilter
-import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark._
 import org.apache.spark.internal.Logging
@@ -969,19 +968,7 @@ class ALSSuite extends MLTest with DefaultReadWriteTest with Logging {
   }
 }
 
-class ALSCleanerSuite extends SparkFunSuite with BeforeAndAfterEach {
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    // Once `Utils.getOrCreateLocalRootDirs` is called, it is cached in `Utils.localRootDirs`.
-    // Unless this is manually cleared before and after a test, it returns the same directory
-    // set before even if 'spark.local.dir' is configured afterwards.
-    Utils.clearLocalRootDirs()
-  }
-
-  override def afterEach(): Unit = {
-    Utils.clearLocalRootDirs()
-    super.afterEach()
-  }
+class ALSCleanerSuite extends SparkFunSuite with LocalRootDirsTest {
 
   test("ALS shuffle cleanup in algorithm") {
     val conf = new SparkConf()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleDataIOSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/shuffle/KubernetesLocalDiskShuffleDataIOSuite.scala
@@ -21,25 +21,28 @@ import scala.concurrent.duration._
 
 import org.scalatest.concurrent.Eventually.{eventually, interval, timeout}
 
-import org.apache.spark.{LocalSparkContext, MapOutputTrackerMaster, SparkConf, SparkContext, SparkFunSuite, TestUtils}
+import org.apache.spark.{LocalRootDirsTest, MapOutputTrackerMaster, SparkContext, SparkFunSuite, TestUtils}
 import org.apache.spark.LocalSparkContext.withSpark
 import org.apache.spark.deploy.k8s.Config.KUBERNETES_DRIVER_REUSE_PVC
 import org.apache.spark.internal.config._
 import org.apache.spark.scheduler.cluster.StandaloneSchedulerBackend
 
-class KubernetesLocalDiskShuffleDataIOSuite extends SparkFunSuite with LocalSparkContext {
+class KubernetesLocalDiskShuffleDataIOSuite extends SparkFunSuite with LocalRootDirsTest {
 
-  val conf = new SparkConf()
-    .setAppName("ShuffleExecutorComponentsSuite")
-    .setMaster("local-cluster[1,1,1024]")
-    .set(UI.UI_ENABLED, false)
-    .set(DYN_ALLOCATION_ENABLED, true)
-    .set(DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED, true)
-    .set(DYN_ALLOCATION_INITIAL_EXECUTORS, 1)
-    .set(DYN_ALLOCATION_MIN_EXECUTORS, 1)
-    .set(IO_ENCRYPTION_ENABLED, false)
-    .set(KUBERNETES_DRIVER_REUSE_PVC, true)
-    .set(SHUFFLE_IO_PLUGIN_CLASS, classOf[KubernetesLocalDiskShuffleDataIO].getName)
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    conf
+      .setAppName("ShuffleExecutorComponentsSuite")
+      .setMaster("local-cluster[1,1,1024]")
+      .set(UI.UI_ENABLED, false)
+      .set(DYN_ALLOCATION_ENABLED, true)
+      .set(DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED, true)
+      .set(DYN_ALLOCATION_INITIAL_EXECUTORS, 1)
+      .set(DYN_ALLOCATION_MIN_EXECUTORS, 1)
+      .set(IO_ENCRYPTION_ENABLED, false)
+      .set(KUBERNETES_DRIVER_REUSE_PVC, true)
+      .set(SHUFFLE_IO_PLUGIN_CLASS, classOf[KubernetesLocalDiskShuffleDataIO].getName)
+  }
 
   test("recompute is not blocked by the recovery") {
     sc = new SparkContext(conf)
@@ -192,7 +195,7 @@ class KubernetesLocalDiskShuffleDataIOSuite extends SparkFunSuite with LocalSpar
       val rdd3 = rdd2.reduceByKey(_ + _)
       val rdd4 = rdd3.sortByKey()
 
-      assert(rdd4.count() === 3)
+      assert(rdd4.count() === 2)
       assert(master.shuffleStatuses.keys.toSet == Set(0, 1))
       assert(master.shuffleStatuses(0).mapStatuses.map(_.mapId).toSet == Set(0, 1, 2))
       assert(master.shuffleStatuses(1).mapStatuses.map(_.mapId).toSet == Set(6, 7, 8))


### PR DESCRIPTION
### What changes were proposed in this pull request?

To make the test suite more robust, this PR aims to add a new trait, `LocalRootDirsTest`, by refactoring `SortShuffleSuite`'s helper functions and applying it to the following:
- ShuffleNettySuite
- ShuffleOldFetchProtocolSuite
- ExternalShuffleServiceSuite
- KubernetesLocalDiskShuffleDataIOSuite
- LocalDirsSuite
- RDDCleanerSuite
- ALSCleanerSuite

In addition, this fixes a UT in `KubernetesLocalDiskShuffleDataIOSuite`.

### Why are the changes needed?

`ShuffleSuite` is extended by four classes but only `SortShuffleSuite` does the clean-up correctly.
```
ShuffleSuite
- SortShuffleSuite
- ShuffleNettySuite
- ShuffleOldFetchProtocolSuite
- ExternalShuffleServiceSuite
```

Since `KubernetesLocalDiskShuffleDataIOSuite` is looking for the other storage directory, the leftover of `ShuffleSuite` causes flakiness.
- https://amplab.cs.berkeley.edu/jenkins/view/Spark%20QA%20Test%20(Dashboard)/job/spark-master-test-sbt-hadoop-3.2/2649/testReport/junit/org.apache.spark.shuffle/KubernetesLocalDiskShuffleDataIOSuite/recompute_is_not_blocked_by_the_recovery/
```
org.apache.spark.SparkException: Job aborted due to stage failure: task 0.0 in stage 1.0 (TID 3) had a not serializable result: org.apache.spark.ShuffleSuite$NonJavaSerializableClass
...
org.apache.spark.shuffle.KubernetesLocalDiskShuffleDataIOSuite.$anonfun$new$2(KubernetesLocalDiskShuffleDataIOSuite.scala:52)
```

For the other suites, the clean-up implementation is used but not complete. So, they are refactored to use new trait.

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs.