### PR TITLE
[SPARK-35564][SQL] Support subexpression elimination for conditionally evaluated expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
@@ -61,15 +61,22 @@ class EquivalentExpressions(
   private def updateExprInMap(
       expr: Expression,
       map: mutable.HashMap[ExpressionEquals, ExpressionStats],
-      useCount: Int = 1): Boolean = {
+      useCount: Int = 1,
+      conditional: Boolean = false): Boolean = {
     if (expr.deterministic) {
       val wrapper = ExpressionEquals(expr)
       map.get(wrapper) match {
         case Some(stats) =>
-          stats.useCount += useCount
-          if (stats.useCount > 0) {
+          val count = if (conditional) {
+            stats.conditionalUseCount += useCount
+            stats.conditionalUseCount
+          } else {
+            stats.useCount += useCount
+            stats.useCount
+          }
+          if (count > 0) {
             true
-          } else if (stats.useCount == 0) {
+          } else if (count == 0) {
             map -= wrapper
             false
           } else {
@@ -79,7 +86,12 @@ class EquivalentExpressions(
           }
         case _ =>
           if (useCount > 0) {
-            map.put(wrapper, ExpressionStats(expr)(useCount))
+            val stats = if (conditional) {
+              ExpressionStats(expr)(useCount = 0, conditionalUseCount = useCount)
+            } else {
+              ExpressionStats(expr)(useCount)
+            }
+            map.put(wrapper, stats)
           }
           false
       }
@@ -89,32 +101,34 @@ class EquivalentExpressions(
   }
 
   /**
-   * Adds or removes only expressions which are common in each of given expressions, in a recursive
+   * Returns a list of expressions which are common in each of given expressions, in a recursive
    * way.
    * For example, given two expressions `(a + (b + (c + 1)))` and `(d + (e + (c + 1)))`, the common
-   * expression `(c + 1)` will be added into `equivalenceMap`.
+   * expression `(c + 1)` will be returned.
    *
    * Note that as we don't know in advance if any child node of an expression will be common across
    * all given expressions, we compute local equivalence maps for all given expressions and filter
    * only the common nodes.
-   * Those common nodes are then removed from the local map and added to the final map of
+   * Those common nodes are then removed from the local map and added to the final list of
    * expressions.
+   *
+   * Conditional expressions are not considered because we are simply looking for expressions
+   * evaluated once in each parent expression.
    */
-  private def updateCommonExprs(
-      exprs: Seq[Expression],
-      map: mutable.HashMap[ExpressionEquals, ExpressionStats],
-      useCount: Int): Unit = {
+  private def getCommonExprs(exprs: Seq[Expression]): Seq[ExpressionEquals] = {
     assert(exprs.length > 1)
     var localEquivalenceMap = mutable.HashMap.empty[ExpressionEquals, ExpressionStats]
-    updateExprTree(exprs.head, localEquivalenceMap)
+    updateExprTree(exprs.head, localEquivalenceMap, conditionalsEnabled = false)
 
     exprs.tail.foreach { expr =>
       val otherLocalEquivalenceMap = mutable.HashMap.empty[ExpressionEquals, ExpressionStats]
-      updateExprTree(expr, otherLocalEquivalenceMap)
+      updateExprTree(expr, otherLocalEquivalenceMap, conditionalsEnabled = false)
       localEquivalenceMap = localEquivalenceMap.filter { case (key, _) =>
         otherLocalEquivalenceMap.contains(key)
       }
     }
+
+    val commonExpressions = mutable.ListBuffer.empty[ExpressionEquals]
 
     // Start with the highest expression, remove it from `localEquivalenceMap` and add it to `map`.
     // The remaining highest expression in `localEquivalenceMap` is also common expression so loop
@@ -122,11 +136,12 @@ class EquivalentExpressions(
     var statsOption = Some(localEquivalenceMap).filter(_.nonEmpty).map(_.maxBy(_._1.height)._2)
     while (statsOption.nonEmpty) {
       val stats = statsOption.get
-      updateExprTree(stats.expr, localEquivalenceMap, -stats.useCount)
-      updateExprTree(stats.expr, map, useCount)
+      updateExprTree(stats.expr, localEquivalenceMap, -stats.useCount, conditionalsEnabled = false)
+      commonExpressions += ExpressionEquals(stats.expr)
 
       statsOption = Some(localEquivalenceMap).filter(_.nonEmpty).map(_.maxBy(_._1.height)._2)
     }
+    commonExpressions.toSeq
   }
 
   private def skipForShortcut(expr: Expression): Expression = {
@@ -143,21 +158,17 @@ class EquivalentExpressions(
     }
   }
 
-  // There are some special expressions that we should not recurse into all of its children.
-  //   1. CodegenFallback: it's children will not be used to generate code (call eval() instead)
-  //   2. ConditionalExpression: use its children that will always be evaluated.
-  private def childrenToRecurse(expr: Expression): Seq[Expression] = expr match {
-    case _: CodegenFallback => Nil
-    case c: ConditionalExpression => c.alwaysEvaluatedInputs.map(skipForShortcut)
-    case other => skipForShortcut(other).children
-  }
-
-  // For some special expressions we cannot just recurse into all of its children, but we can
-  // recursively add the common expressions shared between all of its children.
-  private def commonChildrenToRecurse(expr: Expression): Seq[Seq[Expression]] = expr match {
-    case _: CodegenFallback => Nil
-    case c: ConditionalExpression => c.branchGroups
-    case _ => Nil
+  /**
+   * There are some expressions that need special handling:
+   *    1. CodegenFallback: It's children will not be used to generate code (call eval() instead).
+   *    2. ConditionalExpression: use its children that will always be evaluated.
+   */
+  private def childrenToRecurse(expr: Expression): RecurseChildren = expr match {
+    case _: CodegenFallback => RecurseChildren(Nil)
+    case c: ConditionalExpression =>
+      RecurseChildren(c.alwaysEvaluatedInputs.map(skipForShortcut), c.branchGroups,
+        c.conditionallyEvaluatedInputs)
+    case other => RecurseChildren(skipForShortcut(other).children)
   }
 
   private def supportedExpression(e: Expression): Boolean = {
@@ -184,13 +195,48 @@ class EquivalentExpressions(
   private def updateExprTree(
       expr: Expression,
       map: mutable.HashMap[ExpressionEquals, ExpressionStats] = equivalenceMap,
-      useCount: Int = 1): Unit = {
-    val skip = useCount == 0 || expr.isInstanceOf[LeafExpression]
+      useCount: Int = 1,
+      conditionalsEnabled: Boolean = SQLConf.get.subexpressionEliminationConditionalsEnabled,
+      conditional: Boolean = false,
+      skipExpressions: Set[ExpressionEquals] = Set.empty[ExpressionEquals]
+      ): Unit = {
+    val skip = useCount == 0 ||
+      expr.isInstanceOf[LeafExpression] ||
+      skipExpressions.contains(ExpressionEquals(expr))
 
-    if (!skip && !updateExprInMap(expr, map, useCount)) {
+    if (!skip && !updateExprInMap(expr, map, useCount, conditional)) {
       val uc = useCount.sign
-      childrenToRecurse(expr).foreach(updateExprTree(_, map, uc))
-      commonChildrenToRecurse(expr).filter(_.nonEmpty).foreach(updateCommonExprs(_, map, uc))
+      val recurseChildren = childrenToRecurse(expr)
+      recurseChildren.alwaysChildren.foreach { child =>
+        updateExprTree(child, map, uc, conditionalsEnabled, conditional, skipExpressions)
+      }
+
+      /**
+       * If the `commonExpressions` already appears in the equivalence map, calling
+       * `updateExprTree` will increase the `useCount` and mark it as a common subexpression.
+       * Otherwise, `updateExprTree` will recursively add `commonExpressions` and its descendant to
+       * the equivalence map, in case they also appear in other places. For example,
+       * `If(a + b > 1, a + b + c, a + b + c)`, `a + b` also appears in the condition and should
+       * be treated as common subexpression.
+       */
+      val commonExpressions = recurseChildren.commonChildren.flatMap { exprs =>
+        if (exprs.nonEmpty) {
+          getCommonExprs(exprs)
+        } else {
+          Nil
+        }
+      }
+      commonExpressions.foreach { ce =>
+        updateExprTree(ce.e, map, uc, conditionalsEnabled, conditional, skipExpressions)
+      }
+
+      if (conditionalsEnabled) {
+        // Add all conditional expressions, skipping those that were already counted as common
+        // expressions.
+        recurseChildren.conditionalChildren.foreach { cc =>
+          updateExprTree(cc, map, uc, true, true, commonExpressions.toSet)
+        }
+      }
     }
   }
 
@@ -208,7 +254,7 @@ class EquivalentExpressions(
 
   // Exposed for testing.
   private[sql] def getAllExprStates(count: Int = 0): Seq[ExpressionStats] = {
-    equivalenceMap.filter(_._2.useCount > count).toSeq.sortBy(_._1.height).map(_._2)
+    equivalenceMap.filter(_._2.getUseCount() > count).toSeq.sortBy(_._1.height).map(_._2)
   }
 
   /**
@@ -225,8 +271,11 @@ class EquivalentExpressions(
   def debugString(all: Boolean = false): String = {
     val sb = new java.lang.StringBuilder()
     sb.append("Equivalent expressions:\n")
-    equivalenceMap.values.filter(stats => all || stats.useCount > 1).foreach { stats =>
-      sb.append("  ").append(s"${stats.expr}: useCount = ${stats.useCount}").append('\n')
+    equivalenceMap.values.filter(stats => all || stats.getUseCount() > 1).foreach { stats =>
+      sb.append("  ")
+        .append(s"${stats.expr}: useCount = ${stats.useCount} ")
+        .append(s"conditionalUseCount = ${stats.conditionalUseCount}")
+        .append('\n')
     }
     sb.toString()
   }
@@ -255,4 +304,32 @@ case class ExpressionEquals(e: Expression) {
  * Instead of appending to a mutable list/buffer of Expressions, just update the "flattened"
  * useCount in this wrapper in-place.
  */
-case class ExpressionStats(expr: Expression)(var useCount: Int)
+case class ExpressionStats(expr: Expression)(
+    var useCount: Int = 1,
+    var conditionalUseCount: Int = 0) {
+  def getUseCount(): Int = if (useCount > 0) {
+    useCount + conditionalUseCount
+  } else {
+    0
+  }
+}
+
+/**
+ * A wrapper for the different types of children of expressions.
+ *
+ * `alwaysChildren` are child expressions that will always be evaluated and should be considered
+ * for subexpressions.
+ *
+ * `commonChildren` are children such that each of the children might be evaluated, but at last once
+ * will definitely be evaluated. If there are any common expressions among them, those expressions
+ * will definitely be evaluated and should be considered for subexpressions.
+ *
+ * `conditionalChildren` are children that are conditionally evaluated, such as in If, CaseWhen,
+ * or Coalesce expressions, and should only be considered for subexpressions if they are evaluated
+ * non-conditionally elsewhere.
+ */
+case class RecurseChildren(
+    alwaysChildren: Seq[Expression],
+    commonChildren: Seq[Seq[Expression]] = Nil,
+    conditionalChildren: Seq[Expression] = Nil
+  )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
@@ -61,15 +61,22 @@ class EquivalentExpressions(
   private def updateExprInMap(
       expr: Expression,
       map: mutable.HashMap[ExpressionEquals, ExpressionStats],
-      useCount: Int = 1): Boolean = {
+      useCount: Int = 1,
+      conditional: Boolean = false): Boolean = {
     if (expr.deterministic) {
       val wrapper = ExpressionEquals(expr)
       map.get(wrapper) match {
         case Some(stats) =>
-          stats.useCount += useCount
-          if (stats.useCount > 0) {
+          val count = if (conditional) {
+            stats.conditionalUseCount += useCount
+            stats.conditionalUseCount
+          } else {
+            stats.useCount += useCount
+            stats.useCount
+          }
+          if (count > 0) {
             true
-          } else if (stats.useCount == 0) {
+          } else if (count == 0) {
             map -= wrapper
             false
           } else {
@@ -79,7 +86,12 @@ class EquivalentExpressions(
           }
         case _ =>
           if (useCount > 0) {
-            map.put(wrapper, ExpressionStats(expr)(useCount))
+            val stats = if (conditional) {
+              ExpressionStats(expr)(useCount = 0, conditionalUseCount = useCount)
+            } else {
+              ExpressionStats(expr)(useCount)
+            }
+            map.put(wrapper, stats)
           }
           false
       }
@@ -89,32 +101,34 @@ class EquivalentExpressions(
   }
 
   /**
-   * Adds or removes only expressions which are common in each of given expressions, in a recursive
+   * Returns a list of expressions which are common in each of given expressions, in a recursive
    * way.
    * For example, given two expressions `(a + (b + (c + 1)))` and `(d + (e + (c + 1)))`, the common
-   * expression `(c + 1)` will be added into `equivalenceMap`.
+   * expression `(c + 1)` will be returned.
    *
    * Note that as we don't know in advance if any child node of an expression will be common across
    * all given expressions, we compute local equivalence maps for all given expressions and filter
    * only the common nodes.
-   * Those common nodes are then removed from the local map and added to the final map of
+   * Those common nodes are then removed from the local map and added to the final list of
    * expressions.
+   *
+   * Conditional expressions are not considered because we are simply looking for expressions
+   * evaluated once in each parent expression.
    */
-  private def updateCommonExprs(
-      exprs: Seq[Expression],
-      map: mutable.HashMap[ExpressionEquals, ExpressionStats],
-      useCount: Int): Unit = {
+  private def getCommonExprs(exprs: Seq[Expression]): Seq[ExpressionEquals] = {
     assert(exprs.length > 1)
     var localEquivalenceMap = mutable.HashMap.empty[ExpressionEquals, ExpressionStats]
-    updateExprTree(exprs.head, localEquivalenceMap)
+    updateExprTree(exprs.head, localEquivalenceMap, conditionalsEnabled = false)
 
     exprs.tail.foreach { expr =>
       val otherLocalEquivalenceMap = mutable.HashMap.empty[ExpressionEquals, ExpressionStats]
-      updateExprTree(expr, otherLocalEquivalenceMap)
+      updateExprTree(expr, otherLocalEquivalenceMap, conditionalsEnabled = false)
       localEquivalenceMap = localEquivalenceMap.filter { case (key, _) =>
         otherLocalEquivalenceMap.contains(key)
       }
     }
+
+    val commonExpressions = mutable.ListBuffer.empty[ExpressionEquals]
 
     // Start with the highest expression, remove it from `localEquivalenceMap` and add it to `map`.
     // The remaining highest expression in `localEquivalenceMap` is also common expression so loop
@@ -122,11 +136,12 @@ class EquivalentExpressions(
     var statsOption = Some(localEquivalenceMap).filter(_.nonEmpty).map(_.maxBy(_._1.height)._2)
     while (statsOption.nonEmpty) {
       val stats = statsOption.get
-      updateExprTree(stats.expr, localEquivalenceMap, -stats.useCount)
-      updateExprTree(stats.expr, map, useCount)
+      updateExprTree(stats.expr, localEquivalenceMap, -stats.useCount, conditionalsEnabled = false)
+      commonExpressions += ExpressionEquals(stats.expr)
 
       statsOption = Some(localEquivalenceMap).filter(_.nonEmpty).map(_.maxBy(_._1.height)._2)
     }
+    commonExpressions.toSeq
   }
 
   private def skipForShortcut(expr: Expression): Expression = {
@@ -149,25 +164,18 @@ class EquivalentExpressions(
     }
   }
 
-  // There are some special expressions that we should not recurse into all of its children.
-  //   1. CodegenFallback: it's children will not be used to generate code (call eval() instead)
-  //   2. ConditionalExpression: use its children that will always be evaluated.
-  //   3. HigherOrderFunction: lambda functions operate in the context of local lambdas and can't
-  //        be called outside of that scope, only always-evaluated arguments can be evaluated
-  //        ahead of time.
-  private def childrenToRecurse(expr: Expression): Seq[Expression] = expr match {
-    case _: CodegenFallback => Nil
-    case c: ConditionalExpression => c.alwaysEvaluatedInputs.map(skipForShortcut)
-    case h: HigherOrderFunction => h.alwaysEvaluatedArguments
-    case other => skipForShortcut(other).children
-  }
-
-  // For some special expressions we cannot just recurse into all of its children, but we can
-  // recursively add the common expressions shared between all of its children.
-  private def commonChildrenToRecurse(expr: Expression): Seq[Seq[Expression]] = expr match {
-    case _: CodegenFallback => Nil
-    case c: ConditionalExpression => c.branchGroups
-    case _ => Nil
+  /**
+   * There are some expressions that need special handling:
+   *    1. CodegenFallback: It's children will not be used to generate code (call eval() instead).
+   *    2. ConditionalExpression: use its children that will always be evaluated.
+   */
+  private def childrenToRecurse(expr: Expression): RecurseChildren = expr match {
+    case _: CodegenFallback => RecurseChildren(Nil)
+    case c: ConditionalExpression =>
+      RecurseChildren(c.alwaysEvaluatedInputs.map(skipForShortcut), c.branchGroups,
+        c.conditionallyEvaluatedInputs)
+    case h: HigherOrderFunction => RecurseChildren(h.alwaysEvaluatedArguments)
+    case other => RecurseChildren(skipForShortcut(other).children)
   }
 
   private def supportedExpression(e: Expression): Boolean = {
@@ -194,13 +202,48 @@ class EquivalentExpressions(
   private def updateExprTree(
       expr: Expression,
       map: mutable.HashMap[ExpressionEquals, ExpressionStats] = equivalenceMap,
-      useCount: Int = 1): Unit = {
-    val skip = useCount == 0 || expr.isInstanceOf[LeafExpression]
+      useCount: Int = 1,
+      conditionalsEnabled: Boolean = SQLConf.get.subexpressionEliminationConditionalsEnabled,
+      conditional: Boolean = false,
+      skipExpressions: Set[ExpressionEquals] = Set.empty[ExpressionEquals]
+      ): Unit = {
+    val skip = useCount == 0 ||
+      expr.isInstanceOf[LeafExpression] ||
+      skipExpressions.contains(ExpressionEquals(expr))
 
-    if (!skip && !updateExprInMap(expr, map, useCount)) {
+    if (!skip && !updateExprInMap(expr, map, useCount, conditional)) {
       val uc = useCount.sign
-      childrenToRecurse(expr).foreach(updateExprTree(_, map, uc))
-      commonChildrenToRecurse(expr).filter(_.nonEmpty).foreach(updateCommonExprs(_, map, uc))
+      val recurseChildren = childrenToRecurse(expr)
+      recurseChildren.alwaysChildren.foreach { child =>
+        updateExprTree(child, map, uc, conditionalsEnabled, conditional, skipExpressions)
+      }
+
+      /**
+       * If the `commonExpressions` already appears in the equivalence map, calling
+       * `updateExprTree` will increase the `useCount` and mark it as a common subexpression.
+       * Otherwise, `updateExprTree` will recursively add `commonExpressions` and its descendant to
+       * the equivalence map, in case they also appear in other places. For example,
+       * `If(a + b > 1, a + b + c, a + b + c)`, `a + b` also appears in the condition and should
+       * be treated as common subexpression.
+       */
+      val commonExpressions = recurseChildren.commonChildren.flatMap { exprs =>
+        if (exprs.nonEmpty) {
+          getCommonExprs(exprs)
+        } else {
+          Nil
+        }
+      }
+      commonExpressions.foreach { ce =>
+        updateExprTree(ce.e, map, uc, conditionalsEnabled, conditional, skipExpressions)
+      }
+
+      if (conditionalsEnabled) {
+        // Add all conditional expressions, skipping those that were already counted as common
+        // expressions.
+        recurseChildren.conditionalChildren.foreach { cc =>
+          updateExprTree(cc, map, uc, true, true, commonExpressions.toSet)
+        }
+      }
     }
   }
 
@@ -218,7 +261,7 @@ class EquivalentExpressions(
 
   // Exposed for testing.
   private[sql] def getAllExprStates(count: Int = 0): Seq[ExpressionStats] = {
-    equivalenceMap.filter(_._2.useCount > count).toSeq.sortBy(_._1.height).map(_._2)
+    equivalenceMap.filter(_._2.getUseCount() > count).toSeq.sortBy(_._1.height).map(_._2)
   }
 
   /**
@@ -235,8 +278,11 @@ class EquivalentExpressions(
   def debugString(all: Boolean = false): String = {
     val sb = new java.lang.StringBuilder()
     sb.append("Equivalent expressions:\n")
-    equivalenceMap.values.filter(stats => all || stats.useCount > 1).foreach { stats =>
-      sb.append("  ").append(s"${stats.expr}: useCount = ${stats.useCount}").append('\n')
+    equivalenceMap.values.filter(stats => all || stats.getUseCount() > 1).foreach { stats =>
+      sb.append("  ")
+        .append(s"${stats.expr}: useCount = ${stats.useCount} ")
+        .append(s"conditionalUseCount = ${stats.conditionalUseCount}")
+        .append('\n')
     }
     sb.toString()
   }
@@ -265,4 +311,32 @@ case class ExpressionEquals(e: Expression) {
  * Instead of appending to a mutable list/buffer of Expressions, just update the "flattened"
  * useCount in this wrapper in-place.
  */
-case class ExpressionStats(expr: Expression)(var useCount: Int)
+case class ExpressionStats(expr: Expression)(
+    var useCount: Int = 1,
+    var conditionalUseCount: Int = 0) {
+  def getUseCount(): Int = if (useCount > 0) {
+    useCount + conditionalUseCount
+  } else {
+    0
+  }
+}
+
+/**
+ * A wrapper for the different types of children of expressions.
+ *
+ * `alwaysChildren` are child expressions that will always be evaluated and should be considered
+ * for subexpressions.
+ *
+ * `commonChildren` are children such that each of the children might be evaluated, but at last once
+ * will definitely be evaluated. If there are any common expressions among them, those expressions
+ * will definitely be evaluated and should be considered for subexpressions.
+ *
+ * `conditionalChildren` are children that are conditionally evaluated, such as in If, CaseWhen,
+ * or Coalesce expressions, and should only be considered for subexpressions if they are evaluated
+ * non-conditionally elsewhere.
+ */
+case class RecurseChildren(
+    alwaysChildren: Seq[Expression],
+    commonChildren: Seq[Seq[Expression]] = Nil,
+    conditionalChildren: Seq[Expression] = Nil
+  )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -581,6 +581,12 @@ trait ConditionalExpression extends Expression {
    * so that we can eagerly evaluate the common expressions of a group.
    */
   def branchGroups: Seq[Seq[Expression]]
+
+  /**
+   * Returns children expressions which are conditionally evaluated. If the same expression
+   * will be always evaluated elsewhere, we can make it a subexpression.
+   */
+  def conditionallyEvaluatedInputs: Seq[Expression]
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -584,6 +584,12 @@ trait ConditionalExpression extends Expression {
    * so that we can eagerly evaluate the common expressions of a group.
    */
   def branchGroups: Seq[Seq[Expression]]
+
+  /**
+   * Returns children expressions which are conditionally evaluated. If the same expression
+   * will be always evaluated elsewhere, we can make it a subexpression.
+   */
+  def conditionallyEvaluatedInputs: Seq[Expression]
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -65,6 +65,8 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
 
   override def branchGroups: Seq[Seq[Expression]] = Seq(Seq(trueValue, falseValue))
 
+  override def conditionallyEvaluatedInputs: Seq[Expression] = Seq(trueValue, falseValue)
+
   final override val nodePatterns : Seq[TreePattern] = Seq(IF)
 
   override def checkInputDataTypes(): TypeCheckResult = {
@@ -241,28 +243,11 @@ case class CaseWhen(
   }
 
   override def branchGroups: Seq[Seq[Expression]] = {
-    // We look at subexpressions in conditions and values of `CaseWhen` separately. It is
-    // because a subexpression in conditions will be run no matter which condition is matched
-    // if it is shared among conditions, but it doesn't need to be shared in values. Similarly,
-    // a subexpression among values doesn't need to be in conditions because no matter which
-    // condition is true, it will be evaluated.
-    val conditions = if (branches.length > 1) {
-      branches.map(_._1)
-    } else {
-      // If there is only one branch, the first condition is already covered by
-      // `alwaysEvaluatedInputs` and we should exclude it here.
-      Nil
-    }
-    // For an expression to be in all branch values of a CaseWhen statement, it must also be in
-    // the elseValue.
-    val values = if (elseValue.nonEmpty) {
-      branches.map(_._2) ++ elseValue
-    } else {
-      Nil
-    }
-
-    Seq(conditions, values)
+    // If there's an else value then we will definitely evaluate at least one branch value
+    if (elseValue.isDefined) Seq(branches.map(_._2) ++ elseValue) else Nil
   }
+
+  override def conditionallyEvaluatedInputs: Seq[Expression] = children.tail
 
   override def eval(input: InternalRow): Any = {
     var i = 0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -71,6 +71,8 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
 
   override def branchGroups: Seq[Seq[Expression]] = Seq(Seq(trueValue, falseValue))
 
+  override def conditionallyEvaluatedInputs: Seq[Expression] = Seq(trueValue, falseValue)
+
   final override val nodePatterns : Seq[TreePattern] = Seq(IF)
 
   override def checkInputDataTypes(): TypeCheckResult = {
@@ -247,28 +249,11 @@ case class CaseWhen(
   }
 
   override def branchGroups: Seq[Seq[Expression]] = {
-    // We look at subexpressions in conditions and values of `CaseWhen` separately. It is
-    // because a subexpression in conditions will be run no matter which condition is matched
-    // if it is shared among conditions, but it doesn't need to be shared in values. Similarly,
-    // a subexpression among values doesn't need to be in conditions because no matter which
-    // condition is true, it will be evaluated.
-    val conditions = if (branches.length > 1) {
-      branches.map(_._1)
-    } else {
-      // If there is only one branch, the first condition is already covered by
-      // `alwaysEvaluatedInputs` and we should exclude it here.
-      Nil
-    }
-    // For an expression to be in all branch values of a CaseWhen statement, it must also be in
-    // the elseValue.
-    val values = if (elseValue.nonEmpty) {
-      branches.map(_._2) ++ elseValue
-    } else {
-      Nil
-    }
-
-    Seq(conditions, values)
+    // If there's an else value then we will definitely evaluate at least one branch value
+    if (elseValue.isDefined) Seq(branches.map(_._2) ++ elseValue) else Nil
   }
+
+  override def conditionallyEvaluatedInputs: Seq[Expression] = children.tail
 
   override def eval(input: InternalRow): Any = {
     var i = 0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -75,13 +75,9 @@ case class Coalesce(children: Seq[Expression])
     withNewChildrenInternal(alwaysEvaluatedInputs.toIndexedSeq ++ children.drop(1))
   }
 
-  override def branchGroups: Seq[Seq[Expression]] = if (children.length > 1) {
-    // If there is only one child, the first child is already covered by
-    // `alwaysEvaluatedInputs` and we should exclude it here.
-    Seq(children)
-  } else {
-    Nil
-  }
+  override def branchGroups: Seq[Seq[Expression]] = Nil
+
+  override def conditionallyEvaluatedInputs: Seq[Expression] = children.tail
 
   override def eval(input: InternalRow): Any = {
     var result: Any = null
@@ -348,7 +344,9 @@ case class NaNvl(left: Expression, right: Expression)
     copy(left = alwaysEvaluatedInputs.head)
   }
 
-  override def branchGroups: Seq[Seq[Expression]] = Seq(children)
+  override def branchGroups: Seq[Seq[Expression]] = Nil
+
+  override def conditionallyEvaluatedInputs: Seq[Expression] = right :: Nil
 
   override def eval(input: InternalRow): Any = {
     val value = left.eval(input)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -80,13 +80,9 @@ case class Coalesce(children: Seq[Expression])
     withNewChildrenInternal(alwaysEvaluatedInputs.toIndexedSeq ++ children.drop(1))
   }
 
-  override def branchGroups: Seq[Seq[Expression]] = if (children.length > 1) {
-    // If there is only one child, the first child is already covered by
-    // `alwaysEvaluatedInputs` and we should exclude it here.
-    Seq(children)
-  } else {
-    Nil
-  }
+  override def branchGroups: Seq[Seq[Expression]] = Nil
+
+  override def conditionallyEvaluatedInputs: Seq[Expression] = children.tail
 
   override def eval(input: InternalRow): Any = {
     var result: Any = null
@@ -432,7 +428,9 @@ case class NaNvl(left: Expression, right: Expression)
     copy(left = alwaysEvaluatedInputs.head)
   }
 
-  override def branchGroups: Seq[Seq[Expression]] = Seq(children)
+  override def branchGroups: Seq[Seq[Expression]] = Nil
+
+  override def conditionallyEvaluatedInputs: Seq[Expression] = right :: Nil
 
   override def eval(input: InternalRow): Any = {
     val value = left.eval(input)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1666,6 +1666,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val SUBEXPRESSION_ELIMINATION_CONDITIONALS_ENABLED =
+    buildConf("spark.sql.subexpressionElimination.conditionals.enabled")
+      .internal()
+      .doc("When true, common conditional subexpressions will be eliminated.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .booleanConf
+      .createWithDefault(false)
+
   val CASE_SENSITIVE = buildConf(SqlApiConfHelper.CASE_SENSITIVE_KEY)
     .internal()
     .doc("Whether the query analyzer should be case sensitive or not. " +
@@ -9117,6 +9126,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def subexpressionEliminationFilterExecEnabled: Boolean =
     getConf(SUBEXPRESSION_ELIMINATION_FILTER_EXEC_ENABLED)
+
+  def subexpressionEliminationConditionalsEnabled: Boolean =
+    getConf(SUBEXPRESSION_ELIMINATION_CONDITIONALS_ENABLED)
 
   def autoBroadcastJoinThreshold: Long = getConf(AUTO_BROADCASTJOIN_THRESHOLD)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1339,6 +1339,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val SUBEXPRESSION_ELIMINATION_CONDITIONALS_ENABLED =
+    buildConf("spark.sql.subexpressionElimination.conditionals.enabled")
+      .internal()
+      .doc("When true, common conditional subexpressions will be eliminated.")
+      .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .booleanConf
+      .createWithDefault(false)
+
   val CASE_SENSITIVE = buildConf(SqlApiConfHelper.CASE_SENSITIVE_KEY)
     .internal()
     .doc("Whether the query analyzer should be case sensitive or not. " +
@@ -7946,6 +7955,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def subexpressionEliminationSkipForShotcutExpr: Boolean =
     getConf(SUBEXPRESSION_ELIMINATION_SKIP_FOR_SHORTCUT_EXPR)
+
+  def subexpressionEliminationConditionalsEnabled: Boolean =
+    getConf(SUBEXPRESSION_ELIMINATION_CONDITIONALS_ENABLED)
 
   def autoBroadcastJoinThreshold: Long = getConf(AUTO_BROADCASTJOIN_THRESHOLD)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{BinaryType, DataType, IntegerType, ObjectType}
+import org.apache.spark.sql.types.{BinaryType, DataType, IntegerType, LongType, ObjectType}
 
 class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("Semantic equals and hash") {
@@ -197,13 +197,15 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
       (GreaterThan(add2, Literal(4)), add1) ::
       (GreaterThan(add2, Literal(5)), add1) :: Nil
 
-    val caseWhenExpr1 = CaseWhen(conditions1, None)
-    val equivalence1 = new EquivalentExpressions
-    equivalence1.addExprTree(caseWhenExpr1)
+    withSQLConf(SQLConf.SUBEXPRESSION_ELIMINATION_CONDITIONALS_ENABLED.key -> "true") {
+      val caseWhenExpr1 = CaseWhen(conditions1, None)
+      val equivalence1 = new EquivalentExpressions
+      equivalence1.addExprTree(caseWhenExpr1)
 
-    // `add2` is repeatedly in all conditions.
-    assert(equivalence1.getAllExprStates().count(_.useCount == 2) == 1)
-    assert(equivalence1.getAllExprStates().filter(_.useCount == 2).head.expr eq add2)
+      // `add2` is repeatedly in all conditions.
+      assert(equivalence1.getAllExprStates().count(_.getUseCount() == 3) == 1)
+      assert(equivalence1.getAllExprStates().filter(_.getUseCount() == 3).head.expr eq add2)
+    }
 
     val conditions2 = (GreaterThan(add1, Literal(3)), add1) ::
       (GreaterThan(add2, Literal(4)), add1) ::
@@ -235,13 +237,15 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
       GreaterThan(add2, Literal(4)) ::
       GreaterThan(add2, Literal(5)) :: Nil
 
-    val coalesceExpr1 = Coalesce(conditions1)
-    val equivalence1 = new EquivalentExpressions
-    equivalence1.addExprTree(coalesceExpr1)
+    withSQLConf(SQLConf.SUBEXPRESSION_ELIMINATION_CONDITIONALS_ENABLED.key -> "true") {
+      val coalesceExpr1 = Coalesce(conditions1)
+      val equivalence1 = new EquivalentExpressions
+      equivalence1.addExprTree(coalesceExpr1)
 
-    // `add2` is repeatedly in all conditions.
-    assert(equivalence1.getAllExprStates().count(_.useCount == 2) == 1)
-    assert(equivalence1.getAllExprStates().filter(_.useCount == 2).head.expr eq add2)
+      // `add2` is repeatedly in all conditions.
+      assert(equivalence1.getAllExprStates().count(_.getUseCount() == 3) == 1)
+      assert(equivalence1.getAllExprStates().filter(_.getUseCount() == 3).head.expr eq add2)
+    }
 
     // Negative case. `add1` and `add2` both are not used in all branches.
     val conditions2 = GreaterThan(add1, Literal(3)) ::
@@ -402,6 +406,71 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     assert(equivalence.getAllExprStates().count(_.useCount == 2) == 0)
   }
 
+  test("SPARK-35564: Subexpressions should be extracted from conditional values if that value "
+    + "will always be evaluated elsewhere") {
+    withSQLConf(SQLConf.SUBEXPRESSION_ELIMINATION_CONDITIONALS_ENABLED.key -> "true") {
+      val add1 = Add(Literal(1), Literal(2))
+      val add2 = Add(Literal(2), Literal(3))
+
+      val conditions1 = (GreaterThan(add1, Literal(3)), add1) :: Nil
+      val caseWhenExpr1 = CaseWhen(conditions1, None)
+      val equivalence1 = new EquivalentExpressions
+      equivalence1.addExprTree(caseWhenExpr1)
+
+      // `add1` is evaluated once in the first condition, and optionally in the first value
+      assert(equivalence1.getCommonSubexpressions.size == 1)
+
+      val ifExpr = If(GreaterThan(add1, Literal(3)), add1, add2)
+      val equivalence2 = new EquivalentExpressions
+      equivalence2.addExprTree(ifExpr)
+
+      // `add1` is evaluated once in the condition, and optionally in the true value
+      assert(equivalence2.getCommonSubexpressions.size == 1)
+    }
+  }
+
+  test("SPARK-35564: Common expressions don't infinite loop with conditional expressions") {
+    withSQLConf(SQLConf.SUBEXPRESSION_ELIMINATION_CONDITIONALS_ENABLED.key -> "true") {
+      val add1 = Add(Literal(1), Literal(2))
+      val add2 = Add(Literal(2), Literal(3))
+
+      val inner = CaseWhen((GreaterThan(add2, Literal(2)), add1) :: Nil)
+      val outer = CaseWhen((GreaterThan(add1, Literal(2)), inner) :: Nil, add1)
+
+      val equivalence = new EquivalentExpressions
+      equivalence.addExprTree(outer)
+
+      // `add1` is evaluated in the outer condition, and optionally in the inner value
+      assert(equivalence.getCommonSubexpressions.size == 1)
+
+      val when1 = CaseWhen((GreaterThan(Literal(1), Literal(1)), Cast(Literal(1), LongType)) :: Nil)
+      val when2 = CaseWhen((GreaterThan(when1, Literal(2)), when1) :: Nil, when1)
+      val when3 = CaseWhen((GreaterThan(when1, Literal(1)), when2) :: Nil)
+
+      val equivalence2 = new EquivalentExpressions
+      equivalence2.addExprTree(when3)
+
+      // `when1` is evaluated in the outer condition, and optionally in the inner value multiple
+      // times including in a nested conditional
+      assert(equivalence2.getCommonSubexpressions.size == 1)
+    }
+  }
+
+  test("SPARK-35564: Don't double count conditional expressions if present in all branches") {
+    withSQLConf(SQLConf.SUBEXPRESSION_ELIMINATION_CONDITIONALS_ENABLED.key -> "true") {
+      val add1 = Add(Literal(1), Literal(2))
+      val add2 = Add(Literal(2), Literal(3))
+      val add3 = Add(add2, Literal(4))
+
+      val caseWhenExpr1 = CaseWhen((GreaterThan(add1, Literal(3)), add3) :: Nil, add2)
+      val equivalence1 = new EquivalentExpressions
+      equivalence1.addExprTree(caseWhenExpr1)
+
+      // `add2` will only be evaluated once so don't create a subexpression
+      assert(equivalence1.getCommonSubexpressions.size == 0)
+    }
+  }
+
   test("SPARK-35829: SubExprEliminationState keeps children sub exprs") {
     val add1 = Add(Literal(1), Literal(2))
     val add2 = Add(add1, add1)
@@ -440,17 +509,19 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
   }
 
   test("SPARK-39040: Respect NaNvl in EquivalentExpressions for expression elimination") {
-    val add = Add(Literal(1), Literal(0))
-    val n1 = NaNvl(Literal(1.0d), Add(add, add))
-    val e1 = new EquivalentExpressions
-    e1.addExprTree(n1)
-    assert(e1.getCommonSubexpressions.isEmpty)
+    withSQLConf(SQLConf.SUBEXPRESSION_ELIMINATION_CONDITIONALS_ENABLED.key -> "true") {
+      val add = Add(Literal(1), Literal(0))
+      val n1 = NaNvl(Literal(1.0d), Add(add, add))
+      val e1 = new EquivalentExpressions
+      e1.addExprTree(n1)
+      assert(e1.getCommonSubexpressions.isEmpty)
 
-    val n2 = NaNvl(add, add)
-    val e2 = new EquivalentExpressions
-    e2.addExprTree(n2)
-    assert(e2.getCommonSubexpressions.size == 1)
-    assert(e2.getCommonSubexpressions.head == add)
+      val n2 = NaNvl(add, add)
+      val e2 = new EquivalentExpressions
+      e2.addExprTree(n2)
+      assert(e2.getCommonSubexpressions.size == 1)
+      assert(e2.getCommonSubexpressions.head == add)
+    }
   }
 
   test("SPARK-42851: Handle supportExpression consistently across add and get") {
@@ -537,10 +608,9 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
   test("Equivalent ternary expressions have different children") {
     val add1 = Add(Add(Literal(1), Literal(2)), Literal(3))
     val add2 = Add(Add(Literal(3), Literal(1)), Literal(2))
-    val conditions1 = (GreaterThan(add1, Literal(3)), Literal(1)) ::
-      (GreaterThan(add2, Literal(0)), Literal(2)) :: Nil
+    val conditions1 = (GreaterThan(add1, Literal(3)), add1) :: Nil
 
-    val caseWhenExpr1 = CaseWhen(conditions1, Literal(0))
+    val caseWhenExpr1 = CaseWhen(conditions1, add2)
     val equivalence1 = new EquivalentExpressions
     equivalence1.addExprTree(caseWhenExpr1)
     assert(equivalence1.getCommonSubexpressions.size == 1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
I am proposing to add support for conditionally evaluated expressions during subexpression elimination. Currently, only expressions that will definitely be always at least twice are candidates for subexpression elimination. This PR updates that logic so that expressions that are always evaluated at least once and conditionally evaluated at least once are also candidates for subexpression elimination. This helps optimize a common case during data normalization and cleaning and want to null out values that don't match a certain pattern, where you have something like:

```
transformed = F.regexp_replace(F.lower(F.trim('my_column')))
df.withColumn('normalized_value', F.when(F.length(transformed) > 0, transformed))
```
or
```
df.withColumn('normalized_value', F.when(transformed.rlike(<some regex>), transformed))
```

In these cases, `transformed` will always be fully calculated twice, because it might only be needed once. I am proposing creating a subexpression for `transformed` in this case.

In practice I've seen a decrease in runtime and codegen size of 10-30% in our production pipelines that heavily make use of this type of logic.

The only potential downside is creating extra subexpressions, and therefore function calls, more than necessary. This should only be an issue for certain edge cases where your conditional overwhelming evaluates to false. And then the only overhead is running your conditional logic potentially in a separate function rather than inlined in the codegen. I added a config to control this behavior if that is actually a real concern to anyone, but I'd be happy to just remove the config.

I also updated some of the existing logic for common expressions in coalesce and when that are actually better handled by the new logic, since you are only guaranteed to have the first value of a Coalesce evaluated, as well as the first conditional of a CaseWhen expression.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To increase the performance of conditional expressions.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, just performance improvements.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New and updated UT.
