### PR TITLE
[SPARK-35835][SQL] Select filter query with struct complex type should be case insensitive

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -185,8 +185,9 @@ object NestedColumnAliasing {
 
         // Each expression can contain multiple nested fields.
         // Note that we keep the original names to deliver to parquet in a case-sensitive way.
+        val exprIdMap = scala.collection.mutable.HashMap[Expression, ExprId]()
         val nestedFieldToAlias = dedupNestedFields.distinct.map { f =>
-          val exprId = NamedExpression.newExprId
+          val exprId = exprIdMap.getOrElseUpdate(f.canonicalized, NamedExpression.newExprId)
           (f, Alias(f, s"_gen_alias_${exprId.id}")(exprId, Seq.empty, None))
         }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2583,6 +2583,16 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       }
     }
   }
+
+  test("SPARK-35835: Select filter query with struct complex type should be case insensitive") {
+    withTable("contact") {
+      sql("create table contact(SL_NO int,ID_NAME struct<ID:int,name:string>) stored as parquet")
+      sql("INSERT INTO contact values(1, struct(1, 'adam'))")
+      checkAnswer(sql("select ID_NAME.name, ID_NAME.Name,ID_NAME.NAME from contact group by " +
+        "ID_NAME.name, ID_NAME.Name, ID_NAME.NAME order by " +
+        "ID_NAME.name, ID_NAME.Name, ID_NAME.NAME"), Row("adam", "adam", "adam"))
+    }
+  }
 }
 
 @SlowHiveTest


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?

When we use a Select filter query with struct complex type and use a different case in the query, nested column aliasing maps the name a different  and throws exception

Reproduce Scenario:
create table Struct_com (CUST_ID string, YEAR int, MONTH int, AGE int, GENDER string, EDUCATED string, IS_MARRIED string, STRUCT_INT_DOUBLE_STRING_DATE struct<ID:int,SALARY:double,COUNTRY:STRING,CHECK_DATE:string>,CARD_COUNT int,DEBIT_COUNT int, CREDIT_COUNT int, DEPOSIT double, HQ_DEPOSIT double) stored as parquet;

SELECT struct_int_double_string_date.COUNTRY,struct_int_double_string_date.CHECK_DATE,struct_int_double_string_date.CHECK_DATE,struct_in t_double_string_date.Country, SUM(struct_int_double_string_date.id) AS Sum FROM (select * from Struct_com) SUB_QRY WHERE struct_int_double_string_date.id > 5700 GRO UP BY struct_int_double_string_date.COUNTRY,struct_int_double_string_date.CHECK_DATE,struct_int_double_string_date.CHECK_DATE,struct_int_double_string_date.Country ORDER BY struct_int_double_string_date.COUNTRY asc,struct_int_double_string_date.CHECK_DATE asc,struct_int_double_string_date.CHECK_DATE asc, struct_int_double_stri ng_date.Country asc;

Caused by: java.lang.RuntimeException: Couldn't find _gen_alias_139930#139930 in _gen_alias_139928#139928,_gen_alias_139929#139929,sum(cast(_gen_alias_139931#13993 1 as bigint))#139901L
at scala.sys.package$.error(package.scala:30)
at org.apache.spark.sql.catalyst.expressions.BindReferences$$anonfun$bindReference$1.$anonfun$applyOrElse$1(BoundAttribute.scala:81)
at org.apache.spark.sql.catalyst.errors.package$.attachTree(package.scala:52)
... 90 more (state=,code=0)

### Why are the changes needed?
Select filter query with complex struct fails when query uses case insensitive field name.
Issue is present only in 3.1 branch.


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
UT
