### PR TITLE
[SPARK-35846][SQL] Introduce ParquetReadState to track various states while reading a Parquet column chunk

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet;
+
+/**
+ * Helper class to store intermediate state while reading a Parquet column chunk.
+ */
+final class ParquetReadState {
+  /** Maximum definition level */
+  int maxDefinitionLevel;
+
+  /** The offset to add the next value in the current batch */
+  int offset;
+
+  /** The remaining number of values to read in the current page */
+  int valuesToReadInPage;
+
+  /** The remaining number of values to read in the current batch */
+  int valuesToReadInBatch;
+
+  ParquetReadState(int maxDefinitionLevel) {
+    this.maxDefinitionLevel = maxDefinitionLevel;
+  }
+
+  /**
+   * Called at the beginning of reading a new batch.
+   */
+  void resetForBatch(int batchSize) {
+    this.offset = 0;
+    this.valuesToReadInBatch = batchSize;
+  }
+
+  /**
+   * Called at the beginning of reading a new page.
+   */
+  void resetForPage(int totalValuesInPage) {
+    this.valuesToReadInPage = totalValuesInPage;
+  }
+
+  /**
+   * Returns whether there are more values to read in the current page.
+   */
+  boolean hasMoreInPage(int newOffset) {
+    return newOffset - offset < valuesToReadInPage && newOffset - offset < valuesToReadInBatch;
+  }
+
+  /**
+   * Advance the current offset to the new values.
+   */
+  void advanceOffset(int newOffset) {
+    valuesToReadInBatch -= (newOffset - offset);
+    valuesToReadInPage -= (newOffset - offset);
+    offset = newOffset;
+  }
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
@@ -53,13 +53,6 @@ final class ParquetReadState {
   }
 
   /**
-   * Returns whether there are more values to read in the current page.
-   */
-  boolean hasMoreInPage(int newOffset) {
-    return newOffset - offset < valuesToReadInPage && newOffset - offset < valuesToReadInBatch;
-  }
-
-  /**
    * Advance the current offset to the new values.
    */
   void advanceOffset(int newOffset) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetReadState.java
@@ -22,9 +22,9 @@ package org.apache.spark.sql.execution.datasources.parquet;
  */
 final class ParquetReadState {
   /** Maximum definition level */
-  int maxDefinitionLevel;
+  final int maxDefinitionLevel;
 
-  /** The offset to add the next value in the current batch */
+  /** The offset in the current batch to put the next value */
   int offset;
 
   /** The remaining number of values to read in the current page */

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -175,11 +175,11 @@ public final class VectorizedRleValuesReader extends ValuesReader
       VectorizedValuesReader valueReader,
       ParquetVectorUpdater updater) throws IOException {
     int offset = state.offset;
+    int left = Math.min(state.valuesToReadInBatch, state.valuesToReadInPage);
 
-    while (state.hasMoreInPage(offset)) {
+    while (left > 0) {
       if (this.currentCount == 0) this.readNextGroup();
-      int n = Math.min(state.valuesToReadInBatch + state.offset - offset, this.currentCount);
-      n = Math.min(state.valuesToReadInPage + state.offset - offset, n);
+      int n = Math.min(left, this.currentCount);
 
       switch (mode) {
         case RLE:
@@ -200,6 +200,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
           break;
       }
       offset += n;
+      left -= n;
       currentCount -= n;
     }
 
@@ -216,11 +217,11 @@ public final class VectorizedRleValuesReader extends ValuesReader
       WritableColumnVector nulls,
       VectorizedValuesReader data) throws IOException {
     int offset = state.offset;
+    int left = Math.min(state.valuesToReadInBatch, state.valuesToReadInPage);
 
-    while (state.hasMoreInPage(offset)) {
+    while (left > 0) {
       if (this.currentCount == 0) this.readNextGroup();
-      int n = Math.min(state.valuesToReadInBatch + state.offset - offset, this.currentCount);
-      n = Math.min(state.valuesToReadInPage + state.offset - offset, n);
+      int n = Math.min(left, this.currentCount);
 
       switch (mode) {
         case RLE:
@@ -241,6 +242,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
           break;
       }
       offset += n;
+      left -= n;
       currentCount -= n;
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Move all the bookkeeping states while scanning a Parquet column chunk into a single class `ParquetReadState`. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As suggested [here](https://github.com/apache/spark/pull/32753#discussion_r655580942). To support column index in the vectorized reader path, we'll going to introduce more states to track. These are spread across different classes which make the code harder to maintain. Therefore, this proposes to move them into a single class so they can be managed better.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing UTs.