### PR TITLE
[SPARK-35853][SQL] Remark the shuffle origin to ENSURE_REQUIREMENTS as far as possible

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -87,6 +87,7 @@ case class AdaptiveSparkPlanExec(
   private def queryStagePreparationRules: Seq[Rule[SparkPlan]] = Seq(
     RemoveRedundantProjects,
     EnsureRequirements,
+    RemarkShuffleOrigin,
     RemoveRedundantSorts,
     DisableUnnecessaryBucketedScan
   ) ++ context.session.sessionState.queryStagePrepRules

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/RemarkShuffleOrigin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/RemarkShuffleOrigin.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, BroadcastDistribution, Distribution, UnspecifiedDistribution}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, ShuffleExchangeExec}
+
+/**
+ * Remark the shuffle origin to `ENSURE_REQUIREMENTS` as far as possible.
+ * For example:
+ *   SELECT * FROM t1 JOIN (SELECT /*+ REPARTITION(1024, col) */ * FROM t2)t2 ON t1.col = t2.col
+ * The shuffle origin of join right side is `REPARTITION_BY_NUM` but we can use
+ * `ENSURE_REQUIREMENTS` instead so that AQE can optimize it using more rules.
+ *
+ * Note that, this rule must be applied after [[EnsureRequirements]].
+ */
+object RemarkShuffleOrigin extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan = plan.transformDown {
+    case plan =>
+      def tryRemarkShuffleOrigin(
+          child: SparkPlan, distribution: Distribution): SparkPlan = child match {
+        case shuffle: ShuffleExchangeExec if shuffle.shuffleOrigin != ENSURE_REQUIREMENTS &&
+          shuffle.outputPartitioning.satisfies(distribution) =>
+          shuffle.copy(shuffleOrigin = ENSURE_REQUIREMENTS)
+        case shuffle: ShuffleExchangeExec => shuffle
+        // For simple, here only track ShuffleExchangeExec through UnaryExecNode and
+        // in general it's enough.
+        case unary: UnaryExecNode
+            if unary.requiredChildDistribution.head == UnspecifiedDistribution =>
+          unary.withNewChildren(tryRemarkShuffleOrigin(unary.child, distribution) :: Nil)
+        case other => other
+      }
+
+      assert(plan.requiredChildDistribution.length == plan.children.length)
+      val newChildren = plan.children.zip(plan.requiredChildDistribution).map {
+        case (child, UnspecifiedDistribution | AllTuples | _: BroadcastDistribution) => child
+        case (child, distribution) => tryRemarkShuffleOrigin(child, distribution)
+      }
+      plan.withNewChildren(newChildren)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/RemarkShuffleOriginSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/RemarkShuffleOriginSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class RemarkShuffleOriginSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
-
   import testImplicits._
 
   test("remark shuffle origin with join") {
@@ -52,8 +51,7 @@ class RemarkShuffleOriginSuite extends SharedSparkSession with AdaptiveSparkPlan
   }
 
   test("remark shuffle origin with agg") {
-    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
-      SQLConf.SHUFFLE_PARTITIONS.key -> "5",
+    withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "5",
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
       val df = Seq((1, 2)).toDF("c1", "c2")
       import org.apache.spark.sql.functions._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/RemarkShuffleOriginSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/RemarkShuffleOriginSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.exchange
+
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class RemarkShuffleOriginSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
+
+  import testImplicits._
+
+  test("remark shuffle origin with join") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.SHUFFLE_PARTITIONS.key -> "5",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+      val df1 = Seq((1, 2)).toDF("c1", "c2")
+      val df2 = Seq((1, 3)).toDF("c3", "c4")
+      // single join
+      val res1 = df1.repartition(10, $"c1")
+        .join(df2, $"c1" === $"c3")
+      res1.collect()
+      assert(collect(res1.queryExecution.executedPlan) {
+        case s: ShuffleExchangeLike if s.shuffleOrigin == ENSURE_REQUIREMENTS => s
+      }.size == 2)
+
+      // multi-join
+      val df3 = Seq((1, 4)).toDF("c5", "c6")
+      val res2 = df1.repartition(10, $"c1")
+        .join(df2, $"c1" === $"c3")
+        .join(df3, $"c1" === $"c5")
+      res2.collect()
+      assert(collect(res2.queryExecution.executedPlan) {
+        case s: ShuffleExchangeLike if s.shuffleOrigin == ENSURE_REQUIREMENTS => s
+      }.size == 3)
+    }
+  }
+
+  test("remark shuffle origin with agg") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.SHUFFLE_PARTITIONS.key -> "5",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+      val df = Seq((1, 2)).toDF("c1", "c2")
+      import org.apache.spark.sql.functions._
+      val res1 = df.repartition(10, $"c1")
+        .groupBy($"c1").agg(max($"c2"))
+      res1.collect()
+      assert(collect(res1.queryExecution.executedPlan) {
+        case s: ShuffleExchangeLike if s.shuffleOrigin == ENSURE_REQUIREMENTS => s
+      }.size == 1)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a rule `RemarkShuffleOrigin` in AQE queryStagePreparationRules after EnsureRequirements.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In some queries, we might repartition by some columns with a large partition number manually to make parallelism big enough. However if its output partitioning satisfies some other node (e.g. join/aggregate), this shuffle can not be optimized by AQE due to the shuffle origin. 

So, this new rule aims to remark the shuffle origin to `ENSURE_REQUIREMENTS` as far as possible if it's safe.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, the plan may be changed

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add test.