### PR TITLE
[SPARK-35318][SQL][FOLLOWUP] Hide the internal view properties for `show tblproperties`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -907,7 +907,8 @@ case class ShowTablePropertiesCommand(
             Seq(Row(p, propValue))
           }
         case None =>
-          catalogTable.properties.map(p => Row(p._1, p._2)).toSeq
+          catalogTable.properties.filterKeys(!_.startsWith(CatalogTable.VIEW_PREFIX))
+            .map(p => Row(p._1, p._2)).toSeq
       }
     }
   }

--- a/sql/core/src/test/resources/sql-tests/results/show-tblproperties.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-tblproperties.sql.out
@@ -59,13 +59,6 @@ struct<key:string,value:string>
 -- !query output
 p1	v1
 p2	v2
-view.catalogAndNamespace.numParts	2
-view.catalogAndNamespace.part.0	spark_catalog
-view.catalogAndNamespace.part.1	default
-view.query.out.col.0	c1
-view.query.out.numCols	1
-view.referredTempFunctionsNames	[]
-view.referredTempViewNames	[]
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?
PR #32441 hid the internal view properties for describe table command, But the `show tblproperties view` case is not covered.

### Why are the changes needed?
Avoid internal properties confusing the users.

### Does this PR introduce _any_ user-facing change?
Yes
Before this change, the user will see below output for  `show tblproperties test_view` 
```
....
p1 v1
p2 v2
view.catalogAndNamespace.numParts	2
view.catalogAndNamespace.part.0	spark_catalog
view.catalogAndNamespace.part.1	default
view.query.out.col.0	c1
view.query.out.numCols	1
view.referredTempFunctionsNames	[]
view.referredTempViewNames	[]
...
```
After this change, the internal properties will be hidden.
```
....
p1 v1
p2 v2
...
```
### How was this patch tested?
existing UT
