### PR TITLE
[SPARK-35856][SQL][TESTS] Move new interval type test cases from CastSuite to CastBaseSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
@@ -27,7 +27,7 @@ import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Test suite base for both [[Cast]] expression with ANSI mode enabled and [[AnsiCast]] expression.
- * Note: for new test cases that works for both [[Cast]] and [[AnsiCast]], please add them
+ * Note: for new test cases that work for both [[Cast]] and [[AnsiCast]], please add them
  *       in `CastSuiteBase` instead of this file to ensure the test coverage.
  */
 abstract class AnsiCastSuiteBase extends CastSuiteBase {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
@@ -26,8 +26,11 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
- * Test suite base for both [[Cast]] expression with ANSI mode enabled and [[AnsiCast]] expression.
- * Note: for new test cases that work for both [[Cast]] and [[AnsiCast]], please add them
+ * Test suite base for
+ *   1. [[Cast]] with ANSI mode enabled
+ *   2. [[AnsiCast]]
+ *   3. [[TryCast]]
+ * Note: for new test cases that work for [[Cast]], [[AnsiCast]] and [[TryCast]], please add them
  *       in `CastSuiteBase` instead of this file to ensure the test coverage.
  */
 abstract class AnsiCastSuiteBase extends CastSuiteBase {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
@@ -25,6 +25,11 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
+/**
+ * Test suite base for both [[Cast]] expression with ANSI mode enabled and [[AnsiCast]] expression.
+ * Note: for new test cases that works for both [[Cast]] and [[AnsiCast]], please add them
+ *       in `CastSuiteBase` instead of this file to ensure the test coverage.
+ */
 abstract class AnsiCastSuiteBase extends CastSuiteBase {
 
   private def testIntMaxAndMin(dt: DataType): Unit = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -18,8 +18,6 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.sql.{Date, Timestamp}
-import java.time.{Duration, Period}
-import java.time.temporal.ChronoUnit
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
@@ -30,12 +28,12 @@ import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.types.DayTimeIntervalType._
-import org.apache.spark.sql.types.YearMonthIntervalType._
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
- * Test suite for data type casting expression [[Cast]].
+ * Test suite for data type casting expression [[Cast]] with ANSI mode disabled.
+ * Note: for new test cases that works for both [[Cast]] and [[AnsiCast]], please add them
+ *       in `CastSuiteBase` instead of this file to ensure the test coverage.
  */
 class CastSuite extends CastSuiteBase {
 
@@ -568,92 +566,6 @@ class CastSuite extends CastSuiteBase {
     }
   }
 
-  test("SPARK-35112: Cast string to day-time interval") {
-    checkEvaluation(cast(Literal.create("0 0:0:0"), DayTimeIntervalType()), 0L)
-    checkEvaluation(cast(Literal.create(" interval '0 0:0:0' Day TO second   "),
-      DayTimeIntervalType()), 0L)
-    checkEvaluation(cast(Literal.create("INTERVAL '1 2:03:04' DAY TO SECOND"),
-      DayTimeIntervalType()), 93784000000L)
-    checkEvaluation(cast(Literal.create("INTERVAL '1 03:04:00' DAY TO SECOND"),
-      DayTimeIntervalType()), 97440000000L)
-    checkEvaluation(cast(Literal.create("INTERVAL '1 03:04:00.0000' DAY TO SECOND"),
-      DayTimeIntervalType()), 97440000000L)
-    checkEvaluation(cast(Literal.create("1 2:03:04"), DayTimeIntervalType()), 93784000000L)
-    checkEvaluation(cast(Literal.create("INTERVAL '-10 2:03:04' DAY TO SECOND"),
-      DayTimeIntervalType()), -871384000000L)
-    checkEvaluation(cast(Literal.create("-10 2:03:04"), DayTimeIntervalType()), -871384000000L)
-    checkEvaluation(cast(Literal.create("-106751991 04:00:54.775808"), DayTimeIntervalType()),
-      Long.MinValue)
-    checkEvaluation(cast(Literal.create("106751991 04:00:54.775807"), DayTimeIntervalType()),
-      Long.MaxValue)
-
-    Seq("-106751991 04:00:54.775808", "106751991 04:00:54.775807").foreach { interval =>
-      val ansiInterval = s"INTERVAL '$interval' DAY TO SECOND"
-      checkEvaluation(
-        cast(cast(Literal.create(interval), DayTimeIntervalType()), StringType), ansiInterval)
-      checkEvaluation(cast(cast(Literal.create(ansiInterval),
-        DayTimeIntervalType()), StringType), ansiInterval)
-    }
-
-    Seq("INTERVAL '-106751991 04:00:54.775809' YEAR TO MONTH",
-      "INTERVAL '106751991 04:00:54.775808' YEAR TO MONTH").foreach { interval =>
-        val e = intercept[IllegalArgumentException] {
-          cast(Literal.create(interval), DayTimeIntervalType()).eval()
-        }.getMessage
-        assert(e.contains("Interval string must match day-time format of"))
-      }
-
-    Seq(Byte.MaxValue, Short.MaxValue, Int.MaxValue, Long.MaxValue, Long.MinValue + 1,
-      Long.MinValue).foreach { duration =>
-        val interval = Literal.create(
-          Duration.of(duration, ChronoUnit.MICROS),
-          DayTimeIntervalType())
-        checkEvaluation(cast(cast(interval, StringType), DayTimeIntervalType()), duration)
-      }
-  }
-
-  test("SPARK-35111: Cast string to year-month interval") {
-    checkEvaluation(cast(Literal.create("INTERVAL '1-0' YEAR TO MONTH"),
-      YearMonthIntervalType()), 12)
-    checkEvaluation(cast(Literal.create("INTERVAL '-1-0' YEAR TO MONTH"),
-      YearMonthIntervalType()), -12)
-    checkEvaluation(cast(Literal.create("INTERVAL -'-1-0' YEAR TO MONTH"),
-      YearMonthIntervalType()), 12)
-    checkEvaluation(cast(Literal.create("INTERVAL +'-1-0' YEAR TO MONTH"),
-      YearMonthIntervalType()), -12)
-    checkEvaluation(cast(Literal.create("INTERVAL +'+1-0' YEAR TO MONTH"),
-      YearMonthIntervalType()), 12)
-    checkEvaluation(cast(Literal.create("INTERVAL +'1-0' YEAR TO MONTH"),
-      YearMonthIntervalType()), 12)
-    checkEvaluation(cast(Literal.create(" interval +'1-0' YEAR  TO MONTH "),
-      YearMonthIntervalType()), 12)
-    checkEvaluation(cast(Literal.create(" -1-0 "), YearMonthIntervalType()), -12)
-    checkEvaluation(cast(Literal.create("-1-0"), YearMonthIntervalType()), -12)
-    checkEvaluation(cast(Literal.create(null, StringType), YearMonthIntervalType()), null)
-
-    Seq("0-0", "10-1", "-178956970-7", "178956970-7", "-178956970-8").foreach { interval =>
-      val ansiInterval = s"INTERVAL '$interval' YEAR TO MONTH"
-      checkEvaluation(
-        cast(cast(Literal.create(interval), YearMonthIntervalType()), StringType), ansiInterval)
-      checkEvaluation(cast(cast(Literal.create(ansiInterval),
-        YearMonthIntervalType()), StringType), ansiInterval)
-    }
-
-    Seq("INTERVAL '-178956970-9' YEAR TO MONTH", "INTERVAL '178956970-8' YEAR TO MONTH")
-      .foreach { interval =>
-        val e = intercept[IllegalArgumentException] {
-          cast(Literal.create(interval), YearMonthIntervalType()).eval()
-        }.getMessage
-        assert(e.contains("Error parsing interval year-month string: integer overflow"))
-      }
-
-    Seq(Byte.MaxValue, Short.MaxValue, Int.MaxValue, Int.MinValue + 1, Int.MinValue)
-      .foreach { period =>
-        val interval = Literal.create(Period.ofMonths(period), YearMonthIntervalType())
-        checkEvaluation(cast(cast(interval, StringType), YearMonthIntervalType()), period)
-      }
-  }
-
   test("SPARK-35720: cast invalid string input to timestamp without time zone") {
     Seq("00:00:00",
       "a",
@@ -663,35 +575,5 @@ class CastSuite extends CastSuiteBase {
       "2021-06-17 00:00:00ABC").foreach { invalidInput =>
       checkEvaluation(cast(invalidInput, TimestampWithoutTZType), null)
     }
-  }
-
-  test("SPARK-35820: Support cast DayTimeIntervalType in different fields") {
-    val duration = Duration.ofSeconds(12345678L, 123456789)
-    Seq((DayTimeIntervalType(DAY, DAY), 12268800000000L, -12268800000000L),
-      (DayTimeIntervalType(DAY, HOUR), 12344400000000L, -12344400000000L),
-      (DayTimeIntervalType(DAY, MINUTE), 12345660000000L, -12345660000000L),
-      (DayTimeIntervalType(DAY, SECOND), 12345678123456L, -12345678123457L),
-      (DayTimeIntervalType(HOUR, HOUR), 12344400000000L, -12344400000000L),
-      (DayTimeIntervalType(HOUR, MINUTE), 12345660000000L, -12345660000000L),
-      (DayTimeIntervalType(HOUR, SECOND), 12345678123456L, -12345678123457L),
-      (DayTimeIntervalType(MINUTE, MINUTE), 12345660000000L, -12345660000000L),
-      (DayTimeIntervalType(MINUTE, SECOND), 12345678123456L, -12345678123457L),
-      (DayTimeIntervalType(SECOND, SECOND), 12345678123456L, -12345678123457L))
-      .foreach { case (dt, positive, negative) =>
-        checkEvaluation(
-          cast(Literal.create(duration, DayTimeIntervalType(DAY, SECOND)), dt), positive)
-        checkEvaluation(
-          cast(Literal.create(duration.negated(), DayTimeIntervalType(DAY, SECOND)), dt), negative)
-      }
-  }
-
-  test("SPARK-35819: Support cast YearMonthIntervalType in different fields") {
-    val ym = cast(Literal.create("1-1"), YearMonthIntervalType(YEAR, MONTH))
-    Seq(YearMonthIntervalType(YEAR) -> 12,
-      YearMonthIntervalType(YEAR, MONTH) -> 13,
-      YearMonthIntervalType(MONTH) -> 13)
-      .foreach { case (dt, value) =>
-        checkEvaluation(cast(ym, dt), value)
-      }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Test suite for data type casting expression [[Cast]] with ANSI mode disabled.
- * Note: for new test cases that work for both [[Cast]] and [[AnsiCast]], please add them
+ * Note: for new test cases that work for [[Cast]], [[AnsiCast]] and [[TryCast]], please add them
  *       in `CastSuiteBase` instead of this file to ensure the test coverage.
  */
 class CastSuite extends CastSuiteBase {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Test suite for data type casting expression [[Cast]] with ANSI mode disabled.
- * Note: for new test cases that works for both [[Cast]] and [[AnsiCast]], please add them
+ * Note: for new test cases that work for both [[Cast]] and [[AnsiCast]], please add them
  *       in `CastSuiteBase` instead of this file to ensure the test coverage.
  */
 class CastSuite extends CastSuiteBase {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -37,8 +37,13 @@ import org.apache.spark.sql.catalyst.util.IntervalUtils.microsToDuration
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, yearMonthIntervalTypes}
+import org.apache.spark.sql.types.DayTimeIntervalType.{DAY, HOUR, MINUTE, SECOND}
+import org.apache.spark.sql.types.YearMonthIntervalType.{MONTH, YEAR}
 import org.apache.spark.unsafe.types.UTF8String
 
+/**
+ * Test suite base for both [[Cast]] and [[AnsiCast]] expressions.
+ */
 abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
 
   protected def cast(v: Any, targetType: DataType, timeZoneId: Option[String] = None): CastBase
@@ -948,5 +953,121 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     // The input string can contain date only
     checkEvaluation(cast("2021-06-17", TimestampWithoutTZType),
       LocalDateTime.of(2021, 6, 17, 0, 0))
+  }
+
+  test("SPARK-35112: Cast string to day-time interval") {
+    checkEvaluation(cast(Literal.create("0 0:0:0"), DayTimeIntervalType()), 0L)
+    checkEvaluation(cast(Literal.create(" interval '0 0:0:0' Day TO second   "),
+      DayTimeIntervalType()), 0L)
+    checkEvaluation(cast(Literal.create("INTERVAL '1 2:03:04' DAY TO SECOND"),
+      DayTimeIntervalType()), 93784000000L)
+    checkEvaluation(cast(Literal.create("INTERVAL '1 03:04:00' DAY TO SECOND"),
+      DayTimeIntervalType()), 97440000000L)
+    checkEvaluation(cast(Literal.create("INTERVAL '1 03:04:00.0000' DAY TO SECOND"),
+      DayTimeIntervalType()), 97440000000L)
+    checkEvaluation(cast(Literal.create("1 2:03:04"), DayTimeIntervalType()), 93784000000L)
+    checkEvaluation(cast(Literal.create("INTERVAL '-10 2:03:04' DAY TO SECOND"),
+      DayTimeIntervalType()), -871384000000L)
+    checkEvaluation(cast(Literal.create("-10 2:03:04"), DayTimeIntervalType()), -871384000000L)
+    checkEvaluation(cast(Literal.create("-106751991 04:00:54.775808"), DayTimeIntervalType()),
+      Long.MinValue)
+    checkEvaluation(cast(Literal.create("106751991 04:00:54.775807"), DayTimeIntervalType()),
+      Long.MaxValue)
+
+    Seq("-106751991 04:00:54.775808", "106751991 04:00:54.775807").foreach { interval =>
+      val ansiInterval = s"INTERVAL '$interval' DAY TO SECOND"
+      checkEvaluation(
+        cast(cast(Literal.create(interval), DayTimeIntervalType()), StringType), ansiInterval)
+      checkEvaluation(cast(cast(Literal.create(ansiInterval),
+        DayTimeIntervalType()), StringType), ansiInterval)
+    }
+
+    Seq("INTERVAL '-106751991 04:00:54.775809' YEAR TO MONTH",
+      "INTERVAL '106751991 04:00:54.775808' YEAR TO MONTH").foreach { interval =>
+      val e = intercept[IllegalArgumentException] {
+        cast(Literal.create(interval), DayTimeIntervalType()).eval()
+      }.getMessage
+      assert(e.contains("Interval string must match day-time format of"))
+    }
+
+    Seq(Byte.MaxValue, Short.MaxValue, Int.MaxValue, Long.MaxValue, Long.MinValue + 1,
+      Long.MinValue).foreach { duration =>
+      val interval = Literal.create(
+        Duration.of(duration, ChronoUnit.MICROS),
+        DayTimeIntervalType())
+      checkEvaluation(cast(cast(interval, StringType), DayTimeIntervalType()), duration)
+    }
+  }
+
+  test("SPARK-35111: Cast string to year-month interval") {
+    checkEvaluation(cast(Literal.create("INTERVAL '1-0' YEAR TO MONTH"),
+      YearMonthIntervalType()), 12)
+    checkEvaluation(cast(Literal.create("INTERVAL '-1-0' YEAR TO MONTH"),
+      YearMonthIntervalType()), -12)
+    checkEvaluation(cast(Literal.create("INTERVAL -'-1-0' YEAR TO MONTH"),
+      YearMonthIntervalType()), 12)
+    checkEvaluation(cast(Literal.create("INTERVAL +'-1-0' YEAR TO MONTH"),
+      YearMonthIntervalType()), -12)
+    checkEvaluation(cast(Literal.create("INTERVAL +'+1-0' YEAR TO MONTH"),
+      YearMonthIntervalType()), 12)
+    checkEvaluation(cast(Literal.create("INTERVAL +'1-0' YEAR TO MONTH"),
+      YearMonthIntervalType()), 12)
+    checkEvaluation(cast(Literal.create(" interval +'1-0' YEAR  TO MONTH "),
+      YearMonthIntervalType()), 12)
+    checkEvaluation(cast(Literal.create(" -1-0 "), YearMonthIntervalType()), -12)
+    checkEvaluation(cast(Literal.create("-1-0"), YearMonthIntervalType()), -12)
+    checkEvaluation(cast(Literal.create(null, StringType), YearMonthIntervalType()), null)
+
+    Seq("0-0", "10-1", "-178956970-7", "178956970-7", "-178956970-8").foreach { interval =>
+      val ansiInterval = s"INTERVAL '$interval' YEAR TO MONTH"
+      checkEvaluation(
+        cast(cast(Literal.create(interval), YearMonthIntervalType()), StringType), ansiInterval)
+      checkEvaluation(cast(cast(Literal.create(ansiInterval),
+        YearMonthIntervalType()), StringType), ansiInterval)
+    }
+
+    Seq("INTERVAL '-178956970-9' YEAR TO MONTH", "INTERVAL '178956970-8' YEAR TO MONTH")
+      .foreach { interval =>
+        val e = intercept[IllegalArgumentException] {
+          cast(Literal.create(interval), YearMonthIntervalType()).eval()
+        }.getMessage
+        assert(e.contains("Error parsing interval year-month string: integer overflow"))
+      }
+
+    Seq(Byte.MaxValue, Short.MaxValue, Int.MaxValue, Int.MinValue + 1, Int.MinValue)
+      .foreach { period =>
+        val interval = Literal.create(Period.ofMonths(period), YearMonthIntervalType())
+        checkEvaluation(cast(cast(interval, StringType), YearMonthIntervalType()), period)
+      }
+  }
+
+  test("SPARK-35820: Support cast DayTimeIntervalType in different fields") {
+    val duration = Duration.ofSeconds(12345678L, 123456789)
+    Seq((DayTimeIntervalType(DAY, DAY), 12268800000000L, -12268800000000L),
+      (DayTimeIntervalType(DAY, HOUR), 12344400000000L, -12344400000000L),
+      (DayTimeIntervalType(DAY, MINUTE), 12345660000000L, -12345660000000L),
+      (DayTimeIntervalType(DAY, SECOND), 12345678123456L, -12345678123457L),
+      (DayTimeIntervalType(HOUR, HOUR), 12344400000000L, -12344400000000L),
+      (DayTimeIntervalType(HOUR, MINUTE), 12345660000000L, -12345660000000L),
+      (DayTimeIntervalType(HOUR, SECOND), 12345678123456L, -12345678123457L),
+      (DayTimeIntervalType(MINUTE, MINUTE), 12345660000000L, -12345660000000L),
+      (DayTimeIntervalType(MINUTE, SECOND), 12345678123456L, -12345678123457L),
+      (DayTimeIntervalType(SECOND, SECOND), 12345678123456L, -12345678123457L))
+      .foreach { case (dt, positive, negative) =>
+        checkEvaluation(
+          cast(Literal.create(duration, DayTimeIntervalType(DAY, SECOND)), dt), positive)
+        checkEvaluation(
+          cast(Literal.create(duration.negated(), DayTimeIntervalType(DAY, SECOND)), dt), negative)
+      }
+  }
+
+  test("SPARK-35819: Support cast YearMonthIntervalType in different fields") {
+    val ym = cast(Literal.create("1-1"), YearMonthIntervalType(YEAR, MONTH))
+    Seq(YearMonthIntervalType(YEAR) -> 12,
+      YearMonthIntervalType(YEAR, MONTH) -> 13,
+      YearMonthIntervalType(MONTH) -> 13)
+      .foreach { case (dt, value) =>
+        checkEvaluation(cast(ym, dt), value)
+      }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
@@ -30,7 +30,7 @@ class TryCastSuite extends AnsiCastSuiteBase {
     }
   }
 
-  override def isAlwaysNullable: Boolean = true
+  override def isTryCast: Boolean = true
 
   override protected def setConfigurationHint: String = ""
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
There are a few test cases that are supposed to be in CastSuiteBase instead of CastSuite:

- SPARK-35112: Cast string to day-time interval
- SPARK-35111: Cast string to year-month interval
- SPARK-35820: Support cast DayTimeIntervalType in different fields
- SPARK-35819: Support cast YearMonthIntervalType in different fields

This PR is to 
1. Move the above test cases to CastSuiteBase
2. Adds comments for the scope of CastSuiteBase/CastSuite/AnsiCastSuiteBase.
3. Refactor code to add a flag `isTryCast` in `CastSuiteBase`.
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Increase test coverage so that we can test the casting under ANSI mode.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing UT
