### PR TITLE
[SPARK-35812][PYTHON] Throw ValueError if version and timestamp are used together in to_delta

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -507,11 +507,14 @@ def read_delta(
         Path to the Delta Lake table.
     version : string, optional
         Specifies the table version (based on Delta's internal transaction version) to read from,
-        using Delta's time travel feature. This sets Delta's 'versionAsOf' option.
+        using Delta's time travel feature. This sets Delta's 'versionAsOf' option. Note that
+        this paramter and `timestamp` paramter cannot be used together, otherwise it will raise a
+        `ValueError`.
     timestamp : string, optional
         Specifies the table version (based on timestamp) to read from,
         using Delta's time travel feature. This must be a valid date or timestamp string in Spark,
-        and sets Delta's 'timestampAsOf' option.
+        and sets Delta's 'timestampAsOf' option. Note that this paramter and `version` paramter
+        cannot be used together, otherwise it will raise a `ValueError`.
     index_col : str or list of str, optional, default: None
         Index column of table in Spark.
     options

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -562,6 +562,8 @@ def read_delta(
     3      13
     4      14
     """
+    if version is not None and timestamp is not None:
+        raise ValueError("version and timestamp cannot be used together.")
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
         options = options.get("options")  # type: ignore
 

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -20,7 +20,7 @@ import itertools
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.pandas.namespace import _get_index_map
+from pyspark.pandas.namespace import _get_index_map, read_delta
 from pyspark.pandas.utils import spark_column_equals
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
@@ -328,6 +328,13 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
         check(_get_index_map(sdf, ["year", "month"]), (["year", "month"], [("year",), ("month",)]))
 
         self.assertRaises(KeyError, lambda: _get_index_map(sdf, ["year", "hour"]))
+
+    def test_read_delta_with_wrong_input(self):
+        self.assertRaisesRegex(
+            ValueError,
+            "version and timestamp cannot be used together",
+            lambda: read_delta("fake_path", version="0", timestamp="2021-06-22"),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

Throw ValueError if version and timestamp are used together in to_delta

### Why are the changes needed?
read_delta has arguments named `version` and `timestamp`, but they cannot be used together.

We should raise the proper error message when they are used together.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
