### PR TITLE
[SPARK-35860][SQL] Support UpCast between different field of YearMonthIntervalType/DayTimeIntervalType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -174,6 +174,9 @@ object Cast {
             resolvableNullability(f1.nullable, f2.nullable) && canUpCast(f1.dataType, f2.dataType)
         }
 
+    case (_: DayTimeIntervalType, _: DayTimeIntervalType) => true
+    case (_: YearMonthIntervalType, _: YearMonthIntervalType) => true
+
     case (from: UserDefinedType[_], to: UserDefinedType[_]) if to.acceptsType(from) => true
 
     case _ => false

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -665,6 +665,18 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     atomicTypes.foreach { atomicType =>
       assert(Cast.canUpCast(NullType, atomicType))
     }
+
+    dayTimeIntervalTypes.foreach { from =>
+      dayTimeIntervalTypes.foreach { to =>
+        assert(Cast.canUpCast(from, to))
+      }
+    }
+
+    yearMonthIntervalTypes.foreach { from =>
+      yearMonthIntervalTypes.foreach { to =>
+        assert(Cast.canUpCast(from, to))
+      }
+    }
   }
 
   test("SPARK-27671: cast from nested null type in struct") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support UpCast between different field of YearMonthIntervalType/DayTimeIntervalType


### Why are the changes needed?
Since in our encoder we handle Period/Duration as default  YearMonthIntervalType/DayTimeIntervalType, when we use udf to handle this type, it will upcast all type of YearMonthIntervalType/DayTimeIntervalType to default YearMonthIntervalType/DayTimeIntervalType, so we need to support this.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added Ut
