### PR TITLE
Raise compiler stack space to 256m when building in CI's build_and_test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -455,7 +455,7 @@ jobs:
         java-version: 11
     - name: Build with Maven
       run: |
-        export MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
+        export MAVEN_OPTS="-Xss256m -Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
         export MAVEN_CLI_OPTS="--no-transfer-progress"
         # It uses Maven's 'install' intentionally, see https://github.com/apache/spark/pull/26414.
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Djava.version=11 install


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change the stack space available to the maven compiler when running CI for building for testing purposes. The current default used is `64m`, so increasing to `256m` should be sufficient headroom.


### Why are the changes needed?
There is currently a stack overflow on compilation happening in the CI environment, which is almost always due to insufficient stack space.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Running CI. Not possible to reproduce locally, but have run in our internal CI.
