### PR TITLE
[SPARK-35301][PYTHON][DOCS] Document migration guide from Koalas to pandas APIs on Spark

### DIFF
--- a/python/docs/source/migration_guide/index.rst
+++ b/python/docs/source/migration_guide/index.rst
@@ -33,6 +33,12 @@ This page describes the migration guide specific to PySpark.
    pyspark_1.4_to_1.5
    pyspark_1.0_1.2_to_1.3
 
+The guide below is for those who are from `Koalas <https://koalas.readthedocs.io/en/latest>`_.
+
+.. toctree::
+   :maxdepth: 2
+
+   koalas_to_pyspark
 
 Many items of other migration guides can also be applied when migrating PySpark to higher versions because PySpark internally shares other components.
 Please also refer other migration guides:

--- a/python/docs/source/migration_guide/koalas_to_pyspark.rst
+++ b/python/docs/source/migration_guide/koalas_to_pyspark.rst
@@ -1,0 +1,36 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+============================================
+Migrating from Koalas to pandas API on Spark
+============================================
+
+* The package name to import should be changed to ``pyspark.pandas`` from ``databricks.koalas``.
+
+   .. code-block:: python
+   
+      # import databricks.koalas as ks
+      import pyspark.pandas as ps
+
+* ``DataFrame.koalas`` in Koalas DataFrame was renamed to ``DataFrame.pandas_on_spark`` in pandas-on-Spark DataFrame. ``DataFrame.koalas`` was kept for compatibility reason but deprecated as of Spark 3.2.
+  ``DataFrame.koalas`` will be removed in the future releases.
+
+* Monkey-patched ``DataFrame.to_koalas`` in PySpark DataFrame was renamed to ``DataFrame.to_pandas_on_spark`` in PySpark DataFrame. ``DataFrame.to_koalas`` was kept for compatibility reason but deprecated as of Spark 3.2.
+  ``DataFrame.to_koalas`` will be removed in the future releases.
+
+* ``databricks.koalas.__version__`` was removed. ``pyspark.__version__`` should be used instead.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add a migration guide for legacy Koalas users in pandas API on Spark.

### Why are the changes needed?

For easier migration.

### Does this PR introduce _any_ user-facing change?

Yes, this adds a new page for migration from Koalas.

### How was this patch tested?

Manually built the docs and checked manually.