### PR TITLE
[SPARK-35696][PYTHON][DOCS][FOLLOW-UP] Fix underline for title in FAQ to remove warnings.

### DIFF
--- a/python/docs/source/user_guide/pandas_on_spark/faq.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/faq.rst
@@ -9,7 +9,7 @@ If you are already familiar with pandas and want to leverage Spark for big data,
 If you are learning Spark from ground up, we recommend you start with PySpark's API.
 
 Does pandas API on Spark support Structured Streaming?
------------------------------------------
+------------------------------------------------------
 
 No, pandas API on Spark does not support Structured Streaming officially.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR follow-up for SPARK-35696 to fix incorrect underline in the documents to remove warnings.

### Why are the changes needed?

We should build the docs without any incorrect documentation style

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually build docs and see the warning is removed