### PR TITLE
[SPARK-35871][SQL] Literal.create(value, dataType) should support fields

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -153,7 +153,13 @@ object Literal {
   def fromObject(obj: Any): Literal = new Literal(obj, ObjectType(obj.getClass))
 
   def create(v: Any, dataType: DataType): Literal = {
-    Literal(CatalystTypeConverters.convertToCatalyst(v), dataType)
+    dataType match {
+      case _: YearMonthIntervalType if v.isInstanceOf[Period] =>
+        Literal(CatalystTypeConverters.createToCatalystConverter(dataType)(v), dataType)
+      case _: DayTimeIntervalType if v.isInstanceOf[Duration] =>
+        Literal(CatalystTypeConverters.createToCatalystConverter(dataType)(v), dataType)
+      case _ => Literal(CatalystTypeConverters.convertToCatalyst(v), dataType)
+    }
   }
 
   def create[T : TypeTag](v: T): Literal = Try {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -325,7 +325,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkException(days = Int.MaxValue)
   }
 
-  ignore("SPARK-34824: multiply year-month interval by numeric") {
+  test("SPARK-34824: multiply year-month interval by numeric") {
     Seq(
       (Period.ofYears(-123), Literal(null, DecimalType.USER_DEFAULT)) -> null,
       (Period.ofMonths(0), 10) -> Period.ofMonths(0),
@@ -362,7 +362,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  ignore("SPARK-34850: multiply day-time interval by numeric") {
+  test("SPARK-34850: multiply day-time interval by numeric") {
     Seq(
       (Duration.ofHours(-123), Literal(null, DecimalType.USER_DEFAULT)) -> null,
       (Duration.ofMinutes(0), 10) -> Duration.ofMinutes(0),
@@ -399,7 +399,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  ignore("SPARK-34868: divide year-month interval by numeric") {
+  test("SPARK-34868: divide year-month interval by numeric") {
     Seq(
       (Period.ofYears(-123), Literal(null, DecimalType.USER_DEFAULT)) -> null,
       (Period.ofMonths(0), 10) -> Period.ofMonths(0),
@@ -436,7 +436,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  ignore("SPARK-34875: divide day-time interval by numeric") {
+  test("SPARK-34875: divide day-time interval by numeric") {
     Seq(
       (Duration.ofDays(-123), Literal(null, DecimalType.USER_DEFAULT)) -> null,
       (Duration.ZERO, 10) -> Duration.ZERO,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -325,7 +325,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkException(days = Int.MaxValue)
   }
 
-  test("SPARK-34824: multiply year-month interval by numeric") {
+  ignore("SPARK-34824: multiply year-month interval by numeric") {
     Seq(
       (Period.ofYears(-123), Literal(null, DecimalType.USER_DEFAULT)) -> null,
       (Period.ofMonths(0), 10) -> Period.ofMonths(0),
@@ -362,7 +362,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  test("SPARK-34850: multiply day-time interval by numeric") {
+  ignore("SPARK-34850: multiply day-time interval by numeric") {
     Seq(
       (Duration.ofHours(-123), Literal(null, DecimalType.USER_DEFAULT)) -> null,
       (Duration.ofMinutes(0), 10) -> Duration.ofMinutes(0),
@@ -399,7 +399,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  test("SPARK-34868: divide year-month interval by numeric") {
+  ignore("SPARK-34868: divide year-month interval by numeric") {
     Seq(
       (Period.ofYears(-123), Literal(null, DecimalType.USER_DEFAULT)) -> null,
       (Period.ofMonths(0), 10) -> Period.ofMonths(0),
@@ -436,7 +436,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  test("SPARK-34875: divide day-time interval by numeric") {
+  ignore("SPARK-34875: divide day-time interval by numeric") {
     Seq(
       (Duration.ofDays(-123), Literal(null, DecimalType.USER_DEFAULT)) -> null,
       (Duration.ZERO, 10) -> Duration.ZERO,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -437,23 +437,22 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("SPARK-35871: Literal.create(value, dataType) should support fields") {
     val period = Period.ofMonths(13)
-    Seq(YearMonthIntervalType(YEAR, MONTH) -> 13,
-      YearMonthIntervalType(YEAR) -> 12,
-      YearMonthIntervalType(MONTH) -> 13).foreach { case (dt, result) =>
+    DataTypeTestUtils.yearMonthIntervalTypes.foreach { dt =>
+      val result = dt.endField match {
+        case YEAR => 12
+        case MONTH => 13
+      }
       checkEvaluation(Literal.create(period, dt), result)
     }
 
     val duration = Duration.ofSeconds(86400 + 3600 + 60 + 1)
-    Seq(DayTimeIntervalType(DAY) -> 86400000000L,
-      DayTimeIntervalType(DAY, HOUR) -> 90000000000L,
-      DayTimeIntervalType(DAY, MINUTE) -> 90060000000L,
-      DayTimeIntervalType(DAY, SECOND) -> 90061000000L,
-      DayTimeIntervalType(HOUR) -> 90000000000L,
-      DayTimeIntervalType(HOUR, MINUTE) -> 90060000000L,
-      DayTimeIntervalType(HOUR, SECOND) -> 90061000000L,
-      DayTimeIntervalType(MINUTE) -> 90060000000L,
-      DayTimeIntervalType(MINUTE, SECOND) -> 90061000000L,
-      DayTimeIntervalType(SECOND) -> 90061000000L).foreach { case (dt, result) =>
+    DataTypeTestUtils.dayTimeIntervalTypes.foreach { dt =>
+      val result = dt.endField match {
+        case DAY => 86400000000L
+        case HOUR => 90000000000L
+        case MINUTE => 90060000000L
+        case SECOND => 90061000000L
+      }
       checkEvaluation(Literal.create(duration, dt), result)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -432,4 +432,22 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       assert(literal.toString === expected)
     }
   }
+
+  test("SPARK-35871: Literal.create(value, dataType) should support fields") {
+    Seq((Period.ofMonths(13), Array(13, 12, 13)))
+      .foreach { case (period, expect) =>
+        DataTypeTestUtils.yearMonthIntervalTypes.zip(expect).foreach { case (dt, result) =>
+          checkEvaluation(Literal.create(period, dt), result)
+        }
+      }
+
+    Seq((Duration.ofSeconds(86400 + 3600 + 60 + 1),
+      Array(86400000000L, 90000000000L, 90060000000L, 90061000000L, 90000000000L,
+        90060000000L, 90061000000L, 90060000000L, 90061000000L, 90061000000L)))
+      .foreach { case (duration, expect) =>
+        DataTypeTestUtils.dayTimeIntervalTypes.zip(expect).foreach { case (dt, result) =>
+          checkEvaluation(Literal.create(duration, dt), result)
+        }
+      }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -32,6 +32,8 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DayTimeIntervalType._
+import org.apache.spark.sql.types.YearMonthIntervalType._
 import org.apache.spark.unsafe.types.CalendarInterval
 
 class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
@@ -434,20 +436,25 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("SPARK-35871: Literal.create(value, dataType) should support fields") {
-    Seq((Period.ofMonths(13), Array(13, 12, 13)))
-      .foreach { case (period, expect) =>
-        DataTypeTestUtils.yearMonthIntervalTypes.zip(expect).foreach { case (dt, result) =>
-          checkEvaluation(Literal.create(period, dt), result)
-        }
-      }
+    val period = Period.ofMonths(13)
+    Seq(YearMonthIntervalType(YEAR, MONTH) -> 13,
+      YearMonthIntervalType(YEAR) -> 12,
+      YearMonthIntervalType(MONTH) -> 13).foreach { case (dt, result) =>
+      checkEvaluation(Literal.create(period, dt), result)
+    }
 
-    Seq((Duration.ofSeconds(86400 + 3600 + 60 + 1),
-      Array(86400000000L, 90000000000L, 90060000000L, 90061000000L, 90000000000L,
-        90060000000L, 90061000000L, 90060000000L, 90061000000L, 90061000000L)))
-      .foreach { case (duration, expect) =>
-        DataTypeTestUtils.dayTimeIntervalTypes.zip(expect).foreach { case (dt, result) =>
-          checkEvaluation(Literal.create(duration, dt), result)
-        }
-      }
+    val duration = Duration.ofSeconds(86400 + 3600 + 60 + 1)
+    Seq(DayTimeIntervalType(DAY) -> 86400000000L,
+      DayTimeIntervalType(DAY, HOUR) -> 90000000000L,
+      DayTimeIntervalType(DAY, MINUTE) -> 90060000000L,
+      DayTimeIntervalType(DAY, SECOND) -> 90061000000L,
+      DayTimeIntervalType(HOUR) -> 90000000000L,
+      DayTimeIntervalType(HOUR, MINUTE) -> 90060000000L,
+      DayTimeIntervalType(HOUR, SECOND) -> 90061000000L,
+      DayTimeIntervalType(MINUTE) -> 90060000000L,
+      DayTimeIntervalType(MINUTE, SECOND) -> 90061000000L,
+      DayTimeIntervalType(SECOND) -> 90061000000L).foreach { case (dt, result) =>
+      checkEvaluation(Literal.create(duration, dt), result)
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current Literal.create(data, dataType) for Period to YearMonthIntervalType and Duration to DayTimeIntervalType is not correct.

if data type is Period/Duration, it will create converter of default YearMonthIntervalType/DayTimeIntervalType,  then the result is not correct, this pr fix this bug.

### Why are the changes needed?
Fix  bug when use Literal.create()


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT