### PR TITLE
Revert "[SPARK-35778][SQL][TESTS] Check multiply/divide of year month interval of any fields by numeric"

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -325,6 +325,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkException(days = Int.MaxValue)
   }
 
+  // TODO(SPARK-35778): Check multiply/divide of year-month intervals of any fields by numeric
   test("SPARK-34824: multiply year-month interval by numeric") {
     Seq(
       (Period.ofYears(-123), Literal(null, DecimalType.USER_DEFAULT)) -> null,
@@ -336,9 +337,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       (Period.ofYears(9999), 0.0001d) -> Period.ofYears(1),
       (Period.ofYears(9999), BigDecimal(0.0001)) -> Period.ofYears(1)
     ).foreach { case ((period, num), expected) =>
-      DataTypeTestUtils.yearMonthIntervalTypes.foreach { dt =>
-        checkEvaluation(MultiplyYMInterval(Literal.create(period, dt), Literal(num)), expected)
-      }
+      checkEvaluation(MultiplyYMInterval(Literal(period), Literal(num)), expected)
     }
 
     Seq(
@@ -399,6 +398,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
+  // TODO(SPARK-35778): Check multiply/divide of year-month intervals of any fields by numeric
   test("SPARK-34868: divide year-month interval by numeric") {
     Seq(
       (Period.ofYears(-123), Literal(null, DecimalType.USER_DEFAULT)) -> null,
@@ -412,9 +412,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       (Period.ofYears(1000), 100d) -> Period.ofYears(10),
       (Period.ofMonths(2), BigDecimal(0.1)) -> Period.ofMonths(20)
     ).foreach { case ((period, num), expected) =>
-      DataTypeTestUtils.yearMonthIntervalTypes.foreach { dt =>
-        checkEvaluation(DivideYMInterval(Literal.create(period, dt), Literal(num)), expected)
-      }
+      checkEvaluation(DivideYMInterval(Literal(period), Literal(num)), expected)
     }
 
     Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Revert https://github.com/apache/spark/commit/3904c0edbad1838d70cbde0aec0318dea1ecdf4a

### Why are the changes needed?
The merged test doesn't check different interval fields, actually. Need to apply this https://github.com/apache/spark/pull/33056 first of all.

### Does this PR introduce _any_ user-facing change?
No. This is tests.

### How was this patch tested?
By existing GAs.
