### PR TITLE
[SPARK-35862][SS] Remove hardcoded time zone time format for watermark stats

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetricsReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetricsReporter.scala
@@ -43,7 +43,6 @@ class MetricsReporter(
   registerGauge("latency", _.durationMs.get("triggerExecution").longValue(), 0L)
 
   private val timestampFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") // ISO8601
-  timestampFormat.setTimeZone(DateTimeUtils.getTimeZone("UTC"))
 
   registerGauge("eventTime-watermark",
     progress => convertStringDateToMillis(progress.eventTime.get("watermark")), 0L)
@@ -51,9 +50,9 @@ class MetricsReporter(
   registerGauge("states-rowsTotal", _.stateOperators.map(_.numRowsTotal).sum, 0L)
   registerGauge("states-usedBytes", _.stateOperators.map(_.memoryUsedBytes).sum, 0L)
 
-  private def convertStringDateToMillis(isoUtcDateStr: String) = {
-    if (isoUtcDateStr != null) {
-      timestampFormat.parse(isoUtcDateStr).getTime
+  private def convertStringDateToMillis(isoDateStr: String) = {
+    if (isoDateStr != null) {
+      timestampFormat.parse(isoDateStr).getTime
     } else {
       0L
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetricsReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MetricsReporter.scala
@@ -23,7 +23,6 @@ import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.source.{Source => CodahaleSource}
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.streaming.StreamingQueryProgress
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -27,7 +27,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, LogicalPlan}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.MILLIS_PER_SECOND
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, ReportsSourceMetrics, SparkDataStream}
 import org.apache.spark.sql.execution.QueryExecution
@@ -91,7 +90,6 @@ trait ProgressReporter extends Logging {
   private var lastNoExecutionProgressEventTime = Long.MinValue
 
   private val timestampFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") // ISO8601
-  timestampFormat.setTimeZone(DateTimeUtils.getTimeZone("UTC"))
 
   @volatile
   protected var currentStatus: StreamingQueryStatus = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use global timezone to format watermark stats instead of hardcoded as UTC
before:
`timestampFormat.setTimeZone(DateTimeUtils.getTimeZone("UTC"))`
after: None


### Why are the changes needed?
Avoid multiple time zone information causing confusion to users in different time zone


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass the GitHub Actions
