### PR TITLE
[SPARK-35884][SQL] EXPLAIN FORMATTED for AQE

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -130,7 +130,7 @@ case class AdaptiveSparkPlanExec(
 
   @transient private val costEvaluator = SimpleCostEvaluator
 
-  @transient private val initialPlan = context.session.withActive {
+  @transient val initialPlan = context.session.withActive {
     applyPhysicalRules(
       inputPlan, queryStagePreparationRules, Some((planChangeLogger, "AQE Preparations")))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -527,13 +527,13 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
 class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuite {
   import testImplicits._
 
-  test("Explain formatted") {
+  test("SPARK-35884: Explain Formatted") {
     val df1 = Seq((1, 2), (2, 3)).toDF("k", "v1")
     val df2 = Seq((2, 3), (1, 1)).toDF("k", "v2")
     val testDf = df1.join(df2, "k").groupBy("k").agg(count("v1"), sum("v1"), avg("v2"))
     // trigger the final plan for AQE
     testDf.collect()
-    // AdaptiveSparkPlan (13)
+    // AdaptiveSparkPlan (21)
     // +- == Final Plan ==
     //    * HashAggregate (12)
     //    +- CustomShuffleReader (11)
@@ -547,30 +547,107 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
     //                         +- BroadcastExchange (4)
     //                            +- * Project (3)
     //                               +- * LocalTableScan (2)
+    // +- == Initial Plan ==
+    //    HashAggregate (20)
+    //    +- Exchange (19)
+    //       +- HashAggregate (18)
+    //          +- Project (17)
+    //             +- BroadcastHashJoin Inner BuildRight (16)
+    //                :- Project (14)
+    //                :  +- LocalTableScan (13)
+    //                +- BroadcastExchange (15)
+    //                   +- Project (3)
+    //                      +- LocalTableScan (2)
     checkKeywordsExistsInExplain(
       testDf,
       FormattedMode,
-      s"""
-         |(5) BroadcastQueryStage
-         |Output [2]: [k#x, v2#x]
-         |Arguments: 0
-         |""".stripMargin,
-      s"""
-         |(10) ShuffleQueryStage
-         |Output [5]: [k#x, count#xL, sum#xL, sum#x, count#xL]
-         |Arguments: 1
-         |""".stripMargin,
-      s"""
-         |(11) CustomShuffleReader
-         |Input [5]: [k#x, count#xL, sum#xL, sum#x, count#xL]
-         |Arguments: coalesced
-         |""".stripMargin,
-      s"""
-         |(13) AdaptiveSparkPlan
-         |Output [4]: [k#x, count(v1)#xL, sum(v1)#xL, avg(v2)#x]
-         |Arguments: isFinalPlan=true
-         |""".stripMargin
+      """
+        |(5) BroadcastQueryStage
+        |Output [2]: [k#x, v2#x]
+        |Arguments: 0""".stripMargin,
+      """
+        |(10) ShuffleQueryStage
+        |Output [5]: [k#x, count#xL, sum#xL, sum#x, count#xL]
+        |Arguments: 1""".stripMargin,
+      """
+        |(11) CustomShuffleReader
+        |Input [5]: [k#x, count#xL, sum#xL, sum#x, count#xL]
+        |""".stripMargin,
+      """
+        |(16) BroadcastHashJoin
+        |Left keys [1]: [k#x]
+        |Right keys [1]: [k#x]
+        |Join condition: None
+        |""".stripMargin,
+      """
+        |(19) Exchange
+        |Input [5]: [k#x, count#xL, sum#xL, sum#x, count#xL]
+        |""".stripMargin,
+      """
+        |(21) AdaptiveSparkPlan
+        |Output [4]: [k#x, count(v1)#xL, sum(v1)#xL, avg(v2)#x]
+        |Arguments: isFinalPlan=true
+        |""".stripMargin
     )
+    checkKeywordsNotExistsInExplain(testDf, FormattedMode, "unknown")
+  }
+
+  test("SPARK-35884: Explain should only display one plan before AQE takes effect") {
+    val df = (0 to 10).toDF("id").where('id > 5)
+    val modes = Seq(SimpleMode, ExtendedMode, CostMode, FormattedMode)
+    modes.foreach { mode =>
+      checkKeywordsExistsInExplain(df, mode, "AdaptiveSparkPlan")
+      checkKeywordsNotExistsInExplain(df, mode, "Initial Plan", "Current Plan")
+    }
+    df.collect()
+    modes.foreach { mode =>
+      checkKeywordsExistsInExplain(df, mode, "Initial Plan", "Final Plan")
+      checkKeywordsNotExistsInExplain(df, mode, "unknown")
+    }
+  }
+
+  test("SPARK-35884: Explain formatted with subquery") {
+    withTempView("t1", "t2") {
+      spark.range(100).select('id % 10 as "key", 'id as "value").createOrReplaceTempView("t1")
+      spark.range(10).createOrReplaceTempView("t2")
+      val query =
+        """
+          |SELECT key, value FROM t1
+          |JOIN t2 ON t1.key = t2.id
+          |WHERE value > (SELECT MAX(id) FROM t2)
+          |""".stripMargin
+      val df = sql(query).toDF()
+      df.collect()
+      checkKeywordsExistsInExplain(df, FormattedMode,
+        """
+          |(2) Filter [codegen id : 2]
+          |Input [1]: [id#xL]
+          |Condition : ((id#xL > Subquery subquery#x, [id=#x]) AND isnotnull((id#xL % 10)))
+          |""".stripMargin,
+        """
+          |(6) BroadcastQueryStage
+          |Output [1]: [id#xL]
+          |Arguments: 0""".stripMargin,
+        """
+          |(12) AdaptiveSparkPlan
+          |Output [2]: [key#xL, value#xL]
+          |Arguments: isFinalPlan=true
+          |""".stripMargin,
+        """
+          |Subquery:1 Hosting operator id = 2 Hosting Expression = Subquery subquery#x, [id=#x]
+          |""".stripMargin,
+        """
+          |(16) ShuffleQueryStage
+          |Output [1]: [max#xL]
+          |Arguments: 0""".stripMargin,
+        """
+          |(20) AdaptiveSparkPlan
+          |Output [1]: [max(id)#xL]
+          |Arguments: isFinalPlan=true
+          |""".stripMargin
+      )
+      checkKeywordsNotExistsInExplain(df, FormattedMode, "unknown")
+    }
   }
 
   test("SPARK-35133: explain codegen should work with AQE") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/29137 , which has some issues when running EXPLAIN FORMATTED
```
AdaptiveSparkPlan (13)
+- == Final Plan ==
   * HashAggregate (12)
   +- CustomShuffleReader (11)
      +- ShuffleQueryStage (10)
         +- Exchange (9)
            +- * HashAggregate (8)
               +- * Project (7)
                  +- * BroadcastHashJoin Inner BuildRight (6)
                     :- * LocalTableScan (1)
                     +- BroadcastQueryStage (5)
                        +- BroadcastExchange (4)
                           +- * Project (3)
                              +- * LocalTableScan (2)
+- == Initial Plan ==
   HashAggregate (unknown)
   +- Exchange (unknown)
      +- HashAggregate (unknown)
         +- Project (unknown)
            +- BroadcastHashJoin Inner BuildRight (unknown)
               :- Project (unknown)
               :  +- LocalTableScan (unknown)
               +- BroadcastExchange (unknown)
                  +- Project (3)
                     +- LocalTableScan (2)
```

Some nodes do not have an ID and show `unknown`. This PR fixes the issue.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
bug fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
EXPLAIN FORMATTED with AQE displays correctly.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new tests