### PR TITLE
[SPARK-36461][SQL] Enable ObjectHashAggregate for more Aggregate functions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -145,7 +145,7 @@ case class ObjectHashAggregateExec(
 object ObjectHashAggregateExec {
   def supportsAggregate(aggregateExpressions: Seq[AggregateExpression]): Boolean = {
     aggregateExpressions.map(_.aggregateFunction).exists {
-      case _: TypedImperativeAggregate[_] => true
+      case _: ImperativeAggregate | _: DeclarativeAggregate => true
       case _ => false
     }
   }

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -1032,13 +1032,11 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-AdaptiveSparkPlan (7)
-+- SortAggregate (6)
-   +- Sort (5)
-      +- Exchange (4)
-         +- SortAggregate (3)
-            +- Sort (2)
-               +- Scan parquet default.explain_temp4 (1)
+AdaptiveSparkPlan (5)
++- ObjectHashAggregate (4)
+   +- Exchange (3)
+      +- ObjectHashAggregate (2)
+         +- Scan parquet default.explain_temp4 (1)
 
 
 (1) Scan parquet default.explain_temp4
@@ -1047,33 +1045,25 @@ Batched: true
 Location [not included in comparison]/{warehouse_dir}/explain_temp4]
 ReadSchema: struct<key:int,val:string>
 
-(2) Sort
-Input [2]: [key#x, val#x]
-Arguments: [key#x ASC NULLS FIRST], false, 0
-
-(3) SortAggregate
+(2) ObjectHashAggregate
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
 Functions [1]: [partial_min(val#x)]
 Aggregate Attributes [1]: [min#x]
 Results [2]: [key#x, min#x]
 
-(4) Exchange
+(3) Exchange
 Input [2]: [key#x, min#x]
 Arguments: hashpartitioning(key#x, 4), ENSURE_REQUIREMENTS, [id=#x]
 
-(5) Sort
-Input [2]: [key#x, min#x]
-Arguments: [key#x ASC NULLS FIRST], false, 0
-
-(6) SortAggregate
+(4) ObjectHashAggregate
 Input [2]: [key#x, min#x]
 Keys [1]: [key#x]
 Functions [1]: [min(val#x)]
 Aggregate Attributes [1]: [min(val#x)#x]
 Results [2]: [key#x, min(val#x)#x AS min(val)#x]
 
-(7) AdaptiveSparkPlan
+(5) AdaptiveSparkPlan
 Output [2]: [key#x, min(val)#x]
 Arguments: isFinalPlan=false
 

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -975,13 +975,11 @@ EXPLAIN FORMATTED
 struct<plan:string>
 -- !query output
 == Physical Plan ==
-SortAggregate (7)
-+- * Sort (6)
-   +- Exchange (5)
-      +- SortAggregate (4)
-         +- * Sort (3)
-            +- * ColumnarToRow (2)
-               +- Scan parquet default.explain_temp4 (1)
+ObjectHashAggregate (5)
++- Exchange (4)
+   +- ObjectHashAggregate (3)
+      +- * ColumnarToRow (2)
+         +- Scan parquet default.explain_temp4 (1)
 
 
 (1) Scan parquet default.explain_temp4
@@ -993,26 +991,18 @@ ReadSchema: struct<key:int,val:string>
 (2) ColumnarToRow [codegen id : 1]
 Input [2]: [key#x, val#x]
 
-(3) Sort [codegen id : 1]
-Input [2]: [key#x, val#x]
-Arguments: [key#x ASC NULLS FIRST], false, 0
-
-(4) SortAggregate
+(3) ObjectHashAggregate
 Input [2]: [key#x, val#x]
 Keys [1]: [key#x]
 Functions [1]: [partial_min(val#x)]
 Aggregate Attributes [1]: [min#x]
 Results [2]: [key#x, min#x]
 
-(5) Exchange
+(4) Exchange
 Input [2]: [key#x, min#x]
 Arguments: hashpartitioning(key#x, 4), ENSURE_REQUIREMENTS, [id=#x]
 
-(6) Sort [codegen id : 2]
-Input [2]: [key#x, min#x]
-Arguments: [key#x ASC NULLS FIRST], false, 0
-
-(7) SortAggregate
+(5) ObjectHashAggregate
 Input [2]: [key#x, min#x]
 Keys [1]: [key#x]
 Functions [1]: [min(val#x)]

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ObjectHashAggregateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ObjectHashAggregateSuite.scala
@@ -242,7 +242,7 @@ class ObjectHashAggregateSuite
     val typed = percentile_approx($"c0", 0.5)
 
     // A ImperativeAggregate function
-    val imper_agg = approx_count_distinct($"c0")
+    val imperAgg = approx_count_distinct($"c0")
 
     // A Spark SQL native aggregate function with partial aggregation support that can be executed
     // by the Tungsten `HashAggregateExec`
@@ -257,7 +257,7 @@ class ObjectHashAggregateSuite
 
     val allAggs = Seq(
       "typed" -> typed,
-      "imper_agg" -> imper_agg,
+      "imperAgg" -> imperAgg,
       "with partial + unsafe" -> withPartialUnsafe,
       "with partial + safe" -> withPartialSafe,
       "with distinct" -> withDistinct


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Enabing more `ObjectHashAggregate` for more aggregate functions, as it has better performance compared to `SortAggregate` according to current benchmark.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We are pretty conservative with `ObjectHashAggregate` right now. Except for enabling it by configuring, there is also a fallback threshold. With the fallback threshold, it looks like that even `ObjectHashAggregate` is bad at memory estimation, it is unlikely to OOM easily. For now the users cannot work with `ObjectHashAggregate` for these aggregation functions even they enable the config. That's said, `ObjectHashAggregate` is not much able to be applicable under these limitations. As we are enough conservative with fallback threshold value, it is also disable-able using the config, the limitations on applicable aggregation functions look not necessary.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. Some aggregations will be applied with `ObjectHashAggregate` after this change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added unit tests.