### PR TITLE
[SPARK-35887][BUILD] Find and set JAVA_HOME from javac location

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -17,6 +17,13 @@
 # limitations under the License.
 #
 
+SELF=$(cd $(dirname $0) && pwd)
+. "$SELF/util.sh"
+
+if [ -z "${JAVA_HOME}" -a "$(command -v javac)" ]; then
+  export JAVA_HOME="$(dirname $(dirname $(realpath $(command -v javac))))"
+fi
+
 # Determine the current working directory
 _DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Preserve the calling directory

--- a/build/sbt
+++ b/build/sbt
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+SELF=$(cd $(dirname $0) && pwd)
+. "$SELF/util.sh"
+
 # When creating new tests for Spark SQL Hive, the HADOOP_CLASSPATH must contain the hive jars so
 # that we can run Hive to generate the golden answer.  This is not required for normal development
 # or testing.
@@ -26,26 +29,6 @@ if [ -n "$HIVE_HOME" ]; then
     done
     export HADOOP_CLASSPATH
 fi
-
-realpath () {
-(
-  TARGET_FILE="$1"
-
-  cd "$(dirname "$TARGET_FILE")"
-  TARGET_FILE="$(basename "$TARGET_FILE")"
-
-  COUNT=0
-  while [ -L "$TARGET_FILE" -a $COUNT -lt 100 ]
-  do
-      TARGET_FILE="$(readlink "$TARGET_FILE")"
-      cd $(dirname "$TARGET_FILE")
-      TARGET_FILE="$(basename $TARGET_FILE)"
-      COUNT=$(($COUNT + 1))
-  done
-
-  echo "$(pwd -P)/"$TARGET_FILE""
-)
-}
 
 . "$(dirname "$(realpath "$0")")"/sbt-launch-lib.bash
 

--- a/build/util.sh
+++ b/build/util.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+realpath () {
+(
+  TARGET_FILE="$1"
+
+  cd "$(dirname "$TARGET_FILE")"
+  TARGET_FILE="$(basename "$TARGET_FILE")"
+
+  COUNT=0
+  while [ -L "$TARGET_FILE" -a $COUNT -lt 100 ]
+  do
+      TARGET_FILE="$(readlink "$TARGET_FILE")"
+      cd $(dirname "$TARGET_FILE")
+      TARGET_FILE="$(basename $TARGET_FILE)"
+      COUNT=$(($COUNT + 1))
+  done
+
+  echo "$(pwd -P)/"$TARGET_FILE""
+)
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to find and set JAVA_HOME from the javac location.

### Why are the changes needed?
Since SPARK-35850, maven compile fails with Java8 when there is no JAVA_HOME and `java` path is JRE java.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually run mvn in vanilla ubuntu. 