### PR TITLE
[SPARK-35888][SQL] Add dataSize field in CoalescedPartitionSpec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
@@ -32,7 +32,16 @@ sealed trait ShufflePartitionSpec
 // `endReducerIndex` (exclusive).
 case class CoalescedPartitionSpec(
     startReducerIndex: Int,
-    endReducerIndex: Int) extends ShufflePartitionSpec
+    endReducerIndex: Int,
+    @transient dataSize: Option[Long] = None) extends ShufflePartitionSpec
+
+object CoalescedPartitionSpec {
+  def apply(startReducerIndex: Int,
+            endReducerIndex: Int,
+            dataSize: Long): CoalescedPartitionSpec = {
+    CoalescedPartitionSpec(startReducerIndex, endReducerIndex, Some(dataSize))
+  }
+}
 
 // A partition that reads partial data of one reducer, from `startMapIndex` (inclusive) to
 // `endMapIndex` (exclusive).
@@ -161,7 +170,7 @@ class ShuffledRowRDD(
   override def getPreferredLocations(partition: Partition): Seq[String] = {
     val tracker = SparkEnv.get.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
     partition.asInstanceOf[ShuffledRowRDDPartition].spec match {
-      case CoalescedPartitionSpec(startReducerIndex, endReducerIndex) =>
+      case CoalescedPartitionSpec(startReducerIndex, endReducerIndex, _) =>
         // TODO order by partition size.
         startReducerIndex.until(endReducerIndex).flatMap { reducerIndex =>
           tracker.getPreferredLocationsForShuffle(dependency, reducerIndex)
@@ -181,7 +190,7 @@ class ShuffledRowRDD(
     // as well as the `tempMetrics` for basic shuffle metrics.
     val sqlMetricsReporter = new SQLShuffleReadMetricsReporter(tempMetrics, metrics)
     val reader = split.asInstanceOf[ShuffledRowRDDPartition].spec match {
-      case CoalescedPartitionSpec(startReducerIndex, endReducerIndex) =>
+      case CoalescedPartitionSpec(startReducerIndex, endReducerIndex, _) =>
         SparkEnv.get.shuffleManager.getReader(
           dependency.shuffleHandle,
           startReducerIndex,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CustomShuffleReaderExec.scala
@@ -103,10 +103,10 @@ case class CustomShuffleReaderExec private(
 
   @transient private lazy val partitionDataSizes: Option[Seq[Long]] = {
     if (partitionSpecs.nonEmpty && !isLocalReader && shuffleStage.get.mapStats.isDefined) {
-      val bytesByPartitionId = shuffleStage.get.mapStats.get.bytesByPartitionId
       Some(partitionSpecs.map {
-        case CoalescedPartitionSpec(startReducerIndex, endReducerIndex) =>
-          startReducerIndex.until(endReducerIndex).map(bytesByPartitionId).sum
+        case p: CoalescedPartitionSpec =>
+          assert(p.dataSize.isDefined)
+          p.dataSize.get
         case p: PartialReducerPartitionSpec => p.dataSize
         case p => throw new IllegalStateException(s"unexpected $p")
       })

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -189,7 +189,10 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
       val isLeftSkew = canSplitLeft && leftSize > leftSkewThreshold
       val rightSize = rightSizes(partitionIndex)
       val isRightSkew = canSplitRight && rightSize > rightSkewThreshold
-      val noSkewPartitionSpec = Seq(CoalescedPartitionSpec(partitionIndex, partitionIndex + 1))
+      val leftNoSkewPartitionSpec =
+        Seq(CoalescedPartitionSpec(partitionIndex, partitionIndex + 1, leftSize))
+      val rightNoSkewPartitionSpec =
+        Seq(CoalescedPartitionSpec(partitionIndex, partitionIndex + 1, rightSize))
 
       val leftParts = if (isLeftSkew) {
         val skewSpecs = createSkewPartitionSpecs(
@@ -200,9 +203,9 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
             s"split it into ${skewSpecs.get.length} parts.")
           numSkewedLeft += 1
         }
-        skewSpecs.getOrElse(noSkewPartitionSpec)
+        skewSpecs.getOrElse(leftNoSkewPartitionSpec)
       } else {
-        noSkewPartitionSpec
+        leftNoSkewPartitionSpec
       }
 
       val rightParts = if (isRightSkew) {
@@ -214,9 +217,9 @@ object OptimizeSkewedJoin extends CustomShuffleReaderRule {
             s"split it into ${skewSpecs.get.length} parts.")
           numSkewedRight += 1
         }
-        skewSpecs.getOrElse(noSkewPartitionSpec)
+        skewSpecs.getOrElse(rightNoSkewPartitionSpec)
       } else {
-        noSkewPartitionSpec
+        rightNoSkewPartitionSpec
       }
 
       for {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -84,7 +84,7 @@ object ShufflePartitionsUtil extends Logging {
     val numShuffles = mapOutputStatistics.length
     // If all input RDDs have 0 partition, we create an empty partition for every shuffle reader.
     if (validMetrics.isEmpty) {
-      return Seq.fill(numShuffles)(Seq(CoalescedPartitionSpec(0, 0)))
+      return Seq.fill(numShuffles)(Seq(CoalescedPartitionSpec(0, 0, 0)))
     }
 
     // We may have different pre-shuffle partition numbers, don't reduce shuffle partition number
@@ -96,8 +96,9 @@ object ShufflePartitionsUtil extends Logging {
 
     val numPartitions = validMetrics.head.bytesByPartitionId.length
     val newPartitionSpecs = coalescePartitions(0, numPartitions, validMetrics, targetSize)
-    if (newPartitionSpecs.length < numPartitions) {
-      Seq.fill(numShuffles)(newPartitionSpecs)
+    assert(newPartitionSpecs.nonEmpty)
+    if (newPartitionSpecs.head.length < numPartitions) {
+      newPartitionSpecs
     } else {
       Seq.empty
     }
@@ -119,7 +120,7 @@ object ShufflePartitionsUtil extends Logging {
     // Extract the start indices of each partition spec. Give invalid index -1 to unexpected
     // partition specs. When we reach here, it means skew join optimization has been applied.
     val partitionIndicesSeq = inputPartitionSpecs.map(_.get.map {
-      case CoalescedPartitionSpec(start, end) if start + 1 == end => start
+      case CoalescedPartitionSpec(start, end, _) if start + 1 == end => start
       case PartialReducerPartitionSpec(reducerId, _, _, _) => reducerId
       case _ => -1 // invalid
     })
@@ -147,7 +148,7 @@ object ShufflePartitionsUtil extends Logging {
         if (i - 1 > start) {
           val partitionSpecs = coalescePartitions(
             partitionIndices(start), repeatValue, validMetrics, targetSize)
-          newPartitionSpecsSeq.foreach(_ ++= partitionSpecs)
+          newPartitionSpecsSeq.zip(partitionSpecs).foreach(spec => spec._1 ++= spec._2)
         }
         // find the end of this skew section, skipping partition(i - 1) and partition(i).
         var repeatIndex = i + 1
@@ -172,7 +173,7 @@ object ShufflePartitionsUtil extends Logging {
     if (numPartitions > start) {
       val partitionSpecs = coalescePartitions(
         partitionIndices(start), partitionIndices.last + 1, validMetrics, targetSize)
-      newPartitionSpecsSeq.foreach(_ ++= partitionSpecs)
+      newPartitionSpecsSeq.zip(partitionSpecs).foreach(spec => spec._1 ++= spec._2)
     }
     // only return coalesced result if any coalescing has happened.
     if (newPartitionSpecsSeq.head.length < numPartitions) {
@@ -203,16 +204,18 @@ object ShufflePartitionsUtil extends Logging {
    *  - coalesced partition 2: shuffle partition 2 (size 170 MiB)
    *  - coalesced partition 3: shuffle partition 3 and 4 (size 50 MiB)
    *
-   *  @return A sequence of [[CoalescedPartitionSpec]]s. For example, if partitions [0, 1, 2, 3, 4]
-   *          split at indices [0, 2, 3], the returned partition specs will be:
-   *          CoalescedPartitionSpec(0, 2), CoalescedPartitionSpec(2, 3) and
-   *          CoalescedPartitionSpec(3, 5).
+   *  @return A sequence of sequence of [[CoalescedPartitionSpec]]s. which each inner sequence as
+   *          the new partition specs for its corresponding shuffle after coalescing. For example,
+   *          if partitions [0, 1, 2, 3, 4] and partition bytes [10, 10, 100, 10, 20] with
+   *          targetSize 100, split at indices [0, 2, 3], the returned partition specs will be:
+   *          CoalescedPartitionSpec(0, 2, 20), CoalescedPartitionSpec(2, 3, 100) and
+   *          CoalescedPartitionSpec(3, 5, 30).
    */
   private def coalescePartitions(
       start: Int,
       end: Int,
       mapOutputStatistics: Seq[MapOutputStatistics],
-      targetSize: Long): Seq[CoalescedPartitionSpec] = {
+      targetSize: Long): Seq[Seq[CoalescedPartitionSpec]] = {
     val partitionSpecs = ArrayBuffer.empty[CoalescedPartitionSpec]
     var coalescedSize = 0L
     var i = start
@@ -248,7 +251,15 @@ object ShufflePartitionsUtil extends Logging {
     }
     // Create at least one partition if all partitions are empty.
     createPartitionSpec(partitionSpecs.isEmpty)
-    partitionSpecs.toSeq
+
+    // add data size for each partitionSpecs
+    mapOutputStatistics.map { mapStats =>
+      partitionSpecs.map { spec =>
+        val dataSize = spec.startReducerIndex.until(spec.endReducerIndex)
+          .map(mapStats.bytesByPartitionId).sum
+        spec.copy(dataSize = Some(dataSize))
+      }.toSeq
+    }.toSeq
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -96,7 +96,7 @@ object ShufflePartitionsUtil extends Logging {
 
     val numPartitions = validMetrics.head.bytesByPartitionId.length
     val newPartitionSpecs = coalescePartitions(0, numPartitions, validMetrics, targetSize)
-    assert(newPartitionSpecs.nonEmpty)
+    assert(newPartitionSpecs.length == validMetrics.length)
     if (newPartitionSpecs.head.length < numPartitions) {
       newPartitionSpecs
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
@@ -24,7 +24,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
 
   private def checkEstimation(
       bytesByPartitionIdArray: Array[Array[Long]],
-      expectedPartitionStartIndices: Seq[CoalescedPartitionSpec],
+      expectedPartitionStartIndices: Seq[Seq[CoalescedPartitionSpec]],
       targetSize: Long,
       minNumPartitions: Int = 1): Unit = {
     val mapOutputStatistics = bytesByPartitionIdArray.zipWithIndex.map {
@@ -36,7 +36,10 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       Seq.fill(mapOutputStatistics.length)(None),
       targetSize,
       minNumPartitions)
-    assert(estimatedPartitionStartIndices.forall(_ === expectedPartitionStartIndices))
+    assert(estimatedPartitionStartIndices.length === expectedPartitionStartIndices.length)
+    estimatedPartitionStartIndices.zip(expectedPartitionStartIndices).foreach {
+      case (actual, expect) => assert(actual === expect)
+    }
   }
 
   test("1 shuffle") {
@@ -46,45 +49,42 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       // Some bytes per partition are 0 and total size is less than the target size.
       // 1 coalesced partition is expected.
       val bytesByPartitionId = Array[Long](10, 0, 20, 0, 0)
-      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 5))
-      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs, targetSize)
+      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 5, 30))
+      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs :: Nil, targetSize)
     }
 
     {
       // 2 coalesced partitions are expected.
       val bytesByPartitionId = Array[Long](10, 0, 90, 20, 0)
-      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 3), CoalescedPartitionSpec(3, 5))
-      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs, targetSize)
+      val expectedPartitionSpecs =
+        Seq(CoalescedPartitionSpec(0, 3, 100), CoalescedPartitionSpec(3, 5, 20))
+      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs :: Nil, targetSize)
     }
 
     {
       // There are a few large shuffle partitions.
       val bytesByPartitionId = Array[Long](110, 10, 100, 110, 0)
       val expectedPartitionSpecs = Seq(
-        CoalescedPartitionSpec(0, 1),
-        CoalescedPartitionSpec(1, 2),
-        CoalescedPartitionSpec(2, 3),
-        CoalescedPartitionSpec(3, 4))
-      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs, targetSize)
+        CoalescedPartitionSpec(0, 1, 110),
+        CoalescedPartitionSpec(1, 2, 10),
+        CoalescedPartitionSpec(2, 3, 100),
+        CoalescedPartitionSpec(3, 4, 110))
+      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs :: Nil, targetSize)
     }
 
     {
       // All shuffle partitions are larger than the targeted size.
+      // return Nil if cannot coalesce
       val bytesByPartitionId = Array[Long](100, 110, 100, 110, 110)
-      val expectedPartitionSpecs = Seq(
-        CoalescedPartitionSpec(0, 1),
-        CoalescedPartitionSpec(1, 2),
-        CoalescedPartitionSpec(2, 3),
-        CoalescedPartitionSpec(3, 4),
-        CoalescedPartitionSpec(4, 5))
-      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs, targetSize)
+      checkEstimation(Array(bytesByPartitionId), Nil, targetSize)
     }
 
     {
       // The last shuffle partition is in a single coalesced partition.
       val bytesByPartitionId = Array[Long](30, 30, 0, 40, 110)
-      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 4), CoalescedPartitionSpec(4, 5))
-      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs, targetSize)
+      val expectedPartitionSpecs =
+        Seq(CoalescedPartitionSpec(0, 4, 100), CoalescedPartitionSpec(4, 5, 110))
+      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs :: Nil, targetSize)
     }
   }
 
@@ -109,10 +109,11 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       // 1 coalesced partition is expected.
       val bytesByPartitionId1 = Array[Long](0, 10, 0, 20, 0)
       val bytesByPartitionId2 = Array[Long](30, 0, 20, 0, 20)
-      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 5))
+      val expectedPartitionSpecs1 = Seq(CoalescedPartitionSpec(0, 5, 30))
+      val expectedPartitionSpecs2 = Seq(CoalescedPartitionSpec(0, 5, 70))
       checkEstimation(
         Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs,
+        Seq(expectedPartitionSpecs1, expectedPartitionSpecs2),
         targetSize)
     }
 
@@ -120,13 +121,17 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       // 2 coalesced partition are expected.
       val bytesByPartitionId1 = Array[Long](0, 10, 0, 20, 0)
       val bytesByPartitionId2 = Array[Long](30, 0, 70, 0, 30)
-      val expectedPartitionSpecs = Seq(
-        CoalescedPartitionSpec(0, 2),
-        CoalescedPartitionSpec(2, 4),
-        CoalescedPartitionSpec(4, 5))
+      val expectedPartitionSpecs1 = Seq(
+        CoalescedPartitionSpec(0, 2, 10),
+        CoalescedPartitionSpec(2, 4, 20),
+        CoalescedPartitionSpec(4, 5, 0))
+      val expectedPartitionSpecs2 = Seq(
+        CoalescedPartitionSpec(0, 2, 30),
+        CoalescedPartitionSpec(2, 4, 70),
+        CoalescedPartitionSpec(4, 5, 30))
       checkEstimation(
         Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs,
+        Seq(expectedPartitionSpecs1, expectedPartitionSpecs2),
         targetSize)
     }
 
@@ -134,14 +139,19 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       // 4 coalesced partition are expected.
       val bytesByPartitionId1 = Array[Long](0, 99, 0, 20, 0)
       val bytesByPartitionId2 = Array[Long](30, 0, 70, 0, 30)
-      val expectedPartitionSpecs = Seq(
-        CoalescedPartitionSpec(0, 1),
-        CoalescedPartitionSpec(1, 2),
-        CoalescedPartitionSpec(2, 4),
-        CoalescedPartitionSpec(4, 5))
+      val expectedPartitionSpecs1 = Seq(
+        CoalescedPartitionSpec(0, 1, 0),
+        CoalescedPartitionSpec(1, 2, 99),
+        CoalescedPartitionSpec(2, 4, 20),
+        CoalescedPartitionSpec(4, 5, 0))
+      val expectedPartitionSpecs2 = Seq(
+        CoalescedPartitionSpec(0, 1, 30),
+        CoalescedPartitionSpec(1, 2, 0),
+        CoalescedPartitionSpec(2, 4, 70),
+        CoalescedPartitionSpec(4, 5, 30))
       checkEstimation(
         Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs,
+        Seq(expectedPartitionSpecs1, expectedPartitionSpecs2),
         targetSize)
     }
 
@@ -149,47 +159,36 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       // 2 coalesced partition are needed.
       val bytesByPartitionId1 = Array[Long](0, 100, 0, 30, 0)
       val bytesByPartitionId2 = Array[Long](30, 0, 70, 0, 30)
-      val expectedPartitionSpecs = Seq(
-        CoalescedPartitionSpec(0, 1),
-        CoalescedPartitionSpec(1, 2),
-        CoalescedPartitionSpec(2, 4),
-        CoalescedPartitionSpec(4, 5))
+      val expectedPartitionSpecs1 = Seq(
+        CoalescedPartitionSpec(0, 1, 0),
+        CoalescedPartitionSpec(1, 2, 100),
+        CoalescedPartitionSpec(2, 4, 30),
+        CoalescedPartitionSpec(4, 5, 0))
+      val expectedPartitionSpecs2 = Seq(
+        CoalescedPartitionSpec(0, 1, 30),
+        CoalescedPartitionSpec(1, 2, 0),
+        CoalescedPartitionSpec(2, 4, 70),
+        CoalescedPartitionSpec(4, 5, 30))
       checkEstimation(
         Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs,
+        Seq(expectedPartitionSpecs1, expectedPartitionSpecs2),
         targetSize)
     }
 
     {
       // There are a few large shuffle partitions.
+      // return Nil if cannot coalesce
       val bytesByPartitionId1 = Array[Long](0, 100, 40, 30, 0)
       val bytesByPartitionId2 = Array[Long](30, 0, 60, 0, 110)
-      val expectedPartitionSpecs = Seq(
-        CoalescedPartitionSpec(0, 1),
-        CoalescedPartitionSpec(1, 2),
-        CoalescedPartitionSpec(2, 3),
-        CoalescedPartitionSpec(3, 4),
-        CoalescedPartitionSpec(4, 5))
-      checkEstimation(
-        Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs,
-        targetSize)
+      checkEstimation(Array(bytesByPartitionId1, bytesByPartitionId2), Nil, targetSize)
     }
 
     {
       // All pairs of shuffle partitions are larger than the targeted size.
+      // return Nil if cannot coalesce
       val bytesByPartitionId1 = Array[Long](100, 100, 40, 30, 0)
       val bytesByPartitionId2 = Array[Long](30, 0, 60, 70, 110)
-      val expectedPartitionSpecs = Seq(
-        CoalescedPartitionSpec(0, 1),
-        CoalescedPartitionSpec(1, 2),
-        CoalescedPartitionSpec(2, 3),
-        CoalescedPartitionSpec(3, 4),
-        CoalescedPartitionSpec(4, 5))
-      checkEstimation(
-        Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs,
-        targetSize)
+      checkEstimation(Array(bytesByPartitionId1, bytesByPartitionId2), Nil, targetSize)
     }
   }
 
@@ -203,22 +202,23 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       val bytesByPartitionId1 = Array[Long](0, 0, 0, 0, 0)
       val bytesByPartitionId2 = Array[Long](0, 0, 0, 0, 0)
       // Create at least one partition spec
-      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 5))
+      val expectedPartitionSpecs1 = Seq(CoalescedPartitionSpec(0, 5, 0))
+      val expectedPartitionSpecs2 = Seq(CoalescedPartitionSpec(0, 5, 0))
       checkEstimation(
         Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs, targetSize, minNumPartitions)
+        Seq(expectedPartitionSpecs1, expectedPartitionSpecs2), targetSize, minNumPartitions)
     }
-
 
     {
       // The minimal number of coalesced partitions is not enforced because
       // there are too many 0-size partitions.
       val bytesByPartitionId1 = Array[Long](200, 0, 0)
       val bytesByPartitionId2 = Array[Long](100, 0, 0)
-      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 1))
+      val expectedPartitionSpecs1 = Seq(CoalescedPartitionSpec(0, 1, 200))
+      val expectedPartitionSpecs2 = Seq(CoalescedPartitionSpec(0, 1, 100))
       checkEstimation(
         Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs,
+        Seq(expectedPartitionSpecs1, expectedPartitionSpecs2),
         targetSize, minNumPartitions)
     }
 
@@ -226,10 +226,13 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       // The minimal number of coalesced partitions is enforced.
       val bytesByPartitionId1 = Array[Long](10, 5, 5, 0, 20)
       val bytesByPartitionId2 = Array[Long](5, 10, 0, 10, 5)
-      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 3), CoalescedPartitionSpec(3, 5))
+      val expectedPartitionSpecs1 =
+        Seq(CoalescedPartitionSpec(0, 3, 20), CoalescedPartitionSpec(3, 5, 20))
+      val expectedPartitionSpecs2 =
+        Seq(CoalescedPartitionSpec(0, 3, 15), CoalescedPartitionSpec(3, 5, 15))
       checkEstimation(
         Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs,
+        Seq(expectedPartitionSpecs1, expectedPartitionSpecs2),
         targetSize, minNumPartitions)
     }
 
@@ -237,14 +240,19 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       // The number of coalesced partitions is determined by the algorithm.
       val bytesByPartitionId1 = Array[Long](10, 50, 20, 80, 20)
       val bytesByPartitionId2 = Array[Long](40, 10, 0, 10, 30)
-      val expectedPartitionSpecs = Seq(
-        CoalescedPartitionSpec(0, 1),
-        CoalescedPartitionSpec(1, 3),
-        CoalescedPartitionSpec(3, 4),
-        CoalescedPartitionSpec(4, 5))
+      val expectedPartitionSpecs1 = Seq(
+        CoalescedPartitionSpec(0, 1, 10),
+        CoalescedPartitionSpec(1, 3, 70),
+        CoalescedPartitionSpec(3, 4, 80),
+        CoalescedPartitionSpec(4, 5, 20))
+      val expectedPartitionSpecs2 = Seq(
+        CoalescedPartitionSpec(0, 1, 40),
+        CoalescedPartitionSpec(1, 3, 10),
+        CoalescedPartitionSpec(3, 4, 10),
+        CoalescedPartitionSpec(4, 5, 30))
       checkEstimation(
         Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs,
+        Seq(expectedPartitionSpecs1, expectedPartitionSpecs2),
         targetSize, minNumPartitions)
     }
   }
@@ -256,37 +264,37 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
     {
       // 1 shuffle: All bytes per partition are 0, 1 empty partition spec created.
       val bytesByPartitionId = Array[Long](0, 0, 0, 0, 0)
-      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 5))
-      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs, targetSize)
+      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 5, 0))
+      checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs :: Nil, targetSize)
     }
 
     {
       // 2 shuffles: All bytes per partition are 0, 1 empty partition spec created.
       val bytesByPartitionId1 = Array[Long](0, 0, 0, 0, 0)
       val bytesByPartitionId2 = Array[Long](0, 0, 0, 0, 0)
-      val expectedPartitionSpecs = Seq(CoalescedPartitionSpec(0, 5))
+      val expectedPartitionSpecs1 = Seq(CoalescedPartitionSpec(0, 5, 0))
+      val expectedPartitionSpecs2 = Seq(CoalescedPartitionSpec(0, 5, 0))
       checkEstimation(
-        Array(bytesByPartitionId1, bytesByPartitionId2), expectedPartitionSpecs, targetSize)
+        Array(bytesByPartitionId1, bytesByPartitionId2),
+        Seq(expectedPartitionSpecs1, expectedPartitionSpecs2),
+        targetSize)
     }
 
     {
       // No partition spec created for the 0-size partitions.
       val bytesByPartitionId1 = Array[Long](200, 0, 0, 0, 0)
       val bytesByPartitionId2 = Array[Long](100, 0, 300, 0, 0)
-      val expectedPartitionSpecs = Seq(
-        CoalescedPartitionSpec(0, 1),
-        CoalescedPartitionSpec(2, 3))
+      val expectedPartitionSpecs1 = Seq(
+        CoalescedPartitionSpec(0, 1, 200),
+        CoalescedPartitionSpec(2, 3, 0))
+      val expectedPartitionSpecs2 = Seq(
+        CoalescedPartitionSpec(0, 1, 100),
+        CoalescedPartitionSpec(2, 3, 300))
       checkEstimation(
         Array(bytesByPartitionId1, bytesByPartitionId2),
-        expectedPartitionSpecs,
+        Seq(expectedPartitionSpecs1, expectedPartitionSpecs2),
         targetSize, minNumPartitions)
     }
-  }
-
-  test("return Nil if cannot coalesce") {
-    val targetSize = 100
-    val bytesByPartitionId = Array[Long](110, 120, 130)
-    checkEstimation(Array(bytesByPartitionId), Nil, targetSize)
   }
 
   test("coalesce after skew splitting") {
@@ -297,29 +305,29 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       val bytesByPartitionId1 = Array[Long](10, 5, 300, 10, 8, 10, 10, 20)
       val bytesByPartitionId2 = Array[Long](10, 10, 10, 8, 10, 200, 7, 20)
       val specs1 =
-        Seq.tabulate(2)(i => CoalescedPartitionSpec(i, i + 1)) ++ // 0, 1
+        Seq(CoalescedPartitionSpec(0, 1, 10), CoalescedPartitionSpec(1, 2, 15)) ++ // 0, 1
         Seq.tabulate(3)(i => PartialReducerPartitionSpec(2, i, i + 1, 100L)) ++ // 2 - skew
-        Seq.tabulate(2)(i => CoalescedPartitionSpec(i + 3, i + 4)) ++ // 3, 4
-        Seq.fill(2)(CoalescedPartitionSpec(5, 6)) ++ // 5 - other side skew
-        Seq.tabulate(2)(i => CoalescedPartitionSpec(i + 6, i + 7)) // 6, 7
+        Seq(CoalescedPartitionSpec(3, 4, 10), CoalescedPartitionSpec(4, 5, 8)) ++ // 3, 4
+        Seq.fill(2)(CoalescedPartitionSpec(5, 6, 10)) ++ // 5 - other side skew
+        Seq(CoalescedPartitionSpec(6, 7, 10), CoalescedPartitionSpec(7, 8, 20)) // 6, 7
       val specs2 =
-        Seq.tabulate(2)(i => CoalescedPartitionSpec(i, i + 1)) ++ // 0, 1
-        Seq.fill(3)(CoalescedPartitionSpec(2, 3)) ++ // 2 - other side skew
-        Seq.tabulate(2)(i => CoalescedPartitionSpec(i + 3, i + 4)) ++ // 3, 4
+        Seq(CoalescedPartitionSpec(0, 1, 10), CoalescedPartitionSpec(1, 2, 10)) ++ // 0, 1
+        Seq.fill(3)(CoalescedPartitionSpec(2, 3, 10)) ++ // 2 - other side skew
+        Seq(CoalescedPartitionSpec(3, 4, 8), CoalescedPartitionSpec(4, 5, 10)) ++ // 3, 4
         Seq.tabulate(2)(i => PartialReducerPartitionSpec(5, i, i + 1, 100L)) ++ // 5 - skew
-        Seq.tabulate(2)(i => CoalescedPartitionSpec(i + 6, i + 7)) // 6, 7
+        Seq(CoalescedPartitionSpec(6, 7, 7), CoalescedPartitionSpec(7, 8, 20)) // 6, 7
       val expected1 =
-        Seq(CoalescedPartitionSpec(0, 2)) ++ // 0, 1 - coalesced
+        Seq(CoalescedPartitionSpec(0, 2, 15)) ++ // 0, 1 - coalesced
         Seq.tabulate(3)(i => PartialReducerPartitionSpec(2, i, i + 1, 100L)) ++ // 2 - skew
-        Seq(CoalescedPartitionSpec(3, 5)) ++ // 3, 4 - coalesced
-        Seq.fill(2)(CoalescedPartitionSpec(5, 6)) ++ // 5 - other side skew
-        Seq(CoalescedPartitionSpec(6, 8)) // 6, 7 - coalesced
+        Seq(CoalescedPartitionSpec(3, 5, 18)) ++ // 3, 4 - coalesced
+        Seq.fill(2)(CoalescedPartitionSpec(5, 6, 10)) ++ // 5 - other side skew
+        Seq(CoalescedPartitionSpec(6, 8, 30)) // 6, 7 - coalesced
       val expected2 =
-        Seq(CoalescedPartitionSpec(0, 2)) ++ // 0, 1 - coalesced
-        Seq.fill(3)(CoalescedPartitionSpec(2, 3)) ++ // 2 - other side skew
-        Seq(CoalescedPartitionSpec(3, 5)) ++ // 3, 4 - coalesced
+        Seq(CoalescedPartitionSpec(0, 2, 20)) ++ // 0, 1 - coalesced
+        Seq.fill(3)(CoalescedPartitionSpec(2, 3, 10)) ++ // 2 - other side skew
+        Seq(CoalescedPartitionSpec(3, 5, 18)) ++ // 3, 4 - coalesced
         Seq.tabulate(2)(i => PartialReducerPartitionSpec(5, i, i + 1, 100L)) ++ // 5 - skew
-        Seq(CoalescedPartitionSpec(6, 8)) // 6, 7 - coalesced
+        Seq(CoalescedPartitionSpec(6, 8, 27)) // 6, 7 - coalesced
       val coalesced = ShufflePartitionsUtil.coalescePartitions(
         Array(
           Some(new MapOutputStatistics(0, bytesByPartitionId1)),
@@ -337,21 +345,26 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       val bytesByPartitionId2 = Array[Long](10, 10, 10, 8, 10, 20, 7, 200)
       val specs1 =
         Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
-        Seq.tabulate(6)(i => CoalescedPartitionSpec(i + 1, i + 2)) ++ // 1, 2, 3, 4, 5, 6
-        Seq.fill(2)(CoalescedPartitionSpec(7, 8)) // 7 - other side skew
+        Seq(CoalescedPartitionSpec(1, 2, 5), CoalescedPartitionSpec(2, 3, 10),
+          CoalescedPartitionSpec(3, 4, 10), CoalescedPartitionSpec(4, 5, 8),
+          CoalescedPartitionSpec(5, 6, 10), CoalescedPartitionSpec(6, 7, 10)
+        ) ++ // 1, 2, 3, 4, 5, 6
+        Seq.fill(2)(CoalescedPartitionSpec(7, 8, 20)) // 7 - other side skew
       val specs2 =
-        Seq.fill(3)(CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
-        Seq.tabulate(6)(i => CoalescedPartitionSpec(i + 1, i + 2)) ++ // 1, 2, 3, 4, 5, 6
+        Seq.fill(3)(CoalescedPartitionSpec(0, 1, 10)) ++ // 0 - other side skew
+        Seq(CoalescedPartitionSpec(1, 2, 10), CoalescedPartitionSpec(2, 3, 10),
+          CoalescedPartitionSpec(3, 4, 8), CoalescedPartitionSpec(4, 5, 10),
+          CoalescedPartitionSpec(5, 6, 20), CoalescedPartitionSpec(6, 7, 7)) ++ // 1, 2, 3, 4, 5, 6
         Seq.tabulate(2)(i => PartialReducerPartitionSpec(7, i, i + 1, 100L)) // 7 - skew
       val expected1 =
         Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
-        Seq(CoalescedPartitionSpec(1, 5)) ++ // 1, 2, 3, 4 - coalesced
-        Seq(CoalescedPartitionSpec(5, 7)) ++ // 6, 7 - coalesced
-        Seq.fill(2)(CoalescedPartitionSpec(7, 8)) // 7 - other side skew
+        Seq(CoalescedPartitionSpec(1, 5, 33)) ++ // 1, 2, 3, 4 - coalesced
+        Seq(CoalescedPartitionSpec(5, 7, 20)) ++ // 6, 7 - coalesced
+        Seq.fill(2)(CoalescedPartitionSpec(7, 8, 20)) // 7 - other side skew
       val expected2 =
-        Seq.fill(3)(CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
-        Seq(CoalescedPartitionSpec(1, 5)) ++ // 1, 2, 3, 4 - coalesced
-        Seq(CoalescedPartitionSpec(5, 7)) ++ // 6, 7 - coalesced
+        Seq.fill(3)(CoalescedPartitionSpec(0, 1, 10)) ++ // 0 - other side skew
+        Seq(CoalescedPartitionSpec(1, 5, 38)) ++ // 1, 2, 3, 4 - coalesced
+        Seq(CoalescedPartitionSpec(5, 7, 27)) ++ // 6, 7 - coalesced
         Seq.tabulate(2)(i => PartialReducerPartitionSpec(7, i, i + 1, 100L)) // 7 - skew
       val coalesced = ShufflePartitionsUtil.coalescePartitions(
         Array(
@@ -370,28 +383,30 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       val bytesByPartitionId2 = Array[Long](10, 500, 10, 8, 10, 20, 7, 20)
       val specs1 =
         Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
-        Seq.fill(5)(CoalescedPartitionSpec(1, 2)) ++ // 1 - other side skew
-        Seq.tabulate(4)(i => CoalescedPartitionSpec(i + 2, i + 3)) ++ // 2, 3, 4, 5
+        Seq.fill(5)(CoalescedPartitionSpec(1, 2, 50)) ++ // 1 - other side skew
+        Seq(CoalescedPartitionSpec(2, 3, 10), CoalescedPartitionSpec(3, 4, 10),
+          CoalescedPartitionSpec(4, 5, 8), CoalescedPartitionSpec(5, 6, 10)) ++ // 2, 3, 4, 5
         Seq.tabulate(4)(i => PartialReducerPartitionSpec(6, i, i + 1, 100L)) ++ // 6 - skew
         Seq.tabulate(2)(i => PartialReducerPartitionSpec(7, i, i + 1, 100L)) // 7 - skew
       val specs2 =
-        Seq.fill(3)(CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
+        Seq.fill(3)(CoalescedPartitionSpec(0, 1, 10)) ++ // 0 - other side skew
         Seq.tabulate(5)(i => PartialReducerPartitionSpec(1, i, i + 1, 100L)) ++ // 1 - skew
-        Seq.tabulate(4)(i => CoalescedPartitionSpec(i + 2, i + 3)) ++ // 2, 3, 4, 5
-        Seq.fill(4)(CoalescedPartitionSpec(6, 7)) ++ // 6 - other side skew
-        Seq.fill(2)(CoalescedPartitionSpec(7, 8)) // 7 - other side skew
+        Seq(CoalescedPartitionSpec(2, 3, 10), CoalescedPartitionSpec(3, 4, 8),
+          CoalescedPartitionSpec(4, 5, 10), CoalescedPartitionSpec(5, 6, 20)) ++ // 2, 3, 4, 5
+        Seq.fill(4)(CoalescedPartitionSpec(6, 7, 7)) ++ // 6 - other side skew
+        Seq.fill(2)(CoalescedPartitionSpec(7, 8, 20)) // 7 - other side skew
       val expected1 =
         Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
-        Seq.fill(5)(CoalescedPartitionSpec(1, 2)) ++ // 1 - other side skew
-        Seq(CoalescedPartitionSpec(2, 6)) ++ // 2, 3, 4, 5 - coalesced
+        Seq.fill(5)(CoalescedPartitionSpec(1, 2, 50)) ++ // 1 - other side skew
+        Seq(CoalescedPartitionSpec(2, 6, 38)) ++ // 2, 3, 4, 5 - coalesced
         Seq.tabulate(4)(i => PartialReducerPartitionSpec(6, i, i + 1, 100L)) ++ // 6 - skew
         Seq.tabulate(2)(i => PartialReducerPartitionSpec(7, i, i + 1, 100L)) // 7 - skew
       val expected2 =
-        Seq.fill(3)(CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
+        Seq.fill(3)(CoalescedPartitionSpec(0, 1, 10)) ++ // 0 - other side skew
         Seq.tabulate(5)(i => PartialReducerPartitionSpec(1, i, i + 1, 100L)) ++ // 1 - skew
-        Seq(CoalescedPartitionSpec(2, 6)) ++ // 2, 3, 4, 5 - coalesced
-        Seq.fill(4)(CoalescedPartitionSpec(6, 7)) ++ // 6 - other side skew
-        Seq.fill(2)(CoalescedPartitionSpec(7, 8)) // 7 - other side skew
+        Seq(CoalescedPartitionSpec(2, 6, 48)) ++ // 2, 3, 4, 5 - coalesced
+        Seq.fill(4)(CoalescedPartitionSpec(6, 7, 7)) ++ // 6 - other side skew
+        Seq.fill(2)(CoalescedPartitionSpec(7, 8, 20)) // 7 - other side skew
       val coalesced = ShufflePartitionsUtil.coalescePartitions(
         Array(
           Some(new MapOutputStatistics(0, bytesByPartitionId1)),
@@ -409,32 +424,34 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       val bytesByPartitionId2 = Array[Long](10, 10, 500, 8, 10, 7, 200, 20)
       val specs1 =
         Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
-        Seq(CoalescedPartitionSpec(1, 2)) ++ // 1
-        Seq.fill(5)(CoalescedPartitionSpec(2, 3)) ++ // 2 - other side skew
-        Seq.tabulate(3)(i => CoalescedPartitionSpec(i + 3, i + 4)) ++ // 3, 4, 5
-        Seq.fill(2)(CoalescedPartitionSpec(6, 7)) ++ // 6 - other side skew
-        Seq(CoalescedPartitionSpec(7, 8)) // 7
+        Seq(CoalescedPartitionSpec(1, 2, 16)) ++ // 1
+        Seq.fill(5)(CoalescedPartitionSpec(2, 3, 30)) ++ // 2 - other side skew
+        Seq(CoalescedPartitionSpec(3, 4, 10), CoalescedPartitionSpec(4, 5, 8),
+          CoalescedPartitionSpec(5, 6, 10)) ++ // 3, 4, 5
+        Seq.fill(2)(CoalescedPartitionSpec(6, 7, 10)) ++ // 6 - other side skew
+        Seq(CoalescedPartitionSpec(7, 8, 20)) // 7
       val specs2 =
-        Seq.tabulate(3)(i => CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
-        Seq(CoalescedPartitionSpec(1, 2)) ++ // 1
+        Seq.tabulate(3)(i => CoalescedPartitionSpec(0, 1, 10)) ++ // 0 - other side skew
+        Seq(CoalescedPartitionSpec(1, 2, 10)) ++ // 1
         Seq.tabulate(5)(i => PartialReducerPartitionSpec(2, i, i + 1, 100L)) ++ // 2- skew
-        Seq.tabulate(3)(i => CoalescedPartitionSpec(i + 3, i + 4)) ++ // 3, 4, 5
+        Seq(CoalescedPartitionSpec(3, 4, 8), CoalescedPartitionSpec(4, 5, 10),
+          CoalescedPartitionSpec(5, 6, 7)) ++ // 3, 4, 5
         Seq.tabulate(2)(i => PartialReducerPartitionSpec(6, i, i + 1, 100L)) ++ // 6 - skew
-        Seq(CoalescedPartitionSpec(7, 8)) // 7
+        Seq(CoalescedPartitionSpec(7, 8, 20)) // 7
       val expected1 =
         Seq.tabulate(3)(i => PartialReducerPartitionSpec(0, i, i + 1, 100L)) ++ // 0 - skew
-        Seq(CoalescedPartitionSpec(1, 2)) ++ // 1
-        Seq.fill(5)(CoalescedPartitionSpec(2, 3)) ++ // 2 - other side skew
-        Seq(CoalescedPartitionSpec(3, 6)) ++ // 3, 4, 5 - coalesced
-        Seq.fill(2)(CoalescedPartitionSpec(6, 7)) ++ // 6 - other side skew
-        Seq(CoalescedPartitionSpec(7, 8)) // 7
+        Seq(CoalescedPartitionSpec(1, 2, 16)) ++ // 1
+        Seq.fill(5)(CoalescedPartitionSpec(2, 3, 30)) ++ // 2 - other side skew
+        Seq(CoalescedPartitionSpec(3, 6, 28)) ++ // 3, 4, 5 - coalesced
+        Seq.fill(2)(CoalescedPartitionSpec(6, 7, 10)) ++ // 6 - other side skew
+        Seq(CoalescedPartitionSpec(7, 8, 20)) // 7
       val expected2 =
-        Seq.tabulate(3)(i => CoalescedPartitionSpec(0, 1)) ++ // 0 - other side skew
-        Seq(CoalescedPartitionSpec(1, 2)) ++ // 1
+        Seq.tabulate(3)(i => CoalescedPartitionSpec(0, 1, 10)) ++ // 0 - other side skew
+        Seq(CoalescedPartitionSpec(1, 2, 10)) ++ // 1
         Seq.tabulate(5)(i => PartialReducerPartitionSpec(2, i, i + 1, 100L)) ++ // 2- skew
-        Seq(CoalescedPartitionSpec(3, 6)) ++ // 3, 4, 5 - coalesced
+        Seq(CoalescedPartitionSpec(3, 6, 25)) ++ // 3, 4, 5 - coalesced
         Seq.tabulate(2)(i => PartialReducerPartitionSpec(6, i, i + 1, 100L)) ++ // 6 - skew
-        Seq(CoalescedPartitionSpec(7, 8)) // 7
+        Seq(CoalescedPartitionSpec(7, 8, 20)) // 7
       val coalesced = ShufflePartitionsUtil.coalescePartitions(
         Array(
           Some(new MapOutputStatistics(0, bytesByPartitionId1)),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
* add `dataSize` field in `CoalescedPartitionSpec`
* add data size test suite in `ShufflePartitionsUtilSuite`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, all test suite about `CoalescedPartitionSpec` do not check the data size due to it doesn't contains data size field.

We can add data size in `CoalescedPartitionSpec` and then add test case for better coverage.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass CI