### PR TITLE
[SPARK-35886][SQL] CodeGenerator.getLocalInputVariableValues should handle case that expression match  SubExprEliminationState but not  VariableValue

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4042,6 +4042,21 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         Row(1, 2, 1, 2) :: Nil)
     }
   }
+
+  test("SPARK-35886: Codegen issue for decimal type") {
+    withTable("t") {
+      sql(
+        """
+          |CREATE TABLE t (
+          |  c1 DECIMAL(18,6),
+          |  c2 DECIMAL(18,6),
+          |  c3 DECIMAL(18,6))
+          |USING parquet;
+          |""".stripMargin)
+      sql("INSERT INTO t SELECT 1, 1, 1")
+      checkAnswer(sql("SELECT sum(c1 * c3) + sum(c2 * c3) FROM t"), Row(2.00000000000) :: Nil)
+    }
+  }
 }
 
 case class Foo(bar: Option[String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4044,7 +4044,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   }
 
   test("SPARK-35886: CodeGenerator.getLocalInputVariableValues should handle " +
-    "matched subQuery but not VariableValue") {
+    "expression match SubExprEliminationState but not VariableValue") {
     withTable("tbl") {
       sql(
         """

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4043,18 +4043,19 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK-35886: Codegen issue for decimal type") {
-    withTable("t") {
+  test("SPARK-35886: CodeGenerator.getLocalInputVariableValues should handle " +
+    "matched subQuery but not VariableValue") {
+    withTable("tbl") {
       sql(
         """
-          |CREATE TABLE t (
+          |CREATE TABLE tbl (
           |  c1 DECIMAL(18,6),
           |  c2 DECIMAL(18,6),
           |  c3 DECIMAL(18,6))
           |USING parquet;
           |""".stripMargin)
-      sql("INSERT INTO t SELECT 1, 1, 1")
-      checkAnswer(sql("SELECT sum(c1 * c3) + sum(c2 * c3) FROM t"), Row(2.00000000000) :: Nil)
+      sql("INSERT INTO tbl SELECT 1, 1, 1")
+      checkAnswer(sql("SELECT sum(c1 * c3) + sum(c2 * c3) FROM tbl"), Row(2.00000000000) :: Nil)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
For test case 
```
spark.sql(
  """
    |CREATE TABLE t1 (
    |  c1 DECIMAL(18,6),
    |  c2 DECIMAL(18,6),
    |  c3 DECIMAL(18,6))
    |USING parquet;
    |""".stripMargin)

spark.sql("SELECT sum(c1 * c3) + sum(c2 * c3) FROM t1").show
```
failed when codegen
```
20:23:36.272 ERROR org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator: failed to compile: org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 56, Column 6: Expression "agg_exprIsNull_2_0" is not an rvalue
org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 56, Column 6: Expression "agg_exprIsNull_2_0" is not an rvalue
	at org.codehaus.janino.UnitCompiler.compileError(UnitCompiler.java:12675)
	at org.codehaus.janino.UnitCompiler.toRvalueOrCompileException(UnitCompiler.java:7676)

```

It's caused by when call CodeGenerator.getLocalInputVariableValues, expression match `SubExprEliminationState` but is not  `VariableValue`,  then skip this whole expression, but when call `splitAggregateExpressions`,  since we need to find all input variables by this method, this will cause we skip some inputs.
Here in this case , we put expression's children to stack too.

### Why are the changes needed?
Fix Bug


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT