### PR TITLE
[SPARK-35628][SS][FOLLOW-UP] Fix the consistent break on Scala 2.13 build

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -34,8 +34,8 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 import java.util.zip.{GZIPInputStream, ZipInputStream}
 
 import scala.annotation.tailrec
-import scala.collection.{mutable, Map, Seq}
 import scala.collection.JavaConverters._
+import scala.collection.Map
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
 import scala.reflect.ClassTag
@@ -3128,7 +3128,7 @@ private[spark] object Utils extends Logging {
    * addressing the directory here. Also, we rely on the caller side to address any exceptions.
    */
   def unzipFilesFromFile(fs: FileSystem, dfsZipFile: Path, localDir: File): Seq[File] = {
-    val files = new mutable.ArrayBuffer[File]()
+    val files = new ArrayBuffer[File]()
     val in = new ZipInputStream(fs.open(dfsZipFile))
     var out: OutputStream = null
     try {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -3152,7 +3152,7 @@ private[spark] object Utils extends Logging {
       IOUtils.closeQuietly(in)
       IOUtils.closeQuietly(out)
     }
-    files
+    files.toSeq
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the consistent break on Scala 2.13 build caused by the PR https://github.com/apache/spark/pull/32767

### Why are the changes needed?
Fix the consistent break.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.
