### PR TITLE
[SPARK-35466][PYTHON] Fix disallow_untyped_defs mypy checks for pyspark.pandas.data_type_ops.*

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -153,8 +153,3 @@ ignore_missing_imports = True
 
 [mypy-sklearn.*]
 ignore_missing_imports = True
-
-; TODO(SPARK-35464): Enable disallow_untyped_defs
-
-[mypy-pyspark.pandas.data_type_ops.*]
-disallow_untyped_defs = False

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
 
 
 T_IndexOps = TypeVar("T_IndexOps", bound="IndexOpsMixin")
+IndexOpsLike = Union["Series", "Index"]
 
 
 def is_valid_operand_for_numeric_arithmetic(operand: Any, *, allow_bool: bool = True) -> bool:
@@ -196,7 +197,7 @@ def _as_other_type(
 class DataTypeOps(object, metaclass=ABCMeta):
     """The base class for binary operations of pandas-on-Spark objects (of different data types)."""
 
-    def __new__(cls, dtype: Dtype, spark_type: DataType):
+    def __new__(cls, dtype: Dtype, spark_type: DataType) -> "DataTypeOps":
         from pyspark.pandas.data_type_ops.binary_ops import BinaryOps
         from pyspark.pandas.data_type_ops.boolean_ops import BooleanOps, BooleanExtensionOps
         from pyspark.pandas.data_type_ops.categorical_ops import CategoricalOps
@@ -270,58 +271,58 @@ class DataTypeOps(object, metaclass=ABCMeta):
     def pretty_name(self) -> str:
         raise NotImplementedError()
 
-    def add(self, left, right) -> Union["Series", "Index"]:
+    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Addition can not be applied to %s." % self.pretty_name)
 
-    def sub(self, left, right) -> Union["Series", "Index"]:
+    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Subtraction can not be applied to %s." % self.pretty_name)
 
-    def mul(self, left, right) -> Union["Series", "Index"]:
+    def mul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Multiplication can not be applied to %s." % self.pretty_name)
 
-    def truediv(self, left, right) -> Union["Series", "Index"]:
+    def truediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("True division can not be applied to %s." % self.pretty_name)
 
-    def floordiv(self, left, right) -> Union["Series", "Index"]:
+    def floordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Floor division can not be applied to %s." % self.pretty_name)
 
-    def mod(self, left, right) -> Union["Series", "Index"]:
+    def mod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Modulo can not be applied to %s." % self.pretty_name)
 
-    def pow(self, left, right) -> Union["Series", "Index"]:
+    def pow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Exponentiation can not be applied to %s." % self.pretty_name)
 
-    def radd(self, left, right) -> Union["Series", "Index"]:
+    def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Addition can not be applied to %s." % self.pretty_name)
 
-    def rsub(self, left, right) -> Union["Series", "Index"]:
+    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Subtraction can not be applied to %s." % self.pretty_name)
 
-    def rmul(self, left, right) -> Union["Series", "Index"]:
+    def rmul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Multiplication can not be applied to %s." % self.pretty_name)
 
-    def rtruediv(self, left, right) -> Union["Series", "Index"]:
+    def rtruediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("True division can not be applied to %s." % self.pretty_name)
 
-    def rfloordiv(self, left, right) -> Union["Series", "Index"]:
+    def rfloordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Floor division can not be applied to %s." % self.pretty_name)
 
-    def rmod(self, left, right) -> Union["Series", "Index"]:
+    def rmod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Modulo can not be applied to %s." % self.pretty_name)
 
-    def rpow(self, left, right) -> Union["Series", "Index"]:
+    def rpow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Exponentiation can not be applied to %s." % self.pretty_name)
 
-    def __and__(self, left, right) -> Union["Series", "Index"]:
+    def __and__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Bitwise and can not be applied to %s." % self.pretty_name)
 
-    def __or__(self, left, right) -> Union["Series", "Index"]:
+    def __or__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("Bitwise or can not be applied to %s." % self.pretty_name)
 
-    def rand(self, left, right) -> Union["Series", "Index"]:
+    def rand(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         return left.__and__(right)
 
-    def ror(self, left, right) -> Union["Series", "Index"]:
+    def ror(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         return left.__or__(right)
 
     def restore(self, col: pd.Series) -> pd.Series:

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from pandas.api.types import CategoricalDtype
 
@@ -59,7 +59,9 @@ class BinaryOps(DataTypeOps):
 
     def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, bytes):
-            return column_op(F.concat)(F.lit(right), left)
+            return cast(
+                IndexOpsLike, left._with_new_scol(F.concat(F.lit(right), left.spark.column))
+            )
         else:
             raise TypeError(
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import Any, Union, cast
 
 from pandas.api.types import CategoricalDtype
 
@@ -32,10 +32,6 @@ from pyspark.pandas.data_type_ops.base import (
 from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.types import BinaryType, BooleanType, StringType
-
-if TYPE_CHECKING:
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class BinaryOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -15,13 +15,14 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
+    IndexOpsLike,
     T_IndexOps,
     _as_bool_type,
     _as_categorical_type,
@@ -46,7 +47,7 @@ class BinaryOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "binaries"
 
-    def add(self, left, right) -> Union["Series", "Index"]:
+    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, BinaryType):
             return column_op(F.concat)(left, right)
         elif isinstance(right, bytes):
@@ -56,9 +57,9 @@ class BinaryOps(DataTypeOps):
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def radd(self, left, right) -> Union["Series", "Index"]:
+    def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, bytes):
-            return left._with_new_scol(F.concat(F.lit(right), left.spark.column))
+            return column_op(F.concat)(F.lit(right), left)
         else:
             raise TypeError(
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -16,7 +16,7 @@
 #
 
 import numbers
-from typing import TYPE_CHECKING, Any, Union
+from typing import Any, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -38,10 +38,6 @@ from pyspark.pandas.typedef.typehints import as_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.column import Column
 from pyspark.sql.types import BooleanType, StringType
-
-if TYPE_CHECKING:
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class BooleanOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -16,17 +16,17 @@
 #
 
 import numbers
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark import sql as spark
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
-    is_valid_operand_for_numeric_arithmetic,
     DataTypeOps,
+    IndexOpsLike,
     T_IndexOps,
+    is_valid_operand_for_numeric_arithmetic,
     transform_boolean_operand_to_numeric,
     _as_bool_type,
     _as_categorical_type,
@@ -36,6 +36,7 @@ from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 from pyspark.pandas.typedef.typehints import as_spark_type
 from pyspark.sql import functions as F
+from pyspark.sql.column import Column
 from pyspark.sql.types import BooleanType, StringType
 
 if TYPE_CHECKING:
@@ -52,7 +53,7 @@ class BooleanOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "booleans"
 
-    def add(self, left, right) -> Union["Series", "Index"]:
+    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError(
                 "Addition can not be applied to %s and the given type." % self.pretty_name
@@ -71,7 +72,7 @@ class BooleanOps(DataTypeOps):
                 left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
                 return left + right
 
-    def sub(self, left, right) -> Union["Series", "Index"]:
+    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name
@@ -84,7 +85,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left - right
 
-    def mul(self, left, right) -> Union["Series", "Index"]:
+    def mul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError(
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name
@@ -102,7 +103,7 @@ class BooleanOps(DataTypeOps):
                 left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
                 return left * right
 
-    def truediv(self, left, right) -> Union["Series", "Index"]:
+    def truediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "True division can not be applied to %s and the given type." % self.pretty_name
@@ -115,7 +116,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left / right
 
-    def floordiv(self, left, right) -> Union["Series", "Index"]:
+    def floordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Floor division can not be applied to %s and the given type." % self.pretty_name
@@ -128,7 +129,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left // right
 
-    def mod(self, left, right) -> Union["Series", "Index"]:
+    def mod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Modulo can not be applied to %s and the given type." % self.pretty_name
@@ -141,7 +142,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left % right
 
-    def pow(self, left, right) -> Union["Series", "Index"]:
+    def pow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name
@@ -154,7 +155,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left ** right
 
-    def radd(self, left, right) -> Union["Series", "Index"]:
+    def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, bool):
             return left.__or__(right)
         elif isinstance(right, numbers.Number):
@@ -165,7 +166,7 @@ class BooleanOps(DataTypeOps):
                 "Addition can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rsub(self, left, right) -> Union["Series", "Index"]:
+    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right - left
@@ -174,7 +175,7 @@ class BooleanOps(DataTypeOps):
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rmul(self, left, right) -> Union["Series", "Index"]:
+    def rmul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, bool):
             return left.__and__(right)
         elif isinstance(right, numbers.Number):
@@ -185,7 +186,7 @@ class BooleanOps(DataTypeOps):
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rtruediv(self, left, right) -> Union["Series", "Index"]:
+    def rtruediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right / left
@@ -194,7 +195,7 @@ class BooleanOps(DataTypeOps):
                 "True division can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rfloordiv(self, left, right) -> Union["Series", "Index"]:
+    def rfloordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right // left
@@ -203,7 +204,7 @@ class BooleanOps(DataTypeOps):
                 "Floor division can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rpow(self, left, right) -> Union["Series", "Index"]:
+    def rpow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right ** left
@@ -212,7 +213,7 @@ class BooleanOps(DataTypeOps):
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rmod(self, left, right) -> Union["Series", "Index"]:
+    def rmod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right % left
@@ -221,13 +222,13 @@ class BooleanOps(DataTypeOps):
                 "Modulo can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def __and__(self, left, right) -> Union["Series", "Index"]:
+    def __and__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__and__(left)
         else:
 
-            def and_func(left, right):
-                if not isinstance(right, spark.Column):
+            def and_func(left: Column, right: Any) -> Column:
+                if not isinstance(right, Column):
                     if pd.isna(right):
                         right = F.lit(None)
                     else:
@@ -237,13 +238,13 @@ class BooleanOps(DataTypeOps):
 
             return column_op(and_func)(left, right)
 
-    def __or__(self, left, right) -> Union["Series", "Index"]:
+    def __or__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__or__(left)
         else:
 
-            def or_func(left, right):
-                if not isinstance(right, spark.Column) and pd.isna(right):
+            def or_func(left: Column, right: Any) -> Column:
+                if not isinstance(right, Column) and pd.isna(right):
                     return F.lit(False)
                 else:
                     scol = left | F.lit(right)
@@ -282,9 +283,9 @@ class BooleanExtensionOps(BooleanOps):
     and dtype BooleanDtype.
     """
 
-    def __and__(self, left, right) -> Union["Series", "Index"]:
-        def and_func(left, right):
-            if not isinstance(right, spark.Column):
+    def __and__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+        def and_func(left: Column, right: Any) -> Column:
+            if not isinstance(right, Column):
                 if pd.isna(right):
                     right = F.lit(None)
                 else:
@@ -293,9 +294,9 @@ class BooleanExtensionOps(BooleanOps):
 
         return column_op(and_func)(left, right)
 
-    def __or__(self, left, right) -> Union["Series", "Index"]:
-        def or_func(left, right):
-            if not isinstance(right, spark.Column):
+    def __or__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+        def or_func(left: Column, right: Any) -> Column:
+            if not isinstance(right, Column):
                 if pd.isna(right):
                     right = F.lit(None)
                 else:

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -16,7 +16,7 @@
 #
 
 from itertools import chain
-from typing import TYPE_CHECKING, Union
+from typing import Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -24,10 +24,6 @@ from pandas.api.types import CategoricalDtype
 from pyspark.pandas.data_type_ops.base import DataTypeOps, T_IndexOps
 from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql import functions as F
-
-if TYPE_CHECKING:
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class CategoricalOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import Any, Union, cast
 
 from pandas.api.types import CategoricalDtype
 
@@ -32,10 +32,6 @@ from pyspark.pandas.data_type_ops.base import (
 from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.types import ArrayType, BooleanType, NumericType, StringType
-
-if TYPE_CHECKING:
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class ArrayOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -15,13 +15,14 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
+    IndexOpsLike,
     T_IndexOps,
     _as_bool_type,
     _as_categorical_type,
@@ -46,7 +47,7 @@ class ArrayOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "arrays"
 
-    def add(self, left, right) -> Union["Series", "Index"]:
+    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if not isinstance(right, IndexOpsMixin) or (
             isinstance(right, IndexOpsMixin) and not isinstance(right.spark.data_type, ArrayType)
         ):
@@ -54,8 +55,8 @@ class ArrayOps(DataTypeOps):
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name
             )
 
-        left_type = left.spark.data_type.elementType
-        right_type = right.spark.data_type.elementType
+        left_type = cast(ArrayType, left.spark.data_type).elementType
+        right_type = cast(ArrayType, right.spark.data_type).elementType
 
         if left_type != right_type and not (
             isinstance(left_type, NumericType) and isinstance(right_type, NumericType)

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -17,7 +17,7 @@
 
 import datetime
 import warnings
-from typing import TYPE_CHECKING, Any, Union
+from typing import Any, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -36,10 +36,6 @@ from pyspark.pandas.data_type_ops.base import (
     _as_string_type,
 )
 from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
-
-if TYPE_CHECKING:
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class DateOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -17,7 +17,7 @@
 
 import datetime
 import warnings
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -28,6 +28,7 @@ from pyspark.sql.types import BooleanType, DateType, StringType
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
+    IndexOpsLike,
     T_IndexOps,
     _as_bool_type,
     _as_categorical_type,
@@ -50,7 +51,7 @@ class DateOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "dates"
 
-    def sub(self, left, right) -> Union["Series", "Index"]:
+    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         # Note that date subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' in days from date's subtraction.
         msg = (
@@ -67,7 +68,7 @@ class DateOps(DataTypeOps):
         else:
             raise TypeError("date subtraction can only be applied to date series.")
 
-    def rsub(self, left, right) -> Union["Series", "Index"]:
+    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         # Note that date subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' in days from date's subtraction.
         msg = (

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -17,7 +17,7 @@
 
 import datetime
 import warnings
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import Any, Union, cast
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -36,10 +36,6 @@ from pyspark.pandas.data_type_ops.base import (
 )
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.typedef import as_spark_type, Dtype, extension_dtypes, pandas_on_spark_type
-
-if TYPE_CHECKING:
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class DatetimeOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -17,7 +17,7 @@
 
 import datetime
 import warnings
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -28,6 +28,7 @@ from pyspark.sql.types import BooleanType, StringType, TimestampType
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
+    IndexOpsLike,
     T_IndexOps,
     _as_bool_type,
     _as_categorical_type,
@@ -50,7 +51,7 @@ class DatetimeOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "datetimes"
 
-    def sub(self, left, right) -> Union["Series", "Index"]:
+    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         # Note that timestamp subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' from 'datetime64[ns]'s subtraction.
         msg = (
@@ -63,13 +64,16 @@ class DatetimeOps(DataTypeOps):
             return left.astype("long") - right.astype("long")
         elif isinstance(right, datetime.datetime):
             warnings.warn(msg, UserWarning)
-            return left.astype("long").spark.transform(
-                lambda scol: scol - F.lit(right).cast(as_spark_type("long"))
+            return cast(
+                IndexOpsLike,
+                left.spark.transform(
+                    lambda scol: scol.astype("long") - F.lit(right).cast(as_spark_type("long"))
+                ),
             )
         else:
             raise TypeError("datetime subtraction can only be applied to datetime series.")
 
-    def rsub(self, left, right) -> Union["Series", "Index"]:
+    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         # Note that timestamp subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' from 'datetime64[ns]'s subtraction.
         msg = (
@@ -79,13 +83,16 @@ class DatetimeOps(DataTypeOps):
         )
         if isinstance(right, datetime.datetime):
             warnings.warn(msg, UserWarning)
-            return -(left.astype("long")).spark.transform(
-                lambda scol: scol - F.lit(right).cast(as_spark_type("long"))
+            return cast(
+                IndexOpsLike,
+                left.spark.transform(
+                    lambda scol: F.lit(right).cast(as_spark_type("long")) - scol.astype("long")
+                ),
             )
         else:
             raise TypeError("datetime subtraction can only be applied to datetime series.")
 
-    def prepare(self, col):
+    def prepare(self, col: pd.Series) -> pd.Series:
         """Prepare column when from_pandas."""
         return col
 

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING, Union
+from typing import Union
 
 from pandas.api.types import CategoricalDtype
 
@@ -29,10 +29,6 @@ from pyspark.pandas.data_type_ops.base import (
 )
 from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
 from pyspark.sql.types import BooleanType, StringType
-
-if TYPE_CHECKING:
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class NullOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -16,7 +16,7 @@
 #
 
 import numbers
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
 import pandas as pd
@@ -24,9 +24,10 @@ from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op
 from pyspark.pandas.data_type_ops.base import (
-    is_valid_operand_for_numeric_arithmetic,
     DataTypeOps,
+    IndexOpsLike,
     T_IndexOps,
+    is_valid_operand_for_numeric_arithmetic,
     transform_boolean_operand_to_numeric,
     _as_bool_type,
     _as_categorical_type,
@@ -56,7 +57,7 @@ class NumericOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "numerics"
 
-    def add(self, left, right) -> Union["Series", "Index"]:
+    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -69,7 +70,7 @@ class NumericOps(DataTypeOps):
 
         return column_op(Column.__add__)(left, right)
 
-    def sub(self, left, right) -> Union["Series", "Index"]:
+    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -82,7 +83,7 @@ class NumericOps(DataTypeOps):
 
         return column_op(Column.__sub__)(left, right)
 
-    def mod(self, left, right) -> Union["Series", "Index"]:
+    def mod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -93,12 +94,12 @@ class NumericOps(DataTypeOps):
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
-        def mod(left, right):
+        def mod(left: Column, right: Any) -> Column:
             return ((left % right) + right) % right
 
         return column_op(mod)(left, right)
 
-    def pow(self, left, right) -> Union["Series", "Index"]:
+    def pow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -109,12 +110,12 @@ class NumericOps(DataTypeOps):
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
-        def pow_func(left, right):
+        def pow_func(left: Column, right: Any) -> Column:
             return F.when(left == 1, left).otherwise(Column.__pow__(left, right))
 
         return column_op(pow_func)(left, right)
 
-    def radd(self, left, right) -> Union["Series", "Index"]:
+    def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("string addition can only be applied to string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -122,7 +123,7 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__radd__)(left, right)
 
-    def rsub(self, left, right) -> Union["Series", "Index"]:
+    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("subtraction can not be applied to string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -130,7 +131,7 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rsub__)(left, right)
 
-    def rmul(self, left, right) -> Union["Series", "Index"]:
+    def rmul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
         if not isinstance(right, numbers.Number):
@@ -138,25 +139,25 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rmul__)(left, right)
 
-    def rpow(self, left, right) -> Union["Series", "Index"]:
+    def rpow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("exponentiation can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("exponentiation can not be applied to given types.")
 
-        def rpow_func(left, right):
+        def rpow_func(left: Column, right: Any) -> Column:
             return F.when(F.lit(right == 1), right).otherwise(Column.__rpow__(left, right))
 
         right = transform_boolean_operand_to_numeric(right)
         return column_op(rpow_func)(left, right)
 
-    def rmod(self, left, right) -> Union["Series", "Index"]:
+    def rmod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("modulo can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("modulo can not be applied to given types.")
 
-        def rmod(left, right):
+        def rmod(left: Column, right: Any) -> Column:
             return ((right % left) + left) % left
 
         right = transform_boolean_operand_to_numeric(right)
@@ -173,7 +174,7 @@ class IntegralOps(NumericOps):
     def pretty_name(self) -> str:
         return "integrals"
 
-    def mul(self, left, right) -> Union["Series", "Index"]:
+    def mul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
 
@@ -190,7 +191,7 @@ class IntegralOps(NumericOps):
 
         return column_op(Column.__mul__)(left, right)
 
-    def truediv(self, left, right) -> Union["Series", "Index"]:
+    def truediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -201,14 +202,14 @@ class IntegralOps(NumericOps):
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
-        def truediv(left, right):
+        def truediv(left: Column, right: Any) -> Column:
             return F.when(F.lit(right != 0) | F.lit(right).isNull(), left.__div__(right)).otherwise(
                 F.lit(np.inf).__div__(left)
             )
 
         return numpy_column_op(truediv)(left, right)
 
-    def floordiv(self, left, right) -> Union["Series", "Index"]:
+    def floordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -219,7 +220,7 @@ class IntegralOps(NumericOps):
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
-        def floordiv(left, right):
+        def floordiv(left: Column, right: Any) -> Column:
             return F.when(F.lit(right is np.nan), np.nan).otherwise(
                 F.when(
                     F.lit(right != 0) | F.lit(right).isNull(), F.floor(left.__div__(right))
@@ -228,13 +229,13 @@ class IntegralOps(NumericOps):
 
         return numpy_column_op(floordiv)(left, right)
 
-    def rtruediv(self, left, right) -> Union["Series", "Index"]:
+    def rtruediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
-        def rtruediv(left, right):
+        def rtruediv(left: Column, right: Any) -> Column:
             return F.when(left == 0, F.lit(np.inf).__div__(right)).otherwise(
                 F.lit(right).__truediv__(left)
             )
@@ -242,13 +243,13 @@ class IntegralOps(NumericOps):
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rtruediv)(left, right)
 
-    def rfloordiv(self, left, right) -> Union["Series", "Index"]:
+    def rfloordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
-        def rfloordiv(left, right):
+        def rfloordiv(left: Column, right: Any) -> Column:
             return F.when(F.lit(left == 0), F.lit(np.inf).__div__(right)).otherwise(
                 F.floor(F.lit(right).__div__(left))
             )
@@ -279,7 +280,7 @@ class FractionalOps(NumericOps):
     def pretty_name(self) -> str:
         return "fractions"
 
-    def mul(self, left, right) -> Union["Series", "Index"]:
+    def mul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
 
@@ -293,7 +294,7 @@ class FractionalOps(NumericOps):
 
         return column_op(Column.__mul__)(left, right)
 
-    def truediv(self, left, right) -> Union["Series", "Index"]:
+    def truediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -304,7 +305,7 @@ class FractionalOps(NumericOps):
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
-        def truediv(left, right):
+        def truediv(left: Column, right: Any) -> Column:
             return F.when(F.lit(right != 0) | F.lit(right).isNull(), left.__div__(right)).otherwise(
                 F.when(F.lit(left == np.inf) | F.lit(left == -np.inf), left).otherwise(
                     F.lit(np.inf).__div__(left)
@@ -313,7 +314,7 @@ class FractionalOps(NumericOps):
 
         return numpy_column_op(truediv)(left, right)
 
-    def floordiv(self, left, right) -> Union["Series", "Index"]:
+    def floordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -324,7 +325,7 @@ class FractionalOps(NumericOps):
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
-        def floordiv(left, right):
+        def floordiv(left: Column, right: Any) -> Column:
             return F.when(F.lit(right is np.nan), np.nan).otherwise(
                 F.when(
                     F.lit(right != 0) | F.lit(right).isNull(), F.floor(left.__div__(right))
@@ -337,13 +338,13 @@ class FractionalOps(NumericOps):
 
         return numpy_column_op(floordiv)(left, right)
 
-    def rtruediv(self, left, right) -> Union["Series", "Index"]:
+    def rtruediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
-        def rtruediv(left, right):
+        def rtruediv(left: Column, right: Any) -> Column:
             return F.when(left == 0, F.lit(np.inf).__div__(right)).otherwise(
                 F.lit(right).__truediv__(left)
             )
@@ -351,13 +352,13 @@ class FractionalOps(NumericOps):
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rtruediv)(left, right)
 
-    def rfloordiv(self, left, right) -> Union["Series", "Index"]:
+    def rfloordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
-        def rfloordiv(left, right):
+        def rfloordiv(left: Column, right: Any) -> Column:
             return F.when(F.lit(left == 0), F.lit(np.inf).__div__(right)).otherwise(
                 F.when(F.lit(left) == np.nan, np.nan).otherwise(F.floor(F.lit(right).__div__(left)))
             )

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -16,7 +16,7 @@
 #
 
 import numbers
-from typing import TYPE_CHECKING, Any, Union
+from typing import Any, Union
 
 import numpy as np
 import pandas as pd
@@ -44,10 +44,6 @@ from pyspark.sql.types import (
     StringType,
     TimestampType,
 )
-
-if TYPE_CHECKING:
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class NumericOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -89,7 +89,10 @@ class StringOps(DataTypeOps):
 
     def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
-            return column_op(F.concat)(F.lit(right), left)
+            return cast(
+                IndexOpsLike,
+                left._with_new_scol(F.concat(F.lit(right), left.spark.column)),  # TODO: dtype?
+            )
         else:
             raise TypeError("string addition can only be applied to string series or literals.")
 

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import Any, Union, cast
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -36,10 +36,6 @@ from pyspark.pandas.internal import InternalField
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
 from pyspark.sql.types import BooleanType
-
-if TYPE_CHECKING:
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class StringOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -26,6 +26,7 @@ from pyspark.sql.types import IntegralType, StringType
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
+    IndexOpsLike,
     T_IndexOps,
     _as_categorical_type,
     _as_other_type,
@@ -50,7 +51,7 @@ class StringOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "strings"
 
-    def add(self, left, right) -> Union["Series", "Index"]:
+    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType):
             return column_op(F.concat)(left, right)
         elif isinstance(right, str):
@@ -58,10 +59,10 @@ class StringOps(DataTypeOps):
         else:
             raise TypeError("string addition can only be applied to string series or literals.")
 
-    def sub(self, left, right):
+    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("subtraction can not be applied to string series or literals.")
 
-    def mul(self, left, right) -> Union["Series", "Index"]:
+    def mul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
 
@@ -74,43 +75,43 @@ class StringOps(DataTypeOps):
         else:
             raise TypeError("a string series can only be multiplied to an int series or literal")
 
-    def truediv(self, left, right):
+    def truediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def floordiv(self, left, right):
+    def floordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def mod(self, left, right):
+    def mod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("modulo can not be applied on string series or literals.")
 
-    def pow(self, left, right):
+    def pow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("exponentiation can not be applied on string series or literals.")
 
-    def radd(self, left, right) -> Union["Series", "Index"]:
+    def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, str):
-            return left._with_new_scol(F.concat(F.lit(right), left.spark.column))  # TODO: dtype?
+            return column_op(F.concat)(F.lit(right), left)
         else:
             raise TypeError("string addition can only be applied to string series or literals.")
 
-    def rsub(self, left, right):
+    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("subtraction can not be applied to string series or literals.")
 
-    def rmul(self, left, right) -> Union["Series", "Index"]:
+    def rmul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         if isinstance(right, int):
             return column_op(SF.repeat)(left, right)
         else:
             raise TypeError("a string series can only be multiplied to an int series or literal")
 
-    def rtruediv(self, left, right):
+    def rtruediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def rfloordiv(self, left, right):
+    def rfloordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def rpow(self, left, right):
+    def rpow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("exponentiation can not be applied on string series or literals.")
 
-    def rmod(self, left, right):
+    def rmod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
         raise TypeError("modulo can not be applied on string series or literals.")
 
     def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds more type annotations in the files `python/pyspark/pandas/data_type_ops/*.py` and fixes the mypy check failures.

### Why are the changes needed?

We should enable more disallow_untyped_defs mypy checks.

### Does this PR introduce _any_ user-facing change?

Yes.
This PR adds more type annotations in pandas APIs on Spark module, which can impact interaction with development tools for users.

### How was this patch tested?

The mypy check with a new configuration and existing tests should pass.