### PR TITLE
[SPARK-35339][PYTHON] Improve unit tests for data-type-based basic operations

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -26,15 +26,9 @@ from pandas.api.types import CategoricalDtype
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
-from pyspark.pandas.typedef.typehints import (
-    extension_float_dtypes_available,
-    extension_object_dtypes_available,
-)
+from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
 from pyspark.sql.types import BooleanType
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-
-if extension_float_dtypes_available:
-    from pandas import Float32Dtype, Float64Dtype
 
 
 class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -576,6 +576,8 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser.astype("category"), psser.astype("category"))
         cat_type = CategoricalDtype(categories=[False, True])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
+        for dtype in self.extension_dtypes:
+            self.check_extension(pser.astype(dtype), psser.astype(dtype))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -586,18 +586,9 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         cat_type = CategoricalDtype(categories=[False, True])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
         for dtype in self.extension_dtypes:
-            if extension_float_dtypes_available:
-                is_extension_float_dtype = dtype in [
-                    "Float32",
-                    "Float64",
-                    Float32Dtype(),
-                    Float64Dtype(),
-                ]
-
-                if is_extension_float_dtype:
-                    self.assert_eq([1.0, 0.0, np.nan], self.psser.astype(dtype).tolist())
-                else:
-                    self.check_extension(pser.astype(dtype), psser.astype(dtype))
+            if dtype in self.fractional_extension_dtypes:
+                # A pandas boolean extension series cannot be casted to fractional extension dtypes
+                self.assert_eq([1.0, 0.0, np.nan], self.psser.astype(dtype).tolist())
             else:
                 self.check_extension(pser.astype(dtype), psser.astype(dtype))
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -579,7 +579,7 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         pser = self.pser
         psser = self.psser
 
-        # [True, False, <NA>] is returned in pandas
+        # TODO(SPARK-35976): [True, False, <NA>] is returned in pandas
         self.assert_eq(["True", "False", "None"], self.psser.astype(str).tolist())
 
         self.assert_eq(pser.astype("category"), psser.astype("category"))

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -29,6 +29,7 @@ from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
     extension_float_dtypes_available,
+    extension_object_dtypes_available,
 )
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
@@ -322,8 +323,7 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 class IntegralExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     @property
     def intergral_extension_psers(self):
-        dtypes = ["Int8", "Int16", "Int32", "Int64"]
-        return [pd.Series([1, 2, 3, None], dtype=dtype) for dtype in dtypes]
+        return [pd.Series([1, 2, 3, None], dtype=dtype) for dtype in self.integral_extension_dtypes]
 
     @property
     def intergral_extension_pssers(self):
@@ -342,6 +342,11 @@ class IntegralExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in self.intergral_extension_pser_psser_pairs:
             self.assert_eq(pser.isnull(), psser.isnull())
 
+    def test_astype(self):
+        for pser, psser in self.intergral_extension_pser_psser_pairs:
+            for dtype in self.extension_dtypes:
+                self.check_extension(pser.astype(dtype), psser.astype(dtype))
+
 
 @unittest.skipIf(
     not extension_float_dtypes_available, "pandas extension float dtypes are not available"
@@ -349,8 +354,10 @@ class IntegralExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 class FractionalExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     @property
     def fractional_extension_psers(self):
-        dtypes = ["Float32", "Float64"]
-        return [pd.Series([0.1, 0.2, 0.3, None], dtype=dtype) for dtype in dtypes]
+        return [
+            pd.Series([0.1, 0.2, 0.3, None], dtype=dtype)
+            for dtype in self.fractional_extension_dtypes
+        ]
 
     @property
     def fractional_extension_pssers(self):
@@ -368,6 +375,11 @@ class FractionalExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def test_isnull(self):
         for pser, psser in self.fractional_extension_pser_psser_pairs:
             self.assert_eq(pser.isnull(), psser.isnull())
+
+    def test_astype(self):
+        for pser, psser in self.fractional_extension_pser_psser_pairs:
+            for dtype in self.extension_dtypes:
+                self.check_extension(pser.astype(dtype), psser.astype(dtype))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -29,7 +29,6 @@ from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
     extension_float_dtypes_available,
-    extension_object_dtypes_available,
 )
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -224,7 +224,7 @@ class StringExtensionOpsTest(StringOpsTest, PandasOnSparkTestCase, TestCasesUtil
         pser = self.pser
         psser = self.psser
 
-        # [x, y, z, <NA>] is returned in pandas
+        # TODO(SPARK-35976): [x, y, z, <NA>] is returned in pandas
         self.assert_eq(["x", "y", "z", "None"], self.psser.astype(str).tolist())
 
         self.assert_eq(pser.astype("category"), psser.astype("category"))

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -27,6 +27,9 @@ from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
 from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
+if extension_object_dtypes_available:
+    from pandas import StringDtype
+
 
 class StringOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     @property
@@ -216,6 +219,20 @@ class StringExtensionOpsTest(StringOpsTest, PandasOnSparkTestCase, TestCasesUtil
 
     def test_isnull(self):
         self.assert_eq(self.pser.isnull(), self.psser.isnull())
+
+    def test_astype(self):
+        pser = self.pser
+        psser = self.psser
+
+        # [x, y, z, <NA>] is returned in pandas
+        self.assert_eq(["x", "y", "z", "None"], self.psser.astype(str).tolist())
+
+        self.assert_eq(pser.astype("category"), psser.astype("category"))
+        cat_type = CategoricalDtype(categories=["x", "y"])
+        self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
+        for dtype in self.object_extension_dtypes:
+            if dtype in ["string", StringDtype()]:
+                self.check_extension(pser.astype(dtype), psser.astype(dtype))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -25,6 +25,21 @@ import pandas as pd
 import pyspark.pandas as ps
 from pyspark.pandas.typedef import extension_dtypes
 
+from pyspark.pandas.typedef.typehints import (
+    extension_dtypes_available,
+    extension_float_dtypes_available,
+    extension_object_dtypes_available,
+)
+
+if extension_dtypes_available:
+    from pandas import Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype
+
+if extension_float_dtypes_available:
+    from pandas import Float32Dtype, Float64Dtype
+
+if extension_object_dtypes_available:
+    from pandas import BooleanDtype, StringDtype
+
 
 class TestCasesUtils(object):
     """A utility holding common test cases for arithmetic operations of different data types."""
@@ -80,6 +95,47 @@ class TestCasesUtils(object):
     @property
     def pser_psser_pairs(self):
         return zip(self.psers, self.pssers)
+
+    @property
+    def object_extension_dtypes(self):
+        return (
+            ["boolean", "string", BooleanDtype(), StringDtype()]
+            if extension_object_dtypes_available
+            else []
+        )
+
+    @property
+    def fractional_extension_dtypes(self):
+        return (
+            ["Float32", "Float64", Float32Dtype(), Float64Dtype()]
+            if extension_float_dtypes_available
+            else []
+        )
+
+    @property
+    def integral_extension_dtypes(self):
+        return (
+            [
+                "Int8",
+                "Int16",
+                "Int32",
+                "Int64",
+                Int8Dtype(),
+                Int16Dtype(),
+                Int32Dtype(),
+                Int64Dtype(),
+            ]
+            if extension_dtypes_available
+            else []
+        )
+
+    @property
+    def extension_dtypes(self):
+        return (
+            self.object_extension_dtypes
+            + self.fractional_extension_dtypes
+            + self.integral_extension_dtypes
+        )
 
     def check_extension(self, psser, pser):
         """

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -57,8 +57,6 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         pser = self.pser
         psser = self.psser
 
-        self.assert_eq(psser + 1, pser + 1)
-        self.assert_eq(1 + psser, 1 + pser)
         self.assert_eq(psser + 1 + 10 * psser, pser + 1 + 10 * pser)
         self.assert_eq(psser + 1 + 10 * psser.index, pser + 1 + 10 * pser.index)
         self.assert_eq(psser.index + 1 + 10 * psser, pser.index + 1 + 10 * pser)
@@ -91,51 +89,6 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             self.assertTrue(isinstance(psser.dtype, extension_dtypes))
         else:
             self.assert_eq(psser, pser)
-
-    @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
-    def test_extension_dtypes(self):
-        for pser in [
-            pd.Series([1, 2, None, 4], dtype="Int8"),
-            pd.Series([1, 2, None, 4], dtype="Int16"),
-            pd.Series([1, 2, None, 4], dtype="Int32"),
-            pd.Series([1, 2, None, 4], dtype="Int64"),
-        ]:
-            psser = ps.from_pandas(pser)
-
-            self._check_extension(psser, pser)
-            self._check_extension(psser + psser, pser + pser)
-
-    @unittest.skipIf(
-        not extension_object_dtypes_available, "pandas extension object dtypes are not available"
-    )
-    def test_extension_object_dtypes(self):
-        # string
-        pser = pd.Series(["a", None, "c", "d"], dtype="string")
-        psser = ps.from_pandas(pser)
-
-        self._check_extension(psser, pser)
-
-        # boolean
-        pser = pd.Series([True, False, True, None], dtype="boolean")
-        psser = ps.from_pandas(pser)
-
-        self._check_extension(psser, pser)
-        self._check_extension(psser & psser, pser & pser)
-        self._check_extension(psser | psser, pser | pser)
-
-    @unittest.skipIf(
-        not extension_float_dtypes_available, "pandas extension float dtypes are not available"
-    )
-    def test_extension_float_dtypes(self):
-        for pser in [
-            pd.Series([1.0, 2.0, None, 4.0], dtype="Float32"),
-            pd.Series([1.0, 2.0, None, 4.0], dtype="Float64"),
-        ]:
-            psser = ps.from_pandas(pser)
-
-            self._check_extension(psser, pser)
-            self._check_extension(psser + 1, pser + 1)
-            self._check_extension(psser + psser, pser + pser)
 
     def test_empty_series(self):
         pser_a = pd.Series([], dtype="i1")
@@ -868,18 +821,16 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psser.nlargest(), pser.nlargest())
         self.assert_eq((psser + 1).nlargest(), (pser + 1).nlargest())
 
-    def test_isnull(self):
+    def test_notnull(self):
         pser = pd.Series([1, 2, 3, 4, np.nan, 6], name="x")
         psser = ps.from_pandas(pser)
 
         self.assert_eq(psser.notnull(), pser.notnull())
-        self.assert_eq(psser.isnull(), pser.isnull())
 
         pser = self.pser
         psser = self.psser
 
         self.assert_eq(psser.notnull(), pser.notnull())
-        self.assert_eq(psser.isnull(), pser.isnull())
 
     def test_all(self):
         for pser in [


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Improve unit tests for data-type-based basic operations by:
- removing redundant test cases
- adding `astype` test for ExtensionDtypes

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Some test cases for basic operations are duplicated after introducing data-type-based basic operations. The PR is proposed to remove redundant test cases.
`astype` is not tested for ExtensionDtypes, which will be adjusted in this PR as well.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.

Keyword: SPARK-35337