### PR TITLE
[SPARK-35904][SQL] Collapse above RebalancePartitions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -911,6 +911,11 @@ object CollapseRepartition extends Rule[LogicalPlan] {
     // we can remove the child.
     case r @ RepartitionByExpression(_, child: RepartitionOperation, _) =>
       r.copy(child = child.child)
+
+    // Case 3: When a RebalancePartitions has a child of Repartition or RepartitionByExpression
+    // we can remove the child.
+    case r @ RebalancePartitions(_, child: RepartitionOperation) =>
+      r.copy(child = child.child)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1373,15 +1373,17 @@ object RepartitionByExpression {
  */
 case class RebalancePartitions(
     partitionExpressions: Seq[Expression],
-    child: LogicalPlan) extends UnaryNode {
-  override def maxRows: Option[Long] = child.maxRows
-  override def output: Seq[Attribute] = child.output
+    child: LogicalPlan) extends RepartitionOperation {
+
+  override def numPartitions: Int = conf.numShufflePartitions
 
   def partitioning: Partitioning = if (partitionExpressions.isEmpty) {
     RoundRobinPartitioning(conf.numShufflePartitions)
   } else {
     HashPartitioning(partitionExpressions, conf.numShufflePartitions)
   }
+
+  override def shuffle: Boolean = true
 
   override protected def withNewChildInternal(newChild: LogicalPlan): RebalancePartitions =
     copy(child = newChild)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseRepartitionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseRepartitionSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.plans.PlanTest
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, RebalancePartitions}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 
 class CollapseRepartitionSuite extends PlanTest {
@@ -194,5 +194,14 @@ class CollapseRepartitionSuite extends PlanTest {
 
     comparePlans(optimized1, correctAnswer)
     comparePlans(optimized2, correctAnswer)
+  }
+
+  test("SPARK-35904: Collapse above RebalancePartitions") {
+    comparePlans(
+      Optimize.execute(RebalancePartitions(Seq('b), testRelation.distribute('b)(10)).analyze),
+      RebalancePartitions(Seq('b), testRelation).analyze)
+    comparePlans(
+      Optimize.execute(RebalancePartitions(Seq('b), testRelation).distribute('a)(10).analyze),
+      testRelation.distribute('a)(10).analyze)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Make `RebalancePartitions` extend `RepartitionOperation`.
2. Make `CollapseRepartition` support `RebalancePartitions`.

### Why are the changes needed?

`CollapseRepartition` can optimize `RebalancePartitions` if possible.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
