### PR TITLE
[SPARK-35908][SQL] Remove repartition if the child maximum number of rows less than or equal to 1

### DIFF
--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -2025,7 +2025,7 @@ abstract class AvroSuite
 
   test("SPARK-31327: Write Spark version into Avro file metadata") {
     withTempPath { path =>
-      spark.range(1).repartition(1).write.format("avro").save(path.getCanonicalPath)
+      spark.range(2).repartition(1).write.format("avro").save(path.getCanonicalPath)
       checkMetaData(path, SPARK_VERSION_METADATA_KEY, SPARK_VERSION_SHORT)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.logical.{RepartitionOperation, _}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.trees.AlwaysProcess
 import org.apache.spark.sql.catalyst.trees.TreePattern._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -922,8 +922,8 @@ object CollapseRepartition extends Rule[LogicalPlan] {
 object OptimizeRepartition extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
     _.containsPattern(REPARTITION_OPERATION), ruleId) {
-    case r: RepartitionOperation
-      if r.child.maxRows.exists(_ <= 1L) => r.child
+    case r: RepartitionOperation if r.child.maxRows.exists(_ <= 1L) =>
+      r.child
     case r @ RepartitionByExpression(partitionExpressions, _, numPartitions)
       if partitionExpressions.nonEmpty && partitionExpressions.forall(_.foldable) &&
         numPartitions.isEmpty =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeRepartitionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeRepartitionSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class OptimizeRepartitionSuite extends PlanTest {
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("OptimizeRepartition", FixedPoint(10),
+        OptimizeRepartition) :: Nil
+  }
+
+  val testRelation = LocalRelation.fromExternalRows(
+    Seq('a.int, 'b.int, 'c.int),
+    Seq(Row(1, 2, 3), Row(4, 5, 6)))
+
+  test("Remove repartition if the child maximum number of rows less than or equal to 1") {
+    comparePlans(
+      Optimize.execute(testRelation.limit(1).repartition(10).analyze),
+      testRelation.limit(1).analyze)
+    comparePlans(
+      Optimize.execute(testRelation.groupBy()(count(1).as("cnt")).coalesce(1)).analyze,
+      testRelation.groupBy()(count(1).as("cnt")).analyze)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1577,20 +1577,20 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
 
       withTempView("t1", "t2", "t3") {
         withSQLConf(SQLConf.CAN_CHANGE_CACHED_PLAN_OUTPUT_PARTITIONING.key -> "false") {
-          sql("CACHE TABLE t1 as SELECT /*+ REPARTITION */ * FROM values(1) as t(c)")
+          sql("CACHE TABLE t1 as SELECT /*+ REPARTITION */ * FROM values (1), (2) as t(c)")
           assert(spark.table("t1").rdd.partitions.length == 2)
         }
 
         withSQLConf(SQLConf.CAN_CHANGE_CACHED_PLAN_OUTPUT_PARTITIONING.key -> "true") {
           assert(spark.table("t1").rdd.partitions.length == 2)
-          sql("CACHE TABLE t2 as SELECT /*+ REPARTITION */ * FROM values(2) as t(c)")
+          sql("CACHE TABLE t2 as SELECT /*+ REPARTITION */ * FROM values (2), (3) as t(c)")
           assert(spark.table("t2").rdd.partitions.length == 1)
         }
 
         withSQLConf(SQLConf.CAN_CHANGE_CACHED_PLAN_OUTPUT_PARTITIONING.key -> "false") {
           assert(spark.table("t1").rdd.partitions.length == 2)
           assert(spark.table("t2").rdd.partitions.length == 1)
-          sql("CACHE TABLE t3 as SELECT /*+ REPARTITION */ * FROM values(3) as t(c)")
+          sql("CACHE TABLE t3 as SELECT /*+ REPARTITION */ * FROM values(3), (4) as t(c)")
           assert(spark.table("t3").rdd.partitions.length == 2)
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3695,7 +3695,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
   test("Fold RepartitionExpression num partition should check if partition expression is empty") {
     withSQLConf((SQLConf.SHUFFLE_PARTITIONS.key, "5")) {
-      val df = spark.range(1).hint("REPARTITION_BY_RANGE")
+      val df = spark.range(2).hint("REPARTITION_BY_RANGE")
       val plan = df.queryExecution.optimizedPlan
       val res = plan.collect {
         case r: RepartitionByExpression if r.numPartitions == 5 => true

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -367,7 +367,7 @@ abstract class OrcSuite extends OrcTest with BeforeAndAfterAll with CommonFileDa
 
   test("Write Spark version into ORC file metadata") {
     withTempPath { path =>
-      spark.range(1).repartition(1).write.orc(path.getCanonicalPath)
+      spark.range(2).repartition(1).write.orc(path.getCanonicalPath)
 
       val partFiles = path.listFiles()
         .filter(f => f.isFile && !f.getName.startsWith(".") && !f.getName.startsWith("_"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
@@ -43,9 +43,9 @@ abstract class ParquetFileFormatSuite
         val path2 = new Path(basePath, "second")
         val path3 = new Path(basePath, "third")
 
-        spark.range(1).toDF("a").coalesce(1).write.parquet(path1.toString)
-        spark.range(1, 2).toDF("a").coalesce(1).write.parquet(path2.toString)
-        spark.range(2, 3).toDF("a").coalesce(1).write.json(path3.toString)
+        spark.range(2).toDF("a").coalesce(1).write.parquet(path1.toString)
+        spark.range(1, 3).toDF("a").coalesce(1).write.parquet(path2.toString)
+        spark.range(2, 4).toDF("a").coalesce(1).write.json(path3.toString)
 
         val fileStatuses =
           Seq(fs.listStatus(path1), fs.listStatus(path2), fs.listStatus(path3)).flatten


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enhance `OptimizeRepartition` to remove repartition if the child maximum number of rows less than or equal to 1. For example:
```scala
spark.sql("select count(*) from range(1, 10, 2, 2)").repartition(10).explain("cost")
```

Before this PR:
```
== Optimized Logical Plan ==
Repartition 10, true, Statistics(sizeInBytes=16.0 B, rowCount=1)
+- Aggregate [count(1) AS count(1)#2L], Statistics(sizeInBytes=16.0 B, rowCount=1)
   +- Project, Statistics(sizeInBytes=20.0 B)
      +- Range (1, 10, step=2, splits=Some(2)), Statistics(sizeInBytes=40.0 B, rowCount=5)
```

After this PR:
```
== Optimized Logical Plan ==
Aggregate [count(1) AS count(1)#2L], Statistics(sizeInBytes=16.0 B, rowCount=1)
+- Project, Statistics(sizeInBytes=20.0 B)
   +- Range (1, 10, step=2, splits=Some(2)), Statistics(sizeInBytes=40.0 B, rowCount=5)
```

### Why are the changes needed?

Improve query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.
