### PR TITLE
[SPARK-35913][SQL] Create hive permanent function with owner name

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -925,7 +925,7 @@ private[hive] class HiveClientImpl(
   }
 
   override def createFunction(db: String, func: CatalogFunction): Unit = withHiveState {
-    shim.createFunction(client, db, func)
+    shim.createFunction(client, db, func, userName)
   }
 
   override def dropFunction(db: String, name: String): Unit = withHiveState {
@@ -933,11 +933,11 @@ private[hive] class HiveClientImpl(
   }
 
   override def renameFunction(db: String, oldName: String, newName: String): Unit = withHiveState {
-    shim.renameFunction(client, db, oldName, newName)
+    shim.renameFunction(client, db, oldName, newName, userName)
   }
 
   override def alterFunction(db: String, func: CatalogFunction): Unit = withHiveState {
-    shim.alterFunction(client, db, func)
+    shim.alterFunction(client, db, func, userName)
   }
 
   override def getFunctionOption(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -933,7 +933,7 @@ private[hive] class HiveClientImpl(
   }
 
   override def renameFunction(db: String, oldName: String, newName: String): Unit = withHiveState {
-    shim.renameFunction(client, db, oldName, newName, userName)
+    shim.renameFunction(client, db, oldName, newName)
   }
 
   override def alterFunction(db: String, func: CatalogFunction): Unit = withHiveState {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -137,7 +137,7 @@ private[client] sealed abstract class Shim {
 
   def dropFunction(hive: Hive, db: String, name: String): Unit
 
-  def renameFunction(hive: Hive, db: String, oldName: String, newName: String, owner: String): Unit
+  def renameFunction(hive: Hive, db: String, oldName: String, newName: String): Unit
 
   def alterFunction(hive: Hive, db: String, func: CatalogFunction, owner: String): Unit
 
@@ -464,11 +464,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
     throw new NoSuchPermanentFunctionException(db, name)
   }
 
-  def renameFunction(hive: Hive,
-       db: String,
-       oldName: String,
-       newName: String,
-       owner: String): Unit = {
+  def renameFunction(hive: Hive, db: String, oldName: String, newName: String): Unit = {
     throw new NoSuchPermanentFunctionException(db, oldName)
   }
 
@@ -588,15 +584,11 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
     hive.dropFunction(db, name)
   }
 
-  override def renameFunction(hive: Hive,
-      db: String,
-      oldName: String,
-      newName: String,
-      owner: String): Unit = {
+  override def renameFunction(hive: Hive, db: String, oldName: String, newName: String): Unit = {
     val catalogFunc = getFunctionOption(hive, db, oldName)
       .getOrElse(throw new NoSuchPermanentFunctionException(db, oldName))
       .copy(identifier = FunctionIdentifier(newName, Some(db)))
-    val hiveFunc = toHiveFunction(catalogFunc, db, owner)
+    val hiveFunc = toHiveFunction(catalogFunc, db, hive.getFunction(db, oldName).getOwnerName)
     hive.alterFunction(db, oldName, hiveFunc)
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -460,11 +460,15 @@ private[client] class Shim_v0_12 extends Shim with Logging {
     throw QueryCompilationErrors.hiveCreatePermanentFunctionsUnsupportedError()
   }
 
-  def dropFunction(hive: Hive, db: String, name: String, owner: String): Unit = {
+  def dropFunction(hive: Hive, db: String, name: String): Unit = {
     throw new NoSuchPermanentFunctionException(db, name)
   }
 
-  def renameFunction(hive: Hive, db: String, oldName: String, newName: String): Unit = {
+  def renameFunction(hive: Hive,
+       db: String,
+       oldName: String,
+       newName: String,
+       owner: String): Unit = {
     throw new NoSuchPermanentFunctionException(db, oldName)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Create hive permanent function with owner name


### Why are the changes needed?
The hive permanent function created by spark does not have an owner name, while the permanent function created by hive has an owner name


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
manual test
