### PR TITLE
[SPARK-35859][PYTHON] Cleanup type hints in pandas-on-Spark

### DIFF
--- a/python/pyspark/pandas/_typing.py
+++ b/python/pyspark/pandas/_typing.py
@@ -23,19 +23,24 @@ from pandas.api.extensions import ExtensionDtype
 
 if TYPE_CHECKING:
     from pyspark.pandas.base import IndexOpsMixin  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.frame import DataFrame  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.generic import Frame  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.indexes.base import Index  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
+# TypeVars
 T = TypeVar("T")
 
+IndexOpsLike = TypeVar("IndexOpsLike", bound="IndexOpsMixin")
+FrameLike = TypeVar("FrameLike", bound="Frame")
+
+# Type aliases
 Scalar = Union[
     int, float, bool, str, bytes, decimal.Decimal, datetime.date, datetime.datetime, None
 ]
 
 Dtype = Union[np.dtype, ExtensionDtype]
 
+DataFrameOrSeries = Union["DataFrame", "Series"]
 SeriesOrIndex = Union["Series", "Index"]
-IndexOpsLike = TypeVar("IndexOpsLike", bound="IndexOpsMixin")
-FrameLike = TypeVar("FrameLike", bound="Frame")

--- a/python/pyspark/pandas/_typing.py
+++ b/python/pyspark/pandas/_typing.py
@@ -36,6 +36,6 @@ Scalar = Union[
 
 Dtype = Union[np.dtype, ExtensionDtype]
 
-IndexOpsLike = Union["Series", "Index"]
+SeriesOrIndex = Union["Series", "Index"]
 T_IndexOps = TypeVar("T_IndexOps", bound="IndexOpsMixin")
 T_Frame = TypeVar("T_Frame", bound="Frame")

--- a/python/pyspark/pandas/_typing.py
+++ b/python/pyspark/pandas/_typing.py
@@ -37,5 +37,5 @@ Scalar = Union[
 Dtype = Union[np.dtype, ExtensionDtype]
 
 SeriesOrIndex = Union["Series", "Index"]
-T_IndexOps = TypeVar("T_IndexOps", bound="IndexOpsMixin")
-T_Frame = TypeVar("T_Frame", bound="Frame")
+IndexOpsLike = TypeVar("IndexOpsLike", bound="IndexOpsMixin")
+FrameLike = TypeVar("FrameLike", bound="Frame")

--- a/python/pyspark/pandas/_typing.py
+++ b/python/pyspark/pandas/_typing.py
@@ -32,8 +32,8 @@ if TYPE_CHECKING:
 # TypeVars
 T = TypeVar("T")
 
-IndexOpsLike = TypeVar("IndexOpsLike", bound="IndexOpsMixin")
 FrameLike = TypeVar("FrameLike", bound="Frame")
+IndexOpsLike = TypeVar("IndexOpsLike", bound="IndexOpsMixin")
 
 # Type aliases
 Scalar = Union[

--- a/python/pyspark/pandas/_typing.py
+++ b/python/pyspark/pandas/_typing.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import datetime
+import decimal
+from typing import TypeVar, Union, TYPE_CHECKING
+
+import numpy as np
+from pandas.api.extensions import ExtensionDtype
+
+if TYPE_CHECKING:
+    from pyspark.pandas.base import IndexOpsMixin  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.generic import Frame  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.indexes.base import Index  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
+
+
+T = TypeVar("T")
+
+Scalar = Union[
+    int, float, bool, str, bytes, decimal.Decimal, datetime.date, datetime.datetime, None
+]
+
+Dtype = Union[np.dtype, ExtensionDtype]
+
+IndexOpsLike = Union["Series", "Index"]
+T_IndexOps = TypeVar("T_IndexOps", bound="IndexOpsMixin")
+T_Frame = TypeVar("T_Frame", bound="Frame")

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -28,6 +28,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import DataType, LongType, StructField, StructType
 
+from pyspark.pandas._typing import DataFrameOrSeries
 from pyspark.pandas.internal import (
     InternalField,
     InternalFrame,
@@ -415,7 +416,7 @@ class PandasOnSparkFrameMethods(object):
 
     def transform_batch(
         self, func: Callable[..., Union[pd.DataFrame, pd.Series]], *args: Any, **kwargs: Any
-    ) -> Union["DataFrame", "Series"]:
+    ) -> DataFrameOrSeries:
         """
         Transform chunks with a function that takes pandas DataFrame and outputs pandas DataFrame.
         The pandas DataFrame given to the function is of a batch used internally. The length of

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -21,7 +21,7 @@ Base and utility classes for pandas-on-Spark objects.
 from abc import ABCMeta, abstractmethod
 from functools import wraps, partial
 from itertools import chain
-from typing import Any, Callable, Optional, Sequence, Tuple, TypeVar, Union, cast, TYPE_CHECKING
+from typing import Any, Callable, Optional, Sequence, Tuple, Union, cast, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd  # noqa: F401
@@ -35,6 +35,7 @@ from pyspark.sql.types import (
 )
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
+from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
 from pyspark.pandas.config import get_option, option_context
 from pyspark.pandas.internal import (
     InternalField,
@@ -43,10 +44,7 @@ from pyspark.pandas.internal import (
     SPARK_DEFAULT_INDEX_NAME,
 )
 from pyspark.pandas.spark.accessors import SparkIndexOpsMethods
-from pyspark.pandas.typedef import (
-    Dtype,
-    extension_dtypes,
-)
+from pyspark.pandas.typedef import extension_dtypes
 from pyspark.pandas.utils import (
     combine_frames,
     same_anchor,
@@ -58,12 +56,7 @@ from pyspark.pandas.frame import DataFrame
 
 if TYPE_CHECKING:
     from pyspark.pandas.data_type_ops.base import DataTypeOps  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
-
-
-T_IndexOps = TypeVar("T_IndexOps", bound="IndexOpsMixin")
-IndexOpsLike = Union["Series", "Index"]
 
 
 def should_alignment_for_column_op(self: IndexOpsLike, other: IndexOpsLike) -> bool:

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -55,6 +55,8 @@ from pyspark.pandas.utils import (
 from pyspark.pandas.frame import DataFrame
 
 if TYPE_CHECKING:
+    from pyspark.sql._typing import ColumnOrName  # noqa: F401 (SPARK-34943)
+
     from pyspark.pandas.data_type_ops.base import DataTypeOps  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
@@ -1125,11 +1127,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return self._shift(periods, fill_value).spark.analyzed
 
     def _shift(
-        self: T_IndexOps,
-        periods: int,
-        fill_value: Any,
-        *,
-        part_cols: Sequence[Union[str, Column]] = ()
+        self: T_IndexOps, periods: int, fill_value: Any, *, part_cols: Sequence["ColumnOrName"] = ()
     ) -> T_IndexOps:
         if not isinstance(periods, int):
             raise TypeError("periods should be an int; however, got [%s]" % type(periods).__name__)

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -817,7 +817,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         >>> ser.rename("a").to_frame().set_index("a").index.astype('int64')
         Int64Index([1, 2], dtype='int64', name='a')
         """
-        return cast(IndexOpsLike, self._dtype_op.astype(cast(SeriesOrIndex, self), dtype))
+        return self._dtype_op.astype(self, dtype)
 
     def isin(self: IndexOpsLike, values: Sequence[Any]) -> IndexOpsLike:
         """

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -26,8 +26,7 @@ from typing import Any, Callable, Optional, Sequence, Tuple, Union, cast, TYPE_C
 import numpy as np
 import pandas as pd  # noqa: F401
 from pandas.api.types import is_list_like, CategoricalDtype
-from pyspark import sql as spark
-from pyspark.sql import functions as F, Window, Column
+from pyspark.sql import functions as F, Column, Window
 from pyspark.sql.types import (
     DoubleType,
     FloatType,
@@ -291,7 +290,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     @abstractmethod
     def _with_new_scol(
-        self: IndexOpsLike, scol: spark.Column, *, field: Optional[InternalField] = None
+        self: IndexOpsLike, scol: Column, *, field: Optional[InternalField] = None
     ) -> IndexOpsLike:
         pass
 

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -42,7 +42,7 @@ from pyspark.sql.types import (
     TimestampType,
     UserDefinedType,
 )
-from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
+from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.typedef import extension_dtypes
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
@@ -99,8 +99,8 @@ def transform_boolean_operand_to_numeric(
 
 
 def _as_categorical_type(
-    index_ops: T_IndexOps, dtype: CategoricalDtype, spark_type: DataType
-) -> T_IndexOps:
+    index_ops: IndexOpsLike, dtype: CategoricalDtype, spark_type: DataType
+) -> IndexOpsLike:
     """Cast `index_ops` to categorical dtype, given `dtype` and `spark_type`."""
     assert isinstance(dtype, CategoricalDtype)
     if dtype.categories is None:
@@ -128,7 +128,7 @@ def _as_categorical_type(
         )
 
 
-def _as_bool_type(index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+def _as_bool_type(index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
     """Cast `index_ops` to BooleanType Spark type, given `dtype`."""
     from pyspark.pandas.internal import InternalField
 
@@ -145,8 +145,8 @@ def _as_bool_type(index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_In
 
 
 def _as_string_type(
-    index_ops: T_IndexOps, dtype: Union[str, type, Dtype], *, null_str: str = str(None)
-) -> T_IndexOps:
+    index_ops: IndexOpsLike, dtype: Union[str, type, Dtype], *, null_str: str = str(None)
+) -> IndexOpsLike:
     """Cast `index_ops` to StringType Spark type, given `dtype` and `null_str`,
     representing null Spark column.
     """
@@ -164,8 +164,8 @@ def _as_string_type(
 
 
 def _as_other_type(
-    index_ops: T_IndexOps, dtype: Union[str, type, Dtype], spark_type: DataType
-) -> T_IndexOps:
+    index_ops: IndexOpsLike, dtype: Union[str, type, Dtype], spark_type: DataType
+) -> IndexOpsLike:
     """Cast `index_ops` to a `dtype` (`spark_type`) that needs no pre-processing.
 
     Destination types that need pre-processing: CategoricalDtype, BooleanType, and StringType.
@@ -263,58 +263,58 @@ class DataTypeOps(object, metaclass=ABCMeta):
     def pretty_name(self) -> str:
         raise NotImplementedError()
 
-    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def add(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Addition can not be applied to %s." % self.pretty_name)
 
-    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Subtraction can not be applied to %s." % self.pretty_name)
 
-    def mul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Multiplication can not be applied to %s." % self.pretty_name)
 
-    def truediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("True division can not be applied to %s." % self.pretty_name)
 
-    def floordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Floor division can not be applied to %s." % self.pretty_name)
 
-    def mod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Modulo can not be applied to %s." % self.pretty_name)
 
-    def pow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def pow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Exponentiation can not be applied to %s." % self.pretty_name)
 
-    def radd(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def radd(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Addition can not be applied to %s." % self.pretty_name)
 
-    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Subtraction can not be applied to %s." % self.pretty_name)
 
-    def rmul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rmul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Multiplication can not be applied to %s." % self.pretty_name)
 
-    def rtruediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("True division can not be applied to %s." % self.pretty_name)
 
-    def rfloordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Floor division can not be applied to %s." % self.pretty_name)
 
-    def rmod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Modulo can not be applied to %s." % self.pretty_name)
 
-    def rpow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rpow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Exponentiation can not be applied to %s." % self.pretty_name)
 
-    def __and__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def __and__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Bitwise and can not be applied to %s." % self.pretty_name)
 
-    def __or__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def __or__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("Bitwise or can not be applied to %s." % self.pretty_name)
 
-    def rand(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rand(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         return left.__and__(right)
 
-    def ror(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def ror(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         return left.__or__(right)
 
     def restore(self, col: pd.Series) -> pd.Series:
@@ -325,7 +325,7 @@ class DataTypeOps(object, metaclass=ABCMeta):
         """Prepare column when from_pandas."""
         return col.replace({np.nan: None})
 
-    def isnull(self, index_ops: T_IndexOps) -> T_IndexOps:
+    def isnull(self, index_ops: IndexOpsLike) -> IndexOpsLike:
         return index_ops._with_new_scol(
             index_ops.spark.column.isNull(),
             field=index_ops._internal.data_fields[0].copy(
@@ -333,5 +333,5 @@ class DataTypeOps(object, metaclass=ABCMeta):
             ),
         )
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         raise TypeError("astype can not be applied to %s." % self.pretty_name)

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -42,7 +42,7 @@ from pyspark.sql.types import (
     TimestampType,
     UserDefinedType,
 )
-from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
+from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
 from pyspark.pandas.typedef import extension_dtypes
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
@@ -263,58 +263,58 @@ class DataTypeOps(object, metaclass=ABCMeta):
     def pretty_name(self) -> str:
         raise NotImplementedError()
 
-    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Addition can not be applied to %s." % self.pretty_name)
 
-    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Subtraction can not be applied to %s." % self.pretty_name)
 
-    def mul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def mul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Multiplication can not be applied to %s." % self.pretty_name)
 
-    def truediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def truediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("True division can not be applied to %s." % self.pretty_name)
 
-    def floordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def floordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Floor division can not be applied to %s." % self.pretty_name)
 
-    def mod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def mod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Modulo can not be applied to %s." % self.pretty_name)
 
-    def pow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def pow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Exponentiation can not be applied to %s." % self.pretty_name)
 
-    def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def radd(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Addition can not be applied to %s." % self.pretty_name)
 
-    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Subtraction can not be applied to %s." % self.pretty_name)
 
-    def rmul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rmul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Multiplication can not be applied to %s." % self.pretty_name)
 
-    def rtruediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rtruediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("True division can not be applied to %s." % self.pretty_name)
 
-    def rfloordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rfloordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Floor division can not be applied to %s." % self.pretty_name)
 
-    def rmod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rmod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Modulo can not be applied to %s." % self.pretty_name)
 
-    def rpow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rpow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Exponentiation can not be applied to %s." % self.pretty_name)
 
-    def __and__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def __and__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Bitwise and can not be applied to %s." % self.pretty_name)
 
-    def __or__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def __or__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("Bitwise or can not be applied to %s." % self.pretty_name)
 
-    def rand(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rand(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         return left.__and__(right)
 
-    def ror(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def ror(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         return left.__or__(right)
 
     def restore(self, col: pd.Series) -> pd.Series:

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -18,7 +18,7 @@
 import numbers
 from abc import ABCMeta
 from itertools import chain
-from typing import Any, Optional, TypeVar, Union, TYPE_CHECKING
+from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -42,7 +42,8 @@ from pyspark.sql.types import (
     TimestampType,
     UserDefinedType,
 )
-from pyspark.pandas.typedef import Dtype, extension_dtypes
+from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
+from pyspark.pandas.typedef import extension_dtypes
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
     extension_float_dtypes_available,
@@ -57,15 +58,6 @@ if extension_float_dtypes_available:
 
 if extension_object_dtypes_available:
     from pandas import BooleanDtype, StringDtype
-
-if TYPE_CHECKING:
-    from pyspark.pandas.base import IndexOpsMixin  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
-
-
-T_IndexOps = TypeVar("T_IndexOps", bound="IndexOpsMixin")
-IndexOpsLike = Union["Series", "Index"]
 
 
 def is_valid_operand_for_numeric_arithmetic(operand: Any, *, allow_bool: bool = True) -> bool:

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -20,7 +20,7 @@ from typing import Any, Union, cast
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
+from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     _as_bool_type,
@@ -42,7 +42,7 @@ class BinaryOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "binaries"
 
-    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def add(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, BinaryType):
             return column_op(F.concat)(left, right)
         elif isinstance(right, bytes):
@@ -52,7 +52,7 @@ class BinaryOps(DataTypeOps):
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def radd(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def radd(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, bytes):
             return cast(
                 SeriesOrIndex, left._with_new_scol(F.concat(F.lit(right), left.spark.column))
@@ -62,7 +62,7 @@ class BinaryOps(DataTypeOps):
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype):

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -20,7 +20,7 @@ from typing import Any, Union, cast
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
+from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     _as_bool_type,
@@ -42,7 +42,7 @@ class BinaryOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "binaries"
 
-    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, BinaryType):
             return column_op(F.concat)(left, right)
         elif isinstance(right, bytes):
@@ -52,10 +52,10 @@ class BinaryOps(DataTypeOps):
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def radd(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, bytes):
             return cast(
-                IndexOpsLike, left._with_new_scol(F.concat(F.lit(right), left.spark.column))
+                SeriesOrIndex, left._with_new_scol(F.concat(F.lit(right), left.spark.column))
             )
         else:
             raise TypeError(

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -20,16 +20,15 @@ from typing import Any, Union, cast
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
+from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
-    IndexOpsLike,
-    T_IndexOps,
     _as_bool_type,
     _as_categorical_type,
     _as_other_type,
     _as_string_type,
 )
-from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
+from pyspark.pandas.typedef import pandas_on_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.types import BinaryType, BooleanType, StringType
 

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -22,10 +22,9 @@ import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
+from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
-    IndexOpsLike,
-    T_IndexOps,
     is_valid_operand_for_numeric_arithmetic,
     transform_boolean_operand_to_numeric,
     _as_bool_type,
@@ -33,7 +32,7 @@ from pyspark.pandas.data_type_ops.base import (
     _as_other_type,
 )
 from pyspark.pandas.internal import InternalField
-from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.typedef import extension_dtypes, pandas_on_spark_type
 from pyspark.pandas.typedef.typehints import as_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.column import Column

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -22,7 +22,7 @@ import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
+from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     is_valid_operand_for_numeric_arithmetic,
@@ -48,7 +48,7 @@ class BooleanOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "booleans"
 
-    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError(
                 "Addition can not be applied to %s and the given type." % self.pretty_name
@@ -67,7 +67,7 @@ class BooleanOps(DataTypeOps):
                 left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
                 return left + right
 
-    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name
@@ -80,7 +80,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left - right
 
-    def mul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def mul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError(
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name
@@ -98,7 +98,7 @@ class BooleanOps(DataTypeOps):
                 left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
                 return left * right
 
-    def truediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def truediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "True division can not be applied to %s and the given type." % self.pretty_name
@@ -111,7 +111,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left / right
 
-    def floordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def floordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Floor division can not be applied to %s and the given type." % self.pretty_name
@@ -124,7 +124,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left // right
 
-    def mod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def mod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Modulo can not be applied to %s and the given type." % self.pretty_name
@@ -137,7 +137,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left % right
 
-    def pow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def pow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name
@@ -150,7 +150,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left ** right
 
-    def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def radd(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, bool):
             return left.__or__(right)
         elif isinstance(right, numbers.Number):
@@ -161,7 +161,7 @@ class BooleanOps(DataTypeOps):
                 "Addition can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right - left
@@ -170,7 +170,7 @@ class BooleanOps(DataTypeOps):
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rmul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rmul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, bool):
             return left.__and__(right)
         elif isinstance(right, numbers.Number):
@@ -181,7 +181,7 @@ class BooleanOps(DataTypeOps):
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rtruediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rtruediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right / left
@@ -190,7 +190,7 @@ class BooleanOps(DataTypeOps):
                 "True division can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rfloordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rfloordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right // left
@@ -199,7 +199,7 @@ class BooleanOps(DataTypeOps):
                 "Floor division can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rpow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rpow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right ** left
@@ -208,7 +208,7 @@ class BooleanOps(DataTypeOps):
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rmod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rmod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right % left
@@ -217,7 +217,7 @@ class BooleanOps(DataTypeOps):
                 "Modulo can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def __and__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def __and__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__and__(left)
         else:
@@ -233,7 +233,7 @@ class BooleanOps(DataTypeOps):
 
             return column_op(and_func)(left, right)
 
-    def __or__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def __or__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__or__(left)
         else:
@@ -278,7 +278,7 @@ class BooleanExtensionOps(BooleanOps):
     and dtype BooleanDtype.
     """
 
-    def __and__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def __and__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         def and_func(left: Column, right: Any) -> Column:
             if not isinstance(right, Column):
                 if pd.isna(right):
@@ -289,7 +289,7 @@ class BooleanExtensionOps(BooleanOps):
 
         return column_op(and_func)(left, right)
 
-    def __or__(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def __or__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         def or_func(left: Column, right: Any) -> Column:
             if not isinstance(right, Column):
                 if pd.isna(right):

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -22,7 +22,7 @@ import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas.base import column_op, IndexOpsMixin
-from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
+from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     is_valid_operand_for_numeric_arithmetic,
@@ -48,7 +48,7 @@ class BooleanOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "booleans"
 
-    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def add(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError(
                 "Addition can not be applied to %s and the given type." % self.pretty_name
@@ -67,7 +67,7 @@ class BooleanOps(DataTypeOps):
                 left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
                 return left + right
 
-    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name
@@ -80,7 +80,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left - right
 
-    def mul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError(
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name
@@ -98,7 +98,7 @@ class BooleanOps(DataTypeOps):
                 left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
                 return left * right
 
-    def truediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "True division can not be applied to %s and the given type." % self.pretty_name
@@ -111,7 +111,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left / right
 
-    def floordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Floor division can not be applied to %s and the given type." % self.pretty_name
@@ -124,7 +124,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left // right
 
-    def mod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Modulo can not be applied to %s and the given type." % self.pretty_name
@@ -137,7 +137,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left % right
 
-    def pow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def pow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right, allow_bool=False):
             raise TypeError(
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name
@@ -150,7 +150,7 @@ class BooleanOps(DataTypeOps):
             left = transform_boolean_operand_to_numeric(left, right.spark.data_type)
             return left ** right
 
-    def radd(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def radd(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, bool):
             return left.__or__(right)
         elif isinstance(right, numbers.Number):
@@ -161,7 +161,7 @@ class BooleanOps(DataTypeOps):
                 "Addition can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right - left
@@ -170,7 +170,7 @@ class BooleanOps(DataTypeOps):
                 "Subtraction can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rmul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rmul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, bool):
             return left.__and__(right)
         elif isinstance(right, numbers.Number):
@@ -181,7 +181,7 @@ class BooleanOps(DataTypeOps):
                 "Multiplication can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rtruediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right / left
@@ -190,7 +190,7 @@ class BooleanOps(DataTypeOps):
                 "True division can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rfloordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right // left
@@ -199,7 +199,7 @@ class BooleanOps(DataTypeOps):
                 "Floor division can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rpow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rpow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right ** left
@@ -208,7 +208,7 @@ class BooleanOps(DataTypeOps):
                 "Exponentiation can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def rmod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, numbers.Number) and not isinstance(right, bool):
             left = left.spark.transform(lambda scol: scol.cast(as_spark_type(type(right))))
             return right % left
@@ -217,7 +217,7 @@ class BooleanOps(DataTypeOps):
                 "Modulo can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def __and__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def __and__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__and__(left)
         else:
@@ -233,7 +233,7 @@ class BooleanOps(DataTypeOps):
 
             return column_op(and_func)(left, right)
 
-    def __or__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def __or__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__or__(left)
         else:
@@ -247,7 +247,7 @@ class BooleanOps(DataTypeOps):
 
             return column_op(or_func)(left, right)
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype):
@@ -278,7 +278,7 @@ class BooleanExtensionOps(BooleanOps):
     and dtype BooleanDtype.
     """
 
-    def __and__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def __and__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         def and_func(left: Column, right: Any) -> Column:
             if not isinstance(right, Column):
                 if pd.isna(right):
@@ -289,7 +289,7 @@ class BooleanExtensionOps(BooleanOps):
 
         return column_op(and_func)(left, right)
 
-    def __or__(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def __or__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         def or_func(left: Column, right: Any) -> Column:
             if not isinstance(right, Column):
                 if pd.isna(right):

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -21,7 +21,7 @@ from typing import Union
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas._typing import Dtype, T_IndexOps
+from pyspark.pandas._typing import Dtype, IndexOpsLike
 from pyspark.pandas.data_type_ops.base import DataTypeOps
 from pyspark.pandas.typedef import pandas_on_spark_type
 from pyspark.sql import functions as F
@@ -46,7 +46,7 @@ class CategoricalOps(DataTypeOps):
         """Prepare column when from_pandas."""
         return col.cat.codes
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype) and dtype.categories is None:

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -21,8 +21,9 @@ from typing import Union
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas.data_type_ops.base import DataTypeOps, T_IndexOps
-from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
+from pyspark.pandas._typing import Dtype, T_IndexOps
+from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.pandas.typedef import pandas_on_spark_type
 from pyspark.sql import functions as F
 
 

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -19,17 +19,16 @@ from typing import Any, Union, cast
 
 from pandas.api.types import CategoricalDtype
 
+from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
-    IndexOpsLike,
-    T_IndexOps,
     _as_bool_type,
     _as_categorical_type,
     _as_other_type,
     _as_string_type,
 )
-from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
+from pyspark.pandas.typedef import pandas_on_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.types import ArrayType, BooleanType, NumericType, StringType
 

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -19,7 +19,7 @@ from typing import Any, Union, cast
 
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
+from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
@@ -42,7 +42,7 @@ class ArrayOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "arrays"
 
-    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if not isinstance(right, IndexOpsMixin) or (
             isinstance(right, IndexOpsMixin) and not isinstance(right.spark.data_type, ArrayType)
         ):

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -19,7 +19,7 @@ from typing import Any, Union, cast
 
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
+from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
@@ -42,7 +42,7 @@ class ArrayOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "arrays"
 
-    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def add(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, IndexOpsMixin) or (
             isinstance(right, IndexOpsMixin) and not isinstance(right.spark.data_type, ArrayType)
         ):
@@ -62,7 +62,7 @@ class ArrayOps(DataTypeOps):
 
         return column_op(F.concat)(left, right)
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype):

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -25,17 +25,16 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, DateType, StringType
 
+from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
-    IndexOpsLike,
-    T_IndexOps,
     _as_bool_type,
     _as_categorical_type,
     _as_other_type,
     _as_string_type,
 )
-from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
+from pyspark.pandas.typedef import pandas_on_spark_type
 
 
 class DateOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -25,7 +25,7 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, DateType, StringType
 
-from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
+from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
@@ -46,7 +46,7 @@ class DateOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "dates"
 
-    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         # Note that date subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' in days from date's subtraction.
         msg = (
@@ -63,7 +63,7 @@ class DateOps(DataTypeOps):
         else:
             raise TypeError("date subtraction can only be applied to date series.")
 
-    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         # Note that date subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' in days from date's subtraction.
         msg = (
@@ -77,7 +77,7 @@ class DateOps(DataTypeOps):
         else:
             raise TypeError("date subtraction can only be applied to date series.")
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype):

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -25,7 +25,7 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, DateType, StringType
 
-from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
+from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
@@ -46,7 +46,7 @@ class DateOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "dates"
 
-    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         # Note that date subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' in days from date's subtraction.
         msg = (
@@ -63,7 +63,7 @@ class DateOps(DataTypeOps):
         else:
             raise TypeError("date subtraction can only be applied to date series.")
 
-    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         # Note that date subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' in days from date's subtraction.
         msg = (

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -25,7 +25,7 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, StringType, TimestampType
 
-from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
+from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
@@ -46,7 +46,7 @@ class DatetimeOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "datetimes"
 
-    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         # Note that timestamp subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' from 'datetime64[ns]'s subtraction.
         msg = (
@@ -68,7 +68,7 @@ class DatetimeOps(DataTypeOps):
         else:
             raise TypeError("datetime subtraction can only be applied to datetime series.")
 
-    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         # Note that timestamp subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' from 'datetime64[ns]'s subtraction.
         msg = (
@@ -91,7 +91,7 @@ class DatetimeOps(DataTypeOps):
         """Prepare column when from_pandas."""
         return col
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype):

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -25,17 +25,16 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, StringType, TimestampType
 
+from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
-    IndexOpsLike,
-    T_IndexOps,
     _as_bool_type,
     _as_categorical_type,
     _as_other_type,
 )
 from pyspark.pandas.internal import InternalField
-from pyspark.pandas.typedef import as_spark_type, Dtype, extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.typedef import as_spark_type, extension_dtypes, pandas_on_spark_type
 
 
 class DatetimeOps(DataTypeOps):

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -25,7 +25,7 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, StringType, TimestampType
 
-from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
+from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
@@ -46,7 +46,7 @@ class DatetimeOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "datetimes"
 
-    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         # Note that timestamp subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' from 'datetime64[ns]'s subtraction.
         msg = (
@@ -60,7 +60,7 @@ class DatetimeOps(DataTypeOps):
         elif isinstance(right, datetime.datetime):
             warnings.warn(msg, UserWarning)
             return cast(
-                IndexOpsLike,
+                SeriesOrIndex,
                 left.spark.transform(
                     lambda scol: scol.astype("long") - F.lit(right).cast(as_spark_type("long"))
                 ),
@@ -68,7 +68,7 @@ class DatetimeOps(DataTypeOps):
         else:
             raise TypeError("datetime subtraction can only be applied to datetime series.")
 
-    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         # Note that timestamp subtraction casts arguments to integer. This is to mimic pandas's
         # behaviors. pandas returns 'timedelta64[ns]' from 'datetime64[ns]'s subtraction.
         msg = (
@@ -79,7 +79,7 @@ class DatetimeOps(DataTypeOps):
         if isinstance(right, datetime.datetime):
             warnings.warn(msg, UserWarning)
             return cast(
-                IndexOpsLike,
+                SeriesOrIndex,
                 left.spark.transform(
                     lambda scol: F.lit(right).cast(as_spark_type("long")) - scol.astype("long")
                 ),

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -19,15 +19,15 @@ from typing import Union
 
 from pandas.api.types import CategoricalDtype
 
+from pyspark.pandas._typing import Dtype, T_IndexOps
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
-    T_IndexOps,
     _as_bool_type,
     _as_categorical_type,
     _as_other_type,
     _as_string_type,
 )
-from pyspark.pandas.typedef import Dtype, pandas_on_spark_type
+from pyspark.pandas.typedef import pandas_on_spark_type
 from pyspark.sql.types import BooleanType, StringType
 
 

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -19,7 +19,7 @@ from typing import Union
 
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas._typing import Dtype, T_IndexOps
+from pyspark.pandas._typing import Dtype, IndexOpsLike
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     _as_bool_type,
@@ -40,7 +40,7 @@ class NullOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "nulls"
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype):

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -22,11 +22,10 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
+from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
 from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
-    IndexOpsLike,
-    T_IndexOps,
     is_valid_operand_for_numeric_arithmetic,
     transform_boolean_operand_to_numeric,
     _as_bool_type,
@@ -36,7 +35,7 @@ from pyspark.pandas.data_type_ops.base import (
 )
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.spark import functions as SF
-from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.typedef import extension_dtypes, pandas_on_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.column import Column
 from pyspark.sql.types import (

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
+from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
 from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
@@ -52,7 +52,7 @@ class NumericOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "numerics"
 
-    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -65,7 +65,7 @@ class NumericOps(DataTypeOps):
 
         return column_op(Column.__add__)(left, right)
 
-    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -78,7 +78,7 @@ class NumericOps(DataTypeOps):
 
         return column_op(Column.__sub__)(left, right)
 
-    def mod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def mod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -94,7 +94,7 @@ class NumericOps(DataTypeOps):
 
         return column_op(mod)(left, right)
 
-    def pow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def pow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -110,7 +110,7 @@ class NumericOps(DataTypeOps):
 
         return column_op(pow_func)(left, right)
 
-    def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def radd(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("string addition can only be applied to string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -118,7 +118,7 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__radd__)(left, right)
 
-    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("subtraction can not be applied to string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -126,7 +126,7 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rsub__)(left, right)
 
-    def rmul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rmul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
         if not isinstance(right, numbers.Number):
@@ -134,7 +134,7 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rmul__)(left, right)
 
-    def rpow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rpow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("exponentiation can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -146,7 +146,7 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(rpow_func)(left, right)
 
-    def rmod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rmod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("modulo can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -169,7 +169,7 @@ class IntegralOps(NumericOps):
     def pretty_name(self) -> str:
         return "integrals"
 
-    def mul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def mul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
 
@@ -186,7 +186,7 @@ class IntegralOps(NumericOps):
 
         return column_op(Column.__mul__)(left, right)
 
-    def truediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def truediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -204,7 +204,7 @@ class IntegralOps(NumericOps):
 
         return numpy_column_op(truediv)(left, right)
 
-    def floordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def floordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -224,7 +224,7 @@ class IntegralOps(NumericOps):
 
         return numpy_column_op(floordiv)(left, right)
 
-    def rtruediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rtruediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -238,7 +238,7 @@ class IntegralOps(NumericOps):
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rtruediv)(left, right)
 
-    def rfloordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rfloordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -275,7 +275,7 @@ class FractionalOps(NumericOps):
     def pretty_name(self) -> str:
         return "fractions"
 
-    def mul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def mul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
 
@@ -289,7 +289,7 @@ class FractionalOps(NumericOps):
 
         return column_op(Column.__mul__)(left, right)
 
-    def truediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def truediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -309,7 +309,7 @@ class FractionalOps(NumericOps):
 
         return numpy_column_op(truediv)(left, right)
 
-    def floordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def floordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -333,7 +333,7 @@ class FractionalOps(NumericOps):
 
         return numpy_column_op(floordiv)(left, right)
 
-    def rtruediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rtruediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -347,7 +347,7 @@ class FractionalOps(NumericOps):
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rtruediv)(left, right)
 
-    def rfloordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rfloordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
+from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
@@ -52,7 +52,7 @@ class NumericOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "numerics"
 
-    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def add(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -65,7 +65,7 @@ class NumericOps(DataTypeOps):
 
         return column_op(Column.__add__)(left, right)
 
-    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -78,7 +78,7 @@ class NumericOps(DataTypeOps):
 
         return column_op(Column.__sub__)(left, right)
 
-    def mod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -94,7 +94,7 @@ class NumericOps(DataTypeOps):
 
         return column_op(mod)(left, right)
 
-    def pow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def pow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -110,7 +110,7 @@ class NumericOps(DataTypeOps):
 
         return column_op(pow_func)(left, right)
 
-    def radd(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def radd(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("string addition can only be applied to string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -118,7 +118,7 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__radd__)(left, right)
 
-    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("subtraction can not be applied to string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -126,7 +126,7 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rsub__)(left, right)
 
-    def rmul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rmul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
         if not isinstance(right, numbers.Number):
@@ -134,7 +134,7 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rmul__)(left, right)
 
-    def rpow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rpow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("exponentiation can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -146,7 +146,7 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(rpow_func)(left, right)
 
-    def rmod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("modulo can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -169,7 +169,7 @@ class IntegralOps(NumericOps):
     def pretty_name(self) -> str:
         return "integrals"
 
-    def mul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
 
@@ -186,7 +186,7 @@ class IntegralOps(NumericOps):
 
         return column_op(Column.__mul__)(left, right)
 
-    def truediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -204,7 +204,7 @@ class IntegralOps(NumericOps):
 
         return numpy_column_op(truediv)(left, right)
 
-    def floordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -224,7 +224,7 @@ class IntegralOps(NumericOps):
 
         return numpy_column_op(floordiv)(left, right)
 
-    def rtruediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -238,7 +238,7 @@ class IntegralOps(NumericOps):
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rtruediv)(left, right)
 
-    def rfloordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -252,7 +252,7 @@ class IntegralOps(NumericOps):
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rfloordiv)(left, right)
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype):
@@ -275,7 +275,7 @@ class FractionalOps(NumericOps):
     def pretty_name(self) -> str:
         return "fractions"
 
-    def mul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
 
@@ -289,7 +289,7 @@ class FractionalOps(NumericOps):
 
         return column_op(Column.__mul__)(left, right)
 
-    def truediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -309,7 +309,7 @@ class FractionalOps(NumericOps):
 
         return numpy_column_op(truediv)(left, right)
 
-    def floordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if (
             isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
         ) or isinstance(right, str):
@@ -333,7 +333,7 @@ class FractionalOps(NumericOps):
 
         return numpy_column_op(floordiv)(left, right)
 
-    def rtruediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -347,7 +347,7 @@ class FractionalOps(NumericOps):
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rtruediv)(left, right)
 
-    def rfloordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
@@ -361,7 +361,7 @@ class FractionalOps(NumericOps):
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
         return numpy_column_op(rfloordiv)(left, right)
 
-    def isnull(self, index_ops: T_IndexOps) -> T_IndexOps:
+    def isnull(self, index_ops: IndexOpsLike) -> IndexOpsLike:
         return index_ops._with_new_scol(
             index_ops.spark.column.isNull() | F.isnan(index_ops.spark.column),
             field=index_ops._internal.data_fields[0].copy(
@@ -369,7 +369,7 @@ class FractionalOps(NumericOps):
             ),
         )
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype):
@@ -402,7 +402,7 @@ class DecimalOps(FractionalOps):
     def pretty_name(self) -> str:
         return "decimal"
 
-    def isnull(self, index_ops: T_IndexOps) -> T_IndexOps:
+    def isnull(self, index_ops: IndexOpsLike) -> IndexOpsLike:
         return index_ops._with_new_scol(
             index_ops.spark.column.isNull(),
             field=index_ops._internal.data_fields[0].copy(
@@ -410,7 +410,7 @@ class DecimalOps(FractionalOps):
             ),
         )
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype):

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -23,7 +23,7 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import IntegralType, StringType
 
-from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
+from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
@@ -46,7 +46,7 @@ class StringOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "strings"
 
-    def add(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType):
             return column_op(F.concat)(left, right)
         elif isinstance(right, str):
@@ -54,10 +54,10 @@ class StringOps(DataTypeOps):
         else:
             raise TypeError("string addition can only be applied to string series or literals.")
 
-    def sub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("subtraction can not be applied to string series or literals.")
 
-    def mul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def mul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
 
@@ -70,46 +70,46 @@ class StringOps(DataTypeOps):
         else:
             raise TypeError("a string series can only be multiplied to an int series or literal")
 
-    def truediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def truediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def floordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def floordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def mod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def mod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("modulo can not be applied on string series or literals.")
 
-    def pow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def pow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("exponentiation can not be applied on string series or literals.")
 
-    def radd(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def radd(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             return cast(
-                IndexOpsLike,
+                SeriesOrIndex,
                 left._with_new_scol(F.concat(F.lit(right), left.spark.column)),  # TODO: dtype?
             )
         else:
             raise TypeError("string addition can only be applied to string series or literals.")
 
-    def rsub(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("subtraction can not be applied to string series or literals.")
 
-    def rmul(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rmul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         if isinstance(right, int):
             return column_op(SF.repeat)(left, right)
         else:
             raise TypeError("a string series can only be multiplied to an int series or literal")
 
-    def rtruediv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rtruediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def rfloordiv(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rfloordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def rpow(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rpow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("exponentiation can not be applied on string series or literals.")
 
-    def rmod(self, left: T_IndexOps, right: Any) -> IndexOpsLike:
+    def rmod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
         raise TypeError("modulo can not be applied on string series or literals.")
 
     def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -23,7 +23,7 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import IntegralType, StringType
 
-from pyspark.pandas._typing import Dtype, SeriesOrIndex, T_IndexOps
+from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
@@ -46,7 +46,7 @@ class StringOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "strings"
 
-    def add(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def add(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType):
             return column_op(F.concat)(left, right)
         elif isinstance(right, str):
@@ -54,10 +54,10 @@ class StringOps(DataTypeOps):
         else:
             raise TypeError("string addition can only be applied to string series or literals.")
 
-    def sub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("subtraction can not be applied to string series or literals.")
 
-    def mul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             raise TypeError("multiplication can not be applied to a string literal.")
 
@@ -70,19 +70,19 @@ class StringOps(DataTypeOps):
         else:
             raise TypeError("a string series can only be multiplied to an int series or literal")
 
-    def truediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def floordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def mod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("modulo can not be applied on string series or literals.")
 
-    def pow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def pow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("exponentiation can not be applied on string series or literals.")
 
-    def radd(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def radd(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
             return cast(
                 SeriesOrIndex,
@@ -91,28 +91,28 @@ class StringOps(DataTypeOps):
         else:
             raise TypeError("string addition can only be applied to string series or literals.")
 
-    def rsub(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("subtraction can not be applied to string series or literals.")
 
-    def rmul(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rmul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, int):
             return column_op(SF.repeat)(left, right)
         else:
             raise TypeError("a string series can only be multiplied to an int series or literal")
 
-    def rtruediv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def rfloordiv(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("division can not be applied on string series or literals.")
 
-    def rpow(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rpow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("exponentiation can not be applied on string series or literals.")
 
-    def rmod(self, left: T_IndexOps, right: Any) -> SeriesOrIndex:
+    def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("modulo can not be applied on string series or literals.")
 
-    def astype(self, index_ops: T_IndexOps, dtype: Union[str, type, Dtype]) -> T_IndexOps:
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
         if isinstance(dtype, CategoricalDtype):

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -23,18 +23,17 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import IntegralType, StringType
 
+from pyspark.pandas._typing import Dtype, IndexOpsLike, T_IndexOps
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
-    IndexOpsLike,
-    T_IndexOps,
     _as_categorical_type,
     _as_other_type,
     _as_string_type,
 )
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.spark import functions as SF
-from pyspark.pandas.typedef import Dtype, extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.typedef import extension_dtypes, pandas_on_spark_type
 from pyspark.sql.types import BooleanType
 
 

--- a/python/pyspark/pandas/extensions.py
+++ b/python/pyspark/pandas/extensions.py
@@ -14,16 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Callable, Generic, Optional, Type, TypeVar, Union, TYPE_CHECKING
+from typing import Callable, Generic, Optional, Type, Union, TYPE_CHECKING
 import warnings
+
+from pyspark.pandas._typing import T
 
 if TYPE_CHECKING:
     from pyspark.pandas.frame import DataFrame  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
-
-
-T = TypeVar("T")
 
 
 class CachedAccessor(Generic[T]):

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -83,7 +83,7 @@ from pyspark.sql.types import (  # noqa: F401 (SPARK-34943)
 from pyspark.sql.window import Window
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas._typing import Dtype, Scalar, T
+from pyspark.pandas._typing import DataFrameOrSeries, Dtype, Scalar, T
 from pyspark.pandas.accessors import PandasOnSparkFrameMethods
 from pyspark.pandas.config import option_context, get_option
 from pyspark.pandas.spark.accessors import SparkFrameMethods, CachedSparkFrameMethods
@@ -2882,7 +2882,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     # TODO: add axis parameter can work when '1' or 'columns'
     def xs(
         self, key: Union[Any, Tuple], axis: Union[int, str] = 0, level: Optional[int] = None
-    ) -> Union["DataFrame", "Series"]:
+    ) -> DataFrameOrSeries:
         """
         Return cross-section from the DataFrame.
 
@@ -3195,7 +3195,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
     def where(
-        self, cond: Union["DataFrame", "Series"], other: Union["DataFrame", "Series", Any] = np.nan
+        self, cond: DataFrameOrSeries, other: Union[DataFrameOrSeries, Any] = np.nan
     ) -> "DataFrame":
         """
         Replace values where the condition is False.
@@ -3388,7 +3388,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
     def mask(
-        self, cond: Union["DataFrame", "Series"], other: Union["DataFrame", "Series", Any] = np.nan
+        self, cond: DataFrameOrSeries, other: Union[DataFrameOrSeries, Any] = np.nan
     ) -> "DataFrame":
         """
         Replace values where the condition is True.
@@ -9215,7 +9215,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
         )
 
-    def stack(self) -> Union["DataFrame", "Series"]:
+    def stack(self) -> DataFrameOrSeries:
         """
         Stack the prescribed level(s) from columns to index.
 
@@ -9398,7 +9398,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             return psdf
 
-    def unstack(self) -> Union["DataFrame", "Series"]:
+    def unstack(self) -> DataFrameOrSeries:
         """
         Pivot the (necessarily hierarchical) index labels.
 
@@ -10729,7 +10729,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         axis: Union[int, str] = 0,
         numeric_only: bool = True,
         accuracy: int = 10000,
-    ) -> Union["DataFrame", "Series"]:
+    ) -> DataFrameOrSeries:
         """
         Return value at the given quantile.
 
@@ -11066,7 +11066,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             return cast(DataFrame, self.iloc[:, indices])
 
-    def eval(self, expr: str, inplace: bool = False) -> Optional[Union["DataFrame", "Series"]]:
+    def eval(self, expr: str, inplace: bool = False) -> Optional[DataFrameOrSeries]:
         """
         Evaluate a string describing operations on DataFrame columns.
 
@@ -11429,11 +11429,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     def align(
         self,
-        other: Union["DataFrame", "Series"],
+        other: DataFrameOrSeries,
         join: str = "outer",
         axis: Optional[Union[int, str]] = None,
         copy: bool = True,
-    ) -> Tuple["DataFrame", Union["DataFrame", "Series"]]:
+    ) -> Tuple["DataFrame", DataFrameOrSeries]:
         """
         Align two objects on their axes with the specified join method.
 
@@ -11847,9 +11847,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return [tuple(list(label) + ([""] * (level - len(label)))) for label in labels]
 
     @staticmethod
-    def _index_normalized_frame(
-        level: int, psser_or_psdf: Union["DataFrame", "Series"]
-    ) -> "DataFrame":
+    def _index_normalized_frame(level: int, psser_or_psdf: DataFrameOrSeries) -> "DataFrame":
         """
         Returns a frame that is normalized against the current column index level.
         For example, the name in `pd.Series([...], name="abc")` can be can be

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -43,7 +43,6 @@ from typing import (
     Sequence,
     Tuple,
     Type,
-    TypeVar,
     Union,
     cast,
     no_type_check,
@@ -84,6 +83,7 @@ from pyspark.sql.types import (  # noqa: F401 (SPARK-34943)
 from pyspark.sql.window import Window
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
+from pyspark.pandas._typing import Dtype, Scalar, T
 from pyspark.pandas.accessors import PandasOnSparkFrameMethods
 from pyspark.pandas.config import option_context, get_option
 from pyspark.pandas.spark.accessors import SparkFrameMethods, CachedSparkFrameMethods
@@ -121,9 +121,7 @@ from pyspark.pandas.typedef import (
     infer_return_type,
     spark_type_to_pandas_dtype,
     DataFrameType,
-    Dtype,
     SeriesType,
-    Scalar,
     ScalarType,
 )
 from pyspark.pandas.plot import PandasOnSparkPlotAccessor
@@ -340,8 +338,6 @@ circle        1.0  2.348543e+108
 triangle      8.0   1.532496e+54
 rectangle    16.0  2.348543e+108
 """
-
-T = TypeVar("T")
 
 
 def _create_tuple_for_frame_type(params: Any) -> object:

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -53,7 +53,7 @@ from pyspark.sql.types import (
 )
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas._typing import Dtype, FrameLike, Scalar
+from pyspark.pandas._typing import DataFrameOrSeries, Dtype, FrameLike, Scalar
 from pyspark.pandas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from pyspark.pandas.internal import InternalFrame
 from pyspark.pandas.typedef import spark_type_to_pandas_dtype
@@ -2753,7 +2753,7 @@ class Frame(object, metaclass=ABCMeta):
         after: Optional[Any] = None,
         axis: Optional[Union[int, str]] = None,
         copy: bool_type = True,
-    ) -> Union["DataFrame", "Series"]:
+    ) -> DataFrameOrSeries:
         """
         Truncate a Series or DataFrame before and after some index value.
 
@@ -2890,7 +2890,7 @@ class Frame(object, metaclass=ABCMeta):
             elif axis == 1:
                 result = self.loc[:, before:after]
 
-        return cast(Union[ps.DataFrame, ps.Series], result.copy() if copy else result)
+        return cast(DataFrameOrSeries, result.copy() if copy else result)
 
     def to_markdown(
         self, buf: Optional[Union[IO[str], str]] = None, mode: Optional[str] = None

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -31,7 +31,6 @@ from typing import (
     Optional,
     NoReturn,
     Tuple,
-    TypeVar,
     Union,
     TYPE_CHECKING,
     cast,
@@ -54,9 +53,10 @@ from pyspark.sql.types import (
 )
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
+from pyspark.pandas._typing import Dtype, Scalar, T_Frame
 from pyspark.pandas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from pyspark.pandas.internal import InternalFrame
-from pyspark.pandas.typedef import Dtype, Scalar, spark_type_to_pandas_dtype
+from pyspark.pandas.typedef import spark_type_to_pandas_dtype
 from pyspark.pandas.utils import (
     is_name_like_tuple,
     is_name_like_value,
@@ -76,7 +76,6 @@ if TYPE_CHECKING:
     from pyspark.pandas.window import Rolling, Expanding  # noqa: F401 (SPARK-34943)
 
 
-T_Frame = TypeVar("T_Frame", bound="Frame")
 bool_type = bool
 
 

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -53,7 +53,7 @@ from pyspark.sql.types import (
 )
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas._typing import Dtype, Scalar, T_Frame
+from pyspark.pandas._typing import Dtype, FrameLike, Scalar
 from pyspark.pandas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from pyspark.pandas.internal import InternalFrame
 from pyspark.pandas.typedef import spark_type_to_pandas_dtype
@@ -95,10 +95,10 @@ class Frame(object, metaclass=ABCMeta):
 
     @abstractmethod
     def _apply_series_op(
-        self: T_Frame,
+        self: FrameLike,
         op: Callable[["Series"], Union["Series", Column]],
         should_resolve: bool = False,
-    ) -> T_Frame:
+    ) -> FrameLike:
         pass
 
     @abstractmethod
@@ -127,7 +127,7 @@ class Frame(object, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def copy(self: T_Frame) -> T_Frame:
+    def copy(self: FrameLike) -> FrameLike:
         pass
 
     @abstractmethod
@@ -135,11 +135,11 @@ class Frame(object, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def head(self: T_Frame, n: int = 5) -> T_Frame:
+    def head(self: FrameLike, n: int = 5) -> FrameLike:
         pass
 
     # TODO: add 'axis' parameter
-    def cummin(self: T_Frame, skipna: bool = True) -> T_Frame:
+    def cummin(self: FrameLike, skipna: bool = True) -> FrameLike:
         """
         Return cumulative minimum over a DataFrame or Series axis.
 
@@ -199,7 +199,7 @@ class Frame(object, metaclass=ABCMeta):
         return self._apply_series_op(lambda psser: psser._cum(F.min, skipna), should_resolve=True)
 
     # TODO: add 'axis' parameter
-    def cummax(self: T_Frame, skipna: bool = True) -> T_Frame:
+    def cummax(self: FrameLike, skipna: bool = True) -> FrameLike:
         """
         Return cumulative maximum over a DataFrame or Series axis.
 
@@ -260,7 +260,7 @@ class Frame(object, metaclass=ABCMeta):
         return self._apply_series_op(lambda psser: psser._cum(F.max, skipna), should_resolve=True)
 
     # TODO: add 'axis' parameter
-    def cumsum(self: T_Frame, skipna: bool = True) -> T_Frame:
+    def cumsum(self: FrameLike, skipna: bool = True) -> FrameLike:
         """
         Return cumulative sum over a DataFrame or Series axis.
 
@@ -323,7 +323,7 @@ class Frame(object, metaclass=ABCMeta):
     # TODO: add 'axis' parameter
     # TODO: use pandas_udf to support negative values and other options later
     #  other window except unbounded ones is supported as of Spark 3.0.
-    def cumprod(self: T_Frame, skipna: bool = True) -> T_Frame:
+    def cumprod(self: FrameLike, skipna: bool = True) -> FrameLike:
         """
         Return cumulative product over a DataFrame or Series axis.
 
@@ -2060,7 +2060,7 @@ class Frame(object, metaclass=ABCMeta):
         else:
             return len(self) * num_columns  # type: ignore
 
-    def abs(self: T_Frame) -> T_Frame:
+    def abs(self: FrameLike) -> FrameLike:
         """
         Return a Series/DataFrame with absolute numeric value of each element.
 
@@ -2117,12 +2117,12 @@ class Frame(object, metaclass=ABCMeta):
     # TODO: by argument only support the grouping name and as_index only for now. Documentation
     # should be updated when it's supported.
     def groupby(
-        self: T_Frame,
+        self: FrameLike,
         by: Union[Any, Tuple, "Series", List[Union[Any, Tuple, "Series"]]],
         axis: Union[int, str] = 0,
         as_index: bool = True,
         dropna: bool = True,
-    ) -> "GroupBy[T_Frame]":
+    ) -> "GroupBy[FrameLike]":
         """
         Group DataFrame or Series using a Series of columns.
 
@@ -2247,8 +2247,8 @@ class Frame(object, metaclass=ABCMeta):
 
     @abstractmethod
     def _build_groupby(
-        self: T_Frame, by: List[Union["Series", Tuple]], as_index: bool, dropna: bool
-    ) -> "GroupBy[T_Frame]":
+        self: FrameLike, by: List[Union["Series", Tuple]], as_index: bool, dropna: bool
+    ) -> "GroupBy[FrameLike]":
         pass
 
     def bool(self) -> bool:
@@ -2508,8 +2508,8 @@ class Frame(object, metaclass=ABCMeta):
 
     # TODO: 'center', 'win_type', 'on', 'axis' parameter should be implemented.
     def rolling(
-        self: T_Frame, window: int, min_periods: Optional[int] = None
-    ) -> "Rolling[T_Frame]":
+        self: FrameLike, window: int, min_periods: Optional[int] = None
+    ) -> "Rolling[FrameLike]":
         """
         Provide rolling transformations.
 
@@ -2540,7 +2540,7 @@ class Frame(object, metaclass=ABCMeta):
 
     # TODO: 'center' and 'axis' parameter should be implemented.
     #   'axis' implementation, refer https://github.com/pyspark.pandas/pull/607
-    def expanding(self: T_Frame, min_periods: int = 1) -> "Expanding[T_Frame]":
+    def expanding(self: FrameLike, min_periods: int = 1) -> "Expanding[FrameLike]":
         """
         Provide expanding transformations.
 
@@ -2956,22 +2956,22 @@ class Frame(object, metaclass=ABCMeta):
 
     @abstractmethod
     def fillna(
-        self: T_Frame,
+        self: FrameLike,
         value: Optional[Any] = None,
         method: Optional[str] = None,
         axis: Optional[Union[int, str]] = None,
         inplace: bool_type = False,
         limit: Optional[int] = None,
-    ) -> T_Frame:
+    ) -> FrameLike:
         pass
 
     # TODO: add 'downcast' when value parameter exists
     def bfill(
-        self: T_Frame,
+        self: FrameLike,
         axis: Optional[Union[int, str]] = None,
         inplace: bool_type = False,
         limit: Optional[int] = None,
-    ) -> T_Frame:
+    ) -> FrameLike:
         """
         Synonym for `DataFrame.fillna()` or `Series.fillna()` with ``method=`bfill```.
 
@@ -3046,11 +3046,11 @@ class Frame(object, metaclass=ABCMeta):
 
     # TODO: add 'downcast' when value parameter exists
     def ffill(
-        self: T_Frame,
+        self: FrameLike,
         axis: Optional[Union[int, str]] = None,
         inplace: bool_type = False,
         limit: Optional[int] = None,
-    ) -> T_Frame:
+    ) -> FrameLike:
         """
         Synonym for `DataFrame.fillna()` or `Series.fillna()` with ``method=`ffill```.
 

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -38,7 +38,6 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    TypeVar,
     Union,
     cast,
     TYPE_CHECKING,
@@ -59,9 +58,9 @@ from pyspark.sql.types import (  # noqa: F401
 )
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
+from pyspark.pandas._typing import T_Frame
 from pyspark.pandas.typedef import infer_return_type, DataFrameType, ScalarType, SeriesType
 from pyspark.pandas.frame import DataFrame
-from pyspark.pandas.generic import Frame
 from pyspark.pandas.internal import (
     InternalField,
     InternalFrame,
@@ -94,8 +93,6 @@ if TYPE_CHECKING:
 
 # to keep it the same as pandas
 NamedAgg = namedtuple("NamedAgg", ["column", "aggfunc"])
-
-T_Frame = TypeVar("T_Frame", bound=Frame)
 
 
 class GroupBy(Generic[T_Frame], metaclass=ABCMeta):

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -58,7 +58,7 @@ from pyspark.sql.types import (  # noqa: F401
 )
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas._typing import T_Frame
+from pyspark.pandas._typing import FrameLike
 from pyspark.pandas.typedef import infer_return_type, DataFrameType, ScalarType, SeriesType
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.internal import (
@@ -95,7 +95,7 @@ if TYPE_CHECKING:
 NamedAgg = namedtuple("NamedAgg", ["column", "aggfunc"])
 
 
-class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
+class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
     """
     :ivar _psdf: The parent dataframe that is used to perform the groupby
     :type _psdf: DataFrame
@@ -135,11 +135,11 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         op: Callable[["SeriesGroupBy"], Series],
         should_resolve: bool = False,
         numeric_only: bool = False,
-    ) -> T_Frame:
+    ) -> FrameLike:
         pass
 
     @abstractmethod
-    def _cleanup_and_return(self, psdf: DataFrame) -> T_Frame:
+    def _cleanup_and_return(self, psdf: DataFrame) -> FrameLike:
         pass
 
     # TODO: Series support is not implemented yet.
@@ -368,7 +368,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
             data_spark_columns=[scol_for(sdf, col) for col in data_columns],
         )
 
-    def count(self) -> T_Frame:
+    def count(self) -> FrameLike:
         """
         Compute count of group, excluding missing values.
 
@@ -391,7 +391,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         return self._reduce_for_stat_function(F.count, only_numeric=False)
 
     # TODO: We should fix See Also when Series implementation is finished.
-    def first(self) -> T_Frame:
+    def first(self) -> FrameLike:
         """
         Compute first of group values.
 
@@ -402,7 +402,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         """
         return self._reduce_for_stat_function(F.first, only_numeric=False)
 
-    def last(self) -> T_Frame:
+    def last(self) -> FrameLike:
         """
         Compute last of group values.
 
@@ -415,7 +415,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
             lambda col: F.last(col, ignorenulls=True), only_numeric=False
         )
 
-    def max(self) -> T_Frame:
+    def max(self) -> FrameLike:
         """
         Compute max of group values.
 
@@ -427,7 +427,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         return self._reduce_for_stat_function(F.max, only_numeric=False)
 
     # TODO: examples should be updated.
-    def mean(self) -> T_Frame:
+    def mean(self) -> FrameLike:
         """
         Compute mean of groups, excluding missing values.
 
@@ -458,7 +458,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
 
         return self._reduce_for_stat_function(F.mean, only_numeric=True)
 
-    def min(self) -> T_Frame:
+    def min(self) -> FrameLike:
         """
         Compute min of group values.
 
@@ -470,7 +470,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         return self._reduce_for_stat_function(F.min, only_numeric=False)
 
     # TODO: sync the doc.
-    def std(self, ddof: int = 1) -> T_Frame:
+    def std(self, ddof: int = 1) -> FrameLike:
         """
         Compute standard deviation of groups, excluding missing values.
 
@@ -491,7 +491,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
             F.stddev_pop if ddof == 0 else F.stddev_samp, only_numeric=True
         )
 
-    def sum(self) -> T_Frame:
+    def sum(self) -> FrameLike:
         """
         Compute sum of group values
 
@@ -503,7 +503,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         return self._reduce_for_stat_function(F.sum, only_numeric=True)
 
     # TODO: sync the doc.
-    def var(self, ddof: int = 1) -> T_Frame:
+    def var(self, ddof: int = 1) -> FrameLike:
         """
         Compute variance of groups, excluding missing values.
 
@@ -525,7 +525,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         )
 
     # TODO: skipna should be implemented.
-    def all(self) -> T_Frame:
+    def all(self) -> FrameLike:
         """
         Returns True if all values in the group are truthful, else False.
 
@@ -567,7 +567,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         )
 
     # TODO: skipna should be implemented.
-    def any(self) -> T_Frame:
+    def any(self) -> FrameLike:
         """
         Returns True if any value in the group is truthful, else False.
 
@@ -683,7 +683,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         )
         return first_series(DataFrame(internal))
 
-    def diff(self, periods: int = 1) -> T_Frame:
+    def diff(self, periods: int = 1) -> FrameLike:
         """
         First discrete difference of element.
 
@@ -802,7 +802,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         internal = ret._internal.resolved_copy
         return first_series(DataFrame(internal))
 
-    def cummax(self) -> T_Frame:
+    def cummax(self) -> FrameLike:
         """
         Cumulative max for each group.
 
@@ -851,7 +851,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
             numeric_only=True,
         )
 
-    def cummin(self) -> T_Frame:
+    def cummin(self) -> FrameLike:
         """
         Cumulative min for each group.
 
@@ -900,7 +900,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
             numeric_only=True,
         )
 
-    def cumprod(self) -> T_Frame:
+    def cumprod(self) -> FrameLike:
         """
         Cumulative product for each group.
 
@@ -949,7 +949,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
             numeric_only=True,
         )
 
-    def cumsum(self) -> T_Frame:
+    def cumsum(self) -> FrameLike:
         """
         Cumulative sum for each group.
 
@@ -1307,7 +1307,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
             return DataFrame(internal)
 
     # TODO: implement 'dropna' parameter
-    def filter(self, func: Callable[[T_Frame], T_Frame]) -> T_Frame:
+    def filter(self, func: Callable[[FrameLike], FrameLike]) -> FrameLike:
         """
         Return a copy of a DataFrame excluding elements from groups that
         do not satisfy the boolean criterion specified by func.
@@ -1458,7 +1458,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
 
         return rename_output
 
-    def rank(self, method: str = "average", ascending: bool = True) -> T_Frame:
+    def rank(self, method: str = "average", ascending: bool = True) -> FrameLike:
         """
         Provide the rank of values within each group.
 
@@ -1526,7 +1526,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         )
 
     # TODO: add axis parameter
-    def idxmax(self, skipna: bool = True) -> T_Frame:
+    def idxmax(self, skipna: bool = True) -> FrameLike:
         """
         Return index of first occurrence of maximum over requested axis in group.
         NA/null values are excluded.
@@ -1608,7 +1608,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         return self._cleanup_and_return(DataFrame(internal))
 
     # TODO: add axis parameter
-    def idxmin(self, skipna: bool = True) -> T_Frame:
+    def idxmin(self, skipna: bool = True) -> FrameLike:
         """
         Return index of first occurrence of minimum over requested axis in group.
         NA/null values are excluded.
@@ -1696,7 +1696,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         axis: Optional[Union[int, str]] = None,
         inplace: bool = False,
         limit: Optional[int] = None,
-    ) -> T_Frame:
+    ) -> FrameLike:
         """Fill NA/NaN values in group.
 
         Parameters
@@ -1764,7 +1764,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
             should_resolve=(method is not None),
         )
 
-    def bfill(self, limit: Optional[int] = None) -> T_Frame:
+    def bfill(self, limit: Optional[int] = None) -> FrameLike:
         """
         Synonym for `DataFrame.fillna()` with ``method=`bfill```.
 
@@ -1815,7 +1815,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
 
     backfill = bfill
 
-    def ffill(self, limit: Optional[int] = None) -> T_Frame:
+    def ffill(self, limit: Optional[int] = None) -> FrameLike:
         """
         Synonym for `DataFrame.fillna()` with ``method=`ffill```.
 
@@ -1866,7 +1866,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
 
     pad = ffill
 
-    def _limit(self, n: int, asc: bool) -> T_Frame:
+    def _limit(self, n: int, asc: bool) -> FrameLike:
         """
         Private function for tail and head.
         """
@@ -1910,7 +1910,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         internal = psdf._internal.with_new_sdf(sdf)
         return self._cleanup_and_return(DataFrame(internal).drop(groupkey_labels, axis=1))
 
-    def head(self, n: int = 5) -> T_Frame:
+    def head(self, n: int = 5) -> FrameLike:
         """
         Return first n rows of each group.
 
@@ -1958,7 +1958,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         """
         return self._limit(n, asc=True)
 
-    def tail(self, n: int = 5) -> T_Frame:
+    def tail(self, n: int = 5) -> FrameLike:
         """
         Return last n rows of each group.
 
@@ -2011,7 +2011,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
         """
         return self._limit(n, asc=False)
 
-    def shift(self, periods: int = 1, fill_value: Optional[Any] = None) -> T_Frame:
+    def shift(self, periods: int = 1, fill_value: Optional[Any] = None) -> FrameLike:
         """
         Shift each group by periods observations.
 
@@ -2073,7 +2073,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
             should_resolve=True,
         )
 
-    def transform(self, func: Callable[..., pd.Series], *args: Any, **kwargs: Any) -> T_Frame:
+    def transform(self, func: Callable[..., pd.Series], *args: Any, **kwargs: Any) -> FrameLike:
         """
         Apply function column-by-column to the GroupBy object.
 
@@ -2268,7 +2268,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
 
         return self._cleanup_and_return(DataFrame(internal))
 
-    def nunique(self, dropna: bool = True) -> T_Frame:
+    def nunique(self, dropna: bool = True) -> FrameLike:
         """
         Return DataFrame with number of distinct observations per group for each column.
 
@@ -2321,7 +2321,9 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
 
         return self._reduce_for_stat_function(stat_function, only_numeric=False)
 
-    def rolling(self, window: int, min_periods: Optional[int] = None) -> "RollingGroupby[T_Frame]":
+    def rolling(
+        self, window: int, min_periods: Optional[int] = None
+    ) -> "RollingGroupby[FrameLike]":
         """
         Return an rolling grouper, providing rolling
         functionality per group.
@@ -2350,7 +2352,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
 
         return RollingGroupby(self, window, min_periods=min_periods)
 
-    def expanding(self, min_periods: int = 1) -> "ExpandingGroupby[T_Frame]":
+    def expanding(self, min_periods: int = 1) -> "ExpandingGroupby[FrameLike]":
         """
         Return an expanding grouper, providing expanding
         functionality per group.
@@ -2374,7 +2376,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
 
         return ExpandingGroupby(self, min_periods=min_periods)
 
-    def get_group(self, name: Union[Any, Tuple, List[Union[Any, Tuple]]]) -> T_Frame:
+    def get_group(self, name: Union[Any, Tuple, List[Union[Any, Tuple]]]) -> FrameLike:
         """
         Construct DataFrame from group with provided name.
 
@@ -2453,7 +2455,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
 
         return self._cleanup_and_return(DataFrame(internal))
 
-    def median(self, numeric_only: bool = True, accuracy: int = 10000) -> T_Frame:
+    def median(self, numeric_only: bool = True, accuracy: int = 10000) -> FrameLike:
         """
         Compute median of groups, excluding missing values.
 
@@ -2522,7 +2524,7 @@ class GroupBy(Generic[T_Frame], metaclass=ABCMeta):
 
     def _reduce_for_stat_function(
         self, sfun: Callable[[Column], Column], only_numeric: bool
-    ) -> T_Frame:
+    ) -> FrameLike:
         agg_columns = self._agg_columns
         agg_columns_scols = self._agg_columns_scols
 

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -41,6 +41,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import FractionalType, IntegralType, TimestampType
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
+from pyspark.pandas._typing import Dtype, Scalar
 from pyspark.pandas.config import get_option, option_context
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.frame import DataFrame
@@ -64,7 +65,6 @@ from pyspark.pandas.internal import (
     SPARK_DEFAULT_INDEX_NAME,
     SPARK_INDEX_NAME_FORMAT,
 )
-from pyspark.pandas.typedef import Dtype, Scalar
 
 
 class Index(IndexOpsMixin):

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -36,8 +36,7 @@ from pandas.io.formats.printing import pprint_thing
 from pandas.api.types import CategoricalDtype, is_hashable
 from pandas._libs import lib
 
-from pyspark import sql as spark
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column
 from pyspark.sql.types import FractionalType, IntegralType, TimestampType
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
@@ -218,9 +217,7 @@ class Index(IndexOpsMixin):
     def _column_label(self) -> Optional[Tuple]:
         return self._psdf._internal.index_names[0]
 
-    def _with_new_scol(
-        self, scol: spark.Column, *, field: Optional[InternalField] = None
-    ) -> "Index":
+    def _with_new_scol(self, scol: Column, *, field: Optional[InternalField] = None) -> "Index":
         """
         Copy pandas-on-Spark Index with the new Spark Column.
 

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -29,6 +29,7 @@ from pyspark.sql.types import DataType
 
 # For running doctests and reference resolution in PyCharm.
 from pyspark import pandas as ps  # noqa: F401
+from pyspark.pandas._typing import Scalar
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.indexes.base import Index
@@ -47,7 +48,6 @@ from pyspark.pandas.internal import (
     NATURAL_ORDER_COLUMN_NAME,
     SPARK_INDEX_NAME_FORMAT,
 )
-from pyspark.pandas.typedef import Scalar
 
 
 class MultiIndex(Index):

--- a/python/pyspark/pandas/indexes/numeric.py
+++ b/python/pyspark/pandas/indexes/numeric.py
@@ -20,9 +20,9 @@ import pandas as pd
 from pandas.api.types import is_hashable
 
 from pyspark import pandas as ps
+from pyspark.pandas._typing import Dtype
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.series import Series
-from pyspark.pandas.typedef.typehints import Dtype
 
 
 class NumericIndex(Index):

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -25,8 +25,7 @@ from typing import Any, Optional, List, Tuple, TYPE_CHECKING, Union, cast, Sized
 
 import pandas as pd
 from pandas.api.types import is_list_like
-from pyspark import sql as spark
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column
 from pyspark.sql.types import BooleanType, LongType
 from pyspark.sql.utils import AnalysisException
 import numpy as np
@@ -237,9 +236,7 @@ class iAtIndexer(IndexerLike):
 
 
 class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
-    def _select_rows(
-        self, rows_sel: Any
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    def _select_rows(self, rows_sel: Any) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         """
         Dispatch the logic for select rows to more specific methods by `rows_sel` argument types.
 
@@ -261,7 +258,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             return None, None, None
         elif isinstance(rows_sel, Series):
             return self._select_rows_by_series(rows_sel)
-        elif isinstance(rows_sel, spark.Column):
+        elif isinstance(rows_sel, Column):
             return self._select_rows_by_spark_column(rows_sel)
         elif isinstance(rows_sel, slice):
             if rows_sel == slice(None):
@@ -279,7 +276,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
         self, cols_sel: Any, missing_keys: Optional[List[Tuple]] = None
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -310,7 +307,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             return column_labels, data_spark_columns, data_fields, False, None
         elif isinstance(cols_sel, Series):
             return self._select_cols_by_series(cols_sel, missing_keys)
-        elif isinstance(cols_sel, spark.Column):
+        elif isinstance(cols_sel, Column):
             return self._select_cols_by_spark_column(cols_sel, missing_keys)
         elif isinstance(cols_sel, slice):
             if cols_sel == slice(None):
@@ -332,35 +329,35 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
     @abstractmethod
     def _select_rows_by_series(
         self, rows_sel: "Series"
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         """Select rows by `Series` type key."""
         pass
 
     @abstractmethod
     def _select_rows_by_spark_column(
-        self, rows_sel: spark.Column
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+        self, rows_sel: Column
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         """Select rows by Spark `Column` type key."""
         pass
 
     @abstractmethod
     def _select_rows_by_slice(
         self, rows_sel: slice
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         """Select rows by `slice` type key."""
         pass
 
     @abstractmethod
     def _select_rows_by_iterable(
         self, rows_sel: Iterable
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         """Select rows by `Iterable` type key."""
         pass
 
     @abstractmethod
     def _select_rows_else(
         self, rows_sel: Any
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         """Select rows by other type key."""
         pass
 
@@ -371,7 +368,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
         self, cols_sel: "Series", missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -381,10 +378,10 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
 
     @abstractmethod
     def _select_cols_by_spark_column(
-        self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple]]
+        self, cols_sel: Column, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -397,7 +394,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
         self, cols_sel: slice, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -410,7 +407,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
         self, cols_sel: Iterable, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -423,7 +420,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
         self, cols_sel: Any, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -632,7 +629,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                     self._internal.spark_frame[cast(iLocIndexer, self)._sequence_col] < F.lit(limit)
                 )
 
-            if isinstance(value, (Series, spark.Column)):
+            if isinstance(value, (Series, Column)):
                 if remaining_index is not None and remaining_index == 0:
                     raise ValueError(
                         "No axis named {} for object type {}".format(key, type(value).__name__)
@@ -717,7 +714,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                     self._internal.spark_frame[cast(iLocIndexer, self)._sequence_col] < F.lit(limit)
                 )
 
-            if isinstance(value, (Series, spark.Column)):
+            if isinstance(value, (Series, Column)):
                 if remaining_index is not None and remaining_index == 0:
                     raise ValueError("Incompatible indexer with Series")
                 if len(data_spark_columns) > 1:
@@ -985,20 +982,20 @@ class LocIndexer(LocIndexerLike):
 
     def _select_rows_by_series(
         self, rows_sel: "Series"
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         assert isinstance(rows_sel.spark.data_type, BooleanType), rows_sel.spark.data_type
         return rows_sel.spark.column, None, None
 
     def _select_rows_by_spark_column(
-        self, rows_sel: spark.Column
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+        self, rows_sel: Column
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         spark_type = self._internal.spark_frame.select(rows_sel).schema[0].dataType
         assert isinstance(spark_type, BooleanType), spark_type
         return rows_sel, None, None
 
     def _select_rows_by_slice(
         self, rows_sel: slice
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         from pyspark.pandas.indexes import MultiIndex
 
         if rows_sel.step is not None:
@@ -1028,7 +1025,7 @@ class LocIndexer(LocIndexerLike):
             stop = [row[1] for row in start_and_stop if row[0] == stop]
             stop = stop[-1] if len(stop) > 0 else None
 
-            conds = []  # type: List[spark.Column]
+            conds = []  # type: List[Column]
             if start is not None:
                 conds.append(F.col(NATURAL_ORDER_COLUMN_NAME) >= F.lit(start).cast(LongType()))
             if stop is not None:
@@ -1104,7 +1101,7 @@ class LocIndexer(LocIndexerLike):
                 )[::-1]:
                     compare = MultiIndex._comparator_for_monotonic_increasing(dt)
                     cond = F.when(scol.eqNullSafe(F.lit(value).cast(dt)), cond).otherwise(
-                        compare(scol, F.lit(value).cast(dt), spark.Column.__gt__)
+                        compare(scol, F.lit(value).cast(dt), Column.__gt__)
                     )
                 conds.append(cond)
             if stop is not None:
@@ -1114,7 +1111,7 @@ class LocIndexer(LocIndexerLike):
                 )[::-1]:
                     compare = MultiIndex._comparator_for_monotonic_increasing(dt)
                     cond = F.when(scol.eqNullSafe(F.lit(value).cast(dt)), cond).otherwise(
-                        compare(scol, F.lit(value).cast(dt), spark.Column.__lt__)
+                        compare(scol, F.lit(value).cast(dt), Column.__lt__)
                     )
                 conds.append(cond)
 
@@ -1122,7 +1119,7 @@ class LocIndexer(LocIndexerLike):
 
     def _select_rows_by_iterable(
         self, rows_sel: Iterable
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         rows_sel = list(rows_sel)
         if len(rows_sel) == 0:
             return F.lit(False), None, None
@@ -1148,7 +1145,7 @@ class LocIndexer(LocIndexerLike):
 
     def _select_rows_else(
         self, rows_sel: Any
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         if not isinstance(rows_sel, tuple):
             rows_sel = (rows_sel,)
         if len(rows_sel) > self._internal.index_level:
@@ -1167,9 +1164,7 @@ class LocIndexer(LocIndexerLike):
         missing_keys: Optional[List[Tuple]],
         labels: Optional[List[Tuple]] = None,
         recursed: int = 0,
-    ) -> Tuple[
-        List[Tuple], Optional[List[spark.Column]], List[InternalField], bool, Optional[Tuple]
-    ]:
+    ) -> Tuple[List[Tuple], Optional[List[Column]], List[InternalField], bool, Optional[Tuple]]:
         """Select columns from multi-index columns."""
         assert isinstance(key, tuple)
         if labels is None:
@@ -1220,7 +1215,7 @@ class LocIndexer(LocIndexerLike):
         self, cols_sel: "Series", missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -1231,10 +1226,10 @@ class LocIndexer(LocIndexerLike):
         return column_labels, data_spark_columns, data_fields, True, None
 
     def _select_cols_by_spark_column(
-        self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple]]
+        self, cols_sel: Column, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -1249,7 +1244,7 @@ class LocIndexer(LocIndexerLike):
         self, cols_sel: slice, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -1266,7 +1261,7 @@ class LocIndexer(LocIndexerLike):
         self, cols_sel: Iterable, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -1277,7 +1272,7 @@ class LocIndexer(LocIndexerLike):
             column_labels = [key._column_label for key in cols_sel]
             data_spark_columns = [key.spark.column for key in cols_sel]
             data_fields = [key._internal.data_fields[0] for key in cols_sel]
-        elif all(isinstance(key, spark.Column) for key in cols_sel):
+        elif all(isinstance(key, Column) for key in cols_sel):
             column_labels = [
                 (self._internal.spark_frame.select(col).columns[0],) for col in cols_sel
             ]
@@ -1357,7 +1352,7 @@ class LocIndexer(LocIndexerLike):
         self, cols_sel: Any, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -1557,7 +1552,7 @@ class iLocIndexer(LocIndexerLike):
 
     def _select_rows_by_series(
         self, rows_sel: "Series"
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         raise iLocIndexer._NotImplemented(
             ".iloc requires numeric slice, conditional "
             "boolean Index or a sequence of positions as int, "
@@ -1565,8 +1560,8 @@ class iLocIndexer(LocIndexerLike):
         )
 
     def _select_rows_by_spark_column(
-        self, rows_sel: spark.Column
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+        self, rows_sel: Column
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         raise iLocIndexer._NotImplemented(
             ".iloc requires numeric slice, conditional "
             "boolean Index or a sequence of positions as int, "
@@ -1575,7 +1570,7 @@ class iLocIndexer(LocIndexerLike):
 
     def _select_rows_by_slice(
         self, rows_sel: slice
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         def verify_type(i: int) -> None:
             if not isinstance(i, int):
                 raise TypeError(
@@ -1639,7 +1634,7 @@ class iLocIndexer(LocIndexerLike):
 
     def _select_rows_by_iterable(
         self, rows_sel: Iterable
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         sdf = self._internal.spark_frame
 
         if any(isinstance(key, (int, np.int, np.int64, np.int32)) and key < 0 for key in rows_sel):
@@ -1676,7 +1671,7 @@ class iLocIndexer(LocIndexerLike):
 
     def _select_rows_else(
         self, rows_sel: Any
-    ) -> Tuple[Optional[spark.Column], Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
         if isinstance(rows_sel, int):
             sdf = self._internal.spark_frame
             return (sdf[self._sequence_col] == rows_sel), None, 0
@@ -1693,7 +1688,7 @@ class iLocIndexer(LocIndexerLike):
         self, cols_sel: "Series", missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -1704,10 +1699,10 @@ class iLocIndexer(LocIndexerLike):
         )
 
     def _select_cols_by_spark_column(
-        self, cols_sel: spark.Column, missing_keys: Optional[List[Tuple]]
+        self, cols_sel: Column, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -1721,7 +1716,7 @@ class iLocIndexer(LocIndexerLike):
         self, cols_sel: slice, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -1751,7 +1746,7 @@ class iLocIndexer(LocIndexerLike):
         self, cols_sel: Iterable, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -1770,7 +1765,7 @@ class iLocIndexer(LocIndexerLike):
         self, cols_sel: Any, missing_keys: Optional[List[Tuple]]
     ) -> Tuple[
         List[Tuple],
-        Optional[List[spark.Column]],
+        Optional[List[Column]],
         Optional[List[InternalField]],
         bool,
         Optional[Tuple],
@@ -1789,7 +1784,7 @@ class iLocIndexer(LocIndexerLike):
             )
 
     def __setitem__(self, key: Any, value: Any) -> None:
-        if is_list_like(value) and not isinstance(value, spark.Column):
+        if is_list_like(value) and not isinstance(value, Column):
             iloc_item = self[key]
             if not is_list_like(key) or not is_list_like(iloc_item):
                 raise ValueError("setting an array element with a sequence.")

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -32,6 +32,7 @@ from pyspark.sql.utils import AnalysisException
 import numpy as np
 
 from pyspark import pandas as ps  # noqa: F401
+from pyspark.pandas._typing import Scalar
 from pyspark.pandas.internal import (
     InternalField,
     InternalFrame,
@@ -39,7 +40,6 @@ from pyspark.pandas.internal import (
     SPARK_DEFAULT_SERIES_NAME,
 )
 from pyspark.pandas.exceptions import SparkPandasIndexingError, SparkPandasNotImplementedError
-from pyspark.pandas.typedef.typehints import Scalar
 from pyspark.pandas.utils import (
     is_name_like_tuple,
     is_name_like_value,

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -46,8 +46,7 @@ from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype, is_list
 from pandas.tseries.offsets import DateOffset
 import pyarrow as pa
 import pyarrow.parquet as pq
-from pyspark import sql as spark
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column, DataFrame as SparkDataFrame
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import (
     ByteType,
@@ -2918,8 +2917,8 @@ def read_orc(
 
 
 def _get_index_map(
-    sdf: spark.DataFrame, index_col: Optional[Union[str, List[str]]] = None
-) -> Tuple[Optional[List[spark.Column]], Optional[List[Tuple]]]:
+    sdf: SparkDataFrame, index_col: Optional[Union[str, List[str]]] = None
+) -> Tuple[Optional[List[Column]], Optional[List[Tuple]]]:
     if index_col is not None:
         if isinstance(index_col, str):
             index_col = [index_col]
@@ -2929,7 +2928,7 @@ def _get_index_map(
                 raise KeyError(col)
         index_spark_columns = [
             scol_for(sdf, col) for col in index_col
-        ]  # type: Optional[List[spark.Column]]
+        ]  # type: Optional[List[Column]]
         index_names = [(col,) for col in index_col]  # type: Optional[List[Tuple]]
     else:
         index_spark_columns = None

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -36,7 +36,6 @@ from typing import (
     Sequence,
     Tuple,
     Type,
-    TypeVar,
     Union,
     cast,
     no_type_check,
@@ -68,6 +67,7 @@ from pyspark.sql.types import (
 from pyspark.sql.window import Window
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
+from pyspark.pandas._typing import Dtype, Scalar, T
 from pyspark.pandas.accessors import PandasOnSparkSeriesMethods
 from pyspark.pandas.categorical import CategoricalAccessor
 from pyspark.pandas.config import get_option
@@ -106,9 +106,7 @@ from pyspark.pandas.strings import StringMethods
 from pyspark.pandas.typedef import (
     infer_return_type,
     spark_type_to_pandas_dtype,
-    Dtype,
     ScalarType,
-    Scalar,
     SeriesType,
 )
 
@@ -337,8 +335,6 @@ c    0.0
 d    NaN
 dtype: float64
 """
-
-T = TypeVar("T")
 
 # Needed to disambiguate Series.str and str type
 str_type = str

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -6335,7 +6335,7 @@ def unpack_scalar(sdf: SparkDataFrame) -> Any:
 
 
 @overload
-def first_series(df: DataFrame) -> "Series":
+def first_series(df: DataFrame) -> Series:
     ...
 
 
@@ -6344,7 +6344,7 @@ def first_series(df: pd.DataFrame) -> pd.Series:
     ...
 
 
-def first_series(df: Union[DataFrame, pd.DataFrame]) -> Union["Series", pd.Series]:
+def first_series(df: Union[DataFrame, pd.DataFrame]) -> Union[Series, pd.Series]:
     """
     Takes a DataFrame and returns the first column of the DataFrame as a Series
     """

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -111,6 +111,8 @@ from pyspark.pandas.typedef import (
 )
 
 if TYPE_CHECKING:
+    from pyspark.sql._typing import ColumnOrName  # noqa: F401 (SPARK-34943)
+
     from pyspark.pandas.groupby import SeriesGroupBy  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.indexes import Index  # noqa: F401 (SPARK-34943)
 
@@ -1898,7 +1900,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         method: Optional[str] = None,
         axis: Optional[Union[int, str]] = None,
         limit: Optional[int] = None,
-        part_cols: Sequence[Union[str, Column]] = (),
+        part_cols: Sequence["ColumnOrName"] = (),
     ) -> "Series":
         axis = validate_axis(axis)
         if axis != 0:
@@ -3545,7 +3547,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         method: str = "average",
         ascending: bool = True,
         *,
-        part_cols: Sequence[Union[str, Column]] = ()
+        part_cols: Sequence["ColumnOrName"] = ()
     ) -> "Series":
         if method not in ["average", "min", "max", "first", "dense"]:
             msg = "method must be one of 'average', 'min', 'max', 'first', 'dense'"
@@ -3684,7 +3686,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         return self._diff(periods).spark.analyzed
 
-    def _diff(self, periods: int, *, part_cols: Sequence[Union[str, Column]] = ()) -> "Series":
+    def _diff(self, periods: int, *, part_cols: Sequence["ColumnOrName"] = ()) -> "Series":
         if not isinstance(periods, int):
             raise TypeError("periods should be an int; however, got [%s]" % type(periods).__name__)
         window = (
@@ -6012,7 +6014,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         self,
         func: Callable[[Column], Column],
         skipna: bool,
-        part_cols: Sequence[Union[str, Column]] = (),
+        part_cols: Sequence["ColumnOrName"] = (),
         ascending: bool = True,
     ) -> "Series":
         # This is used to cummin, cummax, cumsum, etc.
@@ -6101,7 +6103,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         return self._with_new_scol(scol)
 
-    def _cumsum(self, skipna: bool, part_cols: Sequence[Union[str, Column]] = ()) -> "Series":
+    def _cumsum(self, skipna: bool, part_cols: Sequence["ColumnOrName"] = ()) -> "Series":
         psser = self
         if isinstance(psser.spark.data_type, BooleanType):
             psser = psser.spark.transform(lambda scol: scol.cast(LongType()))
@@ -6114,7 +6116,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             )
         return psser._cum(F.sum, skipna, part_cols)
 
-    def _cumprod(self, skipna: bool, part_cols: Sequence[Union[str, Column]] = ()) -> "Series":
+    def _cumprod(self, skipna: bool, part_cols: Sequence["ColumnOrName"] = ()) -> "Series":
         if isinstance(self.spark.data_type, BooleanType):
             scol = self._cum(
                 lambda scol: F.min(F.coalesce(scol, F.lit(True))), skipna, part_cols

--- a/python/pyspark/pandas/spark/accessors.py
+++ b/python/pyspark/pandas/spark/accessors.py
@@ -20,12 +20,13 @@ Spark related features. Usually, the features here are missing in pandas
 but Spark has it.
 """
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Callable, Generic, List, Optional, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Union, cast
 
 from pyspark import StorageLevel
 from pyspark.sql import Column, DataFrame as SparkDataFrame
 from pyspark.sql.types import DataType, StructType
 
+from pyspark.pandas._typing import T_IndexOps
 from pyspark.pandas.internal import InternalField
 
 if TYPE_CHECKING:
@@ -33,11 +34,7 @@ if TYPE_CHECKING:
     from pyspark._typing import PrimitiveType  # noqa: F401 (SPARK-34943)
 
     import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
-    from pyspark.pandas.base import IndexOpsMixin  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.frame import CachedDataFrame  # noqa: F401 (SPARK-34943)
-
-
-T_IndexOps = TypeVar("T_IndexOps", bound="IndexOpsMixin")
 
 
 class SparkIndexOpsMethods(Generic[T_IndexOps], metaclass=ABCMeta):

--- a/python/pyspark/pandas/spark/accessors.py
+++ b/python/pyspark/pandas/spark/accessors.py
@@ -26,7 +26,7 @@ from pyspark import StorageLevel
 from pyspark.sql import Column, DataFrame as SparkDataFrame
 from pyspark.sql.types import DataType, StructType
 
-from pyspark.pandas._typing import T_IndexOps
+from pyspark.pandas._typing import IndexOpsLike
 from pyspark.pandas.internal import InternalField
 
 if TYPE_CHECKING:
@@ -37,11 +37,11 @@ if TYPE_CHECKING:
     from pyspark.pandas.frame import CachedDataFrame  # noqa: F401 (SPARK-34943)
 
 
-class SparkIndexOpsMethods(Generic[T_IndexOps], metaclass=ABCMeta):
+class SparkIndexOpsMethods(Generic[IndexOpsLike], metaclass=ABCMeta):
     """Spark related features. Usually, the features here are missing in pandas
     but Spark has it."""
 
-    def __init__(self, data: T_IndexOps):
+    def __init__(self, data: IndexOpsLike):
         self._data = data
 
     @property
@@ -64,7 +64,7 @@ class SparkIndexOpsMethods(Generic[T_IndexOps], metaclass=ABCMeta):
         """
         return self._data._internal.spark_column_for(self._data._column_label)
 
-    def transform(self, func: Callable[[Column], Column]) -> T_IndexOps:
+    def transform(self, func: Callable[[Column], Column]) -> IndexOpsLike:
         """
         Applies a function that takes and returns a Spark column. It allows to natively
         apply a Spark function and column APIs with the Spark column internally used
@@ -131,7 +131,7 @@ class SparkIndexOpsMethods(Generic[T_IndexOps], metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def analyzed(self) -> T_IndexOps:
+    def analyzed(self) -> IndexOpsLike:
         pass
 
 

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -24,14 +24,11 @@ from inspect import getfullargspec, isclass
 from typing import (  # noqa: F401
     Any,
     Callable,
-    Dict,
     Generic,
     List,
     Optional,
     Tuple,
-    TypeVar,
     Union,
-    cast,
 )
 
 import numpy as np

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -37,7 +37,6 @@ from typing import (  # noqa: F401
 import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype, pandas_dtype
-from pandas.api.extensions import ExtensionDtype
 
 try:
     from pandas import Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype
@@ -72,15 +71,8 @@ import pyspark.sql.types as types
 from pyspark.sql.pandas.types import to_arrow_type, from_arrow_type
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
+from pyspark.pandas._typing import Dtype, T
 from pyspark.pandas.typedef.string_typehints import resolve_string_type_hint
-
-T = TypeVar("T")
-
-Scalar = Union[
-    int, float, bool, str, bytes, decimal.Decimal, datetime.date, datetime.datetime, None
-]
-
-Dtype = Union[np.dtype, ExtensionDtype]
 
 
 # A column of data, with the data type.

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -39,8 +39,7 @@ from typing import (  # noqa: F401 (SPARK-34943)
 )
 import warnings
 
-from pyspark import sql as spark
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column, DataFrame as SparkDataFrame, SparkSession
 from pyspark.sql.types import DoubleType
 import pandas as pd
 from pandas.api.types import is_list_like
@@ -388,7 +387,7 @@ def align_diff_frames(
     that_columns_to_apply = []  # type: List[Tuple]
     this_columns_to_apply = []  # type: List[Tuple]
     additional_that_columns = []  # type: List[Tuple]
-    columns_to_keep = []  # type: List[Union[Series, spark.Column]]
+    columns_to_keep = []  # type: List[Union[Series, Column]]
     column_labels_to_keep = []  # type: List[Tuple]
 
     for combined_label in combined_column_labels:
@@ -423,7 +422,7 @@ def align_diff_frames(
         psser_set, column_labels_set = zip(
             *resolve_func(combined, this_columns_to_apply, that_columns_to_apply)
         )
-        columns_applied = list(psser_set)  # type: List[Union[Series, spark.Column]]
+        columns_applied = list(psser_set)  # type: List[Union[Series, Column]]
         column_labels_applied = list(column_labels_set)  # type: List[Tuple]
     else:
         columns_applied = []
@@ -460,11 +459,11 @@ def is_testing() -> bool:
     return "SPARK_TESTING" in os.environ
 
 
-def default_session(conf: Optional[Dict[str, Any]] = None) -> spark.SparkSession:
+def default_session(conf: Optional[Dict[str, Any]] = None) -> SparkSession:
     if conf is None:
         conf = dict()
 
-    builder = spark.SparkSession.builder.appName("pandas-on-Spark")
+    builder = SparkSession.builder.appName("pandas-on-Spark")
     for key, value in conf.items():
         builder = builder.config(key, value)
     # Currently, pandas-on-Spark is dependent on such join due to 'compute.ops_on_diff_frames'
@@ -478,9 +477,7 @@ def default_session(conf: Optional[Dict[str, Any]] = None) -> spark.SparkSession
 
 
 @contextmanager
-def sql_conf(
-    pairs: Dict[str, Any], *, spark: Optional[spark.SparkSession] = None
-) -> Iterator[None]:
+def sql_conf(pairs: Dict[str, Any], *, spark: Optional[SparkSession] = None) -> Iterator[None]:
     """
     A convenient context manager to set `value` to the Spark SQL configuration `key` and
     then restores it back when it exits.
@@ -589,7 +586,7 @@ def lazy_property(fn: Callable[[Any], Any]) -> property:
     return wrapped_lazy_property.deleter(deleter)
 
 
-def scol_for(sdf: spark.DataFrame, column_name: str) -> spark.Column:
+def scol_for(sdf: SparkDataFrame, column_name: str) -> Column:
     """Return Spark Column for the given column name."""
     return sdf["`{}`".format(column_name)]
 
@@ -757,7 +754,7 @@ def validate_how(how: str) -> str:
 
 
 @overload
-def verify_temp_column_name(df: spark.DataFrame, column_name_or_label: str) -> str:
+def verify_temp_column_name(df: SparkDataFrame, column_name_or_label: str) -> str:
     ...
 
 
@@ -769,7 +766,7 @@ def verify_temp_column_name(
 
 
 def verify_temp_column_name(
-    df: Union["DataFrame", spark.DataFrame], column_name_or_label: Union[Any, Tuple]
+    df: Union["DataFrame", SparkDataFrame], column_name_or_label: Union[Any, Tuple]
 ) -> Union[Any, Tuple]:
     """
     Verify that the given column name does not exist in the given pandas-on-Spark or
@@ -867,7 +864,7 @@ def verify_temp_column_name(
         )
         column_name = column_name_or_label
 
-    assert isinstance(df, spark.DataFrame), type(df)
+    assert isinstance(df, SparkDataFrame), type(df)
     assert (
         column_name not in df.columns
     ), "The given column name `{}` already exists in the Spark DataFrame: {}".format(
@@ -877,7 +874,7 @@ def verify_temp_column_name(
     return column_name_or_label
 
 
-def spark_column_equals(left: spark.Column, right: spark.Column) -> bool:
+def spark_column_equals(left: Column, right: Column) -> bool:
     """
     Check both `left` and `right` have the same expressions.
 
@@ -898,38 +895,38 @@ def spark_column_equals(left: spark.Column, right: spark.Column) -> bool:
 
 
 def compare_null_first(
-    left: spark.Column,
-    right: spark.Column,
-    comp: Callable[[spark.Column, spark.Column], spark.Column],
-) -> spark.Column:
+    left: Column,
+    right: Column,
+    comp: Callable[[Column, Column], Column],
+) -> Column:
     return (left.isNotNull() & right.isNotNull() & comp(left, right)) | (
         left.isNull() & right.isNotNull()
     )
 
 
 def compare_null_last(
-    left: spark.Column,
-    right: spark.Column,
-    comp: Callable[[spark.Column, spark.Column], spark.Column],
-) -> spark.Column:
+    left: Column,
+    right: Column,
+    comp: Callable[[Column, Column], Column],
+) -> Column:
     return (left.isNotNull() & right.isNotNull() & comp(left, right)) | (
         left.isNotNull() & right.isNull()
     )
 
 
 def compare_disallow_null(
-    left: spark.Column,
-    right: spark.Column,
-    comp: Callable[[spark.Column, spark.Column], spark.Column],
-) -> spark.Column:
+    left: Column,
+    right: Column,
+    comp: Callable[[Column, Column], Column],
+) -> Column:
     return left.isNotNull() & right.isNotNull() & comp(left, right)
 
 
 def compare_allow_null(
-    left: spark.Column,
-    right: spark.Column,
-    comp: Callable[[spark.Column, spark.Column], spark.Column],
-) -> spark.Column:
+    left: Column,
+    right: Column,
+    comp: Callable[[Column, Column], Column],
+) -> Column:
     return left.isNull() | right.isNull() | comp(left, right)
 
 

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -47,6 +47,7 @@ from pandas.api.types import is_list_like
 
 # For running doctests and reference resolution in PyCharm.
 from pyspark import pandas as ps  # noqa: F401
+from pyspark.pandas._typing import DataFrameOrSeries
 from pyspark.pandas.typedef.typehints import as_spark_type
 
 if TYPE_CHECKING:
@@ -103,7 +104,7 @@ def same_anchor(
 
 def combine_frames(
     this: "DataFrame",
-    *args: Union["DataFrame", "Series"],
+    *args: DataFrameOrSeries,
     how: str = "full",
     preserve_order_column: bool = False
 ) -> "DataFrame":

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -22,7 +22,6 @@ from typing import (  # noqa: F401 (SPARK-34943)
     Generic,
     List,
     Optional,
-    TypeVar,
 )
 
 from pyspark.sql import Window
@@ -36,17 +35,12 @@ from pyspark.pandas.missing.window import (
 
 # For running doctests and reference resolution in PyCharm.
 from pyspark import pandas as ps  # noqa: F401
-
+from pyspark.pandas._typing import T_Frame
+from pyspark.pandas.groupby import GroupBy
 from pyspark.pandas.internal import NATURAL_ORDER_COLUMN_NAME, SPARK_INDEX_NAME_FORMAT
 from pyspark.pandas.utils import scol_for
 from pyspark.sql.column import Column
 from pyspark.sql.window import WindowSpec
-
-from pyspark.pandas.generic import Frame
-from pyspark.pandas.groupby import GroupBy
-
-
-T_Frame = TypeVar("T_Frame", bound=Frame)
 
 
 class RollingAndExpanding(Generic[T_Frame], metaclass=ABCMeta):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Cleaning up the type hints in pandas-on-Spark.

- Use a single file `_typing.py` for type variables or aliases
- Rename `IndexOpsLike` to `SeriesOrIndex`.
- Rename `T_Frame` and `T_IndexOps` to `FrameLike` and `IndexOpsLike` respectively
- Introduce `DataFrameOrSeries` for `Union[DataFrame, Series]`

### Why are the changes needed?

This is a cleanup for the mypy check stuff series.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
