### PR TITLE
[SPARK-35922][BUILD] Upgrade maven-shade-plugin to 3.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2857,19 +2857,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.1</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.ow2.asm</groupId>
-              <artifactId>asm</artifactId>
-              <version>7.3.1</version>
-            </dependency>
-            <dependency>
-              <groupId>org.ow2.asm</groupId>
-              <artifactId>asm-commons</artifactId>
-              <version>7.3.1</version>
-            </dependency>
-          </dependencies>
+          <version>3.2.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `maven-shade-plugin` to 3.2.4.

### Why are the changes needed?

This is required to build with Java 17-ea.

Since `maven-shade-plugin` 3.2.3, `asm` 8.0 is used now. We should remove our custom dependency of `7.3.1`.
- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-shade-plugin/3.2.4
- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-shade-plugin/3.2.3

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.