### PR TITLE
[SPARK-35483][FOLLOWUP][TESTS] Enable docker_integration_tests for catalyst/sql module changes too

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -769,7 +769,7 @@ spark_ganglia_lgpl = Module(
 
 docker_integration_tests = Module(
     name="docker-integration-tests",
-    dependencies=[],
+    dependencies=[sql],
     build_profile_flags=["-Pdocker-integration-tests"],
     source_file_regexes=["external/docker-integration-tests"],
     sbt_test_goals=["docker-integration-tests/test"],

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -177,6 +177,9 @@ catalyst = Module(
     sbt_test_goals=[
         "catalyst/test",
     ],
+    environ=None if "GITHUB_ACTIONS" not in os.environ else {
+        "ENABLE_DOCKER_INTEGRATION_TESTS": "1"
+    },
 )
 
 sql = Module(
@@ -188,6 +191,9 @@ sql = Module(
     sbt_test_goals=[
         "sql/test",
     ],
+    environ=None if "GITHUB_ACTIONS" not in os.environ else {
+        "ENABLE_DOCKER_INTEGRATION_TESTS": "1"
+    },
 )
 
 hive = Module(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `docker_integration_tests` when `catalyst` and `sql` module changes additionally.

### Why are the changes needed?

Currently, `catalyst` and `sql` module changes do not trigger the JDBC integration test.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A