### PR TITLE
[SPARK-35920][FOLLOWUP][BUILD] Fix Kryo Shaded dependency

### DIFF
--- a/common/unsafe/pom.xml
+++ b/common/unsafe/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>chill_${scala.binary.version}</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo-shaded</artifactId>
+    </dependency>
+
     <!-- Core dependencies -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <sbt.project.name>core</sbt.project.name>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -402,6 +402,11 @@
         <artifactId>chill-java</artifactId>
         <version>${chill.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.esotericsoftware</groupId>
+        <artifactId>kryo-shaded</artifactId>
+        <version>4.0.2</version>
+      </dependency>
       <!-- This artifact is a shaded version of ASM 7.x. The POM that was used to produce this
            is at https://github.com/apache/geronimo-xbean/tree/trunk/xbean-asm7-shaded
            For context on why we shade ASM, see SPARK-782 and SPARK-6152. -->
@@ -3317,9 +3322,9 @@
     <profile>
       <id>scala-2.12</id>
       <properties>
-        <!-- 
+        <!--
          SPARK-34774 Add this property to ensure change-scala-version.sh can replace the public `scala.version`
-         property correctly. 
+         property correctly.
         -->
         <scala.version>2.12.14</scala.version>
       </properties>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix Kryo Shaded dependency for build

### Why are the changes needed?
I found that the build failed when I ran the unit test. Spark lost the kryo-shaded dependency after updating Chill recently.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass the CIs.