### PR TITLE
[SPARK-35943][PYTHON] Introduce Axis type alias.

### DIFF
--- a/python/pyspark/pandas/_typing.py
+++ b/python/pyspark/pandas/_typing.py
@@ -40,6 +40,7 @@ Scalar = Union[
     int, float, bool, str, bytes, decimal.Decimal, datetime.date, datetime.datetime, None
 ]
 
+Axis = Union[int, str]
 Dtype = Union[np.dtype, ExtensionDtype]
 
 DataFrameOrSeries = Union["DataFrame", "Series"]

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -34,7 +34,7 @@ from pyspark.sql.types import (
 )
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
+from pyspark.pandas._typing import Axis, Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.config import get_option, option_context
 from pyspark.pandas.internal import (
     InternalField,
@@ -951,7 +951,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
     notna = notnull
 
     # TODO: axis, skipna, and many arguments should be implemented.
-    def all(self, axis: Union[int, str] = 0) -> bool:
+    def all(self, axis: Axis = 0) -> bool:
         """
         Return whether all elements are True.
 
@@ -1014,7 +1014,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             return ret
 
     # TODO: axis, skipna, and many arguments should be implemented.
-    def any(self, axis: Union[int, str] = 0) -> bool:
+    def any(self, axis: Axis = 0) -> bool:
         """
         Return whether any element is True.
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -83,7 +83,7 @@ from pyspark.sql.types import (  # noqa: F401 (SPARK-34943)
 from pyspark.sql.window import Window
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas._typing import DataFrameOrSeries, Dtype, Scalar, T
+from pyspark.pandas._typing import Axis, DataFrameOrSeries, Dtype, Scalar, T
 from pyspark.pandas.accessors import PandasOnSparkFrameMethods
 from pyspark.pandas.config import option_context, get_option
 from pyspark.pandas.spark import functions as SF
@@ -642,7 +642,7 @@ class DataFrame(Frame, Generic[T]):
         self,
         sfun: Union[Callable[[Column], Column], Callable[[Column, DataType], Column]],
         name: str,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         numeric_only: bool = True,
         **kwargs: Any
     ) -> "Series":
@@ -2336,7 +2336,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     T = property(transpose)
 
     def apply(
-        self, func: Callable, axis: Union[int, str] = 0, args: Sequence[Any] = (), **kwds: Any
+        self, func: Callable, axis: Axis = 0, args: Sequence[Any] = (), **kwds: Any
     ) -> Union["Series", "DataFrame", "Index"]:
         """
         Apply a function along an axis of the DataFrame.
@@ -2645,7 +2645,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return result
 
     def transform(
-        self, func: Callable[..., "Series"], axis: Union[int, str] = 0, *args: Any, **kwargs: Any
+        self, func: Callable[..., "Series"], axis: Axis = 0, *args: Any, **kwargs: Any
     ) -> "DataFrame":
         """
         Call ``func`` on self producing a Series with transformed values
@@ -2882,7 +2882,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     # TODO: add axis parameter can work when '1' or 'columns'
     def xs(
-        self, key: Union[Any, Tuple], axis: Union[int, str] = 0, level: Optional[int] = None
+        self, key: Union[Any, Tuple], axis: Axis = 0, level: Optional[int] = None
     ) -> DataFrameOrSeries:
         """
         Return cross-section from the DataFrame.
@@ -3017,7 +3017,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         end_time: Union[datetime.time, str],
         include_start: bool = True,
         include_end: bool = True,
-        axis: Union[int, str] = 0,
+        axis: Axis = 0,
     ) -> "DataFrame":
         """
         Select values between particular times of the day (example: 9:00-9:30 AM).
@@ -3113,7 +3113,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     # TODO: implement axis=1
     def at_time(
-        self, time: Union[datetime.time, str], asof: bool = False, axis: Union[int, str] = 0
+        self, time: Union[datetime.time, str], asof: bool = False, axis: Axis = 0
     ) -> "DataFrame":
         """
         Select values at particular time of day (example: 9:30AM).
@@ -4114,7 +4114,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
     # TODO: axis should support 1 or 'columns' either at this moment
-    def diff(self, periods: int = 1, axis: Union[int, str] = 0) -> "DataFrame":
+    def diff(self, periods: int = 1, axis: Axis = 0) -> "DataFrame":
         """
         First discrete difference of element.
 
@@ -4191,7 +4191,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     # TODO: axis should support 1 or 'columns' either at this moment
     def nunique(
         self,
-        axis: Union[int, str] = 0,
+        axis: Axis = 0,
         dropna: bool = True,
         approx: bool = False,
         rsd: float = 0.05,
@@ -5149,7 +5149,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     def dropna(
         self,
-        axis: Union[int, str] = 0,
+        axis: Axis = 0,
         how: str = "any",
         thresh: Optional[int] = None,
         subset: Optional[Union[Any, Tuple, List[Union[Any, Tuple]]]] = None,
@@ -5362,7 +5362,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         self,
         value: Optional[Union[Any, Dict[Union[Any, Tuple], Any]]] = None,
         method: Optional[str] = None,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         inplace: bool = False,
         limit: Optional[int] = None,
     ) -> Optional["DataFrame"]:
@@ -6523,7 +6523,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
     def droplevel(
-        self, level: Union[int, Any, Tuple, List[Union[int, Any, Tuple]]], axis: Union[int, str] = 0
+        self, level: Union[int, Any, Tuple, List[Union[int, Any, Tuple]]], axis: Axis = 0
     ) -> "DataFrame":
         """
         Return DataFrame with requested index / column level(s) removed.
@@ -6638,7 +6638,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def drop(
         self,
         labels: Optional[Union[Any, Tuple, List[Union[Any, Tuple]]]] = None,
-        axis: Union[int, str] = 1,
+        axis: Axis = 1,
         columns: Union[Any, Tuple, List[Any], List[Tuple]] = None,
     ) -> "DataFrame":
         """
@@ -6875,7 +6875,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
     def sort_index(
         self,
-        axis: int = 0,
+        axis: Axis = 0,
         level: Optional[Union[int, List[int]]] = None,
         ascending: bool = True,
         inplace: bool = False,
@@ -6983,10 +6983,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return psdf
 
     def swaplevel(
-        self,
-        i: Union[int, Any, Tuple] = -2,
-        j: Union[int, Any, Tuple] = -1,
-        axis: Union[int, str] = 0,
+        self, i: Union[int, Any, Tuple] = -2, j: Union[int, Any, Tuple] = -1, axis: Axis = 0
     ) -> "DataFrame":
         """
         Swap levels i and j in a MultiIndex on a particular axis.
@@ -7088,7 +7085,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         return DataFrame(internal)
 
-    def swapaxes(self, i: Union[str, int], j: Union[str, int], copy: bool = True) -> "DataFrame":
+    def swapaxes(self, i: Axis, j: Axis, copy: bool = True) -> "DataFrame":
         """
         Interchange axes and swap values axes appropriately.
 
@@ -8616,7 +8613,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         labels: Optional[Sequence[Any]] = None,
         index: Optional[Union["Index", Sequence[Any]]] = None,
         columns: Optional[Union[pd.Index, Sequence[Any]]] = None,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         copy: Optional[bool] = True,
         fill_value: Optional[Any] = None,
     ) -> "DataFrame":
@@ -9557,7 +9554,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
     # TODO: axis, skipna, and many arguments should be implemented.
-    def all(self, axis: Union[int, str] = 0) -> "Series":
+    def all(self, axis: Axis = 0) -> "Series":
         """
         Return whether all elements are True.
 
@@ -9644,7 +9641,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return first_series(DataFrame(internal))
 
     # TODO: axis, skipna, and many arguments should be implemented.
-    def any(self, axis: Union[int, str] = 0) -> "Series":
+    def any(self, axis: Axis = 0) -> "Series":
         """
         Return whether any element is True.
 
@@ -9809,7 +9806,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         items: Optional[Sequence[Any]] = None,
         like: Optional[str] = None,
         regex: Optional[str] = None,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
     ) -> "DataFrame":
         """
         Subset rows or columns of dataframe according to labels in
@@ -9970,7 +9967,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         mapper: Optional[Union[Dict, Callable[[Any], Any]]] = None,
         index: Optional[Union[Dict, Callable[[Any], Any]]] = None,
         columns: Optional[Union[Dict, Callable[[Any], Any]]] = None,
-        axis: Union[int, str] = "index",
+        axis: Axis = "index",
         inplace: bool = False,
         level: Optional[int] = None,
         errors: str = "ignore",
@@ -10205,7 +10202,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         columns: Union[
             Any, Sequence[Any], Dict[Union[Any, Tuple], Any], Callable[[Union[Any, Tuple]], Any]
         ] = None,
-        axis: Optional[Union[int, str]] = 0,
+        axis: Optional[Axis] = 0,
         inplace: Optional[bool] = False,
     ) -> Optional["DataFrame"]:
         """
@@ -10454,7 +10451,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return self._apply_series_op(op, should_resolve=True)
 
     # TODO: axis = 1
-    def idxmax(self, axis: Union[int, str] = 0) -> "Series":
+    def idxmax(self, axis: Axis = 0) -> "Series":
         """
         Return index of first occurrence of maximum over requested axis.
         NA/null values are excluded.
@@ -10532,7 +10529,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return cast(ps.Series, ps.from_pandas(psdf._to_internal_pandas().idxmax()))
 
     # TODO: axis = 1
-    def idxmin(self, axis: Union[int, str] = 0) -> "Series":
+    def idxmin(self, axis: Axis = 0) -> "Series":
         """
         Return index of first occurrence of minimum over requested axis.
         NA/null values are excluded.
@@ -10727,7 +10724,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def quantile(
         self,
         q: Union[float, Iterable[float]] = 0.5,
-        axis: Union[int, str] = 0,
+        axis: Axis = 0,
         numeric_only: bool = True,
         accuracy: int = 10000,
     ) -> DataFrameOrSeries:
@@ -10986,7 +10983,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             return DataFrame(internal)
 
-    def take(self, indices: List[int], axis: Union[int, str] = 0, **kwargs: Any) -> "DataFrame":
+    def take(self, indices: List[int], axis: Axis = 0, **kwargs: Any) -> "DataFrame":
         """
         Return the elements in the given *positional* indices along an axis.
 
@@ -11251,7 +11248,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         internal = psdf._internal.with_new_sdf(sdf, data_fields=data_fields)
         return DataFrame(internal)
 
-    def mad(self, axis: int = 0) -> "Series":
+    def mad(self, axis: Axis = 0) -> "Series":
         """
         Return the mean absolute deviation of values.
 
@@ -11432,7 +11429,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         self,
         other: DataFrameOrSeries,
         join: str = "outer",
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         copy: bool = True,
     ) -> Tuple["DataFrame", DataFrameOrSeries]:
         """
@@ -11677,7 +11674,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def groupby(
         self,
         by: Union[Any, Tuple, "Series", List[Union[Any, Tuple, "Series"]]],
-        axis: Union[int, str] = 0,
+        axis: Axis = 0,
         as_index: bool = True,
         dropna: bool = True,
     ) -> "DataFrameGroupBy":

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -53,7 +53,7 @@ from pyspark.sql.types import (
 )
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas._typing import DataFrameOrSeries, Dtype, FrameLike, Scalar
+from pyspark.pandas._typing import Axis, DataFrameOrSeries, Dtype, FrameLike, Scalar
 from pyspark.pandas.indexing import AtIndexer, iAtIndexer, iLocIndexer, LocIndexer
 from pyspark.pandas.internal import InternalFrame
 from pyspark.pandas.spark import functions as SF
@@ -107,7 +107,7 @@ class Frame(object, metaclass=ABCMeta):
         self,
         sfun: Union[Callable[[Column], Column], Callable[[Column, DataType], Column]],
         name: str,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         numeric_only: bool = True,
         **kwargs: Any
     ) -> Union["Series", Scalar]:
@@ -1130,7 +1130,7 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     def mean(
-        self, axis: Union[int, str] = None, numeric_only: bool = None
+        self, axis: Optional[Axis] = None, numeric_only: bool = None
     ) -> Union[Scalar, "Series"]:
         """
         Return the mean of the values.
@@ -1193,7 +1193,7 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     def sum(
-        self, axis: Union[int, str] = None, numeric_only: bool = None, min_count: int = 0
+        self, axis: Optional[Axis] = None, numeric_only: bool = None, min_count: int = 0
     ) -> Union[Scalar, "Series"]:
         """
         Return the sum of the values.
@@ -1278,7 +1278,7 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     def product(
-        self, axis: Union[int, str] = None, numeric_only: bool = None, min_count: int = 0
+        self, axis: Optional[Axis] = None, numeric_only: bool = None, min_count: int = 0
     ) -> Union[Scalar, "Series"]:
         """
         Return the product of the values.
@@ -1377,7 +1377,7 @@ class Frame(object, metaclass=ABCMeta):
     prod = product
 
     def skew(
-        self, axis: Union[int, str] = None, numeric_only: bool = None
+        self, axis: Optional[Axis] = None, numeric_only: bool = None
     ) -> Union[Scalar, "Series"]:
         """
         Return unbiased skew normalized by N-1.
@@ -1433,7 +1433,7 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     def kurtosis(
-        self, axis: Union[int, str] = None, numeric_only: bool = None
+        self, axis: Optional[Axis] = None, numeric_only: bool = None
     ) -> Union[Scalar, "Series"]:
         """
         Return unbiased kurtosis using Fisher’s definition of kurtosis (kurtosis of normal == 0.0).
@@ -1492,7 +1492,7 @@ class Frame(object, metaclass=ABCMeta):
     kurt = kurtosis
 
     def min(
-        self, axis: Union[int, str] = None, numeric_only: bool = None
+        self, axis: Optional[Axis] = None, numeric_only: bool = None
     ) -> Union[Scalar, "Series"]:
         """
         Return the minimum of the values.
@@ -1547,7 +1547,7 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     def max(
-        self, axis: Union[int, str] = None, numeric_only: bool = None
+        self, axis: Optional[Axis] = None, numeric_only: bool = None
     ) -> Union[Scalar, "Series"]:
         """
         Return the maximum of the values.
@@ -1602,7 +1602,7 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     def count(
-        self, axis: Union[int, str] = None, numeric_only: bool = False
+        self, axis: Optional[Axis] = None, numeric_only: bool = False
     ) -> Union[Scalar, "Series"]:
         """
         Count non-NA cells for each column.
@@ -1676,7 +1676,7 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     def std(
-        self, axis: Union[int, str] = None, ddof: int = 1, numeric_only: bool = None
+        self, axis: Optional[Axis] = None, ddof: int = 1, numeric_only: bool = None
     ) -> Union[Scalar, "Series"]:
         """
         Return sample standard deviation.
@@ -1755,7 +1755,7 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     def var(
-        self, axis: Union[int, str] = None, ddof: int = 1, numeric_only: bool = None
+        self, axis: Optional[Axis] = None, ddof: int = 1, numeric_only: bool = None
     ) -> Union[Scalar, "Series"]:
         """
         Return unbiased variance.
@@ -1834,7 +1834,7 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     def median(
-        self, axis: Union[int, str] = None, numeric_only: bool = None, accuracy: int = 10000
+        self, axis: Optional[Axis] = None, numeric_only: bool = None, accuracy: int = 10000
     ) -> Union[Scalar, "Series"]:
         """
         Return the median of the values for the requested axis.
@@ -1943,7 +1943,7 @@ class Frame(object, metaclass=ABCMeta):
         )
 
     def sem(
-        self, axis: Union[int, str] = None, ddof: int = 1, numeric_only: bool = None
+        self, axis: Optional[Axis] = None, ddof: int = 1, numeric_only: bool = None
     ) -> Union[Scalar, "Series"]:
         """
         Return unbiased standard error of the mean over requested axis.
@@ -2120,7 +2120,7 @@ class Frame(object, metaclass=ABCMeta):
     def groupby(
         self: FrameLike,
         by: Union[Any, Tuple, "Series", List[Union[Any, Tuple, "Series"]]],
-        axis: Union[int, str] = 0,
+        axis: Axis = 0,
         as_index: bool = True,
         dropna: bool = True,
     ) -> "GroupBy[FrameLike]":
@@ -2614,9 +2614,7 @@ class Frame(object, metaclass=ABCMeta):
         except (KeyError, ValueError, IndexError):
             return default
 
-    def squeeze(
-        self, axis: Optional[Union[int, str]] = None
-    ) -> Union[Scalar, "DataFrame", "Series"]:
+    def squeeze(self, axis: Optional[Axis] = None) -> Union[Scalar, "DataFrame", "Series"]:
         """
         Squeeze 1 dimensional axis objects into scalars.
 
@@ -2752,7 +2750,7 @@ class Frame(object, metaclass=ABCMeta):
         self,
         before: Optional[Any] = None,
         after: Optional[Any] = None,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         copy: bool_type = True,
     ) -> DataFrameOrSeries:
         """
@@ -2960,7 +2958,7 @@ class Frame(object, metaclass=ABCMeta):
         self: FrameLike,
         value: Optional[Any] = None,
         method: Optional[str] = None,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         inplace: bool_type = False,
         limit: Optional[int] = None,
     ) -> FrameLike:
@@ -2969,7 +2967,7 @@ class Frame(object, metaclass=ABCMeta):
     # TODO: add 'downcast' when value parameter exists
     def bfill(
         self: FrameLike,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         inplace: bool_type = False,
         limit: Optional[int] = None,
     ) -> FrameLike:
@@ -3048,7 +3046,7 @@ class Frame(object, metaclass=ABCMeta):
     # TODO: add 'downcast' when value parameter exists
     def ffill(
         self: FrameLike,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         inplace: bool_type = False,
         limit: Optional[int] = None,
     ) -> FrameLike:

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -58,7 +58,7 @@ from pyspark.sql.types import (  # noqa: F401
 )
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas._typing import FrameLike
+from pyspark.pandas._typing import Axis, FrameLike
 from pyspark.pandas.typedef import infer_return_type, DataFrameType, ScalarType, SeriesType
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.internal import (
@@ -1694,7 +1694,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         self,
         value: Optional[Any] = None,
         method: Optional[str] = None,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         inplace: bool = False,
         limit: Optional[int] = None,
     ) -> FrameLike:

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -65,6 +65,7 @@ from pyspark.sql.types import (
 )
 
 from pyspark import pandas as ps  # noqa: F401
+from pyspark.pandas._typing import Axis, Dtype
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.utils import (
     align_diff_frames,
@@ -84,7 +85,6 @@ from pyspark.pandas.internal import (
 from pyspark.pandas.series import Series, first_series
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.spark.utils import as_nullable_spark_type, force_decimal_precision_scale
-from pyspark.pandas.typedef.typehints import Dtype
 from pyspark.pandas.indexes import Index, DatetimeIndex
 
 
@@ -2041,7 +2041,7 @@ def get_dummies(
 # TODO: there are many parameters to implement and support. See pandas's pd.concat.
 def concat(
     objs: List[Union[DataFrame, Series]],
-    axis: Union[int, str] = 0,
+    axis: Axis = 0,
     join: str = "outer",
     ignore_index: bool = False,
     sort: bool = False,

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -67,7 +67,7 @@ from pyspark.sql.types import (
 from pyspark.sql.window import Window
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
-from pyspark.pandas._typing import Dtype, Scalar, T
+from pyspark.pandas._typing import Axis, Dtype, Scalar, T
 from pyspark.pandas.accessors import PandasOnSparkSeriesMethods
 from pyspark.pandas.categorical import CategoricalAccessor
 from pyspark.pandas.config import get_option
@@ -1803,7 +1803,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         self,
         value: Optional[Any] = None,
         method: Optional[str] = None,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         inplace: bool = False,
         limit: Optional[int] = None,
     ) -> Optional["Series"]:
@@ -1899,7 +1899,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         self,
         value: Optional[Any] = None,
         method: Optional[str] = None,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         limit: Optional[int] = None,
         part_cols: Sequence["ColumnOrName"] = (),
     ) -> "Series":
@@ -1955,9 +1955,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             )
         )._psser_for(self._column_label)
 
-    def dropna(
-        self, axis: Union[int, str] = 0, inplace: bool = False, **kwargs: Any
-    ) -> Optional["Series"]:
+    def dropna(self, axis: Axis = 0, inplace: bool = False, **kwargs: Any) -> Optional["Series"]:
         """
         Return a new Series with missing values removed.
 
@@ -2510,7 +2508,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def sort_index(
         self,
-        axis: int = 0,
+        axis: Axis = 0,
         level: Optional[Union[int, List[int]]] = None,
         ascending: bool = True,
         inplace: bool = False,
@@ -2655,7 +2653,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         return first_series(self.to_frame().swaplevel(i, j, axis=0)).rename(self.name)
 
-    def swapaxes(self, i: Union[str, int], j: Union[str, int], copy: bool = True) -> "Series":
+    def swapaxes(self, i: Axis, j: Axis, copy: bool = True) -> "Series":
         """
         Interchange axes and swap values axes appropriately.
 
@@ -3253,11 +3251,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     T = property(transpose)
 
     def transform(
-        self,
-        func: Union[Callable, List[Callable]],
-        axis: Union[int, str] = 0,
-        *args: Any,
-        **kwargs: Any
+        self, func: Union[Callable, List[Callable]], axis: Axis = 0, *args: Any, **kwargs: Any
     ) -> Union["Series", DataFrame]:
         """
         Call ``func`` producing the same type as `self` with transformed values
@@ -3603,7 +3597,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         items: Optional[Sequence[Any]] = None,
         like: Optional[str] = None,
         regex: Optional[str] = None,
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
     ) -> "Series":
         axis = validate_axis(axis)
         if axis == 1:
@@ -5814,7 +5808,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         self,
         other: Union[DataFrame, "Series"],
         join: str = "outer",
-        axis: Optional[Union[int, str]] = None,
+        axis: Optional[Axis] = None,
         copy: bool = True,
     ) -> Tuple["Series", Union[DataFrame, "Series"]]:
         """
@@ -5910,7 +5904,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         end_time: Union[datetime.time, str],
         include_start: bool = True,
         include_end: bool = True,
-        axis: Union[int, str] = 0,
+        axis: Axis = 0,
     ) -> "Series":
         """
         Select values between particular times of the day (example: 9:00-9:30 AM).
@@ -5969,7 +5963,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ).rename(self.name)
 
     def at_time(
-        self, time: Union[datetime.time, str], asof: bool = False, axis: Union[int, str] = 0
+        self, time: Union[datetime.time, str], asof: bool = False, axis: Axis = 0
     ) -> "Series":
         """
         Select values at particular time of day (example: 9:30AM).
@@ -6178,7 +6172,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         self,
         sfun: Union[Callable[[Column], Column], Callable[[Column, DataType], Column]],
         name: str_type,
-        axis: Optional[Union[int, str_type]] = None,
+        axis: Optional[Axis] = None,
         numeric_only: bool = True,
         **kwargs: Any
     ) -> Scalar:
@@ -6220,7 +6214,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def groupby(
         self,
         by: Union[Any, Tuple, "Series", List[Union[Any, Tuple, "Series"]]],
-        axis: Union[int, str_type] = 0,
+        axis: Axis = 0,
         as_index: bool = True,
         dropna: bool = True,
     ) -> "SeriesGroupBy":

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -46,7 +46,7 @@ from pandas.api.types import is_list_like
 
 # For running doctests and reference resolution in PyCharm.
 from pyspark import pandas as ps  # noqa: F401
-from pyspark.pandas._typing import DataFrameOrSeries
+from pyspark.pandas._typing import Axis, DataFrameOrSeries
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef.typehints import as_spark_type
 
@@ -713,12 +713,12 @@ def is_name_like_value(
         return True
 
 
-def validate_axis(axis: Optional[Union[int, str]] = 0, none_axis: int = 0) -> int:
+def validate_axis(axis: Optional[Axis] = 0, none_axis: int = 0) -> int:
     """Check the given axis is valid."""
     # convert to numeric axis
-    axis = cast(
-        Dict[Optional[Union[int, str]], int], {None: none_axis, "index": 0, "columns": 1}
-    ).get(axis, axis)
+    axis = cast(Dict[Optional[Axis], int], {None: none_axis, "index": 0, "columns": 1}).get(
+        axis, axis
+    )
     if axis in (none_axis, 0, 1):
         return cast(int, axis)
     else:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduces `Axis` type alias for `axis` argument to be consistent.

### Why are the changes needed?

There are many places to use `axis` argument. We should define `Axis` type alias and reuse it to be consistent.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.