### PR TITLE
[SPARK-35948][INFRA] Simplify release scripts by removing Spark 2.4/Java7 parts

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -177,10 +177,7 @@ fi
 
 # Depending on the version being built, certain extra profiles need to be activated, and
 # different versions of Scala are supported.
-BASE_PROFILES="-Pmesos -Pyarn"
-if [[ $SPARK_VERSION > "2.3" ]]; then
-  BASE_PROFILES="$BASE_PROFILES -Pkubernetes"
-fi
+BASE_PROFILES="-Pmesos -Pyarn -Pkubernetes"
 
 PUBLISH_SCALA_2_13=1
 SCALA_2_13_PROFILES="-Pscala-2.13"
@@ -188,14 +185,8 @@ if [[ $SPARK_VERSION < "3.2" ]]; then
   PUBLISH_SCALA_2_13=0
 fi
 
-PUBLISH_SCALA_2_12=0
+PUBLISH_SCALA_2_12=1
 SCALA_2_12_PROFILES="-Pscala-2.12"
-if [[ $SPARK_VERSION < "3.0." ]]; then
-  SCALA_2_12_PROFILES="-Pscala-2.12 -Pflume"
-fi
-if [[ $SPARK_VERSION > "2.4" ]]; then
-  PUBLISH_SCALA_2_12=1
-fi
 
 # Hive-specific profiles for some builds
 HIVE_PROFILES="-Phive -Phive-thriftserver"
@@ -236,12 +227,9 @@ if [[ "$1" == "package" ]]; then
   echo "Packaging release source tarballs"
   cp -r spark spark-$SPARK_VERSION
 
-  # For source release in v2.4+, exclude copy of binary license/notice
-  if [[ $SPARK_VERSION > "2.4" ]]; then
-    rm -f spark-$SPARK_VERSION/LICENSE-binary
-    rm -f spark-$SPARK_VERSION/NOTICE-binary
-    rm -rf spark-$SPARK_VERSION/licenses-binary
-  fi
+  rm -f spark-$SPARK_VERSION/LICENSE-binary
+  rm -f spark-$SPARK_VERSION/NOTICE-binary
+  rm -rf spark-$SPARK_VERSION/licenses-binary
 
   tar cvzf spark-$SPARK_VERSION.tgz --exclude spark-$SPARK_VERSION/.git spark-$SPARK_VERSION
   echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour --output spark-$SPARK_VERSION.tgz.asc \
@@ -337,11 +325,7 @@ if [[ "$1" == "package" ]]; then
   BINARY_PKGS_ARGS["hadoop3.2"]="-Phadoop-3.2 $HIVE_PROFILES"
   if ! is_dry_run; then
     BINARY_PKGS_ARGS["without-hadoop"]="-Phadoop-provided"
-    if [[ $SPARK_VERSION < "3.0." ]]; then
-      BINARY_PKGS_ARGS["hadoop2.6"]="-Phadoop-2.6 $HIVE_PROFILES"
-    else
-      BINARY_PKGS_ARGS["hadoop2.7"]="-Phadoop-2.7 $HIVE_PROFILES"
-    fi
+    BINARY_PKGS_ARGS["hadoop2.7"]="-Phadoop-2.7 $HIVE_PROFILES"
   fi
 
   declare -A BINARY_PKGS_EXTRA

--- a/dev/create-release/release-util.sh
+++ b/dev/create-release/release-util.sh
@@ -226,11 +226,5 @@ function init_maven_sbt {
   MVN="build/mvn -B"
   MVN_EXTRA_OPTS=
   SBT_OPTS=
-  if [[ $JAVA_VERSION < "1.8." ]]; then
-    # Needed for maven central when using Java 7.
-    SBT_OPTS="-Dhttps.protocols=TLSv1.1,TLSv1.2"
-    MVN_EXTRA_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dhttps.protocols=TLSv1.1,TLSv1.2"
-    MVN="$MVN $MVN_EXTRA_OPTS"
-  fi
   export MVN MVN_EXTRA_OPTS SBT_OPTS
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to clean up Spark 2.4 and Java7 code path from the release scripts.

### Why are the changes needed?

To simplify the logic.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A