### PR TITLE
[SPARK-35949][CORE]Fixes bug for sparkContext stopped on client mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -958,7 +958,7 @@ private[spark] class SparkSubmit extends Logging {
         throw findCause(t)
     } finally {
       if (!isShell(args.primaryResource) && !isSqlShell(args.mainClass) &&
-        !isThriftServer(args.mainClass)) {
+        !isThriftServer(args.mainClass) && !isClientMode(args.deployMode)) {
         try {
           SparkContext.getActive.foreach(_.stop())
         } catch {
@@ -1096,6 +1096,13 @@ object SparkSubmit extends CommandLineUtils with Logging {
 
   private[deploy] def isInternal(res: String): Boolean = {
     res == SparkLauncher.NO_RESOURCE
+  }
+
+  /**
+   * Return whether the given deployMode is client.
+   */
+  private[deploy] def isClientMode(deployMode: String): Boolean = {
+    deployMode == null || deployMode.equalsIgnoreCase("client")
   }
 
 }

--- a/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/FileCommitProtocol.scala
@@ -20,6 +20,7 @@ package org.apache.spark.internal.io
 import org.apache.hadoop.fs._
 import org.apache.hadoop.mapreduce._
 
+import org.apache.spark.annotation.Unstable
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
 
@@ -41,7 +42,11 @@ import org.apache.spark.util.Utils
  *    (or abortTask if task failed).
  * 3. When all necessary tasks completed successfully, the driver calls commitJob. If the job
  *    failed to execute (e.g. too many failed tasks), the job should call abortJob.
+ *
+ * @note This class is exposed as an API considering the usage of many downstream custom
+ * implementations, but will be subject to be changed and/or moved.
  */
+@Unstable
 abstract class FileCommitProtocol extends Logging {
   import FileCommitProtocol._
 
@@ -107,9 +112,7 @@ abstract class FileCommitProtocol extends Logging {
    * if a task is going to write out multiple files to the same dir. The file commit protocol only
    * guarantees that files written by different tasks will not conflict.
    *
-   * This API should be implemented and called, instead of
-   * [[newTaskTempFile(taskContest, dir, ext)]]. Provide a default implementation here to be
-   * backward compatible with custom [[FileCommitProtocol]] implementations before Spark 3.2.0.
+   * @since 3.2.0
    */
   def newTaskTempFile(
       taskContext: TaskAttemptContext, dir: Option[String], spec: FileNameSpec): String = {
@@ -144,10 +147,7 @@ abstract class FileCommitProtocol extends Logging {
    * if a task is going to write out multiple files to the same dir. The file commit protocol only
    * guarantees that files written by different tasks will not conflict.
    *
-   * This API should be implemented and called, instead of
-   * [[newTaskTempFileAbsPath(taskContest, absoluteDir, ext)]]. Provide a default implementation
-   * here to be backward compatible with custom [[FileCommitProtocol]] implementations before
-   * Spark 3.2.0.
+   * @since 3.2.0
    */
   def newTaskTempFileAbsPath(
       taskContext: TaskAttemptContext, absoluteDir: String, spec: FileNameSpec): String = {

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -229,7 +229,7 @@ git clean -d -f -x
 rm -f .gitignore
 cd ..
 
-export MAVEN_OPTS="-Xmx12g"
+export MAVEN_OPTS="-Xss128m -Xmx12g"
 
 if [[ "$1" == "package" ]]; then
   # Source and binary tarballs

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -177,10 +177,7 @@ fi
 
 # Depending on the version being built, certain extra profiles need to be activated, and
 # different versions of Scala are supported.
-BASE_PROFILES="-Pmesos -Pyarn"
-if [[ $SPARK_VERSION > "2.3" ]]; then
-  BASE_PROFILES="$BASE_PROFILES -Pkubernetes"
-fi
+BASE_PROFILES="-Pmesos -Pyarn -Pkubernetes"
 
 PUBLISH_SCALA_2_13=1
 SCALA_2_13_PROFILES="-Pscala-2.13"
@@ -188,14 +185,8 @@ if [[ $SPARK_VERSION < "3.2" ]]; then
   PUBLISH_SCALA_2_13=0
 fi
 
-PUBLISH_SCALA_2_12=0
+PUBLISH_SCALA_2_12=1
 SCALA_2_12_PROFILES="-Pscala-2.12"
-if [[ $SPARK_VERSION < "3.0." ]]; then
-  SCALA_2_12_PROFILES="-Pscala-2.12 -Pflume"
-fi
-if [[ $SPARK_VERSION > "2.4" ]]; then
-  PUBLISH_SCALA_2_12=1
-fi
 
 # Hive-specific profiles for some builds
 HIVE_PROFILES="-Phive -Phive-thriftserver"
@@ -236,12 +227,9 @@ if [[ "$1" == "package" ]]; then
   echo "Packaging release source tarballs"
   cp -r spark spark-$SPARK_VERSION
 
-  # For source release in v2.4+, exclude copy of binary license/notice
-  if [[ $SPARK_VERSION > "2.4" ]]; then
-    rm -f spark-$SPARK_VERSION/LICENSE-binary
-    rm -f spark-$SPARK_VERSION/NOTICE-binary
-    rm -rf spark-$SPARK_VERSION/licenses-binary
-  fi
+  rm -f spark-$SPARK_VERSION/LICENSE-binary
+  rm -f spark-$SPARK_VERSION/NOTICE-binary
+  rm -rf spark-$SPARK_VERSION/licenses-binary
 
   tar cvzf spark-$SPARK_VERSION.tgz --exclude spark-$SPARK_VERSION/.git spark-$SPARK_VERSION
   echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour --output spark-$SPARK_VERSION.tgz.asc \
@@ -337,11 +325,7 @@ if [[ "$1" == "package" ]]; then
   BINARY_PKGS_ARGS["hadoop3.2"]="-Phadoop-3.2 $HIVE_PROFILES"
   if ! is_dry_run; then
     BINARY_PKGS_ARGS["without-hadoop"]="-Phadoop-provided"
-    if [[ $SPARK_VERSION < "3.0." ]]; then
-      BINARY_PKGS_ARGS["hadoop2.6"]="-Phadoop-2.6 $HIVE_PROFILES"
-    else
-      BINARY_PKGS_ARGS["hadoop2.7"]="-Phadoop-2.7 $HIVE_PROFILES"
-    fi
+    BINARY_PKGS_ARGS["hadoop2.7"]="-Phadoop-2.7 $HIVE_PROFILES"
   fi
 
   declare -A BINARY_PKGS_EXTRA

--- a/dev/create-release/release-util.sh
+++ b/dev/create-release/release-util.sh
@@ -226,11 +226,5 @@ function init_maven_sbt {
   MVN="build/mvn -B"
   MVN_EXTRA_OPTS=
   SBT_OPTS=
-  if [[ $JAVA_VERSION < "1.8." ]]; then
-    # Needed for maven central when using Java 7.
-    SBT_OPTS="-Dhttps.protocols=TLSv1.1,TLSv1.2"
-    MVN_EXTRA_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g -Dhttps.protocols=TLSv1.1,TLSv1.2"
-    MVN="$MVN $MVN_EXTRA_OPTS"
-  fi
   export MVN MVN_EXTRA_OPTS SBT_OPTS
 }

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -296,6 +296,12 @@ Data source options of Avro can be set via:
     </td>
     <td>read and function <code>from_avro</code></td>
   </tr>
+  <tr>
+    <td><code>positionalFieldMatching</code></td>
+    <td>false</td>
+    <td>This can be used in tandem with the `avroSchema` option to adjust the behavior for matching the fields in the provided Avro schema with those in the SQL schema. By default, the matching will be performed using field names, ignoring their positions. If this option is set to "true", the matching will be based on the position of the fields.</td>
+    <td>read and write</td>
+  </tr>
 </table>
 
 ## Configuration

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -30,7 +30,7 @@ import org.apache.avro.Schema.Type._
 import org.apache.avro.generic._
 import org.apache.avro.util.Utf8
 
-import org.apache.spark.sql.avro.AvroUtils.toFieldStr
+import org.apache.spark.sql.avro.AvroUtils.{toFieldDescription, toFieldStr}
 import org.apache.spark.sql.catalyst.{InternalRow, NoopFilters, StructFilters}
 import org.apache.spark.sql.catalyst.expressions.{SpecificInternalRow, UnsafeArrayData}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, DateTimeUtils, GenericArrayData}
@@ -45,6 +45,7 @@ import org.apache.spark.unsafe.types.UTF8String
 private[sql] class AvroDeserializer(
     rootAvroType: Schema,
     rootCatalystType: DataType,
+    positionalFieldMatch: Boolean,
     datetimeRebaseMode: LegacyBehaviorPolicy.Value,
     filters: StructFilters) {
 
@@ -55,6 +56,7 @@ private[sql] class AvroDeserializer(
     this(
       rootAvroType,
       rootCatalystType,
+      positionalFieldMatch = false,
       LegacyBehaviorPolicy.withName(datetimeRebaseMode),
       new NoopFilters)
   }
@@ -338,12 +340,13 @@ private[sql] class AvroDeserializer(
     val validFieldIndexes = ArrayBuffer.empty[Int]
     val fieldWriters = ArrayBuffer.empty[(CatalystDataUpdater, Any) => Unit]
 
-    val avroSchemaHelper = new AvroUtils.AvroSchemaHelper(avroType, avroPath)
+    val avroSchemaHelper =
+      new AvroUtils.AvroSchemaHelper(avroType, avroPath, positionalFieldMatch)
     val length = catalystType.length
     var i = 0
     while (i < length) {
       val catalystField = catalystType.fields(i)
-      avroSchemaHelper.getFieldByName(catalystField.name) match {
+      avroSchemaHelper.getAvroField(catalystField.name, i) match {
         case Some(avroField) =>
           validFieldIndexes += avroField.pos()
 
@@ -359,8 +362,10 @@ private[sql] class AvroDeserializer(
           }
           fieldWriters += fieldWriter
         case None if !catalystField.nullable =>
-          throw new IncompatibleSchemaException(s"Cannot find non-nullable " +
-              s"${toFieldStr(catalystPath :+ catalystField.name)} in Avro schema.")
+          val fieldDescription =
+            toFieldDescription(catalystPath :+ catalystField.name, i, positionalFieldMatch)
+          throw new IncompatibleSchemaException(
+            s"Cannot find non-nullable $fieldDescription in Avro schema.")
         case _ => // nothing to do
       }
       i += 1

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
@@ -138,6 +138,7 @@ private[sql] class AvroFileFormat extends FileFormat
           override val deserializer = new AvroDeserializer(
             userProvidedSchema.getOrElse(reader.getSchema),
             requiredSchema,
+            parsedOptions.positionalFieldMatching,
             datetimeRebaseMode,
             avroFilters)
           override val stopPosition = file.start + file.length

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -68,6 +68,14 @@ private[sql] class AvroOptions(
   }
 
   /**
+   * Iff true, perform Catalyst-to-Avro schema matching based on field position instead of field
+   * name. This allows for a structurally equivalent Catalyst schema to be used with an Avro schema
+   * whose field names do not match. Defaults to false.
+   */
+  val positionalFieldMatching: Boolean =
+    parameters.get("positionalFieldMatching").exists(_.toBoolean)
+
+  /**
    * Top level record name in write result, which is required in Avro spec.
    * See https://avro.apache.org/docs/1.10.2/spec.html#schema_record .
    * Default value is "topLevelRecord"

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriter.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriter.scala
@@ -41,6 +41,7 @@ private[avro] class AvroOutputWriter(
     val path: String,
     context: TaskAttemptContext,
     schema: StructType,
+    positionalFieldMatching: Boolean,
     avroSchema: Schema) extends OutputWriter {
 
   // Whether to rebase datetimes from Gregorian to Julian calendar in write
@@ -48,8 +49,8 @@ private[avro] class AvroOutputWriter(
     SQLConf.get.getConf(SQLConf.AVRO_REBASE_MODE_IN_WRITE))
 
   // The input rows will never be null.
-  private lazy val serializer =
-    new AvroSerializer(schema, avroSchema, nullable = false, datetimeRebaseMode)
+  private lazy val serializer = new AvroSerializer(
+    schema, avroSchema, nullable = false, positionalFieldMatching, datetimeRebaseMode)
 
   /**
    * Overrides the couple of methods responsible for generating the output streams / files so

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
@@ -25,12 +25,16 @@ import org.apache.spark.sql.types.StructType
 
 /**
  * A factory that produces [[AvroOutputWriter]].
+ *
  * @param catalystSchema Catalyst schema of input data.
  * @param avroSchemaAsJsonString Avro schema of output result, in JSON string format.
+ * @param positionalFieldMatching If true, match Avro schema against catalyst schema using field
+ *                                ordering (i.e. position/index) instead of field name.
  */
 private[sql] class AvroOutputWriterFactory(
     catalystSchema: StructType,
-    avroSchemaAsJsonString: String) extends OutputWriterFactory {
+    avroSchemaAsJsonString: String,
+    positionalFieldMatching: Boolean) extends OutputWriterFactory {
 
   private lazy val avroSchema = new Schema.Parser().parse(avroSchemaAsJsonString)
 
@@ -40,6 +44,6 @@ private[sql] class AvroOutputWriterFactory(
       path: String,
       dataSchema: StructType,
       context: TaskAttemptContext): OutputWriter = {
-    new AvroOutputWriter(path, context, catalystSchema, avroSchema)
+    new AvroOutputWriter(path, context, catalystSchema, positionalFieldMatching, avroSchema)
   }
 }

--- a/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroPartitionReaderFactory.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroPartitionReaderFactory.scala
@@ -104,6 +104,7 @@ case class AvroPartitionReaderFactory(
         override val deserializer = new AvroDeserializer(
           userProvidedSchema.getOrElse(reader.getSchema),
           readDataSchema,
+          parsedOptions.positionalFieldMatching,
           datetimeRebaseMode,
           avroFilters)
         override val stopPosition = partitionedFile.start + partitionedFile.length

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
@@ -284,6 +284,7 @@ class AvroCatalystDataConversionSuite extends SparkFunSuite
     val deserializer = new AvroDeserializer(
       schema,
       dataType,
+      false,
       SQLConf.LegacyBehaviorPolicy.CORRECTED,
       filters)
     val deserialized = deserializer.deserialize(data)

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
@@ -70,6 +70,7 @@ class AvroRowReaderSuite
         override val deserializer = new AvroDeserializer(
           reader.getSchema,
           StructType(new StructField("value", IntegerType, true) :: Nil),
+          false,
           CORRECTED,
           new NoopFilters)
         override val stopPosition = fileSize

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSerdeSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSerdeSuite.scala
@@ -20,7 +20,8 @@ import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.avro.generic.GenericRecordBuilder
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
+import org.apache.spark.sql.catalyst.NoopFilters
+import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.CORRECTED
 import org.apache.spark.sql.types.{IntegerType, StructType}
 
 /**
@@ -29,58 +30,75 @@ import org.apache.spark.sql.types.{IntegerType, StructType}
  */
 class AvroSerdeSuite extends SparkFunSuite {
   import AvroSerdeSuite._
-
-  private val defaultRebaseMode = LegacyBehaviorPolicy.CORRECTED.toString
+  import AvroSerdeSuite.MatchType._
 
   test("Test basic conversion") {
-    val avro = createNestedAvroSchemaWithFields("foo", _.optionalInt("bar"))
-    val record = new GenericRecordBuilder(avro)
-        .set("foo", new GenericRecordBuilder(avro.getField("foo").schema()).set("bar", 42).build())
-        .build()
-    val serializer = new AvroSerializer(CATALYST_STRUCT, avro, false)
-    val deserializer = new AvroDeserializer(avro, CATALYST_STRUCT, defaultRebaseMode)
-    assert(serializer.serialize(deserializer.deserialize(record).get) === record)
+    withFieldMatchType { fieldMatch =>
+      val (top, nest) = fieldMatch match {
+        case BY_NAME => ("foo", "bar")
+        case BY_POSITION => ("NOTfoo", "NOTbar")
+      }
+      val avro = createNestedAvroSchemaWithFields(top, _.optionalInt(nest))
+      val record = new GenericRecordBuilder(avro)
+          .set(top, new GenericRecordBuilder(avro.getField(top).schema()).set(nest, 42).build())
+          .build()
+      val serializer = Serializer.create(CATALYST_STRUCT, avro, fieldMatch)
+      val deserializer = Deserializer.create(CATALYST_STRUCT, avro, fieldMatch)
+      assert(serializer.serialize(deserializer.deserialize(record).get) === record)
+    }
   }
 
   test("Fail to convert with field type mismatch") {
     val avro = createAvroSchemaWithTopLevelFields(_.requiredInt("foo"))
-
-    assertFailedConversionMessage(avro, deserialize = true,
-      "Cannot convert Avro field 'foo' to SQL field 'foo' because schema is incompatible " +
+    withFieldMatchType { fieldMatch =>
+      assertFailedConversionMessage(avro, Deserializer, fieldMatch,
+        "Cannot convert Avro field 'foo' to SQL field 'foo' because schema is incompatible " +
           s"""(avroType = "int", sqlType = ${CATALYST_STRUCT.head.dataType.sql})""")
 
-    assertFailedConversionMessage(avro, deserialize = false,
-      s"Cannot convert SQL field 'foo' to Avro field 'foo' because schema is incompatible " +
+      assertFailedConversionMessage(avro, Serializer, fieldMatch,
+        s"Cannot convert SQL field 'foo' to Avro field 'foo' because schema is incompatible " +
           s"""(sqlType = ${CATALYST_STRUCT.head.dataType.sql}, avroType = "int")""")
+    }
   }
 
   test("Fail to convert with nested field type mismatch") {
     val avro = createNestedAvroSchemaWithFields("foo", _.optionalFloat("bar"))
 
-    assertFailedConversionMessage(avro, deserialize = true,
-      "Cannot convert Avro field 'foo.bar' to SQL field 'foo.bar' because schema is " +
+    withFieldMatchType { fieldMatch =>
+      assertFailedConversionMessage(avro, Deserializer, fieldMatch,
+        "Cannot convert Avro field 'foo.bar' to SQL field 'foo.bar' because schema is " +
           """incompatible (avroType = "float", sqlType = INT)""")
 
-    assertFailedConversionMessage(avro, deserialize = false,
-      "Cannot convert SQL field 'foo.bar' to Avro field 'foo.bar' because " +
-        """schema is incompatible (sqlType = INT, avroType = "float")""")
+      assertFailedConversionMessage(avro, Serializer, fieldMatch,
+        "Cannot convert SQL field 'foo.bar' to Avro field 'foo.bar' because " +
+          """schema is incompatible (sqlType = INT, avroType = "float")""")
+    }
   }
 
-  test("Fail to convert with nested field name mismatch") {
+  test("Fail to convert with missing nested Avro fields") {
     val avro = createNestedAvroSchemaWithFields("foo", _.optionalInt("NOTbar"))
     val nonnullCatalyst = new StructType()
         .add("foo", new StructType().add("bar", IntegerType, nullable = false))
+    // Positional matching will work fine with the name change, so add a new field
+    val extraNonnullCatalyst = new StructType().add("foo",
+      new StructType().add("bar", IntegerType).add("baz", IntegerType, nullable = false))
 
     // deserialize should have no issues when 'bar' is nullable but fail when it is nonnull
-    new AvroDeserializer(avro, CATALYST_STRUCT, defaultRebaseMode)
-    assertFailedConversionMessage(avro, deserialize = true,
-      "Cannot find non-nullable field 'foo.bar' in Avro schema.",
+    Deserializer.create(CATALYST_STRUCT, avro, BY_NAME)
+    assertFailedConversionMessage(avro, Deserializer, BY_NAME,
+      "Cannot find non-nullable field 'foo.bar' (at position 0) in Avro schema.",
       nonnullCatalyst)
+    assertFailedConversionMessage(avro, Deserializer, BY_POSITION,
+      "Cannot find non-nullable field at position 1 (field 'foo.baz') in Avro schema.",
+      extraNonnullCatalyst)
 
     // serialize fails whether or not 'bar' is nullable
-    val expectMsg = "Cannot find field 'foo.bar' in Avro schema at field 'foo'"
-    assertFailedConversionMessage(avro, deserialize = false, expectMsg)
-    assertFailedConversionMessage(avro, deserialize = false, expectMsg, nonnullCatalyst)
+    val expectMsg = "Cannot find field 'foo.bar' (at position 0) in Avro schema at field 'foo'"
+    assertFailedConversionMessage(avro, Serializer, BY_NAME, expectMsg)
+    assertFailedConversionMessage(avro, Serializer, BY_NAME, expectMsg, nonnullCatalyst)
+    assertFailedConversionMessage(avro, Serializer, BY_POSITION,
+      "Avro field 'foo' schema length (1) doesn't match SQL field 'foo' schema length (2)",
+      extraNonnullCatalyst)
   }
 
   test("Fail to convert with deeply nested field type mismatch") {
@@ -89,27 +107,33 @@ class AvroSerdeSuite extends SparkFunSuite {
         .noDefault().endRecord()
     val catalyst = new StructType().add("top", CATALYST_STRUCT)
 
-    assertFailedConversionMessage(avro, deserialize = true,
-      "Cannot convert Avro field 'top.foo.bar' to SQL field 'top.foo.bar' because schema " +
-        """is incompatible (avroType = "float", sqlType = INT)""",
-      catalyst)
+    withFieldMatchType { fieldMatch =>
+      assertFailedConversionMessage(avro, Deserializer, fieldMatch,
+        "Cannot convert Avro field 'top.foo.bar' to SQL field 'top.foo.bar' because schema " +
+          """is incompatible (avroType = "float", sqlType = INT)""",
+        catalyst)
 
-    assertFailedConversionMessage(avro, deserialize = false,
-      "Cannot convert SQL field 'top.foo.bar' to Avro field 'top.foo.bar' because schema is " +
+      assertFailedConversionMessage(avro, Serializer, fieldMatch,
+        "Cannot convert SQL field 'top.foo.bar' to Avro field 'top.foo.bar' because schema is " +
           """incompatible (sqlType = INT, avroType = "float")""",
-      catalyst)
+        catalyst)
+    }
   }
 
   test("Fail to convert for serialization with field count mismatch") {
-    val tooManyFields = createAvroSchemaWithTopLevelFields(_.optionalInt("foo").optionalLong("bar"))
-    assertFailedConversionMessage(tooManyFields, deserialize = false,
-      "Avro top-level record schema length (2) " +
-        "doesn't match SQL top-level record schema length (1)")
+    // Note that this is allowed for deserialization, but not serialization
+    withFieldMatchType { fieldMatch =>
+      val tooManyFields =
+        createAvroSchemaWithTopLevelFields(_.optionalInt("foo").optionalLong("bar"))
+      assertFailedConversionMessage(tooManyFields, Serializer, fieldMatch,
+        "Avro top-level record schema length (2) " +
+          "doesn't match SQL top-level record schema length (1)")
 
-    val tooFewFields = createAvroSchemaWithTopLevelFields(f => f)
-    assertFailedConversionMessage(tooFewFields, deserialize = false,
-      "Avro top-level record schema length (0) " +
-        "doesn't match SQL top-level record schema length (1)")
+      val tooFewFields = createAvroSchemaWithTopLevelFields(f => f)
+      assertFailedConversionMessage(tooFewFields, Serializer, fieldMatch,
+        "Avro top-level record schema length (0) " +
+          "doesn't match SQL top-level record schema length (1)")
+    }
   }
 
   /**
@@ -118,23 +142,29 @@ class AvroSerdeSuite extends SparkFunSuite {
    * matching `expectedCauseMessage`.
    */
   private def assertFailedConversionMessage(avroSchema: Schema,
-      deserialize: Boolean,
+      serdeFactory: SerdeFactory[_],
+      fieldMatchType: MatchType,
       expectedCauseMessage: String,
       catalystSchema: StructType = CATALYST_STRUCT): Unit = {
     val e = intercept[IncompatibleSchemaException] {
-      if (deserialize) {
-        new AvroDeserializer(avroSchema, catalystSchema, defaultRebaseMode)
-      } else {
-        new AvroSerializer(catalystSchema, avroSchema, false)
-      }
+      serdeFactory.create(catalystSchema, avroSchema, fieldMatchType)
     }
-    val expectMsg = if (deserialize) {
-      s"Cannot convert Avro type $avroSchema to SQL type ${catalystSchema.sql}."
-    } else {
-      s"Cannot convert SQL type ${catalystSchema.sql} to Avro type $avroSchema."
+    val expectMsg = serdeFactory match {
+      case Deserializer =>
+        s"Cannot convert Avro type $avroSchema to SQL type ${catalystSchema.sql}."
+      case Serializer =>
+        s"Cannot convert SQL type ${catalystSchema.sql} to Avro type $avroSchema."
     }
     assert(e.getMessage === expectMsg)
     assert(e.getCause.getMessage === expectedCauseMessage)
+  }
+
+  def withFieldMatchType(f: MatchType => Unit): Unit = {
+    MatchType.values.foreach { fieldMatchType =>
+      withClue(s"fieldMatchType == $fieldMatchType") {
+        f(fieldMatchType)
+      }
+    }
   }
 }
 
@@ -143,6 +173,34 @@ object AvroSerdeSuite {
 
   private val CATALYST_STRUCT =
     new StructType().add("foo", new StructType().add("bar", IntegerType))
+
+  /**
+   * Specifier for type of field matching to be used for easy creation of tests that do both
+   * positional and by-name field matching.
+   */
+  private object MatchType extends Enumeration {
+    type MatchType = Value
+    val BY_NAME, BY_POSITION = Value
+
+    def isPositional(fieldMatchType: MatchType): Boolean = fieldMatchType == BY_POSITION
+  }
+
+  import MatchType._
+  /**
+   * Specifier for type of serde to be used for easy creation of tests that do both
+   * serialization and deserialization.
+   */
+  private sealed trait SerdeFactory[T] {
+    def create(sqlSchema: StructType, avroSchema: Schema, fieldMatchType: MatchType): T
+  }
+  private object Serializer extends SerdeFactory[AvroSerializer] {
+    override def create(sql: StructType, avro: Schema, matchType: MatchType): AvroSerializer =
+      new AvroSerializer(sql, avro, false, isPositional(matchType), CORRECTED)
+  }
+  private object Deserializer extends SerdeFactory[AvroDeserializer] {
+    override def create(sql: StructType, avro: Schema, matchType: MatchType): AvroDeserializer =
+      new AvroDeserializer(avro, sql, isPositional(matchType), CORRECTED, new NoopFilters)
+  }
 
   /**
    * Convenience method to create a top-level Avro schema with a single nested record

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -25,7 +25,7 @@ import java.util.{Locale, UUID}
 
 import scala.collection.JavaConverters._
 
-import org.apache.avro.{AvroTypeException, Schema}
+import org.apache.avro.{AvroTypeException, Schema, SchemaBuilder}
 import org.apache.avro.Schema.{Field, Type}
 import org.apache.avro.Schema.Type._
 import org.apache.avro.file.{DataFileReader, DataFileWriter}
@@ -1103,6 +1103,43 @@ abstract class AvroSuite
     }
   }
 
+  test("SPARK-34365: support reading renamed schema using positionalFieldMatching") {
+    val renamedSchema = new StructType()
+      .add("foo", StringType)
+      .add("foo_map", MapType(StringType, IntegerType))
+    val dfLoaded = spark
+      .read
+      .option("positionalFieldMatching", true.toString)
+      .schema(renamedSchema)
+      .format("avro")
+      .load(testAvro)
+    assert(dfLoaded.schema === renamedSchema)
+    val expectedDf = spark.read.format("avro").load(testAvro).select("string", "simple_map")
+    assert(dfLoaded.select($"foo".as("string"), $"foo_map".as("simple_map")).collect().toSet ===
+      expectedDf.collect().toSet)
+  }
+
+  test("SPARK-34365: support writing with renamed schema using positionalFieldMatching") {
+    withTempDir { tempDir =>
+      val avroSchema = SchemaBuilder.record("renamed").fields()
+        .requiredString("foo")
+        .name("foo_map").`type`(Schema.createMap(Schema.create(Schema.Type.INT))).noDefault()
+        .endRecord()
+      val expectedDf = spark.read.format("avro").load(testAvro).select("string", "simple_map")
+      val savePath = s"$tempDir/save"
+      expectedDf.write
+        .option("avroSchema", avroSchema.toString)
+        .option("positionalFieldMatching", true.toString)
+        .format("avro")
+        .save(savePath)
+      val reloadedDf = spark.read.format("avro").load(savePath)
+      assert(reloadedDf.schema ===
+        new StructType().add("foo", StringType).add("foo_map", MapType(StringType, IntegerType)))
+      assert(reloadedDf.select($"foo".as("string"), $"foo_map".as("simple_map")).collect().toSet ===
+        expectedDf.collect().toSet)
+    }
+  }
+
   test("unsupported nullable avro type") {
     val catalystSchema =
       StructType(Seq(
@@ -1366,7 +1403,7 @@ abstract class AvroSuite
           df.write.option("avroSchema", avroSchema).format("avro").save(s"$tempDir/save2")
         }
         assertExceptionMsg[IncompatibleSchemaException](e,
-          "Cannot find field 'FOO' in Avro schema at top-level record")
+          "Cannot find field 'FOO' (at position 0) in Avro schema at top-level record")
       }
     }
   }


### PR DESCRIPTION
SPARK-35949
### What changes were proposed in this pull request?

Fixes a bug that the spark context was stopped while application is started on client mode.


### Why are the changes needed?

Due to pr https://github.com/apache/spark/commit/c625eb4f9f970108d93bf3342c7ccb7ec873dc27#diff-f8564df81d845c0cd2f621bc2ed22761cbf9731f28cb2828d9cbd0491f4e7584. In client mode, the spark context will be stopped on application start.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Manually on the production environment in my company.
