### PR TITLE
[SPARK-35959][BUILD][test-maven][test-hadoop3.2][test-java11] Add a new Maven profile "no-shaded-hadoop-client" for Hadoop versions older than 3.2.2/3.3.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -60,9 +60,10 @@ flatbuffers-java/1.9.0//flatbuffers-java-1.9.0.jar
 generex/1.0.2//generex-1.0.2.jar
 gson/2.2.4//gson-2.2.4.jar
 guava/14.0.1//guava-14.0.1.jar
-hadoop-client-api/3.1.1//hadoop-client-api-3.1.1.jar
-hadoop-client-runtime/3.1.1//hadoop-client-runtime-3.1.1.jar
-hadoop-yarn-server-web-proxy/3.1.1//hadoop-yarn-server-web-proxy-3.1.1.jar
+hadoop-annotations/3.1.4//hadoop-annotations-3.1.4.jar
+hadoop-client-api/3.1.4//hadoop-client-api-3.1.4.jar
+hadoop-client-runtime/3.1.4//hadoop-client-runtime-3.1.4.jar
+hadoop-yarn-server-web-proxy/3.1.4//hadoop-yarn-server-web-proxy-3.1.4.jar
 hive-beeline/2.3.9//hive-beeline-2.3.9.jar
 hive-cli/2.3.9//hive-cli-2.3.9.jar
 hive-common/2.3.9//hive-common-2.3.9.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -60,10 +60,9 @@ flatbuffers-java/1.9.0//flatbuffers-java-1.9.0.jar
 generex/1.0.2//generex-1.0.2.jar
 gson/2.2.4//gson-2.2.4.jar
 guava/14.0.1//guava-14.0.1.jar
-hadoop-client-api/3.3.1//hadoop-client-api-3.3.1.jar
-hadoop-client-runtime/3.3.1//hadoop-client-runtime-3.3.1.jar
-hadoop-shaded-guava/1.1.1//hadoop-shaded-guava-1.1.1.jar
-hadoop-yarn-server-web-proxy/3.3.1//hadoop-yarn-server-web-proxy-3.3.1.jar
+hadoop-client-api/3.1.1//hadoop-client-api-3.1.1.jar
+hadoop-client-runtime/3.1.1//hadoop-client-runtime-3.1.1.jar
+hadoop-yarn-server-web-proxy/3.1.1//hadoop-yarn-server-web-proxy-3.1.1.jar
 hive-beeline/2.3.9//hive-beeline-2.3.9.jar
 hive-cli/2.3.9//hive-cli-2.3.9.jar
 hive-common/2.3.9//hive-common-2.3.9.jar

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -333,8 +333,8 @@ def get_hadoop_profiles(hadoop_version):
     """
 
     sbt_maven_hadoop_profiles = {
-        "hadoop2.7": ["-Phadoop-2.7"],
-        "hadoop3.2": ["-Phadoop-3.2"],
+        "hadoop2.7": ["-Phadoop-2.7 -Pno-shaded-hadoop-client"],
+        "hadoop3.2": ["-Phadoop-3.2 -Dhadoop.version=3.1.1 -Pno-shaded-hadoop-client"],
     }
 
     if hadoop_version in sbt_maven_hadoop_profiles:

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -334,7 +334,7 @@ def get_hadoop_profiles(hadoop_version):
 
     sbt_maven_hadoop_profiles = {
         "hadoop2.7": ["-Phadoop-2.7 -Pno-shaded-hadoop-client"],
-        "hadoop3.2": ["-Phadoop-3.2 -Dhadoop.version=3.1.1 -Pno-shaded-hadoop-client"],
+        "hadoop3.2": ["-Phadoop-3.2 -Dhadoop.version=3.1.4 -Pno-shaded-hadoop-client"],
     }
 
     if hadoop_version in sbt_maven_hadoop_profiles:

--- a/pom.xml
+++ b/pom.xml
@@ -3313,6 +3313,15 @@
       </modules>
     </profile>
 
+    <profile>
+      <id>no-shaded-client</id>
+      <properties>
+        <hadoop-client-api.artifact>hadoop-client</hadoop-client-api.artifact>
+        <hadoop-client-runtime.artifact>hadoop-client</hadoop-client-runtime.artifact>
+        <hadoop-client-minicluster.artifact>hadoop-client</hadoop-client-minicluster.artifact>
+      </properties>
+    </profile>
+
     <!-- generally not enabled for automated builds, but will run k8s tests -->
     <profile>
       <id>kubernetes-integration-tests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <hadoop.version>3.1.1</hadoop.version>
+    <hadoop.version>3.1.4</hadoop.version>
     <protobuf.version>2.5.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.6.2</zookeeper.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <hadoop.version>3.3.1</hadoop.version>
+    <hadoop.version>3.1.1</hadoop.version>
     <protobuf.version>2.5.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.6.2</zookeeper.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3314,7 +3314,7 @@
     </profile>
 
     <profile>
-      <id>no-shaded-client</id>
+      <id>no-shaded-hadoop-client</id>
       <properties>
         <hadoop-client-api.artifact>hadoop-client</hadoop-client-api.artifact>
         <hadoop-client-runtime.artifact>hadoop-client</hadoop-client-runtime.artifact>

--- a/resource-managers/yarn/pom.xml
+++ b/resource-managers/yarn/pom.xml
@@ -77,6 +77,33 @@
       </dependencies>
     </profile>
     <profile>
+      <id>no-shaded-client</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-api</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-common</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-web-proxy</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-client</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-tests</artifactId>
+          <classifier>tests</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>hadoop-3.2</id>
       <activation>
         <activeByDefault>true</activeByDefault>

--- a/resource-managers/yarn/pom.xml
+++ b/resource-managers/yarn/pom.xml
@@ -97,6 +97,11 @@
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-yarn-server-tests</artifactId>
           <classifier>tests</classifier>
           <scope>test</scope>

--- a/resource-managers/yarn/pom.xml
+++ b/resource-managers/yarn/pom.xml
@@ -77,7 +77,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>no-shaded-client</id>
+      <id>no-shaded-hadoop-client</id>
       <dependencies>
         <dependency>
           <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add a new Maven profile `no-shaded-hadoop-client` that, when activated, switches to non-shaded Hadoop client (e.g., `hadoop-client`, `hadoop-yarn-client`, etc). 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently Spark uses Hadoop shaded client by default. However, if Spark users want to build Spark with older version of Hadoop, such as 3.1.x, the shaded client cannot be used as it currently it only support Hadoop 3.2.2+ and 3.3.1+). Therefore, this proposes to offer a new Maven profile "no-shaded-hadoop-client" for this use case.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, now users can choose to build Apache Spark with non-shaded Hadoop client, e.g.:
```shell
build/mvn package -DskipTests -Dhadoop.version=3.1.1 -Pno-shaded-hadoop-client
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing tests.