### PR TITLE
[SPARK-35615][PYTHON] Make unary and comparison operators data-type-based 

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -403,13 +403,20 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
     def __ne__(self, other: Any) -> SeriesOrIndex:  # type: ignore[override]
         return column_op(Column.__ne__)(self, other)
 
-    __lt__ = column_op(Column.__lt__)
-    __le__ = column_op(Column.__le__)
-    __ge__ = column_op(Column.__ge__)
-    __gt__ = column_op(Column.__gt__)
+    def __lt__(self, other: Any) -> SeriesOrIndex:
+        return self._dtype_op.lt(self, other)
+
+    def __le__(self, other: Any) -> SeriesOrIndex:
+        return self._dtype_op.le(self, other)
+
+    def __ge__(self, other: Any) -> SeriesOrIndex:
+        return self._dtype_op.ge(self, other)
+
+    def __gt__(self, other: Any) -> SeriesOrIndex:
+        return self._dtype_op.gt(self, other)
 
     def __invert__(self: IndexOpsLike) -> IndexOpsLike:
-        return cast(IndexOpsLike, column_op(Column.__invert__)(self))
+        return cast(IndexOpsLike, self._dtype_op.__invert__(self))
 
     # `and`, `or`, `not` cannot be overloaded in Python,
     # so use bitwise operators as boolean operators
@@ -426,7 +433,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return self._dtype_op.ror(self, other)
 
     def __len__(self) -> int:
-        return len(self._psdf)
+        return self._dtype_op.__len__(self)
 
     # NDArray Compat
     def __array_ufunc__(

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -317,7 +317,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     # arithmetic operators
     def __neg__(self: IndexOpsLike) -> IndexOpsLike:
-        return cast(IndexOpsLike, column_op(Column.__neg__)(self))
+        return cast(IndexOpsLike, self._dtype_op.__neg__(self))
 
     def __add__(self, other: Any) -> SeriesOrIndex:
         return self._dtype_op.add(self, other)
@@ -394,14 +394,14 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return self._dtype_op.rpow(self, other)
 
     def __abs__(self: IndexOpsLike) -> IndexOpsLike:
-        return cast(IndexOpsLike, column_op(F.abs)(self))
+        return cast(IndexOpsLike, self._dtype_op.__abs__(self))
 
     # comparison operators
     def __eq__(self, other: Any) -> SeriesOrIndex:  # type: ignore[override]
-        return column_op(Column.__eq__)(self, other)
+        return self._dtype_op.eq(self, other)
 
     def __ne__(self, other: Any) -> SeriesOrIndex:  # type: ignore[override]
-        return column_op(Column.__ne__)(self, other)
+        return self._dtype_op.ne(self, other)
 
     def __lt__(self, other: Any) -> SeriesOrIndex:
         return self._dtype_op.lt(self, other)

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -317,7 +317,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
     # arithmetic operators
     def __neg__(self: IndexOpsLike) -> IndexOpsLike:
-        return cast(IndexOpsLike, self._dtype_op.__neg__(self))
+        return self._dtype_op.neg(self)
 
     def __add__(self, other: Any) -> SeriesOrIndex:
         return self._dtype_op.add(self, other)
@@ -394,7 +394,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return self._dtype_op.rpow(self, other)
 
     def __abs__(self: IndexOpsLike) -> IndexOpsLike:
-        return cast(IndexOpsLike, self._dtype_op.__abs__(self))
+        return self._dtype_op.abs(self)
 
     # comparison operators
     def __eq__(self, other: Any) -> SeriesOrIndex:  # type: ignore[override]
@@ -416,7 +416,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return self._dtype_op.gt(self, other)
 
     def __invert__(self: IndexOpsLike) -> IndexOpsLike:
-        return cast(IndexOpsLike, self._dtype_op.__invert__(self))
+        return self._dtype_op.invert(self)
 
     # `and`, `or`, `not` cannot be overloaded in Python,
     # so use bitwise operators as boolean operators
@@ -433,7 +433,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         return self._dtype_op.ror(self, other)
 
     def __len__(self) -> int:
-        return self._dtype_op.__len__(self)
+        return len(self._psdf)
 
     # NDArray Compat
     def __array_ufunc__(

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -43,7 +43,6 @@ from pyspark.sql.types import (
     UserDefinedType,
 )
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
-from pyspark.pandas.base import column_op
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import extension_dtypes
 from pyspark.pandas.typedef.typehints import (
@@ -319,19 +318,49 @@ class DataTypeOps(object, metaclass=ABCMeta):
     def ror(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         return left.__or__(right)
 
+    def __neg__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__neg__)(operand)
+
+    def __abs__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(F.abs)(operand)
+
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
         return column_op(Column.__lt__)(left, right)
 
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
         return column_op(Column.__le__)(left, right)
 
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
         return column_op(Column.__ge__)(left, right)
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
         return column_op(Column.__gt__)(left, right)
 
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
+
     def __invert__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
         return column_op(Column.__invert__)(operand)
 
     def __len__(self, operand: IndexOpsLike) -> int:

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -18,13 +18,13 @@
 import numbers
 from abc import ABCMeta
 from itertools import chain
-from typing import Any, cast, Optional, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark.sql import functions as F, Column
+from pyspark.sql import functions as F
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
@@ -319,49 +319,31 @@ class DataTypeOps(object, metaclass=ABCMeta):
         return left.__or__(right)
 
     def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
-        from pyspark.pandas.base import column_op
-
-        return cast(IndexOpsLike, column_op(Column.__neg__)(operand))
+        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
 
     def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
-        from pyspark.pandas.base import column_op
-
-        return cast(IndexOpsLike, column_op(F.abs)(operand))
+        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__lt__)(left, right)
+        raise TypeError("< can not be applied to %s." % self.pretty_name)
 
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__le__)(left, right)
+        raise TypeError("<= can not be applied to %s." % self.pretty_name)
 
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ge__)(left, right)
+        raise TypeError("> can not be applied to %s." % self.pretty_name)
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__gt__)(left, right)
+        raise TypeError(">= can not be applied to %s." % self.pretty_name)
 
     def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
+        raise TypeError("== can not be applied to %s." % self.pretty_name)
 
     def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)
+        raise TypeError("!= can not be applied to %s." % self.pretty_name)
 
     def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
-        from pyspark.pandas.base import column_op
-
-        return cast(IndexOpsLike, column_op(Column.__invert__)(operand))
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
 
     def restore(self, col: pd.Series) -> pd.Series:
         """Restore column when to_pandas."""

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -18,7 +18,7 @@
 import numbers
 from abc import ABCMeta
 from itertools import chain
-from typing import Any, Optional, Union
+from typing import Any, cast, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -318,15 +318,15 @@ class DataTypeOps(object, metaclass=ABCMeta):
     def ror(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         return left.__or__(right)
 
-    def __neg__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
         from pyspark.pandas.base import column_op
 
-        return column_op(Column.__neg__)(operand)
+        return cast(IndexOpsLike, column_op(Column.__neg__)(operand))
 
-    def __abs__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
         from pyspark.pandas.base import column_op
 
-        return column_op(F.abs)(operand)
+        return cast(IndexOpsLike, column_op(F.abs)(operand))
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         from pyspark.pandas.base import column_op
@@ -358,13 +358,10 @@ class DataTypeOps(object, metaclass=ABCMeta):
 
         return column_op(Column.__ne__)(left, right)
 
-    def __invert__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
         from pyspark.pandas.base import column_op
 
-        return column_op(Column.__invert__)(operand)
-
-    def __len__(self, operand: IndexOpsLike) -> int:
-        return len(operand._psdf)
+        return cast(IndexOpsLike, column_op(Column.__invert__)(operand))
 
     def restore(self, col: pd.Series) -> pd.Series:
         """Restore column when to_pandas."""

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -24,7 +24,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
@@ -43,6 +43,7 @@ from pyspark.sql.types import (
     UserDefinedType,
 )
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
+from pyspark.pandas.base import column_op
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import extension_dtypes
 from pyspark.pandas.typedef.typehints import (
@@ -317,6 +318,24 @@ class DataTypeOps(object, metaclass=ABCMeta):
 
     def ror(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         return left.__or__(right)
+
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        return column_op(Column.__lt__)(left, right)
+
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        return column_op(Column.__gt__)(left, right)
+
+    def __invert__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        return column_op(Column.__invert__)(operand)
+
+    def __len__(self, operand: IndexOpsLike) -> int:
+        return len(operand._psdf)
 
     def restore(self, col: pd.Series) -> pd.Series:
         """Restore column when to_pandas."""

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -24,7 +24,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
@@ -337,10 +337,14 @@ class DataTypeOps(object, metaclass=ABCMeta):
         raise TypeError(">= can not be applied to %s." % self.pretty_name)
 
     def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("== can not be applied to %s." % self.pretty_name)
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
 
     def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("!= can not be applied to %s." % self.pretty_name)
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
 
     def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -63,13 +63,13 @@ class BinaryOps(DataTypeOps):
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def __neg__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
 
-    def __invert__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
 
-    def __abs__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise TypeError("abs() can not be applied to %s." % self.pretty_name)
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -83,16 +83,6 @@ class BinaryOps(DataTypeOps):
 
         return column_op(Column.__gt__)(left, right)
 
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)
-
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -30,7 +30,7 @@ from pyspark.pandas.data_type_ops.base import (
 )
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import pandas_on_spark_type
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column
 from pyspark.sql.types import BinaryType, BooleanType, StringType
 
 
@@ -63,14 +63,35 @@ class BinaryOps(DataTypeOps):
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name
             )
 
-    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
 
-    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+        return column_op(Column.__lt__)(left, right)
 
-    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__gt__)(left, right)
+
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)

--- a/python/pyspark/pandas/data_type_ops/binary_ops.py
+++ b/python/pyspark/pandas/data_type_ops/binary_ops.py
@@ -63,6 +63,15 @@ class BinaryOps(DataTypeOps):
                 "Concatenation can not be applied to %s and the given type." % self.pretty_name
             )
 
+    def __neg__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+
+    def __invert__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def __abs__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -16,7 +16,7 @@
 #
 
 import numbers
-from typing import Any, cast, Union
+from typing import Any, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -272,11 +272,11 @@ class BooleanOps(DataTypeOps):
         else:
             return _as_other_type(index_ops, dtype, spark_type)
 
-    def __neg__(self, operand: IndexOpsLike) -> SeriesOrIndex:
-        return cast(SeriesOrIndex, ~operand)
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
+        return ~operand
 
-    def __abs__(self, operand: IndexOpsLike) -> SeriesOrIndex:
-        return cast(SeriesOrIndex, operand)
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
+        return operand
 
 
 class BooleanExtensionOps(BooleanOps):
@@ -315,11 +315,11 @@ class BooleanExtensionOps(BooleanOps):
         """Restore column when to_pandas."""
         return col.astype(self.dtype)
 
-    def __neg__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
 
-    def __invert__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
 
-    def __abs__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise TypeError("abs() can not be applied to %s." % self.pretty_name)

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -298,16 +298,6 @@ class BooleanOps(DataTypeOps):
 
         return column_op(Column.__gt__)(left, right)
 
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)
-
     def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
         from pyspark.pandas.base import column_op
 

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -16,7 +16,7 @@
 #
 
 import numbers
-from typing import Any, Union
+from typing import Any, cast, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -47,7 +47,7 @@ class BooleanOps(DataTypeOps):
 
     @property
     def pretty_name(self) -> str:
-        return "booleans"
+        return "bools"
 
     def add(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
@@ -272,12 +272,22 @@ class BooleanOps(DataTypeOps):
         else:
             return _as_other_type(index_ops, dtype, spark_type)
 
+    def __neg__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        return cast(SeriesOrIndex, ~operand)
+
+    def __abs__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        return cast(SeriesOrIndex, operand)
+
 
 class BooleanExtensionOps(BooleanOps):
     """
     The class for binary operations of pandas-on-Spark objects with spark type BooleanType,
     and dtype BooleanDtype.
     """
+
+    @property
+    def pretty_name(self) -> str:
+        return "booleans"
 
     def __and__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         def and_func(left: Column, right: Any) -> Column:
@@ -304,3 +314,12 @@ class BooleanExtensionOps(BooleanOps):
     def restore(self, col: pd.Series) -> pd.Series:
         """Restore column when to_pandas."""
         return col.astype(self.dtype)
+
+    def __neg__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+
+    def __invert__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def __abs__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        raise TypeError("abs() can not be applied to %s." % self.pretty_name)

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -16,7 +16,7 @@
 #
 
 import numbers
-from typing import Any, Union
+from typing import cast, Any, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -277,6 +277,41 @@ class BooleanOps(DataTypeOps):
 
     def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
         return operand
+
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__lt__)(left, right)
+
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__gt__)(left, right)
+
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
+
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
+        from pyspark.pandas.base import column_op
+
+        return cast(IndexOpsLike, column_op(Column.__invert__)(operand))
 
 
 class BooleanExtensionOps(BooleanOps):

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -66,13 +66,13 @@ class CategoricalOps(DataTypeOps):
             scol.alias(index_ops._internal.data_spark_column_names[0])
         ).astype(dtype)
 
-    def __neg__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
 
-    def __invert__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
 
-    def __abs__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise TypeError("abs() can not be applied to %s." % self.pretty_name)
 
     # TODO(SPARK-35997): Implement comparison operators below

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -16,12 +16,12 @@
 #
 
 from itertools import chain
-from typing import Union
+from typing import Any, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark.pandas._typing import Dtype, IndexOpsLike
+from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.data_type_ops.base import DataTypeOps
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import pandas_on_spark_type
@@ -65,3 +65,25 @@ class CategoricalOps(DataTypeOps):
         return index_ops._with_new_scol(
             scol.alias(index_ops._internal.data_spark_column_names[0])
         ).astype(dtype)
+
+    def __neg__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+
+    def __invert__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def __abs__(self, operand: IndexOpsLike) -> SeriesOrIndex:
+        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+
+    # TODO(SPARK-35997): Implement comparison operators below
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise NotImplementedError("< can not be applied to %s." % self.pretty_name)
+
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise NotImplementedError("<= can not be applied to %s." % self.pretty_name)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise NotImplementedError("> can not be applied to %s." % self.pretty_name)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise NotImplementedError(">= can not be applied to %s." % self.pretty_name)

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -25,7 +25,7 @@ from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.data_type_ops.base import DataTypeOps
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import pandas_on_spark_type
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column
 
 
 class CategoricalOps(DataTypeOps):
@@ -66,15 +66,6 @@ class CategoricalOps(DataTypeOps):
             scol.alias(index_ops._internal.data_spark_column_names[0])
         ).astype(dtype)
 
-    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
-
-    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
-
-    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
-
     # TODO(SPARK-35997): Implement comparison operators below
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise NotImplementedError("< can not be applied to %s." % self.pretty_name)
@@ -87,3 +78,13 @@ class CategoricalOps(DataTypeOps):
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise NotImplementedError(">= can not be applied to %s." % self.pretty_name)
+
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -25,7 +25,7 @@ from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.data_type_ops.base import DataTypeOps
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import pandas_on_spark_type
-from pyspark.sql import functions as F, Column
+from pyspark.sql import functions as F
 
 
 class CategoricalOps(DataTypeOps):
@@ -78,13 +78,3 @@ class CategoricalOps(DataTypeOps):
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise NotImplementedError(">= can not be applied to %s." % self.pretty_name)
-
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -123,3 +123,33 @@ class StructOps(DataTypeOps):
     @property
     def pretty_name(self) -> str:
         return "structs"
+
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__lt__)(left, right)
+
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__gt__)(left, right)
+
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -82,16 +82,6 @@ class ArrayOps(DataTypeOps):
 
         return column_op(Column.__gt__)(left, right)
 
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)
-
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 
@@ -123,16 +113,6 @@ class StructOps(DataTypeOps):
     @property
     def pretty_name(self) -> str:
         return "structs"
-
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         from pyspark.pandas.base import column_op

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -29,7 +29,7 @@ from pyspark.pandas.data_type_ops.base import (
     _as_string_type,
 )
 from pyspark.pandas.typedef import pandas_on_spark_type
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column
 from pyspark.sql.types import ArrayType, BooleanType, NumericType, StringType
 
 
@@ -62,14 +62,35 @@ class ArrayOps(DataTypeOps):
 
         return column_op(F.concat)(left, right)
 
-    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
 
-    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+        return column_op(Column.__lt__)(left, right)
 
-    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__gt__)(left, right)
+
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -62,6 +62,15 @@ class ArrayOps(DataTypeOps):
 
         return column_op(F.concat)(left, right)
 
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -128,3 +128,28 @@ class StructOps(DataTypeOps):
         from pyspark.pandas.base import column_op
 
         return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
+
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__lt__)(left, right)
+
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__gt__)(left, right)

--- a/python/pyspark/pandas/data_type_ops/complex_ops.py
+++ b/python/pyspark/pandas/data_type_ops/complex_ops.py
@@ -124,32 +124,7 @@ class StructOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "structs"
 
-    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__lt__)(left, right)
-
-    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__le__)(left, right)
-
-    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ge__)(left, right)
-
-    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__gt__)(left, right)
-
     def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         from pyspark.pandas.base import column_op
 
         return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -98,16 +98,6 @@ class DateOps(DataTypeOps):
 
         return column_op(Column.__gt__)(left, right)
 
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)
-
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -22,7 +22,7 @@ from typing import Any, Union
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column
 from pyspark.sql.types import BooleanType, DateType, StringType
 
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
@@ -78,14 +78,35 @@ class DateOps(DataTypeOps):
         else:
             raise TypeError("date subtraction can only be applied to date series.")
 
-    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
 
-    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+        return column_op(Column.__lt__)(left, right)
 
-    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__gt__)(left, right)
+
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -78,6 +78,15 @@ class DateOps(DataTypeOps):
         else:
             raise TypeError("date subtraction can only be applied to date series.")
 
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -22,7 +22,7 @@ from typing import Any, Union, cast
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
-from pyspark.sql import functions as F
+from pyspark.sql import functions as F, Column
 from pyspark.sql.types import BooleanType, StringType, TimestampType
 
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
@@ -88,14 +88,35 @@ class DatetimeOps(DataTypeOps):
         else:
             raise TypeError("datetime subtraction can only be applied to datetime series.")
 
-    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
 
-    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+        return column_op(Column.__lt__)(left, right)
 
-    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__gt__)(left, right)
+
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
 
     def prepare(self, col: pd.Series) -> pd.Series:
         """Prepare column when from_pandas."""

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -108,16 +108,6 @@ class DatetimeOps(DataTypeOps):
 
         return column_op(Column.__gt__)(left, right)
 
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)
-
     def prepare(self, col: pd.Series) -> pd.Series:
         """Prepare column when from_pandas."""
         return col

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -88,6 +88,15 @@ class DatetimeOps(DataTypeOps):
         else:
             raise TypeError("datetime subtraction can only be applied to datetime series.")
 
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+
     def prepare(self, col: pd.Series) -> pd.Series:
         """Prepare column when from_pandas."""
         return col

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -62,16 +62,6 @@ class NullOps(DataTypeOps):
 
         return column_op(Column.__gt__)(left, right)
 
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)
-
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -40,6 +40,15 @@ class NullOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "nulls"
 
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Union
+from typing import Any, Union
 
 from pandas.api.types import CategoricalDtype
 
@@ -27,7 +27,9 @@ from pyspark.pandas.data_type_ops.base import (
     _as_other_type,
     _as_string_type,
 )
+from pyspark.pandas._typing import SeriesOrIndex
 from pyspark.pandas.typedef import pandas_on_spark_type
+from pyspark.sql import Column
 from pyspark.sql.types import BooleanType, StringType
 
 
@@ -40,14 +42,35 @@ class NullOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "nulls"
 
-    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
 
-    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+        return column_op(Column.__lt__)(left, right)
 
-    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__gt__)(left, right)
+
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -16,7 +16,7 @@
 #
 
 import numbers
-from typing import Any, Union
+from typing import cast, Any, Union
 
 import numpy as np
 import pandas as pd
@@ -161,6 +161,46 @@ class NumericOps(DataTypeOps):
     # TODO(SPARK-36003): Implement unary operator `invert` as below
     def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
         raise NotImplementedError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
+        from pyspark.pandas.base import column_op
+
+        return cast(IndexOpsLike, column_op(Column.__neg__)(operand))
+
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
+        from pyspark.pandas.base import column_op
+
+        return cast(IndexOpsLike, column_op(F.abs)(operand))
+
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__lt__)(left, right)
+
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__gt__)(left, right)
+
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
 
 
 class IntegralOps(NumericOps):

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -158,6 +158,10 @@ class NumericOps(DataTypeOps):
         right = transform_boolean_operand_to_numeric(right)
         return column_op(rmod)(left, right)
 
+    # TODO(SPARK-36003): Implement unary operator `invert` as below
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise NotImplementedError("Unary ~ can not be applied to %s." % self.pretty_name)
+
 
 class IntegralOps(NumericOps):
     """

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -192,16 +192,6 @@ class NumericOps(DataTypeOps):
 
         return column_op(Column.__gt__)(left, right)
 
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)
-
 
 class IntegralOps(NumericOps):
     """

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -406,6 +406,21 @@ class DecimalOps(FractionalOps):
     def pretty_name(self) -> str:
         return "decimal"
 
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise TypeError("< can not be applied to %s." % self.pretty_name)
+
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise TypeError("<= can not be applied to %s." % self.pretty_name)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise TypeError("> can not be applied to %s." % self.pretty_name)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise TypeError(">= can not be applied to %s." % self.pretty_name)
+
     def isnull(self, index_ops: IndexOpsLike) -> IndexOpsLike:
         return index_ops._with_new_scol(
             index_ops.spark.column.isNull(),

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -112,6 +112,15 @@ class StringOps(DataTypeOps):
     def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("modulo can not be applied on string series or literals.")
 
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -133,16 +133,6 @@ class StringOps(DataTypeOps):
 
         return column_op(Column.__gt__)(left, right)
 
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)
-
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
 

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -34,6 +34,7 @@ from pyspark.pandas.data_type_ops.base import (
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import extension_dtypes, pandas_on_spark_type
+from pyspark.sql import Column
 from pyspark.sql.types import BooleanType
 
 
@@ -112,14 +113,35 @@ class StringOps(DataTypeOps):
     def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("modulo can not be applied on string series or literals.")
 
-    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
 
-    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+        return column_op(Column.__lt__)(left, right)
 
-    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__gt__)(left, right)
+
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__eq__)(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        return column_op(Column.__ne__)(left, right)
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)

--- a/python/pyspark/pandas/data_type_ops/udt_ops.py
+++ b/python/pyspark/pandas/data_type_ops/udt_ops.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from pyspark.pandas._typing import IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.data_type_ops.base import DataTypeOps
+from pyspark.sql import Column
 
 
 class UDTOps(DataTypeOps):
@@ -31,23 +32,12 @@ class UDTOps(DataTypeOps):
     def pretty_name(self) -> str:
         return "user defined types"
 
-    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
 
-    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+        return column_op(Column.__eq__)(left, right)
 
-    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
-        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
 
-    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("< can not be applied to %s." % self.pretty_name)
-
-    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("<= can not be applied to %s." % self.pretty_name)
-
-    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("> can not be applied to %s." % self.pretty_name)
-
-    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError(">= can not be applied to %s." % self.pretty_name)
+        return column_op(Column.__ne__)(left, right)

--- a/python/pyspark/pandas/data_type_ops/udt_ops.py
+++ b/python/pyspark/pandas/data_type_ops/udt_ops.py
@@ -15,11 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Any
-
-from pyspark.pandas._typing import IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.data_type_ops.base import DataTypeOps
-from pyspark.sql import Column
 
 
 class UDTOps(DataTypeOps):
@@ -31,13 +27,3 @@ class UDTOps(DataTypeOps):
     @property
     def pretty_name(self) -> str:
         return "user defined types"
-
-    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__eq__)(left, right)
-
-    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
-        return column_op(Column.__ne__)(left, right)

--- a/python/pyspark/pandas/data_type_ops/udt_ops.py
+++ b/python/pyspark/pandas/data_type_ops/udt_ops.py
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+from typing import Any
+
+from pyspark.pandas._typing import IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.data_type_ops.base import DataTypeOps
 
 
@@ -27,3 +30,24 @@ class UDTOps(DataTypeOps):
     @property
     def pretty_name(self) -> str:
         return "user defined types"
+
+    def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary - can not be applied to %s." % self.pretty_name)
+
+    def invert(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("Unary ~ can not be applied to %s." % self.pretty_name)
+
+    def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
+        raise TypeError("abs() can not be applied to %s." % self.pretty_name)
+
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise TypeError("< can not be applied to %s." % self.pretty_name)
+
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise TypeError("<= can not be applied to %s." % self.pretty_name)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise TypeError("> can not be applied to %s." % self.pretty_name)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        raise TypeError(">= can not be applied to %s." % self.pretty_name)

--- a/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
@@ -33,6 +33,14 @@ class BinaryOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def psser(self):
         return ps.from_pandas(self.pser)
 
+    @property
+    def other_pser(self):
+        return pd.Series([b"2", b"3", b"4"])
+
+    @property
+    def other_psser(self):
+        return ps.from_pandas(self.other_pser)
+
     def test_add(self):
         psser = self.psser
         pser = self.pser
@@ -158,6 +166,48 @@ class BinaryOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser.astype("category"), psser.astype("category"))
         cat_type = CategoricalDtype(categories=[b"2", b"3", b"1"])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
+
+    def test_neg(self):
+        self.assertRaises(TypeError, lambda: -self.psser)
+
+    def test_abs(self):
+        self.assertRaises(TypeError, lambda: abs(self.psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
+            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
+            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser < self.other_pser, self.psser < self.other_psser)
+            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser <= self.other_pser, self.psser <= self.other_psser)
+            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser > self.other_pser, self.psser > self.other_psser)
+            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
+            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
+
+    def test_len(self):
+        self.assert_eq(len(self.pser), len(self.psser))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
@@ -206,9 +206,6 @@ class BinaryOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
             self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
 
-    def test_len(self):
-        self.assert_eq(len(self.pser), len(self.psser))
-
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
@@ -178,33 +178,45 @@ class BinaryOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     def test_eq(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
-            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+            self.assert_eq(
+                self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
-            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+            self.assert_eq(
+                self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser < self.other_pser, self.psser < self.other_psser)
-            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+            self.assert_eq(
+                self.pser < self.other_pser, (self.psser < self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser < self.pser, (self.psser < self.psser).sort_index())
 
     def test_le(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser <= self.other_pser, self.psser <= self.other_psser)
-            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+            self.assert_eq(
+                self.pser <= self.other_pser, (self.psser <= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser <= self.pser, (self.psser <= self.psser).sort_index())
 
     def test_gt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser > self.other_pser, self.psser > self.other_psser)
-            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+            self.assert_eq(
+                self.pser > self.other_pser, (self.psser > self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser > self.pser, (self.psser > self.psser).sort_index())
 
     def test_ge(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
-            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
+            self.assert_eq(
+                self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -325,33 +325,45 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     def test_eq(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
-            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+            self.assert_eq(
+                self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
-            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+            self.assert_eq(
+                self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser < self.other_pser, self.psser < self.other_psser)
-            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+            self.assert_eq(
+                self.pser < self.other_pser, (self.psser < self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser < self.pser, (self.psser < self.psser).sort_index())
 
     def test_le(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser <= self.other_pser, self.psser <= self.other_psser)
-            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+            self.assert_eq(
+                self.pser <= self.other_pser, (self.psser <= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser <= self.pser, (self.psser <= self.psser).sort_index())
 
     def test_gt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser > self.other_pser, self.psser > self.other_psser)
-            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+            self.assert_eq(
+                self.pser > self.other_pser, (self.psser > self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser > self.pser, (self.psser > self.psser).sort_index())
 
     def test_ge(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
-            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
+            self.assert_eq(
+                self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
 
 
 @unittest.skipIf(
@@ -644,33 +656,45 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     def test_eq(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.check_extension(self.pser == self.other_pser, self.psser == self.other_psser)
-            self.check_extension(self.pser == self.pser, self.psser == self.psser)
+            self.check_extension(
+                self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser == self.pser, (self.psser == self.psser).sort_index())
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.check_extension(self.pser != self.other_pser, self.psser != self.other_psser)
-            self.check_extension(self.pser != self.pser, self.psser != self.psser)
+            self.check_extension(
+                self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.check_extension(self.pser < self.other_pser, self.psser < self.other_psser)
-            self.check_extension(self.pser < self.pser, self.psser < self.psser)
+            self.check_extension(
+                self.pser < self.other_pser, (self.psser < self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser < self.pser, (self.psser < self.psser).sort_index())
 
     def test_le(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.check_extension(self.pser <= self.other_pser, self.psser <= self.other_psser)
-            self.check_extension(self.pser <= self.pser, self.psser <= self.psser)
+            self.check_extension(
+                self.pser <= self.other_pser, (self.psser <= self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser <= self.pser, (self.psser <= self.psser).sort_index())
 
     def test_gt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.check_extension(self.pser > self.other_pser, self.psser > self.other_psser)
-            self.check_extension(self.pser > self.pser, self.psser > self.psser)
+            self.check_extension(
+                self.pser > self.other_pser, (self.psser > self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser > self.pser, (self.psser > self.psser).sort_index())
 
     def test_ge(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.check_extension(self.pser >= self.other_pser, self.psser >= self.other_psser)
-            self.check_extension(self.pser >= self.pser, self.psser >= self.psser)
+            self.check_extension(
+                self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -353,9 +353,6 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
             self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
 
-    def test_len(self):
-        self.assert_eq(len(self.pser), len(self.psser))
-
 
 @unittest.skipIf(
     not extension_object_dtypes_available, "pandas extension object dtypes are not available"
@@ -674,9 +671,6 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         with option_context("compute.ops_on_diff_frames", True):
             self.check_extension(self.pser >= self.other_pser, self.psser >= self.other_psser)
             self.check_extension(self.pser >= self.pser, self.psser >= self.psser)
-
-    def test_len(self):
-        self.assert_eq(len(self.pser), len(self.psser))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -48,6 +48,14 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def float_psser(self):
         return ps.from_pandas(self.float_pser)
 
+    @property
+    def other_pser(self):
+        return pd.Series([False, False, True])
+
+    @property
+    def other_psser(self):
+        return ps.from_pandas(self.other_pser)
+
     def test_add(self):
         pser = self.pser
         psser = self.psser
@@ -305,6 +313,48 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser.astype("category"), psser.astype("category"))
         cat_type = CategoricalDtype(categories=[False, True])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
+
+    def test_neg(self):
+        self.assert_eq(-self.pser, -self.psser)
+
+    def test_abs(self):
+        self.assert_eq(abs(self.pser), abs(self.psser))
+
+    def test_invert(self):
+        self.assert_eq(~self.pser, ~self.psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
+            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
+            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser < self.other_pser, self.psser < self.other_psser)
+            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser <= self.other_pser, self.psser <= self.other_psser)
+            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser > self.other_pser, self.psser > self.other_psser)
+            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
+            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
+
+    def test_len(self):
+        self.assert_eq(len(self.pser), len(self.psser))
 
 
 @unittest.skipIf(
@@ -585,6 +635,48 @@ class BooleanExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.assert_eq([1.0, 0.0, np.nan], self.psser.astype(dtype).tolist())
             else:
                 self.check_extension(pser.astype(dtype), psser.astype(dtype))
+
+    def test_neg(self):
+        self.assertRaises(TypeError, lambda: -self.psser)
+
+    def test_abs(self):
+        self.assertRaises(TypeError, lambda: abs(self.psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(self.pser == self.other_pser, self.psser == self.other_psser)
+            self.check_extension(self.pser == self.pser, self.psser == self.psser)
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(self.pser != self.other_pser, self.psser != self.other_psser)
+            self.check_extension(self.pser != self.pser, self.psser != self.psser)
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(self.pser < self.other_pser, self.psser < self.other_psser)
+            self.check_extension(self.pser < self.pser, self.psser < self.psser)
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(self.pser <= self.other_pser, self.psser <= self.other_psser)
+            self.check_extension(self.pser <= self.pser, self.psser <= self.psser)
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(self.pser > self.other_pser, self.psser > self.other_psser)
+            self.check_extension(self.pser > self.pser, self.psser > self.psser)
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(self.pser >= self.other_pser, self.psser >= self.other_psser)
+            self.check_extension(self.pser >= self.pser, self.psser >= self.psser)
+
+    def test_len(self):
+        self.assert_eq(len(self.pser), len(self.psser))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -205,9 +205,6 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def test_ge(self):
         self.assertRaises(NotImplementedError, lambda: self.psser >= self.other_psser)
 
-    def test_len(self):
-        self.assert_eq(len(self.pser), len(self.psser))
-
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -36,6 +36,14 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def psser(self):
         return ps.from_pandas(self.pser)
 
+    @property
+    def other_pser(self):
+        return pd.Series(["y", "x", 1], dtype="category")
+
+    @property
+    def other_psser(self):
+        return ps.from_pandas(self.other_pser)
+
     def test_add(self):
         self.assertRaises(TypeError, lambda: self.psser + "x")
         self.assertRaises(TypeError, lambda: self.psser + 1)
@@ -165,6 +173,40 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
         else:
             self.assert_eq(pd.Series(data).astype(cat_type), psser.astype(cat_type))
+
+    def test_neg(self):
+        self.assertRaises(TypeError, lambda: -self.psser)
+
+    def test_abs(self):
+        self.assertRaises(TypeError, lambda: abs(self.psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
+            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
+            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+
+    def test_lt(self):
+        self.assertRaises(NotImplementedError, lambda: self.psser < self.other_psser)
+
+    def test_le(self):
+        self.assertRaises(NotImplementedError, lambda: self.psser <= self.other_psser)
+
+    def test_gt(self):
+        self.assertRaises(NotImplementedError, lambda: self.psser > self.other_psser)
+
+    def test_ge(self):
+        self.assertRaises(NotImplementedError, lambda: self.psser >= self.other_psser)
+
+    def test_len(self):
+        self.assert_eq(len(self.pser), len(self.psser))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -185,13 +185,17 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     def test_eq(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
-            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+            self.assert_eq(
+                self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
-            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+            self.assert_eq(
+                self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
         self.assertRaises(NotImplementedError, lambda: self.psser < self.other_psser)

--- a/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
@@ -266,6 +266,10 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
             )
             self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
+            self.assert_eq(
+                self.struct_pser != self.struct_pser,
+                (self.struct_psser != self.struct_psser).sort_index(),
+            )
 
     def test_lt(self):
         with option_context("compute.ops_on_diff_frames", True):
@@ -273,6 +277,10 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.pser < self.other_pser, (self.psser < self.other_psser).sort_index()
             )
             self.assert_eq(self.pser < self.pser, (self.psser < self.psser).sort_index())
+            self.assert_eq(
+                self.struct_pser < self.struct_pser,
+                (self.struct_psser < self.struct_psser).sort_index(),
+            )
 
     def test_le(self):
         with option_context("compute.ops_on_diff_frames", True):
@@ -280,6 +288,10 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.pser <= self.other_pser, (self.psser <= self.other_psser).sort_index()
             )
             self.assert_eq(self.pser <= self.pser, (self.psser <= self.psser).sort_index())
+            self.assert_eq(
+                self.struct_pser <= self.struct_pser,
+                (self.struct_psser <= self.struct_psser).sort_index(),
+            )
 
     def test_gt(self):
         with option_context("compute.ops_on_diff_frames", True):
@@ -287,6 +299,10 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.pser > self.other_pser, (self.psser > self.other_psser).sort_index()
             )
             self.assert_eq(self.pser > self.pser, (self.psser > self.psser).sort_index())
+            self.assert_eq(
+                self.struct_pser > self.struct_pser,
+                (self.struct_psser > self.struct_psser).sort_index(),
+            )
 
     def test_ge(self):
         with option_context("compute.ops_on_diff_frames", True):
@@ -294,6 +310,10 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
             )
             self.assert_eq(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
+            self.assert_eq(
+                self.struct_pser >= self.struct_pser,
+                (self.struct_psser >= self.struct_psser).sort_index(),
+            )
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
@@ -81,6 +81,14 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def other_psser(self):
         return ps.from_pandas(self.other_pser)
 
+    @property
+    def struct_pser(self):
+        return pd.Series([("x", 1)])
+
+    @property
+    def struct_psser(self):
+        return ps.Index([("x", 1)]).to_series().reset_index(drop=True)
+
     def test_add(self):
         for pser, psser in zip(self.psers, self.pssers):
             self.assert_eq(pser + pser, psser + psser)
@@ -247,6 +255,10 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
             )
             self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
+            self.assert_eq(
+                self.struct_pser == self.struct_pser,
+                (self.struct_psser == self.struct_psser).sort_index(),
+            )
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):

--- a/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
@@ -73,6 +73,14 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def psser(self):
         return ps.from_pandas(self.pser)
 
+    @property
+    def other_pser(self):
+        return pd.Series([[2, 3, 4]])
+
+    @property
+    def other_psser(self):
+        return ps.from_pandas(self.other_pser)
+
     def test_add(self):
         for pser, psser in zip(self.psers, self.pssers):
             self.assert_eq(pser + pser, psser + psser)
@@ -223,6 +231,45 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     def test_astype(self):
         self.assert_eq(self.pser.astype(str), self.psser.astype(str))
+
+    def test_neg(self):
+        self.assertRaises(TypeError, lambda: -self.psser)
+
+    def test_abs(self):
+        self.assertRaises(TypeError, lambda: abs(self.psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
+            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
+            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser < self.other_pser, self.psser < self.other_psser)
+            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser <= self.other_pser, self.psser <= self.other_psser)
+            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser > self.other_pser, self.psser > self.other_psser)
+            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
+            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
@@ -243,33 +243,45 @@ class ComplexOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     def test_eq(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
-            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+            self.assert_eq(
+                self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
-            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+            self.assert_eq(
+                self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser < self.other_pser, self.psser < self.other_psser)
-            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+            self.assert_eq(
+                self.pser < self.other_pser, (self.psser < self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser < self.pser, (self.psser < self.psser).sort_index())
 
     def test_le(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser <= self.other_pser, self.psser <= self.other_psser)
-            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+            self.assert_eq(
+                self.pser <= self.other_pser, (self.psser <= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser <= self.pser, (self.psser <= self.psser).sort_index())
 
     def test_gt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser > self.other_pser, self.psser > self.other_psser)
-            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+            self.assert_eq(
+                self.pser > self.other_pser, (self.psser > self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser > self.pser, (self.psser > self.psser).sort_index())
 
     def test_ge(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
-            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
+            self.assert_eq(
+                self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -205,33 +205,45 @@ class DateOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     def test_eq(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
-            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+            self.assert_eq(
+                self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
-            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+            self.assert_eq(
+                self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser < self.other_pser, self.psser < self.other_psser)
-            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+            self.assert_eq(
+                self.pser < self.other_pser, (self.psser < self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser < self.pser, (self.psser < self.psser).sort_index())
 
     def test_le(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser <= self.other_pser, self.psser <= self.other_psser)
-            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+            self.assert_eq(
+                self.pser <= self.other_pser, (self.psser <= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser <= self.pser, (self.psser <= self.psser).sort_index())
 
     def test_gt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser > self.other_pser, self.psser > self.other_psser)
-            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+            self.assert_eq(
+                self.pser > self.other_pser, (self.psser > self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser > self.pser, (self.psser > self.psser).sort_index())
 
     def test_ge(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
-            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
+            self.assert_eq(
+                self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -40,6 +40,16 @@ class DateOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         return ps.from_pandas(self.pser)
 
     @property
+    def other_pser(self):
+        return pd.Series(
+            [datetime.date(2000, 1, 31), datetime.date(1994, 3, 1), datetime.date(1990, 2, 2)]
+        )
+
+    @property
+    def other_psser(self):
+        return ps.from_pandas(self.other_pser)
+
+    @property
     def some_date(self):
         return datetime.date(1994, 1, 1)
 
@@ -183,6 +193,45 @@ class DateOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pd.Series([None, None, None]), psser.astype(bool))
         cat_type = CategoricalDtype(categories=["a", "b", "c"])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
+
+    def test_neg(self):
+        self.assertRaises(TypeError, lambda: -self.psser)
+
+    def test_abs(self):
+        self.assertRaises(TypeError, lambda: abs(self.psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
+            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
+            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser < self.other_pser, self.psser < self.other_psser)
+            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser <= self.other_pser, self.psser <= self.other_psser)
+            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser > self.other_pser, self.psser > self.other_psser)
+            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
+            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
@@ -203,33 +203,45 @@ class DatetimeOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     def test_eq(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
-            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+            self.assert_eq(
+                self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
-            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+            self.assert_eq(
+                self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser < self.other_pser, self.psser < self.other_psser)
-            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+            self.assert_eq(
+                self.pser < self.other_pser, (self.psser < self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser < self.pser, (self.psser < self.psser).sort_index())
 
     def test_le(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser <= self.other_pser, self.psser <= self.other_psser)
-            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+            self.assert_eq(
+                self.pser <= self.other_pser, (self.psser <= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser <= self.pser, (self.psser <= self.psser).sort_index())
 
     def test_gt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser > self.other_pser, self.psser > self.other_psser)
-            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+            self.assert_eq(
+                self.pser > self.other_pser, (self.psser > self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser > self.pser, (self.psser > self.psser).sort_index())
 
     def test_ge(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
-            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
+            self.assert_eq(
+                self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
@@ -37,6 +37,14 @@ class DatetimeOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         return ps.from_pandas(self.pser)
 
     @property
+    def other_pser(self):
+        return pd.Series(pd.date_range("1994-4-30 10:30:15", periods=3, freq="M"))
+
+    @property
+    def other_psser(self):
+        return ps.from_pandas(self.other_pser)
+
+    @property
     def some_datetime(self):
         return datetime.datetime(1994, 1, 31, 10, 30, 00)
 
@@ -183,6 +191,45 @@ class DatetimeOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pser.astype("category"), psser.astype("category"))
         cat_type = CategoricalDtype(categories=["a", "b", "c"])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
+
+    def test_neg(self):
+        self.assertRaises(TypeError, lambda: -self.psser)
+
+    def test_abs(self):
+        self.assertRaises(TypeError, lambda: abs(self.psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser == self.other_pser, self.psser == self.other_psser)
+            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser != self.other_pser, self.psser != self.other_psser)
+            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser < self.other_pser, self.psser < self.other_psser)
+            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser <= self.other_pser, self.psser <= self.other_psser)
+            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser > self.other_pser, self.psser > self.other_psser)
+            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser >= self.other_pser, self.psser >= self.other_psser)
+            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_decimal_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_decimal_ops.py
@@ -64,11 +64,9 @@ class DecimalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(self.float_pser.isnull(), self.float_psser.isnull())
 
     def test_neg(self):
-        # self.assert_eq(-self.decimal_pser, -self.decimal_psser)
         self.assert_eq(-self.other_decimal_pser, -self.other_decimal_psser)
 
     def test_abs(self):
-        # self.assert_eq(abs(self.decimal_pser), abs(self.decimal_psser))
         self.assert_eq(abs(self.other_decimal_pser), abs(self.other_decimal_psser))
 
     def test_invert(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_decimal_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_decimal_ops.py
@@ -21,8 +21,9 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from pyspark.pandas.data_type_ops.num_ops import DecimalOps
 from pyspark import pandas as ps
+from pyspark.pandas.config import option_context
+from pyspark.pandas.data_type_ops.num_ops import DecimalOps
 from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
@@ -35,6 +36,14 @@ class DecimalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     @property
     def decimal_psser(self):
         return ps.from_pandas(self.decimal_pser)
+
+    @property
+    def other_decimal_pser(self):
+        return pd.Series([d.Decimal(2.0), d.Decimal(1.0), d.Decimal(-3.0)])
+
+    @property
+    def other_decimal_psser(self):
+        return ps.from_pandas(self.other_decimal_pser)
 
     @property
     def float_pser(self):
@@ -53,6 +62,49 @@ class DecimalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertEqual(self.float_psser._dtype_op.pretty_name, "fractions")
         self.assert_eq(self.decimal_pser.isnull(), self.decimal_psser.isnull())
         self.assert_eq(self.float_pser.isnull(), self.float_psser.isnull())
+
+    def test_neg(self):
+        # self.assert_eq(-self.decimal_pser, -self.decimal_psser)
+        self.assert_eq(-self.other_decimal_pser, -self.other_decimal_psser)
+
+    def test_abs(self):
+        # self.assert_eq(abs(self.decimal_pser), abs(self.decimal_psser))
+        self.assert_eq(abs(self.other_decimal_pser), abs(self.other_decimal_psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.decimal_psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.decimal_pser == self.other_decimal_pser,
+                self.decimal_psser == self.other_decimal_psser,
+            )
+            self.assert_eq(
+                self.decimal_pser == self.decimal_pser, self.decimal_psser == self.decimal_psser
+            )
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.decimal_pser != self.other_decimal_pser,
+                self.decimal_psser != self.other_decimal_psser,
+            )
+            self.assert_eq(
+                self.decimal_pser != self.decimal_pser, self.decimal_psser != self.decimal_psser
+            )
+
+    def test_lt(self):
+        self.assertRaises(TypeError, lambda: self.decimal_psser < self.other_decimal_psser)
+
+    def test_le(self):
+        self.assertRaises(TypeError, lambda: self.decimal_psser <= self.other_decimal_psser)
+
+    def test_gt(self):
+        self.assertRaises(TypeError, lambda: self.decimal_psser > self.other_decimal_psser)
+
+    def test_ge(self):
+        self.assertRaises(TypeError, lambda: self.decimal_psser >= self.other_decimal_psser)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_decimal_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_decimal_ops.py
@@ -76,20 +76,22 @@ class DecimalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
                 self.decimal_pser == self.other_decimal_pser,
-                self.decimal_psser == self.other_decimal_psser,
+                (self.decimal_psser == self.other_decimal_psser).sort_index(),
             )
             self.assert_eq(
-                self.decimal_pser == self.decimal_pser, self.decimal_psser == self.decimal_psser
+                self.decimal_pser == self.decimal_pser,
+                (self.decimal_psser == self.decimal_psser).sort_index(),
             )
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
                 self.decimal_pser != self.other_decimal_pser,
-                self.decimal_psser != self.other_decimal_psser,
+                (self.decimal_psser != self.other_decimal_psser).sort_index(),
             )
             self.assert_eq(
-                self.decimal_pser != self.decimal_pser, self.decimal_psser != self.decimal_psser
+                self.decimal_pser != self.decimal_pser,
+                (self.decimal_psser != self.decimal_psser).sort_index(),
             )
 
     def test_lt(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
@@ -146,27 +146,27 @@ class NullOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     def test_eq(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+            self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+            self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+            self.assert_eq(self.pser < self.pser, (self.psser < self.psser).sort_index())
 
     def test_le(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+            self.assert_eq(self.pser <= self.pser, (self.psser <= self.psser).sort_index())
 
     def test_gt(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+            self.assert_eq(self.pser > self.pser, (self.psser > self.psser).sort_index())
 
     def test_ge(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
+            self.assert_eq(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
@@ -135,6 +135,39 @@ class NullOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         cat_type = CategoricalDtype(categories=[1, 2, 3])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
+    def test_neg(self):
+        self.assertRaises(TypeError, lambda: -self.psser)
+
+    def test_abs(self):
+        self.assertRaises(TypeError, lambda: abs(self.psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser < self.pser, self.psser < self.psser)
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser <= self.pser, self.psser <= self.psser)
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser > self.pser, self.psser > self.psser)
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser >= self.pser, self.psser >= self.psser)
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -30,6 +30,7 @@ from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
     extension_float_dtypes_available,
 )
+from pyspark.sql.types import DecimalType, LongType
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
 
@@ -317,6 +318,57 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             cat_type = CategoricalDtype(categories=[2, 1, 3])
             self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
+    def test_neg(self):
+        for pser, psser in self.numeric_pser_psser_pairs:
+            if not isinstance(psser.spark.data_type, DecimalType):
+                self.assert_eq(-pser, -psser)
+
+    def test_abs(self):
+        for pser, psser in self.numeric_pser_psser_pairs:
+            if not isinstance(psser.spark.data_type, DecimalType):
+                self.assert_eq(abs(pser), abs(psser))
+
+    def test_invert(self):
+        for psser in self.numeric_pssers:
+            if not isinstance(psser.spark.data_type, DecimalType):
+                self.assertRaises(NotImplementedError, lambda: ~psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.numeric_pser_psser_pairs:
+                if not isinstance(psser.spark.data_type, DecimalType):
+                    self.assert_eq(pser == pser, (psser == psser).sort_index())
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.numeric_pser_psser_pairs:
+                if not isinstance(psser.spark.data_type, DecimalType):
+                    self.assert_eq(pser != pser, (psser != psser).sort_index())
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.numeric_pser_psser_pairs:
+                if not isinstance(psser.spark.data_type, DecimalType):
+                    self.assert_eq(pser < pser, (psser < psser).sort_index())
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.numeric_pser_psser_pairs:
+                if not isinstance(psser.spark.data_type, DecimalType):
+                    self.assert_eq(pser <= pser, (psser <= psser).sort_index())
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.numeric_pser_psser_pairs:
+                if not isinstance(psser.spark.data_type, DecimalType):
+                    self.assert_eq(pser > pser, (psser > psser).sort_index())
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.numeric_pser_psser_pairs:
+                if not isinstance(psser.spark.data_type, DecimalType):
+                    self.assert_eq(pser >= pser, (psser >= psser).sort_index())
+
 
 @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
 class IntegralExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
@@ -345,6 +397,48 @@ class IntegralExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in self.intergral_extension_pser_psser_pairs:
             for dtype in self.extension_dtypes:
                 self.check_extension(pser.astype(dtype), psser.astype(dtype))
+
+    def test_neg(self):
+        for pser, psser in self.intergral_extension_pser_psser_pairs:
+            self.check_extension(-pser, -psser)
+
+    def test_abs(self):
+        for pser, psser in self.intergral_extension_pser_psser_pairs:
+            self.check_extension(abs(pser), abs(psser))
+
+    def test_invert(self):
+        for psser in self.intergral_extension_pssers:
+            self.assertRaises(NotImplementedError, lambda: ~psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.intergral_extension_pser_psser_pairs:
+                self.check_extension(pser == pser, (psser == psser).sort_index())
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.intergral_extension_pser_psser_pairs:
+                self.check_extension(pser != pser, (psser != psser).sort_index())
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.intergral_extension_pser_psser_pairs:
+                self.check_extension(pser < pser, (psser < psser).sort_index())
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.intergral_extension_pser_psser_pairs:
+                self.check_extension(pser <= pser, (psser <= psser).sort_index())
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.intergral_extension_pser_psser_pairs:
+                self.check_extension(pser > pser, (psser > psser).sort_index())
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.intergral_extension_pser_psser_pairs:
+                self.check_extension(pser >= pser, (psser >= psser).sort_index())
 
 
 @unittest.skipIf(
@@ -379,6 +473,52 @@ class FractionalExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in self.fractional_extension_pser_psser_pairs:
             for dtype in self.extension_dtypes:
                 self.check_extension(pser.astype(dtype), psser.astype(dtype))
+
+    def test_neg(self):
+        # pandas raises "TypeError: bad operand type for unary -: 'FloatingArray'"
+        for dtype in self.fractional_extension_dtypes:
+            self.assert_eq(
+                ps.Series([-0.1, -0.2, -0.3, None], dtype=dtype),
+                -ps.Series([0.1, 0.2, 0.3, None], dtype=dtype),
+            )
+
+    def test_abs(self):
+        for pser, psser in self.fractional_extension_pser_psser_pairs:
+            self.check_extension(abs(pser), abs(psser))
+
+    def test_invert(self):
+        for psser in self.fractional_extension_pssers:
+            self.assertRaises(NotImplementedError, lambda: ~psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.fractional_extension_pser_psser_pairs:
+                self.check_extension(pser == pser, (psser == psser).sort_index())
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.fractional_extension_pser_psser_pairs:
+                self.check_extension(pser != pser, (psser != psser).sort_index())
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.fractional_extension_pser_psser_pairs:
+                self.check_extension(pser < pser, (psser < psser).sort_index())
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.fractional_extension_pser_psser_pairs:
+                self.check_extension(pser <= pser, (psser <= psser).sort_index())
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.fractional_extension_pser_psser_pairs:
+                self.check_extension(pser > pser, (psser > psser).sort_index())
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            for pser, psser in self.fractional_extension_pser_psser_pairs:
+                self.check_extension(pser >= pser, (psser >= psser).sort_index())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -30,7 +30,7 @@ from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
     extension_float_dtypes_available,
 )
-from pyspark.sql.types import DecimalType, LongType
+from pyspark.sql.types import DecimalType
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -40,6 +40,14 @@ class StringOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def psser(self):
         return ps.from_pandas(self.pser)
 
+    @property
+    def other_pser(self):
+        return pd.Series(["z", "y", "x"])
+
+    @property
+    def other_psser(self):
+        return ps.from_pandas(self.other_pser)
+
     def test_add(self):
         self.assert_eq(self.pser + "x", self.psser + "x")
         self.assertRaises(TypeError, lambda: self.psser + 1)
@@ -179,6 +187,57 @@ class StringOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         cat_type = CategoricalDtype(categories=["3", "1", "2"])
         self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
+    def test_neg(self):
+        self.assertRaises(TypeError, lambda: -self.psser)
+
+    def test_abs(self):
+        self.assertRaises(TypeError, lambda: abs(self.psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.pser < self.other_pser, (self.psser < self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser < self.pser, (self.psser < self.psser).sort_index())
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.pser <= self.other_pser, (self.psser <= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser <= self.pser, (self.psser <= self.psser).sort_index())
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.pser > self.other_pser, (self.psser > self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser > self.pser, (self.psser > self.psser).sort_index())
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
+            )
+            self.assert_eq(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
+
 
 @unittest.skipIf(
     not extension_object_dtypes_available, "pandas extension object dtypes are not available"
@@ -191,6 +250,14 @@ class StringExtensionOpsTest(StringOpsTest, PandasOnSparkTestCase, TestCasesUtil
     @property
     def psser(self):
         return ps.from_pandas(self.pser)
+
+    @property
+    def other_pser(self):
+        return pd.Series([None, "z", "y", "x"], dtype="string")
+
+    @property
+    def other_psser(self):
+        return ps.from_pandas(self.other_pser)
 
     def test_radd(self):
         self.assert_eq("x" + self.pser, ("x" + self.psser).astype("string"))
@@ -234,8 +301,51 @@ class StringExtensionOpsTest(StringOpsTest, PandasOnSparkTestCase, TestCasesUtil
             if dtype in ["string", StringDtype()]:
                 self.check_extension(pser.astype(dtype), psser.astype(dtype))
 
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(
+                self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser == self.pser, (self.psser == self.psser).sort_index())
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(
+                self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser != self.pser, (self.psser != self.psser).sort_index())
+
+    def test_lt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(
+                self.pser < self.other_pser, (self.psser < self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser < self.pser, (self.psser < self.psser).sort_index())
+
+    def test_le(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(
+                self.pser <= self.other_pser, (self.psser <= self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser <= self.pser, (self.psser <= self.psser).sort_index())
+
+    def test_gt(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(
+                self.pser > self.other_pser, (self.psser > self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser > self.pser, (self.psser > self.psser).sort_index())
+
+    def test_ge(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.check_extension(
+                self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
+            )
+            self.check_extension(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
+
 
 if __name__ == "__main__":
+
     from pyspark.pandas.tests.data_type_ops.test_string_ops import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/data_type_ops/test_udt_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_udt_ops.py
@@ -131,6 +131,35 @@ class UDTOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def test_astype(self):
         self.assertRaises(TypeError, lambda: self.psser.astype(str))
 
+    def test_neg(self):
+        self.assertRaises(TypeError, lambda: -self.psser)
+
+    def test_abs(self):
+        self.assertRaises(TypeError, lambda: abs(self.psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.psser)
+
+    def test_eq(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+
+    def test_ne(self):
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+
+    def test_lt(self):
+        self.assertRaises(TypeError, lambda: self.psser < self.psser)
+
+    def test_le(self):
+        self.assertRaises(TypeError, lambda: self.psser <= self.psser)
+
+    def test_gt(self):
+        self.assertRaises(TypeError, lambda: self.psser > self.psser)
+
+    def test_ge(self):
+        self.assertRaises(TypeError, lambda: self.psser >= self.psser)
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/data_type_ops/test_udt_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_udt_ops.py
@@ -142,11 +142,11 @@ class UDTOpsTest(PandasOnSparkTestCase, TestCasesUtils):
 
     def test_eq(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser == self.pser, self.psser == self.psser)
+            self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
 
     def test_ne(self):
         with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(self.pser != self.pser, self.psser != self.psser)
+            self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
         self.assertRaises(TypeError, lambda: self.psser < self.psser)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make unary and comparison operators data-type-based. Refactored operators include: 
- Unary operators: `__neg__`, `__abs__`, `__invert__`, 
- Comparison operators: `>`, `>=`, `<`, `<=`, `==`, `!=`

Non-goal: Tasks below are inspired during the development of this PR.
[[SPARK-35997] Implement comparison operators for CategoricalDtype in pandas API on Spark](https://issues.apache.org/jira/browse/SPARK-35997)
[[SPARK-36000] Support creating a ps.Series/Index with `Decimal('NaN')` with Arrow disabled](https://issues.apache.org/jira/browse/SPARK-36000)
[[SPARK-36001] Assume result's index to be disordered in tests with operations on different Series](https://issues.apache.org/jira/browse/SPARK-36001)
[[SPARK-36002] Consolidate tests for data-type-based operations of decimal Series](https://issues.apache.org/jira/browse/SPARK-36002)
[[SPARK-36003] Implement unary operator `invert` of numeric ps.Series/Index](https://issues.apache.org/jira/browse/SPARK-36003)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We have been refactoring basic operators to be data-type-based for readability, flexibility, and extensibility.
Unary and comparison operators are still not data-type-based yet. We should fill the gaps.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.

- Better error messages. For example,

Before:
```py
>>> import pyspark.pandas as ps
>>> psser = ps.Series([b"2", b"3", b"4"])
>>> -psser
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: cannot resolve '(- `0`)' due to data type mismatch: ...
```
After:
```py
>>> import pyspark.pandas as ps
>>> psser = ps.Series([b"2", b"3", b"4"])
>>> -psser
Traceback (most recent call last):
...
TypeError: Unary - can not be applied to binaries.
>>> 
```
- Support unary `-` of `bool` Series. For example,

Before:
```py
>>> psser = ps.Series([True, False, True])
>>> -psser
Traceback (most recent call last):
...
pyspark.sql.utils.AnalysisException: cannot resolve '(- `0`)' due to data type mismatch: ...
```

After:
```py
>>> psser = ps.Series([True, False, True])
>>> -psser
0    False
1     True
2    False
dtype: bool
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.

Keyword: SPARK-35337