### PR TITLE
[SPARK-35960][BUILD][TEST] Bump the scalatest version to 3.2.9 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -937,7 +937,7 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.9</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION


### What changes were proposed in this pull request?

Bump the scalatest version to 3.2.9 

### Why are the changes needed?

With the scalatestplus change to 3.2.9.0, recent sbt fails to handle the mismatch between scalatest and scalatestplus and resolve resulting in test:compile errors of not being able to find the org.scalatest package.



### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

sbt tags/test:compile failed before and passes with this change.