### PR TITLE
[SPARK-35962][DOCS] Deprecate old Java 8 versions prior to 8u201

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Spark runs on both Windows and UNIX-like systems (e.g. Linux, Mac OS), and it sh
 
 Spark runs on Java 8/11, Scala 2.12, Python 3.6+ and R 3.5+.
 Python 3.6 support is deprecated as of Spark 3.2.0.
-Java 8 prior to version 8u92 support is deprecated as of Spark 3.0.0.
+Java 8 prior to version 8u201 support is deprecated as of Spark 3.0.0.
 For the Scala API, Spark {{site.SPARK_VERSION}}
 uses Scala {{site.SCALA_BINARY_VERSION}}. You will need to use a compatible Scala version
 ({{site.SCALA_BINARY_VERSION}}.x).

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Spark runs on both Windows and UNIX-like systems (e.g. Linux, Mac OS), and it sh
 
 Spark runs on Java 8/11, Scala 2.12, Python 3.6+ and R 3.5+.
 Python 3.6 support is deprecated as of Spark 3.2.0.
-Java 8 prior to version 8u201 support is deprecated as of Spark 3.0.0.
+Java 8 prior to version 8u201 support is deprecated as of Spark 3.2.0.
 For the Scala API, Spark {{site.SPARK_VERSION}}
 uses Scala {{site.SCALA_BINARY_VERSION}}. You will need to use a compatible Scala version
 ({{site.SCALA_BINARY_VERSION}}.x).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to deprecate old Java 8 versions prior to 8u201.

### Why are the changes needed?

This is a preparation of using G1GC during the migration among Java LTS versions (8/11/17).

8u162 has the following fix.
- JDK-8205376: JVM Crash during G1 GC

8u201 has the following fix.
- JDK-8208873: C1: G1 barriers don't preserve FP registers

### Does this PR introduce _any_ user-facing change?

No, Today's Java8 is usually 1.8.0_292 and this is just a deprecation in documentation. 

### How was this patch tested?

N/A