### PR TITLE
[SPARK-35963][SQL] Rename TimestampWithoutTZType to TimestampNTZType

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/SpecializedGettersReader.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/SpecializedGettersReader.java
@@ -65,7 +65,7 @@ public final class SpecializedGettersReader {
     if (dataType instanceof TimestampType) {
       return obj.getLong(ordinal);
     }
-    if (dataType instanceof TimestampWithoutTZType) {
+    if (dataType instanceof TimestampNTZType) {
       return obj.getLong(ordinal);
     }
     if (dataType instanceof CalendarIntervalType) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/types/DataTypes.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/types/DataTypes.java
@@ -55,9 +55,9 @@ public class DataTypes {
   public static final DataType TimestampType = TimestampType$.MODULE$;
 
   /**
-   * Gets the TimestampWithoutTZType object.
+   * Gets the TimestampNTZType object.
    */
-  public static final DataType TimestampWithoutTZType = TimestampWithoutTZType$.MODULE$;
+  public static final DataType TimestampNTZType = TimestampNTZType$.MODULE$;
 
   /**
    * Gets the CalendarIntervalType object.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -68,7 +68,7 @@ object CatalystTypeConverters {
       case DateType => DateConverter
       case TimestampType if SQLConf.get.datetimeJava8ApiEnabled => InstantConverter
       case TimestampType => TimestampConverter
-      case TimestampWithoutTZType => TimestampWithoutTZConverter
+      case TimestampNTZType => TimestampNTZConverter
       case dt: DecimalType => new DecimalConverter(dt)
       case BooleanType => BooleanConverter
       case ByteType => ByteConverter
@@ -357,13 +357,13 @@ object CatalystTypeConverters {
       DateTimeUtils.microsToInstant(row.getLong(column))
   }
 
-  private object TimestampWithoutTZConverter
+  private object TimestampNTZConverter
     extends CatalystTypeConverter[Any, LocalDateTime, Any] {
     override def toCatalystImpl(scalaValue: Any): Any = scalaValue match {
       case l: LocalDateTime => DateTimeUtils.localDateTimeToMicros(l)
       case other => throw new IllegalArgumentException(
         s"The value (${other.toString}) of the type (${other.getClass.getCanonicalName}) "
-          + s"cannot be converted to the ${TimestampWithoutTZType.sql} type")
+          + s"cannot be converted to the ${TimestampNTZType.sql} type")
     }
 
     override def toScala(catalystValue: Any): LocalDateTime =
@@ -511,7 +511,7 @@ object CatalystTypeConverters {
     case ld: LocalDate => LocalDateConverter.toCatalyst(ld)
     case t: Timestamp => TimestampConverter.toCatalyst(t)
     case i: Instant => InstantConverter.toCatalyst(i)
-    case l: LocalDateTime => TimestampWithoutTZConverter.toCatalyst(l)
+    case l: LocalDateTime => TimestampNTZConverter.toCatalyst(l)
     case d: BigDecimal => new DecimalConverter(DecimalType(d.precision, d.scale)).toCatalyst(d)
     case d: JavaBigDecimal => new DecimalConverter(DecimalType(d.precision, d.scale)).toCatalyst(d)
     case seq: Seq[Any] => new GenericArrayData(seq.map(convertToCatalyst).toArray)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
@@ -134,7 +134,7 @@ object InternalRow {
       case ShortType => (input, ordinal) => input.getShort(ordinal)
       case IntegerType | DateType | _: YearMonthIntervalType =>
         (input, ordinal) => input.getInt(ordinal)
-      case LongType | TimestampType | TimestampWithoutTZType | _: DayTimeIntervalType =>
+      case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType =>
         (input, ordinal) => input.getLong(ordinal)
       case FloatType => (input, ordinal) => input.getFloat(ordinal)
       case DoubleType => (input, ordinal) => input.getDouble(ordinal)
@@ -171,7 +171,7 @@ object InternalRow {
     case ShortType => (input, v) => input.setShort(ordinal, v.asInstanceOf[Short])
     case IntegerType | DateType | _: YearMonthIntervalType =>
       (input, v) => input.setInt(ordinal, v.asInstanceOf[Int])
-    case LongType | TimestampType | TimestampWithoutTZType | _: DayTimeIntervalType =>
+    case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType =>
       (input, v) => input.setLong(ordinal, v.asInstanceOf[Long])
     case FloatType => (input, v) => input.setFloat(ordinal, v.asInstanceOf[Float])
     case DoubleType => (input, v) => input.setDouble(ordinal, v.asInstanceOf[Double])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -119,7 +119,7 @@ object JavaTypeInference {
       case c: Class[_] if c == classOf[java.sql.Date] => (DateType, true)
       case c: Class[_] if c == classOf[java.time.Instant] => (TimestampType, true)
       case c: Class[_] if c == classOf[java.sql.Timestamp] => (TimestampType, true)
-      case c: Class[_] if c == classOf[java.time.LocalDateTime] => (TimestampWithoutTZType, true)
+      case c: Class[_] if c == classOf[java.time.LocalDateTime] => (TimestampNTZType, true)
       case c: Class[_] if c == classOf[java.time.Duration] => (DayTimeIntervalType(), true)
       case c: Class[_] if c == classOf[java.time.Period] => (YearMonthIntervalType(), true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -753,7 +753,7 @@ object ScalaReflection extends ScalaReflection {
       case t if isSubtype(t, localTypeOf[java.sql.Timestamp]) =>
         Schema(TimestampType, nullable = true)
       case t if isSubtype(t, localTypeOf[java.time.LocalDateTime]) =>
-        Schema(TimestampWithoutTZType, nullable = true)
+        Schema(TimestampNTZType, nullable = true)
       case t if isSubtype(t, localTypeOf[java.time.LocalDate]) => Schema(DateType, nullable = true)
       case t if isSubtype(t, localTypeOf[java.sql.Date]) => Schema(DateType, nullable = true)
       case t if isSubtype(t, localTypeOf[CalendarInterval]) =>
@@ -858,7 +858,7 @@ object ScalaReflection extends ScalaReflection {
     StringType -> classOf[UTF8String],
     DateType -> classOf[DateType.InternalType],
     TimestampType -> classOf[TimestampType.InternalType],
-    TimestampWithoutTZType -> classOf[TimestampWithoutTZType.InternalType],
+    TimestampNTZType -> classOf[TimestampNTZType.InternalType],
     BinaryType -> classOf[BinaryType.InternalType],
     CalendarIntervalType -> classOf[CalendarInterval]
   )
@@ -873,7 +873,7 @@ object ScalaReflection extends ScalaReflection {
     DoubleType -> classOf[java.lang.Double],
     DateType -> classOf[java.lang.Integer],
     TimestampType -> classOf[java.lang.Long],
-    TimestampWithoutTZType -> classOf[java.lang.Long]
+    TimestampNTZType -> classOf[java.lang.Long]
   )
 
   def dataTypeJavaClass(dt: DataType): Class[_] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SerializerBuildHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SerializerBuildHelper.scala
@@ -89,7 +89,7 @@ object SerializerBuildHelper {
   def createSerializerForLocalDateTime(inputObject: Expression): Expression = {
     StaticInvoke(
       DateTimeUtils.getClass,
-      TimestampWithoutTZType,
+      TimestampNTZType,
       "localDateTimeToMicros",
       inputObject :: Nil,
       returnNullable = false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -357,9 +357,9 @@ class Analyzer(override val catalogManager: CatalogManager)
           case (_: DayTimeIntervalType, DateType) => TimeAdd(Cast(r, TimestampType), l)
           case (DateType, _: YearMonthIntervalType) => DateAddYMInterval(l, r)
           case (_: YearMonthIntervalType, DateType) => DateAddYMInterval(r, l)
-          case (TimestampType | TimestampWithoutTZType, _: YearMonthIntervalType) =>
+          case (TimestampType | TimestampNTZType, _: YearMonthIntervalType) =>
             TimestampAddYMInterval(l, r)
-          case (_: YearMonthIntervalType, TimestampType | TimestampWithoutTZType) =>
+          case (_: YearMonthIntervalType, TimestampType | TimestampNTZType) =>
             TimestampAddYMInterval(r, l)
           case (CalendarIntervalType, CalendarIntervalType) |
                (_: DayTimeIntervalType, _: DayTimeIntervalType) => a
@@ -378,7 +378,7 @@ class Analyzer(override val catalogManager: CatalogManager)
             DatetimeSub(l, r, TimeAdd(Cast(l, TimestampType), UnaryMinus(r, f)))
           case (DateType, _: YearMonthIntervalType) =>
             DatetimeSub(l, r, DateAddYMInterval(l, UnaryMinus(r, f)))
-          case (TimestampType | TimestampWithoutTZType, _: YearMonthIntervalType) =>
+          case (TimestampType | TimestampNTZType, _: YearMonthIntervalType) =>
             DatetimeSub(l, r, TimestampAddYMInterval(l, UnaryMinus(r, f)))
           case (CalendarIntervalType, CalendarIntervalType) |
                (_: DayTimeIntervalType, _: DayTimeIntervalType) => s

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -541,7 +541,7 @@ object FunctionRegistry {
     expression[ParseToDate]("to_date"),
     expression[ToUnixTimestamp]("to_unix_timestamp"),
     expression[ToUTCTimestamp]("to_utc_timestamp"),
-    expression[ParseToTimestampWithoutTZ]("to_timestamp_ntz"),
+    expression[ParseToTimestampNTZ]("to_timestamp_ntz"),
     expression[TruncDate]("trunc"),
     expression[TruncTimestamp]("date_trunc"),
     expression[UnixTimestamp]("unix_timestamp"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -639,8 +639,8 @@ abstract class TypeCoercionBase {
         s.copy(right = Cast(s.right, s.left.dataType))
       case s @ SubtractTimestamps(AnyTimestampType(), AnyTimestampType(), _, _)
         if s.left.dataType != s.right.dataType =>
-        val newLeft = castIfNotSameType(s.left, TimestampWithoutTZType)
-        val newRight = castIfNotSameType(s.right, TimestampWithoutTZType)
+        val newLeft = castIfNotSameType(s.left, TimestampNTZType)
+        val newRight = castIfNotSameType(s.right, TimestampNTZType)
         s.copy(left = newLeft, right = newRight)
 
       case t @ TimeAdd(StringType(), _, _) => t.copy(start = Cast(t.start, TimestampType))
@@ -962,7 +962,7 @@ object TypeCoercion extends TypeCoercionBase {
       // Implicit cast between date time types
       case (DateType, TimestampType) => TimestampType
       case (DateType, AnyTimestampType) => AnyTimestampType.defaultConcreteType
-      case (TimestampType | TimestampWithoutTZType, DateType) => DateType
+      case (TimestampType | TimestampNTZType, DateType) => DateType
 
       // Implicit cast from/to string
       case (StringType, DecimalType) => DecimalType.SYSTEM_DEFAULT

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -298,8 +298,8 @@ package object dsl {
       def timestamp: AttributeReference = AttributeReference(s, TimestampType, nullable = true)()
 
       /** Creates a new AttributeReference of type timestamp without time zone */
-      def timestampWithoutTZ: AttributeReference =
-        AttributeReference(s, TimestampWithoutTZType, nullable = true)()
+      def timestampNTZ: AttributeReference =
+        AttributeReference(s, TimestampNTZType, nullable = true)()
 
       /** Creates a new AttributeReference of the day-time interval type */
       def dayTimeInterval(startField: Byte, endField: Byte): AttributeReference = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
@@ -53,7 +53,7 @@ import org.apache.spark.sql.types._
  *   TimestampType -> java.sql.Timestamp if spark.sql.datetime.java8API.enabled is false
  *   TimestampType -> java.time.Instant if spark.sql.datetime.java8API.enabled is true
  *
- *   TimestampWithoutTZType -> java.time.LocalDateTime
+ *   TimestampNTZType -> java.time.LocalDateTime
  *
  *   DayTimeIntervalType -> java.time.Duration
  *   YearMonthIntervalType -> java.time.Period
@@ -105,7 +105,7 @@ object RowEncoder {
         createSerializerForSqlTimestamp(inputObject)
       }
 
-    case TimestampWithoutTZType => createSerializerForLocalDateTime(inputObject)
+    case TimestampNTZType => createSerializerForLocalDateTime(inputObject)
 
     case DateType =>
       if (SQLConf.get.datetimeJava8ApiEnabled) {
@@ -230,7 +230,7 @@ object RowEncoder {
       } else {
         ObjectType(classOf[java.sql.Timestamp])
       }
-    case TimestampWithoutTZType =>
+    case TimestampNTZType =>
       ObjectType(classOf[java.time.LocalDateTime])
     case DateType =>
       if (SQLConf.get.datetimeJava8ApiEnabled) {
@@ -287,7 +287,7 @@ object RowEncoder {
         createDeserializerForSqlTimestamp(input)
       }
 
-    case TimestampWithoutTZType =>
+    case TimestampNTZType =>
       createDeserializerForLocalDateTime(input)
 
     case DateType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
@@ -160,7 +160,7 @@ object InterpretedUnsafeProjection {
       case IntegerType | DateType | _: YearMonthIntervalType =>
         (v, i) => writer.write(i, v.getInt(i))
 
-      case LongType | TimestampType | TimestampWithoutTZType | _: DayTimeIntervalType =>
+      case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType =>
         (v, i) => writer.write(i, v.getLong(i))
 
       case FloatType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SpecificInternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SpecificInternalRow.scala
@@ -196,7 +196,7 @@ final class SpecificInternalRow(val values: Array[MutableValue]) extends BaseGen
     // We use INT for DATE and YearMonthIntervalType internally
     case IntegerType | DateType | _: YearMonthIntervalType => new MutableInt
     // We use Long for Timestamp, Timestamp without time zone and DayTimeInterval internally
-    case LongType | TimestampType | TimestampWithoutTZType | _: DayTimeIntervalType =>
+    case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType =>
       new MutableLong
     case FloatType => new MutableFloat
     case DoubleType => new MutableDouble

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1893,7 +1893,7 @@ object CodeGenerator extends Logging {
     case ByteType => JAVA_BYTE
     case ShortType => JAVA_SHORT
     case IntegerType | DateType | _: YearMonthIntervalType => JAVA_INT
-    case LongType | TimestampType | TimestampWithoutTZType | _: DayTimeIntervalType => JAVA_LONG
+    case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType => JAVA_LONG
     case FloatType => JAVA_FLOAT
     case DoubleType => JAVA_DOUBLE
     case _: DecimalType => "Decimal"
@@ -1914,7 +1914,7 @@ object CodeGenerator extends Logging {
     case ByteType => java.lang.Byte.TYPE
     case ShortType => java.lang.Short.TYPE
     case IntegerType | DateType | _: YearMonthIntervalType => java.lang.Integer.TYPE
-    case LongType | TimestampType | TimestampWithoutTZType | _: DayTimeIntervalType =>
+    case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType =>
       java.lang.Long.TYPE
     case FloatType => java.lang.Float.TYPE
     case DoubleType => java.lang.Double.TYPE

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -80,7 +80,7 @@ object Literal {
     case d: Decimal => Literal(d, DecimalType(Math.max(d.precision, d.scale), d.scale))
     case i: Instant => Literal(instantToMicros(i), TimestampType)
     case t: Timestamp => Literal(DateTimeUtils.fromJavaTimestamp(t), TimestampType)
-    case l: LocalDateTime => Literal(DateTimeUtils.localDateTimeToMicros(l), TimestampWithoutTZType)
+    case l: LocalDateTime => Literal(DateTimeUtils.localDateTimeToMicros(l), TimestampNTZType)
     case ld: LocalDate => Literal(ld.toEpochDay.toInt, DateType)
     case d: Date => Literal(DateTimeUtils.fromJavaDate(d), DateType)
     case d: Duration => Literal(durationToMicros(d), DayTimeIntervalType())
@@ -120,7 +120,7 @@ object Literal {
     case _ if clz == classOf[Date] => DateType
     case _ if clz == classOf[Instant] => TimestampType
     case _ if clz == classOf[Timestamp] => TimestampType
-    case _ if clz == classOf[LocalDateTime] => TimestampWithoutTZType
+    case _ if clz == classOf[LocalDateTime] => TimestampNTZType
     case _ if clz == classOf[Duration] => DayTimeIntervalType()
     case _ if clz == classOf[Period] => YearMonthIntervalType()
     case _ if clz == classOf[JavaBigDecimal] => DecimalType.SYSTEM_DEFAULT
@@ -185,7 +185,7 @@ object Literal {
     case dt: DecimalType => Literal(Decimal(0, dt.precision, dt.scale))
     case DateType => create(0, DateType)
     case TimestampType => create(0L, TimestampType)
-    case TimestampWithoutTZType => create(0L, TimestampWithoutTZType)
+    case TimestampNTZType => create(0L, TimestampNTZType)
     case it: DayTimeIntervalType => create(0L, it)
     case it: YearMonthIntervalType => create(0, it)
     case StringType => Literal("")
@@ -207,7 +207,7 @@ object Literal {
       case ByteType => v.isInstanceOf[Byte]
       case ShortType => v.isInstanceOf[Short]
       case IntegerType | DateType | _: YearMonthIntervalType => v.isInstanceOf[Int]
-      case LongType | TimestampType | TimestampWithoutTZType | _: DayTimeIntervalType =>
+      case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType =>
         v.isInstanceOf[Long]
       case FloatType => v.isInstanceOf[Float]
       case DoubleType => v.isInstanceOf[Double]
@@ -434,7 +434,7 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
           }
         case ByteType | ShortType =>
           ExprCode.forNonNullValue(JavaCode.expression(s"($javaType)$value", dataType))
-        case TimestampType | TimestampWithoutTZType | LongType | _: DayTimeIntervalType =>
+        case TimestampType | TimestampNTZType | LongType | _: DayTimeIntervalType =>
           toExprCode(s"${value}L")
         case _ =>
           val constRef = ctx.addReferenceObj("literal", value, javaType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -30,7 +30,7 @@ import sun.util.calendar.ZoneInfo
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.RebaseDateTime._
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.types.{DateType, Decimal, TimestampType, TimestampWithoutTZType}
+import org.apache.spark.sql.types.{DateType, Decimal, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 /**
@@ -467,7 +467,7 @@ object DateTimeUtils {
 
   def stringToTimestampWithoutTimeZoneAnsi(s: UTF8String): Long = {
     stringToTimestampWithoutTimeZone(s).getOrElse {
-      throw QueryExecutionErrors.cannotCastUTF8StringToDataTypeError(s, TimestampWithoutTZType)
+      throw QueryExecutionErrors.cannotCastUTF8StringToDataTypeError(s, TimestampNTZType)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -340,15 +340,15 @@ object TimestampFormatter {
       locale: Locale = defaultLocale,
       legacyFormat: LegacyDateFormat = LENIENT_SIMPLE_DATE_FORMAT,
       isParsing: Boolean,
-      forTimestampWithoutTZ: Boolean = false): TimestampFormatter = {
+      forTimestampNTZ: Boolean = false): TimestampFormatter = {
     val pattern = format.getOrElse(defaultPattern)
-    val formatter = if (SQLConf.get.legacyTimeParserPolicy == LEGACY && !forTimestampWithoutTZ) {
+    val formatter = if (SQLConf.get.legacyTimeParserPolicy == LEGACY && !forTimestampNTZ) {
       getLegacyFormatter(pattern, zoneId, locale, legacyFormat)
     } else {
       new Iso8601TimestampFormatter(
         pattern, zoneId, locale, legacyFormat, isParsing)
     }
-    formatter.validatePatternString(checkLegacy = !forTimestampWithoutTZ)
+    formatter.validatePatternString(checkLegacy = !forTimestampNTZ)
     formatter
   }
 
@@ -389,9 +389,9 @@ object TimestampFormatter {
       zoneId: ZoneId,
       legacyFormat: LegacyDateFormat,
       isParsing: Boolean,
-      forTimestampWithoutTZ: Boolean): TimestampFormatter = {
+      forTimestampNTZ: Boolean): TimestampFormatter = {
     getFormatter(Some(format), zoneId, defaultLocale, legacyFormat, isParsing,
-      forTimestampWithoutTZ)
+      forTimestampNTZ)
   }
 
   def apply(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -216,7 +216,7 @@ private[sql] object AnyTimestampType extends AbstractDataType with Serializable 
   override private[sql] def defaultConcreteType: DataType = TimestampType
 
   override private[sql] def acceptsType(other: DataType): Boolean =
-    other.isInstanceOf[TimestampType] || other.isInstanceOf[TimestampWithoutTZType]
+    other.isInstanceOf[TimestampType] || other.isInstanceOf[TimestampNTZType]
 
   override private[sql] def simpleString = "(timestamp or timestamp without time zone)"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -184,7 +184,7 @@ object DataType {
       YearMonthIntervalType(YEAR),
       YearMonthIntervalType(MONTH),
       YearMonthIntervalType(YEAR, MONTH),
-      TimestampWithoutTZType)
+      TimestampNTZType)
       .map(t => t.typeName -> t).toMap
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampNTZType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampNTZType.scala
@@ -28,11 +28,11 @@ import org.apache.spark.annotation.Unstable
  * Its valid range is [0001-01-01T00:00:00.000000, 9999-12-31T23:59:59.999999].
  * To represent an absolute point in time, use `TimestampType` instead.
  *
- * Please use the singleton `DataTypes.TimestampWithoutTZType` to refer the type.
+ * Please use the singleton `DataTypes.TimestampNTZType` to refer the type.
  * @since 3.2.0
  */
 @Unstable
-class TimestampWithoutTZType private() extends AtomicType {
+class TimestampNTZType private() extends AtomicType {
   /**
    * Internally, a timestamp is stored as the number of microseconds from
    * the epoch of 1970-01-01T00:00:00.000000(Unix system time zero)
@@ -44,22 +44,22 @@ class TimestampWithoutTZType private() extends AtomicType {
   private[sql] val ordering = implicitly[Ordering[InternalType]]
 
   /**
-   * The default size of a value of the TimestampWithoutTZType is 8 bytes.
+   * The default size of a value of the TimestampNTZType is 8 bytes.
    */
   override def defaultSize: Int = 8
 
   override def typeName: String = "timestamp without time zone"
 
-  private[spark] override def asNullable: TimestampWithoutTZType = this
+  private[spark] override def asNullable: TimestampNTZType = this
 }
 
 /**
  * The companion case object and its class is separated so the companion object also subclasses
- * the TimestampWithoutTZType class. Otherwise, the companion object would be of type
- * "TimestampWithoutTZType" in byte code. Defined with a private constructor so the companion
+ * the TimestampNTZType class. Otherwise, the companion object would be of type
+ * "TimestampNTZType" in byte code. Defined with a private constructor so the companion
  * object is the only possible instantiation.
  *
  * @since 3.2.0
  */
 @Unstable
-case object TimestampWithoutTZType extends TimestampWithoutTZType
+case object TimestampNTZType extends TimestampNTZType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -271,7 +271,7 @@ object RandomDataGenerator {
             getRandomTimestamp,
             specialTs.map(java.sql.Timestamp.valueOf))
         }
-      case TimestampWithoutTZType =>
+      case TimestampNTZType =>
         randomNumeric[LocalDateTime](
           rand,
           (rand: Random) => {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -191,7 +191,7 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
     }
   }
 
-  test("SPARK-35664: converting java.time.LocalDateTime to TimestampWithoutTZType") {
+  test("SPARK-35664: converting java.time.LocalDateTime to TimestampNTZType") {
     Seq(
       "0101-02-16T10:11:32",
       "1582-10-02T01:02:03.04",
@@ -207,7 +207,7 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
     }
   }
 
-  test("SPARK-35664: converting TimestampWithoutTZType to java.time.LocalDateTime") {
+  test("SPARK-35664: converting TimestampNTZType to java.time.LocalDateTime") {
     Seq(
       -9463427405253013L,
       -244000001L,
@@ -215,7 +215,7 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
       99628200102030L,
       1543749753123456L).foreach { us =>
       val localDateTime = DateTimeUtils.microsToLocalDateTime(us)
-      assert(CatalystTypeConverters.createToScalaConverter(TimestampWithoutTZType)(us) ===
+      assert(CatalystTypeConverters.createToScalaConverter(TimestampNTZType)(us) ===
         localDateTime)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -331,8 +331,8 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
     }
   }
 
-  test("SPARK-35664: encoding/decoding TimestampWithoutTZType to/from java.time.LocalDateTime") {
-    val schema = new StructType().add("t", TimestampWithoutTZType)
+  test("SPARK-35664: encoding/decoding TimestampNTZType to/from java.time.LocalDateTime") {
+    val schema = new StructType().add("t", TimestampNTZType)
     val encoder = RowEncoder(schema).resolveAndBind()
     val localDateTime = java.time.LocalDateTime.parse("2019-02-26T16:56:00")
     val row = toRow(encoder, Row(localDateTime))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AnsiCastSuiteBase.scala
@@ -418,8 +418,8 @@ abstract class AnsiCastSuiteBase extends CastSuiteBase {
       "2021-06-17abc",
       "2021-06-17 00:00:00ABC").foreach { invalidInput =>
       checkExceptionInExpression[DateTimeException](
-        cast(invalidInput, TimestampWithoutTZType),
-        s"Cannot cast $invalidInput to TimestampWithoutTZType")
+        cast(invalidInput, TimestampNTZType),
+        s"Cannot cast $invalidInput to TimestampNTZType")
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -573,7 +573,7 @@ class CastSuite extends CastSuiteBase {
       "a2021-06-17",
       "2021-06-17abc",
       "2021-06-17 00:00:00ABC").foreach { invalidInput =>
-      checkEvaluation(cast(invalidInput, TimestampWithoutTZType), null)
+      checkEvaluation(cast(invalidInput, TimestampNTZType), null)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -920,7 +920,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       val inputDate = LocalDate.parse(s.split("T")(0))
       // The hour/minute/second of the expect result should be 0
       val expectedTs = LocalDateTime.parse(s.split("T")(0) + "T00:00:00")
-      checkEvaluation(cast(inputDate, TimestampWithoutTZType), expectedTs)
+      checkEvaluation(cast(inputDate, TimestampNTZType), expectedTs)
     }
   }
 
@@ -930,7 +930,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         specialTs.foreach { s =>
           val input = Timestamp.valueOf(s.replace("T", " "))
           val expectedTs = LocalDateTime.parse(s)
-          checkEvaluation(cast(input, TimestampWithoutTZType), expectedTs)
+          checkEvaluation(cast(input, TimestampNTZType), expectedTs)
         }
       }
     }
@@ -938,34 +938,34 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
 
   test("disallow type conversions between Numeric types and Timestamp without time zone type") {
     import DataTypeTestUtils.numericTypes
-    checkInvalidCastFromNumericType(TimestampWithoutTZType)
+    checkInvalidCastFromNumericType(TimestampNTZType)
     var errorMsg = "cannot cast bigint to timestamp without time zone"
-    verifyCastFailure(cast(Literal(0L), TimestampWithoutTZType), Some(errorMsg))
+    verifyCastFailure(cast(Literal(0L), TimestampNTZType), Some(errorMsg))
 
-    val timestampWithoutTZLiteral = Literal.create(LocalDateTime.now(), TimestampWithoutTZType)
+    val timestampNTZLiteral = Literal.create(LocalDateTime.now(), TimestampNTZType)
     errorMsg = "cannot cast timestamp without time zone to"
     numericTypes.foreach { numericType =>
-      verifyCastFailure(cast(timestampWithoutTZLiteral, numericType), Some(errorMsg))
+      verifyCastFailure(cast(timestampNTZLiteral, numericType), Some(errorMsg))
     }
   }
 
   test("SPARK-35720: cast string to timestamp without timezone") {
     specialTs.foreach { s =>
       val expectedTs = LocalDateTime.parse(s)
-      checkEvaluation(cast(s, TimestampWithoutTZType), expectedTs)
+      checkEvaluation(cast(s, TimestampNTZType), expectedTs)
       // Trim spaces before casting
-      checkEvaluation(cast("  " + s + "   ", TimestampWithoutTZType), expectedTs)
+      checkEvaluation(cast("  " + s + "   ", TimestampNTZType), expectedTs)
       // The result is independent of timezone
       outstandingZoneIds.foreach { zoneId =>
-        checkEvaluation(cast(s + zoneId.toString, TimestampWithoutTZType), expectedTs)
+        checkEvaluation(cast(s + zoneId.toString, TimestampNTZType), expectedTs)
         val tsWithMicros = s + ".123456"
         val expectedTsWithNanoSeconds = LocalDateTime.parse(tsWithMicros)
-        checkEvaluation(cast(tsWithMicros + zoneId.toString, TimestampWithoutTZType),
+        checkEvaluation(cast(tsWithMicros + zoneId.toString, TimestampNTZType),
           expectedTsWithNanoSeconds)
       }
     }
     // The input string can contain date only
-    checkEvaluation(cast("2021-06-17", TimestampWithoutTZType),
+    checkEvaluation(cast("2021-06-17", TimestampNTZType),
       LocalDateTime.of(2021, 6, 17, 0, 0))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralGenerator.scala
@@ -139,10 +139,10 @@ object LiteralGenerator {
       yield Literal.create(new Timestamp(millis), TimestampType)
   }
 
-  lazy val timestampWithoutTZLiteralGen: Gen[Literal] = {
+  lazy val timestampNTZLiteralGen: Gen[Literal] = {
     for { millis <- millisGen }
       yield Literal.create(
-        DateTimeUtils.microsToLocalDateTime(millis * MICROS_PER_MILLIS), TimestampWithoutTZType)
+        DateTimeUtils.microsToLocalDateTime(millis * MICROS_PER_MILLIS), TimestampNTZType)
   }
 
   // Valid range for DateType and TimestampType is [0001-01-01, 9999-12-31]
@@ -197,7 +197,7 @@ object LiteralGenerator {
       case FloatType => floatLiteralGen
       case DateType => dateLiteralGen
       case TimestampType => timestampLiteralGen
-      case TimestampWithoutTZType => timestampWithoutTZLiteralGen
+      case TimestampNTZType => timestampNTZLiteralGen
       case BooleanType => booleanLiteralGen
       case StringType => stringLiteralGen
       case BinaryType => binaryLiteralGen

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -316,7 +316,7 @@ class DataTypeSuite extends SparkFunSuite {
   checkDefaultSize(DecimalType.SYSTEM_DEFAULT, 16)
   checkDefaultSize(DateType, 4)
   checkDefaultSize(TimestampType, 8)
-  checkDefaultSize(TimestampWithoutTZType, 8)
+  checkDefaultSize(TimestampNTZType, 8)
   checkDefaultSize(StringType, 20)
   checkDefaultSize(BinaryType, 100)
   checkDefaultSize(ArrayType(DoubleType, true), 8)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
@@ -81,7 +81,7 @@ object DataTypeTestUtils {
   val ordered: Set[DataType] = numericTypeWithoutDecimal ++ Set(
     BooleanType,
     TimestampType,
-    TimestampWithoutTZType,
+    TimestampNTZType,
     DateType,
     StringType,
     BinaryType) ++ dayTimeIntervalTypes ++ yearMonthIntervalTypes
@@ -100,7 +100,7 @@ object DataTypeTestUtils {
     DateType,
     StringType,
     TimestampType,
-    TimestampWithoutTZType) ++ dayTimeIntervalTypes ++ yearMonthIntervalTypes
+    TimestampNTZType) ++ dayTimeIntervalTypes ++ yearMonthIntervalTypes
 
   /**
    * Instances of [[ArrayType]] for all [[AtomicType]]s. Arrays of these types may contain null.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/HiveResult.scala
@@ -101,7 +101,7 @@ object HiveResult {
     case (ld: LocalDate, DateType) => formatters.date.format(ld)
     case (t: Timestamp, TimestampType) => formatters.timestamp.format(t)
     case (i: Instant, TimestampType) => formatters.timestamp.format(i)
-    case (l: LocalDateTime, TimestampWithoutTZType) => formatters.timestamp.format(l)
+    case (l: LocalDateTime, TimestampNTZType) => formatters.timestamp.format(l)
     case (bin: Array[Byte], BinaryType) => new String(bin, StandardCharsets.UTF_8)
     case (decimal: java.math.BigDecimal, DecimalType()) => decimal.toPlainString
     case (n, _: NumericType) => n.toString

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -206,7 +206,7 @@
 | org.apache.spark.sql.catalyst.expressions.Overlay | overlay | SELECT overlay('Spark SQL' PLACING '_' FROM 6) | struct<overlay(Spark SQL, _, 6, -1):string> |
 | org.apache.spark.sql.catalyst.expressions.ParseToDate | to_date | SELECT to_date('2009-07-30 04:17:52') | struct<to_date(2009-07-30 04:17:52):date> |
 | org.apache.spark.sql.catalyst.expressions.ParseToTimestamp | to_timestamp | SELECT to_timestamp('2016-12-31 00:12:00') | struct<to_timestamp(2016-12-31 00:12:00):timestamp> |
-| org.apache.spark.sql.catalyst.expressions.ParseToTimestampWithoutTZ | to_timestamp_ntz | SELECT to_timestamp_ntz('2016-12-31 00:12:00') | struct<to_timestamp_ntz(2016-12-31 00:12:00):timestamp without time zone> |
+| org.apache.spark.sql.catalyst.expressions.ParseToTimestampNTZ | to_timestamp_ntz | SELECT to_timestamp_ntz('2016-12-31 00:12:00') | struct<to_timestamp_ntz(2016-12-31 00:12:00):timestamp without time zone> |
 | org.apache.spark.sql.catalyst.expressions.ParseUrl | parse_url | SELECT parse_url('http://spark.apache.org/path?query=1', 'HOST') | struct<parse_url(http://spark.apache.org/path?query=1, HOST):string> |
 | org.apache.spark.sql.catalyst.expressions.PercentRank | percent_rank | SELECT a, b, percent_rank(b) OVER (PARTITION BY a ORDER BY b) FROM VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1) tab(a, b) | struct<a:string,b:int,PERCENT_RANK() OVER (PARTITION BY a ORDER BY b ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):double> |
 | org.apache.spark.sql.catalyst.expressions.Pi | pi | SELECT pi() | struct<PI():double> |

--- a/sql/core/src/test/resources/sql-tests/inputs/datetime.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/datetime.sql
@@ -236,7 +236,7 @@ select next_day("xx", "Mon");
 select next_day(null, "Mon");
 select next_day(null, "xx");
 
--- TimestampWithoutTZ + Intervals
+-- TimestampNTZ + Intervals
 select to_timestamp_ntz('2021-06-25 10:11:12') + interval 2 day;
 select to_timestamp_ntz('2021-06-25 10:11:12') + interval '0-0' year to month;
 select to_timestamp_ntz('2021-06-25 10:11:12') + interval '1-2' year to month;
@@ -247,7 +247,7 @@ select to_timestamp_ntz('2021-06-25 10:11:12') + interval '20 15' day to hour;
 select to_timestamp_ntz('2021-06-25 10:11:12') + interval '20 15:40' day to minute;
 select to_timestamp_ntz('2021-06-25 10:11:12') + interval '20 15:40:32.99899999' day to second;
 
--- TimestampWithoutTZ - Intervals
+-- TimestampNTZ - Intervals
 select to_timestamp_ntz('2021-06-25 10:11:12') - interval 2 day;
 select to_timestamp_ntz('2021-06-25 10:11:12') - interval '0-0' year to month;
 select to_timestamp_ntz('2021-06-25 10:11:12') - interval '1-2' year to month;

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -853,19 +853,19 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     val plusYear = udf((l: java.time.LocalDateTime) => l.plusYears(1))
     val result = input.select(plusYear($"dateTime").as("newDateTime"))
     checkAnswer(result, Row(java.time.LocalDateTime.parse("2022-01-01T00:00:00")) :: Nil)
-    assert(result.schema === new StructType().add("newDateTime", TimestampWithoutTZType))
+    assert(result.schema === new StructType().add("newDateTime", TimestampNTZType))
     // UDF produces `null`
     val nullFunc = udf((_: java.time.LocalDateTime) => null.asInstanceOf[java.time.LocalDateTime])
     val nullResult = input.select(nullFunc($"dateTime").as("nullDateTime"))
     checkAnswer(nullResult, Row(null) :: Nil)
-    assert(nullResult.schema === new StructType().add("nullDateTime", TimestampWithoutTZType))
+    assert(nullResult.schema === new StructType().add("nullDateTime", TimestampNTZType))
     // Input parameter of UDF is null
     val nullInput = Seq(null.asInstanceOf[java.time.LocalDateTime]).toDF("nullDateTime")
     val constDuration = udf((_: java.time.LocalDateTime) =>
       java.time.LocalDateTime.parse("2021-01-01T00:00:00"))
     val constResult = nullInput.select(constDuration($"nullDateTime").as("firstDayOf2021"))
     checkAnswer(constResult, Row(java.time.LocalDateTime.parse("2021-01-01T00:00:00")) :: Nil)
-    assert(constResult.schema === new StructType().add("firstDayOf2021", TimestampWithoutTZType))
+    assert(constResult.schema === new StructType().add("firstDayOf2021", TimestampNTZType))
     // Error in the conversion of UDF result to the internal representation of timestamp without
     // time zone
     val overflowFunc = udf((l: java.time.LocalDateTime) => l.plusDays(Long.MaxValue))

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -121,7 +121,7 @@ private[hive] class SparkExecuteStatementOperation(
           false,
           timeFormatters)
       case _: ArrayType | _: StructType | _: MapType | _: UserDefinedType[_] |
-          _: YearMonthIntervalType | _: DayTimeIntervalType | _: TimestampWithoutTZType =>
+          _: YearMonthIntervalType | _: DayTimeIntervalType | _: TimestampNTZType =>
         to += toHiveString((from.get(ordinal), dataTypes(ordinal)), false, timeFormatters)
     }
   }
@@ -379,7 +379,7 @@ object SparkExecuteStatementOperation {
         case CalendarIntervalType => StringType.catalogString
         case _: YearMonthIntervalType => "interval_year_month"
         case _: DayTimeIntervalType => "interval_day_time"
-        case _: TimestampWithoutTZType => "timestamp"
+        case _: TimestampNTZType => "timestamp"
         case other => other.catalogString
       }
       new FieldSchema(field.name, attrTypeString, field.getComment.getOrElse(""))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Rename TimestampWithoutTZType to TimestampNTZType


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The time name of `TimestampWithoutTZType` is verbose. Rename it as `TimestampNTZType` so that
1. it is easier to read and type.
2. As we have the function to_timestamp_ntz, this makes the names consistent.
3. We will introduce a new SQL configuration `spark.sql.timestampType` for the default timestamp type. The configuration values can be "TIMESTMAP_NTZ" or "TIMESTMAP_LTZ" for simplicity.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the new timestamp type is not released yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Run `git grep -i WithoutTZ` and there is no result.
And Ci tests.