### PR TITLE
[SPARK-35968][SQL] Make sure partitions are not too small in AQE partition coalescing

### DIFF
--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -3542,6 +3542,8 @@ test_that("repartition by columns on DataFrame", {
   conf <- callJMethod(sparkSession, "conf")
   shufflepartitionsvalue <- callJMethod(conf, "get", "spark.sql.shuffle.partitions")
   callJMethod(conf, "set", "spark.sql.shuffle.partitions", "5")
+  coalesceEnabled <- callJMethod(conf, "get", "spark.sql.adaptive.coalescePartitions.enabled")
+  callJMethod(conf, "set", "spark.sql.adaptive.coalescePartitions.enabled", "false")
   tryCatch({
     df <- createDataFrame(
       list(list(1L, 1, "1", 0.1), list(1L, 2, "2", 0.2), list(3L, 3, "3", 0.3)),
@@ -3583,6 +3585,7 @@ test_that("repartition by columns on DataFrame", {
   finally = {
     # Resetting the conf back to default value
     callJMethod(conf, "set", "spark.sql.shuffle.partitions", shufflepartitionsvalue)
+    callJMethod(conf, "set", "spark.sql.adaptive.coalescePartitions.enabled", coalesceEnabled)
   })
 })
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -918,10 +918,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         +---+-----+
         |age| name|
         +---+-----+
-        |  5|  Bob|
+        |  2|Alice|
         |  5|  Bob|
         |  2|Alice|
-        |  2|Alice|
+        |  5|  Bob|
         +---+-----+
         >>> data = data.repartition(7, "age")
         >>> data.show()
@@ -935,7 +935,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         +---+-----+
         >>> data.rdd.getNumPartitions()
         7
-        >>> data = data.repartition("name", "age")
+        >>> data = data.repartition(3, "name", "age")
         >>> data.show()
         +---+-----+
         |age| name|

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -209,7 +209,7 @@ class DataFrameTests(ReusedSQLTestCase):
         self.assertEqual(df4.rdd.take(3), df2.rdd.take(3))
 
         # test repartitionByRange(*cols)
-        df5 = df1.repartitionByRange("name", "age")
+        df5 = df1.repartitionByRange(5, "name", "age")
         self.assertEqual(df5.rdd.first(), df2.rdd.first())
         self.assertEqual(df5.rdd.take(3), df2.rdd.take(3))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -525,17 +525,33 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  private val MIN_PARTITION_NUM_KEY = "spark.sql.adaptive.coalescePartitions.minPartitionNum"
+  private val MIN_PARTITION_SIZE_KEY = "spark.sql.adaptive.coalescePartitions.minPartitionSize"
+
   val COALESCE_PARTITIONS_MIN_PARTITION_NUM =
-    buildConf("spark.sql.adaptive.coalescePartitions.minPartitionNum")
+    buildConf(MIN_PARTITION_NUM_KEY)
       .doc("The suggested (not guaranteed) minimum number of shuffle partitions after " +
         "coalescing. If not set, the default value is the default parallelism of the " +
-        "Spark cluster. This configuration only has an effect when " +
-        s"'${ADAPTIVE_EXECUTION_ENABLED.key}' and " +
+        s"Spark cluster, w.r.t. the minimum partition size set by '$MIN_PARTITION_SIZE_KEY'. " +
+        s"This configuration only has an effect when '${ADAPTIVE_EXECUTION_ENABLED.key}' and " +
         s"'${COALESCE_PARTITIONS_ENABLED.key}' are both true.")
       .version("3.0.0")
       .intConf
       .checkValue(_ > 0, "The minimum number of partitions must be positive.")
       .createOptional
+
+  val COALESCE_PARTITIONS_MIN_PARTITION_SIZE =
+    buildConf(MIN_PARTITION_SIZE_KEY)
+      .doc(s"The minimum size of shuffle partitions after coalescing if '$MIN_PARTITION_NUM_KEY' " +
+        s"is not set. When '$MIN_PARTITION_NUM_KEY' is not set, the minimum number of " +
+        "shuffle partitions after coalescing will fall back to the default parallelism " +
+        "of the Spark cluster, sometimes causing partition sizes to be too small. This config " +
+        "aims to prevent this situation. Note that this config does not take effect if " +
+        s"'${COALESCE_PARTITIONS_MIN_PARTITION_NUM.key}' is set by the user.")
+      .version("3.2.0")
+      .bytesConf(ByteUnit.BYTE)
+      .checkValue(_ > 0, "The minimum partition size must be positive.")
+      .createWithDefaultString("1MB")
 
   val COALESCE_PARTITIONS_INITIAL_PARTITION_NUM =
     buildConf("spark.sql.adaptive.coalescePartitions.initialPartitionNum")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -547,10 +547,10 @@ object SQLConf {
         "shuffle partitions after coalescing will fall back to the default parallelism " +
         "of the Spark cluster, sometimes causing partition sizes to be too small. This config " +
         "aims to prevent this situation. Note that this config does not take effect if " +
-        s"'${COALESCE_PARTITIONS_MIN_PARTITION_NUM.key}' is set by the user.")
+        s"'$MIN_PARTITION_NUM_KEY' is set by the user. Its maximum value is the value " +
+        s"of '${ADVISORY_PARTITION_SIZE_IN_BYTES.key}'.")
       .version("3.2.0")
       .bytesConf(ByteUnit.BYTE)
-      .checkValue(_ > 0, "The minimum partition size must be positive.")
       .createWithDefaultString("1MB")
 
   val COALESCE_PARTITIONS_INITIAL_PARTITION_NUM =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -525,33 +525,29 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  private val MIN_PARTITION_NUM_KEY = "spark.sql.adaptive.coalescePartitions.minPartitionNum"
-  private val MIN_PARTITION_SIZE_KEY = "spark.sql.adaptive.coalescePartitions.minPartitionSize"
+  val COALESCE_PARTITIONS_PARALLELISM_FIRST =
+    buildConf("spark.sql.adaptive.coalescePartitions.parallelismFirst")
+      .doc("When true, Spark will coalesce contiguous shuffle partitions with 1MB as the target " +
+        s"size, instead of '${ADVISORY_PARTITION_SIZE_IN_BYTES.key}', to maximize the " +
+        "parallelism. This is to avoid performance regression when enabling adaptive query " +
+        "execution. It's recommended to set this config to false and use " +
+        s"'${ADVISORY_PARTITION_SIZE_IN_BYTES.key}' as the target size.")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(true)
 
   val COALESCE_PARTITIONS_MIN_PARTITION_NUM =
-    buildConf(MIN_PARTITION_NUM_KEY)
+    buildConf("spark.sql.adaptive.coalescePartitions.minPartitionNum")
+      .internal()
       .doc("The suggested (not guaranteed) minimum number of shuffle partitions after " +
         "coalescing. If not set, the default value is the default parallelism of the " +
-        s"Spark cluster, w.r.t. the minimum partition size set by '$MIN_PARTITION_SIZE_KEY'. " +
-        s"This configuration only has an effect when '${ADAPTIVE_EXECUTION_ENABLED.key}' and " +
+        "Spark cluster. This configuration only has an effect when " +
+        s"'${ADAPTIVE_EXECUTION_ENABLED.key}' and " +
         s"'${COALESCE_PARTITIONS_ENABLED.key}' are both true.")
       .version("3.0.0")
       .intConf
       .checkValue(_ > 0, "The minimum number of partitions must be positive.")
       .createOptional
-
-  val COALESCE_PARTITIONS_MIN_PARTITION_SIZE =
-    buildConf(MIN_PARTITION_SIZE_KEY)
-      .doc(s"The minimum size of shuffle partitions after coalescing if '$MIN_PARTITION_NUM_KEY' " +
-        s"is not set. When '$MIN_PARTITION_NUM_KEY' is not set, the minimum number of " +
-        "shuffle partitions after coalescing will fall back to the default parallelism " +
-        "of the Spark cluster, sometimes causing partition sizes to be too small. This config " +
-        "aims to prevent this situation. Note that this config does not take effect if " +
-        s"'$MIN_PARTITION_NUM_KEY' is set by the user. Its maximum value is the value " +
-        s"of '${ADVISORY_PARTITION_SIZE_IN_BYTES.key}'.")
-      .version("3.2.0")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("1MB")
 
   val COALESCE_PARTITIONS_INITIAL_PARTITION_NUM =
     buildConf("spark.sql.adaptive.coalescePartitions.initialPartitionNum")
@@ -3340,7 +3336,9 @@ object SQLConf {
       DeprecatedConfig(AVRO_REBASE_MODE_IN_READ.alternatives.head, "3.2",
         s"Use '${AVRO_REBASE_MODE_IN_READ.key}' instead."),
       DeprecatedConfig(LEGACY_REPLACE_DATABRICKS_SPARK_AVRO_ENABLED.key, "3.2",
-        """Use `.format("avro")` in `DataFrameWriter` or `DataFrameReader` instead.""")
+        """Use `.format("avro")` in `DataFrameWriter` or `DataFrameReader` instead."""),
+      DeprecatedConfig(COALESCE_PARTITIONS_MIN_PARTITION_NUM.key, "3.2",
+        s"Use '${COALESCE_PARTITIONS_PARALLELISM_FIRST.key}' instead.")
     )
 
     Map(configs.map { cfg => cfg.key -> cfg } : _*)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -45,7 +45,8 @@ object ShufflePartitionsUtil extends Logging {
       mapOutputStatistics: Seq[Option[MapOutputStatistics]],
       inputPartitionSpecs: Seq[Option[Seq[ShufflePartitionSpec]]],
       advisoryTargetSize: Long,
-      minNumPartitions: Int): Seq[Seq[ShufflePartitionSpec]] = {
+      minNumPartitions: Int,
+      minPartitionSize: Long): Seq[Seq[ShufflePartitionSpec]] = {
     assert(mapOutputStatistics.length == inputPartitionSpecs.length)
 
     if (mapOutputStatistics.isEmpty) {
@@ -65,19 +66,22 @@ object ShufflePartitionsUtil extends Logging {
 
     val shuffleIds = mapOutputStatistics.flatMap(_.map(_.shuffleId)).mkString(", ")
     logInfo(s"For shuffle($shuffleIds), advisory target size: $advisoryTargetSize, " +
-      s"actual target size $targetSize.")
+      s"actual target size $targetSize, minimum partition size: $minPartitionSize")
 
     // If `inputPartitionSpecs` are all empty, it means skew join optimization is not applied.
     if (inputPartitionSpecs.forall(_.isEmpty)) {
-      coalescePartitionsWithoutSkew(mapOutputStatistics, targetSize)
+      coalescePartitionsWithoutSkew(
+        mapOutputStatistics, targetSize, minPartitionSize)
     } else {
-      coalescePartitionsWithSkew(mapOutputStatistics, inputPartitionSpecs, targetSize)
+      coalescePartitionsWithSkew(
+        mapOutputStatistics, inputPartitionSpecs, targetSize, minPartitionSize)
     }
   }
 
   private def coalescePartitionsWithoutSkew(
       mapOutputStatistics: Seq[Option[MapOutputStatistics]],
-      targetSize: Long): Seq[Seq[ShufflePartitionSpec]] = {
+      targetSize: Long,
+      minPartitionSize: Long): Seq[Seq[ShufflePartitionSpec]] = {
     // `ShuffleQueryStageExec#mapStats` returns None when the input RDD has 0 partitions,
     // we should skip it when calculating the `partitionStartIndices`.
     val validMetrics = mapOutputStatistics.flatten
@@ -95,7 +99,8 @@ object ShufflePartitionsUtil extends Logging {
     }
 
     val numPartitions = validMetrics.head.bytesByPartitionId.length
-    val newPartitionSpecs = coalescePartitions(0, numPartitions, validMetrics, targetSize)
+    val newPartitionSpecs = coalescePartitions(
+      0, numPartitions, validMetrics, targetSize, minPartitionSize)
     if (newPartitionSpecs.length < numPartitions) {
       attachDataSize(mapOutputStatistics, newPartitionSpecs)
     } else {
@@ -106,7 +111,8 @@ object ShufflePartitionsUtil extends Logging {
   private def coalescePartitionsWithSkew(
       mapOutputStatistics: Seq[Option[MapOutputStatistics]],
       inputPartitionSpecs: Seq[Option[Seq[ShufflePartitionSpec]]],
-      targetSize: Long): Seq[Seq[ShufflePartitionSpec]] = {
+      targetSize: Long,
+      minPartitionSize: Long): Seq[Seq[ShufflePartitionSpec]] = {
     // Do not coalesce if any of the map output stats are missing or if not all shuffles have
     // partition specs, which should not happen in practice.
     if (!mapOutputStatistics.forall(_.isDefined) || !inputPartitionSpecs.forall(_.isDefined)) {
@@ -146,7 +152,12 @@ object ShufflePartitionsUtil extends Logging {
         // coalesce any partitions before partition(i - 1) and after the end of latest skew section.
         if (i - 1 > start) {
           val partitionSpecs = coalescePartitions(
-            partitionIndices(start), repeatValue, validMetrics, targetSize, true)
+            partitionIndices(start),
+            repeatValue,
+            validMetrics,
+            targetSize,
+            minPartitionSize,
+            allowReturnEmpty = true)
           newPartitionSpecsSeq.zip(attachDataSize(mapOutputStatistics, partitionSpecs))
             .foreach(spec => spec._1 ++= spec._2)
         }
@@ -172,7 +183,12 @@ object ShufflePartitionsUtil extends Logging {
     // coalesce any partitions after the end of last skew section.
     if (numPartitions > start) {
       val partitionSpecs = coalescePartitions(
-        partitionIndices(start), partitionIndices.last + 1, validMetrics, targetSize, true)
+        partitionIndices(start),
+        partitionIndices.last + 1,
+        validMetrics,
+        targetSize,
+        minPartitionSize,
+        allowReturnEmpty = true)
       newPartitionSpecsSeq.zip(attachDataSize(mapOutputStatistics, partitionSpecs))
         .foreach(spec => spec._1 ++= spec._2)
     }
@@ -215,11 +231,18 @@ object ShufflePartitionsUtil extends Logging {
       end: Int,
       mapOutputStatistics: Seq[MapOutputStatistics],
       targetSize: Long,
+      minPartitionSize: Long,
       allowReturnEmpty: Boolean = false): Seq[CoalescedPartitionSpec] = {
+    // `minPartitionSize` is not effective in most cases, as it's usually much smaller than
+    // `targetSize`, and the coalesced partitions will always be larger than `minPartitionSize`.
+    // The useful case is: for [64MB, 0.5MB, 64MB], we can't coalesce, because merging 0.5MB to
+    // either the left or right partition will exceed the target size. If 0.5MB is smaller than
+    // `minPartitionSize`, we will force-merge it to the left/right side.
     val partitionSpecs = ArrayBuffer.empty[CoalescedPartitionSpec]
     var coalescedSize = 0L
     var i = start
     var latestSplitPoint = i
+    var latestPartitionSize = 0L
 
     def createPartitionSpec(forceCreate: Boolean = false): Unit = {
       // Skip empty inputs, as it is a waste to launch an empty task.
@@ -237,20 +260,45 @@ object ShufflePartitionsUtil extends Logging {
         j += 1
       }
 
-      // If including the `totalSizeOfCurrentPartition` would exceed the target size, then start a
-      // new coalesced partition.
+      // If including the `totalSizeOfCurrentPartition` would exceed the target size and the
+      // current size has reached the `minPartitionSize`, then start a new coalesced partition.
       if (i > latestSplitPoint && coalescedSize + totalSizeOfCurrentPartition > targetSize) {
-        createPartitionSpec()
-        latestSplitPoint = i
-        // reset postShuffleInputSize.
-        coalescedSize = totalSizeOfCurrentPartition
+        if (coalescedSize < minPartitionSize) {
+          // the current partition size is below `minPartitionSize`.
+          // pack it with the smaller one between the two adjacent partitions (before and after).
+          if (latestPartitionSize > 0 && latestPartitionSize < totalSizeOfCurrentPartition) {
+            // pack with the before partition.
+            partitionSpecs(partitionSpecs.length - 1) =
+              CoalescedPartitionSpec(partitionSpecs.last.startReducerIndex, i)
+            latestSplitPoint = i
+            latestPartitionSize += coalescedSize
+            // reset postShuffleInputSize.
+            coalescedSize = totalSizeOfCurrentPartition
+          } else {
+            // pack with the after partition.
+            coalescedSize += totalSizeOfCurrentPartition
+          }
+        } else {
+          createPartitionSpec()
+          latestSplitPoint = i
+          latestPartitionSize = coalescedSize
+          // reset postShuffleInputSize.
+          coalescedSize = totalSizeOfCurrentPartition
+        }
       } else {
         coalescedSize += totalSizeOfCurrentPartition
       }
       i += 1
     }
-    // If do not allowReturnEmpty, create at least one partition if all partitions are empty.
-    createPartitionSpec(!allowReturnEmpty && partitionSpecs.isEmpty)
+
+    if (coalescedSize < minPartitionSize && latestPartitionSize > 0) {
+      // pack with the last partition.
+      partitionSpecs(partitionSpecs.length - 1) =
+        CoalescedPartitionSpec(partitionSpecs.last.startReducerIndex, end)
+    } else {
+      // If do not allowReturnEmpty, create at least one partition if all partitions are empty.
+      createPartitionSpec(!allowReturnEmpty && partitionSpecs.isEmpty)
+    }
     partitionSpecs.toSeq
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -233,11 +233,9 @@ object ShufflePartitionsUtil extends Logging {
       targetSize: Long,
       minPartitionSize: Long,
       allowReturnEmpty: Boolean = false): Seq[CoalescedPartitionSpec] = {
-    // `minPartitionSize` is not effective in most cases, as it's usually much smaller than
-    // `targetSize`, and the coalesced partitions will always be larger than `minPartitionSize`.
-    // The useful case is: for [64MB, 0.5MB, 64MB], we can't coalesce, because merging 0.5MB to
-    // either the left or right partition will exceed the target size. If 0.5MB is smaller than
-    // `minPartitionSize`, we will force-merge it to the left/right side.
+    // `minPartitionSize` is useful for cases like [64MB, 0.5MB, 64MB]: we can't do coalesce,
+    // because merging 0.5MB to either the left or right partition will exceed the target size.
+    // If 0.5MB is smaller than `minPartitionSize`, we will force-merge it to the left/right side.
     val partitionSpecs = ArrayBuffer.empty[CoalescedPartitionSpec]
     var coalescedSize = 0L
     var i = start

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -65,11 +65,14 @@ object ShufflePartitionsUtil extends Logging {
       math.ceil(totalPostShuffleInputSize / minNumPartitions.toDouble).toLong, 16)
     // The target size can be very small if minNumPartitions is super big. Here we use
     // minPartitionSize as the lower bound to avoid too small partitions after coalescing.
-    val targetSize = math.max(math.min(maxTargetSize, advisoryTargetSize), minPartitionSize)
+    val targetSize = math.max(
+      math.min(maxTargetSize, advisoryTargetSize),
+      // Prevent min partition size from being larger than advisoryTargetSize.
+      math.min(minPartitionSize, advisoryTargetSize))
 
     val shuffleIds = mapOutputStatistics.flatMap(_.map(_.shuffleId)).mkString(", ")
     logInfo(s"For shuffle($shuffleIds), advisory target size: $advisoryTargetSize, " +
-      s"actual target size $targetSize.")
+      s"minimum partition size: $minPartitionSize, actual target size $targetSize.")
 
     // If `inputPartitionSpecs` are all empty, it means skew join optimization is not applied.
     if (inputPartitionSpecs.forall(_.isEmpty)) {

--- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/groupingsets.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/groupingsets.sql
@@ -102,7 +102,7 @@ select a, b, grouping(a), grouping(b), sum(v), count(*), max(v)
   from gstest1 group by rollup (a,b) order by b desc, a;
 -- select a, b, grouping(a,b), sum(v), count(*), max(v)
 select a, b, grouping(a), grouping(b), sum(v), count(*), max(v)
-  from gstest1 group by rollup (a,b) order by coalesce(a,0)+coalesce(b,0);
+  from gstest1 group by rollup (a,b) order by coalesce(a,0)+coalesce(b,0), a;
 
 -- [SPARK-28664] ORDER BY in aggregate function
 -- various types of ordered aggs

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-order-by.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-order-by.sql
@@ -105,7 +105,7 @@ WHERE  t1b IN (SELECT Min(t2b)
                FROM   t2
                WHERE  t1b = t2b
                ORDER  BY Min(t2b))
-ORDER BY t1c DESC nulls first;
+ORDER BY t1c DESC nulls first, t1a DESC, t1d DESC, t1h;
 
 -- TC 01.07
 SELECT t1a,

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/groupingsets.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/groupingsets.sql.out
@@ -149,7 +149,7 @@ NULL	NULL	1	1	145	10	19
 
 -- !query
 select a, b, grouping(a), grouping(b), sum(v), count(*), max(v)
-  from gstest1 group by rollup (a,b) order by coalesce(a,0)+coalesce(b,0)
+  from gstest1 group by rollup (a,b) order by coalesce(a,0)+coalesce(b,0), a
 -- !query schema
 struct<a:int,b:int,grouping(a):tinyint,grouping(b):tinyint,sum(v):bigint,count(1):bigint,max(v):int>
 -- !query output
@@ -157,12 +157,12 @@ NULL	NULL	1	1	145	10	19
 1	NULL	0	1	60	5	14
 1	1	0	0	21	2	11
 2	NULL	0	1	15	1	15
-3	NULL	0	1	33	2	17
 1	2	0	0	25	2	13
+3	NULL	0	1	33	2	17
 1	3	0	0	14	1	14
 4	NULL	0	1	37	2	19
-4	1	0	0	37	2	19
 2	3	0	0	15	1	15
+4	1	0	0	37	2	19
 3	3	0	0	16	1	16
 3	4	0	0	17	1	17
 

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-order-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-order-by.sql.out
@@ -143,16 +143,16 @@ WHERE  t1b IN (SELECT Min(t2b)
                FROM   t2
                WHERE  t1b = t2b
                ORDER  BY Min(t2b))
-ORDER BY t1c DESC nulls first
+ORDER BY t1c DESC nulls first, t1a DESC, t1d DESC, t1h
 -- !query schema
 struct<t1a:string,t1b:smallint,t1c:int,t1d:bigint,t1e:float,t1f:double,t1g:decimal(4,0),t1h:timestamp,t1i:date>
 -- !query output
 val1e	10	NULL	25	17.0	25.0	2600	2014-08-04 01:01:00	2014-08-04
+val1e	10	NULL	19	17.0	25.0	2600	2014-05-04 01:01:00	2014-05-04
 val1e	10	NULL	19	17.0	25.0	2600	2014-09-04 01:02:00.001	2014-09-04
 val1d	10	NULL	12	17.0	25.0	2600	2015-05-04 01:01:00	2015-05-04
-val1e	10	NULL	19	17.0	25.0	2600	2014-05-04 01:01:00	2014-05-04
-val1b	8	16	19	17.0	25.0	2600	2014-05-04 01:01:00	2014-05-04
 val1c	8	16	19	17.0	25.0	2600	2014-05-04 01:02:00.001	2014-05-05
+val1b	8	16	19	17.0	25.0	2600	2014-05-04 01:01:00	2014-05-04
 val1a	6	8	10	15.0	20.0	2000	2014-04-04 01:00:00	2014-04-04
 val1a	6	8	10	15.0	20.0	2000	2014-04-04 01:02:00.001	2014-04-04
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1813,7 +1813,7 @@ class DataFrameSuite extends QueryTest
       (1 to 100).map(i => TestData2(i % 10, i))).toDF()
 
     // Distribute and order by.
-    val df4 = data.repartition($"a").sortWithinPartitions($"b".desc)
+    val df4 = data.repartition(5, $"a").sortWithinPartitions($"b".desc)
     // Walk each partition and verify that it is sorted descending and does not contain all
     // the values.
     df4.rdd.foreachPartition { p =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ShufflePartitionsUtilSuite.scala
@@ -26,8 +26,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       bytesByPartitionIdArray: Array[Array[Long]],
       expectedPartitionStartIndices: Seq[Seq[CoalescedPartitionSpec]],
       targetSize: Long,
-      minNumPartitions: Int = 1,
-      minPartitionSize: Long = 0): Unit = {
+      minNumPartitions: Int = 1): Unit = {
     val mapOutputStatistics = bytesByPartitionIdArray.zipWithIndex.map {
       case (bytesByPartitionId, index) =>
         Some(new MapOutputStatistics(index, bytesByPartitionId))
@@ -36,8 +35,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       mapOutputStatistics,
       Seq.fill(mapOutputStatistics.length)(None),
       targetSize,
-      minNumPartitions,
-      minPartitionSize)
+      minNumPartitions)
     assert(estimatedPartitionStartIndices.length === expectedPartitionStartIndices.length)
     estimatedPartitionStartIndices.zip(expectedPartitionStartIndices).foreach {
       case (actual, expect) => assert(actual === expect)
@@ -102,7 +100,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
         Array(
           Some(new MapOutputStatistics(0, bytesByPartitionId1)),
           Some(new MapOutputStatistics(1, bytesByPartitionId2))),
-        Seq.fill(2)(None), targetSize)
+        Seq.fill(2)(None), targetSize, 1)
       assert(coalesced.isEmpty)
     }
 
@@ -299,15 +297,6 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
     }
   }
 
-  test("minPartitionSize") {
-    val bytesByPartitionId = Array[Long](1000, 500, 2000, 200, 1000)
-    val expectedPartitionSpecs = Seq(
-      CoalescedPartitionSpec(0, 2, 1500),
-      CoalescedPartitionSpec(2, 3, 2000),
-      CoalescedPartitionSpec(3, 5, 1200))
-    checkEstimation(Array(bytesByPartitionId), expectedPartitionSpecs :: Nil, 5000, 20, 2000)
-  }
-
   test("coalesce after skew splitting") {
     val targetSize = 100
 
@@ -351,7 +340,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
         Seq(
           Some(specs1),
           Some(specs2)),
-        targetSize)
+        targetSize, 1)
       assert(coalesced == Seq(expected1, expected2))
     }
 
@@ -384,7 +373,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
         Seq(
           Some(specs1),
           Some(specs2)),
-        targetSize)
+        targetSize, 1)
       assert(coalesced == Seq(expected1, expected2))
     }
 
@@ -423,7 +412,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
         Seq(
           Some(specs1),
           Some(specs2)),
-        targetSize)
+        targetSize, 1)
       assert(coalesced == Seq(expected1, expected2))
     }
 
@@ -466,7 +455,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
         Seq(
           Some(specs1),
           Some(specs2)),
-        targetSize)
+        targetSize, 1)
       assert(coalesced == Seq(expected1, expected2))
     }
 
@@ -493,7 +482,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
         Seq(
           Some(specs1),
           Some(specs2)),
-        targetSize)
+        targetSize, 1)
       assert(coalesced.isEmpty)
     }
   }
@@ -513,7 +502,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
         Seq(
           Some(specs1),
           None),
-        targetSize)
+        targetSize, 1)
       assert(coalesced.isEmpty)
     }
 
@@ -529,7 +518,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
         Seq(
           Some(specs1),
           Some(specs2)),
-        targetSize)
+        targetSize, 1)
       assert(coalesced.isEmpty)
     }
 
@@ -548,7 +537,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
           Seq(
             Some(specs1),
             Some(specs2)),
-          targetSize)
+          targetSize, 1)
       }
     }
 
@@ -566,7 +555,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
           Seq(
             Some(specs1),
             Some(specs2)),
-          targetSize)
+          targetSize, 1)
       }
     }
 
@@ -585,7 +574,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
           Seq(
             Some(specs1),
             Some(specs2)),
-          targetSize)
+          targetSize, 1)
       }
     }
 
@@ -606,7 +595,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
           Seq(
             Some(specs1),
             Some(specs2)),
-          targetSize)
+          targetSize, 1)
       }
     }
 
@@ -624,7 +613,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
           Seq(
             Some(specs1),
             Some(specs2)),
-          targetSize)
+          targetSize, 1)
       }
     }
 
@@ -643,7 +632,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
           Seq(
             Some(specs1),
             Some(specs2)),
-          targetSize)
+          targetSize, 1)
       }
     }
 
@@ -662,7 +651,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
           Seq(
             Some(specs1),
             Some(specs2)),
-          targetSize)
+          targetSize, 1)
       }
     }
   }
@@ -731,7 +720,7 @@ class ShufflePartitionsUtilSuite extends SparkFunSuite {
       Seq(
         Some(specs1),
         Some(specs2)),
-      targetSize)
+      targetSize, 1)
     assert(coalesced == Seq(expected1, expected2))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
By default, AQE will set `COALESCE_PARTITIONS_MIN_PARTITION_NUM` to the spark default parallelism, which is usually quite big. This is to keep the parallelism on par with non-AQE, to avoid perf regressions.

However, this usually leads to many small/empty partitions, and hurts performance (although not worse than non-AQE). Users usually blindly set `COALESCE_PARTITIONS_MIN_PARTITION_NUM` to 1, which makes this config quite useless.

This PR adds a new config to set the min partition size, to avoid too small partitions after coalescing. By default, Spark will not respect the target size, and only respect this min partition size, to maximize the parallelism and avoid perf regression in AQE. This PR also adds a bool config to respect the target size when coalescing partitions, and it's recommended to set it to get better overall performance. This PR also deprecates the `COALESCE_PARTITIONS_MIN_PARTITION_NUM` config.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
AQE is default on now, we should make the perf better in the default case.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, a new config.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new tests