### PR TITLE
[SPARK-35973][SQL] DataSourceV2: Support SHOW CATALOGS

### DIFF
--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -303,6 +303,7 @@ Below is a list of all the keywords in Spark SQL.
 |CASCADE|non-reserved|non-reserved|non-reserved|
 |CASE|reserved|non-reserved|reserved|
 |CAST|reserved|non-reserved|reserved|
+|CATALOGS|non-reserved|non-reserved|non-reserved|
 |CHANGE|non-reserved|non-reserved|non-reserved|
 |CHECK|reserved|non-reserved|reserved|
 |CLEAR|non-reserved|non-reserved|non-reserved|

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -212,6 +212,7 @@ statement
         (LIKE? (multipartIdentifier | pattern=STRING))?                #showFunctions
     | SHOW CREATE TABLE multipartIdentifier (AS SERDE)?                #showCreateTable
     | SHOW CURRENT NAMESPACE                                           #showCurrentNamespace
+    | SHOW CATALOGS                                                    #showCatalogs
     | (DESC | DESCRIBE) FUNCTION EXTENDED? describeFuncName            #describeFunction
     | (DESC | DESCRIBE) namespace EXTENDED?
         multipartIdentifier                                            #describeNamespace
@@ -1061,6 +1062,7 @@ ansiNonReserved
     | BY
     | CACHE
     | CASCADE
+    | CATALOGS
     | CHANGE
     | CLEAR
     | CLUSTER
@@ -1289,6 +1291,7 @@ nonReserved
     | CASCADE
     | CASE
     | CAST
+    | CATALOGS
     | CHANGE
     | CHECK
     | CLEAR
@@ -1542,6 +1545,7 @@ CACHE: 'CACHE';
 CASCADE: 'CASCADE';
 CASE: 'CASE';
 CAST: 'CAST';
+CATALOGS: 'CATALOGS';
 CHANGE: 'CHANGE';
 CHECK: 'CHECK';
 CLEAR: 'CLEAR';

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -212,7 +212,7 @@ statement
         (LIKE? (multipartIdentifier | pattern=STRING))?                #showFunctions
     | SHOW CREATE TABLE multipartIdentifier (AS SERDE)?                #showCreateTable
     | SHOW CURRENT NAMESPACE                                           #showCurrentNamespace
-    | SHOW CATALOGS                                                    #showCatalogs
+    | SHOW CATALOGS (LIKE? pattern=STRING)?                            #showCatalogs
     | (DESC | DESCRIBE) FUNCTION EXTENDED? describeFuncName            #describeFunction
     | (DESC | DESCRIBE) namespace EXTENDED?
         multipartIdentifier                                            #describeNamespace

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -92,6 +92,9 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
 
     case ShowCurrentNamespaceStatement() =>
       ShowCurrentNamespace(catalogManager)
+
+    case ShowCatalogsStatement() =>
+      ShowCatalogs(catalogManager)
   }
 
   object NonSessionCatalogAndTable {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -93,8 +93,8 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
     case ShowCurrentNamespaceStatement() =>
       ShowCurrentNamespace(catalogManager)
 
-    case ShowCatalogsStatement() =>
-      ShowCatalogs(catalogManager)
+    case ShowCatalogsStatement(pattern) =>
+      ShowCatalogs(catalogManager, pattern)
   }
 
   object NonSessionCatalogAndTable {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3554,7 +3554,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
    */
   override def visitShowCatalogs(
       ctx: ShowCatalogsContext) : LogicalPlan = withOrigin(ctx) {
-    ShowCatalogsStatement()
+    ShowCatalogsStatement(Option(ctx.pattern).map(string))
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3550,6 +3550,14 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
   }
 
   /**
+   * Create a [[ShowCatalogsStatement]].
+   */
+  override def visitShowCatalogs(
+      ctx: ShowCatalogsContext) : LogicalPlan = withOrigin(ctx) {
+    ShowCatalogsStatement()
+  }
+
+  /**
    * Create a [[ShowTables]] command.
    */
   override def visitShowTables(ctx: ShowTablesContext): LogicalPlan = withOrigin(ctx) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -292,6 +292,11 @@ case class UseStatement(isNamespaceSet: Boolean, nameParts: Seq[String]) extends
 case class ShowCurrentNamespaceStatement() extends LeafParsedStatement
 
 /**
+ * A SHOW ALL CATALOGS statement, as parsed from SQL
+ */
+case class ShowCatalogsStatement() extends LeafParsedStatement
+
+/**
  *  CREATE FUNCTION statement, as parsed from SQL
  */
 case class CreateFunctionStatement(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -294,7 +294,7 @@ case class ShowCurrentNamespaceStatement() extends LeafParsedStatement
 /**
  * A SHOW ALL CATALOGS statement, as parsed from SQL
  */
-case class ShowCatalogsStatement() extends LeafParsedStatement
+case class ShowCatalogsStatement(pattern: Option[String]) extends LeafParsedStatement
 
 /**
  *  CREATE FUNCTION statement, as parsed from SQL

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -645,10 +645,11 @@ case class ShowCurrentNamespace(catalogManager: CatalogManager) extends LeafComm
 /**
  * The logical plan of the SHOW CATALOGS command.
  */
-case class ShowCatalogs(catalogManager: CatalogManager) extends LeafCommand {
+case class ShowCatalogs(
+    catalogManager: CatalogManager,
+    pattern: Option[String]) extends LeafCommand {
   override val output: Seq[Attribute] = Seq(
-    AttributeReference("catalog", StringType, nullable = false)(),
-    AttributeReference("default-namespace", StringType, nullable = false)())
+    AttributeReference("catalog", StringType, nullable = false)())
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -647,8 +647,12 @@ case class ShowCurrentNamespace(catalogManager: CatalogManager) extends LeafComm
  */
 case class ShowCatalogs(
     catalogManager: CatalogManager,
-    pattern: Option[String]) extends LeafCommand {
-  override val output: Seq[Attribute] = Seq(
+    pattern: Option[String],
+    override val output: Seq[Attribute] = ShowCatalogs.getOutputAttrs) extends LeafCommand {
+}
+
+object ShowCatalogs {
+  def getOutputAttrs: Seq[Attribute] = Seq(
     AttributeReference("catalog", StringType, nullable = false)())
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -643,6 +643,15 @@ case class ShowCurrentNamespace(catalogManager: CatalogManager) extends LeafComm
 }
 
 /**
+ * The logical plan of the SHOW CATALOGS command.
+ */
+case class ShowCatalogs(catalogManager: CatalogManager) extends LeafCommand {
+  override val output: Seq[Attribute] = Seq(
+    AttributeReference("catalog", StringType, nullable = false)(),
+    AttributeReference("default-namespace", StringType, nullable = false)())
+}
+
+/**
  * The logical plan of the SHOW TBLPROPERTIES command.
  */
 case class ShowTableProperties(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -128,6 +128,10 @@ class CatalogManager(
     }
   }
 
+  def listCatalogs(): mutable.HashMap[String, CatalogPlugin] = synchronized {
+    catalogs
+  }
+
   // Clear all the registered catalogs. Only used in tests.
   private[sql] def reset(): Unit = synchronized {
     catalogs.clear()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2107,10 +2107,19 @@ class DDLParserSuite extends AnalysisTest {
       ShowCurrentNamespaceStatement())
   }
 
-  test("show catalogs") {
+  test("SPARK-35973: show all catalogs") {
     comparePlans(
       parsePlan("SHOW CATALOGS"),
-      ShowCatalogsStatement())
+      ShowCatalogsStatement(None))
+  }
+
+  test("SPARK-35973: show catalogs with pattern") {
+    comparePlans(
+      parsePlan("SHOW CATALOGS LIKE 'defau*'"),
+      ShowCatalogsStatement(Some("defau*")))
+    comparePlans(
+      parsePlan("SHOW CATALOGS LIKE '*defau*'"),
+      ShowCatalogsStatement(Some("*defau*")))
   }
 
   test("alter table: SerDe properties") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2107,6 +2107,12 @@ class DDLParserSuite extends AnalysisTest {
       ShowCurrentNamespaceStatement())
   }
 
+  test("show catalogs") {
+    comparePlans(
+      parsePlan("SHOW CATALOGS"),
+      ShowCatalogsStatement())
+  }
+
   test("alter table: SerDe properties") {
     val sql1 = "ALTER TABLE table_name SET SERDE 'org.apache.class'"
     val hint = Some("Please use ALTER VIEW instead.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -333,7 +333,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       ShowCurrentNamespaceExec(r.output, r.catalogManager) :: Nil
 
     case r: ShowCatalogs =>
-      ShowCatalogsExec(r.output, r.catalogManager) :: Nil
+      ShowCatalogsExec(r.output, r.catalogManager, r.pattern) :: Nil
 
     case r @ ShowTableProperties(rt: ResolvedTable, propertyKey, output) =>
       ShowTablePropertiesExec(output, rt.table, propertyKey) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -332,6 +332,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
     case r: ShowCurrentNamespace =>
       ShowCurrentNamespaceExec(r.output, r.catalogManager) :: Nil
 
+    case r: ShowCatalogs =>
+      ShowCatalogsExec(r.output, r.catalogManager) :: Nil
+
     case r @ ShowTableProperties(rt: ResolvedTable, propertyKey, output) =>
       ShowTablePropertiesExec(output, rt.table, propertyKey) :: Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCatalogsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCatalogsExec.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.NamespaceHelper
+
+/**
+ * Physical plan node for showing all catalogs.
+ */
+case class ShowCatalogsExec(
+    output: Seq[Attribute],
+    catalogManager: CatalogManager)
+  extends LeafV2CommandExec {
+  override protected def run(): Seq[InternalRow] = {
+    val rows = new ArrayBuffer[InternalRow]()
+    catalogManager.listCatalogs().foreach { case (key, value) =>
+      rows += toCatalystRow(key, value.defaultNamespace().quoted)
+    }
+    rows.toSeq
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCatalogsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCatalogsExec.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.util.{escapeSingleQuotedString, StringUtils}
+import org.apache.spark.sql.catalyst.util.StringUtils
 import org.apache.spark.sql.connector.catalog.CatalogManager
 
 /**
@@ -34,7 +34,7 @@ case class ShowCatalogsExec(
   extends LeafV2CommandExec {
   override protected def run(): Seq[InternalRow] = {
     val rows = new ArrayBuffer[InternalRow]()
-    val catalogs = catalogManager.listCatalogs.map(_._1).map(escapeSingleQuotedString(_))
+    val catalogs = catalogManager.listCatalogs.toSeq.sortBy(_._1).map(_._1)
 
     catalogs.map { name =>
       if (pattern.map(StringUtils.filterPattern(Seq(name), _).nonEmpty).getOrElse(true)) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2917,7 +2917,7 @@ class DataSourceV2SQLSuite
     }
   }
 
-  test("ShowCatalogs") {
+  test("SPARK-35973: ShowCatalogs") {
     val schema = new StructType()
       .add("catalog", StringType, nullable = false)
       .add("default-namespace", StringType, nullable = false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -21,6 +21,7 @@ import java.sql.Timestamp
 import java.time.LocalDate
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql._
@@ -2914,6 +2915,21 @@ class DataSourceV2SQLSuite
         checkAnswer(query, Seq(Row(1, "a", 0, "3/1"), Row(2, "b", 0, "0/2"), Row(3, "c", 0, "1/3")))
       }
     }
+  }
+
+  test("ShowCatalogs") {
+    val schema = new StructType()
+      .add("catalog", StringType, nullable = false)
+      .add("default-namespace", StringType, nullable = false)
+    val r = new ArrayBuffer[Row]()
+    r += Row("spark_catalog", "default")
+    val df = sql("SHOW CATALOGS")
+    assert(df.schema === schema)
+    assert(df.collect === r.toSeq)
+
+    sql("use testcat")
+    r += Row("testcat", "")
+    assert(sql("SHOW CATALOGS").collect === r.toSeq)
   }
 
   private def testNotSupportedV2Command(sqlCommand: String, sqlParams: String): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Datasource V2 can support multiple catalogs. Having "SHOW CATALOGS" to list the catalogs name will be useful.


### Why are the changes needed?
[SPARK-35973](https://issues.apache.org/jira/browse/SPARK-35973)


### Does this PR introduce _any_ user-facing change?
Yes, we can use `SHOW CATALOGS` command to list catalogs info. eg:
```
+-------------+
|      catalog|
+-------------+
|spark_catalog|
|      testcat|
+-------------+
```

### How was this patch tested?
Add ut test
