### PR TITLE
[SPARK-35980][CORE] ThreadAudit logs whether thread is daemon

### DIFF
--- a/core/src/test/scala/org/apache/spark/ThreadAudit.scala
+++ b/core/src/test/scala/org/apache/spark/ThreadAudit.scala
@@ -112,7 +112,8 @@ trait ThreadAudit extends Logging {
         .filterNot { t => threadExcludeList.exists(t.getName.matches(_)) }
       if (remainingThreads.nonEmpty) {
         logWarning(s"\n\n===== POSSIBLE THREAD LEAK IN SUITE $shortSuiteName, " +
-          s"threads: ${remainingThreads.map{ t => s"${t.getName} (daemon=${t.isDaemon})" }.mkString(", ")} =====\n")
+          s"threads: ${remainingThreads.map{ t => s"${t.getName} (daemon=${t.isDaemon})" }
+	  .mkString(", ")} =====\n")
       }
     } else {
       logWarning("\n\n===== THREAD AUDIT POST ACTION CALLED " +

--- a/core/src/test/scala/org/apache/spark/ThreadAudit.scala
+++ b/core/src/test/scala/org/apache/spark/ThreadAudit.scala
@@ -107,11 +107,12 @@ trait ThreadAudit extends Logging {
     val shortSuiteName = this.getClass.getName.replaceAll("org.apache.spark", "o.a.s")
 
     if (threadNamesSnapshot.nonEmpty) {
-      val remainingThreadNames = runningThreadNames().diff(threadNamesSnapshot)
-        .filterNot { s => threadExcludeList.exists(s.matches(_)) }
-      if (remainingThreadNames.nonEmpty) {
+      val remainingThreads = runningThreads()
+        .filterNot { t => threadNamesSnapshot.contains(t.getName) }
+        .filterNot { t => threadExcludeList.exists(t.getName.matches(_)) }
+      if (remainingThreads.nonEmpty) {
         logWarning(s"\n\n===== POSSIBLE THREAD LEAK IN SUITE $shortSuiteName, " +
-          s"thread names: ${remainingThreadNames.mkString(", ")} =====\n")
+          s"threads: ${remainingThreads.map{ t => s"${t.getName} (daemon=${t.isDaemon})" }.mkString(", ")} =====\n")
       }
     } else {
       logWarning("\n\n===== THREAD AUDIT POST ACTION CALLED " +
@@ -120,6 +121,10 @@ trait ThreadAudit extends Logging {
   }
 
   private def runningThreadNames(): Set[String] = {
-    Thread.getAllStackTraces.keySet().asScala.map(_.getName).toSet
+    runningThreads.map(_.getName).toSet
+  }
+
+  private def runningThreads(): Set[Thread] = {
+    Thread.getAllStackTraces.keySet().asScala.toSet
   }
 }

--- a/core/src/test/scala/org/apache/spark/ThreadAudit.scala
+++ b/core/src/test/scala/org/apache/spark/ThreadAudit.scala
@@ -113,7 +113,7 @@ trait ThreadAudit extends Logging {
       if (remainingThreads.nonEmpty) {
         logWarning(s"\n\n===== POSSIBLE THREAD LEAK IN SUITE $shortSuiteName, " +
           s"threads: ${remainingThreads.map{ t => s"${t.getName} (daemon=${t.isDaemon})" }
-	  .mkString(", ")} =====\n")
+          .mkString(", ")} =====\n")
       }
     } else {
       logWarning("\n\n===== THREAD AUDIT POST ACTION CALLED " +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
Add `daemon={true|false}` to the POSSIBLE THREAD LEAK IN SUITE warning printed by test framework. 
### Why are the changes needed?
This is to slightly accelerate interpretation of that warning, since non-daemon threads can block the process from exiting and are likely to be problematic.

Only affects test code.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually ran some tests, inspected the output log line.
