### PR TITLE
[SPARK-35984][SQL][TEST] Config to force applying shuffled hash join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -276,7 +276,7 @@ trait JoinSelectionHelper {
       hintToPreferShuffleHashJoinLeft(hint) ||
         (!conf.preferSortMergeJoin && canBuildLocalHashMapBySize(left, conf) &&
           muchSmaller(left, right)) ||
-        (Utils.isTesting && forceApplyShuffledHashJoin(conf))
+        forceApplyShuffledHashJoin(conf)
     }
     val buildRight = if (hintOnly) {
       hintToShuffleHashJoinRight(hint)
@@ -284,8 +284,7 @@ trait JoinSelectionHelper {
       hintToPreferShuffleHashJoinRight(hint) ||
         (!conf.preferSortMergeJoin && canBuildLocalHashMapBySize(right, conf) &&
           muchSmaller(right, left)) ||
-        (Utils.isTesting && forceApplyShuffledHashJoin(conf))
-
+        forceApplyShuffledHashJoin(conf)
     }
     getBuildSide(
       canBuildShuffledHashJoinLeft(joinType) && buildLeft,
@@ -434,7 +433,8 @@ trait JoinSelectionHelper {
    * The config key is hard-coded because it's testing only and should not be exposed.
    */
   private def forceApplyShuffledHashJoin(conf: SQLConf): Boolean = {
-    conf.getConfString("spark.sql.join.forceApplyShuffledHashJoin", "false") == "true"
+    Utils.isTesting &&
+      conf.getConfString("spark.sql.join.forceApplyShuffledHashJoin", "false") == "true"
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -272,14 +272,14 @@ trait JoinSelectionHelper {
     val buildLeft = if (hintOnly) {
       hintToShuffleHashJoinLeft(hint)
     } else {
-      hintToPreferShuffleHashJoinLeft(hint) ||
+      hintToPreferShuffleHashJoinLeft(hint) || conf.forceApplyShuffledHashJoin ||
         (!conf.preferSortMergeJoin && canBuildLocalHashMapBySize(left, conf) &&
           muchSmaller(left, right))
     }
     val buildRight = if (hintOnly) {
       hintToShuffleHashJoinRight(hint)
     } else {
-      hintToPreferShuffleHashJoinRight(hint) ||
+      hintToPreferShuffleHashJoinRight(hint) || conf.forceApplyShuffledHashJoin ||
         (!conf.preferSortMergeJoin && canBuildLocalHashMapBySize(right, conf) &&
           muchSmaller(right, left))
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -276,15 +276,16 @@ trait JoinSelectionHelper {
       hintToPreferShuffleHashJoinLeft(hint) ||
         (!conf.preferSortMergeJoin && canBuildLocalHashMapBySize(left, conf) &&
           muchSmaller(left, right)) ||
-        (Utils.isTesting && conf.forceApplyShuffledHashJoin)
+        (Utils.isTesting && forceApplyShuffledHashJoin(conf))
     }
     val buildRight = if (hintOnly) {
       hintToShuffleHashJoinRight(hint)
     } else {
-      hintToPreferShuffleHashJoinRight(hint) || conf.forceApplyShuffledHashJoin ||
+      hintToPreferShuffleHashJoinRight(hint) ||
         (!conf.preferSortMergeJoin && canBuildLocalHashMapBySize(right, conf) &&
           muchSmaller(right, left)) ||
-        (Utils.isTesting && conf.forceApplyShuffledHashJoin)
+        (Utils.isTesting && forceApplyShuffledHashJoin(conf))
+
     }
     getBuildSide(
       canBuildShuffledHashJoinLeft(joinType) && buildLeft,
@@ -426,6 +427,14 @@ trait JoinSelectionHelper {
    */
   private def muchSmaller(a: LogicalPlan, b: LogicalPlan): Boolean = {
     a.stats.sizeInBytes * 3 <= b.stats.sizeInBytes
+  }
+
+  /**
+   * Returns whether a shuffled hash join should be force applied.
+   * The config key is hard-coded because it's testing only and should not be exposed.
+   */
+  private def forceApplyShuffledHashJoin(conf: SQLConf): Boolean = {
+    conf.getConfString("spark.sql.join.forceApplyShuffledHashJoin", "false") == "true"
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -423,8 +423,8 @@ object SQLConf {
     .internal()
     .doc("When true, force applying shuffled hash join even if the table sizes exceed the " +
       "threshold. This is for testing/benchmarking only. If this config is set to true, the " +
-      "value spark.sql.join.perferSortMergejoin will be ignored.")
-    .version("3.2.0")
+      s"value ${PREFER_SORTMERGEJOIN.key} will be ignored.")
+    .version("3.3.0")
     .booleanConf
     .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -419,15 +419,6 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
-  val FORCE_APPLY_SHUFFLEDHASHJOIN = buildConf("spark.sql.join.forceApplyShuffledHashJoin")
-    .internal()
-    .doc("When true, force applying shuffled hash join even if the table sizes exceed the " +
-      "threshold. This is for testing/benchmarking only. If this config is set to true, the " +
-      s"value ${PREFER_SORTMERGEJOIN.key} will be ignored.")
-    .version("3.3.0")
-    .booleanConf
-    .createWithDefault(false)
-
   val RADIX_SORT_ENABLED = buildConf("spark.sql.sort.enableRadixSort")
     .internal()
     .doc("When true, enable use of radix sort when possible. Radix sort is much faster but " +
@@ -3726,8 +3717,6 @@ class SQLConf extends Serializable with Logging {
     getConf(ADVANCED_PARTITION_PREDICATE_PUSHDOWN)
 
   def preferSortMergeJoin: Boolean = getConf(PREFER_SORTMERGEJOIN)
-
-  def forceApplyShuffledHashJoin: Boolean = getConf(FORCE_APPLY_SHUFFLEDHASHJOIN)
 
   def enableRadixSort: Boolean = getConf(RADIX_SORT_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -419,6 +419,15 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val FORCE_APPLY_SHUFFLEDHASHJOIN = buildConf("spark.sql.join.forceApplyShuffledHashJoin")
+    .internal()
+    .doc("When true, force applying shuffled hash join even if the table sizes exceed the " +
+      "threshold. This is for testing/benchmarking only. If this config is set to true, the " +
+      "value spark.sql.join.perferSortMergejoin will be ignored.")
+    .version("3.2.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val RADIX_SORT_ENABLED = buildConf("spark.sql.sort.enableRadixSort")
     .internal()
     .doc("When true, enable use of radix sort when possible. Radix sort is much faster but " +
@@ -3717,6 +3726,8 @@ class SQLConf extends Serializable with Logging {
     getConf(ADVANCED_PARTITION_PREDICATE_PUSHDOWN)
 
   def preferSortMergeJoin: Boolean = getConf(PREFER_SORTMERGEJOIN)
+
+  def forceApplyShuffledHashJoin: Boolean = getConf(FORCE_APPLY_SHUFFLEDHASHJOIN)
 
   def enableRadixSort: Boolean = getConf(RADIX_SORT_ENABLED)
 

--- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/join.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/join.sql
@@ -13,7 +13,7 @@
 
 --CONFIG_DIM1 spark.sql.autoBroadcastJoinThreshold=10485760
 --CONFIG_DIM1 spark.sql.autoBroadcastJoinThreshold=-1,spark.sql.join.preferSortMergeJoin=true
---CONFIG_DIM1 spark.sql.autoBroadcastJoinThreshold=-1,spark.sql.join.conf.forceApplyShuffledHashJoin=true
+--CONFIG_DIM1 spark.sql.autoBroadcastJoinThreshold=-1,spark.sql.join.forceApplyShuffledHashJoin=true
 
 --CONFIG_DIM2 spark.sql.codegen.wholeStage=true
 --CONFIG_DIM2 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=CODEGEN_ONLY

--- a/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/join.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/postgreSQL/join.sql
@@ -13,7 +13,7 @@
 
 --CONFIG_DIM1 spark.sql.autoBroadcastJoinThreshold=10485760
 --CONFIG_DIM1 spark.sql.autoBroadcastJoinThreshold=-1,spark.sql.join.preferSortMergeJoin=true
---CONFIG_DIM1 spark.sql.autoBroadcastJoinThreshold=-1,spark.sql.join.preferSortMergeJoin=false
+--CONFIG_DIM1 spark.sql.autoBroadcastJoinThreshold=-1,spark.sql.join.conf.forceApplyShuffledHashJoin=true
 
 --CONFIG_DIM2 spark.sql.codegen.wholeStage=true
 --CONFIG_DIM2 spark.sql.codegen.wholeStage=false,spark.sql.codegen.factoryMode=CODEGEN_ONLY

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1398,7 +1398,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
   test("SPARK-35984: Config to force applying shuffled hash join") {
     val sql = "SELECT * FROM testData JOIN testData2 ON key = a"
     assertJoin(sql, classOf[SortMergeJoinExec])
-    withSQLConf(SQLConf.FORCE_APPLY_SHUFFLEDHASHJOIN.key -> "true") {
+    withSQLConf("spark.sql.join.forceApplyShuffledHashJoin" -> "true") {
       assertJoin(sql, classOf[ShuffledHashJoinExec])
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1394,4 +1394,12 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       checkAnswer(fullJoinDF, Row(100))
     }
   }
+
+  test("SPARK-35984: Config to force applying shuffled hash join") {
+    val sql = "SELECT * FROM testData JOIN testData2 ON key = a"
+    assertJoin(sql, classOf[SortMergeJoinExec])
+    withSQLConf(SQLConf.FORCE_APPLY_SHUFFLEDHASHJOIN.key -> "true") {
+      assertJoin(sql, classOf[ShuffledHashJoinExec])
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a config `spark.sql.join.forceApplyShuffledHashJoin` to force applying shuffled hash join
during the join selection.


### Why are the changes needed?
In the `SQLQueryTestSuite`, we want to cover 3 kinds of join (BHJ, SHJ, SMJ) in join.sql. But even
if the `spark.sql.join.preferSortMergeJoin` is set to `false`, shuffled hash join is still not guaranteed.
Thus, we need another config to force the selection.


### Does this PR introduce _any_ user-facing change?
No, only for testing


### How was this patch tested?
newly added tests
Verified all queries in join.sql will use `ShuffledHashJoin` when the config set to `true`