### PR TITLE
[SPARK-35972][SQL] When replace ExtractValue in NestedColumnAliasing we should use semanticEquals

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -169,8 +169,13 @@ object NestedColumnAliasing {
       projectList: Seq[NamedExpression],
       nestedFieldToAlias: Map[ExtractValue, Alias]): Seq[NamedExpression] = {
     projectList.map(_.transform {
-      case f: ExtractValue if nestedFieldToAlias.contains(f) =>
-        nestedFieldToAlias(f).toAttribute
+      case f: ExtractValue =>
+        val matched = nestedFieldToAlias.find(_._1.semanticEquals(f))
+        if (matched.isDefined) {
+          matched.get._2.toAttribute
+        } else {
+          f
+        }
     }.asInstanceOf[NamedExpression])
   }
 
@@ -185,8 +190,13 @@ object NestedColumnAliasing {
     plan.withNewChildren(plan.children.map { plan =>
       Project(plan.output.flatMap(a => attrToAliases.getOrElse(a, Seq(a))), plan)
     }).transformExpressions {
-      case f: ExtractValue if nestedFieldToAlias.contains(f) =>
-        nestedFieldToAlias(f).toAttribute
+      case f: ExtractValue =>
+        val matched = nestedFieldToAlias.find(_._1.semanticEquals(f))
+        if (matched.isDefined) {
+          matched.get._2.toAttribute
+        } else {
+          f
+        }
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.Cross
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
-import org.apache.spark.sql.types.{IntegerType, Metadata, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 class NestedColumnAliasingSuite extends SchemaPruningTest {
 
@@ -745,7 +745,7 @@ class NestedColumnAliasingSuite extends SchemaPruningTest {
       .add(StructField("search_params", StructType(Seq(
         StructField("col1", StringType),
         StructField("col2", StringType)
-      )), true, Metadata.fromJson("{\"name\":\"aaa\",\"idx\":0}")))
+      ))))
     val relation = LocalRelation('struct_data.struct(dataType))
     val plan = relation
       .repartition(100)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
@@ -739,7 +739,7 @@ class NestedColumnAliasingSuite extends SchemaPruningTest {
     comparePlans(optimized, query)
   }
 
-  test("SPARK-35972: When replace ExtractValue we should use semanticEquals") {
+  test("SPARK-35972: NestedColumnAliasing should consider semantic equality") {
     val dataType = new StructType()
       .add(StructField("itemid", StringType))
       .add(StructField("search_params", StructType(Seq(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
@@ -762,7 +762,6 @@ class NestedColumnAliasingSuite extends SchemaPruningTest {
         $"_extract_search_params.col1".as("col1"),
         $"_extract_search_params.col2".as("col2")).analyze
     comparePlans(optimized, query)
-
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ideally, in SQL query, nested columns should result to GetStructField with non-None name. But there are places that can create GetStructField with None name, such as UnresolvedStar.expand, Dataset encoder stuff, etc.
the current `nestedFieldToAlias` cannot catch it up and will cause job failed.

 

### Why are the changes needed?
Fix bug

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT,
