### PR TITLE
[SPARK-35994][INFRA] Publish snapshot from branch-3.2

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         branch:
           - master
+          - branch-3.2
           - branch-3.1
     steps:
     - name: Checkout Spark repository


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to publish snapshot artifacts from branch-3.2 additionally.

### Why are the changes needed?

`GitHub Action`'s cronjob feature is only supported in the default branch. So, to have a daily job, we should add here.

Currently, it's publishing master and 3.1.
- https://github.com/apache/spark/actions/workflows/publish_snapshot.yml

<img width="273" alt="Screen Shot 2021-07-02 at 10 22 41 AM" src="https://user-images.githubusercontent.com/9700541/124309380-7c407400-db1f-11eb-9aa4-30db61a72b80.png">


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A