### PR TITLE
[SPARK-35995][INFRA][3.2] Enable GitHub Action build_and_test on branch-3.2

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,8 +3,15 @@ name: Build and test
 on:
   push:
     branches:
-    - '**'
-    - '!branch-*.*'
+    - branch-3.2
+  pull_request:
+    branches:
+    - branch-3.2
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Target branch to run'
+        required: true
 
 jobs:
   # Build: build Spark and run the tests for specified modules.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Like branch-3.1, this PR aims to update GitHub Action `build_and_test` in branch-3.2.

### Why are the changes needed?

Currently, GitHub Action on branch-3.2 is working.
- https://github.com/apache/spark/commits/branch-3.2

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A