### PR TITLE
[SPARK-36005][SQL] The canCast method of type of char/varchar is modified to be consistent with StringType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -54,38 +54,38 @@ object Cast {
 
     case (NullType, _) => true
 
-    case (_, StringType) => true
+    case (_, StringType | CharType(_) | VarcharType(_)) => true
 
-    case (StringType, BinaryType) => true
+    case (StringType | CharType(_) | VarcharType(_), BinaryType) => true
     case (_: IntegralType, BinaryType) => true
 
-    case (StringType, BooleanType) => true
+    case (StringType | CharType(_) | VarcharType(_), BooleanType) => true
     case (DateType, BooleanType) => true
     case (TimestampType, BooleanType) => true
     case (_: NumericType, BooleanType) => true
 
-    case (StringType, TimestampType) => true
+    case (StringType | CharType(_) | VarcharType(_), TimestampType) => true
     case (BooleanType, TimestampType) => true
     case (DateType, TimestampType) => true
     case (_: NumericType, TimestampType) => true
     case (TimestampNTZType, TimestampType) => true
 
-    case (StringType, TimestampNTZType) => true
+    case (StringType | CharType(_) | VarcharType(_), TimestampNTZType) => true
     case (DateType, TimestampNTZType) => true
     case (TimestampType, TimestampNTZType) => true
 
-    case (StringType, DateType) => true
+    case (StringType | CharType(_) | VarcharType(_), DateType) => true
     case (TimestampType, DateType) => true
     case (TimestampNTZType, DateType) => true
 
-    case (StringType, CalendarIntervalType) => true
-    case (StringType, _: DayTimeIntervalType) => true
-    case (StringType, _: YearMonthIntervalType) => true
+    case (StringType | CharType(_) | VarcharType(_), CalendarIntervalType) => true
+    case (StringType | CharType(_) | VarcharType(_), _: DayTimeIntervalType) => true
+    case (StringType | CharType(_) | VarcharType(_), _: YearMonthIntervalType) => true
 
     case (_: DayTimeIntervalType, _: DayTimeIntervalType) => true
     case (_: YearMonthIntervalType, _: YearMonthIntervalType) => true
 
-    case (StringType, _: NumericType) => true
+    case (StringType | CharType(_) | VarcharType(_), _: NumericType) => true
     case (BooleanType, _: NumericType) => true
     case (DateType, _: NumericType) => true
     case (TimestampType, _: NumericType) => true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -76,6 +76,11 @@ class CastSuite extends CastSuiteBase {
     checkEvaluation(Cast(Literal("2015-031-8"), DateType), null)
   }
 
+  test("cast varchar to date") {
+    assert(Cast.canCast(VarcharType(10), DoubleType))
+    assert(Cast.canCast(CharType(10), DoubleType))
+  }
+
   test("casting to fixed-precision decimals") {
     assert(cast(123, DecimalType.USER_DEFAULT).nullable === false)
     assert(cast(10.03f, DecimalType.SYSTEM_DEFAULT).nullable)


### PR DESCRIPTION

### What changes were proposed in this pull request?


The canCast method of type of char/varchar is modified to be consistent with StringType


the method cast will change the type char/varchar to StringType 

  def cast(to: DataType): Column = withExpr {
    val cast = Cast(expr, CharVarcharUtils.replaceCharVarcharWithStringForCast(to))
    cast.setTagValue(Cast.USER_SPECIFIED_CAST, true)
    cast
  }


The canCast method of type of char/varchar  must   be consistent with StringType




### Why are the changes needed?

Before I used stringType instead of char/varchar, my application code has the logic to judge using canCast. There was no problem before, but now it’s changed to char/varchar, and the judgment of canCast fails. If it doesn’t pass, I Need to change a lot of application code



### Does this PR introduce _any_ user-facing change?

no


### How was this patch tested?

i add UT。
