### PR TITLE
[SPARK-35912][SQL] Fix nullability of `spark.read.json`

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -22,6 +22,10 @@ license: |
 * Table of contents
 {:toc}
 
+## Upgrading from Spark SQL 3.2 to 3.3
+
+  - In Spark 3.3, spark will fail when parsing a JSON/CSV string with `PERMISSIVE` mode and schema contains non-nullable fields. You can set mode to `FAILFAST/DROPMALFORMED` if you want to read JSON/CSV with a schema that contains nullable fields.
+
 ## Upgrading from Spark SQL 3.1 to 3.2
 
   - Since Spark 3.2, ADD FILE/JAR/ARCHIVE commands require each path to be enclosed by `"` or `'` if the path contains whitespaces.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -438,26 +438,26 @@ class JacksonParser(
     }
   }
 
-  private lazy val checkNotNullableInRow = {
-    // As PERMISSIVE mode only works with nullable fields, we can skip this not nullable check when
-    // the mode is PERMISSIVE. (see FailureSafeParser.checkNullabilityForPermissiveMode)
-    if (options.parseMode != PermissiveMode) {
-      (row: GenericInternalRow, schema: StructType, skipRow: Boolean,
-          runtimeExceptionOption: Option[Throwable]) => {
-        if (runtimeExceptionOption.isEmpty && !skipRow) {
-          var index = 0
-          while (index < schema.length) {
-            if (!schema(index).nullable && row.isNullAt(index)) {
-              throw new IllegalSchemaArgumentException(
-                s"field ${schema(index).name} is not nullable but it's missing in one record.")
-            }
-            index += 1
+  // As PERMISSIVE mode only works with nullable fields, we can skip this not nullable check when
+  // the mode is PERMISSIVE. (see FailureSafeParser.checkNullabilityForPermissiveMode)
+  private lazy val checkNotNullableInRow = if (options.parseMode != PermissiveMode) {
+    (row: GenericInternalRow,
+        schema: StructType,
+        skipRow: Boolean,
+        runtimeExceptionOption: Option[Throwable]) => {
+      if (runtimeExceptionOption.isEmpty && !skipRow) {
+        var index = 0
+        while (index < schema.length) {
+          if (!schema(index).nullable && row.isNullAt(index)) {
+            throw new IllegalSchemaArgumentException(
+              s"field ${schema(index).name} is not nullable but it's missing in one record.")
           }
+          index += 1
         }
       }
-    } else {
-      (_: GenericInternalRow, _: StructType, _: Boolean, _: Option[Throwable]) => {}
     }
+  } else {
+    (_: GenericInternalRow, _: StructType, _: Boolean, _: Option[Throwable]) => {}
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -411,7 +411,7 @@ class JacksonParser(
             checkedIndexSet += index
           } catch {
             case e: SparkUpgradeException => throw e
-            case e: IllegalArgumentException => throw e
+            case e: IllegalSchemaArgumentException => throw e
             case NonFatal(e) if isRoot =>
               badRecordException = badRecordException.orElse(Some(e))
               parser.skipChildren()
@@ -425,7 +425,7 @@ class JacksonParser(
     var index = 0
     while (badRecordException.isEmpty && !skipRow && index < schema.length) {
       if (!schema(index).nullable && row.isNullAt(index)) {
-        throw new IllegalArgumentException(
+        throw new IllegalSchemaArgumentException(
           s"the null value found when parsing non-nullable field ${schema(index).name}.")
       }
       if (!checkedIndexSet.contains(index)) {
@@ -499,7 +499,7 @@ class JacksonParser(
       }
     } catch {
       case e: SparkUpgradeException => throw e
-      case e: IllegalArgumentException => throw e
+      case e: IllegalSchemaArgumentException => throw e
       case e @ (_: RuntimeException | _: JsonProcessingException | _: MalformedInputException) =>
         // JSON parser currently doesn't support partial results for corrupted records.
         // For such records, all fields other than the field configured by

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -409,7 +409,7 @@ class JacksonParser(
             val fieldValue = fieldConverters(index).apply(parser)
             if (!schema(index).nullable && fieldValue == null) {
               throw new IllegalSchemaArgumentException(
-                s"the null value found when parsing non-nullable field ${schema(index).name}.")
+                s"field ${schema(index).name} is not nullable but the parsed value is null.")
             }
             row.update(index, fieldValue)
             skipRow = structFilters.skipRow(row, index)
@@ -431,7 +431,7 @@ class JacksonParser(
     while (badRecordException.isEmpty && !skipRow && index < schema.length) {
       if (!schema(index).nullable && row.isNullAt(index)) {
         throw new IllegalSchemaArgumentException(
-          s"the null value found when parsing non-nullable field ${schema(index).name}.")
+          s"field ${schema(index).name} is not nullable but it's missing in one record.")
       }
       if (!checkedIndexSet.contains(index)) {
         skipRow = structFilters.skipRow(row, index)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -426,7 +426,7 @@ class JacksonParser(
 
     // When the input schema is setting to `nullable = false`, make sure the field is not null.
     // As PERMISSIVE mode only works with nullable fields, we can skip this not nullable check when
-    // the mode is PERMISSIVE. (see FailureSafeParser.disableNotNullableForPermissiveMode)
+    // the mode is PERMISSIVE. (see FailureSafeParser.checkNullabilityForPermissiveMode)
     val checkNotNullable =
       badRecordException.isEmpty && !skipRow && options.parseMode != PermissiveMode
     if (checkNotNullable) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -406,7 +406,12 @@ class JacksonParser(
       schema.getFieldIndex(parser.getCurrentName) match {
         case Some(index) =>
           try {
-            row.update(index, fieldConverters(index).apply(parser))
+            val fieldValue = fieldConverters(index).apply(parser)
+            if (!schema(index).nullable && fieldValue == null) {
+              throw new IllegalSchemaArgumentException(
+                s"the null value found when parsing non-nullable field ${schema(index).name}.")
+            }
+            row.update(index, fieldValue)
             skipRow = structFilters.skipRow(row, index)
             checkedIndexSet += index
           } catch {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/BadRecordException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/BadRecordException.scala
@@ -41,3 +41,8 @@ case class BadRecordException(
     record: () => UTF8String,
     partialResult: () => Option[InternalRow],
     cause: Throwable) extends Exception(cause)
+
+/**
+ * Exception thrown when the actual value is null but the schema is setting to non-nullable.
+ */
+case class IllegalSchemaArgumentException(message: String) extends Exception(message)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
@@ -29,7 +29,7 @@ class FailureSafeParser[IN](
     schema: StructType,
     columnNameOfCorruptRecord: String) {
 
-  disableNotNullableForPermissiveMode
+  disableNotNullableForPermissiveMode()
   private val corruptFieldIndex = schema.getFieldIndex(columnNameOfCorruptRecord)
   private val actualSchema = StructType(schema.filterNot(_.name == columnNameOfCorruptRecord))
   private val resultRow = new GenericInternalRow(schema.length)
@@ -37,12 +37,12 @@ class FailureSafeParser[IN](
 
   // As PERMISSIVE mode should not fail at runtime, so fail if the mode is PERMISSIVE and schema
   // contains non-nullable fields.
-  private def disableNotNullableForPermissiveMode: Unit = {
+  private def disableNotNullableForPermissiveMode(): Unit = {
     def checkNotNullableRecursively(schema: StructType): Unit = {
       schema.fields.foreach {
         case _ @ StructField(name, _, nullable, _) if (!nullable) =>
-          throw new IllegalSchemaArgumentException(s"field ${name} is not nullable but the " +
-            "not nullable field is not allowed in PERMISSIVE mode.")
+          throw new IllegalSchemaArgumentException(s"Field ${name} is not nullable but " +
+            "PERMISSIVE mode only works with nullable fields.")
         case _ @ StructField(_, dt: StructType, _, _) => checkNotNullableRecursively(dt)
         case _ =>
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
@@ -67,6 +67,8 @@ class FailureSafeParser[IN](
         case FailFastMode =>
           throw QueryExecutionErrors.malformedRecordsDetectedInRecordParsingError(e)
       }
+      case _ if (mode == DropMalformedMode) =>
+        Iterator.empty
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
@@ -86,7 +86,7 @@ class FailureSafeParser[IN](
         case FailFastMode =>
           throw QueryExecutionErrors.malformedRecordsDetectedInRecordParsingError(e)
       }
-      case _: IllegalSchemaArgumentException if (mode == DropMalformedMode) =>
+      case _: IllegalSchemaArgumentException if mode == DropMalformedMode =>
         Iterator.empty
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JacksonParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JacksonParserSuite.scala
@@ -20,40 +20,23 @@ package org.apache.spark.sql.catalyst.json
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.IllegalSchemaArgumentException
-import org.apache.spark.sql.sources.{EqualTo, Filter, IsNotNull, IsNull, StringStartsWith}
+import org.apache.spark.sql.sources.{EqualTo, Filter, StringStartsWith}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 class JacksonParserSuite extends SparkFunSuite {
-  private val missingFieldInput = """{"c1":1}"""
-  private val nullValueInput = """{"c1": 1, "c2": null}"""
 
   private def check(
       input: String = """{"i":1, "s": "a"}""",
       schema: StructType = StructType.fromDDL("i INTEGER"),
       filters: Seq[Filter],
+      config: Map[String, String] = Map.empty,
       expected: Seq[InternalRow]): Unit = {
-    val options = new JSONOptions(Map.empty[String, String], "GMT", "")
+    val options = new JSONOptions(config, "GMT", "")
     val parser = new JacksonParser(schema, options, false, filters)
     val createParser = CreateJacksonParser.string _
     val actual = parser.parse(input, createParser, UTF8String.fromString)
     assert(actual === expected)
-  }
-
-  private def assertAction(nullable: Boolean, input: String)(action: => Unit): Unit = {
-    if (nullable) {
-      action
-    } else {
-      val msg = intercept[IllegalSchemaArgumentException] {
-        action
-      }.message
-      val expected = if (input == missingFieldInput) {
-        "field c2 is not nullable but it's missing in one record."
-      } else {
-        "field c2 is not nullable but the parsed value is null."
-      }
-      assert(msg.contains(expected))
-    }
   }
 
   test("skipping rows using pushdown filters") {
@@ -76,42 +59,38 @@ class JacksonParserSuite extends SparkFunSuite {
   }
 
   test("SPARK-35912: nullability with different schema nullable setting") {
-    Seq(true, false).foreach { nullable =>
-      val schema = StructType(Seq(
-        StructField("c1", IntegerType),
-        StructField("c2", IntegerType, nullable = nullable)
-      ))
-      val expected = Seq(InternalRow(1, null))
-      Seq(missingFieldInput, nullValueInput).foreach { input =>
-        assertAction(nullable, input) {
-          check(input = input, schema = schema, filters = Seq.empty, expected = expected)
+    val missingFieldInput = """{"c1":1}"""
+    val nullValueInput = """{"c1": 1, "c2": null}"""
+
+    def assertAction(nullable: Boolean, input: String)(action: => Unit): Unit = {
+      if (nullable) {
+        action
+      } else {
+        val msg = intercept[IllegalSchemaArgumentException] {
+          action
+        }.message
+        val expected = if (input == missingFieldInput) {
+          "field c2 is not nullable but it's missing in one record."
+        } else {
+          "field c2 is not nullable but the parsed value is null."
         }
+        assert(msg.contains(expected))
       }
     }
-  }
 
-  test("SPARK-35912: skipping rows with not exist field and null value field") {
-    Seq(true, false).foreach { nullable =>
-      val schema = StructType(Seq(
-        StructField("c1", IntegerType),
-        StructField("c2", IntegerType, nullable = nullable)
-      ))
-      Seq(missingFieldInput, nullValueInput).foreach { input =>
-        assertAction(nullable, input) {
-          check(input = input, schema = schema, filters = Seq(EqualTo("c2", 1)),
-            expected = Seq.empty)
-        }
-        assertAction(nullable, input) {
-          check(input = input, schema = schema, filters = Seq(EqualTo("c2", 0)),
-            expected = Seq.empty)
-        }
-        assertAction(nullable, input) {
-          check(input = input, schema = schema, filters = Seq(IsNotNull("c2")),
-            expected = Seq.empty)
-        }
-        assertAction(nullable, input) {
-          check(input = input, schema = schema, filters = Seq(IsNull("c2")),
-            expected = Seq(InternalRow(1, null)))
+    Seq("FAILFAST", "DROPMALFORMED").foreach { mode =>
+      val config = Map("mode" -> mode)
+      Seq(true, false).foreach { nullable =>
+        val schema = StructType(Seq(
+          StructField("c1", IntegerType),
+          StructField("c2", IntegerType, nullable = nullable)
+        ))
+        val expected = Seq(InternalRow(1, null))
+        Seq(missingFieldInput, nullValueInput).foreach { input =>
+          assertAction(nullable, input) {
+            check(input = input, schema = schema, filters = Seq.empty, config = config,
+              expected = expected)
+          }
         }
       }
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JacksonParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JacksonParserSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.json
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.IllegalSchemaArgumentException
 import org.apache.spark.sql.sources.{EqualTo, Filter, IsNotNull, IsNull, StringStartsWith}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -60,7 +61,7 @@ class JacksonParserSuite extends SparkFunSuite {
       if (nullable) {
         action
       } else {
-        assertThrows[IllegalArgumentException] {
+        assertThrows[IllegalSchemaArgumentException] {
           action
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DeprecatedAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DeprecatedAPISuite.scala
@@ -182,8 +182,8 @@ class DeprecatedAPISuite extends QueryTest with SharedSparkSession {
       jsonDF = sqlContext.jsonRDD(jsonRDD.toJavaRDD())
       checkAnswer(jsonDF, Row(18, "Marry") :: Row(20, "Jack") :: Nil)
 
-      schema = StructType(StructField("name", StringType, false) ::
-        StructField("age", IntegerType, false) :: Nil)
+      schema = StructType(StructField("name", StringType, true) ::
+        StructField("age", IntegerType, true) :: Nil)
       jsonDF = sqlContext.jsonRDD(jsonRDD, schema)
       checkAnswer(jsonDF, Row("Jack", 20) :: Row("Marry", 18) :: Nil)
       jsonDF = sqlContext.jsonRDD(jsonRDD.toJavaRDD(), schema)

--- a/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
@@ -147,8 +147,8 @@ class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with Parque
       "{\"id\":2,\"vec\":[2.25,4.5,8.75]}"
     )
     val schema = StructType(Seq(
-      StructField("id", IntegerType, false),
-      StructField("vec", new TestUDT.MyDenseVectorUDT, false)
+      StructField("id", IntegerType, true),
+      StructField("vec", new TestUDT.MyDenseVectorUDT, true)
     ))
 
     val jsonRDD = spark.read.schema(schema).json(data.toDS())
@@ -167,8 +167,8 @@ class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with Parque
     )
 
     val schema = StructType(Seq(
-      StructField("id", IntegerType, false),
-      StructField("vec", new TestUDT.MyDenseVectorUDT, false)
+      StructField("id", IntegerType, true),
+      StructField("vec", new TestUDT.MyDenseVectorUDT, true)
     ))
 
     val jsonDataset = spark.read.schema(schema).json(data.toDS())

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -924,7 +924,7 @@ abstract class JsonSuite
   test("Applying schemas with MapType") {
     withTempView("jsonWithSimpleMap", "jsonWithComplexMap") {
       val schemaWithSimpleMap = StructType(
-        StructField("map", MapType(StringType, IntegerType, true), false) :: Nil)
+        StructField("map", MapType(StringType, IntegerType, true), true) :: Nil)
       val jsonWithSimpleMap = spark.read.schema(schemaWithSimpleMap).json(mapType1)
 
       jsonWithSimpleMap.createOrReplaceTempView("jsonWithSimpleMap")
@@ -953,7 +953,7 @@ abstract class JsonSuite
         StructField("field1", ArrayType(IntegerType, true), true) ::
         StructField("field2", IntegerType, true) :: Nil)
       val schemaWithComplexMap = StructType(
-        StructField("map", MapType(StringType, innerStruct, true), false) :: Nil)
+        StructField("map", MapType(StringType, innerStruct, true), true) :: Nil)
 
       val jsonWithComplexMap = spark.read.schema(schemaWithComplexMap).json(mapType2)
 
@@ -1392,7 +1392,7 @@ abstract class JsonSuite
     withSQLConf(SQLConf.COLUMN_NAME_OF_CORRUPT_RECORD.key -> "_unparsed") {
       withTempDir { dir =>
         val schemaWithSimpleMap = StructType(
-          StructField("map", MapType(StringType, IntegerType, true), false) :: Nil)
+          StructField("map", MapType(StringType, IntegerType, true), true) :: Nil)
         val df = spark.read.schema(schemaWithSimpleMap).json(mapType1)
 
         val path = dir.getAbsolutePath

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2962,7 +2962,7 @@ abstract class JsonSuite
             load("PERMISSIVE", schema, jsonString).collect
           }
           val expectedMsg2 =
-            "field c2 is not nullable but the not nullable field is not allowed in PERMISSIVE mode."
+            "Field c2 is not nullable but PERMISSIVE mode only works with nullable fields."
           assert(exceptionMsg2.getMessage.contains(expectedMsg2))
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2924,13 +2924,7 @@ abstract class JsonSuite
     // JSON field is missing.
     val missingFieldInput = """{"c1": 1}"""
     // JSON filed is null.
-    val nullValueInput =
-      """
-        |{
-        |  "c1": 1,
-        |  "c2": null
-        |}
-        |""".stripMargin
+    val nullValueInput = """{"c1": 1, "c2": null}"""
 
     val load = (mode: String, schema: StructType, inputJson: String) => {
       val json = spark.createDataset(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2919,6 +2919,50 @@ abstract class JsonSuite
       }
     }
   }
+
+  test("SPARK-35912: nullability with different parse mode -- struct") {
+    val input =
+      """
+        |{
+        |  "c1": {
+        |    "c2": 1
+        |  }
+        |}
+        |""".stripMargin
+    val json = spark.createDataset(spark.sparkContext.parallelize(input :: Nil))(Encoders.STRING)
+
+    val load = (mode: String, schema: StructType) => {
+      spark.read
+        .option("mode", mode)
+        .schema(schema)
+        .json(json)
+    }
+
+    Seq(true, false).foreach { nullable =>
+      val schema = StructType(Seq(
+        StructField("c1",
+          StructType(Seq(
+            StructField("c2", IntegerType, nullable = false),
+            StructField("not_exist_col", IntegerType, nullable = false)
+          )),
+          nullable = nullable))
+      )
+
+      checkAnswer(load("DROPMALFORMED", schema), Seq.empty)
+
+      val exception = intercept[SparkException] {
+        load("FAILFAST", schema).collect
+      }.getMessage
+      assert(exception.contains(
+        "the null value found when parsing non-nullable field not_exist_col."))
+
+      val e = intercept[SparkException] {
+        load("PERMISSIVE", schema).collect()
+      }
+      assert(e.getMessage.contains(
+        "the null value found when parsing non-nullable field not_exist_col."))
+    }
+  }
 }
 
 class JsonV1Suite extends JsonSuite {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Rework [PR](https://github.com/apache/spark/pull/33146#discussion_r661973792) with suggestions.

This PR changes the behavior of spark.read.json when nullability fields are false. the JacksonParser should fail and throw an exception instead of setting a null value.

here is an example:
```scala
  val schema = StructType(Seq(StructField("value",
    StructType(Seq(
      StructField("x", IntegerType, nullable = true),
      StructField("y", IntegerType, nullable = false)
    ))
  )))
  schema.printTreeString()
  // root
  // |-- value: struct (nullable = true)
  // |    |-- x: integer (nullable = false)
  // |    |-- y: integer (nullable = false)
  
  val testDS = Seq("""{"value":{"x":1}}""").toDS
  val jsonDS = spark.read.schema(schema).json(testDS)

  jsonDS.show()
```

output before this pr:
```
+---------+
|    value|
+---------+
|{1, null}|
+---------+
```

output has different behavior with different parse modes after this pr:


- PERMISSIVE mode

throw an IllegalSchemaArgumentException which contains the message:

```
Field c2 is not nullable but PERMISSIVE mode only works with nullable fields.
```

- FAILFAST mode

throw an IllegalSchemaArgumentException which contains the message:

```
field y is not nullable but it's missing in one record.
```

- DROPMALFORMED mode

```
+-----+
|value|
+-----+
+-----+
```



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. when reading a missing value(or null value) JSON with a not nullable field, Spark will fail and throw an exception for PERMISSIVE/FAILFAST mode, and drop records for DROPMALFORMED mode.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

New test.
