### PR TITLE
[SPARK-35664][SQL][FOLLOWUP] Fix incorrect comment for TimestampNTZType.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -116,7 +116,7 @@ object Encoders {
 
   /**
    * Creates an encoder that serializes instances of the `java.time.LocalDateTime` class
-   * to the internal representation of nullable Catalyst's DateType.
+   * to the internal representation of nullable Catalyst's TimestampNTZType.
    *
    * @since 3.2.0
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fix the incorrect comment for `TimestampNTZType`.


### Why are the changes needed?
Fix the incorrect comment


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
No need.
