### PR TITLE
[SPARK-35972][SQL][3.1] When replace ExtractValue in NestedColumnAliasing we should use semanticEquals

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
@@ -708,6 +708,7 @@ class NestedColumnAliasingSuite extends SchemaPruningTest {
         $"_extract_search_params.col1".as("col1"),
         $"_extract_search_params.col2".as("col2")).analyze
     comparePlans(optimized, query)
+  }
 }
 
 object NestedColumnAliasingSuite {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
@@ -700,13 +700,15 @@ class NestedColumnAliasingSuite extends SchemaPruningTest {
         $"struct_data.search_params.col1".as("col1"),
         $"struct_data.search_params.col2".as("col2")).analyze
     val query = Optimize.execute(plan)
+    val alias = collectGeneratedAliases(query)
+
     val optimized = relation
-      .select(GetStructField('struct_data, 1, None).as("_extract_search_params"))
+      .select(GetStructField('struct_data, 1, None).as(alias(0)))
       .repartition(100)
       .select(
-        $"_extract_search_params".as("value"),
-        $"_extract_search_params.col1".as("col1"),
-        $"_extract_search_params.col2".as("col2")).analyze
+        $"${alias(0)}".as("value"),
+        $"${alias(0)}.col1".as("col1"),
+        $"${alias(0)}.col2".as("col2")).analyze
     comparePlans(optimized, query)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
@@ -684,6 +684,30 @@ class NestedColumnAliasingSuite extends SchemaPruningTest {
     ).analyze
     comparePlans(optimized2, expected2)
   }
+
+  test("SPARK-35972: NestedColumnAliasing should consider semantic equality") {
+    val dataType = new StructType()
+      .add(StructField("itemid", StringType))
+      .add(StructField("search_params", StructType(Seq(
+        StructField("col1", StringType),
+        StructField("col2", StringType)
+      ))))
+    val relation = LocalRelation('struct_data.struct(dataType))
+    val plan = relation
+      .repartition(100)
+      .select(
+        GetStructField('struct_data, 1, None).as("value"),
+        $"struct_data.search_params.col1".as("col1"),
+        $"struct_data.search_params.col2".as("col2")).analyze
+    val query = Optimize.execute(plan)
+    val optimized = relation
+      .select(GetStructField('struct_data, 1, None).as("_extract_search_params"))
+      .repartition(100)
+      .select(
+        $"_extract_search_params".as("value"),
+        $"_extract_search_params.col1".as("col1"),
+        $"_extract_search_params.col2".as("col2")).analyze
+    comparePlans(optimized, query)
 }
 
 object NestedColumnAliasingSuite {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ideally, in SQL query, nested columns should result to GetStructField with non-None name. But there are places that can create GetStructField with None name, such as UnresolvedStar.expand, Dataset encoder stuff, etc.
the current `nestedFieldToAlias` cannot catch it up and will cause job failed.

 

### Why are the changes needed?
Fix bug

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT,
