### PR TITLE
[SPARK-36025][SQL][TESTS] Reduce the run time of DateExpressionsSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -25,7 +25,9 @@ import java.time.temporal.ChronoUnit
 import java.util.{Calendar, Locale, TimeZone}
 import java.util.concurrent.TimeUnit._
 
+import scala.language.postfixOps
 import scala.reflect.ClassTag
+import scala.util.Random
 
 import org.apache.spark.{SparkFunSuite, SparkUpgradeException}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -195,8 +197,9 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val c = Calendar.getInstance()
     (1999 to 2000).foreach { y =>
       c.set(y, 0, 1, 0, 0, 0)
-      (0 to 365).foreach { d =>
-        c.add(Calendar.DATE, 1)
+      val random = new Random(System.nanoTime)
+      random.shuffle(0 to 365 toList).take(10).foreach { d =>
+        c.set(Calendar.DAY_OF_YEAR, d)
         checkEvaluation(DayOfMonth(Literal(new Date(c.getTimeInMillis))),
           c.get(Calendar.DAY_OF_MONTH))
       }
@@ -328,23 +331,19 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Hour(Literal(ts), UTC_OPT), 13)
 
     val c = Calendar.getInstance()
-    for (zid <- outstandingZoneIds) {
+    for (zid <- outstandingZoneIdSample) {
       val timeZoneId = Option(zid.getId)
       c.setTimeZone(TimeZone.getTimeZone(zid))
       (0 to 24 by 5).foreach { h =>
-        (0 to 60 by 29).foreach { m =>
-          (0 to 60 by 29).foreach { s =>
-            // validate timestamp with local time zone
-            c.set(2015, 18, 3, h, m, s)
-            checkEvaluation(
-              Hour(Literal(new Timestamp(c.getTimeInMillis)), timeZoneId),
-              c.get(Calendar.HOUR_OF_DAY))
+        // validate timestamp with local time zone
+        c.set(2015, 18, 3, h, 29, 59)
+        checkEvaluation(
+          Hour(Literal(new Timestamp(c.getTimeInMillis)), timeZoneId),
+          c.get(Calendar.HOUR_OF_DAY))
 
-            // validate timestamp without time zone
-            val localDateTime = LocalDateTime.of(2015, 1, 3, h, m, s)
-            checkEvaluation(Hour(Literal(localDateTime), timeZoneId), h)
-          }
-        }
+        // validate timestamp without time zone
+        val localDateTime = LocalDateTime.of(2015, 1, 3, h, 29, 59)
+        checkEvaluation(Hour(Literal(localDateTime), timeZoneId), h)
       }
       Seq(TimestampType, TimestampNTZType).foreach { dt =>
         checkConsistencyBetweenInterpretedAndCodegen(
@@ -363,21 +362,19 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Minute(Literal(ts), UTC_OPT), 10)
 
     val c = Calendar.getInstance()
-    for (zid <- outstandingZoneIds) {
+    for (zid <- outstandingZoneIdSample) {
       val timeZoneId = Option(zid.getId)
       c.setTimeZone(TimeZone.getTimeZone(zid))
       (0 to 59 by 5).foreach { m =>
-        (0 to 59 by 15).foreach { s =>
-          // validate timestamp with local time zone
-          c.set(2015, 18, 3, 3, m, s)
-          checkEvaluation(
-            Minute(Literal(new Timestamp(c.getTimeInMillis)), timeZoneId),
-            c.get(Calendar.MINUTE))
+        // validate timestamp with local time zone
+        c.set(2015, 18, 3, 3, m, 3)
+        checkEvaluation(
+          Minute(Literal(new Timestamp(c.getTimeInMillis)), timeZoneId),
+          c.get(Calendar.MINUTE))
 
-          // validate timestamp without time zone
-          val localDateTime = LocalDateTime.of(2015, 1, 3, 3, m, s)
-          checkEvaluation(Minute(Literal(localDateTime), timeZoneId), m)
-        }
+        // validate timestamp without time zone
+        val localDateTime = LocalDateTime.of(2015, 1, 3, 3, m, 3)
+        checkEvaluation(Minute(Literal(localDateTime), timeZoneId), m)
       }
       Seq(TimestampType, TimestampNTZType).foreach { dt =>
         checkConsistencyBetweenInterpretedAndCodegen(
@@ -1757,7 +1754,7 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("SPARK-34761,SPARK-35889: add a day-time interval to a timestamp") {
     val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
     Seq(TimestampType, TimestampNTZType).foreach { dt =>
-      for (zid <- outstandingZoneIds) {
+      for (zid <- outstandingZoneIdSample) {
         val timeZoneId = Option(zid.getId)
         sdf.setTimeZone(TimeZone.getTimeZone(zid))
         checkEvaluation(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -124,8 +124,8 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     (2000 to 2002).foreach { y =>
       (0 to 11 by 11).foreach { m =>
         c.set(y, m, 28)
-        (0 to 5 * 24).foreach { i =>
-          c.add(Calendar.HOUR_OF_DAY, 1)
+        (0 to 12).foreach { i =>
+          c.add(Calendar.HOUR_OF_DAY, 10)
           checkEvaluation(Year(Literal(new Date(c.getTimeInMillis))),
             c.get(Calendar.YEAR))
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -331,7 +331,7 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Hour(Literal(ts), UTC_OPT), 13)
 
     val c = Calendar.getInstance()
-    for (zid <- outstandingZoneIdSample) {
+    for (zid <- outstandingZoneIds) {
       val timeZoneId = Option(zid.getId)
       c.setTimeZone(TimeZone.getTimeZone(zid))
       (0 to 24 by 5).foreach { h =>
@@ -362,7 +362,7 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Minute(Literal(ts), UTC_OPT), 10)
 
     val c = Calendar.getInstance()
-    for (zid <- outstandingZoneIdSample) {
+    for (zid <- outstandingZoneIds) {
       val timeZoneId = Option(zid.getId)
       c.setTimeZone(TimeZone.getTimeZone(zid))
       (0 to 59 by 5).foreach { m =>
@@ -1754,7 +1754,7 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("SPARK-34761,SPARK-35889: add a day-time interval to a timestamp") {
     val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
     Seq(TimestampType, TimestampNTZType).foreach { dt =>
-      for (zid <- outstandingZoneIdSample) {
+      for (zid <- outstandingZoneIds) {
         val timeZoneId = Option(zid.getId)
         sdf.setTimeZone(TimeZone.getTimeZone(zid))
         checkEvaluation(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
@@ -22,6 +22,7 @@ import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
+import scala.util.Random
 
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.getZoneId
@@ -53,6 +54,13 @@ object DateTimeTestUtils {
     "Asia/Hong_Kong",
     "Europe/Amsterdam")
   val outstandingZoneIds: Seq[ZoneId] = outstandingTimezonesIds.map(getZoneId)
+
+  private val random = new Random(System.nanoTime())
+
+  // Take 2 samples from the `outstandingZoneIds`. This is useful when the test case is slow.
+  def outstandingZoneIdSample: Seq[ZoneId] = {
+    random.shuffle(outstandingZoneIds).take(2)
+  }
 
   def withDefaultTimeZone[T](newDefaultTimeZone: ZoneId)(block: => T): T = {
     val originalDefaultTimeZone = ZoneId.systemDefault()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
@@ -22,7 +22,6 @@ import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
-import scala.util.Random
 
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.getZoneId
@@ -54,13 +53,6 @@ object DateTimeTestUtils {
     "Asia/Hong_Kong",
     "Europe/Amsterdam")
   val outstandingZoneIds: Seq[ZoneId] = outstandingTimezonesIds.map(getZoneId)
-
-  private val random = new Random(System.nanoTime())
-
-  // Take 2 samples from the `outstandingZoneIds`. This is useful when the test case is slow.
-  def outstandingZoneIdSample: Seq[ZoneId] = {
-    random.shuffle(outstandingZoneIds).take(2)
-  }
 
   def withDefaultTimeZone[T](newDefaultTimeZone: ZoneId)(block: => T): T = {
     val originalDefaultTimeZone = ZoneId.systemDefault()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Some of the test cases in `DateExpressionsSuite` are quite slow:

- `Hour`: 24s
- `Minute`: 26s
- `Day / DayOfMonth`: 8s
- `Year`: 4s

Each test case has a large loop. We should improve them.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Save test running time

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Verified the run times on local:
- `Hour`: 2s
- `Minute`: 3.2
- `Day / DayOfMonth`:0.5s
- `Year`: 2s

Total reduced time: 54.3s