### PR TITLE
[SPARK-36011][SQL][3.1] Disallow altering permanent views based on temporary views or UDFs

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -264,8 +264,9 @@ case class AlterViewAsCommand(
     val qe = session.sessionState.executePlan(query)
     qe.assertAnalyzed()
     val analyzedPlan = qe.analyzed
-
-    if (session.sessionState.catalog.isTemporaryTable(name)) {
+    val isTemporary = session.sessionState.catalog.isTemporaryTable(name)
+    verifyTemporaryObjectsNotExists(session.sessionState.catalog, isTemporary, name, query)
+    if (isTemporary) {
       alterTemporaryView(session, analyzedPlan)
     } else {
       alterPermanentView(session, analyzedPlan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -378,4 +378,32 @@ class GlobalTempViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
 class PersistedViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
   override protected def viewTypeString: String = "VIEW"
   override protected def formattedViewName(viewName: String): String = s"default.$viewName"
+
+  test("SPARK-36011: Disallow altering permanent views based on temporary views or UDFs") {
+    import testImplicits._
+    withTable("t") {
+      (1 to 10).toDF("id").write.saveAsTable("t")
+      withView("v1") {
+        withTempView("v2") {
+          sql("CREATE VIEW v1 AS SELECT * FROM t")
+          sql("CREATE TEMPORARY VIEW v2 AS  SELECT * FROM t")
+          var e = intercept[AnalysisException] {
+            sql("ALTER VIEW v1 AS SELECT * FROM v2")
+          }.getMessage
+          assert(e.contains("Not allowed to create a permanent view `default`.`v1` by " +
+            "referencing a temporary view v2"))
+          val tempFunctionName = "temp_udf"
+          val functionClass = "test.org.apache.spark.sql.MyDoubleAvg"
+          withUserDefinedFunction(tempFunctionName -> true) {
+            sql(s"CREATE TEMPORARY FUNCTION $tempFunctionName AS '$functionClass'")
+            e = intercept[AnalysisException] {
+              sql(s"ALTER VIEW v1 AS SELECT $tempFunctionName(id) from t")
+            }.getMessage
+            assert(e.contains("Not allowed to create a permanent view `default`.`v1` by " +
+              s"referencing a temporary function `$tempFunctionName`"))
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
backport #33204 to 3.1

### What changes were proposed in this pull request?
PR #15764 disabled creating permanent views based on temporary views or UDFs.  But AlterViewCommand didn't block temporary objects.

### Why are the changes needed?
More robust view canonicalization.

### Does this PR introduce _any_ user-facing change?
Yes, now if you alter a permanent view based on temporary views or UDFs, the operation will fail.

### How was this patch tested?
Add new unit tests.
