### PR TITLE
[SPARK-36027][SQL] Add the code change to pushdown filter in case of typedFilter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1442,6 +1442,12 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
       pushDownPredicate(filter, u.child) { predicate =>
         u.withNewChildren(Seq(Filter(predicate, u.child)))
       }
+
+    // Push down filter predicates in case filter having child as TypedFilter.
+    // In this scenario inorder to push the filter predicates there is need to
+    // to push Filter beneath the TypedFilter.
+    case Filter(condition, typeFilter @ TypedFilter(_, _, _, _, _)) =>
+      typeFilter.copy(child = Filter(condition, typeFilter.child))
   }
 
   def canPushThrough(p: UnaryNode): Boolean = p match {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -1390,7 +1390,7 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("push down filter predicate having typedFilter as child") {
+  test("SPARK-36027: push down filter predicate having typedFilter as child") {
 
     val f1 = (i: (Int, Int, Int)) => i._1 > 0
     val f2 = (i: (Int, Int, Int)) => i._1 < 100
@@ -1408,6 +1408,5 @@ class FilterPushdownSuite extends PlanTest {
     query = testRelation.where(attrB <= 5).filter(f1).filter(f2).analyze
     expected = Optimize.execute(query)
     comparePlans(optimized, expected)
-
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In case of Filter having child as TypedFilter, Pushdown of Filters does not take place

scala> def testUdfFunction(r: String): Boolean = {
 | r.equals("hello")
 | }
testUdfFunction: (r: String)Boolean

val df= spark.read.parquet("/testDir/testParquetSize/Parquetgzip/")
df: org.apache.spark.sql.DataFrame = [_1: string, _2: string ... 1 more field]

Before Fix 
```
df.filter(x => testUdfFunction(x.getAs("_1"))).filter("_2<='id103855'").queryExecution.executedPlan
 
Filter (isnotnull(_2#1) AND (_2#1 <= id103855))
+- *(1) Filter $line20.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$Lambda$3184/1455948476@5ce4af92.apply
 +- *(1) ColumnarToRow
 +- FileScan parquet [_1#0,_2#1,_3#2] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex[file:/testDir/testParquetSize/Parquetgzip], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<_1:string,_2:string,_3:string>
 
df.filter(x => testUdfFunction(x.getAs("_1"))).filter("_2<='id103855'").queryExecution.optimizedPlan

Filter (isnotnull(_2#1) AND (_2#1 <= id103855))
+- TypedFilter $line22.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$Lambda$3191/320569017@37a2806c, interface org.apache.spark.sql.Row, [StructField(_1,StringType,true), StructField(_2,StringType,true), StructField(_3,StringType,true)], createexternalrow(_1#0.toString, _2#1.toString, _3#2.toString, StructField(_1,StringType,true), StructField(_2,StringType,true), StructField(_3,StringType,true))
 +- Relation[_1#0,_2#1,_3#2] parquet

```

After fix
```
df.filter(x => testUdfFunction(x.getAs("_1"))).filter("_2<='id103855'").queryExecution.executedPlan

*(1) Filter $line16.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$Lambda$2966/426572525@4155e85d.apply
+- *(1) Filter (isnotnull(_2#1) AND (_2#1 <= id103855))
   +- *(1) ColumnarToRow
      +- FileScan parquet [_1#0,_2#1,_3#2] Batched: true, DataFilters: [isnotnull(_2#1), (_2#1 <= id103855)], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/testDir/testParquetSize/Parquetgzip], PartitionFilters: [], PushedFilters: [IsNotNull(_2), LessThanOrEqual(_2,id103855)], ReadSchema: struct<_1:string,_2:string,_3:string>

df.filter(x => testUdfFunction(x.getAs("_1"))).filter("_2<='id103855'").queryExecution.optimizedPlan

TypedFilter $line18.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$Lambda$3445/1423649465@62065a8c, interface org.apache.spark.sql.Row, [StructField(_1,StringType,true), StructField(_2,StringType,true), StructField(_3,StringType,true)], createexternalrow(_1#0.toString, _2#1.toString, _3#2.toString, StructField(_1,StringType,true), StructField(_2,StringType,true), StructField(_3,StringType,true))
+- Filter (isnotnull(_2#1) AND (_2#1 <= id103855))
   +- Relation [_1#0,_2#1,_3#2] parquet
```

### Why are the changes needed?
Till now when Filter is having child as TypedFilter, the filter is not pushed down, There is a need to add this code change for pushing down the filter.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added the unit test and tested on spark-shell