### PR TITLE
[SPARK-35340][PYTHON] Standardize TypeError messages for unsupported basic operations

### DIFF
--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -62,7 +62,7 @@ class DateOps(DataTypeOps):
             warnings.warn(msg, UserWarning)
             return column_op(F.datediff)(left, SF.lit(right)).astype("long")
         else:
-            raise TypeError("date subtraction can only be applied to date series.")
+            raise TypeError("Date subtraction can only be applied to date series.")
 
     def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         # Note that date subtraction casts arguments to integer. This is to mimic pandas's
@@ -76,7 +76,7 @@ class DateOps(DataTypeOps):
             warnings.warn(msg, UserWarning)
             return -column_op(F.datediff)(left, SF.lit(right)).astype("long")
         else:
-            raise TypeError("date subtraction can only be applied to date series.")
+            raise TypeError("Date subtraction can only be applied to date series.")
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -67,7 +67,7 @@ class DatetimeOps(DataTypeOps):
                 ),
             )
         else:
-            raise TypeError("datetime subtraction can only be applied to datetime series.")
+            raise TypeError("Datetime subtraction can only be applied to datetime series.")
 
     def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         # Note that timestamp subtraction casts arguments to integer. This is to mimic pandas's
@@ -86,7 +86,7 @@ class DatetimeOps(DataTypeOps):
                 ),
             )
         else:
-            raise TypeError("datetime subtraction can only be applied to datetime series.")
+            raise TypeError("Datetime subtraction can only be applied to datetime series.")
 
     def prepare(self, col: pd.Series) -> pd.Series:
         """Prepare column when from_pandas."""

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -54,7 +54,7 @@ class NumericOps(DataTypeOps):
 
     def add(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("addition can not be applied to given types.")
+            raise TypeError("Addition can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -62,7 +62,7 @@ class NumericOps(DataTypeOps):
 
     def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("subtraction can not be applied to given types.")
+            raise TypeError("Subtraction can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -70,7 +70,7 @@ class NumericOps(DataTypeOps):
 
     def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("modulo can not be applied to given types.")
+            raise TypeError("Modulo can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -81,7 +81,7 @@ class NumericOps(DataTypeOps):
 
     def pow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("exponentiation can not be applied to given types.")
+            raise TypeError("Exponentiation can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -92,25 +92,25 @@ class NumericOps(DataTypeOps):
 
     def radd(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("addition can not be applied to given types.")
+            raise TypeError("Addition can not be applied to given types.")
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__radd__)(left, right)
 
     def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("subtraction can not be applied to given types.")
+            raise TypeError("Subtraction can not be applied to given types.")
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rsub__)(left, right)
 
     def rmul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("multiplication can not be applied to given types.")
+            raise TypeError("Multiplication can not be applied to given types.")
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rmul__)(left, right)
 
     def rpow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("exponentiation can not be applied to given types.")
+            raise TypeError("Exponentiation can not be applied to given types.")
 
         def rpow_func(left: Column, right: Any) -> Column:
             return F.when(SF.lit(right == 1), right).otherwise(Column.__rpow__(left, right))
@@ -120,7 +120,7 @@ class NumericOps(DataTypeOps):
 
     def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("modulo can not be applied to given types.")
+            raise TypeError("Modulo can not be applied to given types.")
 
         def rmod(left: Column, right: Any) -> Column:
             return ((right % left) + left) % left
@@ -144,7 +144,7 @@ class IntegralOps(NumericOps):
             return column_op(SF.repeat)(right, left)
 
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("multiplication can not be applied to given types.")
+            raise TypeError("Multiplication can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -152,7 +152,7 @@ class IntegralOps(NumericOps):
 
     def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("division can not be applied to given types.")
+            raise TypeError("Division can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -165,7 +165,7 @@ class IntegralOps(NumericOps):
 
     def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("division can not be applied to given types.")
+            raise TypeError("Division can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -180,7 +180,7 @@ class IntegralOps(NumericOps):
 
     def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("division can not be applied to given types.")
+            raise TypeError("Division can not be applied to given types.")
 
         def rtruediv(left: Column, right: Any) -> Column:
             return F.when(left == 0, SF.lit(np.inf).__div__(right)).otherwise(
@@ -192,7 +192,7 @@ class IntegralOps(NumericOps):
 
     def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("division can not be applied to given types.")
+            raise TypeError("Division can not be applied to given types.")
 
         def rfloordiv(left: Column, right: Any) -> Column:
             return F.when(SF.lit(left == 0), SF.lit(np.inf).__div__(right)).otherwise(
@@ -227,7 +227,7 @@ class FractionalOps(NumericOps):
 
     def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("multiplication can not be applied to given types.")
+            raise TypeError("Multiplication can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -235,7 +235,7 @@ class FractionalOps(NumericOps):
 
     def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("division can not be applied to given types.")
+            raise TypeError("Division can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -252,7 +252,7 @@ class FractionalOps(NumericOps):
 
     def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("division can not be applied to given types.")
+            raise TypeError("Division can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -271,7 +271,7 @@ class FractionalOps(NumericOps):
 
     def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("division can not be applied to given types.")
+            raise TypeError("Division can not be applied to given types.")
 
         def rtruediv(left: Column, right: Any) -> Column:
             return F.when(left == 0, SF.lit(np.inf).__div__(right)).otherwise(
@@ -283,7 +283,7 @@ class FractionalOps(NumericOps):
 
     def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("division can not be applied to given types.")
+            raise TypeError("Division can not be applied to given types.")
 
         def rfloordiv(left: Column, right: Any) -> Column:
             return F.when(SF.lit(left == 0), SF.lit(np.inf).__div__(right)).otherwise(

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -41,7 +41,6 @@ from pyspark.sql.column import Column
 from pyspark.sql.types import (
     BooleanType,
     StringType,
-    TimestampType,
 )
 
 

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -53,11 +53,6 @@ class NumericOps(DataTypeOps):
         return "numerics"
 
     def add(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if (
-            isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
-        ) or isinstance(right, str):
-            raise TypeError("string addition can only be applied to string series or literals.")
-
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("addition can not be applied to given types.")
 
@@ -66,11 +61,6 @@ class NumericOps(DataTypeOps):
         return column_op(Column.__add__)(left, right)
 
     def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if (
-            isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
-        ) or isinstance(right, str):
-            raise TypeError("subtraction can not be applied to string series or literals.")
-
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("subtraction can not be applied to given types.")
 
@@ -79,11 +69,6 @@ class NumericOps(DataTypeOps):
         return column_op(Column.__sub__)(left, right)
 
     def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if (
-            isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
-        ) or isinstance(right, str):
-            raise TypeError("modulo can not be applied on string series or literals.")
-
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("modulo can not be applied to given types.")
 
@@ -95,11 +80,6 @@ class NumericOps(DataTypeOps):
         return column_op(mod)(left, right)
 
     def pow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if (
-            isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
-        ) or isinstance(right, str):
-            raise TypeError("exponentiation can not be applied on string series or literals.")
-
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("exponentiation can not be applied to given types.")
 
@@ -111,32 +91,24 @@ class NumericOps(DataTypeOps):
         return column_op(pow_func)(left, right)
 
     def radd(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("string addition can only be applied to string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("addition can not be applied to given types.")
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__radd__)(left, right)
 
     def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("subtraction can not be applied to string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("subtraction can not be applied to given types.")
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rsub__)(left, right)
 
     def rmul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("multiplication can not be applied to a string literal.")
         if not isinstance(right, numbers.Number):
             raise TypeError("multiplication can not be applied to given types.")
         right = transform_boolean_operand_to_numeric(right)
         return column_op(Column.__rmul__)(left, right)
 
     def rpow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("exponentiation can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("exponentiation can not be applied to given types.")
 
@@ -147,8 +119,6 @@ class NumericOps(DataTypeOps):
         return column_op(rpow_func)(left, right)
 
     def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("modulo can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("modulo can not be applied to given types.")
 

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -151,11 +151,6 @@ class IntegralOps(NumericOps):
         return column_op(Column.__mul__)(left, right)
 
     def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if (
-            isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
-        ) or isinstance(right, str):
-            raise TypeError("division can not be applied on string series or literals.")
-
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("division can not be applied to given types.")
 
@@ -169,11 +164,6 @@ class IntegralOps(NumericOps):
         return numpy_column_op(truediv)(left, right)
 
     def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if (
-            isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
-        ) or isinstance(right, str):
-            raise TypeError("division can not be applied on string series or literals.")
-
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("division can not be applied to given types.")
 
@@ -189,8 +179,6 @@ class IntegralOps(NumericOps):
         return numpy_column_op(floordiv)(left, right)
 
     def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
@@ -203,8 +191,6 @@ class IntegralOps(NumericOps):
         return numpy_column_op(rtruediv)(left, right)
 
     def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
@@ -248,11 +234,6 @@ class FractionalOps(NumericOps):
         return column_op(Column.__mul__)(left, right)
 
     def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if (
-            isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
-        ) or isinstance(right, str):
-            raise TypeError("division can not be applied on string series or literals.")
-
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("division can not be applied to given types.")
 
@@ -270,11 +251,6 @@ class FractionalOps(NumericOps):
         return numpy_column_op(truediv)(left, right)
 
     def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if (
-            isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType)
-        ) or isinstance(right, str):
-            raise TypeError("division can not be applied on string series or literals.")
-
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("division can not be applied to given types.")
 
@@ -294,8 +270,6 @@ class FractionalOps(NumericOps):
         return numpy_column_op(floordiv)(left, right)
 
     def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 
@@ -308,8 +282,6 @@ class FractionalOps(NumericOps):
         return numpy_column_op(rtruediv)(left, right)
 
     def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("division can not be applied on string series or literals.")
         if not isinstance(right, numbers.Number):
             raise TypeError("division can not be applied to given types.")
 

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -152,7 +152,7 @@ class IntegralOps(NumericOps):
 
     def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("Division can not be applied to given types.")
+            raise TypeError("True division can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -165,7 +165,7 @@ class IntegralOps(NumericOps):
 
     def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("Division can not be applied to given types.")
+            raise TypeError("Floor division can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -180,7 +180,7 @@ class IntegralOps(NumericOps):
 
     def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("Division can not be applied to given types.")
+            raise TypeError("True division can not be applied to given types.")
 
         def rtruediv(left: Column, right: Any) -> Column:
             return F.when(left == 0, SF.lit(np.inf).__div__(right)).otherwise(
@@ -192,7 +192,7 @@ class IntegralOps(NumericOps):
 
     def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("Division can not be applied to given types.")
+            raise TypeError("Floor division can not be applied to given types.")
 
         def rfloordiv(left: Column, right: Any) -> Column:
             return F.when(SF.lit(left == 0), SF.lit(np.inf).__div__(right)).otherwise(
@@ -235,7 +235,7 @@ class FractionalOps(NumericOps):
 
     def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("Division can not be applied to given types.")
+            raise TypeError("True division can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -252,7 +252,7 @@ class FractionalOps(NumericOps):
 
     def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not is_valid_operand_for_numeric_arithmetic(right):
-            raise TypeError("Division can not be applied to given types.")
+            raise TypeError("Floor division can not be applied to given types.")
 
         right = transform_boolean_operand_to_numeric(right, left.spark.data_type)
 
@@ -271,7 +271,7 @@ class FractionalOps(NumericOps):
 
     def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("Division can not be applied to given types.")
+            raise TypeError("True division can not be applied to given types.")
 
         def rtruediv(left: Column, right: Any) -> Column:
             return F.when(left == 0, SF.lit(np.inf).__div__(right)).otherwise(
@@ -283,7 +283,7 @@ class FractionalOps(NumericOps):
 
     def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if not isinstance(right, numbers.Number):
-            raise TypeError("Division can not be applied to given types.")
+            raise TypeError("Floor division can not be applied to given types.")
 
         def rfloordiv(left: Column, right: Any) -> Column:
             return F.when(SF.lit(left == 0), SF.lit(np.inf).__div__(right)).otherwise(

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -140,12 +140,6 @@ class IntegralOps(NumericOps):
         return "integrals"
 
     def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("multiplication can not be applied to a string literal.")
-
-        if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, TimestampType):
-            raise TypeError("multiplication can not be applied to date times.")
-
         if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, StringType):
             return column_op(SF.repeat)(right, left)
 
@@ -246,12 +240,6 @@ class FractionalOps(NumericOps):
         return "fractions"
 
     def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("multiplication can not be applied to a string literal.")
-
-        if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, TimestampType):
-            raise TypeError("multiplication can not be applied to date times.")
-
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("multiplication can not be applied to given types.")
 

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -74,10 +74,10 @@ class StringOps(DataTypeOps):
         raise TypeError("division can not be applied to %s." % self.pretty_name)
 
     def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("modulo can not be applied on string series or literals.")
+        raise TypeError("modulo can not be applied to %s." % self.pretty_name)
 
     def pow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("exponentiation can not be applied on string series or literals.")
+        raise TypeError("exponentiation can not be applied to %s." % self.pretty_name)
 
     def radd(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -52,10 +52,7 @@ class StringOps(DataTypeOps):
         elif isinstance(right, str):
             return column_op(F.concat)(left, SF.lit(right))
         else:
-            raise TypeError("addition can not be applied to given types.")
-
-    def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("subtraction can not be applied to %s." % self.pretty_name)
+            raise TypeError("Addition can not be applied to given types.")
 
     def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if (
@@ -65,19 +62,7 @@ class StringOps(DataTypeOps):
         ) or isinstance(right, int):
             return column_op(SF.repeat)(left, right)
         else:
-            raise TypeError("multiplication can not be applied to given types.")
-
-    def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("division can not be applied to %s." % self.pretty_name)
-
-    def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("division can not be applied to %s." % self.pretty_name)
-
-    def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("modulo can not be applied to %s." % self.pretty_name)
-
-    def pow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("exponentiation can not be applied to %s." % self.pretty_name)
+            raise TypeError("Multiplication can not be applied to given types.")
 
     def radd(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, str):
@@ -86,28 +71,13 @@ class StringOps(DataTypeOps):
                 left._with_new_scol(F.concat(SF.lit(right), left.spark.column)),  # TODO: dtype?
             )
         else:
-            raise TypeError("addition can not be applied to given types.")
-
-    def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("subtraction can not be applied to %s." % self.pretty_name)
+            raise TypeError("Addition can not be applied to given types.")
 
     def rmul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, int):
             return column_op(SF.repeat)(left, right)
         else:
-            raise TypeError("multiplication can not be applied to given types.")
-
-    def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("division can not be applied to %s." % self.pretty_name)
-
-    def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("division can not be applied to %s." % self.pretty_name)
-
-    def rpow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("exponentiation can not be applied to %s." % self.pretty_name)
-
-    def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("modulo can not be applied to %s." % self.pretty_name)
+            raise TypeError("Multiplication can not be applied to given types.")
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -55,7 +55,7 @@ class StringOps(DataTypeOps):
             raise TypeError("addition can not be applied to given types.")
 
     def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("subtraction can not be applied to string series or literals.")
+        raise TypeError("subtraction can not be applied to %s." % self.pretty_name)
 
     def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if (
@@ -68,10 +68,10 @@ class StringOps(DataTypeOps):
             raise TypeError("multiplication can not be applied to given types.")
 
     def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("division can not be applied on string series or literals.")
+        raise TypeError("division can not be applied to %s." % self.pretty_name)
 
     def floordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("division can not be applied on string series or literals.")
+        raise TypeError("division can not be applied to %s." % self.pretty_name)
 
     def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("modulo can not be applied on string series or literals.")
@@ -89,7 +89,7 @@ class StringOps(DataTypeOps):
             raise TypeError("addition can not be applied to given types.")
 
     def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("subtraction can not be applied to string series or literals.")
+        raise TypeError("subtraction can not be applied to %s." % self.pretty_name)
 
     def rmul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         if isinstance(right, int):
@@ -98,16 +98,16 @@ class StringOps(DataTypeOps):
             raise TypeError("multiplication can not be applied to given types.")
 
     def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("division can not be applied on string series or literals.")
+        raise TypeError("division can not be applied to %s." % self.pretty_name)
 
     def rfloordiv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("division can not be applied on string series or literals.")
+        raise TypeError("division can not be applied to %s." % self.pretty_name)
 
     def rpow(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("exponentiation can not be applied on string series or literals.")
+        raise TypeError("exponentiation can not be applied to %s." % self.pretty_name)
 
     def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        raise TypeError("modulo can not be applied on string series or literals.")
+        raise TypeError("modulo can not be applied to %s." % self.pretty_name)
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -52,7 +52,7 @@ class StringOps(DataTypeOps):
         elif isinstance(right, str):
             return column_op(F.concat)(left, SF.lit(right))
         else:
-            raise TypeError("string addition can only be applied to string series or literals.")
+            raise TypeError("addition can not be applied to given types.")
 
     def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("subtraction can not be applied to string series or literals.")
@@ -89,7 +89,7 @@ class StringOps(DataTypeOps):
                 left._with_new_scol(F.concat(SF.lit(right), left.spark.column)),  # TODO: dtype?
             )
         else:
-            raise TypeError("string addition can only be applied to string series or literals.")
+            raise TypeError("addition can not be applied to given types.")
 
     def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("subtraction can not be applied to string series or literals.")

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -58,9 +58,6 @@ class StringOps(DataTypeOps):
         raise TypeError("subtraction can not be applied to string series or literals.")
 
     def mul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        if isinstance(right, str):
-            raise TypeError("multiplication can not be applied to a string literal.")
-
         if (
             isinstance(right, IndexOpsMixin)
             and isinstance(right.spark.data_type, IntegralType)
@@ -68,7 +65,7 @@ class StringOps(DataTypeOps):
         ) or isinstance(right, int):
             return column_op(SF.repeat)(left, right)
         else:
-            raise TypeError("a string series can only be multiplied to an int series or literal")
+            raise TypeError("multiplication can not be applied to given types.")
 
     def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("division can not be applied on string series or literals.")
@@ -98,7 +95,7 @@ class StringOps(DataTypeOps):
         if isinstance(right, int):
             return column_op(SF.repeat)(left, right)
         else:
-            raise TypeError("a string series can only be multiplied to an int series or literal")
+            raise TypeError("multiplication can not be applied to given types.")
 
     def rtruediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("division can not be applied on string series or literals.")

--- a/python/pyspark/pandas/tests/indexes/test_datetime.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime.py
@@ -212,7 +212,7 @@ class DatetimeIndexTest(PandasOnSparkTestCase, TestUtils):
                 self.assertRaisesRegex(TypeError, expected_err_msg, lambda: psidx % other)
                 self.assertRaisesRegex(TypeError, expected_err_msg, lambda: other % psidx)
 
-            expected_err_msg = "datetime subtraction can only be applied to datetime series."
+            expected_err_msg = "Datetime subtraction can only be applied to datetime series."
 
             for other in [1, 0.1]:
                 self.assertRaisesRegex(TypeError, expected_err_msg, lambda: psidx - other)

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -2436,12 +2436,11 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [2]})
-        ks_err_msg = "multiplication can not be applied to a string literal"
+        ks_err_msg = "multiplication can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] * "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] * "literal")
 
-        ks_err_msg = "a string series can only be multiplied to an int series or literal"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] * psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] * 0.1)
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 0.1 * psdf["a"])

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -2386,23 +2386,27 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = "division can not be applied on string series or literals"
 
-        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] / psdf["b"])
+        ks_err_msg = "division can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] / psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] / "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" / psdf["b"])
+
+        ks_err_msg = "division can not be applied to strings"
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] / psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 / psdf["a"])
 
     def test_binary_operator_floordiv(self):
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = "division can not be applied on string series or literals"
 
+        ks_err_msg = "division can not be applied to strings"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] // psdf["b"])
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 // psdf["a"])
+
+        ks_err_msg = "division can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] // psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] // "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" // psdf["b"])
-        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 // psdf["a"])
 
     def test_binary_operator_mod(self):
         # Positive

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -2347,7 +2347,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psdf["c"] + psdf["d"], pdf["c"] + pdf["d"])
 
         # Negative
-        ks_err_msg = "addition can not be applied to given types"
+        ks_err_msg = "Addition can not be applied to given types"
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] + psdf["c"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["c"] + psdf["a"])
@@ -2365,12 +2365,12 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = "subtraction can not be applied to given types"
+        ks_err_msg = "Subtraction can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] - psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] - "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" - psdf["b"])
 
-        ks_err_msg = "subtraction can not be applied to strings"
+        ks_err_msg = "Subtraction can not be applied to strings"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] - psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 - psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] - 1)
@@ -2388,23 +2388,23 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
 
-        ks_err_msg = "division can not be applied to given types"
+        ks_err_msg = "Division can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] / psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] / "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" / psdf["b"])
 
-        ks_err_msg = "division can not be applied to strings"
+        ks_err_msg = "Division can not be applied to strings"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] / psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 / psdf["a"])
 
     def test_binary_operator_floordiv(self):
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
 
-        ks_err_msg = "division can not be applied to strings"
+        ks_err_msg = "Division can not be applied to strings"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] // psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 // psdf["a"])
 
-        ks_err_msg = "division can not be applied to given types"
+        ks_err_msg = "Division can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] // psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] // "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" // psdf["b"])
@@ -2418,11 +2418,11 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = "modulo can not be applied to given types"
+        ks_err_msg = "Modulo can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] % psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] % "literal")
 
-        ks_err_msg = "modulo can not be applied to strings"
+        ks_err_msg = "Modulo can not be applied to strings"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] % psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 % psdf["a"])
 
@@ -2442,7 +2442,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [2]})
-        ks_err_msg = "multiplication can not be applied to given types"
+        ks_err_msg = "Multiplication can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] * "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" * psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] * "literal")

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -2388,23 +2388,23 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
 
-        ks_err_msg = "Division can not be applied to given types"
+        ks_err_msg = "True division can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] / psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] / "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" / psdf["b"])
 
-        ks_err_msg = "Division can not be applied to strings"
+        ks_err_msg = "True division can not be applied to strings"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] / psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 / psdf["a"])
 
     def test_binary_operator_floordiv(self):
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
 
-        ks_err_msg = "Division can not be applied to strings"
+        ks_err_msg = "Floor division can not be applied to strings"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] // psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 // psdf["a"])
 
-        ks_err_msg = "Division can not be applied to given types"
+        ks_err_msg = "Floor division can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] // psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] // "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" // psdf["b"])

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -2347,7 +2347,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psdf["c"] + psdf["d"], pdf["c"] + pdf["d"])
 
         # Negative
-        ks_err_msg = "string addition can only be applied to string series or literals"
+        ks_err_msg = "addition can not be applied to given types"
 
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] + psdf["c"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["c"] + psdf["a"])

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -2365,12 +2365,13 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = "subtraction can not be applied to string series or literals"
-
-        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] - psdf["b"])
+        ks_err_msg = "subtraction can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] - psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] - "literal")
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: "literal" - psdf["b"])
+
+        ks_err_msg = "subtraction can not be applied to strings"
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] - psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 - psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] - 1)
 
@@ -2417,11 +2418,12 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
         # Negative
         psdf = ps.DataFrame({"a": ["x"], "b": [1]})
-        ks_err_msg = "modulo can not be applied on string series or literals"
-
-        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] % psdf["b"])
+        ks_err_msg = "modulo can not be applied to given types"
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] % psdf["a"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["b"] % "literal")
+
+        ks_err_msg = "modulo can not be applied to strings"
+        self.assertRaisesRegex(TypeError, ks_err_msg, lambda: psdf["a"] % psdf["b"])
         self.assertRaisesRegex(TypeError, ks_err_msg, lambda: 1 % psdf["a"])
 
     def test_binary_operator_multiply(self):

--- a/python/pyspark/pandas/tests/test_series_datetime.py
+++ b/python/pyspark/pandas/tests/test_series_datetime.py
@@ -70,7 +70,7 @@ class SeriesDateTimeTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf = ps.DataFrame(
             {"a": pd.date_range("2016-12-31", "2017-01-08", freq="D"), "b": pd.Series(range(9))}
         )
-        expected_error_message = "datetime subtraction can only be applied to datetime series."
+        expected_error_message = "Datetime subtraction can only be applied to datetime series."
         with self.assertRaisesRegex(TypeError, expected_error_message):
             psdf["a"] - psdf["b"]
         with self.assertRaisesRegex(TypeError, expected_error_message):
@@ -104,7 +104,7 @@ class SeriesDateTimeTest(PandasOnSparkTestCase, SQLTestUtils):
             self.assertRaisesRegex(TypeError, expected_err_msg, lambda: psser % other)
             self.assertRaisesRegex(TypeError, expected_err_msg, lambda: other % psser)
 
-        expected_err_msg = "datetime subtraction can only be applied to datetime series."
+        expected_err_msg = "Datetime subtraction can only be applied to datetime series."
 
         for other in [1, 0.1]:
             self.assertRaisesRegex(TypeError, expected_err_msg, lambda: psser - other)
@@ -135,7 +135,7 @@ class SeriesDateTimeTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf = ps.DataFrame(
             {"a": pd.date_range("2016-12-31", "2017-01-08", freq="D"), "b": pd.Series(range(9))}
         )
-        expected_error_message = "date subtraction can only be applied to date series."
+        expected_error_message = "Date subtraction can only be applied to date series."
         with self.assertRaisesRegex(TypeError, expected_error_message):
             psdf["a"].dt.date - psdf["b"]
         with self.assertRaisesRegex(TypeError, expected_error_message):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
The PR is proposed to standardize TypeError messages for unsupported basic operations by:
- Capitalize the first letter
- Leverage TypeError messages defined in `pyspark/pandas/data_type_ops/base.py`
- Take advantage of the utility `is_valid_operand_for_numeric_arithmetic` to save duplicated TypeError messages

Related unit tests should be adjusted as well.

### Why are the changes needed?
Inconsistent TypeError messages are shown for unsupported data-type-based basic operations.

Take addition's TypeError messages for example:
- addition can not be applied to given types.
- string addition can only be applied to string series or literals.

Standardizing TypeError messages would improve user experience and reduce maintenance costs.


### Does this PR introduce _any_ user-facing change?
No user-facing behavior change. Only TypeError messages are modified.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests.

Keyword: SPARK-35337