### PR TITLE
[SPARK-36048][TEST][CORE] Fix HealthTrackerSuite.allExecutorAndHostIds

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/HealthTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/HealthTrackerSuite.scala
@@ -62,11 +62,11 @@ class HealthTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with Mock
   // All executors and hosts used in tests should be in this set, so that [[assertEquivalentToSet]]
   // works.  Its OK if its got extraneous entries
   val allExecutorAndHostIds = {
-    (('A' to 'Z')++ (1 to 100).map(_.toString))
-      .flatMap{ suffix =>
+    ('A' to 'Z')
+      .flatMap { suffix =>
         Seq(s"host$suffix", s"host-$suffix")
       }
-  }.toSet
+  }.toSet ++ (1 to 100).map(_.toString)
 
   /**
    * Its easier to write our tests as if we could directly look at the sets of nodes & executors in
@@ -74,11 +74,9 @@ class HealthTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with Mock
    * something similar, since we know the universe of values that might appear in these sets.
    */
   def assertEquivalentToSet(f: String => Boolean, expected: Set[String]): Unit = {
-    allExecutorAndHostIds.foreach { id =>
-      val actual = f(id)
-      val exp = expected.contains(id)
-      assert(actual === exp, raw"""for string "$id" """)
-    }
+    val actual = allExecutorAndHostIds.filter(f)
+    assert(actual.size === expected.size)
+    assert(actual.forall(expected.contains))
   }
 
   def mockTaskSchedWithConf(conf: SparkConf): TaskSchedulerImpl = {

--- a/core/src/test/scala/org/apache/spark/scheduler/HealthTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/HealthTrackerSuite.scala
@@ -74,9 +74,11 @@ class HealthTrackerSuite extends SparkFunSuite with BeforeAndAfterEach with Mock
    * something similar, since we know the universe of values that might appear in these sets.
    */
   def assertEquivalentToSet(f: String => Boolean, expected: Set[String]): Unit = {
-    val actual = allExecutorAndHostIds.filter(f)
-    assert(actual.size === expected.size)
-    assert(actual.forall(expected.contains))
+    allExecutorAndHostIds.foreach { id =>
+      val actual = f(id)
+      val exp = expected.contains(id)
+      assert(actual === exp, raw"""for string "$id" """)
+    }
   }
 
   def mockTaskSchedWithConf(conf: SparkConf): TaskSchedulerImpl = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error message, please read the guideline first:
     https://spark.apache.org/error-message-guidelines.html
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Fix the executor ids that are declared at `allExecutorAndHostIds`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, `HealthTrackerSuite.allExecutorAndHostIds` is mistakenly declared, which leads to the executor exclusion isn't correctly tested.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Pass existing tests in `HealthTrackerSuite`.