### PR TITLE
[SPARK-35956][K8S] Support auto assigning labels to decommissioning pods

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -8,9 +8,9 @@ license: |
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -422,7 +422,7 @@ Your Kubernetes config file typically lives under `.kube/config` in your home di
 
 ### Contexts
 
-Kubernetes configuration files can contain multiple contexts that allow for switching between different clusters and/or user identities.  By default Spark on Kubernetes will use your current context (which can be checked by running `kubectl config current-context`) when doing the initial auto-configuration of the Kubernetes client.  
+Kubernetes configuration files can contain multiple contexts that allow for switching between different clusters and/or user identities.  By default Spark on Kubernetes will use your current context (which can be checked by running `kubectl config current-context`) when doing the initial auto-configuration of the Kubernetes client.
 
 In order to use an alternative context users can specify the desired context via the Spark configuration property `spark.kubernetes.context` e.g. `spark.kubernetes.context=minikube`.
 
@@ -1038,7 +1038,7 @@ See the [configuration page](configuration.html) for information on Spark config
    <code>spark.kubernetes.executor.secrets.ENV_VAR=spark-secret:key</code>.
   </td>
   <td>2.4.0</td>
-</tr>   
+</tr>
 <tr>
   <td><code>spark.kubernetes.driver.volumes.[VolumeType].[VolumeName].mount.path</code></td>
   <td>(none)</td>
@@ -1270,7 +1270,7 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
   <td>3.0.0</td>
 </tr>
-<tr>  
+<tr>
   <td><code>spark.kubernetes.appKillPodDeletionGracePeriod</code></td>
   <td>(none)</td>
   <td>
@@ -1289,7 +1289,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>3.0.0</td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.executor.pod.decommmissionLabel<code></td>
+  <td><code>spark.kubernetes.executor.decommmissionLabel<code></td>
   <td>(none)</td>
   <td>
     Label to be applied to pods which are exiting or being decommissioned. Intended for use
@@ -1298,11 +1298,11 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>3.3.0</td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.executor.pod.decommmissionLabelValue<code></td>
-  <td>""</td>
+  <td><code>spark.kubernetes.executor.decommmissionLabelValue<code></td>
+  <td>(none)</td>
   <td>
     Value to be applied with the label when
-	<code>spark.kubernetes.executor.pod.decommmissionLabel</code> is enabled.
+    <code>spark.kubernetes.executor.decommmissionLabel</code> is enabled.
   </td>
   <td>3.3.0</td>
 </tr>

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1288,6 +1288,24 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
   <td>3.0.0</td>
 </tr>
+<tr>
+  <td><code>spark.kubernetes.executor.pod.decommmissionLabel<code></td>
+  <td>(none)</td>
+  <td>
+    Label to be applied to pods which are exiting or being decommissioned. Intended for use
+    with pod disruption budgets, deletion costs, and similar.
+  </td>
+  <td>3.3.0</td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.executor.pod.decommmissionLabelValue<code></td>
+  <td>""</td>
+  <td>
+    Value to be applied with the label when
+	<code>spark.kubernetes.executor.pod.decommmissionLabel</code> is enabled.
+  </td>
+  <td>3.3.0</td>
+</tr>
 </table>
 
 #### Pod template properties

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -305,6 +305,24 @@ private[spark] object Config extends Logging {
       .toSequence
       .createWithDefault(Nil)
 
+  val KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL =
+    ConfigBuilder("spark.kubernetes.executor.pod.decommmissionLabel")
+      .doc("Label to apply to a pod which is being decommissioned." +
+        " Designed for use with pod disruption budgets and similar mechanism " +
+        " such as pod-deletion-cost.")
+      .version("3.2.0")
+      .stringConf
+      .createOptional
+
+  val KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL_VALUE =
+    ConfigBuilder("spark.kubernetes.executor.pod.decommmissionLabelValue")
+      .doc("Label value to apply to a pod which is being decommissioned." +
+        " Designed for use with pod disruption budgets and similar mechanism " +
+        " such as pod-deletion-cost.")
+      .version("3.2.0")
+      .stringConf
+      .createWithDefault("")
+
   val KUBERNETES_ALLOCATION_BATCH_SIZE =
     ConfigBuilder("spark.kubernetes.allocation.batch.size")
       .doc("Number of pods to launch at once in each round of executor allocation.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -321,7 +321,7 @@ private[spark] object Config extends Logging {
         " such as pod-deletion-cost.")
       .version("3.3.0")
       .stringConf
-      .createWithDefault("")
+      .createOptional
 
   val KUBERNETES_ALLOCATION_BATCH_SIZE =
     ConfigBuilder("spark.kubernetes.allocation.batch.size")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -305,8 +305,8 @@ private[spark] object Config extends Logging {
       .toSequence
       .createWithDefault(Nil)
 
-  val KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL =
-    ConfigBuilder("spark.kubernetes.executor.pod.decommmissionLabel")
+  val KUBERNETES_EXECUTOR_DECOMMISSION_LABEL =
+    ConfigBuilder("spark.kubernetes.executor.decommmissionLabel")
       .doc("Label to apply to a pod which is being decommissioned." +
         " Designed for use with pod disruption budgets and similar mechanism" +
         " such as pod-deletion-cost.")
@@ -314,8 +314,8 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
-  val KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL_VALUE =
-    ConfigBuilder("spark.kubernetes.executor.pod.decommmissionLabelValue")
+  val KUBERNETES_EXECUTOR_DECOMMISSION_LABEL_VALUE =
+    ConfigBuilder("spark.kubernetes.executor.decommmissionLabelValue")
       .doc("Label value to apply to a pod which is being decommissioned." +
         " Designed for use with pod disruption budgets and similar mechanism" +
         " such as pod-deletion-cost.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -308,18 +308,18 @@ private[spark] object Config extends Logging {
   val KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL =
     ConfigBuilder("spark.kubernetes.executor.pod.decommmissionLabel")
       .doc("Label to apply to a pod which is being decommissioned." +
-        " Designed for use with pod disruption budgets and similar mechanism " +
+        " Designed for use with pod disruption budgets and similar mechanism" +
         " such as pod-deletion-cost.")
-      .version("3.2.0")
+      .version("3.3.0")
       .stringConf
       .createOptional
 
   val KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL_VALUE =
     ConfigBuilder("spark.kubernetes.executor.pod.decommmissionLabelValue")
       .doc("Label value to apply to a pod which is being decommissioned." +
-        " Designed for use with pod disruption budgets and similar mechanism " +
+        " Designed for use with pod disruption budgets and similar mechanism" +
         " such as pod-deletion-cost.")
-      .version("3.2.0")
+      .version("3.3.0")
       .stringConf
       .createWithDefault("")
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -188,8 +188,8 @@ private[spark] class KubernetesClusterSchedulerBackend(
   private def labelLowPriorityExecs(execIds: Seq[String]) = {
     // Only kick off the labeling task if we have a label.
     conf.get(KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL).foreach { label =>
-      val labelTask = new Runnable() {
-        override def run(): Unit = Utils.tryLogNonFatalError {
+//      val labelTask = new Runnable() {
+//        override def run(): Unit = Utils.tryLogNonFatalError {
 
           val podsToLabel = kubernetesClient.pods()
             .withLabel(SPARK_APP_ID_LABEL, applicationId())
@@ -206,9 +206,9 @@ private[spark] class KubernetesClusterSchedulerBackend(
                 .endMetadata()
                 .build()})
           }
-        }
-      }
-      executorService.submit(labelTask)
+//        }
+//      }
+//      executorService.submit(labelTask)
     }
   }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -188,8 +188,8 @@ private[spark] class KubernetesClusterSchedulerBackend(
   private def labelLowPriorityExecs(execIds: Seq[String]) = {
     // Only kick off the labeling task if we have a label.
     conf.get(KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL).foreach { label =>
-//      val labelTask = new Runnable() {
-//        override def run(): Unit = Utils.tryLogNonFatalError {
+      val labelTask = new Runnable() {
+        override def run(): Unit = Utils.tryLogNonFatalError {
 
           val podsToLabel = kubernetesClient.pods()
             .withLabel(SPARK_APP_ID_LABEL, applicationId())
@@ -206,9 +206,9 @@ private[spark] class KubernetesClusterSchedulerBackend(
                 .endMetadata()
                 .build()})
           }
-//        }
-//      }
-//      executorService.submit(labelTask)
+        }
+      }
+      executorService.execute(labelTask)
     }
   }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -185,7 +185,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
     super.getExecutorIds()
   }
 
-  private def labelLowPriorityExecs(execIds: Seq[String]) = {
+  private def labelDecommissioningExecs(execIds: Seq[String]) = {
     // Only kick off the labeling task if we have a label.
     conf.get(KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL).foreach { label =>
       val labelTask = new Runnable() {
@@ -219,7 +219,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
     // If decommissioning is triggered by the executor the K8s cluster manager has already
     // picked the pod to evict so we don't need to update the labels.
     if (!triggeredByExecutor) {
-      labelLowPriorityExecs(executorsAndDecomInfo.map(_._1))
+      labelDecommissioningExecs(executorsAndDecomInfo.map(_._1))
     }
     super.decommissionExecutors(executorsAndDecomInfo, adjustTargetNumExecutors,
       triggeredByExecutor)
@@ -227,7 +227,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
 
   override def doKillExecutors(executorIds: Seq[String]): Future[Boolean] = {
     // If we've decided to remove some executors we should tell Kubernetes that we don't care.
-    labelLowPriorityExecs(executorIds)
+    labelDecommissioningExecs(executorIds)
 
     // Tell the executors to exit themselves.
     executorIds.foreach { id =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -202,7 +202,8 @@ private[spark] class KubernetesClusterSchedulerBackend(
               .inNamespace(pod.getMetadata.getNamespace)
               .withName(pod.getMetadata.getName)
               .edit({p: Pod => new PodBuilder(p).editMetadata()
-                .addToLabels(label, conf.get(KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL_VALUE))
+                .addToLabels(label,
+                  conf.get(KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL_VALUE).getOrElse(""))
                 .endMetadata()
                 .build()})
           }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -187,7 +187,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
 
   private def labelDecommissioningExecs(execIds: Seq[String]) = {
     // Only kick off the labeling task if we have a label.
-    conf.get(KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL).foreach { label =>
+    conf.get(KUBERNETES_EXECUTOR_DECOMMISSION_LABEL).foreach { label =>
       val labelTask = new Runnable() {
         override def run(): Unit = Utils.tryLogNonFatalError {
 
@@ -203,7 +203,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
               .withName(pod.getMetadata.getName)
               .edit({p: Pod => new PodBuilder(p).editMetadata()
                 .addToLabels(label,
-                  conf.get(KUBERNETES_EXECUTOR_POD_DECOMMISSION_LABEL_VALUE).getOrElse(""))
+                  conf.get(KUBERNETES_EXECUTOR_DECOMMISSION_LABEL_VALUE).getOrElse(""))
                 .endMetadata()
                 .build()})
           }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
@@ -211,11 +211,11 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
     schedulerBackendUnderTest.doKillExecutors(Seq("1", "2"))
     verify(driverEndpointRef).send(RemoveExecutor("1", ExecutorKilled))
     verify(driverEndpointRef).send(RemoveExecutor("2", ExecutorKilled))
+    verify(labeledPods, never()).delete()
     verify(pod1op, never()).edit(any(
       classOf[java.util.function.UnaryOperator[io.fabric8.kubernetes.api.model.Pod]]))
     verify(pod2op, never()).edit(any(
       classOf[java.util.function.UnaryOperator[io.fabric8.kubernetes.api.model.Pod]]))
-    verify(labeledPods, never()).delete()
     schedulerExecutorService.tick(sparkConf.get(KUBERNETES_DYN_ALLOC_KILL_GRACE_PERIOD) * 2,
       TimeUnit.MILLISECONDS)
     verify(labeledPods, never()).delete()
@@ -227,6 +227,7 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
     when(podList.getItems()).thenReturn(Arrays.asList(pod1))
     schedulerBackendUnderTest.doKillExecutors(Seq("1", "2"))
     verify(labeledPods, never()).delete()
+    schedulerExecutorService.runUntilIdle()
     verify(pod1op).edit(any(
       classOf[java.util.function.UnaryOperator[io.fabric8.kubernetes.api.model.Pod]]))
     verify(pod2op, never()).edit(any(

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
@@ -19,8 +19,9 @@ package org.apache.spark.scheduler.cluster.k8s
 import java.util.Arrays
 import java.util.concurrent.TimeUnit
 
-import io.fabric8.kubernetes.api.model.{Pod, PodList}
+import io.fabric8.kubernetes.api.model.{ObjectMeta, Pod, PodList}
 import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.dsl.{NonNamespaceOperation, PodResource}
 import org.jmock.lib.concurrent.DeterministicScheduler
 import org.mockito.{ArgumentCaptor, Mock, MockitoAnnotations}
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
@@ -169,10 +170,8 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
   test("Kill executors") {
     schedulerBackendUnderTest.start()
 
-    val operation = mock(classOf[io.fabric8.kubernetes.client.dsl.NonNamespaceOperation[
-      io.fabric8.kubernetes.api.model.Pod,
-      io.fabric8.kubernetes.api.model.PodList,
-      io.fabric8.kubernetes.client.dsl.PodResource[io.fabric8.kubernetes.api.model.Pod]]])
+    val operation = mock(classOf[NonNamespaceOperation[
+      Pod, PodList, PodResource[Pod]]])
 
     when(podOperations.inNamespace(any())).thenReturn(operation)
     when(podOperations.withField(any(), any())).thenReturn(labeledPods)
@@ -182,21 +181,19 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
     when(labeledPods.withLabelIn(SPARK_EXECUTOR_ID_LABEL, "1", "2")).thenReturn(labeledPods)
 
     val pod1 = mock(classOf[Pod])
-    val pod1Metadata = mock(classOf[io.fabric8.kubernetes.api.model.ObjectMeta])
+    val pod1Metadata = mock(classOf[ObjectMeta])
     when(pod1Metadata.getNamespace).thenReturn("coffeeIsLife")
     when(pod1Metadata.getName).thenReturn("pod1")
     when(pod1.getMetadata).thenReturn(pod1Metadata)
 
     val pod2 = mock(classOf[Pod])
-    val pod2Metadata = mock(classOf[io.fabric8.kubernetes.api.model.ObjectMeta])
+    val pod2Metadata = mock(classOf[ObjectMeta])
     when(pod2Metadata.getNamespace).thenReturn("coffeeIsLife")
     when(pod2Metadata.getName).thenReturn("pod2")
     when(pod2.getMetadata).thenReturn(pod2Metadata)
 
-    val pod1op = mock(classOf[
-      io.fabric8.kubernetes.client.dsl.PodResource[io.fabric8.kubernetes.api.model.Pod]])
-    val pod2op = mock(classOf[
-      io.fabric8.kubernetes.client.dsl.PodResource[io.fabric8.kubernetes.api.model.Pod]])
+    val pod1op = mock(classOf[PodResource[Pod]])
+    val pod2op = mock(classOf[PodResource[Pod]])
     when(operation.withName("pod1")).thenReturn(pod1op)
     when(operation.withName("pod2")).thenReturn(pod2op)
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
@@ -45,8 +45,8 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
   private val sparkConf = new SparkConf(false)
     .set("spark.executor.instances", "3")
     .set("spark.app.id", TEST_SPARK_APP_ID)
-    .set("spark.kubernetes.executor.pod.decommmissionLabel", "soLong")
-    .set("spark.kubernetes.executor.pod.decommmissionLabelValue", "cruelWorld")
+    .set("spark.kubernetes.executor.decommmissionLabel", "soLong")
+    .set("spark.kubernetes.executor.decommmissionLabelValue", "cruelWorld")
 
   @Mock
   private var sc: SparkContext = _

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
@@ -204,7 +204,6 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
       TimeUnit.MILLISECONDS)
     verify(labeledPods, never()).delete()
 
-
     schedulerBackendUnderTest.doKillExecutors(Seq("1", "2"))
     verify(driverEndpointRef).send(RemoveExecutor("1", ExecutorKilled))
     verify(driverEndpointRef).send(RemoveExecutor("2", ExecutorKilled))

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -105,8 +105,8 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
       // give enough time to validate the labels are set.
       .set("spark.storage.decommission.replicationReattemptInterval", "60")
       // Configure labels for decommissioning pods.
-      .set("spark.kubernetes.executor.pod.decommmissionLabel", "solong")
-      .set("spark.kubernetes.executor.pod.decommmissionLabelValue", "cruelworld")
+      .set("spark.kubernetes.executor.decommmissionLabel", "solong")
+      .set("spark.kubernetes.executor.decommmissionLabelValue", "cruelworld")
 
     // This is called on all exec pods but we only care about exec 0 since it's the "first."
     // We only do this inside of this test since the other tests trigger k8s side deletes where we

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -103,7 +103,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
       .set(config.DYN_ALLOCATION_ENABLED.key, "true")
       // The default of 30 seconds is fine, but for testing we just want to
       // give enough time to validate the labels are set.
-      .set("spark.storage.decommission.replicationReattemptInterval", "60")
+      .set("spark.storage.decommission.replicationReattemptInterval", "75")
       // Configure labels for decommissioning pods.
       .set("spark.kubernetes.executor.decommmissionLabel", "solong")
       .set("spark.kubernetes.executor.decommmissionLabelValue", "cruelworld")
@@ -116,7 +116,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
         val client = kubernetesTestComponents.kubernetesClient
         // The label will be added eventually, but k8s objects don't refresh.
         Eventually.eventually(
-          PatienceConfiguration.Timeout(Span(900, Seconds)),
+          PatienceConfiguration.Timeout(Span(1200, Seconds)),
           PatienceConfiguration.Interval(Span(1, Seconds))) {
 
           val currentPod = client.pods().withName(pod.getMetadata.getName).get

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -116,7 +116,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
         val client = kubernetesTestComponents.kubernetesClient
         // The label will be added eventually, but k8s objects don't refresh.
         Eventually.eventually(
-          PatienceConfiguration.Timeout(Span(180, Seconds)),
+          PatienceConfiguration.Timeout(Span(900, Seconds)),
           PatienceConfiguration.Interval(Span(1, Seconds))) {
 
           val currentPod = client.pods().withName(pod.getMetadata.getName).get

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -101,9 +101,9 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
       .set(config.DYN_ALLOCATION_MIN_EXECUTORS.key, "1")
       .set(config.DYN_ALLOCATION_INITIAL_EXECUTORS.key, "2")
       .set(config.DYN_ALLOCATION_ENABLED.key, "true")
-      // The default of 30 seconds is fine, but for testing we just want to get this done fast
-      // but give enough time to validate the labels are set.
-      .set("spark.storage.decommission.replicationReattemptInterval", "20")
+      // The default of 30 seconds is fine, but for testing we just want to
+      // give enough time to validate the labels are set.
+      .set("spark.storage.decommission.replicationReattemptInterval", "60")
       // Configure labels for decommissioning pods.
       .set("spark.kubernetes.executor.pod.decommmissionLabel", "solong")
       .set("spark.kubernetes.executor.pod.decommmissionLabelValue", "cruelworld")
@@ -116,8 +116,8 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
         val client = kubernetesTestComponents.kubernetesClient
         // The label will be added eventually, but k8s objects don't refresh.
         Eventually.eventually(
-          PatienceConfiguration.Timeout(Span(120, Seconds)),
-          PatienceConfiguration.Interval(Span(2, Seconds))) {
+          PatienceConfiguration.Timeout(Span(180, Seconds)),
+          PatienceConfiguration.Interval(Span(1, Seconds))) {
 
           val currentPod = client.pods().withName(pod.getMetadata.getName).get
           val labels = currentPod.getMetadata.getLabels.asScala

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -16,9 +16,11 @@
  */
 package org.apache.spark.deploy.k8s.integrationtest
 
-import org.scalatest.concurrent.PatienceConfiguration
-import org.scalatest.time.Minutes
-import org.scalatest.time.Span
+import scala.collection.JavaConverters._
+
+import io.fabric8.kubernetes.api.model.Pod
+import org.scalatest.concurrent.{Eventually, PatienceConfiguration}
+import org.scalatest.time.{Minutes, Seconds, Span}
 
 import org.apache.spark.internal.config
 
@@ -98,10 +100,32 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
       .set(config.DYN_ALLOCATION_MIN_EXECUTORS.key, "1")
       .set(config.DYN_ALLOCATION_INITIAL_EXECUTORS.key, "2")
       .set(config.DYN_ALLOCATION_ENABLED.key, "true")
-      // The default of 30 seconds is fine, but for testing we just want to get this done fast.
-      .set("spark.storage.decommission.replicationReattemptInterval", "1")
+      // The default of 30 seconds is fine, but for testing we just want to get this done fast
+      // but give enough time to validate the labels are set.
+      .set("spark.storage.decommission.replicationReattemptInterval", "10")
+      // Configure labels for decommissioning pods.
+      .set("spark.kubernetes.executor.pod.decommmissionLabel", "soLong")
+      .set("spark.kubernetes.executor.pod.decommmissionLabelValue", "cruelWorld")
 
-    var execLogs: String = ""
+    // This is called on all exec pods but we only care about exec 0 since it's the "first."
+    // We only do this inside of this test since the other tests trigger k8s side deletes where we
+    // do not apply labels.
+    def checkFirstExecutorPodGetsLabeled(pod: Pod): Unit = {
+      if (pod.getMetadata.getName.endsWith("-1")) {
+        val client = kubernetesTestComponents.kubernetesClient
+        // The label will be added eventually, but k8s objects don't refresh.
+        Eventually.eventually(
+          PatienceConfiguration.Timeout(Span(30, Seconds)),
+          PatienceConfiguration.Interval(Span(1, Seconds))) {
+
+          val currentPod = client.pods().withName(pod.getMetadata.getName).get
+          val labels = currentPod.getMetadata.getLabels.asScala
+          assert(labels.contains("soLong"))
+          assert(labels.get("soLong") === "cruelWorld")
+        }
+      }
+      doBasicExecutorPyPodCheck(pod)
+    }
 
     runSparkApplicationAndVerifyCompletion(
       appResource = PYSPARK_SCALE,
@@ -113,7 +137,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
           "driver killed: 0, unexpectedly exited: 0)."),
       appArgs = Array.empty[String],
       driverPodChecker = doBasicDriverPyPodCheck,
-      executorPodChecker = doBasicExecutorPyPodCheck,
+      executorPodChecker = checkFirstExecutorPodGetsLabeled,
       isJVM = false,
       pyFiles = None,
       executorPatience = Some(None, Some(DECOMMISSIONING_FINISHED_TIMEOUT)),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new configuration flag to allow Spark to provide hints to the scheduler when we are decommissioning or exiting a pod that this pod will have the least impact for a pre-emption event.

### Why are the changes needed?

Kubernetes added the concepts of pod disruption budgets (which can have selectors based on labels) as well pod deletion for providing hints to the scheduler as to what we would prefer to have pre-empted.

### Does this PR introduce _any_ user-facing change?

New configuration flag

### How was this patch tested?

The deletion unit test was extended.