### PR TITLE
[SPARK-36044][SQL] Suport TimestampNTZ in functions unix_timestamp/to_unix_timestamp

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1091,8 +1091,13 @@ abstract class ToTimestamp
   override protected def formatString: Expression = right
   override protected def isParsing = true
 
+  override def forTimestampNTZ: Boolean = left.dataType match {
+    case TimestampNTZType => true
+    case _ => false
+  }
+
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(StringType, DateType, TimestampType), StringType)
+    Seq(TypeCollection(StringType, DateType, TimestampType, TimestampNTZType), StringType)
 
   override def dataType: DataType = LongType
   override def nullable: Boolean = if (failOnError) children.exists(_.nullable) else true
@@ -1112,7 +1117,7 @@ abstract class ToTimestamp
       left.dataType match {
         case DateType =>
           daysToMicros(t.asInstanceOf[Int], zoneId) / downScaleFactor
-        case TimestampType =>
+        case TimestampType | TimestampNTZType =>
           t.asInstanceOf[Long] / downScaleFactor
         case StringType =>
           val fmt = right.eval(input)
@@ -1192,7 +1197,7 @@ abstract class ToTimestamp
              |}
              |""".stripMargin)
       }
-      case TimestampType =>
+      case TimestampType | TimestampNTZType =>
         val eval1 = left.genCode(ctx)
         ev.copy(code = code"""
           ${eval1.code}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1091,10 +1091,7 @@ abstract class ToTimestamp
   override protected def formatString: Expression = right
   override protected def isParsing = true
 
-  override def forTimestampNTZ: Boolean = left.dataType match {
-    case TimestampNTZType => true
-    case _ => false
-  }
+  override def forTimestampNTZ: Boolean = left.dataType == TimestampNTZType
 
   override def inputTypes: Seq[AbstractDataType] =
     Seq(TypeCollection(StringType, DateType, TimestampType, TimestampNTZType), StringType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -915,6 +915,11 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
                 Literal(new Timestamp(1000000)), Literal("yyyy-MM-dd HH:mm:ss"), timeZoneId),
               1000L)
             checkEvaluation(
+              UnixTimestamp(
+                Literal(DateTimeUtils.microsToLocalDateTime(DateTimeUtils.millisToMicros(1000000))),
+                Literal("yyyy-MM-dd HH:mm:ss"), timeZoneId),
+              1000L)
+            checkEvaluation(
               UnixTimestamp(Literal(date1), Literal("yyyy-MM-dd HH:mm:ss"), timeZoneId),
               MICROSECONDS.toSeconds(
                 DateTimeUtils.daysToMicros(DateTimeUtils.fromJavaDate(date1), tz.toZoneId)))
@@ -979,6 +984,10 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
               1000L)
             checkEvaluation(ToUnixTimestamp(
               Literal(new Timestamp(1000000)), Literal(fmt1)),
+              1000L)
+            checkEvaluation(ToUnixTimestamp(
+              Literal(DateTimeUtils.microsToLocalDateTime(DateTimeUtils.millisToMicros(1000000))),
+              Literal(fmt1)),
               1000L)
             checkEvaluation(
               ToUnixTimestamp(Literal(date1), Literal(fmt1), timeZoneId),


### PR DESCRIPTION
### What changes were proposed in this pull request?
The functions `unix_timestamp`/`to_unix_timestamp` should be able to accept input of `TimestampNTZType`.


### Why are the changes needed?
The functions `unix_timestamp`/`to_unix_timestamp` should be able to accept input of `TimestampNTZType`.


### Does this PR introduce _any_ user-facing change?
'Yes'.


### How was this patch tested?
New tests.
