### PR TITLE
[SPARK-36073][SQL] EquivalentExpressions fixes and improvements

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
@@ -24,7 +24,6 @@ import scala.collection.mutable
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.objects.LambdaVariable
-import org.apache.spark.sql.errors.QueryExecutionErrors
 
 /**
  * This class is used to compute equality of (sub)expression trees. Expressions can be added
@@ -67,14 +66,16 @@ class EquivalentExpressions {
             false
           } else {
             // Should not happen
-            throw QueryExecutionErrors.updateEquivalentExpressionsError(expr, map, useCount)
+            throw new IllegalStateException(
+              s"Cannot update expression: $expr in map: $map with use count: $useCount")
           }
         case _ =>
           if (useCount > 0) {
             map.put(wrapper, ExpressionStats(expr)(useCount))
           } else {
             // Should not happen
-            throw QueryExecutionErrors.updateEquivalentExpressionsError(expr, map, useCount)
+            throw new IllegalStateException(
+              s"Cannot update expression: $expr in map: $map with use count: $useCount")
           }
           false
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -28,8 +28,6 @@ import java.time.temporal.ChronoField
 import java.util.ConcurrentModificationException
 import java.util.concurrent.TimeoutException
 
-import scala.collection.mutable
-
 import com.fasterxml.jackson.core.{JsonParser, JsonToken}
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FileStatus, Path}
 import org.apache.hadoop.fs.permission.FsPermission
@@ -44,7 +42,7 @@ import org.apache.spark.sql.catalyst.ScalaReflection.Schema
 import org.apache.spark.sql.catalyst.WalkedTypePath
 import org.apache.spark.sql.catalyst.analysis.UnresolvedGenerator
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogTable}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, ExpressionEquals, ExpressionStats, UnevaluableAggregate}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, UnevaluableAggregate}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.{DomainJoin, LogicalPlan}
@@ -1890,14 +1888,6 @@ object QueryExecutionErrors {
 
   def hiveTableWithAnsiIntervalsError(tableName: String): Throwable = {
     new UnsupportedOperationException(s"Hive table $tableName with ANSI intervals is not supported")
-  }
-
-  def updateEquivalentExpressionsError(
-      expr: Expression,
-      map: mutable.HashMap[ExpressionEquals, ExpressionStats],
-      useCount: Int): Throwable = {
-    throw new IllegalArgumentException(
-      s"Cannot update expression: $expr in map: $map with use count: $useCount")
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -28,6 +28,8 @@ import java.time.temporal.ChronoField
 import java.util.ConcurrentModificationException
 import java.util.concurrent.TimeoutException
 
+import scala.collection.mutable
+
 import com.fasterxml.jackson.core.{JsonParser, JsonToken}
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FileStatus, Path}
 import org.apache.hadoop.fs.permission.FsPermission
@@ -42,7 +44,7 @@ import org.apache.spark.sql.catalyst.ScalaReflection.Schema
 import org.apache.spark.sql.catalyst.WalkedTypePath
 import org.apache.spark.sql.catalyst.analysis.UnresolvedGenerator
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, CatalogTable}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, UnevaluableAggregate}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, ExpressionEquals, ExpressionStats, UnevaluableAggregate}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.{DomainJoin, LogicalPlan}
@@ -1889,4 +1891,13 @@ object QueryExecutionErrors {
   def hiveTableWithAnsiIntervalsError(tableName: String): Throwable = {
     new UnsupportedOperationException(s"Hive table $tableName with ANSI intervals is not supported")
   }
+
+  def updateEquivalentExpressionsError(
+      expr: Expression,
+      map: mutable.HashMap[ExpressionEquals, ExpressionStats],
+      useCount: Int): Throwable = {
+    throw new IllegalArgumentException(
+      s"Cannot update expression: $expr in map: $map with use count: $useCount")
+  }
 }
+

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -338,6 +338,19 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     assert(commonExprs.head.expr eq add)
   }
 
+  test("SPARK-36073: Transparently canonicalized expressions are not necessary subexpressions") {
+    val add = Add(Literal(1), Literal(2))
+    val transparent = PromotePrecision(add)
+
+    val equivalence = new EquivalentExpressions
+    equivalence.addExprTree(transparent)
+
+    val commonExprs = equivalence.getAllExprStates()
+    assert(commonExprs.size == 2)
+    assert(commonExprs.map(_.useCount) === Seq(1, 1))
+    assert(commonExprs.map(_.expr) === Seq(add, transparent))
+  }
+
   test("SPARK-35439: Children subexpr should come first than parent subexpr") {
     val add = Add(Literal(1), Literal(2))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -323,6 +323,21 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     assert(commonExprs.head.expr eq add3)
   }
 
+  test("SPARK-36073: SubExpr elimination should include common child exprs of conditional " +
+    "expressions") {
+    val add = Add(Literal(1), Literal(2))
+    val ifExpr1 = If(Literal(true), add, Literal(3))
+    val ifExpr3 = If(GreaterThan(add, Literal(4)), Add(ifExpr1, add), Multiply(ifExpr1, add))
+
+    val equivalence = new EquivalentExpressions
+    equivalence.addExprTree(ifExpr3)
+
+    val commonExprs = equivalence.getAllExprStates(1)
+    assert(commonExprs.size == 1)
+    assert(commonExprs.head.useCount == 2)
+    assert(commonExprs.head.expr eq add)
+  }
+
   test("SPARK-35439: Children subexpr should come first than parent subexpr") {
     val add = Add(Literal(1), Literal(2))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR:
- Fixes the performance issue mentioned in https://github.com/apache/spark/pull/32559/files#r633488455 and partially fixed in https://github.com/apache/spark/pull/33142/files#r660897248 using a new option to remove expressions from equivalence maps.
- Fixes a bug with identifying common expressions in conditional expressions (a side effect of the above new approach). After this PR, `add` will be common subexpression in the following example:
  ```
  val add = Add(Literal(1), Literal(2))
  val ifExpr1 = If(Literal(true), add, Literal(3))
  val ifExpr3 = If(GreaterThan(add, Literal(4)), Add(ifExpr1, add), Multiply(ifExpr1, add))
  var equivalence = new EquivalentExpressions
  equivalence.addExprTree(ifExpr3)
  ```
- Fixes a bug of transparently canonicalized expressions (like `PromotePrecision`) are considered common subexpressions.
  After this PR, `transparent` will not be common subexpression in the following example:
  ```
  val add = Add(Literal(1), Literal(2))
  val transparent = PromotePrecision(add)
  var equivalence = new EquivalentExpressions
  equivalence.addExprTree(transparent)
  ```

### Why are the changes needed?
Bugfix + performance improvement.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing + new UTs.

