### PR TITLE
[SPARK-36079][SQL] Null-based filter estimate should always be in the range [0, 1]

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
@@ -127,10 +127,10 @@ case class ColumnStat(
       updatedColumnStatOpt: Option[ColumnStat] = None): ColumnStat = {
     val updatedColumnStat = updatedColumnStatOpt.getOrElse(this)
     val newDistinctCount = EstimationUtils.updateStat(oldNumRows, newNumRows,
-      distinctCount.get, updatedColumnStat.distinctCount)
+      distinctCount.get, updatedColumnStat.distinctCount.get)
     val newNullCount = EstimationUtils.updateStat(oldNumRows, newNumRows,
-      nullCount.get, updatedColumnStat.nullCount)
-    updatedColumnStat.copy(distinctCount = newDistinctCount, nullCount = newNullCount)
+      nullCount.get, updatedColumnStat.nullCount.get)
+    updatedColumnStat.copy(distinctCount = Some(newDistinctCount), nullCount = Some(newNullCount))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
@@ -127,10 +127,10 @@ case class ColumnStat(
       updatedColumnStatOpt: Option[ColumnStat] = None): ColumnStat = {
     val updatedColumnStat = updatedColumnStatOpt.getOrElse(this)
     val newDistinctCount = EstimationUtils.updateStat(oldNumRows, newNumRows,
-      distinctCount.get, updatedColumnStat.distinctCount.get)
+      distinctCount, updatedColumnStat.distinctCount)
     val newNullCount = EstimationUtils.updateStat(oldNumRows, newNumRows,
-      nullCount.get, updatedColumnStat.nullCount.get)
-    updatedColumnStat.copy(distinctCount = Some(newDistinctCount), nullCount = Some(newNullCount))
+      nullCount, updatedColumnStat.nullCount)
+    updatedColumnStat.copy(distinctCount = newDistinctCount, nullCount = newNullCount)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
@@ -130,8 +130,7 @@ case class ColumnStat(
       distinctCount.get, updatedColumnStat.distinctCount)
     val newNullCount = EstimationUtils.updateStat(oldNumRows, newNumRows,
       nullCount.get, updatedColumnStat.nullCount)
-    updatedColumnStat.copy(
-      distinctCount = Some(newDistinctCount), nullCount = Some(newNullCount))
+    updatedColumnStat.copy(distinctCount = newDistinctCount, nullCount = newNullCount)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Statistics.scala
@@ -24,6 +24,7 @@ import net.jpountz.lz4.{LZ4BlockInputStream, LZ4BlockOutputStream}
 
 import org.apache.spark.sql.catalyst.catalog.CatalogColumnStat
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
@@ -119,6 +120,19 @@ case class ColumnStat(
       maxLen = maxLen,
       histogram = histogram,
       version = version)
+
+  def updateCountStats(
+      oldNumRows: BigInt,
+      newNumRows: BigInt,
+      updatedColumnStatOpt: Option[ColumnStat] = None): ColumnStat = {
+    val updatedColumnStat = updatedColumnStatOpt.getOrElse(this)
+    val newDistinctCount = EstimationUtils.updateStat(oldNumRows, newNumRows,
+      distinctCount.get, updatedColumnStat.distinctCount)
+    val newNullCount = EstimationUtils.updateStat(oldNumRows, newNumRows,
+      nullCount.get, updatedColumnStat.nullCount)
+    updatedColumnStat.copy(
+      distinctCount = Some(newDistinctCount), nullCount = Some(newNullCount))
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -59,11 +59,11 @@ object EstimationUtils {
       oldNumRows: BigInt,
       newNumRows: BigInt,
       oldStat: BigInt,
-      updatedStatOpt: Option[BigInt]): BigInt = {
+      updatedStatOpt: Option[BigInt]): Option[BigInt] = {
     if (updatedStatOpt.forall(_ > 1) && newNumRows < oldNumRows) {
-      ceil(BigDecimal(oldStat) * BigDecimal(newNumRows) / BigDecimal(oldNumRows))
+      Some(ceil(BigDecimal(oldStat) * BigDecimal(newNumRows) / BigDecimal(oldNumRows)))
     } else {
-      updatedStatOpt.getOrElse(oldStat)
+      updatedStatOpt
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -52,14 +52,18 @@ object EstimationUtils {
   }
 
   /**
-   * Updates (scales down) the number of distinct values if the number of rows decreases after
-   * some operation (such as filter, join). Otherwise keep it unchanged.
+   * Updates (scales down) a statistic (eg. number of distinct values) if the number of rows
+   * decreases after some operation (such as filter, join). Otherwise keep it unchanged.
    */
-  def updateNdv(oldNumRows: BigInt, newNumRows: BigInt, oldNdv: BigInt): BigInt = {
-    if (newNumRows < oldNumRows) {
-      ceil(BigDecimal(oldNdv) * BigDecimal(newNumRows) / BigDecimal(oldNumRows))
+  def updateStat(
+      oldNumRows: BigInt,
+      newNumRows: BigInt,
+      oldStat: BigInt,
+      updatedStatOpt: Option[BigInt]): BigInt = {
+    if (updatedStatOpt.forall(_ > 1) && newNumRows < oldNumRows) {
+      ceil(BigDecimal(oldStat) * BigDecimal(newNumRows) / BigDecimal(oldNumRows))
     } else {
-      oldNdv
+      updatedStatOpt.getOrElse(oldStat)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -58,13 +58,14 @@ object EstimationUtils {
   def updateStat(
       oldNumRows: BigInt,
       newNumRows: BigInt,
-      oldStat: BigInt,
-      updatedStat: BigInt): BigInt = {
-    if (updatedStat > 1 && newNumRows < oldNumRows) {
-      // no need to scale down since it is already down to 1
-      ceil(BigDecimal(oldStat) * BigDecimal(newNumRows) / BigDecimal(oldNumRows))
+      oldStatOpt: Option[BigInt],
+      updatedStatOpt: Option[BigInt]): Option[BigInt] = {
+    if (oldStatOpt.isDefined && updatedStatOpt.isDefined && updatedStatOpt.get > 1 &&
+      newNumRows < oldNumRows) {
+        // no need to scale down since it is already down to 1
+        Some(ceil(BigDecimal(oldStatOpt.get) * BigDecimal(newNumRows) / BigDecimal(oldNumRows)))
     } else {
-      updatedStat
+      updatedStatOpt
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -61,6 +61,7 @@ object EstimationUtils {
       oldStat: BigInt,
       updatedStat: BigInt): BigInt = {
     if (updatedStat > 1 && newNumRows < oldNumRows) {
+      // no need to scale down since it is already down to 1
       ceil(BigDecimal(oldStat) * BigDecimal(newNumRows) / BigDecimal(oldNumRows))
     } else {
       updatedStat

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -59,11 +59,11 @@ object EstimationUtils {
       oldNumRows: BigInt,
       newNumRows: BigInt,
       oldStat: BigInt,
-      updatedStatOpt: Option[BigInt]): Option[BigInt] = {
-    if (updatedStatOpt.forall(_ > 1) && newNumRows < oldNumRows) {
-      Some(ceil(BigDecimal(oldStat) * BigDecimal(newNumRows) / BigDecimal(oldNumRows)))
+      updatedStat: BigInt): BigInt = {
+    if (updatedStat > 1 && newNumRows < oldNumRows) {
+      ceil(BigDecimal(oldStat) * BigDecimal(newNumRows) / BigDecimal(oldNumRows))
     } else {
-      updatedStatOpt
+      updatedStat
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -115,7 +115,7 @@ case class FilterEstimation(plan: Filter) extends Logging {
         }
 
       case _ =>
-        calculateSingleCondition(condition, update)
+        boundProbability(calculateSingleCondition(condition, update))
     }
   }
 
@@ -856,6 +856,10 @@ case class FilterEstimation(plan: Filter) extends Logging {
     Some(percent)
   }
 
+  // Bound result in [0, 1]
+  private def boundProbability(p: Double): Double = {
+    Math.max(0.0, Math.min(1.0, p))
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -106,7 +106,7 @@ case class FilterEstimation(plan: Filter) extends Logging {
       // The foldable Not has been processed in the ConstantFolding rule
       // This is a top-down traversal. The Not could be pushed down by the above two cases.
       case Not(l @ Literal(null, _)) =>
-        calculateSingleCondition(l, update = false)
+        calculateSingleCondition(l, update = false).map(boundProbability(_))
 
       case Not(cond) =>
         calculateFilterSelectivity(cond, update = false) match {
@@ -115,7 +115,7 @@ case class FilterEstimation(plan: Filter) extends Logging {
         }
 
       case _ =>
-        boundProbability(calculateSingleCondition(condition, update))
+        calculateSingleCondition(condition, update).map(boundProbability(_))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -233,6 +233,8 @@ case class FilterEstimation(plan: Filter) extends Logging {
     val rowCountValue = childStats.rowCount.get
     val nullPercent: Double = if (rowCountValue == 0) {
       0
+    } else if (colStat.nullCount.get > rowCountValue) {
+      1
     } else {
       (BigDecimal(colStat.nullCount.get) / BigDecimal(rowCountValue)).toDouble
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -932,7 +932,12 @@ case class ColumnStatsMap(originalMap: AttributeMap[ColumnStat]) {
         // no need to scale down since it is already down to 1 (for skewed distribution case)
         colStat.distinctCount
       }
-      attr -> colStat.copy(distinctCount = newNdv)
+      val newNullCount = if (colStat.nullCount.isEmpty) {
+        None
+      } else {
+        Some(colStat.nullCount.get.min(rowsAfterFilter))
+      }
+      attr -> colStat.copy(distinctCount = newNdv, nullCount = newNullCount)
     }
     AttributeMap(newColumnStats.toSeq)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/JoinEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/JoinEstimation.scala
@@ -308,17 +308,12 @@ case class JoinEstimation(join: Join) extends Logging {
         outputAttrStats += a -> keyStatsAfterJoin(a)
       } else {
         val oldColStat = oldAttrStats(a)
-        val oldNdv = oldColStat.distinctCount
-        val newNdv = if (oldNdv.isDefined) {
-          Some(if (join.left.outputSet.contains(a)) {
-            updateNdv(oldNumRows = leftRows, newNumRows = outputRows, oldNdv = oldNdv.get)
-          } else {
-            updateNdv(oldNumRows = rightRows, newNumRows = outputRows, oldNdv = oldNdv.get)
-          })
+        val oldNumRows = if (join.left.outputSet.contains(a)) {
+          leftRows
         } else {
-          None
+          rightRows
         }
-        val newColStat = oldColStat.copy(distinctCount = newNdv)
+        val newColStat = oldColStat.updateCountStats(oldNumRows, outputRows)
         // TODO: support nullCount updates for specific outer joins
         outputAttrStats += a -> newColStat
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -833,6 +833,17 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 0)
   }
 
+  test("SPARK-36079: Bound selectivity >= 0") {
+    val colStatNullableString = colStatString.copy(nullCount = Some(-1))
+    val condition = Filter(IsNotNull(attrString),
+      childStatsTestPlan(Seq(attrString), tableRowCount = 10L,
+        attributeMap = AttributeMap(Seq(attrString -> colStatNullableString))))
+    validateEstimatedStats(
+      condition,
+      Seq(attrString -> colStatString),
+      expectedRowCount = 10)
+  }
+
   test("ColumnStatsMap tests") {
     val attrNoDistinct = AttributeReference("att_without_distinct", IntegerType)()
     val attrNoCount = AttributeReference("att_without_count", BooleanType)()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -822,6 +822,19 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 3)
   }
 
+  test("SPARK-36079: Null count should be no higher than row count after filter") {
+    val colStatNullableString = colStatString.copy(nullCount = Some(10))
+    val condition = Filter(EqualTo(attrBool, Literal(true)),
+      childStatsTestPlan(Seq(attrBool, attrString), tableRowCount = 10L,
+        attributeMap = AttributeMap(Seq(
+          attrBool -> colStatBool, attrString -> colStatNullableString))))
+    validateEstimatedStats(
+      condition,
+      Seq(attrBool -> colStatBool.copy(distinctCount = Some(1), min = Some(true)),
+        attrString -> colStatNullableString.copy(distinctCount = Some(5), nullCount = Some(5))),
+      expectedRowCount = 5)
+  }
+
   test("SPARK-36079: Null count higher than row count") {
     val colStatNullableString = colStatString.copy(nullCount = Some(15))
     val condition = Filter(IsNotNull(attrString),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -822,6 +822,17 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 3)
   }
 
+  test("SPARK-36079: Null count higher than row count") {
+    val colStatNullableString = colStatString.copy(nullCount = Some(15))
+    val condition = Filter(IsNotNull(attrString),
+      childStatsTestPlan(Seq(attrString), tableRowCount = 10L,
+        attributeMap = AttributeMap(Seq(attrString -> colStatNullableString))))
+    validateEstimatedStats(
+      condition,
+      Seq(attrString -> colStatNullableString),
+      expectedRowCount = 0)
+  }
+
   test("ColumnStatsMap tests") {
     val attrNoDistinct = AttributeReference("att_without_distinct", IntegerType)()
     val attrNoCount = AttributeReference("att_without_count", BooleanType)()
@@ -848,7 +859,10 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     assert(!columnStatsMap.hasMinMaxStats(attrNoMinMax))
   }
 
-  private def childStatsTestPlan(outList: Seq[Attribute], tableRowCount: BigInt): StatsTestPlan = {
+  private def childStatsTestPlan(
+      outList: Seq[Attribute],
+      tableRowCount: BigInt,
+      attributeMap: AttributeMap[ColumnStat] = attributeMap): StatsTestPlan = {
     StatsTestPlan(
       outputList = outList,
       rowCount = tableRowCount,

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
@@ -4,217 +4,229 @@ TakeOrderedAndProject (39)
    +- Exchange (37)
       +- * HashAggregate (36)
          +- * Project (35)
-            +- * BroadcastHashJoin Inner BuildLeft (34)
-               :- BroadcastExchange (29)
-               :  +- * Project (28)
-               :     +- * BroadcastHashJoin Inner BuildLeft (27)
-               :        :- BroadcastExchange (22)
-               :        :  +- * Project (21)
-               :        :     +- * BroadcastHashJoin Inner BuildLeft (20)
-               :        :        :- BroadcastExchange (16)
-               :        :        :  +- * Project (15)
-               :        :        :     +- * BroadcastNestedLoopJoin Inner BuildLeft (14)
-               :        :        :        :- BroadcastExchange (10)
-               :        :        :        :  +- * Project (9)
-               :        :        :        :     +- * BroadcastHashJoin Inner BuildLeft (8)
-               :        :        :        :        :- BroadcastExchange (4)
-               :        :        :        :        :  +- * Filter (3)
-               :        :        :        :        :     +- * ColumnarToRow (2)
-               :        :        :        :        :        +- Scan parquet default.store_sales (1)
-               :        :        :        :        +- * Filter (7)
-               :        :        :        :           +- * ColumnarToRow (6)
-               :        :        :        :              +- Scan parquet default.store (5)
-               :        :        :        +- * Filter (13)
-               :        :        :           +- * ColumnarToRow (12)
-               :        :        :              +- Scan parquet default.customer_address (11)
-               :        :        +- * Filter (19)
-               :        :           +- * ColumnarToRow (18)
-               :        :              +- Scan parquet default.customer (17)
-               :        +- * Project (26)
-               :           +- * Filter (25)
-               :              +- * ColumnarToRow (24)
-               :                 +- Scan parquet default.item (23)
-               +- * Project (33)
-                  +- * Filter (32)
-                     +- * ColumnarToRow (31)
-                        +- Scan parquet default.date_dim (30)
+            +- * BroadcastHashJoin Inner BuildRight (34)
+               :- * Project (28)
+               :  +- * BroadcastHashJoin Inner BuildLeft (27)
+               :     :- BroadcastExchange (23)
+               :     :  +- * Project (22)
+               :     :     +- * BroadcastHashJoin Inner BuildRight (21)
+               :     :        :- * Project (16)
+               :     :        :  +- * BroadcastHashJoin Inner BuildLeft (15)
+               :     :        :     :- BroadcastExchange (11)
+               :     :        :     :  +- * Project (10)
+               :     :        :     :     +- * BroadcastHashJoin Inner BuildLeft (9)
+               :     :        :     :        :- BroadcastExchange (5)
+               :     :        :     :        :  +- * Project (4)
+               :     :        :     :        :     +- * Filter (3)
+               :     :        :     :        :        +- * ColumnarToRow (2)
+               :     :        :     :        :           +- Scan parquet default.date_dim (1)
+               :     :        :     :        +- * Filter (8)
+               :     :        :     :           +- * ColumnarToRow (7)
+               :     :        :     :              +- Scan parquet default.store_sales (6)
+               :     :        :     +- * Filter (14)
+               :     :        :        +- * ColumnarToRow (13)
+               :     :        :           +- Scan parquet default.customer (12)
+               :     :        +- BroadcastExchange (20)
+               :     :           +- * Filter (19)
+               :     :              +- * ColumnarToRow (18)
+               :     :                 +- Scan parquet default.store (17)
+               :     +- * Filter (26)
+               :        +- * ColumnarToRow (25)
+               :           +- Scan parquet default.customer_address (24)
+               +- BroadcastExchange (33)
+                  +- * Project (32)
+                     +- * Filter (31)
+                        +- * ColumnarToRow (30)
+                           +- Scan parquet default.item (29)
 
 
-(1) Scan parquet default.store_sales
-Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#5), (ss_sold_date_sk#5 >= 2451484), (ss_sold_date_sk#5 <= 2451513), dynamicpruningexpression(true)]
-PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_store_sk)]
-ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ext_sales_price:decimal(7,2)>
-
-(2) ColumnarToRow [codegen id : 1]
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
-
-(3) Filter [codegen id : 1]
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
-Condition : ((isnotnull(ss_item_sk#1) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_store_sk#3))
-
-(4) BroadcastExchange
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, false] as bigint)),false), [id=#6]
-
-(5) Scan parquet default.store
-Output [2]: [s_store_sk#7, s_zip#8]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_zip:string>
-
-(6) ColumnarToRow
-Input [2]: [s_store_sk#7, s_zip#8]
-
-(7) Filter
-Input [2]: [s_store_sk#7, s_zip#8]
-Condition : (isnotnull(s_zip#8) AND isnotnull(s_store_sk#7))
-
-(8) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#7]
-Join condition: None
-
-(9) Project [codegen id : 2]
-Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, s_zip#8]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, s_store_sk#7, s_zip#8]
-
-(10) BroadcastExchange
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, s_zip#8]
-Arguments: IdentityBroadcastMode, [id=#9]
-
-(11) Scan parquet default.customer_address
-Output [2]: [ca_address_sk#10, ca_zip#11]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_zip)]
-ReadSchema: struct<ca_address_sk:int,ca_zip:string>
-
-(12) ColumnarToRow
-Input [2]: [ca_address_sk#10, ca_zip#11]
-
-(13) Filter
-Input [2]: [ca_address_sk#10, ca_zip#11]
-Condition : (isnotnull(ca_address_sk#10) AND isnotnull(ca_zip#11))
-
-(14) BroadcastNestedLoopJoin [codegen id : 3]
-Join condition: NOT (substr(ca_zip#11, 1, 5) = substr(s_zip#8, 1, 5))
-
-(15) Project [codegen id : 3]
-Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, ca_address_sk#10]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, s_zip#8, ca_address_sk#10, ca_zip#11]
-
-(16) BroadcastExchange
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, ca_address_sk#10]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[4, int, true] as bigint) & 4294967295))),false), [id=#12]
-
-(17) Scan parquet default.customer
-Output [2]: [c_customer_sk#13, c_current_addr_sk#14]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
-
-(18) ColumnarToRow
-Input [2]: [c_customer_sk#13, c_current_addr_sk#14]
-
-(19) Filter
-Input [2]: [c_customer_sk#13, c_current_addr_sk#14]
-Condition : (isnotnull(c_customer_sk#13) AND isnotnull(c_current_addr_sk#14))
-
-(20) BroadcastHashJoin [codegen id : 4]
-Left keys [2]: [ss_customer_sk#2, ca_address_sk#10]
-Right keys [2]: [c_customer_sk#13, c_current_addr_sk#14]
-Join condition: None
-
-(21) Project [codegen id : 4]
-Output [3]: [ss_item_sk#1, ss_ext_sales_price#4, ss_sold_date_sk#5]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, ca_address_sk#10, c_customer_sk#13, c_current_addr_sk#14]
-
-(22) BroadcastExchange
-Input [3]: [ss_item_sk#1, ss_ext_sales_price#4, ss_sold_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
-
-(23) Scan parquet default.item
-Output [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,7), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manufact_id:int,i_manufact:string,i_manager_id:int>
-
-(24) ColumnarToRow
-Input [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
-
-(25) Filter
-Input [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
-Condition : ((isnotnull(i_manager_id#21) AND (i_manager_id#21 = 7)) AND isnotnull(i_item_sk#16))
-
-(26) Project
-Output [5]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
-Input [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
-
-(27) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#16]
-Join condition: None
-
-(28) Project [codegen id : 5]
-Output [6]: [ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
-Input [8]: [ss_item_sk#1, ss_ext_sales_price#4, ss_sold_date_sk#5, i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
-
-(29) BroadcastExchange
-Input [6]: [ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#22]
-
-(30) Scan parquet default.date_dim
-Output [3]: [d_date_sk#23, d_year#24, d_moy#25]
+(1) Scan parquet default.date_dim
+Output [3]: [d_date_sk#1, d_year#2, d_moy#3]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,11), EqualTo(d_year,1999), GreaterThanOrEqual(d_date_sk,2451484), LessThanOrEqual(d_date_sk,2451513), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(31) ColumnarToRow
-Input [3]: [d_date_sk#23, d_year#24, d_moy#25]
+(2) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
-(32) Filter
-Input [3]: [d_date_sk#23, d_year#24, d_moy#25]
-Condition : ((((((isnotnull(d_moy#25) AND isnotnull(d_year#24)) AND (d_moy#25 = 11)) AND (d_year#24 = 1999)) AND (d_date_sk#23 >= 2451484)) AND (d_date_sk#23 <= 2451513)) AND isnotnull(d_date_sk#23))
+(3) Filter [codegen id : 1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
+Condition : ((((((isnotnull(d_moy#3) AND isnotnull(d_year#2)) AND (d_moy#3 = 11)) AND (d_year#2 = 1999)) AND (d_date_sk#1 >= 2451484)) AND (d_date_sk#1 <= 2451513)) AND isnotnull(d_date_sk#1))
 
-(33) Project
-Output [1]: [d_date_sk#23]
-Input [3]: [d_date_sk#23, d_year#24, d_moy#25]
+(4) Project [codegen id : 1]
+Output [1]: [d_date_sk#1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
+
+(5) BroadcastExchange
+Input [1]: [d_date_sk#1]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#4]
+
+(6) Scan parquet default.store_sales
+Output [5]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, ss_sold_date_sk#9]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#9), (ss_sold_date_sk#9 >= 2451484), (ss_sold_date_sk#9 <= 2451513), dynamicpruningexpression(ss_sold_date_sk#9 IN dynamicpruning#10)]
+PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_store_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ext_sales_price:decimal(7,2)>
+
+(7) ColumnarToRow
+Input [5]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, ss_sold_date_sk#9]
+
+(8) Filter
+Input [5]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, ss_sold_date_sk#9]
+Condition : ((isnotnull(ss_item_sk#5) AND isnotnull(ss_customer_sk#6)) AND isnotnull(ss_store_sk#7))
+
+(9) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [d_date_sk#1]
+Right keys [1]: [ss_sold_date_sk#9]
+Join condition: None
+
+(10) Project [codegen id : 2]
+Output [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
+Input [6]: [d_date_sk#1, ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, ss_sold_date_sk#9]
+
+(11) BroadcastExchange
+Input [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#11]
+
+(12) Scan parquet default.customer
+Output [2]: [c_customer_sk#12, c_current_addr_sk#13]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
+
+(13) ColumnarToRow
+Input [2]: [c_customer_sk#12, c_current_addr_sk#13]
+
+(14) Filter
+Input [2]: [c_customer_sk#12, c_current_addr_sk#13]
+Condition : (isnotnull(c_customer_sk#12) AND isnotnull(c_current_addr_sk#13))
+
+(15) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_customer_sk#6]
+Right keys [1]: [c_customer_sk#12]
+Join condition: None
+
+(16) Project [codegen id : 4]
+Output [4]: [ss_item_sk#5, ss_store_sk#7, ss_ext_sales_price#8, c_current_addr_sk#13]
+Input [6]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, c_customer_sk#12, c_current_addr_sk#13]
+
+(17) Scan parquet default.store
+Output [2]: [s_store_sk#14, s_zip#15]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_zip:string>
+
+(18) ColumnarToRow [codegen id : 3]
+Input [2]: [s_store_sk#14, s_zip#15]
+
+(19) Filter [codegen id : 3]
+Input [2]: [s_store_sk#14, s_zip#15]
+Condition : (isnotnull(s_zip#15) AND isnotnull(s_store_sk#14))
+
+(20) BroadcastExchange
+Input [2]: [s_store_sk#14, s_zip#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+
+(21) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_store_sk#7]
+Right keys [1]: [s_store_sk#14]
+Join condition: None
+
+(22) Project [codegen id : 4]
+Output [4]: [ss_item_sk#5, ss_ext_sales_price#8, c_current_addr_sk#13, s_zip#15]
+Input [6]: [ss_item_sk#5, ss_store_sk#7, ss_ext_sales_price#8, c_current_addr_sk#13, s_store_sk#14, s_zip#15]
+
+(23) BroadcastExchange
+Input [4]: [ss_item_sk#5, ss_ext_sales_price#8, c_current_addr_sk#13, s_zip#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#17]
+
+(24) Scan parquet default.customer_address
+Output [2]: [ca_address_sk#18, ca_zip#19]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_zip)]
+ReadSchema: struct<ca_address_sk:int,ca_zip:string>
+
+(25) ColumnarToRow
+Input [2]: [ca_address_sk#18, ca_zip#19]
+
+(26) Filter
+Input [2]: [ca_address_sk#18, ca_zip#19]
+Condition : (isnotnull(ca_address_sk#18) AND isnotnull(ca_zip#19))
+
+(27) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [c_current_addr_sk#13]
+Right keys [1]: [ca_address_sk#18]
+Join condition: NOT (substr(ca_zip#19, 1, 5) = substr(s_zip#15, 1, 5))
+
+(28) Project [codegen id : 6]
+Output [2]: [ss_item_sk#5, ss_ext_sales_price#8]
+Input [6]: [ss_item_sk#5, ss_ext_sales_price#8, c_current_addr_sk#13, s_zip#15, ca_address_sk#18, ca_zip#19]
+
+(29) Scan parquet default.item
+Output [6]: [i_item_sk#20, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufact#24, i_manager_id#25]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,7), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manufact_id:int,i_manufact:string,i_manager_id:int>
+
+(30) ColumnarToRow [codegen id : 5]
+Input [6]: [i_item_sk#20, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufact#24, i_manager_id#25]
+
+(31) Filter [codegen id : 5]
+Input [6]: [i_item_sk#20, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufact#24, i_manager_id#25]
+Condition : ((isnotnull(i_manager_id#25) AND (i_manager_id#25 = 7)) AND isnotnull(i_item_sk#20))
+
+(32) Project [codegen id : 5]
+Output [5]: [i_item_sk#20, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufact#24]
+Input [6]: [i_item_sk#20, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufact#24, i_manager_id#25]
+
+(33) BroadcastExchange
+Input [5]: [i_item_sk#20, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufact#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
 
 (34) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#23]
+Left keys [1]: [ss_item_sk#5]
+Right keys [1]: [i_item_sk#20]
 Join condition: None
 
 (35) Project [codegen id : 6]
-Output [5]: [ss_ext_sales_price#4, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
-Input [7]: [ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, d_date_sk#23]
+Output [5]: [ss_ext_sales_price#8, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufact#24]
+Input [7]: [ss_item_sk#5, ss_ext_sales_price#8, i_item_sk#20, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufact#24]
 
 (36) HashAggregate [codegen id : 6]
-Input [5]: [ss_ext_sales_price#4, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
-Keys [4]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#4))]
-Aggregate Attributes [1]: [sum#26]
-Results [5]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, sum#27]
+Input [5]: [ss_ext_sales_price#8, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufact#24]
+Keys [4]: [i_brand#22, i_brand_id#21, i_manufact_id#23, i_manufact#24]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#8))]
+Aggregate Attributes [1]: [sum#27]
+Results [5]: [i_brand#22, i_brand_id#21, i_manufact_id#23, i_manufact#24, sum#28]
 
 (37) Exchange
-Input [5]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, sum#27]
-Arguments: hashpartitioning(i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, 5), ENSURE_REQUIREMENTS, [id=#28]
+Input [5]: [i_brand#22, i_brand_id#21, i_manufact_id#23, i_manufact#24, sum#28]
+Arguments: hashpartitioning(i_brand#22, i_brand_id#21, i_manufact_id#23, i_manufact#24, 5), ENSURE_REQUIREMENTS, [id=#29]
 
 (38) HashAggregate [codegen id : 7]
-Input [5]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, sum#27]
-Keys [4]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#4))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#4))#29]
-Results [5]: [i_brand_id#17 AS brand_id#30, i_brand#18 AS brand#31, i_manufact_id#19, i_manufact#20, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#4))#29,17,2) AS ext_price#32]
+Input [5]: [i_brand#22, i_brand_id#21, i_manufact_id#23, i_manufact#24, sum#28]
+Keys [4]: [i_brand#22, i_brand_id#21, i_manufact_id#23, i_manufact#24]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#8))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#8))#30]
+Results [5]: [i_brand_id#21 AS brand_id#31, i_brand#22 AS brand#32, i_manufact_id#23, i_manufact#24, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#8))#30,17,2) AS ext_price#33]
 
 (39) TakeOrderedAndProject
-Input [5]: [brand_id#30, brand#31, i_manufact_id#19, i_manufact#20, ext_price#32]
-Arguments: 100, [ext_price#32 DESC NULLS LAST, brand#31 ASC NULLS FIRST, brand_id#30 ASC NULLS FIRST, i_manufact_id#19 ASC NULLS FIRST, i_manufact#20 ASC NULLS FIRST], [brand_id#30, brand#31, i_manufact_id#19, i_manufact#20, ext_price#32]
+Input [5]: [brand_id#31, brand#32, i_manufact_id#23, i_manufact#24, ext_price#33]
+Arguments: 100, [ext_price#33 DESC NULLS LAST, brand#32 ASC NULLS FIRST, brand_id#31 ASC NULLS FIRST, i_manufact_id#23 ASC NULLS FIRST, i_manufact#24 ASC NULLS FIRST], [brand_id#31, brand#32, i_manufact_id#23, i_manufact#24, ext_price#33]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
+ReusedExchange (40)
+
+
+(40) ReusedExchange [Reuses operator id: 5]
+Output [1]: [d_date_sk#1]
+
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
@@ -1,262 +1,220 @@
 == Physical Plan ==
-TakeOrderedAndProject (45)
-+- * HashAggregate (44)
-   +- Exchange (43)
-      +- * HashAggregate (42)
-         +- * Project (41)
-            +- * BroadcastHashJoin Inner BuildRight (40)
-               :- * Project (34)
-               :  +- * SortMergeJoin Inner (33)
-               :     :- * Sort (27)
-               :     :  +- Exchange (26)
-               :     :     +- * Project (25)
-               :     :        +- * BroadcastHashJoin Inner BuildRight (24)
-               :     :           :- * Project (19)
-               :     :           :  +- * SortMergeJoin Inner (18)
-               :     :           :     :- * Sort (12)
-               :     :           :     :  +- Exchange (11)
-               :     :           :     :     +- * Project (10)
-               :     :           :     :        +- * BroadcastHashJoin Inner BuildLeft (9)
-               :     :           :     :           :- BroadcastExchange (5)
-               :     :           :     :           :  +- * Project (4)
-               :     :           :     :           :     +- * Filter (3)
-               :     :           :     :           :        +- * ColumnarToRow (2)
-               :     :           :     :           :           +- Scan parquet default.date_dim (1)
-               :     :           :     :           +- * Filter (8)
-               :     :           :     :              +- * ColumnarToRow (7)
-               :     :           :     :                 +- Scan parquet default.store_sales (6)
-               :     :           :     +- * Sort (17)
-               :     :           :        +- Exchange (16)
-               :     :           :           +- * Filter (15)
-               :     :           :              +- * ColumnarToRow (14)
-               :     :           :                 +- Scan parquet default.customer (13)
-               :     :           +- BroadcastExchange (23)
-               :     :              +- * Filter (22)
-               :     :                 +- * ColumnarToRow (21)
-               :     :                    +- Scan parquet default.store (20)
-               :     +- * Sort (32)
-               :        +- Exchange (31)
-               :           +- * Filter (30)
-               :              +- * ColumnarToRow (29)
-               :                 +- Scan parquet default.customer_address (28)
-               +- BroadcastExchange (39)
-                  +- * Project (38)
-                     +- * Filter (37)
-                        +- * ColumnarToRow (36)
-                           +- Scan parquet default.item (35)
+TakeOrderedAndProject (39)
++- * HashAggregate (38)
+   +- Exchange (37)
+      +- * HashAggregate (36)
+         +- * Project (35)
+            +- * BroadcastHashJoin Inner BuildLeft (34)
+               :- BroadcastExchange (29)
+               :  +- * Project (28)
+               :     +- * BroadcastHashJoin Inner BuildLeft (27)
+               :        :- BroadcastExchange (22)
+               :        :  +- * Project (21)
+               :        :     +- * BroadcastHashJoin Inner BuildLeft (20)
+               :        :        :- BroadcastExchange (16)
+               :        :        :  +- * Project (15)
+               :        :        :     +- * BroadcastNestedLoopJoin Inner BuildLeft (14)
+               :        :        :        :- BroadcastExchange (10)
+               :        :        :        :  +- * Project (9)
+               :        :        :        :     +- * BroadcastHashJoin Inner BuildLeft (8)
+               :        :        :        :        :- BroadcastExchange (4)
+               :        :        :        :        :  +- * Filter (3)
+               :        :        :        :        :     +- * ColumnarToRow (2)
+               :        :        :        :        :        +- Scan parquet default.store_sales (1)
+               :        :        :        :        +- * Filter (7)
+               :        :        :        :           +- * ColumnarToRow (6)
+               :        :        :        :              +- Scan parquet default.store (5)
+               :        :        :        +- * Filter (13)
+               :        :        :           +- * ColumnarToRow (12)
+               :        :        :              +- Scan parquet default.customer_address (11)
+               :        :        +- * Filter (19)
+               :        :           +- * ColumnarToRow (18)
+               :        :              +- Scan parquet default.customer (17)
+               :        +- * Project (26)
+               :           +- * Filter (25)
+               :              +- * ColumnarToRow (24)
+               :                 +- Scan parquet default.item (23)
+               +- * Project (33)
+                  +- * Filter (32)
+                     +- * ColumnarToRow (31)
+                        +- Scan parquet default.date_dim (30)
 
 
-(1) Scan parquet default.date_dim
-Output [3]: [d_date_sk#1, d_year#2, d_moy#3]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,11), EqualTo(d_year,1999), GreaterThanOrEqual(d_date_sk,2451484), LessThanOrEqual(d_date_sk,2451513), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
-
-(2) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
-
-(3) Filter [codegen id : 1]
-Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
-Condition : ((((((isnotnull(d_moy#3) AND isnotnull(d_year#2)) AND (d_moy#3 = 11)) AND (d_year#2 = 1999)) AND (d_date_sk#1 >= 2451484)) AND (d_date_sk#1 <= 2451513)) AND isnotnull(d_date_sk#1))
-
-(4) Project [codegen id : 1]
-Output [1]: [d_date_sk#1]
-Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
-
-(5) BroadcastExchange
-Input [1]: [d_date_sk#1]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#4]
-
-(6) Scan parquet default.store_sales
-Output [5]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, ss_sold_date_sk#9]
+(1) Scan parquet default.store_sales
+Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#9), (ss_sold_date_sk#9 >= 2451484), (ss_sold_date_sk#9 <= 2451513), dynamicpruningexpression(ss_sold_date_sk#9 IN dynamicpruning#10)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#5), (ss_sold_date_sk#5 >= 2451484), (ss_sold_date_sk#5 <= 2451513), dynamicpruningexpression(true)]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(7) ColumnarToRow
-Input [5]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, ss_sold_date_sk#9]
+(2) ColumnarToRow [codegen id : 1]
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
 
-(8) Filter
-Input [5]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, ss_sold_date_sk#9]
-Condition : ((isnotnull(ss_item_sk#5) AND isnotnull(ss_customer_sk#6)) AND isnotnull(ss_store_sk#7))
+(3) Filter [codegen id : 1]
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
+Condition : ((isnotnull(ss_item_sk#1) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_store_sk#3))
 
-(9) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [d_date_sk#1]
-Right keys [1]: [ss_sold_date_sk#9]
-Join condition: None
+(4) BroadcastExchange
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, false] as bigint)),false), [id=#6]
 
-(10) Project [codegen id : 2]
-Output [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
-Input [6]: [d_date_sk#1, ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, ss_sold_date_sk#9]
-
-(11) Exchange
-Input [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
-Arguments: hashpartitioning(ss_customer_sk#6, 5), ENSURE_REQUIREMENTS, [id=#11]
-
-(12) Sort [codegen id : 3]
-Input [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
-Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
-
-(13) Scan parquet default.customer
-Output [2]: [c_customer_sk#12, c_current_addr_sk#13]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
-
-(14) ColumnarToRow [codegen id : 4]
-Input [2]: [c_customer_sk#12, c_current_addr_sk#13]
-
-(15) Filter [codegen id : 4]
-Input [2]: [c_customer_sk#12, c_current_addr_sk#13]
-Condition : (isnotnull(c_customer_sk#12) AND isnotnull(c_current_addr_sk#13))
-
-(16) Exchange
-Input [2]: [c_customer_sk#12, c_current_addr_sk#13]
-Arguments: hashpartitioning(c_customer_sk#12, 5), ENSURE_REQUIREMENTS, [id=#14]
-
-(17) Sort [codegen id : 5]
-Input [2]: [c_customer_sk#12, c_current_addr_sk#13]
-Arguments: [c_customer_sk#12 ASC NULLS FIRST], false, 0
-
-(18) SortMergeJoin [codegen id : 7]
-Left keys [1]: [ss_customer_sk#6]
-Right keys [1]: [c_customer_sk#12]
-Join condition: None
-
-(19) Project [codegen id : 7]
-Output [4]: [ss_item_sk#5, ss_store_sk#7, ss_ext_sales_price#8, c_current_addr_sk#13]
-Input [6]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, c_customer_sk#12, c_current_addr_sk#13]
-
-(20) Scan parquet default.store
-Output [2]: [s_store_sk#15, s_zip#16]
+(5) Scan parquet default.store
+Output [2]: [s_store_sk#7, s_zip#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_zip:string>
 
-(21) ColumnarToRow [codegen id : 6]
-Input [2]: [s_store_sk#15, s_zip#16]
+(6) ColumnarToRow
+Input [2]: [s_store_sk#7, s_zip#8]
 
-(22) Filter [codegen id : 6]
-Input [2]: [s_store_sk#15, s_zip#16]
-Condition : (isnotnull(s_zip#16) AND isnotnull(s_store_sk#15))
+(7) Filter
+Input [2]: [s_store_sk#7, s_zip#8]
+Condition : (isnotnull(s_zip#8) AND isnotnull(s_store_sk#7))
 
-(23) BroadcastExchange
-Input [2]: [s_store_sk#15, s_zip#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
-
-(24) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [ss_store_sk#7]
-Right keys [1]: [s_store_sk#15]
+(8) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [ss_store_sk#3]
+Right keys [1]: [s_store_sk#7]
 Join condition: None
 
-(25) Project [codegen id : 7]
-Output [4]: [ss_item_sk#5, ss_ext_sales_price#8, c_current_addr_sk#13, s_zip#16]
-Input [6]: [ss_item_sk#5, ss_store_sk#7, ss_ext_sales_price#8, c_current_addr_sk#13, s_store_sk#15, s_zip#16]
+(9) Project [codegen id : 2]
+Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, s_zip#8]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, s_store_sk#7, s_zip#8]
 
-(26) Exchange
-Input [4]: [ss_item_sk#5, ss_ext_sales_price#8, c_current_addr_sk#13, s_zip#16]
-Arguments: hashpartitioning(c_current_addr_sk#13, 5), ENSURE_REQUIREMENTS, [id=#18]
+(10) BroadcastExchange
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, s_zip#8]
+Arguments: IdentityBroadcastMode, [id=#9]
 
-(27) Sort [codegen id : 8]
-Input [4]: [ss_item_sk#5, ss_ext_sales_price#8, c_current_addr_sk#13, s_zip#16]
-Arguments: [c_current_addr_sk#13 ASC NULLS FIRST], false, 0
-
-(28) Scan parquet default.customer_address
-Output [2]: [ca_address_sk#19, ca_zip#20]
+(11) Scan parquet default.customer_address
+Output [2]: [ca_address_sk#10, ca_zip#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_address_sk:int,ca_zip:string>
 
-(29) ColumnarToRow [codegen id : 9]
-Input [2]: [ca_address_sk#19, ca_zip#20]
+(12) ColumnarToRow
+Input [2]: [ca_address_sk#10, ca_zip#11]
 
-(30) Filter [codegen id : 9]
-Input [2]: [ca_address_sk#19, ca_zip#20]
-Condition : (isnotnull(ca_address_sk#19) AND isnotnull(ca_zip#20))
+(13) Filter
+Input [2]: [ca_address_sk#10, ca_zip#11]
+Condition : (isnotnull(ca_address_sk#10) AND isnotnull(ca_zip#11))
 
-(31) Exchange
-Input [2]: [ca_address_sk#19, ca_zip#20]
-Arguments: hashpartitioning(ca_address_sk#19, 5), ENSURE_REQUIREMENTS, [id=#21]
+(14) BroadcastNestedLoopJoin [codegen id : 3]
+Join condition: NOT (substr(ca_zip#11, 1, 5) = substr(s_zip#8, 1, 5))
 
-(32) Sort [codegen id : 10]
-Input [2]: [ca_address_sk#19, ca_zip#20]
-Arguments: [ca_address_sk#19 ASC NULLS FIRST], false, 0
+(15) Project [codegen id : 3]
+Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, ca_address_sk#10]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, s_zip#8, ca_address_sk#10, ca_zip#11]
 
-(33) SortMergeJoin [codegen id : 12]
-Left keys [1]: [c_current_addr_sk#13]
-Right keys [1]: [ca_address_sk#19]
-Join condition: NOT (substr(ca_zip#20, 1, 5) = substr(s_zip#16, 1, 5))
+(16) BroadcastExchange
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, ca_address_sk#10]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[4, int, true] as bigint) & 4294967295))),false), [id=#12]
 
-(34) Project [codegen id : 12]
-Output [2]: [ss_item_sk#5, ss_ext_sales_price#8]
-Input [6]: [ss_item_sk#5, ss_ext_sales_price#8, c_current_addr_sk#13, s_zip#16, ca_address_sk#19, ca_zip#20]
+(17) Scan parquet default.customer
+Output [2]: [c_customer_sk#13, c_current_addr_sk#14]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(35) Scan parquet default.item
-Output [6]: [i_item_sk#22, i_brand_id#23, i_brand#24, i_manufact_id#25, i_manufact#26, i_manager_id#27]
+(18) ColumnarToRow
+Input [2]: [c_customer_sk#13, c_current_addr_sk#14]
+
+(19) Filter
+Input [2]: [c_customer_sk#13, c_current_addr_sk#14]
+Condition : (isnotnull(c_customer_sk#13) AND isnotnull(c_current_addr_sk#14))
+
+(20) BroadcastHashJoin [codegen id : 4]
+Left keys [2]: [ss_customer_sk#2, ca_address_sk#10]
+Right keys [2]: [c_customer_sk#13, c_current_addr_sk#14]
+Join condition: None
+
+(21) Project [codegen id : 4]
+Output [3]: [ss_item_sk#1, ss_ext_sales_price#4, ss_sold_date_sk#5]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ext_sales_price#4, ss_sold_date_sk#5, ca_address_sk#10, c_customer_sk#13, c_current_addr_sk#14]
+
+(22) BroadcastExchange
+Input [3]: [ss_item_sk#1, ss_ext_sales_price#4, ss_sold_date_sk#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+
+(23) Scan parquet default.item
+Output [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,7), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manufact_id:int,i_manufact:string,i_manager_id:int>
 
-(36) ColumnarToRow [codegen id : 11]
-Input [6]: [i_item_sk#22, i_brand_id#23, i_brand#24, i_manufact_id#25, i_manufact#26, i_manager_id#27]
+(24) ColumnarToRow
+Input [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
 
-(37) Filter [codegen id : 11]
-Input [6]: [i_item_sk#22, i_brand_id#23, i_brand#24, i_manufact_id#25, i_manufact#26, i_manager_id#27]
-Condition : ((isnotnull(i_manager_id#27) AND (i_manager_id#27 = 7)) AND isnotnull(i_item_sk#22))
+(25) Filter
+Input [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
+Condition : ((isnotnull(i_manager_id#21) AND (i_manager_id#21 = 7)) AND isnotnull(i_item_sk#16))
 
-(38) Project [codegen id : 11]
-Output [5]: [i_item_sk#22, i_brand_id#23, i_brand#24, i_manufact_id#25, i_manufact#26]
-Input [6]: [i_item_sk#22, i_brand_id#23, i_brand#24, i_manufact_id#25, i_manufact#26, i_manager_id#27]
+(26) Project
+Output [5]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
+Input [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
 
-(39) BroadcastExchange
-Input [5]: [i_item_sk#22, i_brand_id#23, i_brand#24, i_manufact_id#25, i_manufact#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#28]
-
-(40) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [ss_item_sk#5]
-Right keys [1]: [i_item_sk#22]
+(27) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#16]
 Join condition: None
 
-(41) Project [codegen id : 12]
-Output [5]: [ss_ext_sales_price#8, i_brand_id#23, i_brand#24, i_manufact_id#25, i_manufact#26]
-Input [7]: [ss_item_sk#5, ss_ext_sales_price#8, i_item_sk#22, i_brand_id#23, i_brand#24, i_manufact_id#25, i_manufact#26]
+(28) Project [codegen id : 5]
+Output [6]: [ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
+Input [8]: [ss_item_sk#1, ss_ext_sales_price#4, ss_sold_date_sk#5, i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
 
-(42) HashAggregate [codegen id : 12]
-Input [5]: [ss_ext_sales_price#8, i_brand_id#23, i_brand#24, i_manufact_id#25, i_manufact#26]
-Keys [4]: [i_brand#24, i_brand_id#23, i_manufact_id#25, i_manufact#26]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#8))]
-Aggregate Attributes [1]: [sum#29]
-Results [5]: [i_brand#24, i_brand_id#23, i_manufact_id#25, i_manufact#26, sum#30]
+(29) BroadcastExchange
+Input [6]: [ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#22]
 
-(43) Exchange
-Input [5]: [i_brand#24, i_brand_id#23, i_manufact_id#25, i_manufact#26, sum#30]
-Arguments: hashpartitioning(i_brand#24, i_brand_id#23, i_manufact_id#25, i_manufact#26, 5), ENSURE_REQUIREMENTS, [id=#31]
+(30) Scan parquet default.date_dim
+Output [3]: [d_date_sk#23, d_year#24, d_moy#25]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,11), EqualTo(d_year,1999), GreaterThanOrEqual(d_date_sk,2451484), LessThanOrEqual(d_date_sk,2451513), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(44) HashAggregate [codegen id : 13]
-Input [5]: [i_brand#24, i_brand_id#23, i_manufact_id#25, i_manufact#26, sum#30]
-Keys [4]: [i_brand#24, i_brand_id#23, i_manufact_id#25, i_manufact#26]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#8))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#8))#32]
-Results [5]: [i_brand_id#23 AS brand_id#33, i_brand#24 AS brand#34, i_manufact_id#25, i_manufact#26, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#8))#32,17,2) AS ext_price#35]
+(31) ColumnarToRow
+Input [3]: [d_date_sk#23, d_year#24, d_moy#25]
 
-(45) TakeOrderedAndProject
-Input [5]: [brand_id#33, brand#34, i_manufact_id#25, i_manufact#26, ext_price#35]
-Arguments: 100, [ext_price#35 DESC NULLS LAST, brand#34 ASC NULLS FIRST, brand_id#33 ASC NULLS FIRST, i_manufact_id#25 ASC NULLS FIRST, i_manufact#26 ASC NULLS FIRST], [brand_id#33, brand#34, i_manufact_id#25, i_manufact#26, ext_price#35]
+(32) Filter
+Input [3]: [d_date_sk#23, d_year#24, d_moy#25]
+Condition : ((((((isnotnull(d_moy#25) AND isnotnull(d_year#24)) AND (d_moy#25 = 11)) AND (d_year#24 = 1999)) AND (d_date_sk#23 >= 2451484)) AND (d_date_sk#23 <= 2451513)) AND isnotnull(d_date_sk#23))
 
-===== Subqueries =====
+(33) Project
+Output [1]: [d_date_sk#23]
+Input [3]: [d_date_sk#23, d_year#24, d_moy#25]
 
-Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
-ReusedExchange (46)
+(34) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ss_sold_date_sk#5]
+Right keys [1]: [d_date_sk#23]
+Join condition: None
 
+(35) Project [codegen id : 6]
+Output [5]: [ss_ext_sales_price#4, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
+Input [7]: [ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, d_date_sk#23]
 
-(46) ReusedExchange [Reuses operator id: 5]
-Output [1]: [d_date_sk#1]
+(36) HashAggregate [codegen id : 6]
+Input [5]: [ss_ext_sales_price#4, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
+Keys [4]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#4))]
+Aggregate Attributes [1]: [sum#26]
+Results [5]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, sum#27]
 
+(37) Exchange
+Input [5]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, sum#27]
+Arguments: hashpartitioning(i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, 5), ENSURE_REQUIREMENTS, [id=#28]
+
+(38) HashAggregate [codegen id : 7]
+Input [5]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, sum#27]
+Keys [4]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#4))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#4))#29]
+Results [5]: [i_brand_id#17 AS brand_id#30, i_brand#18 AS brand#31, i_manufact_id#19, i_manufact#20, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#4))#29,17,2) AS ext_price#32]
+
+(39) TakeOrderedAndProject
+Input [5]: [brand_id#30, brand#31, i_manufact_id#19, i_manufact#20, ext_price#32]
+Arguments: 100, [ext_price#32 DESC NULLS LAST, brand#31 ASC NULLS FIRST, brand_id#30 ASC NULLS FIRST, i_manufact_id#19 ASC NULLS FIRST, i_manufact#20 ASC NULLS FIRST], [brand_id#30, brand#31, i_manufact_id#19, i_manufact#20, ext_price#32]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/simplified.txt
@@ -1,78 +1,58 @@
 TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
-  WholeStageCodegen (13)
+  WholeStageCodegen (7)
     HashAggregate [i_brand,i_brand_id,i_manufact_id,i_manufact,sum] [sum(UnscaledValue(ss_ext_sales_price)),brand_id,brand,ext_price,sum]
       InputAdapter
         Exchange [i_brand,i_brand_id,i_manufact_id,i_manufact] #1
-          WholeStageCodegen (12)
+          WholeStageCodegen (6)
             HashAggregate [i_brand,i_brand_id,i_manufact_id,i_manufact,ss_ext_sales_price] [sum,sum]
               Project [ss_ext_sales_price,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                BroadcastHashJoin [ss_item_sk,i_item_sk]
-                  Project [ss_item_sk,ss_ext_sales_price]
-                    SortMergeJoin [c_current_addr_sk,ca_address_sk,ca_zip,s_zip]
-                      InputAdapter
-                        WholeStageCodegen (8)
-                          Sort [c_current_addr_sk]
+                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                  InputAdapter
+                    BroadcastExchange #2
+                      WholeStageCodegen (5)
+                        Project [ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
+                          BroadcastHashJoin [ss_item_sk,i_item_sk]
                             InputAdapter
-                              Exchange [c_current_addr_sk] #2
-                                WholeStageCodegen (7)
-                                  Project [ss_item_sk,ss_ext_sales_price,c_current_addr_sk,s_zip]
-                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                      Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,c_current_addr_sk]
-                                        SortMergeJoin [ss_customer_sk,c_customer_sk]
-                                          InputAdapter
-                                            WholeStageCodegen (3)
-                                              Sort [ss_customer_sk]
+                              BroadcastExchange #3
+                                WholeStageCodegen (4)
+                                  Project [ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                    BroadcastHashJoin [ss_customer_sk,ca_address_sk,c_customer_sk,c_current_addr_sk]
+                                      InputAdapter
+                                        BroadcastExchange #4
+                                          WholeStageCodegen (3)
+                                            Project [ss_item_sk,ss_customer_sk,ss_ext_sales_price,ss_sold_date_sk,ca_address_sk]
+                                              BroadcastNestedLoopJoin [ca_zip,s_zip]
                                                 InputAdapter
-                                                  Exchange [ss_customer_sk] #3
+                                                  BroadcastExchange #5
                                                     WholeStageCodegen (2)
-                                                      Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price]
-                                                        BroadcastHashJoin [d_date_sk,ss_sold_date_sk]
+                                                      Project [ss_item_sk,ss_customer_sk,ss_ext_sales_price,ss_sold_date_sk,s_zip]
+                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                           InputAdapter
-                                                            BroadcastExchange #4
+                                                            BroadcastExchange #6
                                                               WholeStageCodegen (1)
-                                                                Project [d_date_sk]
-                                                                  Filter [d_moy,d_year,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
-                                                          Filter [ss_item_sk,ss_customer_sk,ss_store_sk]
+                                                                Filter [ss_item_sk,ss_customer_sk,ss_store_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                                          Filter [s_zip,s_store_sk]
                                                             ColumnarToRow
                                                               InputAdapter
-                                                                Scan parquet default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                                                  SubqueryBroadcast [d_date_sk] #1
-                                                                    ReusedExchange [d_date_sk] #4
+                                                                Scan parquet default.store [s_store_sk,s_zip]
+                                                Filter [ca_address_sk,ca_zip]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet default.customer_address [ca_address_sk,ca_zip]
+                                      Filter [c_customer_sk,c_current_addr_sk]
+                                        ColumnarToRow
                                           InputAdapter
-                                            WholeStageCodegen (5)
-                                              Sort [c_customer_sk]
-                                                InputAdapter
-                                                  Exchange [c_customer_sk] #5
-                                                    WholeStageCodegen (4)
-                                                      Filter [c_customer_sk,c_current_addr_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet default.customer [c_customer_sk,c_current_addr_sk]
-                                      InputAdapter
-                                        BroadcastExchange #6
-                                          WholeStageCodegen (6)
-                                            Filter [s_zip,s_store_sk]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet default.store [s_store_sk,s_zip]
-                      InputAdapter
-                        WholeStageCodegen (10)
-                          Sort [ca_address_sk]
-                            InputAdapter
-                              Exchange [ca_address_sk] #7
-                                WholeStageCodegen (9)
-                                  Filter [ca_address_sk,ca_zip]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet default.customer_address [ca_address_sk,ca_zip]
-                  InputAdapter
-                    BroadcastExchange #8
-                      WholeStageCodegen (11)
-                        Project [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                          Filter [i_manager_id,i_item_sk]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet default.item [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact,i_manager_id]
+                                            Scan parquet default.customer [c_customer_sk,c_current_addr_sk]
+                            Project [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
+                              Filter [i_manager_id,i_item_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet default.item [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact,i_manager_id]
+                  Project [d_date_sk]
+                    Filter [d_moy,d_year,d_date_sk]
+                      ColumnarToRow
+                        InputAdapter
+                          Scan parquet default.date_dim [d_date_sk,d_year,d_moy]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/simplified.txt
@@ -6,53 +6,55 @@ TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
           WholeStageCodegen (6)
             HashAggregate [i_brand,i_brand_id,i_manufact_id,i_manufact,ss_ext_sales_price] [sum,sum]
               Project [ss_ext_sales_price,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                  InputAdapter
-                    BroadcastExchange #2
-                      WholeStageCodegen (5)
-                        Project [ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                          BroadcastHashJoin [ss_item_sk,i_item_sk]
-                            InputAdapter
-                              BroadcastExchange #3
-                                WholeStageCodegen (4)
-                                  Project [ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                    BroadcastHashJoin [ss_customer_sk,ca_address_sk,c_customer_sk,c_current_addr_sk]
-                                      InputAdapter
-                                        BroadcastExchange #4
-                                          WholeStageCodegen (3)
-                                            Project [ss_item_sk,ss_customer_sk,ss_ext_sales_price,ss_sold_date_sk,ca_address_sk]
-                                              BroadcastNestedLoopJoin [ca_zip,s_zip]
-                                                InputAdapter
-                                                  BroadcastExchange #5
-                                                    WholeStageCodegen (2)
-                                                      Project [ss_item_sk,ss_customer_sk,ss_ext_sales_price,ss_sold_date_sk,s_zip]
-                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                  Project [ss_item_sk,ss_ext_sales_price]
+                    BroadcastHashJoin [c_current_addr_sk,ca_address_sk,ca_zip,s_zip]
+                      InputAdapter
+                        BroadcastExchange #2
+                          WholeStageCodegen (4)
+                            Project [ss_item_sk,ss_ext_sales_price,c_current_addr_sk,s_zip]
+                              BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,c_current_addr_sk]
+                                  BroadcastHashJoin [ss_customer_sk,c_customer_sk]
+                                    InputAdapter
+                                      BroadcastExchange #3
+                                        WholeStageCodegen (2)
+                                          Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price]
+                                            BroadcastHashJoin [d_date_sk,ss_sold_date_sk]
+                                              InputAdapter
+                                                BroadcastExchange #4
+                                                  WholeStageCodegen (1)
+                                                    Project [d_date_sk]
+                                                      Filter [d_moy,d_year,d_date_sk]
+                                                        ColumnarToRow
                                                           InputAdapter
-                                                            BroadcastExchange #6
-                                                              WholeStageCodegen (1)
-                                                                Filter [ss_item_sk,ss_customer_sk,ss_store_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                                          Filter [s_zip,s_store_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.store [s_store_sk,s_zip]
-                                                Filter [ca_address_sk,ca_zip]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet default.customer_address [ca_address_sk,ca_zip]
-                                      Filter [c_customer_sk,c_current_addr_sk]
+                                                            Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
+                                              Filter [ss_item_sk,ss_customer_sk,ss_store_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                                      SubqueryBroadcast [d_date_sk] #1
+                                                        ReusedExchange [d_date_sk] #4
+                                    Filter [c_customer_sk,c_current_addr_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet default.customer [c_customer_sk,c_current_addr_sk]
+                                InputAdapter
+                                  BroadcastExchange #5
+                                    WholeStageCodegen (3)
+                                      Filter [s_zip,s_store_sk]
                                         ColumnarToRow
                                           InputAdapter
-                                            Scan parquet default.customer [c_customer_sk,c_current_addr_sk]
-                            Project [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                              Filter [i_manager_id,i_item_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet default.item [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact,i_manager_id]
-                  Project [d_date_sk]
-                    Filter [d_moy,d_year,d_date_sk]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
+                                            Scan parquet default.store [s_store_sk,s_zip]
+                      Filter [ca_address_sk,ca_zip]
+                        ColumnarToRow
+                          InputAdapter
+                            Scan parquet default.customer_address [ca_address_sk,ca_zip]
+                  InputAdapter
+                    BroadcastExchange #6
+                      WholeStageCodegen (5)
+                        Project [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
+                          Filter [i_manager_id,i_item_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet default.item [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact,i_manager_id]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/explain.txt
@@ -1,270 +1,275 @@
 == Physical Plan ==
-TakeOrderedAndProject (42)
-+- * Project (41)
-   +- * BroadcastHashJoin Inner BuildLeft (40)
-      :- BroadcastExchange (36)
-      :  +- * Project (35)
-      :     +- * BroadcastHashJoin Inner BuildLeft (34)
-      :        :- BroadcastExchange (30)
-      :        :  +- * HashAggregate (29)
-      :        :     +- Exchange (28)
-      :        :        +- * HashAggregate (27)
-      :        :           +- * Project (26)
-      :        :              +- * BroadcastHashJoin Inner BuildLeft (25)
-      :        :                 :- BroadcastExchange (21)
-      :        :                 :  +- * Project (20)
-      :        :                 :     +- * BroadcastHashJoin Inner BuildRight (19)
-      :        :                 :        :- * Project (13)
-      :        :                 :        :  +- * BroadcastHashJoin Inner BuildRight (12)
-      :        :                 :        :     :- * Project (10)
-      :        :                 :        :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-      :        :                 :        :     :     :- * Filter (3)
-      :        :                 :        :     :     :  +- * ColumnarToRow (2)
-      :        :                 :        :     :     :     +- Scan parquet default.store_sales (1)
-      :        :                 :        :     :     +- BroadcastExchange (8)
-      :        :                 :        :     :        +- * Project (7)
-      :        :                 :        :     :           +- * Filter (6)
-      :        :                 :        :     :              +- * ColumnarToRow (5)
-      :        :                 :        :     :                 +- Scan parquet default.store (4)
-      :        :                 :        :     +- ReusedExchange (11)
-      :        :                 :        +- BroadcastExchange (18)
-      :        :                 :           +- * Project (17)
-      :        :                 :              +- * Filter (16)
-      :        :                 :                 +- * ColumnarToRow (15)
-      :        :                 :                    +- Scan parquet default.household_demographics (14)
-      :        :                 +- * Filter (24)
-      :        :                    +- * ColumnarToRow (23)
-      :        :                       +- Scan parquet default.customer_address (22)
-      :        +- * Filter (33)
-      :           +- * ColumnarToRow (32)
-      :              +- Scan parquet default.customer (31)
-      +- * Filter (39)
-         +- * ColumnarToRow (38)
-            +- Scan parquet default.customer_address (37)
+TakeOrderedAndProject (49)
++- * Project (48)
+   +- * SortMergeJoin Inner (47)
+      :- * Sort (41)
+      :  +- Exchange (40)
+      :     +- * Project (39)
+      :        +- * BroadcastHashJoin Inner BuildLeft (38)
+      :           :- BroadcastExchange (34)
+      :           :  +- * HashAggregate (33)
+      :           :     +- Exchange (32)
+      :           :        +- * HashAggregate (31)
+      :           :           +- * Project (30)
+      :           :              +- * BroadcastHashJoin Inner BuildLeft (29)
+      :           :                 :- BroadcastExchange (24)
+      :           :                 :  +- * Project (23)
+      :           :                 :     +- * BroadcastHashJoin Inner BuildLeft (22)
+      :           :                 :        :- BroadcastExchange (17)
+      :           :                 :        :  +- * Project (16)
+      :           :                 :        :     +- * BroadcastHashJoin Inner BuildLeft (15)
+      :           :                 :        :        :- BroadcastExchange (10)
+      :           :                 :        :        :  +- * Project (9)
+      :           :                 :        :        :     +- * BroadcastHashJoin Inner BuildLeft (8)
+      :           :                 :        :        :        :- BroadcastExchange (4)
+      :           :                 :        :        :        :  +- * Filter (3)
+      :           :                 :        :        :        :     +- * ColumnarToRow (2)
+      :           :                 :        :        :        :        +- Scan parquet default.store_sales (1)
+      :           :                 :        :        :        +- * Filter (7)
+      :           :                 :        :        :           +- * ColumnarToRow (6)
+      :           :                 :        :        :              +- Scan parquet default.customer_address (5)
+      :           :                 :        :        +- * Project (14)
+      :           :                 :        :           +- * Filter (13)
+      :           :                 :        :              +- * ColumnarToRow (12)
+      :           :                 :        :                 +- Scan parquet default.household_demographics (11)
+      :           :                 :        +- * Project (21)
+      :           :                 :           +- * Filter (20)
+      :           :                 :              +- * ColumnarToRow (19)
+      :           :                 :                 +- Scan parquet default.store (18)
+      :           :                 +- * Project (28)
+      :           :                    +- * Filter (27)
+      :           :                       +- * ColumnarToRow (26)
+      :           :                          +- Scan parquet default.date_dim (25)
+      :           +- * Filter (37)
+      :              +- * ColumnarToRow (36)
+      :                 +- Scan parquet default.customer (35)
+      +- * Sort (46)
+         +- Exchange (45)
+            +- * Filter (44)
+               +- * ColumnarToRow (43)
+                  +- Scan parquet default.customer_address (42)
 
 
 (1) Scan parquet default.store_sales
 Output [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [ss_sold_date_sk#9 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246, isnotnull(ss_sold_date_sk#9), dynamicpruningexpression(ss_sold_date_sk#9 IN dynamicpruning#10)]
+PartitionFilters: [ss_sold_date_sk#9 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246, isnotnull(ss_sold_date_sk#9), dynamicpruningexpression(true)]
 PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_ext_sales_price:decimal(7,2),ss_ext_list_price:decimal(7,2),ss_ext_tax:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 4]
+(2) ColumnarToRow [codegen id : 1]
 Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
 
-(3) Filter [codegen id : 4]
+(3) Filter [codegen id : 1]
 Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
 Condition : (((isnotnull(ss_store_sk#4) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_addr_sk#3)) AND isnotnull(ss_customer_sk#1))
 
-(4) Scan parquet default.store
-Output [2]: [s_store_sk#11, s_city#12]
+(4) BroadcastExchange
+Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, false] as bigint)),false), [id=#10]
+
+(5) Scan parquet default.customer_address
+Output [2]: [ca_address_sk#11, ca_city#12]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [In(s_city, [Fairview,Midway]), IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_city:string>
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
+ReadSchema: struct<ca_address_sk:int,ca_city:string>
 
-(5) ColumnarToRow [codegen id : 1]
-Input [2]: [s_store_sk#11, s_city#12]
+(6) ColumnarToRow
+Input [2]: [ca_address_sk#11, ca_city#12]
 
-(6) Filter [codegen id : 1]
-Input [2]: [s_store_sk#11, s_city#12]
-Condition : (s_city#12 IN (Midway,Fairview) AND isnotnull(s_store_sk#11))
+(7) Filter
+Input [2]: [ca_address_sk#11, ca_city#12]
+Condition : (isnotnull(ca_address_sk#11) AND isnotnull(ca_city#12))
 
-(7) Project [codegen id : 1]
-Output [1]: [s_store_sk#11]
-Input [2]: [s_store_sk#11, s_city#12]
-
-(8) BroadcastExchange
-Input [1]: [s_store_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
-
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#4]
-Right keys [1]: [s_store_sk#11]
+(8) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [ss_addr_sk#3]
+Right keys [1]: [ca_address_sk#11]
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
-Input [10]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, s_store_sk#11]
+(9) Project [codegen id : 2]
+Output [10]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
+Input [11]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_address_sk#11, ca_city#12]
 
-(11) ReusedExchange [Reuses operator id: 47]
-Output [1]: [d_date_sk#14]
+(10) BroadcastExchange
+Input [10]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#13]
 
-(12) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#9]
-Right keys [1]: [d_date_sk#14]
-Join condition: None
-
-(13) Project [codegen id : 4]
-Output [7]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
-Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, d_date_sk#14]
-
-(14) Scan parquet default.household_demographics
-Output [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
+(11) Scan parquet default.household_demographics
+Output [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [Or(EqualTo(hd_dep_count,5),EqualTo(hd_vehicle_count,3)), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
 
-(15) ColumnarToRow [codegen id : 3]
-Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
+(12) ColumnarToRow
+Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
 
-(16) Filter [codegen id : 3]
-Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
-Condition : (((hd_dep_count#16 = 5) OR (hd_vehicle_count#17 = 3)) AND isnotnull(hd_demo_sk#15))
+(13) Filter
+Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
+Condition : (((hd_dep_count#15 = 5) OR (hd_vehicle_count#16 = 3)) AND isnotnull(hd_demo_sk#14))
 
-(17) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#15]
-Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
+(14) Project
+Output [1]: [hd_demo_sk#14]
+Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
 
-(18) BroadcastExchange
-Input [1]: [hd_demo_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
-
-(19) BroadcastHashJoin [codegen id : 4]
+(15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#15]
+Right keys [1]: [hd_demo_sk#14]
 Join condition: None
 
-(20) Project [codegen id : 4]
-Output [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
-Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, hd_demo_sk#15]
+(16) Project [codegen id : 3]
+Output [9]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
+Input [11]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12, hd_demo_sk#14]
 
-(21) BroadcastExchange
-Input [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#19]
+(17) BroadcastExchange
+Input [9]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#17]
 
-(22) Scan parquet default.customer_address
-Output [2]: [ca_address_sk#20, ca_city#21]
+(18) Scan parquet default.store
+Output [2]: [s_store_sk#18, s_city#19]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
-ReadSchema: struct<ca_address_sk:int,ca_city:string>
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [In(s_city, [Fairview,Midway]), IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_city:string>
 
-(23) ColumnarToRow
-Input [2]: [ca_address_sk#20, ca_city#21]
+(19) ColumnarToRow
+Input [2]: [s_store_sk#18, s_city#19]
 
-(24) Filter
-Input [2]: [ca_address_sk#20, ca_city#21]
-Condition : (isnotnull(ca_address_sk#20) AND isnotnull(ca_city#21))
+(20) Filter
+Input [2]: [s_store_sk#18, s_city#19]
+Condition : (s_city#19 IN (Midway,Fairview) AND isnotnull(s_store_sk#18))
 
-(25) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_addr_sk#3]
-Right keys [1]: [ca_address_sk#20]
+(21) Project
+Output [1]: [s_store_sk#18]
+Input [2]: [s_store_sk#18, s_city#19]
+
+(22) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_store_sk#4]
+Right keys [1]: [s_store_sk#18]
 Join condition: None
 
-(26) Project [codegen id : 5]
-Output [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_city#21]
-Input [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_address_sk#20, ca_city#21]
+(23) Project [codegen id : 4]
+Output [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
+Input [10]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12, s_store_sk#18]
 
-(27) HashAggregate [codegen id : 5]
-Input [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_city#21]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21]
-Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#6)), partial_sum(UnscaledValue(ss_ext_list_price#7)), partial_sum(UnscaledValue(ss_ext_tax#8))]
-Aggregate Attributes [3]: [sum#22, sum#23, sum#24]
-Results [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21, sum#25, sum#26, sum#27]
+(24) BroadcastExchange
+Input [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[6, int, true] as bigint)),false), [id=#20]
 
-(28) Exchange
-Input [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21, sum#25, sum#26, sum#27]
-Arguments: hashpartitioning(ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21, 5), ENSURE_REQUIREMENTS, [id=#28]
-
-(29) HashAggregate [codegen id : 6]
-Input [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21, sum#25, sum#26, sum#27]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21]
-Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#6)), sum(UnscaledValue(ss_ext_list_price#7)), sum(UnscaledValue(ss_ext_tax#8))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#6))#29, sum(UnscaledValue(ss_ext_list_price#7))#30, sum(UnscaledValue(ss_ext_tax#8))#31]
-Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ca_city#21 AS bought_city#32, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#6))#29,17,2) AS extended_price#33, MakeDecimal(sum(UnscaledValue(ss_ext_list_price#7))#30,17,2) AS list_price#34, MakeDecimal(sum(UnscaledValue(ss_ext_tax#8))#31,17,2) AS extended_tax#35]
-
-(30) BroadcastExchange
-Input [6]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#32, extended_price#33, list_price#34, extended_tax#35]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#36]
-
-(31) Scan parquet default.customer
-Output [4]: [c_customer_sk#37, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int,c_first_name:string,c_last_name:string>
-
-(32) ColumnarToRow
-Input [4]: [c_customer_sk#37, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
-
-(33) Filter
-Input [4]: [c_customer_sk#37, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
-Condition : (isnotnull(c_customer_sk#37) AND isnotnull(c_current_addr_sk#38))
-
-(34) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#37]
-Join condition: None
-
-(35) Project [codegen id : 7]
-Output [8]: [ss_ticket_number#5, bought_city#32, extended_price#33, list_price#34, extended_tax#35, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
-Input [10]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#32, extended_price#33, list_price#34, extended_tax#35, c_customer_sk#37, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
-
-(36) BroadcastExchange
-Input [8]: [ss_ticket_number#5, bought_city#32, extended_price#33, list_price#34, extended_tax#35, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
-Arguments: HashedRelationBroadcastMode(List(cast(input[5, int, true] as bigint)),false), [id=#41]
-
-(37) Scan parquet default.customer_address
-Output [2]: [ca_address_sk#42, ca_city#43]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
-ReadSchema: struct<ca_address_sk:int,ca_city:string>
-
-(38) ColumnarToRow
-Input [2]: [ca_address_sk#42, ca_city#43]
-
-(39) Filter
-Input [2]: [ca_address_sk#42, ca_city#43]
-Condition : (isnotnull(ca_address_sk#42) AND isnotnull(ca_city#43))
-
-(40) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [c_current_addr_sk#38]
-Right keys [1]: [ca_address_sk#42]
-Join condition: NOT (ca_city#43 = bought_city#32)
-
-(41) Project [codegen id : 8]
-Output [8]: [c_last_name#40, c_first_name#39, ca_city#43, bought_city#32, ss_ticket_number#5, extended_price#33, extended_tax#35, list_price#34]
-Input [10]: [ss_ticket_number#5, bought_city#32, extended_price#33, list_price#34, extended_tax#35, c_current_addr_sk#38, c_first_name#39, c_last_name#40, ca_address_sk#42, ca_city#43]
-
-(42) TakeOrderedAndProject
-Input [8]: [c_last_name#40, c_first_name#39, ca_city#43, bought_city#32, ss_ticket_number#5, extended_price#33, extended_tax#35, list_price#34]
-Arguments: 100, [c_last_name#40 ASC NULLS FIRST, ss_ticket_number#5 ASC NULLS FIRST], [c_last_name#40, c_first_name#39, ca_city#43, bought_city#32, ss_ticket_number#5, extended_price#33, extended_tax#35, list_price#34]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (47)
-+- * Project (46)
-   +- * Filter (45)
-      +- * ColumnarToRow (44)
-         +- Scan parquet default.date_dim (43)
-
-
-(43) Scan parquet default.date_dim
-Output [3]: [d_date_sk#14, d_year#44, d_dom#45]
+(25) Scan parquet default.date_dim
+Output [3]: [d_date_sk#21, d_year#22, d_dom#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1999,2000,2001]), In(d_date_sk, [2451180,2451181,2451211,2451212,2451239,2451240,2451270,2451271,2451300,2451301,2451331,2451332,2451361,2451362,2451392,2451393,2451423,2451424,2451453,2451454,2451484,2451485,2451514,2451515,2451545,2451546,2451576,2451577,2451605,2451606,2451636,2451637,2451666,2451667,2451697,2451698,2451727,2451728,2451758,2451759,2451789,2451790,2451819,2451820,2451850,2451851,2451880,2451881,2451911,2451912,2451942,2451943,2451970,2451971,2452001,2452002,2452031,2452032,2452062,2452063,2452092,2452093,2452123,2452124,2452154,2452155,2452184,2452185,2452215,2452216,2452245,2452246]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
-(44) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#14, d_year#44, d_dom#45]
+(26) ColumnarToRow
+Input [3]: [d_date_sk#21, d_year#22, d_dom#23]
 
-(45) Filter [codegen id : 1]
-Input [3]: [d_date_sk#14, d_year#44, d_dom#45]
-Condition : (((((isnotnull(d_dom#45) AND (d_dom#45 >= 1)) AND (d_dom#45 <= 2)) AND d_year#44 IN (1999,2000,2001)) AND d_date_sk#14 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246) AND isnotnull(d_date_sk#14))
+(27) Filter
+Input [3]: [d_date_sk#21, d_year#22, d_dom#23]
+Condition : (((((isnotnull(d_dom#23) AND (d_dom#23 >= 1)) AND (d_dom#23 <= 2)) AND d_year#22 IN (1999,2000,2001)) AND d_date_sk#21 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246) AND isnotnull(d_date_sk#21))
 
-(46) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [3]: [d_date_sk#14, d_year#44, d_dom#45]
+(28) Project
+Output [1]: [d_date_sk#21]
+Input [3]: [d_date_sk#21, d_year#22, d_dom#23]
 
-(47) BroadcastExchange
-Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#46]
+(29) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [ss_sold_date_sk#9]
+Right keys [1]: [d_date_sk#21]
+Join condition: None
 
+(30) Project [codegen id : 5]
+Output [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_city#12]
+Input [9]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12, d_date_sk#21]
+
+(31) HashAggregate [codegen id : 5]
+Input [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_city#12]
+Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12]
+Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#6)), partial_sum(UnscaledValue(ss_ext_list_price#7)), partial_sum(UnscaledValue(ss_ext_tax#8))]
+Aggregate Attributes [3]: [sum#24, sum#25, sum#26]
+Results [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12, sum#27, sum#28, sum#29]
+
+(32) Exchange
+Input [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12, sum#27, sum#28, sum#29]
+Arguments: hashpartitioning(ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12, 5), ENSURE_REQUIREMENTS, [id=#30]
+
+(33) HashAggregate [codegen id : 6]
+Input [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12, sum#27, sum#28, sum#29]
+Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12]
+Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#6)), sum(UnscaledValue(ss_ext_list_price#7)), sum(UnscaledValue(ss_ext_tax#8))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#6))#31, sum(UnscaledValue(ss_ext_list_price#7))#32, sum(UnscaledValue(ss_ext_tax#8))#33]
+Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ca_city#12 AS bought_city#34, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#6))#31,17,2) AS extended_price#35, MakeDecimal(sum(UnscaledValue(ss_ext_list_price#7))#32,17,2) AS list_price#36, MakeDecimal(sum(UnscaledValue(ss_ext_tax#8))#33,17,2) AS extended_tax#37]
+
+(34) BroadcastExchange
+Input [6]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#34, extended_price#35, list_price#36, extended_tax#37]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#38]
+
+(35) Scan parquet default.customer
+Output [4]: [c_customer_sk#39, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int,c_first_name:string,c_last_name:string>
+
+(36) ColumnarToRow
+Input [4]: [c_customer_sk#39, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
+
+(37) Filter
+Input [4]: [c_customer_sk#39, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
+Condition : (isnotnull(c_customer_sk#39) AND isnotnull(c_current_addr_sk#40))
+
+(38) BroadcastHashJoin [codegen id : 7]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#39]
+Join condition: None
+
+(39) Project [codegen id : 7]
+Output [8]: [ss_ticket_number#5, bought_city#34, extended_price#35, list_price#36, extended_tax#37, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
+Input [10]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#34, extended_price#35, list_price#36, extended_tax#37, c_customer_sk#39, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
+
+(40) Exchange
+Input [8]: [ss_ticket_number#5, bought_city#34, extended_price#35, list_price#36, extended_tax#37, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
+Arguments: hashpartitioning(c_current_addr_sk#40, 5), ENSURE_REQUIREMENTS, [id=#43]
+
+(41) Sort [codegen id : 8]
+Input [8]: [ss_ticket_number#5, bought_city#34, extended_price#35, list_price#36, extended_tax#37, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
+Arguments: [c_current_addr_sk#40 ASC NULLS FIRST], false, 0
+
+(42) Scan parquet default.customer_address
+Output [2]: [ca_address_sk#44, ca_city#45]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
+ReadSchema: struct<ca_address_sk:int,ca_city:string>
+
+(43) ColumnarToRow [codegen id : 9]
+Input [2]: [ca_address_sk#44, ca_city#45]
+
+(44) Filter [codegen id : 9]
+Input [2]: [ca_address_sk#44, ca_city#45]
+Condition : (isnotnull(ca_address_sk#44) AND isnotnull(ca_city#45))
+
+(45) Exchange
+Input [2]: [ca_address_sk#44, ca_city#45]
+Arguments: hashpartitioning(ca_address_sk#44, 5), ENSURE_REQUIREMENTS, [id=#46]
+
+(46) Sort [codegen id : 10]
+Input [2]: [ca_address_sk#44, ca_city#45]
+Arguments: [ca_address_sk#44 ASC NULLS FIRST], false, 0
+
+(47) SortMergeJoin [codegen id : 11]
+Left keys [1]: [c_current_addr_sk#40]
+Right keys [1]: [ca_address_sk#44]
+Join condition: NOT (ca_city#45 = bought_city#34)
+
+(48) Project [codegen id : 11]
+Output [8]: [c_last_name#42, c_first_name#41, ca_city#45, bought_city#34, ss_ticket_number#5, extended_price#35, extended_tax#37, list_price#36]
+Input [10]: [ss_ticket_number#5, bought_city#34, extended_price#35, list_price#36, extended_tax#37, c_current_addr_sk#40, c_first_name#41, c_last_name#42, ca_address_sk#44, ca_city#45]
+
+(49) TakeOrderedAndProject
+Input [8]: [c_last_name#42, c_first_name#41, ca_city#45, bought_city#34, ss_ticket_number#5, extended_price#35, extended_tax#37, list_price#36]
+Arguments: 100, [c_last_name#42 ASC NULLS FIRST, ss_ticket_number#5 ASC NULLS FIRST], [c_last_name#42, c_first_name#41, ca_city#45, bought_city#34, ss_ticket_number#5, extended_price#35, extended_tax#37, list_price#36]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/explain.txt
@@ -1,275 +1,285 @@
 == Physical Plan ==
-TakeOrderedAndProject (49)
-+- * Project (48)
-   +- * SortMergeJoin Inner (47)
-      :- * Sort (41)
-      :  +- Exchange (40)
-      :     +- * Project (39)
-      :        +- * BroadcastHashJoin Inner BuildLeft (38)
-      :           :- BroadcastExchange (34)
-      :           :  +- * HashAggregate (33)
-      :           :     +- Exchange (32)
-      :           :        +- * HashAggregate (31)
-      :           :           +- * Project (30)
-      :           :              +- * BroadcastHashJoin Inner BuildLeft (29)
-      :           :                 :- BroadcastExchange (24)
-      :           :                 :  +- * Project (23)
-      :           :                 :     +- * BroadcastHashJoin Inner BuildLeft (22)
-      :           :                 :        :- BroadcastExchange (17)
-      :           :                 :        :  +- * Project (16)
-      :           :                 :        :     +- * BroadcastHashJoin Inner BuildLeft (15)
-      :           :                 :        :        :- BroadcastExchange (10)
-      :           :                 :        :        :  +- * Project (9)
-      :           :                 :        :        :     +- * BroadcastHashJoin Inner BuildLeft (8)
-      :           :                 :        :        :        :- BroadcastExchange (4)
-      :           :                 :        :        :        :  +- * Filter (3)
-      :           :                 :        :        :        :     +- * ColumnarToRow (2)
-      :           :                 :        :        :        :        +- Scan parquet default.store_sales (1)
-      :           :                 :        :        :        +- * Filter (7)
-      :           :                 :        :        :           +- * ColumnarToRow (6)
-      :           :                 :        :        :              +- Scan parquet default.customer_address (5)
-      :           :                 :        :        +- * Project (14)
-      :           :                 :        :           +- * Filter (13)
-      :           :                 :        :              +- * ColumnarToRow (12)
-      :           :                 :        :                 +- Scan parquet default.household_demographics (11)
-      :           :                 :        +- * Project (21)
-      :           :                 :           +- * Filter (20)
-      :           :                 :              +- * ColumnarToRow (19)
-      :           :                 :                 +- Scan parquet default.store (18)
-      :           :                 +- * Project (28)
-      :           :                    +- * Filter (27)
-      :           :                       +- * ColumnarToRow (26)
-      :           :                          +- Scan parquet default.date_dim (25)
-      :           +- * Filter (37)
-      :              +- * ColumnarToRow (36)
-      :                 +- Scan parquet default.customer (35)
-      +- * Sort (46)
-         +- Exchange (45)
-            +- * Filter (44)
-               +- * ColumnarToRow (43)
-                  +- Scan parquet default.customer_address (42)
+TakeOrderedAndProject (45)
++- * Project (44)
+   +- * SortMergeJoin Inner (43)
+      :- * Sort (37)
+      :  +- Exchange (36)
+      :     +- * Project (35)
+      :        +- * BroadcastHashJoin Inner BuildLeft (34)
+      :           :- BroadcastExchange (30)
+      :           :  +- * HashAggregate (29)
+      :           :     +- Exchange (28)
+      :           :        +- * HashAggregate (27)
+      :           :           +- * Project (26)
+      :           :              +- * BroadcastHashJoin Inner BuildLeft (25)
+      :           :                 :- BroadcastExchange (21)
+      :           :                 :  +- * Project (20)
+      :           :                 :     +- * BroadcastHashJoin Inner BuildRight (19)
+      :           :                 :        :- * Project (13)
+      :           :                 :        :  +- * BroadcastHashJoin Inner BuildRight (12)
+      :           :                 :        :     :- * Project (6)
+      :           :                 :        :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+      :           :                 :        :     :     :- * Filter (3)
+      :           :                 :        :     :     :  +- * ColumnarToRow (2)
+      :           :                 :        :     :     :     +- Scan parquet default.store_sales (1)
+      :           :                 :        :     :     +- ReusedExchange (4)
+      :           :                 :        :     +- BroadcastExchange (11)
+      :           :                 :        :        +- * Project (10)
+      :           :                 :        :           +- * Filter (9)
+      :           :                 :        :              +- * ColumnarToRow (8)
+      :           :                 :        :                 +- Scan parquet default.store (7)
+      :           :                 :        +- BroadcastExchange (18)
+      :           :                 :           +- * Project (17)
+      :           :                 :              +- * Filter (16)
+      :           :                 :                 +- * ColumnarToRow (15)
+      :           :                 :                    +- Scan parquet default.household_demographics (14)
+      :           :                 +- * Filter (24)
+      :           :                    +- * ColumnarToRow (23)
+      :           :                       +- Scan parquet default.customer_address (22)
+      :           +- * Filter (33)
+      :              +- * ColumnarToRow (32)
+      :                 +- Scan parquet default.customer (31)
+      +- * Sort (42)
+         +- Exchange (41)
+            +- * Filter (40)
+               +- * ColumnarToRow (39)
+                  +- Scan parquet default.customer_address (38)
 
 
 (1) Scan parquet default.store_sales
 Output [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [ss_sold_date_sk#9 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246, isnotnull(ss_sold_date_sk#9), dynamicpruningexpression(true)]
+PartitionFilters: [ss_sold_date_sk#9 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246, isnotnull(ss_sold_date_sk#9), dynamicpruningexpression(ss_sold_date_sk#9 IN dynamicpruning#10)]
 PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_ext_sales_price:decimal(7,2),ss_ext_list_price:decimal(7,2),ss_ext_tax:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 4]
 Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 4]
 Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
 Condition : (((isnotnull(ss_store_sk#4) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_addr_sk#3)) AND isnotnull(ss_customer_sk#1))
 
-(4) BroadcastExchange
-Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, false] as bigint)),false), [id=#10]
+(4) ReusedExchange [Reuses operator id: 50]
+Output [1]: [d_date_sk#11]
 
-(5) Scan parquet default.customer_address
-Output [2]: [ca_address_sk#11, ca_city#12]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
-ReadSchema: struct<ca_address_sk:int,ca_city:string>
-
-(6) ColumnarToRow
-Input [2]: [ca_address_sk#11, ca_city#12]
-
-(7) Filter
-Input [2]: [ca_address_sk#11, ca_city#12]
-Condition : (isnotnull(ca_address_sk#11) AND isnotnull(ca_city#12))
-
-(8) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_addr_sk#3]
-Right keys [1]: [ca_address_sk#11]
+(5) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#9]
+Right keys [1]: [d_date_sk#11]
 Join condition: None
 
-(9) Project [codegen id : 2]
-Output [10]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
-Input [11]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_address_sk#11, ca_city#12]
+(6) Project [codegen id : 4]
+Output [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
+Input [10]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, d_date_sk#11]
 
-(10) BroadcastExchange
-Input [10]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#13]
-
-(11) Scan parquet default.household_demographics
-Output [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/household_demographics]
-PushedFilters: [Or(EqualTo(hd_dep_count,5),EqualTo(hd_vehicle_count,3)), IsNotNull(hd_demo_sk)]
-ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
-
-(12) ColumnarToRow
-Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
-
-(13) Filter
-Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
-Condition : (((hd_dep_count#15 = 5) OR (hd_vehicle_count#16 = 3)) AND isnotnull(hd_demo_sk#14))
-
-(14) Project
-Output [1]: [hd_demo_sk#14]
-Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
-
-(15) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#14]
-Join condition: None
-
-(16) Project [codegen id : 3]
-Output [9]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
-Input [11]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12, hd_demo_sk#14]
-
-(17) BroadcastExchange
-Input [9]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#17]
-
-(18) Scan parquet default.store
-Output [2]: [s_store_sk#18, s_city#19]
+(7) Scan parquet default.store
+Output [2]: [s_store_sk#12, s_city#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_city, [Fairview,Midway]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_city:string>
 
-(19) ColumnarToRow
-Input [2]: [s_store_sk#18, s_city#19]
+(8) ColumnarToRow [codegen id : 2]
+Input [2]: [s_store_sk#12, s_city#13]
 
-(20) Filter
-Input [2]: [s_store_sk#18, s_city#19]
-Condition : (s_city#19 IN (Midway,Fairview) AND isnotnull(s_store_sk#18))
+(9) Filter [codegen id : 2]
+Input [2]: [s_store_sk#12, s_city#13]
+Condition : (s_city#13 IN (Midway,Fairview) AND isnotnull(s_store_sk#12))
 
-(21) Project
-Output [1]: [s_store_sk#18]
-Input [2]: [s_store_sk#18, s_city#19]
+(10) Project [codegen id : 2]
+Output [1]: [s_store_sk#12]
+Input [2]: [s_store_sk#12, s_city#13]
 
-(22) BroadcastHashJoin [codegen id : 4]
+(11) BroadcastExchange
+Input [1]: [s_store_sk#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+
+(12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
-Right keys [1]: [s_store_sk#18]
+Right keys [1]: [s_store_sk#12]
 Join condition: None
 
-(23) Project [codegen id : 4]
-Output [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
-Input [10]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12, s_store_sk#18]
+(13) Project [codegen id : 4]
+Output [7]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
+Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, s_store_sk#12]
 
-(24) BroadcastExchange
-Input [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[6, int, true] as bigint)),false), [id=#20]
-
-(25) Scan parquet default.date_dim
-Output [3]: [d_date_sk#21, d_year#22, d_dom#23]
+(14) Scan parquet default.household_demographics
+Output [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1999,2000,2001]), In(d_date_sk, [2451180,2451181,2451211,2451212,2451239,2451240,2451270,2451271,2451300,2451301,2451331,2451332,2451361,2451362,2451392,2451393,2451423,2451424,2451453,2451454,2451484,2451485,2451514,2451515,2451545,2451546,2451576,2451577,2451605,2451606,2451636,2451637,2451666,2451667,2451697,2451698,2451727,2451728,2451758,2451759,2451789,2451790,2451819,2451820,2451850,2451851,2451880,2451881,2451911,2451912,2451942,2451943,2451970,2451971,2452001,2452002,2452031,2452032,2452062,2452063,2452092,2452093,2452123,2452124,2452154,2452155,2452184,2452185,2452215,2452216,2452245,2452246]), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
+Location [not included in comparison]/{warehouse_dir}/household_demographics]
+PushedFilters: [Or(EqualTo(hd_dep_count,5),EqualTo(hd_vehicle_count,3)), IsNotNull(hd_demo_sk)]
+ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
 
-(26) ColumnarToRow
-Input [3]: [d_date_sk#21, d_year#22, d_dom#23]
+(15) ColumnarToRow [codegen id : 3]
+Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
 
-(27) Filter
-Input [3]: [d_date_sk#21, d_year#22, d_dom#23]
-Condition : (((((isnotnull(d_dom#23) AND (d_dom#23 >= 1)) AND (d_dom#23 <= 2)) AND d_year#22 IN (1999,2000,2001)) AND d_date_sk#21 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246) AND isnotnull(d_date_sk#21))
+(16) Filter [codegen id : 3]
+Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
+Condition : (((hd_dep_count#16 = 5) OR (hd_vehicle_count#17 = 3)) AND isnotnull(hd_demo_sk#15))
 
-(28) Project
-Output [1]: [d_date_sk#21]
-Input [3]: [d_date_sk#21, d_year#22, d_dom#23]
+(17) Project [codegen id : 3]
+Output [1]: [hd_demo_sk#15]
+Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
 
-(29) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_sold_date_sk#9]
-Right keys [1]: [d_date_sk#21]
+(18) BroadcastExchange
+Input [1]: [hd_demo_sk#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+
+(19) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_hdemo_sk#2]
+Right keys [1]: [hd_demo_sk#15]
 Join condition: None
 
-(30) Project [codegen id : 5]
-Output [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_city#12]
-Input [9]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, ca_city#12, d_date_sk#21]
+(20) Project [codegen id : 4]
+Output [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
+Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, hd_demo_sk#15]
 
-(31) HashAggregate [codegen id : 5]
-Input [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_city#12]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12]
-Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#6)), partial_sum(UnscaledValue(ss_ext_list_price#7)), partial_sum(UnscaledValue(ss_ext_tax#8))]
-Aggregate Attributes [3]: [sum#24, sum#25, sum#26]
-Results [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12, sum#27, sum#28, sum#29]
+(21) BroadcastExchange
+Input [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#19]
 
-(32) Exchange
-Input [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12, sum#27, sum#28, sum#29]
-Arguments: hashpartitioning(ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12, 5), ENSURE_REQUIREMENTS, [id=#30]
-
-(33) HashAggregate [codegen id : 6]
-Input [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12, sum#27, sum#28, sum#29]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#12]
-Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#6)), sum(UnscaledValue(ss_ext_list_price#7)), sum(UnscaledValue(ss_ext_tax#8))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#6))#31, sum(UnscaledValue(ss_ext_list_price#7))#32, sum(UnscaledValue(ss_ext_tax#8))#33]
-Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ca_city#12 AS bought_city#34, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#6))#31,17,2) AS extended_price#35, MakeDecimal(sum(UnscaledValue(ss_ext_list_price#7))#32,17,2) AS list_price#36, MakeDecimal(sum(UnscaledValue(ss_ext_tax#8))#33,17,2) AS extended_tax#37]
-
-(34) BroadcastExchange
-Input [6]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#34, extended_price#35, list_price#36, extended_tax#37]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#38]
-
-(35) Scan parquet default.customer
-Output [4]: [c_customer_sk#39, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int,c_first_name:string,c_last_name:string>
-
-(36) ColumnarToRow
-Input [4]: [c_customer_sk#39, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
-
-(37) Filter
-Input [4]: [c_customer_sk#39, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
-Condition : (isnotnull(c_customer_sk#39) AND isnotnull(c_current_addr_sk#40))
-
-(38) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#39]
-Join condition: None
-
-(39) Project [codegen id : 7]
-Output [8]: [ss_ticket_number#5, bought_city#34, extended_price#35, list_price#36, extended_tax#37, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
-Input [10]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#34, extended_price#35, list_price#36, extended_tax#37, c_customer_sk#39, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
-
-(40) Exchange
-Input [8]: [ss_ticket_number#5, bought_city#34, extended_price#35, list_price#36, extended_tax#37, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
-Arguments: hashpartitioning(c_current_addr_sk#40, 5), ENSURE_REQUIREMENTS, [id=#43]
-
-(41) Sort [codegen id : 8]
-Input [8]: [ss_ticket_number#5, bought_city#34, extended_price#35, list_price#36, extended_tax#37, c_current_addr_sk#40, c_first_name#41, c_last_name#42]
-Arguments: [c_current_addr_sk#40 ASC NULLS FIRST], false, 0
-
-(42) Scan parquet default.customer_address
-Output [2]: [ca_address_sk#44, ca_city#45]
+(22) Scan parquet default.customer_address
+Output [2]: [ca_address_sk#20, ca_city#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
 ReadSchema: struct<ca_address_sk:int,ca_city:string>
 
-(43) ColumnarToRow [codegen id : 9]
-Input [2]: [ca_address_sk#44, ca_city#45]
+(23) ColumnarToRow
+Input [2]: [ca_address_sk#20, ca_city#21]
 
-(44) Filter [codegen id : 9]
-Input [2]: [ca_address_sk#44, ca_city#45]
-Condition : (isnotnull(ca_address_sk#44) AND isnotnull(ca_city#45))
+(24) Filter
+Input [2]: [ca_address_sk#20, ca_city#21]
+Condition : (isnotnull(ca_address_sk#20) AND isnotnull(ca_city#21))
 
-(45) Exchange
-Input [2]: [ca_address_sk#44, ca_city#45]
-Arguments: hashpartitioning(ca_address_sk#44, 5), ENSURE_REQUIREMENTS, [id=#46]
+(25) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [ss_addr_sk#3]
+Right keys [1]: [ca_address_sk#20]
+Join condition: None
 
-(46) Sort [codegen id : 10]
-Input [2]: [ca_address_sk#44, ca_city#45]
-Arguments: [ca_address_sk#44 ASC NULLS FIRST], false, 0
+(26) Project [codegen id : 5]
+Output [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_city#21]
+Input [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_address_sk#20, ca_city#21]
 
-(47) SortMergeJoin [codegen id : 11]
-Left keys [1]: [c_current_addr_sk#40]
-Right keys [1]: [ca_address_sk#44]
-Join condition: NOT (ca_city#45 = bought_city#34)
+(27) HashAggregate [codegen id : 5]
+Input [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_city#21]
+Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21]
+Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#6)), partial_sum(UnscaledValue(ss_ext_list_price#7)), partial_sum(UnscaledValue(ss_ext_tax#8))]
+Aggregate Attributes [3]: [sum#22, sum#23, sum#24]
+Results [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21, sum#25, sum#26, sum#27]
 
-(48) Project [codegen id : 11]
-Output [8]: [c_last_name#42, c_first_name#41, ca_city#45, bought_city#34, ss_ticket_number#5, extended_price#35, extended_tax#37, list_price#36]
-Input [10]: [ss_ticket_number#5, bought_city#34, extended_price#35, list_price#36, extended_tax#37, c_current_addr_sk#40, c_first_name#41, c_last_name#42, ca_address_sk#44, ca_city#45]
+(28) Exchange
+Input [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21, sum#25, sum#26, sum#27]
+Arguments: hashpartitioning(ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21, 5), ENSURE_REQUIREMENTS, [id=#28]
 
-(49) TakeOrderedAndProject
-Input [8]: [c_last_name#42, c_first_name#41, ca_city#45, bought_city#34, ss_ticket_number#5, extended_price#35, extended_tax#37, list_price#36]
-Arguments: 100, [c_last_name#42 ASC NULLS FIRST, ss_ticket_number#5 ASC NULLS FIRST], [c_last_name#42, c_first_name#41, ca_city#45, bought_city#34, ss_ticket_number#5, extended_price#35, extended_tax#37, list_price#36]
+(29) HashAggregate [codegen id : 6]
+Input [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21, sum#25, sum#26, sum#27]
+Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#21]
+Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#6)), sum(UnscaledValue(ss_ext_list_price#7)), sum(UnscaledValue(ss_ext_tax#8))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#6))#29, sum(UnscaledValue(ss_ext_list_price#7))#30, sum(UnscaledValue(ss_ext_tax#8))#31]
+Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ca_city#21 AS bought_city#32, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#6))#29,17,2) AS extended_price#33, MakeDecimal(sum(UnscaledValue(ss_ext_list_price#7))#30,17,2) AS list_price#34, MakeDecimal(sum(UnscaledValue(ss_ext_tax#8))#31,17,2) AS extended_tax#35]
+
+(30) BroadcastExchange
+Input [6]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#32, extended_price#33, list_price#34, extended_tax#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#36]
+
+(31) Scan parquet default.customer
+Output [4]: [c_customer_sk#37, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int,c_first_name:string,c_last_name:string>
+
+(32) ColumnarToRow
+Input [4]: [c_customer_sk#37, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
+
+(33) Filter
+Input [4]: [c_customer_sk#37, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
+Condition : (isnotnull(c_customer_sk#37) AND isnotnull(c_current_addr_sk#38))
+
+(34) BroadcastHashJoin [codegen id : 7]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#37]
+Join condition: None
+
+(35) Project [codegen id : 7]
+Output [8]: [ss_ticket_number#5, bought_city#32, extended_price#33, list_price#34, extended_tax#35, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
+Input [10]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#32, extended_price#33, list_price#34, extended_tax#35, c_customer_sk#37, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
+
+(36) Exchange
+Input [8]: [ss_ticket_number#5, bought_city#32, extended_price#33, list_price#34, extended_tax#35, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
+Arguments: hashpartitioning(c_current_addr_sk#38, 5), ENSURE_REQUIREMENTS, [id=#41]
+
+(37) Sort [codegen id : 8]
+Input [8]: [ss_ticket_number#5, bought_city#32, extended_price#33, list_price#34, extended_tax#35, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
+Arguments: [c_current_addr_sk#38 ASC NULLS FIRST], false, 0
+
+(38) Scan parquet default.customer_address
+Output [2]: [ca_address_sk#42, ca_city#43]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
+ReadSchema: struct<ca_address_sk:int,ca_city:string>
+
+(39) ColumnarToRow [codegen id : 9]
+Input [2]: [ca_address_sk#42, ca_city#43]
+
+(40) Filter [codegen id : 9]
+Input [2]: [ca_address_sk#42, ca_city#43]
+Condition : (isnotnull(ca_address_sk#42) AND isnotnull(ca_city#43))
+
+(41) Exchange
+Input [2]: [ca_address_sk#42, ca_city#43]
+Arguments: hashpartitioning(ca_address_sk#42, 5), ENSURE_REQUIREMENTS, [id=#44]
+
+(42) Sort [codegen id : 10]
+Input [2]: [ca_address_sk#42, ca_city#43]
+Arguments: [ca_address_sk#42 ASC NULLS FIRST], false, 0
+
+(43) SortMergeJoin [codegen id : 11]
+Left keys [1]: [c_current_addr_sk#38]
+Right keys [1]: [ca_address_sk#42]
+Join condition: NOT (ca_city#43 = bought_city#32)
+
+(44) Project [codegen id : 11]
+Output [8]: [c_last_name#40, c_first_name#39, ca_city#43, bought_city#32, ss_ticket_number#5, extended_price#33, extended_tax#35, list_price#34]
+Input [10]: [ss_ticket_number#5, bought_city#32, extended_price#33, list_price#34, extended_tax#35, c_current_addr_sk#38, c_first_name#39, c_last_name#40, ca_address_sk#42, ca_city#43]
+
+(45) TakeOrderedAndProject
+Input [8]: [c_last_name#40, c_first_name#39, ca_city#43, bought_city#32, ss_ticket_number#5, extended_price#33, extended_tax#35, list_price#34]
+Arguments: 100, [c_last_name#40 ASC NULLS FIRST, ss_ticket_number#5 ASC NULLS FIRST], [c_last_name#40, c_first_name#39, ca_city#43, bought_city#32, ss_ticket_number#5, extended_price#33, extended_tax#35, list_price#34]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
+BroadcastExchange (50)
++- * Project (49)
+   +- * Filter (48)
+      +- * ColumnarToRow (47)
+         +- Scan parquet default.date_dim (46)
+
+
+(46) Scan parquet default.date_dim
+Output [3]: [d_date_sk#11, d_year#45, d_dom#46]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1999,2000,2001]), In(d_date_sk, [2451180,2451181,2451211,2451212,2451239,2451240,2451270,2451271,2451300,2451301,2451331,2451332,2451361,2451362,2451392,2451393,2451423,2451424,2451453,2451454,2451484,2451485,2451514,2451515,2451545,2451546,2451576,2451577,2451605,2451606,2451636,2451637,2451666,2451667,2451697,2451698,2451727,2451728,2451758,2451759,2451789,2451790,2451819,2451820,2451850,2451851,2451880,2451881,2451911,2451912,2451942,2451943,2451970,2451971,2452001,2452002,2452031,2452032,2452062,2452063,2452092,2452093,2452123,2452124,2452154,2452155,2452184,2452185,2452215,2452216,2452245,2452246]), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
+
+(47) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#11, d_year#45, d_dom#46]
+
+(48) Filter [codegen id : 1]
+Input [3]: [d_date_sk#11, d_year#45, d_dom#46]
+Condition : (((((isnotnull(d_dom#46) AND (d_dom#46 >= 1)) AND (d_dom#46 <= 2)) AND d_year#45 IN (1999,2000,2001)) AND d_date_sk#11 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246) AND isnotnull(d_date_sk#11))
+
+(49) Project [codegen id : 1]
+Output [1]: [d_date_sk#11]
+Input [3]: [d_date_sk#11, d_year#45, d_dom#46]
+
+(50) BroadcastExchange
+Input [1]: [d_date_sk#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#47]
+
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/simplified.txt
@@ -1,70 +1,77 @@
 TakeOrderedAndProject [c_last_name,ss_ticket_number,c_first_name,ca_city,bought_city,extended_price,extended_tax,list_price]
-  WholeStageCodegen (8)
+  WholeStageCodegen (11)
     Project [c_last_name,c_first_name,ca_city,bought_city,ss_ticket_number,extended_price,extended_tax,list_price]
-      BroadcastHashJoin [c_current_addr_sk,ca_address_sk,ca_city,bought_city]
+      SortMergeJoin [c_current_addr_sk,ca_address_sk,ca_city,bought_city]
         InputAdapter
-          BroadcastExchange #1
-            WholeStageCodegen (7)
-              Project [ss_ticket_number,bought_city,extended_price,list_price,extended_tax,c_current_addr_sk,c_first_name,c_last_name]
-                BroadcastHashJoin [ss_customer_sk,c_customer_sk]
-                  InputAdapter
-                    BroadcastExchange #2
-                      WholeStageCodegen (6)
-                        HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,sum,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_ext_list_price)),sum(UnscaledValue(ss_ext_tax)),bought_city,extended_price,list_price,extended_tax,sum,sum,sum]
-                          InputAdapter
-                            Exchange [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city] #3
-                              WholeStageCodegen (5)
-                                HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax] [sum,sum,sum,sum,sum,sum]
-                                  Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ca_city]
-                                    BroadcastHashJoin [ss_addr_sk,ca_address_sk]
-                                      InputAdapter
-                                        BroadcastExchange #4
-                                          WholeStageCodegen (4)
-                                            Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
-                                              BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                                Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
-                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                    Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk]
-                                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                        Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
+          WholeStageCodegen (8)
+            Sort [c_current_addr_sk]
+              InputAdapter
+                Exchange [c_current_addr_sk] #1
+                  WholeStageCodegen (7)
+                    Project [ss_ticket_number,bought_city,extended_price,list_price,extended_tax,c_current_addr_sk,c_first_name,c_last_name]
+                      BroadcastHashJoin [ss_customer_sk,c_customer_sk]
+                        InputAdapter
+                          BroadcastExchange #2
+                            WholeStageCodegen (6)
+                              HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,sum,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_ext_list_price)),sum(UnscaledValue(ss_ext_tax)),bought_city,extended_price,list_price,extended_tax,sum,sum,sum]
+                                InputAdapter
+                                  Exchange [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city] #3
+                                    WholeStageCodegen (5)
+                                      HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax] [sum,sum,sum,sum,sum,sum]
+                                        Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ca_city]
+                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                            InputAdapter
+                                              BroadcastExchange #4
+                                                WholeStageCodegen (4)
+                                                  Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk,ca_city]
+                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                      InputAdapter
+                                                        BroadcastExchange #5
+                                                          WholeStageCodegen (3)
+                                                            Project [ss_customer_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk,ca_city]
+                                                              BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                                                InputAdapter
+                                                                  BroadcastExchange #6
+                                                                    WholeStageCodegen (2)
+                                                                      Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk,ca_city]
+                                                                        BroadcastHashJoin [ss_addr_sk,ca_address_sk]
+                                                                          InputAdapter
+                                                                            BroadcastExchange #7
+                                                                              WholeStageCodegen (1)
+                                                                                Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk]
+                                                                          Filter [ca_address_sk,ca_city]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet default.customer_address [ca_address_sk,ca_city]
+                                                                Project [hd_demo_sk]
+                                                                  Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
+                                                      Project [s_store_sk]
+                                                        Filter [s_city,s_store_sk]
                                                           ColumnarToRow
                                                             InputAdapter
-                                                              Scan parquet default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk]
-                                                                SubqueryBroadcast [d_date_sk] #1
-                                                                  BroadcastExchange #5
-                                                                    WholeStageCodegen (1)
-                                                                      Project [d_date_sk]
-                                                                        Filter [d_dom,d_year,d_date_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.date_dim [d_date_sk,d_year,d_dom]
-                                                        InputAdapter
-                                                          BroadcastExchange #6
-                                                            WholeStageCodegen (1)
-                                                              Project [s_store_sk]
-                                                                Filter [s_city,s_store_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.store [s_store_sk,s_city]
-                                                    InputAdapter
-                                                      ReusedExchange [d_date_sk] #5
-                                                InputAdapter
-                                                  BroadcastExchange #7
-                                                    WholeStageCodegen (3)
-                                                      Project [hd_demo_sk]
-                                                        Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
-                                      Filter [ca_address_sk,ca_city]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet default.customer_address [ca_address_sk,ca_city]
-                  Filter [c_customer_sk,c_current_addr_sk]
-                    ColumnarToRow
-                      InputAdapter
-                        Scan parquet default.customer [c_customer_sk,c_current_addr_sk,c_first_name,c_last_name]
-        Filter [ca_address_sk,ca_city]
-          ColumnarToRow
-            InputAdapter
-              Scan parquet default.customer_address [ca_address_sk,ca_city]
+                                                              Scan parquet default.store [s_store_sk,s_city]
+                                            Project [d_date_sk]
+                                              Filter [d_dom,d_year,d_date_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.date_dim [d_date_sk,d_year,d_dom]
+                        Filter [c_customer_sk,c_current_addr_sk]
+                          ColumnarToRow
+                            InputAdapter
+                              Scan parquet default.customer [c_customer_sk,c_current_addr_sk,c_first_name,c_last_name]
+        InputAdapter
+          WholeStageCodegen (10)
+            Sort [ca_address_sk]
+              InputAdapter
+                Exchange [ca_address_sk] #8
+                  WholeStageCodegen (9)
+                    Filter [ca_address_sk,ca_city]
+                      ColumnarToRow
+                        InputAdapter
+                          Scan parquet default.customer_address [ca_address_sk,ca_city]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/simplified.txt
@@ -19,48 +19,50 @@ TakeOrderedAndProject [c_last_name,ss_ticket_number,c_first_name,ca_city,bought_
                                     WholeStageCodegen (5)
                                       HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax] [sum,sum,sum,sum,sum,sum]
                                         Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ca_city]
-                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                          BroadcastHashJoin [ss_addr_sk,ca_address_sk]
                                             InputAdapter
                                               BroadcastExchange #4
                                                 WholeStageCodegen (4)
-                                                  Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk,ca_city]
-                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                      InputAdapter
-                                                        BroadcastExchange #5
-                                                          WholeStageCodegen (3)
-                                                            Project [ss_customer_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk,ca_city]
-                                                              BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                                                InputAdapter
-                                                                  BroadcastExchange #6
-                                                                    WholeStageCodegen (2)
-                                                                      Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk,ca_city]
-                                                                        BroadcastHashJoin [ss_addr_sk,ca_address_sk]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #7
-                                                                              WholeStageCodegen (1)
-                                                                                Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk]
-                                                                          Filter [ca_address_sk,ca_city]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.customer_address [ca_address_sk,ca_city]
-                                                                Project [hd_demo_sk]
-                                                                  Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
+                                                  Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
+                                                    BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                                      Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
+                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                          Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
+                                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                              Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk]
+                                                                      SubqueryBroadcast [d_date_sk] #1
+                                                                        BroadcastExchange #5
+                                                                          WholeStageCodegen (1)
+                                                                            Project [d_date_sk]
+                                                                              Filter [d_dom,d_year,d_date_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet default.date_dim [d_date_sk,d_year,d_dom]
+                                                              InputAdapter
+                                                                ReusedExchange [d_date_sk] #5
+                                                          InputAdapter
+                                                            BroadcastExchange #6
+                                                              WholeStageCodegen (2)
+                                                                Project [s_store_sk]
+                                                                  Filter [s_city,s_store_sk]
                                                                     ColumnarToRow
                                                                       InputAdapter
-                                                                        Scan parquet default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
-                                                      Project [s_store_sk]
-                                                        Filter [s_city,s_store_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet default.store [s_store_sk,s_city]
-                                            Project [d_date_sk]
-                                              Filter [d_dom,d_year,d_date_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet default.date_dim [d_date_sk,d_year,d_dom]
+                                                                        Scan parquet default.store [s_store_sk,s_city]
+                                                      InputAdapter
+                                                        BroadcastExchange #7
+                                                          WholeStageCodegen (3)
+                                                            Project [hd_demo_sk]
+                                                              Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
+                                            Filter [ca_address_sk,ca_city]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet default.customer_address [ca_address_sk,ca_city]
                         Filter [c_customer_sk,c_current_addr_sk]
                           ColumnarToRow
                             InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/explain.txt
@@ -1,204 +1,214 @@
 == Physical Plan ==
-* Sort (36)
-+- Exchange (35)
-   +- * Project (34)
-      +- * BroadcastHashJoin Inner BuildLeft (33)
-         :- BroadcastExchange (29)
-         :  +- * Filter (28)
-         :     +- * HashAggregate (27)
-         :        +- Exchange (26)
-         :           +- * HashAggregate (25)
-         :              +- * Project (24)
-         :                 +- * BroadcastHashJoin Inner BuildLeft (23)
-         :                    :- BroadcastExchange (18)
-         :                    :  +- * Project (17)
-         :                    :     +- * BroadcastHashJoin Inner BuildLeft (16)
-         :                    :        :- BroadcastExchange (11)
-         :                    :        :  +- * Project (10)
-         :                    :        :     +- * BroadcastHashJoin Inner BuildLeft (9)
-         :                    :        :        :- BroadcastExchange (4)
-         :                    :        :        :  +- * Filter (3)
-         :                    :        :        :     +- * ColumnarToRow (2)
-         :                    :        :        :        +- Scan parquet default.store_sales (1)
-         :                    :        :        +- * Project (8)
-         :                    :        :           +- * Filter (7)
-         :                    :        :              +- * ColumnarToRow (6)
-         :                    :        :                 +- Scan parquet default.household_demographics (5)
-         :                    :        +- * Project (15)
-         :                    :           +- * Filter (14)
-         :                    :              +- * ColumnarToRow (13)
-         :                    :                 +- Scan parquet default.store (12)
-         :                    +- * Project (22)
-         :                       +- * Filter (21)
-         :                          +- * ColumnarToRow (20)
-         :                             +- Scan parquet default.date_dim (19)
-         +- * Filter (32)
-            +- * ColumnarToRow (31)
-               +- Scan parquet default.customer (30)
+* Sort (32)
++- Exchange (31)
+   +- * Project (30)
+      +- * BroadcastHashJoin Inner BuildLeft (29)
+         :- BroadcastExchange (25)
+         :  +- * Filter (24)
+         :     +- * HashAggregate (23)
+         :        +- Exchange (22)
+         :           +- * HashAggregate (21)
+         :              +- * Project (20)
+         :                 +- * BroadcastHashJoin Inner BuildRight (19)
+         :                    :- * Project (13)
+         :                    :  +- * BroadcastHashJoin Inner BuildRight (12)
+         :                    :     :- * Project (6)
+         :                    :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+         :                    :     :     :- * Filter (3)
+         :                    :     :     :  +- * ColumnarToRow (2)
+         :                    :     :     :     +- Scan parquet default.store_sales (1)
+         :                    :     :     +- ReusedExchange (4)
+         :                    :     +- BroadcastExchange (11)
+         :                    :        +- * Project (10)
+         :                    :           +- * Filter (9)
+         :                    :              +- * ColumnarToRow (8)
+         :                    :                 +- Scan parquet default.store (7)
+         :                    +- BroadcastExchange (18)
+         :                       +- * Project (17)
+         :                          +- * Filter (16)
+         :                             +- * ColumnarToRow (15)
+         :                                +- Scan parquet default.household_demographics (14)
+         +- * Filter (28)
+            +- * ColumnarToRow (27)
+               +- Scan parquet default.customer (26)
 
 
 (1) Scan parquet default.store_sales
 Output [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [ss_sold_date_sk#5 INSET 2450815, 2450816, 2450846, 2450847, 2450874, 2450875, 2450905, 2450906, 2450935, 2450936, 2450966, 2450967, 2450996, 2450997, 2451027, 2451028, 2451058, 2451059, 2451088, 2451089, 2451119, 2451120, 2451149, 2451150, 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, isnotnull(ss_sold_date_sk#5), dynamicpruningexpression(true)]
+PartitionFilters: [ss_sold_date_sk#5 INSET 2450815, 2450816, 2450846, 2450847, 2450874, 2450875, 2450905, 2450906, 2450935, 2450936, 2450966, 2450967, 2450996, 2450997, 2451027, 2451028, 2451058, 2451059, 2451088, 2451089, 2451119, 2451120, 2451149, 2451150, 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, isnotnull(ss_sold_date_sk#5), dynamicpruningexpression(ss_sold_date_sk#5 IN dynamicpruning#6)]
 PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_hdemo_sk:int,ss_store_sk:int,ss_ticket_number:int>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 4]
 Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 4]
 Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
 Condition : ((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1))
 
-(4) BroadcastExchange
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [id=#6]
+(4) ReusedExchange [Reuses operator id: 37]
+Output [1]: [d_date_sk#7]
 
-(5) Scan parquet default.household_demographics
-Output [4]: [hd_demo_sk#7, hd_buy_potential#8, hd_dep_count#9, hd_vehicle_count#10]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/household_demographics]
-PushedFilters: [IsNotNull(hd_vehicle_count), IsNotNull(hd_dep_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,Unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
-ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
-
-(6) ColumnarToRow
-Input [4]: [hd_demo_sk#7, hd_buy_potential#8, hd_dep_count#9, hd_vehicle_count#10]
-
-(7) Filter
-Input [4]: [hd_demo_sk#7, hd_buy_potential#8, hd_dep_count#9, hd_vehicle_count#10]
-Condition : (((((isnotnull(hd_vehicle_count#10) AND isnotnull(hd_dep_count#9)) AND ((hd_buy_potential#8 = >10000         ) OR (hd_buy_potential#8 = Unknown        ))) AND (hd_vehicle_count#10 > 0)) AND ((cast(hd_dep_count#9 as double) / cast(hd_vehicle_count#10 as double)) > 1.0)) AND isnotnull(hd_demo_sk#7))
-
-(8) Project
-Output [1]: [hd_demo_sk#7]
-Input [4]: [hd_demo_sk#7, hd_buy_potential#8, hd_dep_count#9, hd_vehicle_count#10]
-
-(9) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#7]
+(5) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#5]
+Right keys [1]: [d_date_sk#7]
 Join condition: None
 
-(10) Project [codegen id : 2]
-Output [4]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
-Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, hd_demo_sk#7]
+(6) Project [codegen id : 4]
+Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
+Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
 
-(11) BroadcastExchange
-Input [4]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#11]
-
-(12) Scan parquet default.store
-Output [2]: [s_store_sk#12, s_county#13]
+(7) Scan parquet default.store
+Output [2]: [s_store_sk#8, s_county#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_county, [Barrow County,Bronx County,Fairfield County,Ziebach County]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_county:string>
 
-(13) ColumnarToRow
-Input [2]: [s_store_sk#12, s_county#13]
+(8) ColumnarToRow [codegen id : 2]
+Input [2]: [s_store_sk#8, s_county#9]
 
-(14) Filter
-Input [2]: [s_store_sk#12, s_county#13]
-Condition : (s_county#13 IN (Fairfield County,Ziebach County,Bronx County,Barrow County) AND isnotnull(s_store_sk#12))
+(9) Filter [codegen id : 2]
+Input [2]: [s_store_sk#8, s_county#9]
+Condition : (s_county#9 IN (Fairfield County,Ziebach County,Bronx County,Barrow County) AND isnotnull(s_store_sk#8))
 
-(15) Project
-Output [1]: [s_store_sk#12]
-Input [2]: [s_store_sk#12, s_county#13]
+(10) Project [codegen id : 2]
+Output [1]: [s_store_sk#8]
+Input [2]: [s_store_sk#8, s_county#9]
 
-(16) BroadcastHashJoin [codegen id : 3]
+(11) BroadcastExchange
+Input [1]: [s_store_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+
+(12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#12]
+Right keys [1]: [s_store_sk#8]
 Join condition: None
+
+(13) Project [codegen id : 4]
+Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
+Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#8]
+
+(14) Scan parquet default.household_demographics
+Output [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_count#14]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/household_demographics]
+PushedFilters: [IsNotNull(hd_vehicle_count), IsNotNull(hd_dep_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,Unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
+ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
+
+(15) ColumnarToRow [codegen id : 3]
+Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_count#14]
+
+(16) Filter [codegen id : 3]
+Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_count#14]
+Condition : (((((isnotnull(hd_vehicle_count#14) AND isnotnull(hd_dep_count#13)) AND ((hd_buy_potential#12 = >10000         ) OR (hd_buy_potential#12 = Unknown        ))) AND (hd_vehicle_count#14 > 0)) AND ((cast(hd_dep_count#13 as double) / cast(hd_vehicle_count#14 as double)) > 1.0)) AND isnotnull(hd_demo_sk#11))
 
 (17) Project [codegen id : 3]
-Output [3]: [ss_customer_sk#1, ss_ticket_number#4, ss_sold_date_sk#5]
-Input [5]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, s_store_sk#12]
+Output [1]: [hd_demo_sk#11]
+Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_count#14]
 
 (18) BroadcastExchange
-Input [3]: [ss_customer_sk#1, ss_ticket_number#4, ss_sold_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#14]
+Input [1]: [hd_demo_sk#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
 
-(19) Scan parquet default.date_dim
-Output [3]: [d_date_sk#15, d_year#16, d_dom#17]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1998,1999,2000]), In(d_date_sk, [2450815,2450816,2450846,2450847,2450874,2450875,2450905,2450906,2450935,2450936,2450966,2450967,2450996,2450997,2451027,2451028,2451058,2451059,2451088,2451089,2451119,2451120,2451149,2451150,2451180,2451181,2451211,2451212,2451239,2451240,2451270,2451271,2451300,2451301,2451331,2451332,2451361,2451362,2451392,2451393,2451423,2451424,2451453,2451454,2451484,2451485,2451514,2451515,2451545,2451546,2451576,2451577,2451605,2451606,2451636,2451637,2451666,2451667,2451697,2451698,2451727,2451728,2451758,2451759,2451789,2451790,2451819,2451820,2451850,2451851,2451880,2451881]), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
-
-(20) ColumnarToRow
-Input [3]: [d_date_sk#15, d_year#16, d_dom#17]
-
-(21) Filter
-Input [3]: [d_date_sk#15, d_year#16, d_dom#17]
-Condition : (((((isnotnull(d_dom#17) AND (d_dom#17 >= 1)) AND (d_dom#17 <= 2)) AND d_year#16 IN (1998,1999,2000)) AND d_date_sk#15 INSET 2450815, 2450816, 2450846, 2450847, 2450874, 2450875, 2450905, 2450906, 2450935, 2450936, 2450966, 2450967, 2450996, 2450997, 2451027, 2451028, 2451058, 2451059, 2451088, 2451089, 2451119, 2451120, 2451149, 2451150, 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881) AND isnotnull(d_date_sk#15))
-
-(22) Project
-Output [1]: [d_date_sk#15]
-Input [3]: [d_date_sk#15, d_year#16, d_dom#17]
-
-(23) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#15]
+(19) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_hdemo_sk#2]
+Right keys [1]: [hd_demo_sk#11]
 Join condition: None
 
-(24) Project [codegen id : 4]
+(20) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#1, ss_ticket_number#4]
-Input [4]: [ss_customer_sk#1, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#15]
+Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#11]
 
-(25) HashAggregate [codegen id : 4]
+(21) HashAggregate [codegen id : 4]
 Input [2]: [ss_customer_sk#1, ss_ticket_number#4]
 Keys [2]: [ss_ticket_number#4, ss_customer_sk#1]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#18]
-Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count#19]
+Aggregate Attributes [1]: [count#16]
+Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 
-(26) Exchange
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#19]
-Arguments: hashpartitioning(ss_ticket_number#4, ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [id=#20]
+(22) Exchange
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
+Arguments: hashpartitioning(ss_ticket_number#4, ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [id=#18]
 
-(27) HashAggregate [codegen id : 5]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#19]
+(23) HashAggregate [codegen id : 5]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 Keys [2]: [ss_ticket_number#4, ss_customer_sk#1]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#21]
-Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#21 AS cnt#22]
+Aggregate Attributes [1]: [count(1)#19]
+Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#19 AS cnt#20]
 
-(28) Filter [codegen id : 5]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#22]
-Condition : ((cnt#22 >= 1) AND (cnt#22 <= 5))
+(24) Filter [codegen id : 5]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#20]
+Condition : ((cnt#20 >= 1) AND (cnt#20 <= 5))
 
-(29) BroadcastExchange
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#23]
+(25) BroadcastExchange
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#21]
 
-(30) Scan parquet default.customer
-Output [5]: [c_customer_sk#24, c_salutation#25, c_first_name#26, c_last_name#27, c_preferred_cust_flag#28]
+(26) Scan parquet default.customer
+Output [5]: [c_customer_sk#22, c_salutation#23, c_first_name#24, c_last_name#25, c_preferred_cust_flag#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_salutation:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string>
 
-(31) ColumnarToRow
-Input [5]: [c_customer_sk#24, c_salutation#25, c_first_name#26, c_last_name#27, c_preferred_cust_flag#28]
+(27) ColumnarToRow
+Input [5]: [c_customer_sk#22, c_salutation#23, c_first_name#24, c_last_name#25, c_preferred_cust_flag#26]
 
-(32) Filter
-Input [5]: [c_customer_sk#24, c_salutation#25, c_first_name#26, c_last_name#27, c_preferred_cust_flag#28]
-Condition : isnotnull(c_customer_sk#24)
+(28) Filter
+Input [5]: [c_customer_sk#22, c_salutation#23, c_first_name#24, c_last_name#25, c_preferred_cust_flag#26]
+Condition : isnotnull(c_customer_sk#22)
 
-(33) BroadcastHashJoin [codegen id : 6]
+(29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#24]
+Right keys [1]: [c_customer_sk#22]
 Join condition: None
 
-(34) Project [codegen id : 6]
-Output [6]: [c_last_name#27, c_first_name#26, c_salutation#25, c_preferred_cust_flag#28, ss_ticket_number#4, cnt#22]
-Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#22, c_customer_sk#24, c_salutation#25, c_first_name#26, c_last_name#27, c_preferred_cust_flag#28]
+(30) Project [codegen id : 6]
+Output [6]: [c_last_name#25, c_first_name#24, c_salutation#23, c_preferred_cust_flag#26, ss_ticket_number#4, cnt#20]
+Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#20, c_customer_sk#22, c_salutation#23, c_first_name#24, c_last_name#25, c_preferred_cust_flag#26]
 
-(35) Exchange
-Input [6]: [c_last_name#27, c_first_name#26, c_salutation#25, c_preferred_cust_flag#28, ss_ticket_number#4, cnt#22]
-Arguments: rangepartitioning(cnt#22 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [id=#29]
+(31) Exchange
+Input [6]: [c_last_name#25, c_first_name#24, c_salutation#23, c_preferred_cust_flag#26, ss_ticket_number#4, cnt#20]
+Arguments: rangepartitioning(cnt#20 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [id=#27]
 
-(36) Sort [codegen id : 7]
-Input [6]: [c_last_name#27, c_first_name#26, c_salutation#25, c_preferred_cust_flag#28, ss_ticket_number#4, cnt#22]
-Arguments: [cnt#22 DESC NULLS LAST], true, 0
+(32) Sort [codegen id : 7]
+Input [6]: [c_last_name#25, c_first_name#24, c_salutation#23, c_preferred_cust_flag#26, ss_ticket_number#4, cnt#20]
+Arguments: [cnt#20 DESC NULLS LAST], true, 0
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
+BroadcastExchange (37)
++- * Project (36)
+   +- * Filter (35)
+      +- * ColumnarToRow (34)
+         +- Scan parquet default.date_dim (33)
+
+
+(33) Scan parquet default.date_dim
+Output [3]: [d_date_sk#7, d_year#28, d_dom#29]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1998,1999,2000]), In(d_date_sk, [2450815,2450816,2450846,2450847,2450874,2450875,2450905,2450906,2450935,2450936,2450966,2450967,2450996,2450997,2451027,2451028,2451058,2451059,2451088,2451089,2451119,2451120,2451149,2451150,2451180,2451181,2451211,2451212,2451239,2451240,2451270,2451271,2451300,2451301,2451331,2451332,2451361,2451362,2451392,2451393,2451423,2451424,2451453,2451454,2451484,2451485,2451514,2451515,2451545,2451546,2451576,2451577,2451605,2451606,2451636,2451637,2451666,2451667,2451697,2451698,2451727,2451728,2451758,2451759,2451789,2451790,2451819,2451820,2451850,2451851,2451880,2451881]), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
+
+(34) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#7, d_year#28, d_dom#29]
+
+(35) Filter [codegen id : 1]
+Input [3]: [d_date_sk#7, d_year#28, d_dom#29]
+Condition : (((((isnotnull(d_dom#29) AND (d_dom#29 >= 1)) AND (d_dom#29 <= 2)) AND d_year#28 IN (1998,1999,2000)) AND d_date_sk#7 INSET 2450815, 2450816, 2450846, 2450847, 2450874, 2450875, 2450905, 2450906, 2450935, 2450936, 2450966, 2450967, 2450996, 2450997, 2451027, 2451028, 2451058, 2451059, 2451088, 2451089, 2451119, 2451120, 2451149, 2451150, 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881) AND isnotnull(d_date_sk#7))
+
+(36) Project [codegen id : 1]
+Output [1]: [d_date_sk#7]
+Input [3]: [d_date_sk#7, d_year#28, d_dom#29]
+
+(37) BroadcastExchange
+Input [1]: [d_date_sk#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#30]
+
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/explain.txt
@@ -23,7 +23,7 @@
          :                    :        :        +- * Project (8)
          :                    :        :           +- * Filter (7)
          :                    :        :              +- * ColumnarToRow (6)
-         :                    :        :                 +- Scan parquet default.date_dim (5)
+         :                    :        :                 +- Scan parquet default.household_demographics (5)
          :                    :        +- * Project (15)
          :                    :           +- * Filter (14)
          :                    :              +- * ColumnarToRow (13)
@@ -31,7 +31,7 @@
          :                    +- * Project (22)
          :                       +- * Filter (21)
          :                          +- * ColumnarToRow (20)
-         :                             +- Scan parquet default.household_demographics (19)
+         :                             +- Scan parquet default.date_dim (19)
          +- * Filter (32)
             +- * ColumnarToRow (31)
                +- Scan parquet default.customer (30)
@@ -54,96 +54,96 @@ Condition : ((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnu
 
 (4) BroadcastExchange
 Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[4, int, true] as bigint)),false), [id=#6]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [id=#6]
 
-(5) Scan parquet default.date_dim
-Output [3]: [d_date_sk#7, d_year#8, d_dom#9]
+(5) Scan parquet default.household_demographics
+Output [4]: [hd_demo_sk#7, hd_buy_potential#8, hd_dep_count#9, hd_vehicle_count#10]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1998,1999,2000]), In(d_date_sk, [2450815,2450816,2450846,2450847,2450874,2450875,2450905,2450906,2450935,2450936,2450966,2450967,2450996,2450997,2451027,2451028,2451058,2451059,2451088,2451089,2451119,2451120,2451149,2451150,2451180,2451181,2451211,2451212,2451239,2451240,2451270,2451271,2451300,2451301,2451331,2451332,2451361,2451362,2451392,2451393,2451423,2451424,2451453,2451454,2451484,2451485,2451514,2451515,2451545,2451546,2451576,2451577,2451605,2451606,2451636,2451637,2451666,2451667,2451697,2451698,2451727,2451728,2451758,2451759,2451789,2451790,2451819,2451820,2451850,2451851,2451880,2451881]), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
+Location [not included in comparison]/{warehouse_dir}/household_demographics]
+PushedFilters: [IsNotNull(hd_vehicle_count), IsNotNull(hd_dep_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,Unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
+ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
 
 (6) ColumnarToRow
-Input [3]: [d_date_sk#7, d_year#8, d_dom#9]
+Input [4]: [hd_demo_sk#7, hd_buy_potential#8, hd_dep_count#9, hd_vehicle_count#10]
 
 (7) Filter
-Input [3]: [d_date_sk#7, d_year#8, d_dom#9]
-Condition : (((((isnotnull(d_dom#9) AND (d_dom#9 >= 1)) AND (d_dom#9 <= 2)) AND d_year#8 IN (1998,1999,2000)) AND d_date_sk#7 INSET 2450815, 2450816, 2450846, 2450847, 2450874, 2450875, 2450905, 2450906, 2450935, 2450936, 2450966, 2450967, 2450996, 2450997, 2451027, 2451028, 2451058, 2451059, 2451088, 2451089, 2451119, 2451120, 2451149, 2451150, 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881) AND isnotnull(d_date_sk#7))
+Input [4]: [hd_demo_sk#7, hd_buy_potential#8, hd_dep_count#9, hd_vehicle_count#10]
+Condition : (((((isnotnull(hd_vehicle_count#10) AND isnotnull(hd_dep_count#9)) AND ((hd_buy_potential#8 = >10000         ) OR (hd_buy_potential#8 = Unknown        ))) AND (hd_vehicle_count#10 > 0)) AND ((cast(hd_dep_count#9 as double) / cast(hd_vehicle_count#10 as double)) > 1.0)) AND isnotnull(hd_demo_sk#7))
 
 (8) Project
-Output [1]: [d_date_sk#7]
-Input [3]: [d_date_sk#7, d_year#8, d_dom#9]
+Output [1]: [hd_demo_sk#7]
+Input [4]: [hd_demo_sk#7, hd_buy_potential#8, hd_dep_count#9, hd_vehicle_count#10]
 
 (9) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
+Left keys [1]: [ss_hdemo_sk#2]
+Right keys [1]: [hd_demo_sk#7]
 Join condition: None
 
 (10) Project [codegen id : 2]
-Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
-Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
+Output [4]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
+Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, hd_demo_sk#7]
 
 (11) BroadcastExchange
-Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#10]
+Input [4]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#11]
 
 (12) Scan parquet default.store
-Output [2]: [s_store_sk#11, s_county#12]
+Output [2]: [s_store_sk#12, s_county#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_county, [Barrow County,Bronx County,Fairfield County,Ziebach County]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_county:string>
 
 (13) ColumnarToRow
-Input [2]: [s_store_sk#11, s_county#12]
+Input [2]: [s_store_sk#12, s_county#13]
 
 (14) Filter
-Input [2]: [s_store_sk#11, s_county#12]
-Condition : (s_county#12 IN (Fairfield County,Ziebach County,Bronx County,Barrow County) AND isnotnull(s_store_sk#11))
+Input [2]: [s_store_sk#12, s_county#13]
+Condition : (s_county#13 IN (Fairfield County,Ziebach County,Bronx County,Barrow County) AND isnotnull(s_store_sk#12))
 
 (15) Project
-Output [1]: [s_store_sk#11]
-Input [2]: [s_store_sk#11, s_county#12]
+Output [1]: [s_store_sk#12]
+Input [2]: [s_store_sk#12, s_county#13]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#11]
+Right keys [1]: [s_store_sk#12]
 Join condition: None
 
 (17) Project [codegen id : 3]
-Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#11]
+Output [3]: [ss_customer_sk#1, ss_ticket_number#4, ss_sold_date_sk#5]
+Input [5]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, s_store_sk#12]
 
 (18) BroadcastExchange
-Input [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#13]
+Input [3]: [ss_customer_sk#1, ss_ticket_number#4, ss_sold_date_sk#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#14]
 
-(19) Scan parquet default.household_demographics
-Output [4]: [hd_demo_sk#14, hd_buy_potential#15, hd_dep_count#16, hd_vehicle_count#17]
+(19) Scan parquet default.date_dim
+Output [3]: [d_date_sk#15, d_year#16, d_dom#17]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/household_demographics]
-PushedFilters: [IsNotNull(hd_vehicle_count), IsNotNull(hd_dep_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,Unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
-ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1998,1999,2000]), In(d_date_sk, [2450815,2450816,2450846,2450847,2450874,2450875,2450905,2450906,2450935,2450936,2450966,2450967,2450996,2450997,2451027,2451028,2451058,2451059,2451088,2451089,2451119,2451120,2451149,2451150,2451180,2451181,2451211,2451212,2451239,2451240,2451270,2451271,2451300,2451301,2451331,2451332,2451361,2451362,2451392,2451393,2451423,2451424,2451453,2451454,2451484,2451485,2451514,2451515,2451545,2451546,2451576,2451577,2451605,2451606,2451636,2451637,2451666,2451667,2451697,2451698,2451727,2451728,2451758,2451759,2451789,2451790,2451819,2451820,2451850,2451851,2451880,2451881]), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
 (20) ColumnarToRow
-Input [4]: [hd_demo_sk#14, hd_buy_potential#15, hd_dep_count#16, hd_vehicle_count#17]
+Input [3]: [d_date_sk#15, d_year#16, d_dom#17]
 
 (21) Filter
-Input [4]: [hd_demo_sk#14, hd_buy_potential#15, hd_dep_count#16, hd_vehicle_count#17]
-Condition : (((((isnotnull(hd_vehicle_count#17) AND isnotnull(hd_dep_count#16)) AND ((hd_buy_potential#15 = >10000         ) OR (hd_buy_potential#15 = Unknown        ))) AND (hd_vehicle_count#17 > 0)) AND ((cast(hd_dep_count#16 as double) / cast(hd_vehicle_count#17 as double)) > 1.0)) AND isnotnull(hd_demo_sk#14))
+Input [3]: [d_date_sk#15, d_year#16, d_dom#17]
+Condition : (((((isnotnull(d_dom#17) AND (d_dom#17 >= 1)) AND (d_dom#17 <= 2)) AND d_year#16 IN (1998,1999,2000)) AND d_date_sk#15 INSET 2450815, 2450816, 2450846, 2450847, 2450874, 2450875, 2450905, 2450906, 2450935, 2450936, 2450966, 2450967, 2450996, 2450997, 2451027, 2451028, 2451058, 2451059, 2451088, 2451089, 2451119, 2451120, 2451149, 2451150, 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881) AND isnotnull(d_date_sk#15))
 
 (22) Project
-Output [1]: [hd_demo_sk#14]
-Input [4]: [hd_demo_sk#14, hd_buy_potential#15, hd_dep_count#16, hd_vehicle_count#17]
+Output [1]: [d_date_sk#15]
+Input [3]: [d_date_sk#15, d_year#16, d_dom#17]
 
 (23) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#14]
+Left keys [1]: [ss_sold_date_sk#5]
+Right keys [1]: [d_date_sk#15]
 Join condition: None
 
 (24) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#1, ss_ticket_number#4]
-Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#14]
+Input [4]: [ss_customer_sk#1, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#15]
 
 (25) HashAggregate [codegen id : 4]
 Input [2]: [ss_customer_sk#1, ss_ticket_number#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/simplified.txt
@@ -15,39 +15,41 @@ WholeStageCodegen (7)
                             WholeStageCodegen (4)
                               HashAggregate [ss_ticket_number,ss_customer_sk] [count,count]
                                 Project [ss_customer_sk,ss_ticket_number]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                    InputAdapter
-                                      BroadcastExchange #4
-                                        WholeStageCodegen (3)
-                                          Project [ss_customer_sk,ss_ticket_number,ss_sold_date_sk]
-                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                              InputAdapter
-                                                BroadcastExchange #5
-                                                  WholeStageCodegen (2)
-                                                    Project [ss_customer_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
-                                                      BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                                        InputAdapter
-                                                          BroadcastExchange #6
-                                                            WholeStageCodegen (1)
-                                                              Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
-                                                        Project [hd_demo_sk]
-                                                          Filter [hd_vehicle_count,hd_dep_count,hd_buy_potential,hd_demo_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential,hd_dep_count,hd_vehicle_count]
+                                  BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                    Project [ss_customer_sk,ss_hdemo_sk,ss_ticket_number]
+                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                        Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
+                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                            Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
+                                                    SubqueryBroadcast [d_date_sk] #1
+                                                      BroadcastExchange #4
+                                                        WholeStageCodegen (1)
+                                                          Project [d_date_sk]
+                                                            Filter [d_dom,d_year,d_date_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet default.date_dim [d_date_sk,d_year,d_dom]
+                                            InputAdapter
+                                              ReusedExchange [d_date_sk] #4
+                                        InputAdapter
+                                          BroadcastExchange #5
+                                            WholeStageCodegen (2)
                                               Project [s_store_sk]
                                                 Filter [s_county,s_store_sk]
                                                   ColumnarToRow
                                                     InputAdapter
                                                       Scan parquet default.store [s_store_sk,s_county]
-                                    Project [d_date_sk]
-                                      Filter [d_dom,d_year,d_date_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet default.date_dim [d_date_sk,d_year,d_dom]
+                                    InputAdapter
+                                      BroadcastExchange #6
+                                        WholeStageCodegen (3)
+                                          Project [hd_demo_sk]
+                                            Filter [hd_vehicle_count,hd_dep_count,hd_buy_potential,hd_demo_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential,hd_dep_count,hd_vehicle_count]
               Filter [c_customer_sk]
                 ColumnarToRow
                   InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/simplified.txt
@@ -15,17 +15,17 @@ WholeStageCodegen (7)
                             WholeStageCodegen (4)
                               HashAggregate [ss_ticket_number,ss_customer_sk] [count,count]
                                 Project [ss_customer_sk,ss_ticket_number]
-                                  BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                     InputAdapter
                                       BroadcastExchange #4
                                         WholeStageCodegen (3)
-                                          Project [ss_customer_sk,ss_hdemo_sk,ss_ticket_number]
+                                          Project [ss_customer_sk,ss_ticket_number,ss_sold_date_sk]
                                             BroadcastHashJoin [ss_store_sk,s_store_sk]
                                               InputAdapter
                                                 BroadcastExchange #5
                                                   WholeStageCodegen (2)
-                                                    Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
-                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                    Project [ss_customer_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
+                                                      BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
                                                         InputAdapter
                                                           BroadcastExchange #6
                                                             WholeStageCodegen (1)
@@ -33,21 +33,21 @@ WholeStageCodegen (7)
                                                                 ColumnarToRow
                                                                   InputAdapter
                                                                     Scan parquet default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
-                                                        Project [d_date_sk]
-                                                          Filter [d_dom,d_year,d_date_sk]
+                                                        Project [hd_demo_sk]
+                                                          Filter [hd_vehicle_count,hd_dep_count,hd_buy_potential,hd_demo_sk]
                                                             ColumnarToRow
                                                               InputAdapter
-                                                                Scan parquet default.date_dim [d_date_sk,d_year,d_dom]
+                                                                Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential,hd_dep_count,hd_vehicle_count]
                                               Project [s_store_sk]
                                                 Filter [s_county,s_store_sk]
                                                   ColumnarToRow
                                                     InputAdapter
                                                       Scan parquet default.store [s_store_sk,s_county]
-                                    Project [hd_demo_sk]
-                                      Filter [hd_vehicle_count,hd_dep_count,hd_buy_potential,hd_demo_sk]
+                                    Project [d_date_sk]
+                                      Filter [d_dom,d_year,d_date_sk]
                                         ColumnarToRow
                                           InputAdapter
-                                            Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential,hd_dep_count,hd_vehicle_count]
+                                            Scan parquet default.date_dim [d_date_sk,d_year,d_dom]
               Filter [c_customer_sk]
                 ColumnarToRow
                   InputAdapter


### PR DESCRIPTION
### What changes were proposed in this pull request?

Forces the selectivity estimate for null-based filters to be in the range `[0,1]`.

### Why are the changes needed?

I noticed in a few TPC-DS query tests that the column statistic null count can be higher than the table statistic row count. In the current implementation, the selectivity estimate for `IsNotNull` is negative.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit test