### PR TITLE
[SPARK-35561][SQL] Remove leading zeros from empty static number type partition

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -351,8 +351,22 @@ object PartitioningUtils {
    */
   def getPathFragment(spec: TablePartitionSpec, partitionSchema: StructType): String = {
     partitionSchema.map { field =>
-      escapePathName(field.name) + "=" + getPartitionValueString(spec(field.name))
+      escapePathName(field.name) + "=" +
+        getPartitionValueString(
+          removeLeadingZerosFromNumberTypePartition(spec(field.name), field.dataType))
     }.mkString("/")
+  }
+
+  def removeLeadingZerosFromNumberTypePartition(value: String, dataType: DataType): String = {
+    dataType match {
+      case ByteType => value.toByte.toString
+      case ShortType => value.toShort.toString
+      case IntegerType => value.toInt.toString
+      case LongType => value.toLong.toString
+      case FloatType => value.toFloat.toString
+      case DoubleType => value.toDouble.toString
+      case _ => value
+    }
   }
 
   def getPathFragment(spec: TablePartitionSpec, partitionColumns: Seq[Attribute]): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -357,13 +357,12 @@ object PartitioningUtils {
     }.mkString("/")
   }
 
-  def removeLeadingZerosFromNumberTypePartition(value: String, dataType: DataType): String = {
+  def removeLeadingZerosFromNumberTypePartition(value: String, dataType: DataType): String =
     dataType match {
-      case ByteType | ShortType | IntegerType | LongType => value.toLong.toString
-      case FloatType | DoubleType => value.toDouble.toString
+      case ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType =>
+        castPartValueToDesiredType(dataType, value, null).toString
       case _ => value
     }
-  }
 
   def getPathFragment(spec: TablePartitionSpec, partitionColumns: Seq[Attribute]): String = {
     getPathFragment(spec, StructType.fromAttributes(partitionColumns))
@@ -526,9 +525,9 @@ object PartitioningUtils {
     case _ if value == DEFAULT_PARTITION_NAME => null
     case NullType => null
     case StringType => UTF8String.fromString(unescapePathName(value))
-    case IntegerType => Integer.parseInt(value)
+    case ByteType | ShortType | IntegerType => Integer.parseInt(value)
     case LongType => JLong.parseLong(value)
-    case DoubleType => JDouble.parseDouble(value)
+    case FloatType | DoubleType => JDouble.parseDouble(value)
     case _: DecimalType => Literal(new JBigDecimal(value)).value
     case DateType =>
       Cast(Literal(value), DateType, Some(zoneId.getId)).eval()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -359,12 +359,8 @@ object PartitioningUtils {
 
   def removeLeadingZerosFromNumberTypePartition(value: String, dataType: DataType): String = {
     dataType match {
-      case ByteType => value.toByte.toString
-      case ShortType => value.toShort.toString
-      case IntegerType => value.toInt.toString
-      case LongType => value.toLong.toString
-      case FloatType => value.toFloat.toString
-      case DoubleType => value.toDouble.toString
+      case ByteType | ShortType | IntegerType | LongType => value.toLong.toString
+      case FloatType | DoubleType => value.toDouble.toString
       case _ => value
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -1211,6 +1211,13 @@ class ParquetV2PartitionDiscoverySuite extends ParquetPartitionDiscoverySuite {
       .sparkConf
       .set(SQLConf.USE_V1_SOURCE_LIST, "")
 
+  test("SPARK-35561: remove leading zeros from empty static number type partition") {
+    val spec = Map("p_int"-> "010", "p_float"-> "01.00")
+    val schema = new StructType().add("p_int", "int").add("p_float", "float")
+    val path = PartitioningUtils.getPathFragment(spec, schema)
+    assert("p_int=10/p_float=1.0" === path)
+  }
+
   test("read partitioned table - partition key included in Parquet file") {
     withTempDir { base =>
       for {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR removes leading zeros from static number type partition when we insert into a partition table with empty partitions.

create table 

    CREATE TABLE `table_int` ( `id` INT, `c_string` STRING, `p_int` int)
    USING parquet PARTITIONED BY (p_int);

insert 

    insert overwrite table table_int partition (p_int='00011')
    select 1, 'c string'
    where true ;
    
|partition|
|---------|
|p_int=11|

    insert overwrite table table_int partition (p_int='00012')
    select 1, 'c string'
    where false ;

|partition|
|---------|
|p_int=00012|



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR creates consistent result when insert empty or non-empty partition

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add Unit test