### PR TITLE
[SPARK-36076][SQL][3.1] ArrayIndexOutOfBounds in Cast string to times…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -236,136 +236,135 @@ object DateTimeUtils {
    *     - +|-hhmmss
    *  - Region-based zone IDs in the form `area/city`, such as `Europe/Paris`
    */
-  def stringToTimestamp(s: UTF8String, timeZoneId: ZoneId): Option[Long] = {
-    try {
-      if (s == null) {
-        return None
-      }
-      var tz: Option[String] = None
-      val segments: Array[Int] = Array[Int](1, 1, 1, 0, 0, 0, 0, 0, 0)
-      var i = 0
-      var currentSegmentValue = 0
-      val bytes = s.trimAll().getBytes
-      val specialTimestamp = convertSpecialTimestamp(bytes, timeZoneId)
-      if (specialTimestamp.isDefined) return specialTimestamp
-      var j = 0
-      var digitsMilli = 0
-      var justTime = false
-      while (j < bytes.length) {
-        val b = bytes(j)
-        val parsedValue = b - '0'.toByte
-        if (parsedValue < 0 || parsedValue > 9) {
-          if (j == 0 && b == 'T') {
+  def stringToTimestamp(s: UTF8String, timeZoneId: ZoneId): Option[Long] = try {
+    if (s == null) {
+      return None
+    }
+    var tz: Option[String] = None
+    val segments: Array[Int] = Array[Int](1, 1, 1, 0, 0, 0, 0, 0, 0)
+    var i = 0
+    var currentSegmentValue = 0
+    val bytes = s.trimAll().getBytes
+    val specialTimestamp = convertSpecialTimestamp(bytes, timeZoneId)
+    if (specialTimestamp.isDefined) return specialTimestamp
+    var j = 0
+    var digitsMilli = 0
+    var justTime = false
+    while (j < bytes.length) {
+      val b = bytes(j)
+      val parsedValue = b - '0'.toByte
+      if (parsedValue < 0 || parsedValue > 9) {
+        if (j == 0 && b == 'T') {
+          justTime = true
+          i += 3
+        } else if (i < 2) {
+          if (b == '-') {
+            if (i == 0 && j != 4) {
+              // year should have exact four digits
+              return None
+            }
+            segments(i) = currentSegmentValue
+            currentSegmentValue = 0
+            i += 1
+          } else if (i == 0 && b == ':') {
             justTime = true
-            i += 3
-          } else if (i < 2) {
-            if (b == '-') {
-              if (i == 0 && j != 4) {
-                // year should have exact four digits
-                return None
-              }
-              segments(i) = currentSegmentValue
-              currentSegmentValue = 0
-              i += 1
-            } else if (i == 0 && b == ':') {
-              justTime = true
-              segments(3) = currentSegmentValue
-              currentSegmentValue = 0
-              i = 4
-            } else {
-              return None
-            }
-          } else if (i == 2) {
-            if (b == ' ' || b == 'T') {
-              segments(i) = currentSegmentValue
-              currentSegmentValue = 0
-              i += 1
-            } else {
-              return None
-            }
-          } else if (i == 3 || i == 4) {
-            if (b == ':') {
-              segments(i) = currentSegmentValue
-              currentSegmentValue = 0
-              i += 1
-            } else {
-              return None
-            }
-          } else if (i == 5 || i == 6) {
-            if (b == '-' || b == '+') {
-              segments(i) = currentSegmentValue
-              currentSegmentValue = 0
-              i += 1
-              tz = Some(new String(bytes, j, 1))
-            } else if (b == '.' && i == 5) {
-              segments(i) = currentSegmentValue
-              currentSegmentValue = 0
-              i += 1
-            } else {
-              segments(i) = currentSegmentValue
-              currentSegmentValue = 0
-              i += 1
-              tz = Some(new String(bytes, j, bytes.length - j))
-              j = bytes.length - 1
-            }
-            if (i == 6  && b != '.') {
-              i += 1
-            }
+            segments(3) = currentSegmentValue
+            currentSegmentValue = 0
+            i = 4
           } else {
-            if (i < segments.length && (b == ':' || b == ' ')) {
-              segments(i) = currentSegmentValue
-              currentSegmentValue = 0
-              i += 1
-            } else {
-              return None
-            }
+            return None
+          }
+        } else if (i == 2) {
+          if (b == ' ' || b == 'T') {
+            segments(i) = currentSegmentValue
+            currentSegmentValue = 0
+            i += 1
+          } else {
+            return None
+          }
+        } else if (i == 3 || i == 4) {
+          if (b == ':') {
+            segments(i) = currentSegmentValue
+            currentSegmentValue = 0
+            i += 1
+          } else {
+            return None
+          }
+        } else if (i == 5 || i == 6) {
+          if (b == '-' || b == '+') {
+            segments(i) = currentSegmentValue
+            currentSegmentValue = 0
+            i += 1
+            tz = Some(new String(bytes, j, 1))
+          } else if (b == '.' && i == 5) {
+            segments(i) = currentSegmentValue
+            currentSegmentValue = 0
+            i += 1
+          } else {
+            segments(i) = currentSegmentValue
+            currentSegmentValue = 0
+            i += 1
+            tz = Some(new String(bytes, j, bytes.length - j))
+            j = bytes.length - 1
+          }
+          if (i == 6  && b != '.') {
+            i += 1
           }
         } else {
-          if (i == 6) {
-            digitsMilli += 1
+          if (i < segments.length && (b == ':' || b == ' ')) {
+            segments(i) = currentSegmentValue
+            currentSegmentValue = 0
+            i += 1
+          } else {
+            return None
           }
-          currentSegmentValue = currentSegmentValue * 10 + parsedValue
         }
-        j += 1
-      }
-
-      segments(i) = currentSegmentValue
-      if (!justTime && i == 0 && j != 4) {
-        // year should have exact four digits
-        return None
-      }
-
-      while (digitsMilli < 6) {
-        segments(6) *= 10
-        digitsMilli += 1
-      }
-
-      // We are truncating the nanosecond part, which results in loss of precision
-      while (digitsMilli > 6) {
-        segments(6) /= 10
-        digitsMilli -= 1
-      }
-      val zoneId = tz match {
-        case None => timeZoneId
-        case Some("+") => ZoneOffset.ofHoursMinutes(segments(7), segments(8))
-        case Some("-") => ZoneOffset.ofHoursMinutes(-segments(7), -segments(8))
-        case Some(zoneName: String) => getZoneId(zoneName.trim)
-      }
-      val nanoseconds = MICROSECONDS.toNanos(segments(6))
-      val localTime = LocalTime.of(segments(3), segments(4), segments(5), nanoseconds.toInt)
-      val localDate = if (justTime) {
-        LocalDate.now(zoneId)
       } else {
-        LocalDate.of(segments(0), segments(1), segments(2))
+        if (i == 6) {
+          digitsMilli += 1
+        }
+        currentSegmentValue = currentSegmentValue * 10 + parsedValue
       }
-      val localDateTime = LocalDateTime.of(localDate, localTime)
-      val zonedDateTime = ZonedDateTime.of(localDateTime, zoneId)
-      val instant = Instant.from(zonedDateTime)
-      Some(instantToMicros(instant))
-    } catch {
-      case NonFatal(_) => None
+      j += 1
     }
+
+    segments(i) = currentSegmentValue
+    if (!justTime && i == 0 && j != 4) {
+      // year should have exact four digits
+      return None
+    }
+
+    while (digitsMilli < 6) {
+      segments(6) *= 10
+      digitsMilli += 1
+    }
+
+    // We are truncating the nanosecond part, which results in loss of precision
+    while (digitsMilli > 6) {
+      segments(6) /= 10
+      digitsMilli -= 1
+    }
+    val zoneId = tz match {
+      case None => timeZoneId
+      case Some("+") => ZoneOffset.ofHoursMinutes(segments(7), segments(8))
+      case Some("-") => ZoneOffset.ofHoursMinutes(-segments(7), -segments(8))
+      case Some(zoneName: String) => getZoneId(zoneName.trim)
+    }
+    val nanoseconds = MICROSECONDS.toNanos(segments(6))
+    val localTime = LocalTime.of(segments(3), segments(4), segments(5), nanoseconds.toInt)
+    val localDate = if (justTime) {
+      LocalDate.now(zoneId)
+    } else {
+      LocalDate.of(segments(0), segments(1), segments(2))
+    }
+    val localDateTime = LocalDateTime.of(localDate, localTime)
+    val zonedDateTime = ZonedDateTime.of(localDateTime, zoneId)
+    val instant = Instant.from(zonedDateTime)
+    Some(instantToMicros(instant))
+  } catch {
+    case NonFatal(_) => None
   }
+
 
   def stringToTimestampAnsi(s: UTF8String, timeZoneId: ZoneId): Long = {
     val timestamp = stringToTimestamp(s, timeZoneId)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -365,7 +365,6 @@ object DateTimeUtils {
     case NonFatal(_) => None
   }
 
-
   def stringToTimestampAnsi(s: UTF8String, timeZoneId: ZoneId): Long = {
     val timestamp = stringToTimestamp(s, timeZoneId)
     if (timestamp.isEmpty) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -283,6 +283,10 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     }
   }
 
+  test("SPARK-36076: Cast string to timestamp throw ArrayIndexOutOfBounds") {
+    assert(toTimestamp(":8:434421+ 98:38", UTC) === None)
+  }
+
   test("SPARK-15379: special invalid date string") {
     // Test stringToDate
     assert(toDate("2015-02-29 00:00:00").isEmpty)


### PR DESCRIPTION
…tamp
### What changes were proposed in this pull request?
Casting string to timestamp might throw ArrayIndexOutOfBounds in certain cases
This error only occur in branch 3.0, 3.1 and previous, it's not present on 3.2 or master
Code to reproduce:
```
val df = Seq(":8:434421+ 98:38").toDF("c0")
val df2 = df.withColumn("c1", col("c0").cast(DataTypes.TimestampType))
df2.show()
```

Error:
```
java.lang.ArrayIndexOutOfBoundsException: 9
  at org.apache.spark.sql.catalyst.util.DateTimeUtils$.stringToTimestamp(DateTimeUtils.scala:328)
  at org.apache.spark.sql.catalyst.expressions.CastBase.$anonfun$castToTimestamp$2(Cast.scala:455)
  at org.apache.spark.sql.catalyst.expressions.CastBase.buildCast(Cast.scala:295)
  at org.apache.spark.sql.catalyst.expressions.CastBase.$anonfun$castToTimestamp$1(Cast.scala:451)
  at org.apache.spark.sql.catalyst.expressions.CastBase.nullSafeEval(Cast.scala:840)
  at org.apache.spark.sql.catalyst.expressions.UnaryExpression.eval(Expression.scala:476)
```

### Why are the changes needed?
Cast String to timestamp shouldn't throw error, it should return Null instead.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add test in DateTimeUtilsSuite