### PR TITLE
[SPARK-36069][SQL] Add field info to `from_json`'s exception in the FAILFAST mode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -202,7 +202,7 @@ class JacksonParser(
             case "Infinity" => Float.PositiveInfinity
             case "-Infinity" => Float.NegativeInfinity
             case _ => throw QueryExecutionErrors.cannotParseStringAsDataTypeError(
-              parser,VALUE_STRING, FloatType)
+              parser, VALUE_STRING, FloatType)
           }
       }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -201,8 +201,8 @@ class JacksonParser(
             case "NaN" => Float.NaN
             case "Infinity" => Float.PositiveInfinity
             case "-Infinity" => Float.NegativeInfinity
-            case other => throw QueryExecutionErrors.cannotParseStringAsDataTypeError(
-              other, FloatType)
+            case _ => throw QueryExecutionErrors.cannotParseStringAsDataTypeError(
+              parser,VALUE_STRING, FloatType)
           }
       }
 
@@ -217,8 +217,8 @@ class JacksonParser(
             case "NaN" => Double.NaN
             case "Infinity" => Double.PositiveInfinity
             case "-Infinity" => Double.NegativeInfinity
-            case other =>
-              throw QueryExecutionErrors.cannotParseStringAsDataTypeError(other, DoubleType)
+            case _ => throw QueryExecutionErrors.cannotParseStringAsDataTypeError(
+              parser, VALUE_STRING, DoubleType)
           }
       }
 
@@ -383,7 +383,7 @@ class JacksonParser(
     case token =>
       // We cannot parse this token based on the given data type. So, we throw a
       // RuntimeException and this exception will be caught by `parse` method.
-      throw QueryExecutionErrors.failToParseValueForDataTypeError(dataType, token)
+      throw QueryExecutionErrors.failToParseValueForDataTypeError(parser, token, dataType)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -958,7 +958,8 @@ object QueryExecutionErrors {
     new RuntimeException("Parsing JSON arrays as structs is forbidden.")
   }
 
-  def cannotParseStringAsDataTypeError(parser: JsonParser, token: JsonToken, dataType: DataType): Throwable = {
+  def cannotParseStringAsDataTypeError(parser: JsonParser, token: JsonToken, dataType: DataType)
+  : Throwable = {
     new RuntimeException(
       s"Cannot parse field name [${parser.getCurrentName}], " +
         s"field value [${parser.getText}], " +
@@ -970,7 +971,8 @@ object QueryExecutionErrors {
       s"Failed to parse an empty string for data type ${dataType.catalogString}")
   }
 
-  def failToParseValueForDataTypeError(parser: JsonParser, token: JsonToken, dataType: DataType): Throwable = {
+  def failToParseValueForDataTypeError(parser: JsonParser, token: JsonToken, dataType: DataType)
+  : Throwable = {
     new RuntimeException(
       s"Failed to parse field name [${parser.getCurrentName}], " +
         s"field value [${parser.getText}], " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -26,7 +26,7 @@ import java.time.temporal.ChronoField
 import java.util.ConcurrentModificationException
 import java.util.concurrent.TimeoutException
 
-import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.core.{JsonParser, JsonToken}
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FileStatus, Path}
 import org.codehaus.commons.compiler.{CompileException, InternalCompilerException}
 
@@ -958,8 +958,11 @@ object QueryExecutionErrors {
     new RuntimeException("Parsing JSON arrays as structs is forbidden.")
   }
 
-  def cannotParseStringAsDataTypeError(str: String, dataType: DataType): Throwable = {
-    new RuntimeException(s"Cannot parse $str as ${dataType.catalogString}.")
+  def cannotParseStringAsDataTypeError(parser: JsonParser, token: JsonToken, dataType: DataType): Throwable = {
+    new RuntimeException(
+      s"Cannot parse field name [${parser.getCurrentName}], " +
+        s"field value [${parser.getText}], " +
+        s"[${token.toString}] as target spark data type [${dataType}].")
   }
 
   def failToParseEmptyStringForDataTypeError(dataType: DataType): Throwable = {
@@ -967,9 +970,11 @@ object QueryExecutionErrors {
       s"Failed to parse an empty string for data type ${dataType.catalogString}")
   }
 
-  def failToParseValueForDataTypeError(dataType: DataType, token: JsonToken): Throwable = {
+  def failToParseValueForDataTypeError(parser: JsonParser, token: JsonToken, dataType: DataType): Throwable = {
     new RuntimeException(
-      s"Failed to parse a value for data type ${dataType.catalogString} (current token: $token).")
+      s"Failed to parse field name [${parser.getCurrentName}], " +
+        s"field value [${parser.getText}], " +
+        s"[${token.toString}] to target spark data type [${dataType}].")
   }
 
   def rootConverterReturnNullError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -961,9 +961,9 @@ object QueryExecutionErrors {
   def cannotParseStringAsDataTypeError(parser: JsonParser, token: JsonToken, dataType: DataType)
   : Throwable = {
     new RuntimeException(
-      s"Cannot parse field name [${parser.getCurrentName}], " +
-        s"field value [${parser.getText}], " +
-        s"[${token.toString}] as target spark data type [${dataType}].")
+      s"Cannot parse field name ${parser.getCurrentName}, " +
+        s"field value ${parser.getText}, " +
+        s"[$token] as target spark data type [$dataType].")
   }
 
   def failToParseEmptyStringForDataTypeError(dataType: DataType): Throwable = {
@@ -974,9 +974,9 @@ object QueryExecutionErrors {
   def failToParseValueForDataTypeError(parser: JsonParser, token: JsonToken, dataType: DataType)
   : Throwable = {
     new RuntimeException(
-      s"Failed to parse field name [${parser.getCurrentName}], " +
-        s"field value [${parser.getText}], " +
-        s"[${token.toString}] to target spark data type [${dataType}].")
+      s"Failed to parse field name ${parser.getCurrentName}, " +
+        s"field value ${parser.getText}, " +
+        s"[$token] to target spark data type [$dataType].")
   }
 
   def rootConverterReturnNullError(): Throwable = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -595,6 +595,30 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("[SPARK-36069] from_json invalid json schema - check field name and field value") {
+    withSQLConf(SQLConf.COLUMN_NAME_OF_CORRUPT_RECORD.key -> "_unparsed") {
+      val schema = new StructType()
+        .add("a", IntegerType)
+        .add("b", IntegerType)
+        .add("_unparsed", StringType)
+      val badRec = """{"a": "1", "b": 11}"""
+      val df = Seq(badRec, """{"a": 2, "b": 12}""").toDS()
+
+      checkAnswer(
+        df.select(from_json($"value", schema, Map("mode" -> "PERMISSIVE"))),
+        Row(Row(null, 11, badRec)) :: Row(Row(2, 12, null)) :: Nil)
+
+      val exception = intercept[SparkException] {
+        df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
+      }
+      exception.printStackTrace()
+      assert(exception.getMessage.contains(
+        "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
+      assert(exception.getMessage.contains(
+        "Failed to parse field name [a], field value [1], [VALUE_STRING] to target spark data type [IntegerType]."))
+    }
+  }
+  
   test("corrupt record column in the middle") {
     val schema = new StructType()
       .add("a", IntegerType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -615,10 +615,11 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       assert(exception.getMessage.contains(
         "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
       assert(exception.getMessage.contains(
-        "Failed to parse field name [a], field value [1], [VALUE_STRING] to target spark data type [IntegerType]."))
+        "Failed to parse field name [a], field value [1], " +
+          "[VALUE_STRING] to target spark data type [IntegerType]."))
     }
   }
-  
+
   test("corrupt record column in the middle") {
     val schema = new StructType()
       .add("a", IntegerType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -595,7 +595,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("[SPARK-36069] from_json invalid json schema - check field name and field value") {
+  test("SPARK-36069: from_json invalid json schema - check field name and field value") {
     withSQLConf(SQLConf.COLUMN_NAME_OF_CORRUPT_RECORD.key -> "_unparsed") {
       val schema = new StructType()
         .add("a", IntegerType)
@@ -608,14 +608,14 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
         df.select(from_json($"value", schema, Map("mode" -> "PERMISSIVE"))),
         Row(Row(null, 11, badRec)) :: Row(Row(2, 12, null)) :: Nil)
 
-      val exception = intercept[SparkException] {
+      val errMsg = intercept[SparkException] {
         df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
-      }
-      exception.printStackTrace()
-      assert(exception.getMessage.contains(
+      }.getMessage
+      
+      assert(errMsg.contains(
         "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
-      assert(exception.getMessage.contains(
-        "Failed to parse field name [a], field value [1], " +
+      assert(errMsg.contains(
+        "Failed to parse field name a, field value 1, " +
           "[VALUE_STRING] to target spark data type [IntegerType]."))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -595,7 +595,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("[SPARK-36069] from_json invalid json schema - check field name and field value") {
+  test("SPARK-36069: from_json invalid json schema - check field name and field value") {
     withSQLConf(SQLConf.COLUMN_NAME_OF_CORRUPT_RECORD.key -> "_unparsed") {
       val schema = new StructType()
         .add("a", IntegerType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -611,7 +611,7 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       val errMsg = intercept[SparkException] {
         df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
       }.getMessage
-      
+
       assert(errMsg.contains(
         "Malformed records are detected in record parsing. Parse Mode: FAILFAST."))
       assert(errMsg.contains(


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

spark function from_json output field name, field type and field value when FAILFAST mode throw exception.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This infoormation is very important for devlops to find where error input data is located.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

org/apache/spark/sql/JsonFunctionsSuite.scala:598
test("[SPARK-36069] from_json invalid json schema - check field name and field value")
