### PR TITLE
[SPARK-36087][SQL][WIP] An Impl of skew key detection and data inflation optimization

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -626,6 +626,42 @@ object SQLConf {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("256MB")
 
+  val ADAPTIVE_SHUFFLE_SAMPLE_SIZE_PER_PARTITION =
+    buildConf("spark.sql.adaptive.shuffle.sampleSizePerPartition")
+      .doc(s"When '${ADAPTIVE_EXECUTION_ENABLED.key}' are true and sampled data are needed in " +
+        "shuffled join, perform adaptive sampling in the shuffle. This is the number to sample " +
+        "per partition.")
+      .version("3.3.0")
+      .intConf
+      .checkValue(_ > 0, "sample size per partition must be positive")
+      .createWithDefault(100)
+
+  val ADAPTIVE_SHUFFLE_JOIN_DETECT_SKEWNESS =
+    buildConf("spark.sql.adaptive.shuffle.detectSkewness")
+      .doc(s"When '${ADAPTIVE_EXECUTION_ENABLED.key}' are true, detect skewness information " +
+        "(including skewed keys) in shuffled join based on adaptive sampling, and then show " +
+        "it on SparkUI")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val SKEW_JOIN_INFLATION_ENABLED =
+    buildConf("spark.sql.adaptive.skewJoin.inflation.enabled")
+      .doc(s"When true and '${ADAPTIVE_EXECUTION_ENABLED.key}' and '${SKEW_JOIN_ENABLED.key}' " +
+        s"are true, Spark takes data inflation into account when dynamically handling skewness.")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val SKEW_JOIN_INFLATION_FACTOR =
+    buildConf("spark.sql.adaptive.skewJoin.inflation.factor")
+      .doc("A partition is considered as inflated if its estimated joined size is larger than " +
+        "this factor multiplying the median estimation")
+      .version("3.3.0")
+      .intConf
+      .checkValue(_ > 0, "The data inflation factor must be positive.")
+      .createWithDefault(50)
+
   val NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN =
     buildConf("spark.sql.adaptive.nonEmptyPartitionRatioForBroadcastJoin")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan}
-import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_COL, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_COL, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ENSURE_JOIN_REQUIREMENTS, ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_COL, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_COL, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -30,8 +30,8 @@ import org.apache.spark.sql.internal.SQLConf
 case class CoalesceShufflePartitions(session: SparkSession) extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_COL, REBALANCE_PARTITIONS_BY_NONE,
-      REBALANCE_PARTITIONS_BY_COL)
+    Seq(ENSURE_REQUIREMENTS, ENSURE_JOIN_REQUIREMENTS, REPARTITION_BY_COL,
+      REBALANCE_PARTITIONS_BY_NONE, REBALANCE_PARTITIONS_BY_COL)
 
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.coalesceShufflePartitionsEnabled) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeDataInflation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeDataInflation.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.plans.{Inner, JoinType, LeftOuter, RightOuter}
+import org.apache.spark.sql.execution.exchange.{KeySketcher, ShuffleExchangeExec}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Estimate the joined size of each partition, via Independent Bernoulli Sampling:
+ * The join size estimation algorithm is to form independent Bernoulli samples S1 and S2
+ * (with sampling probabilities p1 and p2) of tables T1 and T2 that are being inner joined,
+ * compute the join size J' of the two samples, and then scale it appropriately J = J' / p1 / p2.
+ * This is a simplest and unbiased estimation algorithm.
+ * See section 3.1 in <a href="https://www.vldb.org/pvldb/vol8/p1530-vengerov.pdf">
+ * Join Size Estimation Subject to Filter Conditions</a> for details.
+ */
+object OptimizeDataInflation extends Logging {
+
+  private[sql] def detectDataInflation(
+      conf: SQLConf,
+      left: ShuffleQueryStageExec,
+      right: ShuffleQueryStageExec,
+      joinType: JoinType): Map[Int, Double] = {
+    if (conf.getConf(SQLConf.SKEW_JOIN_ENABLED) &&
+      conf.getConf(SQLConf.SKEW_JOIN_INFLATION_ENABLED) &&
+      Seq(Inner, LeftOuter, RightOuter).contains(joinType)) {
+
+      val leftSketchOpt = left.shuffle.asInstanceOf[ShuffleExchangeExec]
+        .shuffleExecAccumulators.find(_.isInstanceOf[KeySketcher])
+        .map(_.asInstanceOf[KeySketcher])
+      val leftMapOpt = leftSketchOpt.map(_.sketchMap)
+        .filter(map => map != null && map.nonEmpty)
+
+      val rightSketchOpt = right.shuffle.asInstanceOf[ShuffleExchangeExec]
+        .shuffleExecAccumulators.find(_.isInstanceOf[KeySketcher])
+        .map(_.asInstanceOf[KeySketcher])
+      val rightMapOpt = rightSketchOpt.map(_.sketchMap)
+        .filter(map => map != null && map.nonEmpty)
+
+      if (leftMapOpt.isEmpty || rightMapOpt.isEmpty) return Map.empty
+      val (leftMap, rightMap) = (leftMapOpt.get, rightMapOpt.get)
+
+      val numPartitions = leftSketchOpt.get.numPartitions
+      require(numPartitions == rightSketchOpt.get.numPartitions)
+
+      // copied from org.apache.spark.sql.catalyst.expressions.Pmod
+      def pmod(a: Int, n: Int): Int = {
+        val r = a % n
+        if (r < 0) {(r + n) % n} else r
+      }
+
+      def median(array: Array[Double]) : Double = {
+        val len = array.length
+        val sorted = array.sorted
+        if (len % 2 == 0) {
+          math.max(1, (sorted(len / 2) + sorted(len / 2 - 1)) / 2)
+        } else {
+          math.max(1, sorted(len / 2))
+        }
+      }
+
+      val joinedSize = Array.ofDim[Double](numPartitions)
+      joinType match {
+        case Inner =>
+          val Seq(smallMap, bigMap) = Seq(leftMap, rightMap).sortBy(_.size)
+          smallMap.foreach { case (hash64, weight) =>
+            if (bigMap.contains(hash64)) {
+              val partitionId = pmod((hash64 >> 32).toInt, numPartitions)
+              joinedSize(partitionId) += weight.toDouble * bigMap(hash64)
+            }
+          }
+
+        case LeftOuter =>
+          leftMap.foreach { case (hash64, weight) =>
+            val partitionId = pmod((hash64 >> 32).toInt, numPartitions)
+            joinedSize(partitionId) += weight
+            if (rightMap.contains(hash64)) {
+              joinedSize(partitionId) += weight.toDouble * rightMap(hash64)
+            }
+          }
+
+        case RightOuter =>
+          rightMap.foreach { case (hash64, weight) =>
+            val partitionId = pmod((hash64 >> 32).toInt, numPartitions)
+            joinedSize(partitionId) += weight
+            if (leftMap.contains(hash64)) {
+              joinedSize(partitionId) += weight.toDouble * leftMap(hash64)
+            }
+          }
+
+        case _ => throw new UnsupportedOperationException(s"Unsupported joinType = $joinType")
+      }
+      logDebug("OptimizeDataInflation: estimated joined sizes(#row): " +
+        s"${joinedSize.map(_.round).mkString("[", ", ", "]")}")
+
+      val medianEstimatedSize = median(joinedSize)
+      val threshold = conf.getConf(SQLConf.SKEW_JOIN_INFLATION_FACTOR) * medianEstimatedSize
+      joinedSize.iterator.zipWithIndex
+        .filter(_._1 >= threshold)
+        .map { case (estimatedSize, pid) =>
+          (pid, math.min(1000, estimatedSize / medianEstimatedSize))
+        }.toMap
+    } else {
+      Map.empty
+    }
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeLocalShuffleReader.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, EnsureRequirements, REBALANCE_PARTITIONS_BY_NONE, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.exchange.{ENSURE_JOIN_REQUIREMENTS, ENSURE_REQUIREMENTS, EnsureRequirements, REBALANCE_PARTITIONS_BY_NONE, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
 import org.apache.spark.sql.internal.SQLConf
 
@@ -36,7 +36,7 @@ import org.apache.spark.sql.internal.SQLConf
 object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
 
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
-    Seq(ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_NONE)
+    Seq(ENSURE_REQUIREMENTS, ENSURE_JOIN_REQUIREMENTS, REBALANCE_PARTITIONS_BY_NONE)
 
   private val ensureRequirements = EnsureRequirements
 
@@ -142,7 +142,7 @@ object OptimizeLocalShuffleReader extends CustomShuffleReaderRule {
       s.mapStats.isDefined && supportLocalReader(s.shuffle)
     case CustomShuffleReaderExec(s: ShuffleQueryStageExec, partitionSpecs) =>
       s.mapStats.isDefined && partitionSpecs.nonEmpty && supportLocalReader(s.shuffle) &&
-        s.shuffle.shuffleOrigin == ENSURE_REQUIREMENTS
+        Seq(ENSURE_REQUIREMENTS, ENSURE_JOIN_REQUIREMENTS).contains(s.shuffle.shuffleOrigin)
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExecAccumulator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExecAccumulator.scala
@@ -1,0 +1,552 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.exchange
+
+import org.apache.spark.TaskContext
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types.{IntegralType, LongType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.AccumulatorV2
+import org.apache.spark.util.collection.{BitSet, OpenHashMap, Utils}
+import org.apache.spark.util.random.XORShiftRandom
+
+
+trait ShuffleExecAccumulator extends AccumulatorV2[InternalRow, String] {
+
+  private[sql] var mapId = -1
+
+  private[sql] def location: String = {
+    if (mapId == -1) "driver" else s"task_$mapId"
+  }
+
+  private[sql] def onTaskStart(): Unit = {
+    val context = TaskContext.get
+    mapId = if (context == null) -1 else context.partitionId
+  }
+
+  private[sql] def onTaskEnd(): Unit = { }
+}
+
+
+private[sql] object KeySketcher {
+
+  // value computation at driver maybe non-trivial, update cached value per 1 min
+  val UI_DRIVER_REFRESH_INTERVAL = 60000000000L
+
+  // number of skewed keys to show on SparkUI
+  val UI_FREQUENT_KEYS = 16
+
+  val DEBUG_SIZE_DRIVER = 256
+
+  val DEBUG_SIZE_EXECUTOR = 64
+
+  val DEBUG_SIZE_MAX_FACTOR = 2
+
+  // only store keys which are sampled more than this times
+  val DEBUG_MIN_SAMPLED_EXECUTOR = 2
+
+  val MAP_SIZE_FACTOR = 0.75
+}
+
+
+
+/**
+ * An accumulator to sample joined keys in ShuffleExchangeExec. The sampled keys then could be used
+ * in following AQE rules.
+ * To control the memory footprint, a 64-bit hash is used instead of the original key. The
+ * partition id can be obtained from the first 32-bit.
+ * On executors, KeySketcher first try to count the keys exactly by keeping a countMap, when the
+ * countMap is too larger, fallback to reservoir sampling.
+ * At driver, sampled keys and their counts are weighted and gathered in sketchMap.
+ * @param rowSchema       the input row schema.
+ * @param partitionIdExpr the expression to compute partition id.
+ * @param numMappers      number of map tasks.
+ * @param arraySize       number of sampled keys in reservoir sampling.
+ * @param exchangeId      id of corresponding ShuffleExchangeExec, used to get the sampling seed.
+ * @param debug           whether to show debug info on the SparkUI. If true, KeySketcher will
+ *                        maintain a mapping from hash64 to original string for better readability.
+ */
+// TODO: specialized implementation for simple key types like IntegerType/LongType/etc
+private[sql] class KeySketcher(
+    val rowSchema: Seq[Attribute],
+    val partitionIdExpr: Expression,
+    val numMappers: Int,
+    val arraySize: Int,
+    val exchangeId: Int,
+    val debug: Boolean)
+  extends ShuffleExecAccumulator with Logging {
+  import KeySketcher._
+
+  require(arraySize > 0)
+  private val mapSize = (arraySize * MAP_SIZE_FACTOR).ceil.toInt
+
+
+  /* ------------------------------------------------------ *
+   | Private variables and methods                          |
+   * ------------------------------------------------------ */
+
+  // (row: UnsafeRow) -> (key hash64: Long)
+  @transient private lazy val hashFunc = {
+    partitionIdExpr match {
+      case Pmod(h: Murmur3Hash, _, _) =>
+        val hash64 = BitwiseOr(
+          ShiftLeft(
+            Cast(h, LongType),
+            Literal(32)
+          ),
+          BitwiseAnd(
+            // make sure two Murmur3Hash use different seeds
+            Cast(h.copy(seed = -1 - h.seed), LongType),
+            Literal(0xFFFFFFFFL)
+          )
+        )
+        val project = UnsafeProjection.create(Seq(hash64), rowSchema)
+        (row: InternalRow) => project(row).getLong(0)
+
+      case _ => throw new UnsupportedOperationException(
+        s"partExpression Must be Pmod(Murmur3Hash, num), but got $partitionIdExpr")
+    }
+  }
+
+  // (row: UnsafeRow) -> (str: UTF8String)
+  // UnsafeRow.toString returns a HexString, which lacks readability.
+  @transient private lazy val strFunc = {
+    partitionIdExpr match {
+      case Pmod(Murmur3Hash(keys: Seq[Expression], _), _, _) =>
+        val strExpr = if (keys.length == 1) {
+          Cast(keys.head, StringType)
+        } else {
+          Cast(CreateStruct.create(keys), StringType)
+        }
+        val project = UnsafeProjection.create(Seq(strExpr), rowSchema)
+        (row: InternalRow) => project(row).getUTF8String(0).copy()
+
+      case _ => throw new UnsupportedOperationException(
+        s"partExpression Must be Pmod(Murmur3Hash, num), but got $partitionIdExpr")
+    }
+  }
+
+  private[sql] def numPartitions: Int = {
+    partitionIdExpr match {
+      case Pmod(_: Murmur3Hash, Literal(n: Int, _: IntegralType), _) => n
+
+      case _ => throw new UnsupportedOperationException(
+        s"partExpression Must be Pmod(Murmur3Hash, num), but got $partitionIdExpr")
+    }
+  }
+
+  override def isZero: Boolean = {
+    if (mapId < 0) sketchMap == null else sampledHashes == null
+  }
+
+  private[sql] var count = 0L
+
+  private[sql] var sampled = 0L
+
+  @transient private var debugStrMap: OpenHashMap[Long, UTF8String] = _
+
+  private var taskDuration = 0L
+
+  private var accumulationDuration = 0L
+
+  @transient private var lastValue: String = _
+
+  @transient private var lastValueTimestamp = System.nanoTime
+
+  override def value: String = this.synchronized {
+    if (mapId < 0) {
+      if (lastValue == null || System.nanoTime - lastValueTimestamp > UI_DRIVER_REFRESH_INTERVAL) {
+        lastValue = doValue
+        lastValueTimestamp = System.nanoTime
+      }
+      lastValue
+    } else {
+      doValue
+    }
+  }
+
+  private def doValue: String = {
+    if (isZero) {
+      s"$location, Unavailable"
+    } else if (count == 0) {
+      s"$location, Empty"
+    } else if ((mapId < 0 && sampled == sketchMap.size) || (mapId >= 0 && sampledCounts == null)) {
+      s"$location, $count counted, $sampled sampled, Distinct, " +
+        f"cost=${accumulationDuration.toDouble / taskDuration * 100}%.3f%%"
+    } else {
+
+      val start = System.nanoTime
+
+      val percentScale = 100.0 / count
+      val hotKeyStr = if (mapId < 0) {
+        Utils.takeOrdered(sketchMap.iterator, UI_FREQUENT_KEYS)(Ordering.by(-_._2))
+          .map { case (hash64, w) =>
+            if (debugStrMap != null && debugStrMap.contains(hash64)) {
+              f"${debugStrMap(hash64)}:${w * percentScale}%.2f%%"
+            } else {
+              f"${w * percentScale}%.2f%%"
+            }
+          }.mkString("{", ", ", "}")
+      } else {
+        decompressWeightIter.take(UI_FREQUENT_KEYS).zipWithIndex
+          .map { case (w, i) =>
+            if (sampledDebugStrs != null && i < sampledDebugStrs.length &&
+              sampledDebugStrs(i) != null) {
+              f"${sampledDebugStrs(i)}:${w * percentScale}%.2f%%"
+            } else {
+              f"${w * percentScale}%.2f%%"
+            }
+          }.mkString("{", ", ", "}")
+      }
+
+      val hashed = if (mapId < 0) sketchMap.size else sampledHashes.length
+
+      val valueStr = s"$location, $count counted, $sampled sampled, $hashed hashed, " +
+        s"hot keys: $hotKeyStr, " +
+        f"cost=${accumulationDuration.toDouble / taskDuration * 100}%.3f%%"
+
+      logDebug(f"Exchange #$exchangeId, $location, value computation takes " +
+        f"${(System.nanoTime - start) * 1e-9}%.3f sec, " +
+        f"cost=${accumulationDuration.toDouble / taskDuration * 100}%.3f%%")
+
+      valueStr
+    }
+  }
+
+
+  /* ------------------------------------------------------ *
+   | Private variables and methods used only at driver      |
+   * ------------------------------------------------------ */
+
+  // key hash64 -> weight
+  @transient private[sql] var sketchMap: OpenHashMap[Long, Float] = _
+
+  @transient private lazy val mergedMapIds = new BitSet(numMappers)
+
+  override def copy(): KeySketcher = throw new UnsupportedOperationException("Not implemented")
+
+  override def reset(): Unit = this.synchronized {
+    count = 0L
+    sampled = 0L
+
+    sketchMap = null
+    mergedMapIds.clear()
+
+    counting = false
+    countMap = null
+    samplingRNG = null
+    samplingArray = null
+    sampledHashes = null
+    sampledCounts = null
+
+    debugStrMap = null
+    sampledDebugStrs = null
+
+    accumulationDuration = 0L
+    taskDuration = 0L
+  }
+
+  override def copyAndReset(): KeySketcher = {
+    new KeySketcher(rowSchema, partitionIdExpr, numMappers, arraySize, exchangeId, debug)
+  }
+
+
+  override def merge(other: AccumulatorV2[InternalRow, String]): Unit = {
+    other match {
+      case o: KeySketcher =>
+        // other KeySketchers are expected to be compressed and sent from executors
+        if (o.count > 0 && o.mapId >= 0 && o.sampledHashes != null && !mergedMapIds.get(o.mapId)) {
+          val start = System.nanoTime
+          val infoStr = s"Exchange #$exchangeId, this(${this.location}, " +
+            s"sampled=${this.sampled}/${this.count}) " +
+            s"+= other(${o.location}, sampled=${o.sampled}/${o.count})"
+
+          this.synchronized {
+            if (this.sketchMap == null) {
+              this.sketchMap = new OpenHashMap[Long, Float](mapSize)
+            }
+            o.sampledHashes.iterator.zip(o.decompressWeightIter)
+              .foreach { case (hash64, w) => this.sketchMap.changeValue(hash64, w, _ + w) }
+            this.count += o.count
+            this.sampled += o.sampled
+            this.taskDuration += o.taskDuration
+            this.accumulationDuration += o.accumulationDuration
+            this.mergedMapIds.set(o.mapId)
+
+            if (debug && o.sampledDebugStrs != null) {
+              if (this.debugStrMap == null) {
+                this.debugStrMap = new OpenHashMap[Long, UTF8String](DEBUG_SIZE_DRIVER)
+              }
+
+              o.sampledHashes.iterator.zip(o.sampledDebugStrs.iterator)
+                .foreach { case (hash64, str) =>
+                  if (str != null && !this.debugStrMap.contains(hash64)) {
+                    this.debugStrMap.update(hash64, str)
+                  }
+                }
+
+              if (this.debugStrMap.size > DEBUG_SIZE_DRIVER * DEBUG_SIZE_MAX_FACTOR) {
+                val newDebugMap = new OpenHashMap[Long, UTF8String](DEBUG_SIZE_DRIVER)
+                this.debugStrMap.iterator
+                  .filter { case (hash64, _) => this.sketchMap.contains(hash64) }
+                  .map { case (hash64, str) => ((hash64, str), this.sketchMap(hash64)) }
+                  .toArray.sortBy(-_._2).iterator
+                  .map(_._1).take(DEBUG_SIZE_DRIVER)
+                  .foreach { case (hash64, str) => newDebugMap.update(hash64, str) }
+                this.debugStrMap = newDebugMap
+              }
+            }
+          }
+
+          logDebug(f"$infoStr, merge takes ${(System.nanoTime - start) * 1e-9}%.3f sec, " +
+            f"cost=${accumulationDuration.toDouble / taskDuration * 100}%.3f%%")
+        }
+
+      case _ => throw new UnsupportedOperationException(
+        s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
+    }
+  }
+
+
+  /* ------------------------------------------------------ *
+   | Private variables and methods used only in executors   |
+   * ------------------------------------------------------ */
+
+
+  override private[sql] def onTaskStart(): Unit = {
+    super.onTaskStart()
+    taskStart = System.nanoTime
+    sketchMap = null
+    counting = true
+    countMap = new collection.mutable.OpenHashMap[Long, Int](mapSize)
+    debugStrMap = if (debug) new OpenHashMap[Long, UTF8String](DEBUG_SIZE_EXECUTOR) else null
+    accumulationDuration = 0L
+    taskDuration = 0L
+  }
+
+  @transient private var taskStart: Long = _
+
+  @transient private var counting: Boolean = _
+
+  @transient private var countMap: collection.mutable.OpenHashMap[Long, Int] = _
+
+  @transient private var samplingRNG: XORShiftRandom = _
+
+  @transient private var samplingArray: Array[Long] = _
+
+  private var sampledHashes: Array[Long] = _
+
+  private var sampledCounts: Array[Int] = _
+
+  private var sampledDebugStrs: Array[UTF8String] = _
+
+  override def add(row: InternalRow): Unit = this.synchronized {
+    val start = System.nanoTime
+
+    var hash64Opt = Option.empty[Long]
+    if (counting) {
+      hash64Opt = addToMap(row)
+      if (hash64Opt.isEmpty) {
+        fallbackToArray()
+        require(!counting)
+        hash64Opt = addToArray(row)
+      }
+    } else {
+      hash64Opt = addToArray(row)
+    }
+
+    if (debug && hash64Opt.nonEmpty) {
+      val hash64 = hash64Opt.get
+      if (!debugStrMap.contains(hash64) &&
+        countMap.getOrElse(hash64, 0) >= DEBUG_MIN_SAMPLED_EXECUTOR) {
+        debugStrMap.update(hash64, strFunc(row))
+
+        // if debugStrMap is too large, drop keys with low freq
+        if (debugStrMap.size > DEBUG_SIZE_EXECUTOR * DEBUG_SIZE_MAX_FACTOR) {
+          val newDebugMap = new OpenHashMap[Long, UTF8String](DEBUG_SIZE_EXECUTOR)
+          countMap.toArray.sortBy(-_._2).iterator
+            .map(_._1).filter(debugStrMap.contains)
+            .take(DEBUG_SIZE_EXECUTOR)
+            .foreach(hash64 => newDebugMap.update(hash64, debugStrMap(hash64)))
+          debugStrMap = newDebugMap
+        }
+      }
+    }
+
+    accumulationDuration += System.nanoTime - start
+  }
+
+  private def addToMap(row: InternalRow): Option[Long] = {
+    val hash64 = hashFunc(row)
+    if (countMap.size < mapSize || countMap.contains(hash64)) {
+      countMap.update(hash64, countMap.getOrElse(hash64, 0) + 1)
+      count += 1L
+      Some(hash64)
+    } else {
+      None
+    }
+  }
+
+  private def addToArray(row: InternalRow): Option[Long] = {
+    if (count < arraySize) {
+      val hash64 = hashFunc(row)
+      samplingArray(count.toInt) = hash64
+      count += 1L
+      if (debug) {
+        // if debug, still maintain countMap in sampling mode, in order to avoid
+        // calling strFunc for keys with freq less than DEBUG_MIN_SAMPLED_EXECUTOR
+        countMap.update(hash64, countMap.getOrElse(hash64, 0) + 1)
+      }
+      Some(hash64)
+
+    } else {
+
+      count += 1L
+      val replacementIndex = (samplingRNG.nextDouble * count).toLong
+      if (replacementIndex < arraySize) {
+        val hash64 = hashFunc(row)
+
+        if (debug) {
+          // if debug, still maintain countMap in sampling mode
+          val prevHash64 = samplingArray(replacementIndex.toInt)
+          val prevCount = countMap.getOrElse(prevHash64, 0)
+          if (prevCount > 1) {
+            countMap.update(prevHash64, prevCount - 1)
+          } else {
+            countMap.remove(prevHash64)
+          }
+          countMap.update(hash64, countMap.getOrElse(hash64, 0) + 1)
+        }
+
+        samplingArray(replacementIndex.toInt) = hash64
+        Some(hash64)
+      } else {
+        None
+      }
+    }
+  }
+
+  private def fallbackToArray(): Unit = {
+    val start = System.nanoTime
+
+    val prevCount = count
+    count = 0L
+    samplingRNG = new XORShiftRandom(exchangeId + mapId)
+    samplingArray = Array.ofDim[Long](arraySize)
+    countMap.foreach { case (hash64, c) =>
+      var j = 0
+      while (j < c) {
+        if (count < arraySize) {
+          samplingArray(count.toInt) = hash64
+          count += 1L
+        } else {
+          count += 1L
+          val replacementIndex = (samplingRNG.nextDouble * count).toLong
+          if (replacementIndex < arraySize) {
+            samplingArray(replacementIndex.toInt) = hash64
+          }
+        }
+        j += 1
+      }
+    }
+    require(count == prevCount)
+    counting = false
+
+    if (debug) {
+      // if debug, still maintain countMap in sampling mode
+      countMap.clear()
+      Iterator.range(0, math.min(count, arraySize).toInt).foreach { i =>
+        val hash64 = samplingArray(i)
+        countMap.update(hash64, countMap.getOrElse(hash64, 0) + 1)
+      }
+    } else {
+      countMap = null
+    }
+
+    logDebug(s"Exchange #$exchangeId, $location, " +
+      s"countMap reaches maxMapSize=$mapSize at count=$count, " +
+      f"fallbackToArray takes ${(System.nanoTime - start) * 1e-9}%.3f sec")
+  }
+
+
+  private def compress(): Unit = {
+    if (sampledHashes == null) {
+      if (counting) {
+        sampled = count
+      } else {
+        sampled = math.min(count, arraySize)
+
+        countMap = new collection.mutable.OpenHashMap[Long, Int](mapSize)
+        Iterator.range(0, sampled.toInt).foreach { i =>
+          val hash64 = samplingArray(i)
+          countMap.update(hash64, countMap.getOrElse(hash64, 0) + 1)
+        }
+      }
+
+      val (hashes, counts) = countMap.toArray.sortBy(-_._2).unzip
+      // avoid sending count=1
+      sampledCounts = if (counts.forall(_ == 1)) null else counts.filter(_ != 1)
+      sampledHashes = hashes
+
+      if (debug && sampledHashes.nonEmpty && sampledCounts != null &&
+        sampledCounts.nonEmpty && sampledCounts.head >= DEBUG_MIN_SAMPLED_EXECUTOR) {
+
+        var lastIndex = -1
+        sampledDebugStrs = sampledHashes.iterator.zip(sampledCounts.iterator)
+          .take(UI_FREQUENT_KEYS * DEBUG_SIZE_MAX_FACTOR)
+          .zipWithIndex
+          .map { case ((hash64, _), i) =>
+             if (debugStrMap.contains(hash64)) {
+               lastIndex = i
+               debugStrMap(hash64)
+             } else null
+          }.toArray
+
+        if (lastIndex == -1) {
+          sampledDebugStrs = null
+        } else {
+          // strip tailing nulls
+          sampledDebugStrs = sampledDebugStrs.take(lastIndex + 1)
+        }
+      }
+    }
+  }
+
+  private def decompressWeightIter: Iterator[Float] = {
+    val scale = count.toFloat / sampled
+    val n = if (sampledCounts == null) 0 else sampledCounts.length
+    require(n <= sampledHashes.length)
+    Iterator.tabulate(n)(i => sampledCounts(i) * scale) ++
+      Iterator.fill(sampledHashes.length - n)(scale)
+  }
+
+  override private[sql] def onTaskEnd(): Unit = this.synchronized {
+    val start = System.nanoTime
+    compress()
+    sketchMap = null
+    debugStrMap = null
+    counting = false
+    countMap = null
+    samplingRNG = null
+    samplingArray = null
+    accumulationDuration += System.nanoTime - start
+    taskDuration = System.nanoTime - taskStart
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ShuffleExecAccumulatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ShuffleExecAccumulatorSuite.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution.exchange.KeySketcher
+import org.apache.spark.sql.test.SharedSparkSession
+
+
+/**
+ * Test suite for [[ShuffleExecAccumulator]].
+ */
+class ShuffleExecAccumulatorSuite
+  extends SparkFunSuite
+    with SharedSparkSession
+    with ExpressionEvalHelper {
+
+  test("KeySketcher") {
+    val numPartitions = 10
+    val numTasks = 3
+
+    val a = 'a.int
+    val b = 'b.long
+    val c = 'c.double
+
+    val rowSchema = Seq(a, b, c)
+    val keySchema = Seq(a, b)
+      .zipWithIndex
+      .map { case (attr, i) => BoundReference(i, attr.dataType, attr.nullable) }
+
+    val partitionIdExpr = Pmod(new Murmur3Hash(keySchema), Literal(numPartitions))
+
+    val rows = Seq(
+      InternalRow(1, 73L, 3.0),
+      InternalRow(2, 36L, -3.0),
+      InternalRow(3, -66L, 4.0),
+      InternalRow(4, -3L, 6.0)
+    )
+
+    val partitionIdSet = rows.map(row => partitionIdExpr.eval(row).asInstanceOf[Int]).toSet
+
+    def pmod(a: Int, n: Int): Int = {
+      val r = a % n
+      if (r < 0) {(r + n) % n} else r
+    }
+    def getPartId(hash64: Long): Int = {
+      pmod((hash64 >> 32).toInt, numPartitions)
+    }
+
+
+    // Initialization
+    val acc = new KeySketcher(rowSchema, partitionIdExpr, numTasks, 128, 1, false)
+    assert(acc.mapId == -1)
+    assert(acc.isZero)
+    assert(acc.numMappers == numTasks)
+    assert(acc.numPartitions == numPartitions)
+
+
+    // Merge another empty acc from driver
+    val accEmpty1 = acc.copyAndReset()
+    acc.merge(accEmpty1)
+    assert(acc.isZero)
+
+
+    // Merge another empty acc from executor
+    val accEmpty2 = acc.copyAndReset()
+    accEmpty2.mapId = 1
+    acc.merge(accEmpty2)
+    assert(acc.isZero)
+
+
+    // Merge an accumulator
+    val acc1 = acc.copyAndReset()
+    acc1.onTaskStart()
+    acc1.mapId = 1
+    rows.foreach(acc1.add)
+    acc1.onTaskEnd()
+    assert(acc1.count == 4)
+    assert(acc1.sampled == 4)
+
+    assert(acc.isZero)
+    acc.merge(acc1)
+    assert(!acc.isZero)
+    assert(acc.count == 4)
+    assert(acc.sampled == 4)
+
+
+    // Never merge an accumulator twice
+    acc.merge(acc1)
+    assert(acc.count == 4)
+    assert(acc.sampled == 4)
+
+
+    // Check partitionId
+    assert(
+      acc.sketchMap
+        .iterator
+        .map(_._1)
+        .forall(h64 => partitionIdSet.contains(getPartId(h64)))
+    )
+
+
+    // Hot Key
+    val acc2 = acc.copyAndReset()
+    acc2.onTaskStart()
+    acc2.mapId = 0
+    val skewRow = InternalRow(321, 123L, -33.0)
+    val skewHash = partitionIdExpr.eval(skewRow).asInstanceOf[Int]
+    val rng = new scala.util.Random(45678)
+    Iterator.range(0, 100000).map { i =>
+      if (rng.nextDouble < 0.1) {
+        skewRow.copy()
+      } else {
+        InternalRow(rng.nextInt, rng.nextLong, rng.nextDouble)
+      }
+    }.foreach(acc2.add)
+    acc2.onTaskEnd()
+    assert(acc2.count == 100000)
+    assert(acc2.sampled == 128)
+
+    acc.reset()
+    acc.mapId = -1
+    acc.merge(acc2)
+    assert(acc.count == 100000)
+    assert(acc.sampled == 128)
+
+    // most frequent hash64
+    val (h64, w) = acc.sketchMap.maxBy(_._2)
+    assert(getPartId(h64) == skewHash)
+    assert(7000 < w && w < 13000)
+
+
+    // Reset
+    acc.reset()
+    assert(acc.isZero)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, introduce `ShuffleExecAccumulator` in `ShuffleExchangeExec` to support arbitrary statistics;

2, impl a key sampling `ShuffleExecAccumulator` to detect skew keys and show debug info on SparkUI;

3, in `OptimizeSkewedJoin`, estimate the joined size of each partition based on the sampled keys, and split a partition if it is not split yet and its estimated joined size is too larger.


### Why are the changes needed?
1, make it easy to add a new statistics which can be used in AQE rules;
2, showing skew info on sparkUI is usefully;
3, spliting partitions based on joined size can resolve data inflation;


### Does this PR introduce _any_ user-facing change?
Yes, new features are added


### How was this patch tested?
added testsuites
