### PR TITLE
[SPARK-36104][PYTHON] Manage InternalField in DataTypeOps.neg/abs

### DIFF
--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -126,10 +126,12 @@ class NumericOps(DataTypeOps):
         return cast(IndexOpsLike, column_op(F.bitwise_not)(operand))
 
     def neg(self, operand: IndexOpsLike) -> IndexOpsLike:
-        return cast(IndexOpsLike, column_op(Column.__neg__)(operand))
+        return operand._with_new_scol(-operand.spark.column, field=operand._internal.data_fields[0])
 
     def abs(self, operand: IndexOpsLike) -> IndexOpsLike:
-        return cast(IndexOpsLike, column_op(F.abs)(operand))
+        return operand._with_new_scol(
+            F.abs(operand.spark.column), field=operand._internal.data_fields[0]
+        )
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         return column_op(Column.__lt__)(left, right)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Manage InternalField for DataTypeOps.neg/abs.

### Why are the changes needed?
The spark data type and nullability must be the same as the original when DataTypeOps.neg/abs.
We should manage InternalField for this case.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit tests.

Keyword:SPARK-35337