### PR TITLE
[SPARK-35918][AVRO] Unify schema mismatch handling for read/write and enhance error messages

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -21,7 +21,6 @@ import java.math.BigDecimal
 import java.nio.ByteBuffer
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 
 import org.apache.avro.{LogicalTypes, Schema, SchemaBuilder}
 import org.apache.avro.Conversions.DecimalConversion
@@ -30,7 +29,7 @@ import org.apache.avro.Schema.Type._
 import org.apache.avro.generic._
 import org.apache.avro.util.Utf8
 
-import org.apache.spark.sql.avro.AvroUtils.{toFieldDescription, toFieldStr}
+import org.apache.spark.sql.avro.AvroUtils.toFieldStr
 import org.apache.spark.sql.catalyst.{InternalRow, NoopFilters, StructFilters}
 import org.apache.spark.sql.catalyst.expressions.{SpecificInternalRow, UnsafeArrayData}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, DateTimeUtils, GenericArrayData}
@@ -337,39 +336,26 @@ private[sql] class AvroDeserializer(
       avroPath: Seq[String],
       catalystPath: Seq[String],
       applyFilters: Int => Boolean): (CatalystDataUpdater, GenericRecord) => Boolean = {
-    val validFieldIndexes = ArrayBuffer.empty[Int]
-    val fieldWriters = ArrayBuffer.empty[(CatalystDataUpdater, Any) => Unit]
 
-    val avroSchemaHelper =
-      new AvroUtils.AvroSchemaHelper(avroType, avroPath, positionalFieldMatch)
-    val length = catalystType.length
-    var i = 0
-    while (i < length) {
-      val catalystField = catalystType.fields(i)
-      avroSchemaHelper.getAvroField(catalystField.name, i) match {
-        case Some(avroField) =>
-          validFieldIndexes += avroField.pos()
+    val avroSchemaHelper = new AvroUtils.AvroSchemaHelper(
+      avroType, catalystType, avroPath, catalystPath, positionalFieldMatch)
 
-          val baseWriter = newWriter(avroField.schema(), catalystField.dataType,
-            avroPath :+ avroField.name, catalystPath :+ catalystField.name)
-          val ordinal = i
-          val fieldWriter = (fieldUpdater: CatalystDataUpdater, value: Any) => {
-            if (value == null) {
-              fieldUpdater.setNullAt(ordinal)
-            } else {
-              baseWriter(fieldUpdater, ordinal, value)
-            }
+    avroSchemaHelper.assertNoExtraSqlFields(includeNullable = false)
+    // no need to assertNoExtraAvroFields since extra Avro fields are ignored
+
+    val (validFieldIndexes, fieldWriters) = avroSchemaHelper.getMatchedFields.map {
+      case (catalystField, ordinal, avroField) =>
+        val baseWriter = newWriter(avroField.schema(), catalystField.dataType,
+          avroPath :+ avroField.name, catalystPath :+ catalystField.name)
+        val fieldWriter = (fieldUpdater: CatalystDataUpdater, value: Any) => {
+          if (value == null) {
+            fieldUpdater.setNullAt(ordinal)
+          } else {
+            baseWriter(fieldUpdater, ordinal, value)
           }
-          fieldWriters += fieldWriter
-        case None if !catalystField.nullable =>
-          val fieldDescription =
-            toFieldDescription(catalystPath :+ catalystField.name, i, positionalFieldMatch)
-          throw new IncompatibleSchemaException(
-            s"Cannot find non-nullable $fieldDescription in Avro schema.")
-        case _ => // nothing to do
-      }
-      i += 1
-    }
+        }
+        (avroField.pos(), fieldWriter)
+    }.toArray.unzip
 
     (fieldUpdater, record) => {
       var i = 0

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -343,7 +343,7 @@ private[sql] class AvroDeserializer(
     avroSchemaHelper.validateNoExtraCatalystFields(ignoreNullable = true)
     // no need to validateNoExtraAvroFields since extra Avro fields are ignored
 
-    val (validFieldIndexes, fieldWriters) = avroSchemaHelper.getMatchedFields.map {
+    val (validFieldIndexes, fieldWriters) = avroSchemaHelper.matchedFields.map {
       case AvroMatchedField(catalystField, ordinal, avroField) =>
         val baseWriter = newWriter(avroField.schema(), catalystField.dataType,
           avroPath :+ avroField.name, catalystPath :+ catalystField.name)

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -29,7 +29,7 @@ import org.apache.avro.Schema.Type._
 import org.apache.avro.generic._
 import org.apache.avro.util.Utf8
 
-import org.apache.spark.sql.avro.AvroUtils.toFieldStr
+import org.apache.spark.sql.avro.AvroUtils.{toFieldStr, AvroMatchedField}
 import org.apache.spark.sql.catalyst.{InternalRow, NoopFilters, StructFilters}
 import org.apache.spark.sql.catalyst.expressions.{SpecificInternalRow, UnsafeArrayData}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, DateTimeUtils, GenericArrayData}
@@ -340,11 +340,11 @@ private[sql] class AvroDeserializer(
     val avroSchemaHelper = new AvroUtils.AvroSchemaHelper(
       avroType, catalystType, avroPath, catalystPath, positionalFieldMatch)
 
-    avroSchemaHelper.assertNoExtraSqlFields(includeNullable = false)
+    avroSchemaHelper.validateNoExtraCatalystFields(ignoreNullable = true)
     // no need to assertNoExtraAvroFields since extra Avro fields are ignored
 
     val (validFieldIndexes, fieldWriters) = avroSchemaHelper.getMatchedFields.map {
-      case (catalystField, ordinal, avroField) =>
+      case AvroMatchedField(catalystField, ordinal, avroField) =>
         val baseWriter = newWriter(avroField.schema(), catalystField.dataType,
           avroPath :+ avroField.name, catalystPath :+ catalystField.name)
         val fieldWriter = (fieldUpdater: CatalystDataUpdater, value: Any) => {

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -341,7 +341,7 @@ private[sql] class AvroDeserializer(
       avroType, catalystType, avroPath, catalystPath, positionalFieldMatch)
 
     avroSchemaHelper.validateNoExtraCatalystFields(ignoreNullable = true)
-    // no need to assertNoExtraAvroFields since extra Avro fields are ignored
+    // no need to validateNoExtraAvroFields since extra Avro fields are ignored
 
     val (validFieldIndexes, fieldWriters) = avroSchemaHelper.getMatchedFields.map {
       case AvroMatchedField(catalystField, ordinal, avroField) =>

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -32,7 +32,7 @@ import org.apache.avro.generic.GenericData.Record
 import org.apache.avro.util.Utf8
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.avro.AvroUtils.{toFieldDescription, toFieldStr}
+import org.apache.spark.sql.avro.AvroUtils.toFieldStr
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, SpecificInternalRow}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -240,34 +240,19 @@ private[sql] class AvroSerializer(
       catalystPath: Seq[String],
       avroPath: Seq[String]): InternalRow => Record = {
 
-    val avroPathStr = toFieldStr(avroPath)
-    if (avroStruct.getType != RECORD) {
-      throw new IncompatibleSchemaException(s"$avroPathStr was not a RECORD")
-    }
-    val avroFields = avroStruct.getFields.asScala
-    if (avroFields.size != catalystStruct.length) {
-      throw new IncompatibleSchemaException(
-        s"Avro $avroPathStr schema length (${avroFields.size}) doesn't match " +
-        s"SQL ${toFieldStr(catalystPath)} schema length (${catalystStruct.length})")
-    }
-    val avroSchemaHelper =
-      new AvroUtils.AvroSchemaHelper(avroStruct, avroPath, positionalFieldMatch)
+    val avroSchemaHelper = new AvroUtils.AvroSchemaHelper(
+      avroStruct, catalystStruct, avroPath, catalystPath, positionalFieldMatch)
 
-    val (avroIndices: Array[Int], fieldConverters: Array[Converter]) =
-      catalystStruct.zipWithIndex.map { case (catalystField, catalystPos) =>
-        val avroField = avroSchemaHelper.getAvroField(catalystField.name, catalystPos) match {
-          case Some(f) => f
-          case None =>
-            val fieldDescription = toFieldDescription(
-              catalystPath :+ catalystField.name, catalystPos, positionalFieldMatch)
-            throw new IncompatibleSchemaException(
-              s"Cannot find $fieldDescription in Avro schema at $avroPathStr")
-        }
+    avroSchemaHelper.assertNoExtraSqlFields(includeNullable = true)
+    avroSchemaHelper.assertNoExtraAvroFields()
+
+    val (avroIndices, fieldConverters) = avroSchemaHelper.getMatchedFields.map {
+      case (catalystField, _, avroField) =>
         val converter = newConverter(catalystField.dataType,
           resolveNullableType(avroField.schema(), catalystField.nullable),
           catalystPath :+ catalystField.name, avroPath :+ avroField.name)
         (avroField.pos(), converter)
-      }.toArray.unzip
+    }.toArray.unzip
 
     val numFields = catalystStruct.length
     row: InternalRow =>

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -246,7 +246,7 @@ private[sql] class AvroSerializer(
     avroSchemaHelper.validateNoExtraCatalystFields(ignoreNullable = false)
     avroSchemaHelper.validateNoExtraAvroFields()
 
-    val (avroIndices, fieldConverters) = avroSchemaHelper.getMatchedFields.map {
+    val (avroIndices, fieldConverters) = avroSchemaHelper.matchedFields.map {
       case AvroMatchedField(catalystField, _, avroField) =>
         val converter = newConverter(catalystField.dataType,
           resolveNullableType(avroField.schema(), catalystField.nullable),

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -32,7 +32,7 @@ import org.apache.avro.generic.GenericData.Record
 import org.apache.avro.util.Utf8
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.avro.AvroUtils.toFieldStr
+import org.apache.spark.sql.avro.AvroUtils.{toFieldStr, AvroMatchedField}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{SpecializedGetters, SpecificInternalRow}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -243,11 +243,11 @@ private[sql] class AvroSerializer(
     val avroSchemaHelper = new AvroUtils.AvroSchemaHelper(
       avroStruct, catalystStruct, avroPath, catalystPath, positionalFieldMatch)
 
-    avroSchemaHelper.assertNoExtraSqlFields(includeNullable = true)
-    avroSchemaHelper.assertNoExtraAvroFields()
+    avroSchemaHelper.validateNoExtraCatalystFields(ignoreNullable = false)
+    avroSchemaHelper.validateNoExtraAvroFields()
 
     val (avroIndices, fieldConverters) = avroSchemaHelper.getMatchedFields.map {
-      case (catalystField, _, avroField) =>
+      case AvroMatchedField(catalystField, _, avroField) =>
         val converter = newConverter(catalystField.dataType,
           resolveNullableType(avroField.schema(), catalystField.nullable),
           catalystPath :+ catalystField.name, avroPath :+ avroField.name)

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -260,7 +260,7 @@ private[sql] object AvroUtils extends Logging {
           (!ignoreNullable || !sqlField.nullable)) {
           if (positionalFieldMatch) {
             throw new IncompatibleSchemaException("Cannot find field at position " +
-              s"$sqlPos of ${toFieldStr(avroPath)} from Avro schema")
+              s"$sqlPos of ${toFieldStr(avroPath)} from Avro schema (using positional matching)")
           } else {
             throw new IncompatibleSchemaException(
               s"Cannot find ${toFieldStr(catalystPath :+ sqlField.name)} in Avro schema")
@@ -276,8 +276,8 @@ private[sql] object AvroUtils extends Logging {
       (avroFieldArray.toSet -- matchedFields.map(_.avroField)).foreach { extraField =>
         if (positionalFieldMatch) {
           throw new IncompatibleSchemaException(s"Found field '${extraField.name()}' at position " +
-            s"${extraField.pos()} of ${toFieldStr(avroPath)} from Avro schema but there " +
-            s"is no match in the SQL schema at ${toFieldStr(catalystPath)}")
+            s"${extraField.pos()} of ${toFieldStr(avroPath)} from Avro schema but there is no " +
+            s"match in the SQL schema at ${toFieldStr(catalystPath)} (using positional matching)")
         } else {
           throw new IncompatibleSchemaException(
             s"Found ${toFieldStr(avroPath :+ extraField.name())} in Avro schema but there is no " +

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -334,7 +334,7 @@ private[sql] object AvroUtils extends Logging {
       case (Seq(), _) => "top-level record"
       case (_, None) => s"field '$nameStr'"
       case (_, Some(pos)) if positionalFieldMatch => s"field at position $pos ('$nameStr')"
-      case (_, Some(pos)) if !positionalFieldMatch => s"field '$nameStr' (at position $pos)"
+      case (_, Some(pos)) => s"field '$nameStr' (at position $pos)"
     }
   }
 }

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -242,8 +242,8 @@ private[sql] object AvroUtils extends Logging {
       .groupBy(_.name.toLowerCase(Locale.ROOT))
       .mapValues(_.toSeq) // toSeq needed for scala 2.13
 
-    /** Get the fields which have matching equivalents in both Avro and Catalyst schemas. */
-    def getMatchedFields: Seq[AvroMatchedField] = catalystSchema.zipWithIndex.flatMap {
+    /** The fields which have matching equivalents in both Avro and Catalyst schemas. */
+    val matchedFields: Seq[AvroMatchedField] = catalystSchema.zipWithIndex.flatMap {
       case (sqlField, sqlPos) =>
         getAvroField(sqlField.name, sqlPos).map(AvroMatchedField(sqlField, sqlPos, _))
     }
@@ -269,7 +269,7 @@ private[sql] object AvroUtils extends Logging {
      * [[IncompatibleSchemaException]] if such extra fields are found.
      */
     def validateNoExtraAvroFields(): Unit = {
-      (avroFieldArray.toSet -- getMatchedFields.map(_.avroField)).foreach { extraField =>
+      (avroFieldArray.toSet -- matchedFields.map(_.avroField)).foreach { extraField =>
         val desc = toFieldDescription(avroPath :+ extraField.name(), extraField.pos())
         throw new IncompatibleSchemaException(s"Found $desc in Avro schema but there is no " +
           s"match in the SQL schema at ${toFieldStr(catalystPath)}")

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
@@ -28,7 +28,7 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
     val avroSchema = SchemaBuilder.builder().intType()
 
     val msg = intercept[IncompatibleSchemaException] {
-      new AvroUtils.AvroSchemaHelper(avroSchema, Seq(""), false)
+      new AvroUtils.AvroSchemaHelper(avroSchema, StructType(Seq()), Seq(""), Seq(""), false)
     }.getMessage
     assert(msg.contains("Attempting to treat int as a RECORD"))
   }
@@ -42,7 +42,8 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
     )
 
     val avroSchema = SchemaConverters.toAvroType(catalystSchema)
-    val helper = new AvroUtils.AvroSchemaHelper(avroSchema, Seq(""), false)
+    val helper =
+      new AvroUtils.AvroSchemaHelper(avroSchema, StructType(Seq()), Seq(""), Seq(""), false)
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
       assert(helper.getFieldByName("A").get.name() == "A")
       assert(helper.getFieldByName("a").get.name() == "a")
@@ -69,8 +70,10 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
     val catalystSchema = new StructType().add("foo", IntegerType).add("bar", StringType)
     val avroSchema = SchemaConverters.toAvroType(catalystSchema)
 
-    val posHelper = new AvroUtils.AvroSchemaHelper(avroSchema, Seq(""), true)
-    val nameHelper = new AvroUtils.AvroSchemaHelper(avroSchema, Seq(""), false)
+    val posHelper =
+      new AvroUtils.AvroSchemaHelper(avroSchema, catalystSchema, Seq(""), Seq(""), true)
+    val nameHelper =
+      new AvroUtils.AvroSchemaHelper(avroSchema, catalystSchema, Seq(""), Seq(""), false)
 
     for (name <- Seq("foo", "bar"); fieldPos <- Seq(0, 1)) {
       assert(posHelper.getAvroField(name, fieldPos) === Some(avroSchema.getFields.get(fieldPos)))
@@ -81,5 +84,52 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
 
     assert(posHelper.getAvroField("nonexist", 1).isDefined)
     assert(nameHelper.getAvroField("nonexist", 1).isEmpty)
+  }
+
+  test("properly match fields between Avro and Catalyst schemas") {
+    val catalystSchema = StructType(
+      Seq("catalyst1", "catalyst2", "shared1", "shared2").map(StructField(_, IntegerType))
+    )
+    val avroSchema = SchemaBuilder.record("toplevel").fields()
+      .requiredInt("shared1")
+      .requiredInt("shared2")
+      .requiredInt("avro1")
+      .requiredInt("avro2")
+      .endRecord()
+
+    val helper = new AvroUtils.AvroSchemaHelper(avroSchema, catalystSchema, Seq(""), Seq(""), false)
+    assert(helper.getMatchedFields === Seq(
+      (catalystSchema("shared1"), 2, avroSchema.getField("shared1")),
+      (catalystSchema("shared2"), 3, avroSchema.getField("shared2"))
+    ))
+    assertThrows[IncompatibleSchemaException] {
+      helper.assertNoExtraAvroFields()
+    }
+    helper.assertNoExtraSqlFields(includeNullable = false)
+    assertThrows[IncompatibleSchemaException] {
+      helper.assertNoExtraSqlFields(includeNullable = true)
+    }
+  }
+
+  test("respect nullability settings for assertNoExtraSqlFields") {
+    val avroSchema = SchemaBuilder.record("record").fields().requiredInt("bar").endRecord()
+
+    val catalystNonnull = new StructType().add("foo", IntegerType, nullable = false)
+    val helperNonnull =
+      new AvroUtils.AvroSchemaHelper(avroSchema, catalystNonnull, Seq(""), Seq(""), false)
+    assertThrows[IncompatibleSchemaException] {
+      helperNonnull.assertNoExtraSqlFields(includeNullable = false)
+    }
+    assertThrows[IncompatibleSchemaException] {
+      helperNonnull.assertNoExtraSqlFields(includeNullable = true)
+    }
+
+    val catalystNullable = new StructType().add("foo", IntegerType)
+    val helperNullable =
+      new AvroUtils.AvroSchemaHelper(avroSchema, catalystNullable, Seq(""), Seq(""), false)
+    helperNullable.assertNoExtraSqlFields(includeNullable = false)
+    assertThrows[IncompatibleSchemaException] {
+      helperNullable.assertNoExtraSqlFields(includeNullable = true)
+    }
   }
 }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
@@ -112,7 +112,7 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
     }
   }
 
-  test("respect nullability settings for assertNoExtraSqlFields") {
+  test("respect nullability settings for validateNoExtraSqlFields") {
     val avroSchema = SchemaBuilder.record("record").fields().requiredInt("bar").endRecord()
 
     val catalystNonnull = new StructType().add("foo", IntegerType, nullable = false)

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
@@ -99,7 +99,7 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
       .endRecord()
 
     val helper = new AvroUtils.AvroSchemaHelper(avroSchema, catalystSchema, Seq(""), Seq(""), false)
-    assert(helper.getMatchedFields === Seq(
+    assert(helper.matchedFields === Seq(
       AvroMatchedField(catalystSchema("shared1"), 2, avroSchema.getField("shared1")),
       AvroMatchedField(catalystSchema("shared2"), 3, avroSchema.getField("shared2"))
     ))

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.avro
 
 import org.apache.avro.SchemaBuilder
 
+import org.apache.spark.sql.avro.AvroUtils.AvroMatchedField
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
@@ -99,15 +100,15 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
 
     val helper = new AvroUtils.AvroSchemaHelper(avroSchema, catalystSchema, Seq(""), Seq(""), false)
     assert(helper.getMatchedFields === Seq(
-      (catalystSchema("shared1"), 2, avroSchema.getField("shared1")),
-      (catalystSchema("shared2"), 3, avroSchema.getField("shared2"))
+      AvroMatchedField(catalystSchema("shared1"), 2, avroSchema.getField("shared1")),
+      AvroMatchedField(catalystSchema("shared2"), 3, avroSchema.getField("shared2"))
     ))
     assertThrows[IncompatibleSchemaException] {
-      helper.assertNoExtraAvroFields()
+      helper.validateNoExtraAvroFields()
     }
-    helper.assertNoExtraSqlFields(includeNullable = false)
+    helper.validateNoExtraCatalystFields(ignoreNullable = true)
     assertThrows[IncompatibleSchemaException] {
-      helper.assertNoExtraSqlFields(includeNullable = true)
+      helper.validateNoExtraCatalystFields(ignoreNullable = false)
     }
   }
 
@@ -118,18 +119,18 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
     val helperNonnull =
       new AvroUtils.AvroSchemaHelper(avroSchema, catalystNonnull, Seq(""), Seq(""), false)
     assertThrows[IncompatibleSchemaException] {
-      helperNonnull.assertNoExtraSqlFields(includeNullable = false)
+      helperNonnull.validateNoExtraCatalystFields(ignoreNullable = true)
     }
     assertThrows[IncompatibleSchemaException] {
-      helperNonnull.assertNoExtraSqlFields(includeNullable = true)
+      helperNonnull.validateNoExtraCatalystFields(ignoreNullable = false)
     }
 
     val catalystNullable = new StructType().add("foo", IntegerType)
     val helperNullable =
       new AvroUtils.AvroSchemaHelper(avroSchema, catalystNullable, Seq(""), Seq(""), false)
-    helperNullable.assertNoExtraSqlFields(includeNullable = false)
+    helperNullable.validateNoExtraCatalystFields(ignoreNullable = true)
     assertThrows[IncompatibleSchemaException] {
-      helperNullable.assertNoExtraSqlFields(includeNullable = true)
+      helperNullable.validateNoExtraCatalystFields(ignoreNullable = false)
     }
   }
 }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSerdeSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSerdeSuite.scala
@@ -89,7 +89,7 @@ class AvroSerdeSuite extends SparkFunSuite {
       "Cannot find field 'foo.bar' in Avro schema",
       nonnullCatalyst)
     assertFailedConversionMessage(avro, Deserializer, BY_POSITION,
-      "Cannot find field at position 1 of field 'foo' from Avro schema",
+      "Cannot find field at position 1 of field 'foo' from Avro schema (using positional matching)",
       extraNonnullCatalyst)
 
     // serialize fails whether or not 'bar' is nullable
@@ -97,7 +97,7 @@ class AvroSerdeSuite extends SparkFunSuite {
     assertFailedConversionMessage(avro, Serializer, BY_NAME, byNameMsg)
     assertFailedConversionMessage(avro, Serializer, BY_NAME, byNameMsg, nonnullCatalyst)
     assertFailedConversionMessage(avro, Serializer, BY_POSITION,
-      "Cannot find field at position 1 of field 'foo' from Avro schema",
+      "Cannot find field at position 1 of field 'foo' from Avro schema (using positional matching)",
       extraNonnullCatalyst)
   }
 
@@ -128,7 +128,7 @@ class AvroSerdeSuite extends SparkFunSuite {
       "Found field 'bar' in Avro schema but there is no match in the SQL schema")
     assertFailedConversionMessage(tooManyFields, Serializer, BY_POSITION,
       "Found field 'bar' at position 1 of top-level record from Avro schema but there is no " +
-        "match in the SQL schema at top-level record")
+        "match in the SQL schema at top-level record (using positional matching)")
 
     val tooManyFieldsNested =
       createNestedAvroSchemaWithFields("foo", _.optionalInt("bar").optionalInt("baz"))
@@ -136,13 +136,14 @@ class AvroSerdeSuite extends SparkFunSuite {
       "Found field 'foo.baz' in Avro schema but there is no match in the SQL schema")
     assertFailedConversionMessage(tooManyFieldsNested, Serializer, BY_POSITION,
       s"Found field 'baz' at position 1 of field 'foo' from Avro schema but there is no match " +
-        s"in the SQL schema at field 'foo'")
+        s"in the SQL schema at field 'foo' (using positional matching)")
 
     val tooFewFields = createAvroSchemaWithTopLevelFields(f => f)
     assertFailedConversionMessage(tooFewFields, Serializer, BY_NAME,
       "Cannot find field 'foo' in Avro schema")
     assertFailedConversionMessage(tooFewFields, Serializer, BY_POSITION,
-      "Cannot find field at position 0 of top-level record from Avro schema")
+      "Cannot find field at position 0 of top-level record from Avro schema " +
+        "(using positional matching)")
   }
 
   /**

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -1402,8 +1402,7 @@ abstract class AvroSuite
         val e = intercept[SparkException] {
           df.write.option("avroSchema", avroSchema).format("avro").save(s"$tempDir/save2")
         }
-        assertExceptionMsg[IncompatibleSchemaException](e,
-          "Cannot find field 'FOO' (at position 0) in Avro schema at top-level record")
+        assertExceptionMsg[IncompatibleSchemaException](e, "Cannot find field 'FOO' in Avro schema")
       }
     }
   }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -1403,7 +1403,8 @@ abstract class AvroSuite
           df.write.option("avroSchema", avroSchema).format("avro").save(s"$tempDir/save2")
         }
         assertExceptionMsg[IncompatibleSchemaException](e,
-          "Cannot find field 'FOO' (at position 0) in Avro schema at top-level record")
+          "Cannot find SQL field(s) in Avro top-level record: " +
+            "[field 'FOO' (position 0), field 'bar' (position 1)]")
       }
     }
   }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -1403,8 +1403,7 @@ abstract class AvroSuite
           df.write.option("avroSchema", avroSchema).format("avro").save(s"$tempDir/save2")
         }
         assertExceptionMsg[IncompatibleSchemaException](e,
-          "Cannot find SQL field(s) in Avro top-level record: " +
-            "[field 'FOO' (position 0), field 'bar' (position 1)]")
+          "Cannot find field 'FOO' (at position 0) in Avro schema at top-level record")
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This unifies struct schema mismatch-handling logic between `AvroSerializer` and `AvroDeserializer`, pushing it into `AvroUtils` which is used by both. The newly unified exception-handling logic is updated to provide more contextual information in error messages. When a schema mismatch is found, previously we would only report the first missing field that is found, but there may be any others as well, which can make it less clear what exactly is going wrong. Now, we will report on all missing fields.

### Why are the changes needed?
While working on #31490, we discussed that there is room for improvement in how schema mismatch errors are reported ([comment1](https://github.com/apache/spark/pull/31490#discussion_r659970793), [comment2](https://github.com/apache/spark/pull/31490#issuecomment-869866848)). Additionally, the logic between `AvroSerializer` and `AvroDeserializer` was quite similar for handling these issues, but didn't share common code, causing duplication and making it harder to see exactly what differences existed between the two.

### Does this PR introduce _any_ user-facing change?
Some error messages when matching Catalyst struct schemas against Avro record schemas now include more information.

### How was this patch tested?
New unit tests added.