### PR TITLE
[WIP][SPARK-20384][SQL] Support value classes and always encoded as underlying type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -362,8 +362,6 @@ object ScalaReflection extends ScalaReflection {
         val underlyingClsName = getClassNameFromType(underlyingType)
         val clsName = getUnerasedClassNameFromType(t)
         val newTypePath = walkedTypePath.recordValueClass(clsName, underlyingClsName)
-
-        // We only end up here for value classes that should be instansiated
         val arg = deserializerFor(underlyingType, path, newTypePath)
         val cls = getClassFromType(t)
         NewInstance(cls, Seq(arg), ObjectType(cls), propagateNull = false)
@@ -595,7 +593,8 @@ object ScalaReflection extends ScalaReflection {
         val underlyingClsName = getClassNameFromType(underlyingType)
         val clsName = getUnerasedClassNameFromType(t)
         val newPath = walkedTypePath.recordValueClass(clsName, underlyingClsName)
-        val getArg = Invoke(inputObject, name, dataTypeFor(underlyingType))
+        val getArg = Invoke(KnownNotNull(inputObject), name, dataTypeFor(underlyingType),
+          returnNullable = !underlyingType.typeSymbol.asClass.isPrimitive)
         serializerFor(getArg, underlyingType, newPath)
 
       case t if definedByConstructorParams(t) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/WalkedTypePath.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/WalkedTypePath.scala
@@ -46,6 +46,9 @@ case class WalkedTypePath(private val walkedPaths: Seq[String] = Nil) {
   def recordField(className: String, fieldName: String): WalkedTypePath =
     newInstance(s"""- field (class: "$className", name: "$fieldName")""")
 
+  def recordValueClass(className: String, underlyingClassName: String): WalkedTypePath =
+    newInstance(s"""- Scala value class: $className($underlyingClassName)""")
+
   override def toString: String = {
     walkedPaths.mkString("\n")
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -502,7 +502,7 @@ class ScalaReflectionSuite extends SparkFunSuite {
   }
 
   test("SPARK-20384: schema for case class with generic field") {
-    val schema = schemaFor[CaseClassWithGeneric[Int]]
+    val schema = schemaFor[CaseClassWithGeneric[IntWrapper]]
     assert(schema === Schema(
       StructType(Seq(
         StructField("generic", IntegerType, nullable = false))),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -442,6 +442,9 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
   encodeDecodeTest(
     (IntWrapper(1), StringWrapper("a")),
     "SPARK-20384: Tuple with value classes")
+  encodeDecodeTest(
+    CaseClassWithGeneric(IntWrapper(1), StringWrapper("a")),
+    "SPARK-20384: case class with value class in generic fields")
 
   encodeDecodeTest(Option(31), "option of int")
   encodeDecodeTest(Option.empty[Int], "empty option of int")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.expressions.{Aggregator, Window}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, SharedSparkSession}
-import org.apache.spark.sql.test.SQLTestData.{DecimalData, TestData2}
+import org.apache.spark.sql.test.SQLTestData.{ArrayStringWrapper, ContainerStringWrapper, DecimalData, StringWrapper, TestData2}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.Utils
@@ -832,6 +832,56 @@ class DataFrameSuite extends QueryTest
         Row(key, value, key + 1)
       }.toSeq)
     assert(df.schema.map(_.name) === Seq("key", "valueRenamed", "newCol"))
+  }
+
+  test("SPARK-20384: Value class filter") {
+    val df = spark.sparkContext
+      .parallelize(Seq(StringWrapper("a"), StringWrapper("b"), StringWrapper("c")))
+      .toDF()
+    val filtered = df.where("value = \"a\"")
+    checkAnswer(filtered, spark.sparkContext.parallelize(Seq(StringWrapper("a"))).toDF)
+  }
+
+  test("SPARK-20384: Tuple2 of value class filter") {
+    val df = spark.sparkContext
+      .parallelize(Seq(
+        (StringWrapper("a1"), StringWrapper("a2")),
+        (StringWrapper("b1"), StringWrapper("b2"))))
+      .toDF()
+    val filtered = df.where("_2 = \"a2\"")
+    checkAnswer(filtered,
+      spark.sparkContext.parallelize(Seq((StringWrapper("a1"), StringWrapper("a2")))).toDF)
+  }
+
+  test("SPARK-20384: Tuple3 of value class filter") {
+    val df = spark.sparkContext
+      .parallelize(Seq(
+        (StringWrapper("a1"), StringWrapper("a2"), StringWrapper("a3")),
+        (StringWrapper("b1"), StringWrapper("b2"), StringWrapper("b3"))))
+      .toDF()
+    val filtered = df.where("_3  = \"a3\"")
+    checkAnswer(filtered,
+      spark.sparkContext.parallelize(
+        Seq((StringWrapper("a1"), StringWrapper("a2"), StringWrapper("a3")))).toDF)
+  }
+
+  test("SPARK-20384: Array value class filter") {
+    val ab = ArrayStringWrapper(Seq(StringWrapper("a"), StringWrapper("b")))
+    val cd = ArrayStringWrapper(Seq(StringWrapper("c"), StringWrapper("d")))
+
+    val df = spark.sparkContext.parallelize(Seq(ab, cd)).toDF
+    val filtered = df.where(array_contains(col("wrappers"), StringWrapper("b")))
+    checkAnswer(filtered, spark.sparkContext.parallelize(Seq(ab)).toDF)
+  }
+
+  test("SPARK-20384: Nested value class filter") {
+    val a = ContainerStringWrapper(StringWrapper("a"))
+    val b = ContainerStringWrapper(StringWrapper("b"))
+
+    val df = spark.sparkContext.parallelize(Seq(a, b)).toDF
+    // flat value class, `s` field is not in schema
+    val filtered = df.where("wrapper = \"a\"")
+    checkAnswer(filtered, spark.sparkContext.parallelize(Seq(a)).toDF)
   }
 
   private lazy val person2: DataFrame = Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -870,7 +870,7 @@ class DataFrameSuite extends QueryTest
     val cd = ArrayStringWrapper(Seq(StringWrapper("c"), StringWrapper("d")))
 
     val df = spark.sparkContext.parallelize(Seq(ab, cd)).toDF
-    val filtered = df.where(array_contains(col("wrappers"), StringWrapper("b")))
+    val filtered = df.where(array_contains(col("wrappers"), "b"))
     checkAnswer(filtered, spark.sparkContext.parallelize(Seq(ab)).toDF)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -450,4 +450,7 @@ private[sql] object SQLTestData {
   case class CourseSales(course: String, year: Int, earnings: Double)
   case class TrainingSales(training: String, sales: CourseSales)
   case class IntervalData(data: CalendarInterval)
+  case class StringWrapper(s: String) extends AnyVal
+  case class ArrayStringWrapper(wrappers: Seq[StringWrapper])
+  case class ContainerStringWrapper(wrapper: StringWrapper)
 }


### PR DESCRIPTION
The **[WIP]** is only since solutions to the same issue is already being proposed in https://github.com/apache/spark/pull/33205. But the code is complete and should work as expected.


### What changes were proposed in this pull request?
This PR adds support for using value class in nested case classes. This has previously been proposed in the following PRs: https://github.com/apache/spark/pull/22309 https://github.com/apache/spark/pull/27153 https://github.com/apache/spark/pull/33205

The first PR had the same approach as in this one of always encoding the value class as the underlying type. But as noted by @cloud-fan: https://github.com/apache/spark/pull/22309#issuecomment-433913001 the implementation was quite spread out in `ScalaReflection.scala` this is addressed in this PR by "unwrapping" the value class only when used inside a case class. This removes the need for the extra argument `instantiateValueClass` to `deserializerFor` and makes the implementation less spread out.

The other two are both by @mickjermsurawong-stripe  and takes the approach that value class are only "unwrapped" is cases where there there will be no runtime object. This has the advantage of being fully backwards compatible with cases where case class currently work. The partial support for value classes was original added in: https://github.com/apache/spark/pull/15284
does only add test cases for single column value classes. Therefore it seems like other cases where value classes happen to work like `Option[ValueClass]` or `Array[ValueClass]` are mostly accidental and where not thoughtfully designed to have the current behavior.

This PR is meant for discussion and alternative approach to https://github.com/apache/spark/pull/33205 if there is no need for schema backwards compatibility. 

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Support value classes in Datasets, so that they can be used in code bases that currently use them in their modeling.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
This add supports for using value class in DataFrames and Datasets that would previously led to exceptions.

The main change the can effect existing code is that previously single column value classes would be encoded as they where simple case class.
To avoid extra complexity this patch always treats value classes as their underlying type.
Therefore given the following case class:
```
case class MyInt(wrapped: Int) extends AnyVal
```
this means that both `Dataset[Int]` and `Dataset[MyInt]` will have the same schema
```
root
 |-- value: integer (nullable = false)
```
Before this patch the schema of `Dataset[MyInt]` would instead have been
```
root
 |-- wrapped: integer (nullable = false)
```

### How was this patch tested?
New unit tests in: `ScalaReflectionSuite.scala`, `ExpressionEncoderSuite.scala`, `DataFrameSuite.scala` and `DatasetSuite.scala`.