### PR TITLE
[SPARK-35735][SQL][FOLLOWUP] Remove unused method `IntervalUtils.checkIntervalStringDataType()`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils.millisToMicros
 import org.apache.spark.sql.catalyst.util.IntervalStringStyles.{ANSI_STYLE, HIVE_STYLE, IntervalStyle}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DataType, DayTimeIntervalType => DT, Decimal, YearMonthIntervalType => YM}
+import org.apache.spark.sql.types.{DayTimeIntervalType => DT, Decimal, YearMonthIntervalType => YM}
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 // The style of textual representation of intervals
@@ -123,25 +123,6 @@ object IntervalUtils {
         s"when cast to $typeName: ${input.toString}" +
         s"${fallBackNotice.map(s => s", $s").getOrElse("")}")
   }
-
-  private def checkIntervalStringDataType(
-      input: UTF8String,
-      targetStartField: Byte,
-      targetEndField: Byte,
-      inputIntervalType: DataType,
-      fallBackNotice: Option[String] = None): Unit = {
-    val (intervalStr, typeName, inputStartField, inputEndField) = inputIntervalType match {
-      case DT(startField, endField) =>
-        ("day-time", DT(targetStartField, targetEndField).typeName, startField, endField)
-      case YM(startField, endField) =>
-        ("year-month", YM(targetStartField, targetEndField).typeName, startField, endField)
-    }
-    if (targetStartField != inputStartField || targetEndField != inputEndField) {
-      throwIllegalIntervalFormatException(
-        input, targetStartField, targetEndField, intervalStr, typeName, fallBackNotice)
-    }
-  }
-
 
   val supportedFormat = Map(
     (YM.YEAR, YM.MONTH) -> Seq("[+|-]y-m", "INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the private method `checkIntervalStringDataType()` from `IntervalUtils` since it hasn't been used anymore after https://github.com/apache/spark/pull/33242.

### Why are the changes needed?
To improve code maintenance.

### Does this PR introduce _any_ user-facing change?
No. The method is private, and it existing in code base for short time.

### How was this patch tested?
By existing GAs/tests.
