### PR TITLE
[SPARK-36076][SQL][3.0] ArrayIndexOutOfBounds in Cast string to timestamp

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -282,7 +282,7 @@ object DateTimeUtils {
    *     - +|-hhmmss
    *  - Region-based zone IDs in the form `area/city`, such as `Europe/Paris`
    */
-  def stringToTimestamp(s: UTF8String, timeZoneId: ZoneId): Option[SQLTimestamp] = {
+  def stringToTimestamp(s: UTF8String, timeZoneId: ZoneId): Option[SQLTimestamp] = try {
     if (s == null) {
       return None
     }
@@ -390,27 +390,25 @@ object DateTimeUtils {
       segments(6) /= 10
       digitsMilli -= 1
     }
-    try {
-      val zoneId = tz match {
-        case None => timeZoneId
-        case Some("+") => ZoneOffset.ofHoursMinutes(segments(7), segments(8))
-        case Some("-") => ZoneOffset.ofHoursMinutes(-segments(7), -segments(8))
-        case Some(zoneName: String) => getZoneId(zoneName.trim)
-      }
-      val nanoseconds = MICROSECONDS.toNanos(segments(6))
-      val localTime = LocalTime.of(segments(3), segments(4), segments(5), nanoseconds.toInt)
-      val localDate = if (justTime) {
-        LocalDate.now(zoneId)
-      } else {
-        LocalDate.of(segments(0), segments(1), segments(2))
-      }
-      val localDateTime = LocalDateTime.of(localDate, localTime)
-      val zonedDateTime = ZonedDateTime.of(localDateTime, zoneId)
-      val instant = Instant.from(zonedDateTime)
-      Some(instantToMicros(instant))
-    } catch {
-      case NonFatal(_) => None
+    val zoneId = tz match {
+      case None => timeZoneId
+      case Some("+") => ZoneOffset.ofHoursMinutes(segments(7), segments(8))
+      case Some("-") => ZoneOffset.ofHoursMinutes(-segments(7), -segments(8))
+      case Some(zoneName: String) => getZoneId(zoneName.trim)
     }
+    val nanoseconds = MICROSECONDS.toNanos(segments(6))
+    val localTime = LocalTime.of(segments(3), segments(4), segments(5), nanoseconds.toInt)
+    val localDate = if (justTime) {
+      LocalDate.now(zoneId)
+    } else {
+      LocalDate.of(segments(0), segments(1), segments(2))
+    }
+    val localDateTime = LocalDateTime.of(localDate, localTime)
+    val zonedDateTime = ZonedDateTime.of(localDateTime, zoneId)
+    val instant = Instant.from(zonedDateTime)
+    Some(instantToMicros(instant))
+  } catch {
+    case NonFatal(_) => None
   }
 
   // See issue SPARK-35679

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -281,6 +281,10 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     }
   }
 
+  test("SPARK-36076: Cast string to timestamp throw ArrayIndexOutOfBounds") {
+    assert(toTimestamp(":8:434421+ 98:38", UTC) === None)
+  }
+
   test("SPARK-15379: special invalid date string") {
     // Test stringToDate
     assert(toDate("2015-02-29 00:00:00").isEmpty)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Casting string to timestamp might throw ArrayIndexOutOfBounds in certain cases
This error only occur in branch 3.0, 3.1 and previous, it's not present on 3.2 or master
Code to reproduce:
```
val df = Seq(":8:434421+ 98:38").toDF("c0")
val df2 = df.withColumn("c1", col("c0").cast(DataTypes.TimestampType))
df2.show()
```

Error:
```
java.lang.ArrayIndexOutOfBoundsException: 9
  at org.apache.spark.sql.catalyst.util.DateTimeUtils$.stringToTimestamp(DateTimeUtils.scala:328)
  at org.apache.spark.sql.catalyst.expressions.CastBase.$anonfun$castToTimestamp$2(Cast.scala:455)
  at org.apache.spark.sql.catalyst.expressions.CastBase.buildCast(Cast.scala:295)
  at org.apache.spark.sql.catalyst.expressions.CastBase.$anonfun$castToTimestamp$1(Cast.scala:451)
  at org.apache.spark.sql.catalyst.expressions.CastBase.nullSafeEval(Cast.scala:840)
  at org.apache.spark.sql.catalyst.expressions.UnaryExpression.eval(Expression.scala:476)
```

### Why are the changes needed?
Cast String to timestamp shouldn't throw error, it should return Null instead.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add test in DateTimeUtilsSuite