### PR TITLE
[SPARK-36125][PYTHON] Implement non-equality comparison operators between two Categoricals

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -44,6 +44,26 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     def other_psser(self):
         return ps.from_pandas(self.other_pser)
 
+    @property
+    def ordered_pser(self):
+        return pd.Series([1, 2, 3]).astype(CategoricalDtype([3, 2, 1], ordered=True))
+
+    @property
+    def disordered_psser(self):
+        return ps.Series([1, 2, 3]).astype(CategoricalDtype([3, 2, 1]))
+
+    @property
+    def ordered_psser(self):
+        return ps.from_pandas(self.ordered_pser)
+
+    @property
+    def other_ordered_pser(self):
+        return pd.Series([2, 1, 3]).astype(CategoricalDtype([3, 2, 1], ordered=True))
+
+    @property
+    def other_ordered_psser(self):
+        return ps.from_pandas(self.other_ordered_pser)
+
     def test_add(self):
         self.assertRaises(TypeError, lambda: self.psser + "x")
         self.assertRaises(TypeError, lambda: self.psser + 1)
@@ -198,16 +218,137 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
-        self.assertRaises(NotImplementedError, lambda: self.psser < self.other_psser)
+        ordered_pser = self.ordered_pser
+        ordered_psser = self.ordered_psser
+        self.assert_eq(ordered_pser < ordered_pser, ordered_psser < ordered_psser)
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                ordered_pser < self.other_ordered_pser, ordered_psser < self.other_ordered_psser
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Unordered Categoricals can only compare equality or not",
+                lambda: self.disordered_psser < ordered_psser,
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Categoricals can only be compared if 'categories' are the same",
+                lambda: ordered_psser < self.disordered_psser,
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Cannot compare a Categorical with the given type",
+                lambda: ordered_psser < ps.Series([1, 2, 3]),
+            )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser < [1, 2, 3],
+        )
+        self.assertRaisesRegex(
+            TypeError, "Cannot compare a Categorical with the given type", lambda: ordered_psser < 1
+        )
 
     def test_le(self):
-        self.assertRaises(NotImplementedError, lambda: self.psser <= self.other_psser)
+        ordered_pser = self.ordered_pser
+        ordered_psser = self.ordered_psser
+        self.assert_eq(ordered_pser <= ordered_pser, ordered_psser <= ordered_psser)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                ordered_pser <= self.other_ordered_pser, ordered_psser <= self.other_ordered_psser
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Unordered Categoricals can only compare equality or not",
+                lambda: self.disordered_psser <= ordered_psser,
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Categoricals can only be compared if 'categories' are the same",
+                lambda: ordered_psser <= self.disordered_psser,
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Cannot compare a Categorical with the given type",
+                lambda: ordered_psser <= ps.Series([1, 2, 3]),
+            )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser <= [1, 2, 3],
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser <= 1,
+        )
 
     def test_gt(self):
-        self.assertRaises(NotImplementedError, lambda: self.psser > self.other_psser)
+        ordered_pser = self.ordered_pser
+        ordered_psser = self.ordered_psser
+        self.assert_eq(ordered_pser > ordered_pser, ordered_psser > ordered_psser)
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                ordered_pser > self.other_ordered_pser, ordered_psser > self.other_ordered_psser
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Unordered Categoricals can only compare equality or not",
+                lambda: self.disordered_psser > ordered_psser,
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Categoricals can only be compared if 'categories' are the same",
+                lambda: ordered_psser > self.disordered_psser,
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Cannot compare a Categorical with the given type",
+                lambda: ordered_psser > ps.Series([1, 2, 3]),
+            )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser > [1, 2, 3],
+        )
+        self.assertRaisesRegex(
+            TypeError, "Cannot compare a Categorical with the given type", lambda: ordered_psser > 1
+        )
 
     def test_ge(self):
-        self.assertRaises(NotImplementedError, lambda: self.psser >= self.other_psser)
+        ordered_pser = self.ordered_pser
+        ordered_psser = self.ordered_psser
+        self.assert_eq(ordered_pser >= ordered_pser, ordered_psser >= ordered_psser)
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                ordered_pser >= self.other_ordered_pser, ordered_psser >= self.other_ordered_psser
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Unordered Categoricals can only compare equality or not",
+                lambda: self.disordered_psser >= ordered_psser,
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Categoricals can only be compared if 'categories' are the same",
+                lambda: ordered_psser >= self.disordered_psser,
+            )
+            self.assertRaisesRegex(
+                TypeError,
+                "Cannot compare a Categorical with the given type",
+                lambda: ordered_psser >= ps.Series([1, 2, 3]),
+            )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser >= [1, 2, 3],
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser >= 1,
+        )
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -49,10 +49,6 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         return pd.Series([1, 2, 3]).astype(CategoricalDtype([3, 2, 1], ordered=True))
 
     @property
-    def disordered_psser(self):
-        return ps.Series([1, 2, 3]).astype(CategoricalDtype([3, 2, 1]))
-
-    @property
     def ordered_psser(self):
         return ps.from_pandas(self.ordered_pser)
 
@@ -63,6 +59,10 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
     @property
     def other_ordered_psser(self):
         return ps.from_pandas(self.other_ordered_pser)
+
+    @property
+    def unordered_psser(self):
+        return ps.Series([1, 2, 3]).astype(CategoricalDtype([3, 2, 1]))
 
     def test_add(self):
         self.assertRaises(TypeError, lambda: self.psser + "x")
@@ -228,12 +228,12 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assertRaisesRegex(
                 TypeError,
                 "Unordered Categoricals can only compare equality or not",
-                lambda: self.disordered_psser < ordered_psser,
+                lambda: self.unordered_psser < ordered_psser,
             )
             self.assertRaisesRegex(
                 TypeError,
                 "Categoricals can only be compared if 'categories' are the same",
-                lambda: ordered_psser < self.disordered_psser,
+                lambda: ordered_psser < self.unordered_psser,
             )
             self.assertRaisesRegex(
                 TypeError,
@@ -261,12 +261,12 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assertRaisesRegex(
                 TypeError,
                 "Unordered Categoricals can only compare equality or not",
-                lambda: self.disordered_psser <= ordered_psser,
+                lambda: self.unordered_psser <= ordered_psser,
             )
             self.assertRaisesRegex(
                 TypeError,
                 "Categoricals can only be compared if 'categories' are the same",
-                lambda: ordered_psser <= self.disordered_psser,
+                lambda: ordered_psser <= self.unordered_psser,
             )
             self.assertRaisesRegex(
                 TypeError,
@@ -295,12 +295,12 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assertRaisesRegex(
                 TypeError,
                 "Unordered Categoricals can only compare equality or not",
-                lambda: self.disordered_psser > ordered_psser,
+                lambda: self.unordered_psser > ordered_psser,
             )
             self.assertRaisesRegex(
                 TypeError,
                 "Categoricals can only be compared if 'categories' are the same",
-                lambda: ordered_psser > self.disordered_psser,
+                lambda: ordered_psser > self.unordered_psser,
             )
             self.assertRaisesRegex(
                 TypeError,
@@ -327,12 +327,12 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assertRaisesRegex(
                 TypeError,
                 "Unordered Categoricals can only compare equality or not",
-                lambda: self.disordered_psser >= ordered_psser,
+                lambda: self.unordered_psser >= ordered_psser,
             )
             self.assertRaisesRegex(
                 TypeError,
                 "Categoricals can only be compared if 'categories' are the same",
-                lambda: ordered_psser >= self.disordered_psser,
+                lambda: ordered_psser >= self.unordered_psser,
             )
             self.assertRaisesRegex(
                 TypeError,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement non-equality comparison operators between two Categoricals.
Non-goal: supporting Scalar input will be a follow-up task.

### Why are the changes needed?
pandas supports non-equality comparisons between two Categoricals. We should follow that.

### Does this PR introduce _any_ user-facing change?
Yes. No `NotImplementedError` for `<`, `<=`, `>`, `>=` operators between two Categoricals. An example is shown as below:

From:
```py
>>> import pyspark.pandas as ps
>>> from pandas.api.types import CategoricalDtype
>>> psser = ps.Series([1, 2, 3]).astype(CategoricalDtype([3, 2, 1], ordered=True))
>>> other_psser = ps.Series([2, 1, 3]).astype(CategoricalDtype([3, 2, 1], ordered=True))
>>> with ps.option_context("compute.ops_on_diff_frames", True):
...     psser <= other_psser
... 
Traceback (most recent call last):
...
NotImplementedError: <= can not be applied to categoricals.
```

To:
```py
>>> import pyspark.pandas as ps
>>> from pandas.api.types import CategoricalDtype
>>> psser = ps.Series([1, 2, 3]).astype(CategoricalDtype([3, 2, 1], ordered=True))
>>> other_psser = ps.Series([2, 1, 3]).astype(CategoricalDtype([3, 2, 1], ordered=True))
>>> with ps.option_context("compute.ops_on_diff_frames", True):
...     psser <= other_psser
... 
0    False
1     True
2     True
dtype: bool
```
### How was this patch tested?
Unit tests.

Keyword:SPARK-35337