### PR TITLE
[SPARK-36131][SQL][TEST] Refactor ParquetColumnIndexSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnIndexSuite.scala
@@ -23,6 +23,15 @@ import org.apache.spark.sql.test.SharedSparkSession
 class ParquetColumnIndexSuite extends QueryTest with ParquetTest with SharedSparkSession {
   import testImplicits._
 
+  private val actions: Seq[DataFrame => DataFrame] = Seq(
+    "_1 = 500",
+    "_1 = 500 or _1 = 1500",
+    "_1 = 500 or _1 = 501 or _1 = 1500",
+    "_1 = 500 or _1 = 501 or _1 = 1000 or _1 = 1500",
+    "_1 >= 500 and _1 < 1000",
+    "(_1 >= 500 and _1 < 1000) or (_1 >= 1500 and _1 < 1600)"
+  ).map(f => (df: DataFrame) => df.filter(f))
+
   /**
    * create parquet file with two columns and unaligned pages
    * pages will be of the following layout
@@ -31,96 +40,56 @@ class ParquetColumnIndexSuite extends QueryTest with ParquetTest with SharedSpar
    *  |-------|-----|-----|---|---|---|---|---|
    * col_2   400   300   200 200 200 200 200 200
    */
-  def checkUnalignedPages(actions: (DataFrame => DataFrame)*): Unit = {
-    withTempPath(file => {
-      val ds = spark.range(0, 2000).map(i => (i, i + ":" + "o" * (i / 100).toInt))
-      ds.coalesce(1)
-          .write
-          .option("parquet.page.size", "4096")
-          .parquet(file.getCanonicalPath)
+  def checkUnalignedPages(df: DataFrame)(actions: (DataFrame => DataFrame)*): Unit = {
+    Seq(true, false).foreach { enableDictionary =>
+      withTempPath(file => {
+        df.coalesce(1)
+            .write
+            .option("parquet.page.size", "4096")
+            .option("parquet.enable.dictionary", enableDictionary.toString)
+            .parquet(file.getCanonicalPath)
 
-      val parquetDf = spark.read.parquet(file.getCanonicalPath)
+        val parquetDf = spark.read.parquet(file.getCanonicalPath)
 
-      actions.foreach { action =>
-        checkAnswer(action(parquetDf), action(ds.toDF()))
-      }
-    })
+        actions.foreach { action =>
+          checkAnswer(action(parquetDf), action(df))
+        }
+      })
+    }
   }
 
   test("reading from unaligned pages - test filters") {
-    checkUnalignedPages(
-      // single value filter
-      df => df.filter("_1 = 500"),
-      df => df.filter("_1 = 500 or _1 = 1500"),
-      df => df.filter("_1 = 500 or _1 = 501 or _1 = 1500"),
-      df => df.filter("_1 = 500 or _1 = 501 or _1 = 1000 or _1 = 1500"),
-      // range filter
-      df => df.filter("_1 >= 500 and _1 < 1000"),
-      df => df.filter("(_1 >= 500 and _1 < 1000) or (_1 >= 1500 and _1 < 1600)")
-    )
+    val df = spark.range(0, 2000).map(i => (i, i + ":" + "o" * (i / 100).toInt)).toDF()
+    checkUnalignedPages(df)(actions: _*)
   }
 
   test("test reading unaligned pages - test all types") {
-    withTempPath(file => {
-      val df = spark.range(0, 2000).selectExpr(
-        "id as _1",
-        "cast(id as short) as _3",
-        "cast(id as int) as _4",
-        "cast(id as float) as _5",
-        "cast(id as double) as _6",
-        "cast(id as decimal(20,0)) as _7",
-        "cast(cast(1618161925000 + id * 1000 * 60 * 60 * 24 as timestamp) as date) as _9",
-        "cast(1618161925000 + id as timestamp) as _10"
-      )
-      df.coalesce(1)
-          .write
-          .option("parquet.page.size", "4096")
-          .parquet(file.getCanonicalPath)
-
-      val parquetDf = spark.read.parquet(file.getCanonicalPath)
-      val singleValueFilterExpr = "_1 = 500 or _1 = 1500"
-      checkAnswer(
-        parquetDf.filter(singleValueFilterExpr),
-        df.filter(singleValueFilterExpr)
-      )
-      val rangeFilterExpr = "_1 > 500 "
-      checkAnswer(
-        parquetDf.filter(rangeFilterExpr),
-        df.filter(rangeFilterExpr)
-      )
-    })
+    val df = spark.range(0, 2000).selectExpr(
+      "id as _1",
+      "cast(id as short) as _3",
+      "cast(id as int) as _4",
+      "cast(id as float) as _5",
+      "cast(id as double) as _6",
+      "cast(id as decimal(20,0)) as _7",
+      "cast(cast(1618161925000 + id * 1000 * 60 * 60 * 24 as timestamp) as date) as _9",
+      "cast(1618161925000 + id as timestamp) as _10"
+    )
+    checkUnalignedPages(df)(actions: _*)
   }
 
   test("test reading unaligned pages - test all types (dict encode)") {
-    withTempPath(file => {
-      val df = spark.range(0, 2000).selectExpr(
-        "id as _1",
-        "cast(id % 10 as byte) as _2",
-        "cast(id % 10 as short) as _3",
-        "cast(id % 10 as int) as _4",
-        "cast(id % 10 as float) as _5",
-        "cast(id % 10 as double) as _6",
-        "cast(id % 10 as decimal(20,0)) as _7",
-        "cast(id % 2 as boolean) as _8",
-        "cast(cast(1618161925000 + (id % 10) * 1000 * 60 * 60 * 24 as timestamp) as date) as _9",
-        "cast(1618161925000 + (id % 10) as timestamp) as _10"
-      )
-      df.coalesce(1)
-          .write
-          .option("parquet.page.size", "4096")
-          .parquet(file.getCanonicalPath)
-
-      val parquetDf = spark.read.parquet(file.getCanonicalPath)
-      val singleValueFilterExpr = "_1 = 500 or _1 = 1500"
-      checkAnswer(
-        parquetDf.filter(singleValueFilterExpr),
-        df.filter(singleValueFilterExpr)
-      )
-      val rangeFilterExpr = "_1 > 500"
-      checkAnswer(
-        parquetDf.filter(rangeFilterExpr),
-        df.filter(rangeFilterExpr)
-      )
-    })
+    val df = spark.range(0, 2000).selectExpr(
+      "id as _1",
+      "cast(id % 10 as byte) as _2",
+      "cast(id % 10 as short) as _3",
+      "cast(id % 10 as int) as _4",
+      "cast(id % 10 as float) as _5",
+      "cast(id % 10 as double) as _6",
+      "cast(id % 10 as decimal(20,0)) as _7",
+      "cast(id % 2 as boolean) as _8",
+      "cast(cast(1618161925000 + (id % 10) * 1000 * 60 * 60 * 24 as timestamp) as date) as _9",
+      "cast(1618161925000 + (id % 10) as timestamp) as _10"
+    )
+    checkUnalignedPages(df)(actions: _*)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Refactor `ParquetColumnIndexSuite` and allow better code reuse.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

A few methods in the test suite can share the same utility method `checkUnalignedPages` so it's better to do that and remove code duplication.

Additionally, `parquet.enable.dictionary` is tested for both `true` and `false` combination.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing tests.