### PR TITLE
[SPARK-36133][SQL] Add empty check for catalog name

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -44,10 +44,9 @@ class CatalogManager(
   import CatalogV2Util._
 
   private val catalogs = mutable.HashMap.empty[String, CatalogPlugin]
-  private val validNameFormat = "([\\w_]+)".r
 
   def catalog(name: String): CatalogPlugin = synchronized {
-    if (!validNameFormat.pattern.matcher(name).matches()) {
+    if (name.trim.isEmpty) {
       throw QueryCompilationErrors.invalidNameForCatalogError(name)
     }
     if (name.equalsIgnoreCase(SESSION_CATALOG_NAME)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -44,8 +44,12 @@ class CatalogManager(
   import CatalogV2Util._
 
   private val catalogs = mutable.HashMap.empty[String, CatalogPlugin]
+  private val validNameFormat = "([\\w_]+)".r
 
   def catalog(name: String): CatalogPlugin = synchronized {
+    if (!validNameFormat.pattern.matcher(name).matches()) {
+      throw QueryCompilationErrors.invalidNameForCatalogError(name)
+    }
     if (name.equalsIgnoreCase(SESSION_CATALOG_NAME)) {
       v2SessionCatalog
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -571,6 +571,11 @@ object QueryCompilationErrors {
       "Valid names only contain alphabet characters, numbers and _.")
   }
 
+  def invalidNameForCatalogError(name: String): Throwable = {
+    new AnalysisException(s"`$name` is not a valid name for catalog. " +
+      "Valid names only contain alphabet characters, numbers and _.")
+  }
+
   def cannotCreateDatabaseWithSameNameAsPreservedDatabaseError(database: String): Throwable = {
     new AnalysisException(s"$database is a system preserved database, " +
       "you cannot create a database with this name.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -573,7 +573,7 @@ object QueryCompilationErrors {
 
   def invalidNameForCatalogError(name: String): Throwable = {
     new AnalysisException(s"`$name` is not a valid name for catalog. " +
-      "Valid names only contain alphabet characters, numbers and _.")
+      "Valid names can not be empty string or only contain whitespaces.")
   }
 
   def cannotCreateDatabaseWithSameNameAsPreservedDatabaseError(database: String): Throwable = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2916,8 +2916,8 @@ class DataSourceV2SQLSuite
     }
   }
 
-  test("SPARK-36133: the catalog name keep consistent with the namespace naming rule") {
-    Seq("", " ", ".", "a.b", "/", " ab", "a b", "(", "()", "{", "{}", "[", "[]").foreach { name => {
+  test("SPARK-36133: basic check for the catalog name") {
+    Seq("", " ", "    ").foreach { name => {
       spark.conf.set(s"spark.sql.catalog.$name", classOf[InMemoryCatalog].getName)
       assertAnalysisError(
         s"use `$name`",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2916,6 +2916,16 @@ class DataSourceV2SQLSuite
     }
   }
 
+  test("SPARK-36133: the catalog name keep consistent with the namespace naming rule") {
+    Seq("", " ", ".", "a.b", "/", " ab", "a b", "(", "()", "{", "{}", "[", "[]").foreach { name => {
+      spark.conf.set(s"spark.sql.catalog.$name", classOf[InMemoryCatalog].getName)
+      assertAnalysisError(
+        s"use `$name`",
+        s"`$name` is not a valid name for catalog.")
+      }
+    }
+  }
+
   private def testNotSupportedV2Command(sqlCommand: String, sqlParams: String): Unit = {
     val e = intercept[AnalysisException] {
       sql(s"$sqlCommand $sqlParams")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the name check when initialize a catalog by name. Keep consistent with the namespace/table naming rule.

### Why are the changes needed?
When I try to add the command `SHOW CATALOGS`, I found catalog names are meaningless in some cases. eg:
1. if the catalog name is `""`, `" "`, `"  "` that contains some spaces and so on. I think it doesn't make sense
2. if the catalog name is `"a.b"` that contains `.`, I'm more confused. `b` is the name of a namespace or part of catalog name?

[#WISH#SPARK-36133](https://issues.apache.org/jira/browse/SPARK-36133)

### Does this PR introduce _any_ user-facing change?
Yes. If user want to regist external catalog plugin. user shoule keep catalog name in SparkConf is compliant.


### How was this patch tested?
Add ut test
