### PR TITLE
[SPARK-36139][INFRA][TESTS] Remove Python 3.6 from `pyspark` GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -207,18 +207,6 @@ jobs:
         key: pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           pyspark-coursier-
-    - name: Install Python 3.6
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.6
-        architecture: x64
-    # This step takes much less time (~30s) than other Python versions so it is not included
-    # in the Docker image being used. There is also a technical issue to install Python 3.6 on
-    # Ubuntu 20.04. See also SPARK-33162.
-    - name: Install Python packages (Python 3.6)
-      run: |
-        python3.6 -m pip install numpy 'pyarrow<4.0.0' pandas scipy xmlrunner 'plotly>=4.8'
-        python3.6 -m pip list
     - name: List Python packages (Python 3.9)
       run: |
         python3.9 -m pip list

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -480,7 +480,7 @@ def run_python_tests(test_modules, parallelism, with_coverage=False):
         # to test because of Jenkins environment issue. Once Jenkins has Python 3.9 to test,
         # we should remove this change back and add python3.9 into python/run-tests.py script.
         command.append("--python-executable=%s" % ','.join(
-            x for x in ["python3.6", "python3.9", "pypy3"] if which(x)))
+            x for x in ["python3.9", "pypy3"] if which(x)))
     run_cmd(command)
 
     if with_coverage:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove Python 3.6 installation from `pyspark` job in `build and test` GitHub Action Workflow for Apache Spark 3.3.

### Why are the changes needed?

Python 3.6 is deprecated via SPARK-35938. This will save the GitHub Action resource by removing python3.6 testing.

**BEFORE**
```
Will test against the following Python executables: ['python3.6', 'python3.9', 'pypy3']
```

**AFTER**
```
 Will test against the following Python executables: ['python3.9', 'pypy3']
```

Note that Python 3.6 is still used in the following cases.
- In another jobs like `Linter`
- In `dev/run-pip-tests` script, pip packaing testing via `conda`.
  - This is handled via https://github.com/apache/spark/pull/33351

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action.