### PR TITLE
[SPARK-36144][INFRA][TESTS] Use Python 3.9 in `run-pip-tests` conda environment

### DIFF
--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -48,7 +48,7 @@ if hash virtualenv 2>/dev/null && [ ! -n "$USE_CONDA" ]; then
   fi
 elif hash conda 2>/dev/null; then
   echo "Using conda virtual environments"
-  PYTHON_EXECS=('3.6')
+  PYTHON_EXECS=('3.9')
   USE_CONDA=1
 else
   echo "Missing virtualenv & conda, skipping pip installability tests"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Python 3.9 instead of 3.6 during `run-pip-tests` conda environment for Apache Spark 3.3.

### Why are the changes needed?

Python 3.6 is deprecated via SPARK-35938 at Apache Spark 3.2. We had better have Python 3.9 test coverage in Apache Spark 3.3.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Pass the CIs.