### PR TITLE
[SPARK-36150][INFRA][TESTS] Disable MiMa for Scala 2.13 artifacts

### DIFF
--- a/dev/mima
+++ b/dev/mima
@@ -25,6 +25,11 @@ FWDIR="$(cd "`dirname "$0"`"/..; pwd)"
 cd "$FWDIR"
 
 SPARK_PROFILES=${1:-"-Pmesos -Pkubernetes -Pyarn -Pspark-ganglia-lgpl -Pkinesis-asl -Phive-thriftserver -Phive"}
+# Apache Spark doesn't have Scala 2.13 maven artifacts yet.
+# TODO(SPARK-36151) Enable MiMa for Scala 2.13 artifacts after Spark 3.2.0 release
+if [[ "$SPARK_PROFILES" == *"-Pscala-2.13"* ]]; then
+  exit 0
+fi
 TOOLS_CLASSPATH="$(build/sbt -DcopyDependencies=false "export tools/fullClasspath" | grep jar | tail -n1)"
 OLD_DEPS_CLASSPATH="$(build/sbt -DcopyDependencies=false $SPARK_PROFILES "export oldDeps/fullClasspath" | grep jar | tail -n1)"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable MiMa check for Scala 2.13 artifacts.

### Why are the changes needed?

Apache Spark doesn't have Scala 2.13 Maven artifacts yet.
SPARK-36151 will enable this after Apache Spark 3.2.0 release.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual. The following should succeed without real testing.
```
$ dev/mima -Pscala-2.13
```