### PR TITLE
[SPARK-36148][SQL] Fix input data types check for regexp_replace

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -533,6 +533,10 @@ case class RegExpReplace(subject: Expression, regexp: Expression, rep: Expressio
     this(subject, regexp, rep, Literal(1))
 
   override def checkInputDataTypes(): TypeCheckResult = {
+    val defaultCheck = super.checkInputDataTypes()
+    if (defaultCheck.isFailure) {
+      return defaultCheck
+    }
     if (!pos.foldable) {
       return TypeCheckFailure(s"Position expression must be foldable, but got $pos")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -598,4 +598,11 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
     )
 
   }
+
+  test("SPARK-36148: check input data types of regexp_replace") {
+    val m = intercept[AnalysisException] {
+      sql("select regexp_replace(collect_list(1), '1', '2')")
+    }.getMessage
+    assert(m.contains("data type mismatch: argument 1 requires string type"))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`RegExpReplace` overrides `checkInputDataTypes` but doesn't do the basic type check.
This PR adds the type check so that the error message is more readable. 

### Why are the changes needed?
bugfix


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
newly added test case
