### PR TITLE
[SPARK-36159][BUILD] Replace 'python' to 'python3' in dev/test-dependencies.sh

### DIFF
--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -52,7 +52,7 @@ if [ $? != 0 ]; then
     exit 1
 fi
 set -e
-TEMP_VERSION="spark-$(python -S -c "import random; print(random.randrange(100000, 999999))")"
+TEMP_VERSION="spark-$(python3 -S -c "import random; print(random.randrange(100000, 999999))")"
 
 function reset_version {
   # Delete the temporary POMs that we wrote to the local Maven repo:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/26330. There is the last place to fix in `dev/test-dependencies.sh`

### Why are the changes needed?

To stick to Python 3 instead of using Python 2 mistakenly.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.