### PR TITLE
[SPARK-36164][INFRA] run-test.py should not fail when APACHE_SPARK_REF is not defined

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -658,7 +658,7 @@ def main():
         # If we're running the tests in GitHub Actions, attempt to detect and test
         # only the affected modules.
         if test_env == "github_actions":
-            if os.environ["APACHE_SPARK_REF"] != "":
+            if "APACHE_SPARK_REF" in os.environ:
                 # Fork repository
                 changed_files = identify_changed_files_from_git_commits(
                     "HEAD", target_ref=os.environ["APACHE_SPARK_REF"])


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to change run-test.py so that it does not fail when os.environ["APACHE_SPARK_REF"] is not defined.

### Why are the changes needed?
Currently, the run-test.py ends with an error. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass the CIs. 
