### PR TITLE
[SPARK-36127][PYTHON] Support comparison between a Categorical and a scalar

### DIFF
--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -331,10 +331,10 @@ class DataTypeOps(object, metaclass=ABCMeta):
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("<= can not be applied to %s." % self.pretty_name)
 
-    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("> can not be applied to %s." % self.pretty_name)
 
-    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError(">= can not be applied to %s." % self.pretty_name)
 
     def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -115,6 +115,7 @@ def _compare(
         if not is_equality_comparison:
             if not cast(CategoricalDtype, left.dtype).ordered:
                 raise TypeError("Unordered Categoricals can only compare equality or not.")
+        # Check if categoricals have the same dtype, same categories, and same ordered
         if hash(left.dtype) != hash(right.dtype):
             raise TypeError("Categoricals can only be compared if 'categories' are the same.")
         return column_op(f)(left, right)

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -20,6 +20,7 @@ from typing import cast, Any, Callable, Union
 
 import numpy as np
 import pandas as pd
+import numpy as np
 from pandas.api.types import CategoricalDtype
 
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
@@ -118,8 +119,8 @@ def _compare(
         if hash(left.dtype) != hash(right.dtype):
             raise TypeError("Categoricals can only be compared if 'categories' are the same.")
         return column_op(f)(left, right)
-    elif not hasattr(right, "__len__"):
-        categories = left.dtype.categories
+    elif np.isscalar(right):
+        categories = cast(CategoricalDtype, left.dtype).categories
         if right not in categories:
             raise TypeError("Cannot compare a Categorical with a scalar, which is not a category.")
         right_code = categories.get_loc(right)

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -18,10 +18,9 @@
 from itertools import chain
 from typing import cast, Any, Callable, Union
 
-import numpy as np
 import pandas as pd
 import numpy as np
-from pandas.api.types import CategoricalDtype
+from pandas.api.types import is_list_like, CategoricalDtype
 
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin
@@ -119,7 +118,7 @@ def _compare(
         if hash(left.dtype) != hash(right.dtype):
             raise TypeError("Categoricals can only be compared if 'categories' are the same.")
         return column_op(f)(left, right)
-    elif isinstance(right, str) or not hasattr(right, "__len__"):
+    elif not is_list_like(right):
         categories = cast(CategoricalDtype, left.dtype).categories
         if right not in categories:
             raise TypeError("Cannot compare a Categorical with a scalar, which is not a category.")

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -119,7 +119,7 @@ def _compare(
         if hash(left.dtype) != hash(right.dtype):
             raise TypeError("Categoricals can only be compared if 'categories' are the same.")
         return column_op(f)(left, right)
-    elif np.isscalar(right):
+    elif isinstance(right, str) or not hasattr(right, "__len__"):
         categories = cast(CategoricalDtype, left.dtype).categories
         if right not in categories:
             raise TypeError("Cannot compare a Categorical with a scalar, which is not a category.")

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -16,7 +16,7 @@
 #
 
 from itertools import chain
-from typing import Any, Union, cast
+from typing import cast, Any, Callable, Union
 
 import numpy as np
 import pandas as pd
@@ -71,28 +71,58 @@ class CategoricalOps(DataTypeOps):
             scol = map_scol.getItem(index_ops.spark.column)
         return index_ops._with_new_scol(scol).astype(dtype)
 
+    def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        return _compare(left, right, Column.__eq__, is_equality_comparison=True)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        return _compare(left, right, Column.__ne__, is_equality_comparison=True)
+
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        _non_equality_comparison_input_check(left, right)
-        return column_op(Column.__lt__)(left, right)
+        return _compare(left, right, Column.__lt__)
 
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        _non_equality_comparison_input_check(left, right)
-        return column_op(Column.__le__)(left, right)
+        return _compare(left, right, Column.__le__)
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        _non_equality_comparison_input_check(left, right)
-        return column_op(Column.__gt__)(left, right)
+        return _compare(left, right, Column.__gt__)
 
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        _non_equality_comparison_input_check(left, right)
-        return column_op(Column.__ge__)(left, right)
+        return _compare(left, right, Column.__ge__)
 
 
-def _non_equality_comparison_input_check(left: IndexOpsLike, right: Any) -> None:
-    if not cast(CategoricalDtype, left.dtype).ordered:
-        raise TypeError("Unordered Categoricals can only compare equality or not.")
+def _compare(
+    left: IndexOpsLike,
+    right: Any,
+    f: Callable[..., Column],
+    *,
+    is_equality_comparison: bool = False
+) -> SeriesOrIndex:
+    """
+    Compare a Categorical operand `left` to `right` with the given Spark Column function.
+
+    Parameters
+    ----------
+    left: A Categorical operand
+    right: The other operand to compare with
+    f : The Spark Column function to apply
+    is_equality_comparison: True if it is equality comparison, ie. == or !=. False by default.
+
+    Returns
+    -------
+    SeriesOrIndex
+    """
     if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, CategoricalDtype):
+        if not is_equality_comparison:
+            if not cast(CategoricalDtype, left.dtype).ordered:
+                raise TypeError("Unordered Categoricals can only compare equality or not.")
         if hash(left.dtype) != hash(right.dtype):
             raise TypeError("Categoricals can only be compared if 'categories' are the same.")
+        return column_op(f)(left, right)
+    elif not hasattr(right, "__len__"):
+        categories = left.dtype.categories
+        if right not in categories:
+            raise TypeError("Cannot compare a Categorical with a scalar, which is not a category.")
+        right_code = categories.get_loc(right)
+        return column_op(f)(left, right_code)
     else:
         raise TypeError("Cannot compare a Categorical with the given type.")

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -355,10 +355,10 @@ class DecimalOps(FractionalOps):
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("<= can not be applied to %s." % self.pretty_name)
 
-    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError("> can not be applied to %s." % self.pretty_name)
 
-    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         raise TypeError(">= can not be applied to %s." % self.pretty_name)
 
     def isnull(self, index_ops: IndexOpsLike) -> IndexOpsLike:

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -204,153 +204,215 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: ~self.psser)
 
     def test_eq(self):
-        self.assert_eq(self.pser == 1, self.psser == 1)
+        ordered_pser = self.ordered_pser
+        ordered_psser = self.ordered_psser
+        self.assert_eq(ordered_pser == 1, ordered_psser == 1)
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with a scalar, which is not a category",
+            lambda: ordered_psser == 4,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Categoricals can only be compared if 'categories' are the same",
+            lambda: ordered_psser == self.unordered_psser,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser == ps.Series([1, 2, 3]),
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser == [1, 2, 3],
+        )
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
                 self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
             )
             self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
+            self.assert_eq(
+                ordered_pser == ordered_pser, (ordered_psser == ordered_psser).sort_index()
+            )
 
     def test_ne(self):
-        self.assert_eq(self.pser != 1, self.psser != 1)
+        ordered_pser = self.ordered_pser
+        ordered_psser = self.ordered_psser
+        self.assert_eq(ordered_pser != 1, ordered_psser != 1)
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with a scalar, which is not a category",
+            lambda: ordered_psser != 4,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Categoricals can only be compared if 'categories' are the same",
+            lambda: ordered_psser != self.unordered_psser,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser != ps.Series([1, 2, 3]),
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser != [1, 2, 3],
+        )
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
                 self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()
             )
             self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
+            self.assert_eq(
+                ordered_pser != ordered_pser, (ordered_psser != ordered_psser).sort_index()
+            )
 
     def test_lt(self):
         ordered_pser = self.ordered_pser
         ordered_psser = self.ordered_psser
         self.assert_eq(ordered_pser < ordered_pser, ordered_psser < ordered_psser)
-        with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(
-                ordered_pser < self.other_ordered_pser, ordered_psser < self.other_ordered_psser
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Unordered Categoricals can only compare equality or not",
-                lambda: self.unordered_psser < ordered_psser,
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Categoricals can only be compared if 'categories' are the same",
-                lambda: ordered_psser < self.unordered_psser,
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Cannot compare a Categorical with the given type",
-                lambda: ordered_psser < ps.Series([1, 2, 3]),
-            )
+        self.assert_eq(ordered_pser < 1, ordered_psser < 1)
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with a scalar, which is not a category",
+            lambda: ordered_psser < 4,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Unordered Categoricals can only compare equality or not",
+            lambda: self.unordered_psser < ordered_psser,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Categoricals can only be compared if 'categories' are the same",
+            lambda: ordered_psser < self.unordered_psser,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser < ps.Series([1, 2, 3]),
+        )
         self.assertRaisesRegex(
             TypeError,
             "Cannot compare a Categorical with the given type",
             lambda: ordered_psser < [1, 2, 3],
         )
-        self.assertRaisesRegex(
-            TypeError, "Cannot compare a Categorical with the given type", lambda: ordered_psser < 1
-        )
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                ordered_pser < self.other_ordered_pser,
+                (ordered_psser < self.other_ordered_psser).sort_index(),
+            )
 
     def test_le(self):
         ordered_pser = self.ordered_pser
         ordered_psser = self.ordered_psser
         self.assert_eq(ordered_pser <= ordered_pser, ordered_psser <= ordered_psser)
-
-        with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(
-                ordered_pser <= self.other_ordered_pser, ordered_psser <= self.other_ordered_psser
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Unordered Categoricals can only compare equality or not",
-                lambda: self.unordered_psser <= ordered_psser,
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Categoricals can only be compared if 'categories' are the same",
-                lambda: ordered_psser <= self.unordered_psser,
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Cannot compare a Categorical with the given type",
-                lambda: ordered_psser <= ps.Series([1, 2, 3]),
-            )
+        self.assert_eq(ordered_pser <= 1, ordered_psser <= 1)
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with a scalar, which is not a category",
+            lambda: ordered_psser <= 4,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Unordered Categoricals can only compare equality or not",
+            lambda: self.unordered_psser <= ordered_psser,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Categoricals can only be compared if 'categories' are the same",
+            lambda: ordered_psser <= self.unordered_psser,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser <= ps.Series([1, 2, 3]),
+        )
         self.assertRaisesRegex(
             TypeError,
             "Cannot compare a Categorical with the given type",
             lambda: ordered_psser <= [1, 2, 3],
         )
-        self.assertRaisesRegex(
-            TypeError,
-            "Cannot compare a Categorical with the given type",
-            lambda: ordered_psser <= 1,
-        )
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                ordered_pser <= self.other_ordered_pser,
+                (ordered_psser <= self.other_ordered_psser).sort_index(),
+            )
 
     def test_gt(self):
         ordered_pser = self.ordered_pser
         ordered_psser = self.ordered_psser
         self.assert_eq(ordered_pser > ordered_pser, ordered_psser > ordered_psser)
-        with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(
-                ordered_pser > self.other_ordered_pser, ordered_psser > self.other_ordered_psser
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Unordered Categoricals can only compare equality or not",
-                lambda: self.unordered_psser > ordered_psser,
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Categoricals can only be compared if 'categories' are the same",
-                lambda: ordered_psser > self.unordered_psser,
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Cannot compare a Categorical with the given type",
-                lambda: ordered_psser > ps.Series([1, 2, 3]),
-            )
+        self.assert_eq(ordered_pser > 1, ordered_psser > 1)
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with a scalar, which is not a category",
+            lambda: ordered_psser > 4,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Unordered Categoricals can only compare equality or not",
+            lambda: self.unordered_psser > ordered_psser,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Categoricals can only be compared if 'categories' are the same",
+            lambda: ordered_psser > self.unordered_psser,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser > ps.Series([1, 2, 3]),
+        )
         self.assertRaisesRegex(
             TypeError,
             "Cannot compare a Categorical with the given type",
             lambda: ordered_psser > [1, 2, 3],
         )
-        self.assertRaisesRegex(
-            TypeError, "Cannot compare a Categorical with the given type", lambda: ordered_psser > 1
-        )
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                ordered_pser > self.other_ordered_pser,
+                (ordered_psser > self.other_ordered_psser).sort_index(),
+            )
 
     def test_ge(self):
         ordered_pser = self.ordered_pser
         ordered_psser = self.ordered_psser
         self.assert_eq(ordered_pser >= ordered_pser, ordered_psser >= ordered_psser)
-        with option_context("compute.ops_on_diff_frames", True):
-            self.assert_eq(
-                ordered_pser >= self.other_ordered_pser, ordered_psser >= self.other_ordered_psser
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Unordered Categoricals can only compare equality or not",
-                lambda: self.unordered_psser >= ordered_psser,
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Categoricals can only be compared if 'categories' are the same",
-                lambda: ordered_psser >= self.unordered_psser,
-            )
-            self.assertRaisesRegex(
-                TypeError,
-                "Cannot compare a Categorical with the given type",
-                lambda: ordered_psser >= ps.Series([1, 2, 3]),
-            )
+        self.assert_eq(ordered_pser >= 1, ordered_psser >= 1)
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with a scalar, which is not a category",
+            lambda: ordered_psser >= 4,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Unordered Categoricals can only compare equality or not",
+            lambda: self.unordered_psser >= ordered_psser,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Categoricals can only be compared if 'categories' are the same",
+            lambda: ordered_psser >= self.unordered_psser,
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Cannot compare a Categorical with the given type",
+            lambda: ordered_psser >= ps.Series([1, 2, 3]),
+        )
         self.assertRaisesRegex(
             TypeError,
             "Cannot compare a Categorical with the given type",
             lambda: ordered_psser >= [1, 2, 3],
         )
-        self.assertRaisesRegex(
-            TypeError,
-            "Cannot compare a Categorical with the given type",
-            lambda: ordered_psser >= 1,
-        )
+
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                ordered_pser >= self.other_ordered_pser,
+                (ordered_psser >= self.other_ordered_psser).sort_index(),
+            )
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -204,6 +204,7 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: ~self.psser)
 
     def test_eq(self):
+        self.assert_eq(self.pser == 1, self.psser == 1)
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
                 self.pser == self.other_pser, (self.psser == self.other_psser).sort_index()
@@ -211,6 +212,7 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(self.pser == self.pser, (self.psser == self.psser).sort_index())
 
     def test_ne(self):
+        self.assert_eq(self.pser != 1, self.psser != 1)
         with option_context("compute.ops_on_diff_frames", True):
             self.assert_eq(
                 self.pser != self.other_pser, (self.psser != self.other_psser).sort_index()

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -347,7 +347,9 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
                 if isinstance(psser.spark.data_type, DecimalType):
-                    self.assertRaises(TypeError, lambda: psser < psser)
+                    self.assertRaisesRegex(
+                        TypeError, "< can not be applied to", lambda: psser < psser
+                    )
                 else:
                     self.assert_eq(pser < pser, (psser < psser).sort_index())
 
@@ -355,7 +357,9 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
                 if isinstance(psser.spark.data_type, DecimalType):
-                    self.assertRaises(TypeError, lambda: psser <= psser)
+                    self.assertRaisesRegex(
+                        TypeError, "<= can not be applied to", lambda: psser <= psser
+                    )
                 else:
                     self.assert_eq(pser <= pser, (psser <= psser).sort_index())
 
@@ -363,7 +367,9 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
                 if isinstance(psser.spark.data_type, DecimalType):
-                    self.assertRaises(TypeError, lambda: psser > psser)
+                    self.assertRaisesRegex(
+                        TypeError, "> can not be applied to", lambda: psser > psser
+                    )
                 else:
                     self.assert_eq(pser > pser, (psser > psser).sort_index())
 
@@ -371,7 +377,9 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         with option_context("compute.ops_on_diff_frames", True):
             for pser, psser in self.numeric_pser_psser_pairs:
                 if isinstance(psser.spark.data_type, DecimalType):
-                    self.assertRaises(TypeError, lambda: psser >= psser)
+                    self.assertRaisesRegex(
+                        TypeError, ">= can not be applied to", lambda: psser >= psser
+                    )
                 else:
                     self.assert_eq(pser >= pser, (psser >= psser).sort_index())
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_udt_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_udt_ops.py
@@ -149,16 +149,24 @@ class UDTOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(self.pser != self.pser, (self.psser != self.psser).sort_index())
 
     def test_lt(self):
-        self.assertRaises(TypeError, lambda: self.psser < self.psser)
+        self.assertRaisesRegex(
+            TypeError, "< can not be applied to", lambda: self.psser < self.psser
+        )
 
     def test_le(self):
-        self.assertRaises(TypeError, lambda: self.psser <= self.psser)
+        self.assertRaisesRegex(
+            TypeError, "<= can not be applied to", lambda: self.psser <= self.psser
+        )
 
     def test_gt(self):
-        self.assertRaises(TypeError, lambda: self.psser > self.psser)
+        self.assertRaisesRegex(
+            TypeError, "> can not be applied to", lambda: self.psser > self.psser
+        )
 
     def test_ge(self):
-        self.assertRaises(TypeError, lambda: self.psser >= self.psser)
+        self.assertRaisesRegex(
+            TypeError, ">= can not be applied to", lambda: self.psser >= self.psser
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support comparison between a Categorical and a scalar.
There are 3 main changes:
- Modify `==` and `!=` from comparing **codes** of the Categorical to the scalar to comparing **actual values** of the Categorical to the scalar.
- Support `<`, `<=`, `>`, `>=` between a Categorical and a scalar.
- TypeError message fix.

### Why are the changes needed?
pandas supports comparison between a Categorical and a scalar, we should follow pandas' behaviors.

### Does this PR introduce _any_ user-facing change?
Yes.

Before:
```py
>>> import pyspark.pandas as ps
>>> import pandas as pd
>>> from pandas.api.types import CategoricalDtype
>>> pser = pd.Series(pd.Categorical([1, 2, 3], categories=[3, 2, 1], ordered=True))
>>> psser = ps.from_pandas(pser)
>>> psser == 2
0     True
1    False
2    False
dtype: bool
>>> psser <= 1
Traceback (most recent call last):
...
NotImplementedError: <= can not be applied to categoricals.
```

After:
```py
>>> import pyspark.pandas as ps
>>> import pandas as pd
>>> from pandas.api.types import CategoricalDtype
>>> pser = pd.Series(pd.Categorical([1, 2, 3], categories=[3, 2, 1], ordered=True))
>>> psser = ps.from_pandas(pser)
>>> psser == 2
0    False
1     True
2    False
dtype: bool
>>> psser <= 1
0    True
1    True
2    True
dtype: bool

```

### How was this patch tested?
Unit tests.

Keyword:SPARK-35337