### PR TITLE
[SPARK-36167][PYTHON] Revisit more InternalField managements

### DIFF
--- a/python/pyspark/pandas/categorical.py
+++ b/python/pyspark/pandas/categorical.py
@@ -19,6 +19,9 @@ from typing import TYPE_CHECKING, cast
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
+from pyspark.pandas.internal import InternalField
+from pyspark.sql.types import StructField
+
 if TYPE_CHECKING:
     import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
 
@@ -135,7 +138,16 @@ class CategoricalAccessor(object):
         5    2
         dtype: int8
         """
-        return self._data._with_new_scol(self._data.spark.column).rename()
+        return self._data._with_new_scol(
+            self._data.spark.column,
+            field=InternalField.from_struct_field(
+                StructField(
+                    name=self._data._internal.data_spark_column_names[0],
+                    dataType=self._data.spark.data_type,
+                    nullable=self._data.spark.nullable,
+                )
+            ),
+        ).rename()
 
     def add_categories(self, new_categories: pd.Index, inplace: bool = False) -> "ps.Series":
         raise NotImplementedError()

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -18,6 +18,7 @@
 from itertools import chain
 from typing import Any, Union, cast
 
+import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
@@ -43,7 +44,7 @@ class CategoricalOps(DataTypeOps):
         """Restore column when to_pandas."""
         return pd.Series(
             pd.Categorical.from_codes(
-                col,
+                col.replace(np.nan, -1).astype(int),
                 categories=cast(CategoricalDtype, self.dtype).categories,
                 ordered=cast(CategoricalDtype, self.dtype).ordered,
             )

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -117,9 +117,10 @@ from pyspark.pandas.internal import (
 )
 from pyspark.pandas.missing.frame import _MissingPandasLikeDataFrame
 from pyspark.pandas.ml import corr
-from pyspark.pandas.typedef import (
+from pyspark.pandas.typedef.typehints import (
     as_spark_type,
     infer_return_type,
+    pandas_on_spark_type,
     spark_type_to_pandas_dtype,
     DataFrameType,
     SeriesType,
@@ -8069,7 +8070,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 update_sdf = update_sdf.withColumn(
                     column_name, F.when(old_col.isNull(), new_col).otherwise(old_col)
                 )
-            data_fields[self._internal.column_labels.index(column_labels)] = None  # TODO: dtype?
+            data_fields[self._internal.column_labels.index(column_labels)] = None
         sdf = update_sdf.select(
             *[scol_for(update_sdf, col) for col in self._internal.spark_column_names],
             *HIDDEN_COLUMNS,
@@ -8806,8 +8807,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 [scol.alias(index_column) for scol, index_column in zip(scols, index_columns)]
             )
         else:
-            psser = ps.Series(list(index))  # type: ps.Series
-            labels = psser._internal.spark_frame.select(psser.spark.column.alias(index_columns[0]))
+            index = ps.Index(list(index))
+            labels = index._internal.spark_frame.select(index.spark.column.alias(index_columns[0]))
             index_names = self._internal.index_names
 
         if fill_value is not None:
@@ -8852,8 +8853,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     for col in self._internal.data_spark_column_names
                 ],
             )
+            data_fields = None
         else:
             joined_df = frame.join(labels, on=index_columns, how="right")
+            data_fields = [field.copy(nullable=True) for field in self._internal.data_fields]
 
         sdf = joined_df.drop(NATURAL_ORDER_COLUMN_NAME)
         internal = self._internal.copy(
@@ -8862,11 +8865,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 scol_for(sdf, col) for col in self._internal.index_spark_column_names
             ],
             index_names=index_names,
-            index_fields=None,  # TODO: dtypes?
+            index_fields=[
+                field.copy(name=name)
+                for field, name in zip(
+                    index._internal.index_fields, self._internal.index_spark_column_names
+                )
+            ],
             data_spark_columns=[
                 scol_for(sdf, col) for col in self._internal.data_spark_column_names
             ],
-            data_fields=[InternalField(dtype=field.dtype) for field in self._internal.data_fields],
+            data_fields=data_fields,
         )
         return DataFrame(internal)
 
@@ -9365,7 +9373,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             + [sdf["pairs"][name].alias(name) for name in data_columns]
         )
 
-        internal = InternalFrame(  # TODO: dtypes?
+        internal = InternalFrame(
             spark_frame=sdf,
             index_spark_columns=[
                 scol_for(sdf, col)
@@ -9375,7 +9383,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             index_fields=self._internal.index_fields + [None],
             column_labels=list(column_labels),
             data_spark_columns=[scol_for(sdf, col) for col in data_columns],
-            column_label_names=column_label_names,  # type: ignore
+            column_label_names=column_label_names,
         )
         psdf = DataFrame(internal)  # type: "DataFrame"
 
@@ -9496,7 +9504,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             SPARK_INDEX_NAME_FORMAT(i) for i in range(self._internal.column_labels_level)
         ]
 
-        new_index_map = list(zip(new_index_columns, self._internal.column_label_names))
+        new_index_map = list(zip_longest(new_index_columns, self._internal.column_label_names, []))
 
         pairs = F.explode(
             F.array(
@@ -9517,25 +9525,25 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         new_index_len = len(new_index_columns)
         existing_index_columns = []
-        for i, index_name in enumerate(self._internal.index_names):
-            new_index_map.append((SPARK_INDEX_NAME_FORMAT(i + new_index_len), index_name))
-            existing_index_columns.append(
-                self._internal.index_spark_columns[i].alias(
-                    SPARK_INDEX_NAME_FORMAT(i + new_index_len)
-                )
-            )
+        for i, (index_name, index_field) in enumerate(
+            zip(self._internal.index_names, self._internal.index_fields)
+        ):
+            name = SPARK_INDEX_NAME_FORMAT(i + new_index_len)
+            new_index_map.append((name, index_name, index_field.copy(name=name)))
+            existing_index_columns.append(self._internal.index_spark_columns[i].alias(name))
 
         exploded_df = sdf.withColumn("pairs", pairs).select(existing_index_columns + columns)
 
-        index_spark_column_names, index_names = zip(*new_index_map)
+        index_spark_column_names, index_names, index_fields = zip(*new_index_map)
         return first_series(
             DataFrame(
-                InternalFrame(  # TODO: dtypes?
+                InternalFrame(
                     exploded_df,
                     index_spark_columns=[
                         scol_for(exploded_df, col) for col in index_spark_column_names
                     ],
                     index_names=list(index_names),
+                    index_fields=list(index_fields),
                     column_labels=[None],
                 )
             )
@@ -10047,7 +10055,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         def gen_mapper_fn(
             mapper: Union[Dict, Callable[[Any], Any]]
-        ) -> Tuple[Callable[[Any], Any], DataType]:
+        ) -> Tuple[Callable[[Any], Any], Dtype, DataType]:
             if isinstance(mapper, dict):
                 mapper_dict = cast(dict, mapper)
                 if len(mapper_dict) == 0:
@@ -10059,7 +10067,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 type_set = set(map(lambda x: type(x), mapper_dict.values()))
                 if len(type_set) > 1:
                     raise ValueError("Mapper dict should have the same value type.")
-                spark_return_type = as_spark_type(list(type_set)[0])
+                dtype, spark_return_type = pandas_on_spark_type(list(type_set)[0])
 
                 def mapper_fn(x: Any) -> Any:
                     if x in mapper_dict:
@@ -10071,7 +10079,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             elif callable(mapper):
                 mapper_callable = cast(Callable, mapper)
-                spark_return_type = cast(ScalarType, infer_return_type(mapper)).spark_type
+                return_type = cast(ScalarType, infer_return_type(mapper))
+                dtype = return_type.dtype
+                spark_return_type = return_type.spark_type
 
                 def mapper_fn(x: Any) -> Any:
                     return mapper_callable(x)
@@ -10081,7 +10091,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     "`mapper` or `index` or `columns` should be "
                     "either dict-like or function type."
                 )
-            return mapper_fn, spark_return_type
+            return mapper_fn, dtype, spark_return_type
 
         index_mapper_fn = None
         index_mapper_ret_stype = None
@@ -10091,9 +10101,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if mapper:
             axis = validate_axis(axis)
             if axis == 0:
-                index_mapper_fn, index_mapper_ret_stype = gen_mapper_fn(mapper)
+                index_mapper_fn, index_mapper_ret_dtype, index_mapper_ret_stype = gen_mapper_fn(
+                    mapper
+                )
             elif axis == 1:
-                columns_mapper_fn, columns_mapper_ret_stype = gen_mapper_fn(mapper)
+                columns_mapper_fn, _, _ = gen_mapper_fn(mapper)
             else:
                 raise ValueError(
                     "argument axis should be either the axis name "
@@ -10101,9 +10113,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
         else:
             if index:
-                index_mapper_fn, index_mapper_ret_stype = gen_mapper_fn(index)
+                index_mapper_fn, index_mapper_ret_dtype, index_mapper_ret_stype = gen_mapper_fn(
+                    index
+                )
             if columns:
-                columns_mapper_fn, _ = gen_mapper_fn(columns)
+                columns_mapper_fn, _, _ = gen_mapper_fn(columns)
 
             if not index and not columns:
                 raise ValueError("Either `index` or `columns` should be provided.")
@@ -10129,25 +10143,36 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 if level < 0 or level >= num_indices:
                     raise ValueError("level should be an integer between [0, num_indices)")
 
-            def gen_new_index_column(level: int) -> Column:
-                index_col_name = index_columns[level]
+            @pandas_udf(returnType=index_mapper_ret_stype)  # type: ignore
+            def index_mapper_udf(s: pd.Series) -> pd.Series:
+                return s.map(index_mapper_fn)
 
-                @pandas_udf(returnType=index_mapper_ret_stype)  # type: ignore
-                def index_mapper_udf(s: pd.Series) -> pd.Series:
-                    return s.map(index_mapper_fn)
-
-                return index_mapper_udf(scol_for(psdf._internal.spark_frame, index_col_name))
-
-            sdf = psdf._internal.resolved_copy.spark_frame
-            index_fields = self._internal.index_fields.copy()
+            index_spark_columns = psdf._internal.index_spark_columns.copy()
+            index_fields = psdf._internal.index_fields.copy()
             if level is None:
                 for i in range(num_indices):
-                    sdf = sdf.withColumn(index_columns[i], gen_new_index_column(i))
-                    index_fields[i] = None  # TODO: dtype?
+                    index_spark_columns[i] = index_mapper_udf(index_spark_columns[i]).alias(
+                        index_columns[i]
+                    )
+                    index_fields[i] = index_fields[i].copy(
+                        dtype=index_mapper_ret_dtype,
+                        spark_type=index_mapper_ret_stype,
+                        nullable=True,
+                    )
             else:
-                sdf = sdf.withColumn(index_columns[level], gen_new_index_column(level))
-                index_fields[level] = None  # TODO: dtype?
-            psdf = DataFrame(psdf._internal.with_new_sdf(sdf, index_fields=index_fields))
+                index_spark_columns[level] = index_mapper_udf(index_spark_columns[level]).alias(
+                    index_columns[level]
+                )
+                index_fields[level] = index_fields[level].copy(
+                    dtype=index_mapper_ret_dtype,
+                    spark_type=index_mapper_ret_stype,
+                    nullable=True,
+                )
+            psdf = DataFrame(
+                psdf._internal.copy(
+                    index_spark_columns=index_spark_columns, index_fields=index_fields
+                )
+            )
         if columns_mapper_fn:
             # rename column name.
             # Will modify the `_internal._column_labels` and transform underlying spark dataframe
@@ -10168,11 +10193,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             new_column_labels = list(map(gen_new_column_labels_entry, psdf._internal.column_labels))
 
-            new_data_scols = [
+            new_data_pssers = [
                 psdf._psser_for(old_label).rename(new_label)
                 for old_label, new_label in zip(psdf._internal.column_labels, new_column_labels)
             ]
-            psdf = DataFrame(psdf._internal.with_new_columns(new_data_scols))
+            psdf = DataFrame(psdf._internal.with_new_columns(new_data_pssers))
         if inplace:
             self._update_internal_frame(psdf._internal)
             return None
@@ -11223,7 +11248,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         )
 
         data_fields = psdf._internal.data_fields.copy()
-        data_fields[psdf._internal.column_labels.index(psser._column_label)] = None  # TODO: dtype?
+        idx = psdf._internal.column_labels.index(psser._column_label)
+        field = data_fields[idx]
+        spark_type = cast(ArrayType, field.spark_type).elementType
+        dtype = spark_type_to_pandas_dtype(spark_type)
+        data_fields[idx] = field.copy(dtype=dtype, spark_type=spark_type, nullable=True)
 
         internal = psdf._internal.with_new_sdf(sdf, data_fields=data_fields)
         return DataFrame(internal)

--- a/python/pyspark/pandas/indexes/category.py
+++ b/python/pyspark/pandas/indexes/category.py
@@ -22,8 +22,10 @@ from pandas.api.types import is_hashable, CategoricalDtype
 
 from pyspark import pandas as ps
 from pyspark.pandas.indexes.base import Index
+from pyspark.pandas.internal import InternalField
 from pyspark.pandas.missing.indexes import MissingPandasLikeCategoricalIndex
 from pyspark.pandas.series import Series
+from pyspark.sql.types import StructField
 
 
 class CategoricalIndex(Index):
@@ -139,7 +141,16 @@ class CategoricalIndex(Index):
         >>> idx.codes
         Int64Index([0, 1, 1, 2, 2, 2], dtype='int64')
         """
-        return self._with_new_scol(self.spark.column).rename(None)
+        return self._with_new_scol(
+            self.spark.column,
+            field=InternalField.from_struct_field(
+                StructField(
+                    name=self._internal.index_spark_column_names[0],
+                    dataType=self.spark.data_type,
+                    nullable=self.spark.nullable,
+                )
+            ),
+        ).rename(None)
 
     @property
     def categories(self) -> pd.Index:

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -202,6 +202,13 @@ class InternalField:
             ),
         )
 
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, InternalField)
+            and self.dtype == other.dtype
+            and self.struct_field == other.struct_field
+        )
+
     def __repr__(self) -> str:
         return "InternalField(dtype={dtype},struct_field={struct_field})".format(
             dtype=self.dtype, struct_field=self.struct_field

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -55,6 +55,7 @@ from pyspark.sql.types import (
     ArrayType,
     BooleanType,
     DataType,
+    DecimalType,
     DoubleType,
     FloatType,
     IntegerType,
@@ -1894,7 +1895,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             self._psdf._update_internal_frame(psser._psdf._internal, requires_same_anchor=False)
             return None
         else:
-            return psser._with_new_scol(psser.spark.column)  # TODO: dtype?
+            return psser._with_new_scol(psser.spark.column, field=psser._internal.data_fields[0])
 
     def _fillna(
         self,
@@ -3378,7 +3379,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if not isinstance(decimals, int):
             raise TypeError("decimals must be an integer")
         scol = F.round(self.spark.column, decimals)
-        return self._with_new_scol(scol)  # TODO: dtype?
+        return self._with_new_scol(
+            scol,
+            field=(
+                self._internal.data_fields[0].copy(nullable=True)
+                if not isinstance(self.spark.data_type, DecimalType)
+                else None
+            ),
+        )
 
     # TODO: add 'interpolation' parameter.
     def quantile(
@@ -5242,18 +5250,28 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         internal = self._internal.resolved_copy
 
-        index_map = list(zip(internal.index_spark_column_names, internal.index_names))
-        pivot_col, column_label_names = index_map.pop(level)
-        index_scol_names, index_names = zip(*index_map)
+        index_map = list(
+            zip(internal.index_spark_column_names, internal.index_names, internal.index_fields)
+        )
+        pivot_col, column_label_names, _ = index_map.pop(level)
+        index_scol_names, index_names, index_fields = zip(*index_map)
         col = internal.data_spark_column_names[0]
 
         sdf = internal.spark_frame
         sdf = sdf.groupby(list(index_scol_names)).pivot(pivot_col).agg(F.first(scol_for(sdf, col)))
-        internal = InternalFrame(  # TODO: dtypes?
+
+        internal = InternalFrame(
             spark_frame=sdf,
             index_spark_columns=[scol_for(sdf, col) for col in index_scol_names],
             index_names=list(index_names),
+            index_fields=list(index_fields),
             column_label_names=[column_label_names],
+        )
+        internal = internal.copy(
+            data_fields=[
+                field.copy(dtype=self._internal.data_fields[0].dtype)
+                for field in internal.data_fields
+            ]
         )
         return DataFrame(internal)
 

--- a/python/pyspark/pandas/tests/indexes/test_category.py
+++ b/python/pyspark/pandas/tests/indexes/test_category.py
@@ -111,6 +111,75 @@ class CategoricalIndexTest(PandasOnSparkTestCase, TestUtils):
         self.assert_eq(kcodes.tolist(), pcodes.tolist())
         self.assert_eq(kuniques, puniques)
 
+    def test_append(self):
+        pidx1 = pd.CategoricalIndex(["x", "y", "z"], categories=["z", "y", "x", "w"])
+        pidx2 = pd.CategoricalIndex(["y", "x", "w"], categories=["z", "y", "x", "w"])
+        pidx3 = pd.Index(["y", "x", "w", "z"])
+        psidx1 = ps.from_pandas(pidx1)
+        psidx2 = ps.from_pandas(pidx2)
+        psidx3 = ps.from_pandas(pidx3)
+
+        self.assert_eq(psidx1.append(psidx2), pidx1.append(pidx2))
+        self.assert_eq(
+            psidx1.append(psidx3.astype("category")), pidx1.append(pidx3.astype("category"))
+        )
+
+        # TODO: append non-categorical or categorical with a different category
+        self.assertRaises(NotImplementedError, lambda: psidx1.append(psidx3))
+
+        pidx4 = pd.CategoricalIndex(["y", "x", "w"], categories=["z", "y", "x"])
+        psidx4 = ps.from_pandas(pidx4)
+        self.assertRaises(NotImplementedError, lambda: psidx1.append(psidx4))
+
+    def test_union(self):
+        pidx1 = pd.CategoricalIndex(["x", "y", "z"], categories=["z", "y", "x", "w"])
+        pidx2 = pd.CategoricalIndex(["y", "x", "w"], categories=["z", "y", "x", "w"])
+        pidx3 = pd.Index(["y", "x", "w", "z"])
+        psidx1 = ps.from_pandas(pidx1)
+        psidx2 = ps.from_pandas(pidx2)
+        psidx3 = ps.from_pandas(pidx3)
+
+        self.assert_eq(psidx1.union(psidx2), pidx1.union(pidx2))
+        self.assert_eq(
+            psidx1.union(psidx3.astype("category")), pidx1.union(pidx3.astype("category"))
+        )
+
+        # TODO: union non-categorical or categorical with a different category
+        self.assertRaises(NotImplementedError, lambda: psidx1.union(psidx3))
+
+        pidx4 = pd.CategoricalIndex(["y", "x", "w"], categories=["z", "y", "x"])
+        psidx4 = ps.from_pandas(pidx4)
+        self.assertRaises(NotImplementedError, lambda: psidx1.union(psidx4))
+
+    def test_intersection(self):
+        pidx1 = pd.CategoricalIndex(["x", "y", "z"], categories=["z", "y", "x", "w"])
+        pidx2 = pd.CategoricalIndex(["y", "x", "w"], categories=["z", "y", "x", "w"])
+        pidx3 = pd.Index(["y", "x", "w", "z"])
+        psidx1 = ps.from_pandas(pidx1)
+        psidx2 = ps.from_pandas(pidx2)
+        psidx3 = ps.from_pandas(pidx3)
+
+        self.assert_eq(
+            psidx1.intersection(psidx2).sort_values(), pidx1.intersection(pidx2).sort_values()
+        )
+        self.assert_eq(
+            psidx1.intersection(psidx3.astype("category")).sort_values(),
+            pidx1.intersection(pidx3.astype("category")).sort_values(),
+        )
+
+        # TODO: intersection non-categorical or categorical with a different category
+        self.assertRaises(NotImplementedError, lambda: psidx1.intersection(psidx3))
+
+        pidx4 = pd.CategoricalIndex(["y", "x", "w"], categories=["z", "y", "x"])
+        psidx4 = ps.from_pandas(pidx4)
+        self.assertRaises(NotImplementedError, lambda: psidx1.intersection(psidx4))
+
+    def test_insert(self):
+        pidx = pd.CategoricalIndex(["x", "y", "z"], categories=["z", "y", "x", "w"])
+        psidx = ps.from_pandas(pidx)
+
+        self.assert_eq(psidx.insert(1, "w"), pidx.insert(1, "w"))
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/test_categorical.py
+++ b/python/pyspark/pandas/tests/test_categorical.py
@@ -471,6 +471,17 @@ class CategoricalTest(PandasOnSparkTestCase, TestUtils):
             to_category(pdf.a).sort_index(),
         )
 
+    def test_unstack(self):
+        pdf = self.pdf
+        index = pd.MultiIndex.from_tuples(
+            [("x", "a"), ("x", "b"), ("x", "c"), ("y", "a"), ("y", "b"), ("y", "d")]
+        )
+        pdf.index = index
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(psdf.a.unstack().sort_index(), pdf.a.unstack().sort_index())
+        self.assert_eq(psdf.b.unstack().sort_index(), pdf.b.unstack().sort_index())
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -3053,6 +3053,9 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf = ps.from_pandas(pdf)
 
         self.assert_eq(psdf.unstack().sort_index(), pdf.unstack().sort_index(), almost=True)
+        self.assert_eq(
+            psdf.unstack().unstack().sort_index(), pdf.unstack().unstack().sort_index(), almost=True
+        )
 
     def test_pivot_errors(self):
         psdf = ps.range(10)
@@ -5018,7 +5021,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             expected_result2 = pdf
 
         self.assert_eq(psdf.explode("A"), expected_result1, almost=True)
-        self.assert_eq(repr(psdf.explode("B")), repr(expected_result2))
+        self.assert_eq(psdf.explode("B"), expected_result2)
         self.assert_eq(psdf.explode("A").index.name, expected_result1.index.name)
         self.assert_eq(psdf.explode("A").columns.name, expected_result1.columns.name)
 
@@ -5043,7 +5046,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             expected_result2 = pdf
 
         self.assert_eq(psdf.explode("A"), expected_result1, almost=True)
-        self.assert_eq(repr(psdf.explode("B")), repr(expected_result2))
+        self.assert_eq(psdf.explode("B"), expected_result2)
         self.assert_eq(psdf.explode("A").index.names, expected_result1.index.names)
         self.assert_eq(psdf.explode("A").columns.name, expected_result1.columns.name)
 
@@ -5066,7 +5069,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             expected_result3.columns.name = "column2"
 
         self.assert_eq(psdf.explode(("A", "Z")), expected_result1, almost=True)
-        self.assert_eq(repr(psdf.explode(("B", "X"))), repr(expected_result2))
+        self.assert_eq(psdf.explode(("B", "X")), expected_result2)
         self.assert_eq(psdf.explode(("A", "Z")).index.names, expected_result1.index.names)
         self.assert_eq(psdf.explode(("A", "Z")).columns.names, expected_result1.columns.names)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Revisit and manage `InternalField` in more places.

### Why are the changes needed?

There are other places we can manage `InternalField`, and we can keep extension dtypes or `CategoricalDtype`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added some tests.
