### PR TITLE
[SPARK-35810][SPARK-35807][PYTHON] Deprecate ps.broadcast API and the `num_files` argument

### DIFF
--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -861,7 +861,7 @@ class Frame(object, metaclass=ABCMeta):
 
         if num_files is not None:
             warnings.warn(
-                "`num_files` has been deprecated and will be removed in a future version. "
+                "`num_files` has been deprecated and might be removed in a future version. "
                 "Use `DataFrame.spark.repartition` instead.",
                 FutureWarning,
             )

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -860,6 +860,11 @@ class Frame(object, metaclass=ABCMeta):
             )
 
         if num_files is not None:
+            warnings.warn(
+                "`num_files` has been deprecated and will be removed in a future version. "
+                "Use `DataFrame.spark.repartition` instead.",
+                FutureWarning,
+            )
             sdf = sdf.repartition(num_files)
 
         builder = sdf.write.mode(mode)
@@ -998,6 +1003,11 @@ class Frame(object, metaclass=ABCMeta):
         sdf = psdf.to_spark(index_col=index_col)  # type: ignore
 
         if num_files is not None:
+            warnings.warn(
+                "`num_files` has been deprecated and might be removed in a future version. "
+                "Use `DataFrame.spark.repartition` instead.",
+                FutureWarning,
+            )
             sdf = sdf.repartition(num_files)
 
         builder = sdf.write.mode(mode)

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2855,7 +2855,7 @@ def broadcast(obj: DataFrame) -> DataFrame:
     """
     warnings.warn(
         "`broadcast` has been deprecated and will be removed in a future version. "
-        "use `DataFrame.spark.hint` with 'broadcast'.",
+        "use `DataFrame.spark.hint` with 'broadcast' for `name` parameter.",
         FutureWarning,
     )
     if not isinstance(obj, DataFrame):

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2853,6 +2853,11 @@ def broadcast(obj: DataFrame) -> DataFrame:
     ...BroadcastHashJoin...
     ...
     """
+    warnings.warn(
+        "`ps.broadcast` has been deprecated and will be removed in a future version. "
+        "use `DataFrame.spark.hint` with 'broadcast'.",
+        FutureWarning,
+    )
     if not isinstance(obj, DataFrame):
         raise TypeError("Invalid type : expected DataFrame got {}".format(type(obj).__name__))
     return DataFrame(

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2856,7 +2856,7 @@ def broadcast(obj: DataFrame) -> DataFrame:
     ...
     """
     warnings.warn(
-        "`broadcast` has been deprecated and will be removed in a future version. "
+        "`broadcast` has been deprecated and might be removed in a future version. "
         "Use `DataFrame.spark.hint` with 'broadcast' for `name` parameter instead.",
         FutureWarning,
     )

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2823,6 +2823,11 @@ def broadcast(obj: DataFrame) -> DataFrame:
     """
     Marks a DataFrame as small enough for use in broadcast joins.
 
+    Notes
+    -----
+    `broadcast` has been deprecated and will be removed in a future version.
+    Use `DataFrame.spark.hint` with 'broadcast' for `name` parameter instead.
+
     Parameters
     ----------
     obj : DataFrame
@@ -2855,7 +2860,7 @@ def broadcast(obj: DataFrame) -> DataFrame:
     """
     warnings.warn(
         "`broadcast` has been deprecated and will be removed in a future version. "
-        "use `DataFrame.spark.hint` with 'broadcast' for `name` parameter.",
+        "use `DataFrame.spark.hint` with 'broadcast' for `name` parameter instead.",
         FutureWarning,
     )
     if not isinstance(obj, DataFrame):

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2825,7 +2825,6 @@ def broadcast(obj: DataFrame) -> DataFrame:
 
     .. deprecated:: 3.2.0
         Use :func:`DataFrame.spark.hint` instead.
- 
     Parameters
     ----------
     obj : DataFrame

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2823,11 +2823,8 @@ def broadcast(obj: DataFrame) -> DataFrame:
     """
     Marks a DataFrame as small enough for use in broadcast joins.
 
-    Notes
-    -----
-    `broadcast` has been deprecated and will be removed in a future version.
-    Use `DataFrame.spark.hint` with 'broadcast' for `name` parameter instead.
-
+    .. deprecated:: 3.2.0
+        Use :func:`DataFrame.spark.hint` instead.
     Parameters
     ----------
     obj : DataFrame

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2825,6 +2825,7 @@ def broadcast(obj: DataFrame) -> DataFrame:
 
     .. deprecated:: 3.2.0
         Use :func:`DataFrame.spark.hint` instead.
+ 
     Parameters
     ----------
     obj : DataFrame

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2860,7 +2860,7 @@ def broadcast(obj: DataFrame) -> DataFrame:
     """
     warnings.warn(
         "`broadcast` has been deprecated and will be removed in a future version. "
-        "use `DataFrame.spark.hint` with 'broadcast' for `name` parameter instead.",
+        "Use `DataFrame.spark.hint` with 'broadcast' for `name` parameter instead.",
         FutureWarning,
     )
     if not isinstance(obj, DataFrame):

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2853,11 +2853,6 @@ def broadcast(obj: DataFrame) -> DataFrame:
     ...BroadcastHashJoin...
     ...
     """
-    warnings.warn(
-        "`ps.broadcast` has been deprecated and will be removed in a future version. "
-        "use `DataFrame.spark.hint` with 'broadcast'.",
-        FutureWarning,
-    )
     if not isinstance(obj, DataFrame):
         raise TypeError("Invalid type : expected DataFrame got {}".format(type(obj).__name__))
     return DataFrame(

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -39,6 +39,7 @@ from distutils.version import LooseVersion
 from functools import reduce
 from io import BytesIO
 import json
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -2852,6 +2853,11 @@ def broadcast(obj: DataFrame) -> DataFrame:
     ...BroadcastHashJoin...
     ...
     """
+    warnings.warn(
+        "`ps.broadcast` has been deprecated and will be removed in a future version. "
+        "use `DataFrame.spark.hint` with 'broadcast'.",
+        FutureWarning,
+    )
     if not isinstance(obj, DataFrame):
         raise TypeError("Invalid type : expected DataFrame got {}".format(type(obj).__name__))
     return DataFrame(

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2854,7 +2854,7 @@ def broadcast(obj: DataFrame) -> DataFrame:
     ...
     """
     warnings.warn(
-        "`ps.broadcast` has been deprecated and will be removed in a future version. "
+        "`broadcast` has been deprecated and will be removed in a future version. "
         "use `DataFrame.spark.hint` with 'broadcast'.",
         FutureWarning,
     )

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -882,6 +882,11 @@ def approx_count_distinct(col, rsd=None):
 def broadcast(df):
     """Marks a DataFrame as small enough for use in broadcast joins."""
 
+    warnings.warn(
+        "`broadcast` has been deprecated and will be removed in a future version. "
+        "use `DataFrame.hint` with 'broadcast'.",
+        FutureWarning,
+    )
     sc = SparkContext._active_spark_context
     return DataFrame(sc._jvm.functions.broadcast(df._jdf), df.sql_ctx)
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -884,7 +884,8 @@ def broadcast(df):
 
     warnings.warn(
         "`broadcast` has been deprecated and will be removed in a future version. "
-        "use `DataFrame.hint` with 'broadcast'.",
+        "use `DataFrame.hint` with 'broadcast'.\n"
+        "If you're using pandas API on Spark, use `DataFrame.spark.hint` instead.",
         FutureWarning,
     )
     sc = SparkContext._active_spark_context

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -882,12 +882,6 @@ def approx_count_distinct(col, rsd=None):
 def broadcast(df):
     """Marks a DataFrame as small enough for use in broadcast joins."""
 
-    warnings.warn(
-        "`broadcast` has been deprecated and will be removed in a future version. "
-        "use `DataFrame.hint` with 'broadcast'.\n"
-        "If you're using pandas API on Spark, use `DataFrame.spark.hint` instead.",
-        FutureWarning,
-    )
     sc = SparkContext._active_spark_context
     return DataFrame(sc._jvm.functions.broadcast(df._jdf), df.sql_ctx)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `broadcast` functions in `pyspark.pandas` is duplicated to `DataFrame.spark.hint` with `"broadcast"`.

```python
# The below 2 lines are the same
df.spark.hint("broadcast")
ps.broadcast(df)
```

So, we should remove `broadcast` in the future, and show deprecation warning for now.

And the `num_files` argument doesn't actually manage the number of files, but specifying the partition number.

So, we should deprecate the `num_files` argument and encourage users to use `DataFrame.spark.repartition` API instead.

### Why are the changes needed?

For deduplication of functions and arguments.

### Does this PR introduce _any_ user-facing change?

They see the deprecation warning when using `broadcast` in `pyspark.pandas`.

```python
>>> ps.broadcast(df)
FutureWarning: `broadcast` has been deprecated and will be removed in a future version. use `DataFrame.spark.hint` with 'broadcast' for `name` parameter instead.
  warnings.warn(
```

Also see the deprecation warning when using `num_files` argument.

```python
>>> psdf.to_csv("test.csv", num_files=4)
FutureWarning: `num_files` has been deprecated and might be removed in a future version. 
Use `DataFrame.spark.repartition` instead.
  warnings.warn(
```

### How was this patch tested?

Manually check the warning message and see the build passed.