### PR TITLE
[SPARK-36169][SQL] Make 'spark.sql.sources.disabledJdbcConnProviderList' as a static conf (as documneted)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3272,15 +3272,6 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val DISABLED_JDBC_CONN_PROVIDER_LIST =
-    buildConf("spark.sql.sources.disabledJdbcConnProviderList")
-    .internal()
-    .doc("Configures a list of JDBC connection providers, which are disabled. " +
-      "The list contains the name of the JDBC connection providers separated by comma.")
-    .version("3.1.0")
-    .stringConf
-    .createWithDefault("")
-
   val LEGACY_CREATE_HIVE_TABLE_BY_DEFAULT =
     buildConf("spark.sql.legacy.createHiveTableByDefault")
       .internal()
@@ -4043,7 +4034,8 @@ class SQLConf extends Serializable with Logging {
 
   def legacyPathOptionBehavior: Boolean = getConf(SQLConf.LEGACY_PATH_OPTION_BEHAVIOR)
 
-  def disabledJdbcConnectionProviders: String = getConf(SQLConf.DISABLED_JDBC_CONN_PROVIDER_LIST)
+  def disabledJdbcConnectionProviders: String = getConf(
+    StaticSQLConf.DISABLED_JDBC_CONN_PROVIDER_LIST)
 
   def charVarcharAsString: Boolean = getConf(SQLConf.LEGACY_CHAR_VARCHAR_AS_STRING)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -262,4 +262,12 @@ object StaticSQLConf {
       .stringConf
       .toSequence
       .createWithDefault(Nil)
+
+  val DISABLED_JDBC_CONN_PROVIDER_LIST =
+    buildStaticConf("spark.sql.sources.disabledJdbcConnProviderList")
+      .doc("Configures a list of JDBC connection providers, which are disabled. " +
+        "The list contains the name of the JDBC connection providers separated by comma.")
+      .version("3.1.0")
+      .stringConf
+      .createWithDefault("")
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to move `spark.sql.sources.disabledJdbcConnProviderList` from SQLConf to StaticSQLConf which disallows to set in runtime.

### Why are the changes needed?

It's documented as a static configuration. we should make it as a static configuration properly.

### Does this PR introduce _any_ user-facing change?

Previously, the configuration can be set to different value but not effective.
Now it throws an exception if users try to set in runtime.

### How was this patch tested?

Existing unittest was fixed. That should verify the change.