### PR TITLE
[SPARK-36177][R][TESTS][3.1] Disable CRAN in branches lower than the latest version uploaded

### DIFF
--- a/R/run-tests.sh
+++ b/R/run-tests.sh
@@ -43,7 +43,8 @@ NUM_TEST_WARNING="$(grep -c -e 'Warnings ----------------' $LOGFILE)"
 CRAN_CHECK_LOG_FILE=$FWDIR/cran-check.out
 rm -f $CRAN_CHECK_LOG_FILE
 
-NO_TESTS=1 NO_MANUAL=1 $FWDIR/check-cran.sh 2>&1 | tee -a $CRAN_CHECK_LOG_FILE
+# Skip CRAN check for old version in CI. See also SPARK-36177.
+(([ ! -z "$AMPLAB_JENKINS" ] || [ ! -z "$GITHUB_ACTIONS" ]) && touch $CRAN_CHECK_LOG_FILE) || NO_TESTS=1 NO_MANUAL=1 $FWDIR/check-cran.sh 2>&1 | tee -a $CRAN_CHECK_LOG_FILE
 FAILED=$((PIPESTATUS[0]||$FAILED))
 
 NUM_CRAN_WARNING="$(grep -c WARNING$ $CRAN_CHECK_LOG_FILE)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip the CRAN check in old branches (than the latest version uploaded to CRAN)

### Why are the changes needed?

Same as https://github.com/apache/spark/pull/33390. Spark 3.2.0 will very likely come first before Spark 3.1.x.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

It will be tested in the CI at this PR.