### PR TITLE
[SPARK-36178][PYTHON] List pyspark.sql.catalog APIs in documentation

### DIFF
--- a/python/docs/source/reference/pyspark.sql.rst
+++ b/python/docs/source/reference/pyspark.sql.rst
@@ -29,6 +29,7 @@ Core Classes
     :toctree: api/
 
     SparkSession
+    Catalog
     DataFrame
     Column
     Row

--- a/python/docs/source/reference/pyspark.sql.rst
+++ b/python/docs/source/reference/pyspark.sql.rst
@@ -608,7 +608,7 @@ Grouping
 Catalog APIs
 ------------
 
-.. currentmodule:: pyspark.sql.catalog
+.. currentmodule:: pyspark.sql
 
 .. autosummary::
     :toctree: api/

--- a/python/docs/source/reference/pyspark.sql.rst
+++ b/python/docs/source/reference/pyspark.sql.rst
@@ -603,3 +603,30 @@ Grouping
     GroupedData.pivot
     GroupedData.sum
     PandasCogroupedOps.applyInPandas
+
+Catalog APIs
+------------
+
+.. currentmodule:: pyspark.sql.catalog
+
+.. autosummary::
+    :toctree: api/
+
+    Catalog.cacheTable
+    Catalog.clearCache
+    Catalog.createExternalTable
+    Catalog.createTable
+    Catalog.currentDatabase
+    Catalog.dropGlobalTempView
+    Catalog.dropTempView
+    Catalog.isCached
+    Catalog.listColumns
+    Catalog.listDatabases
+    Catalog.listFunctions
+    Catalog.listTables
+    Catalog.recoverPartitions
+    Catalog.refreshByPath
+    Catalog.refreshTable
+    Catalog.registerFunction
+    Catalog.setCurrentDatabase
+    Catalog.uncacheTable


### PR DESCRIPTION

### What changes were proposed in this pull request?
The pyspark.sql.catalog APIs were missing from the documentation. PR fixes this omission.


### Why are the changes needed?
Documentation consistency


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Documentation change only.
