### PR TITLE
[WIP][SPARK-36182][SQL] Support TimestampNTZ type in Parquet file source

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -368,6 +368,23 @@ private[parquet] class ParquetRowConverter(
           }
         }
 
+      case TimestampNTZType
+        if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&
+          parquetType.getLogicalTypeAnnotation
+            .asInstanceOf[TimestampLogicalTypeAnnotation].getUnit == TimeUnit.MICROS =>
+        new ParquetPrimitiveConverter(updater)
+
+      case TimestampNTZType
+        if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&
+          parquetType.getLogicalTypeAnnotation
+            .asInstanceOf[TimestampLogicalTypeAnnotation].getUnit == TimeUnit.MILLIS =>
+        new ParquetPrimitiveConverter(updater) {
+          override def addLong(value: Long): Unit = {
+            val micros = DateTimeUtils.millisToMicros(value)
+            updater.setLong(micros)
+          }
+        }
+
       case DateType =>
         new ParquetPrimitiveConverter(updater) {
           override def addInt(value: Int): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -167,10 +167,13 @@ class ParquetToSparkSchemaConverter(
               case 64 => DecimalType(20, 0)
               case _ => illegalType()
             }
-          case timestamp: TimestampLogicalTypeAnnotation if timestamp.getUnit == TimeUnit.MICROS =>
-            TimestampType
-          case timestamp: TimestampLogicalTypeAnnotation if timestamp.getUnit == TimeUnit.MILLIS =>
-            TimestampType
+          case timestamp: TimestampLogicalTypeAnnotation
+            if timestamp.getUnit == TimeUnit.MICROS || timestamp.getUnit == TimeUnit.MILLIS =>
+            if (timestamp.isAdjustedToUTC) {
+              TimestampType
+            } else {
+              TimestampNTZType
+            }
           case _ => illegalType()
         }
 
@@ -420,6 +423,9 @@ class SparkToParquetSchemaConverter(
               .as(LogicalTypeAnnotation.timestampType(true, TimeUnit.MILLIS)).named(field.name)
         }
 
+      case TimestampNTZType =>
+        Types.primitive(INT64, repetition)
+          .as(LogicalTypeAnnotation.timestampType(false, TimeUnit.MICROS)).named(field.name)
       case BinaryType =>
         Types.primitive(BINARY, repetition).named(field.name)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
@@ -223,6 +223,12 @@ class ParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
               recordConsumer.addLong(millis)
         }
 
+      case TimestampNTZType =>
+        // For TimestampNTZType column, Spark always output as INT64 with Timestamp annotation in
+        // MICROS time unit.
+        (row: SpecializedGetters, ordinal: Int) =>
+          recordConsumer.addLong(row.getLong(ordinal))
+
       case BinaryType =>
         (row: SpecializedGetters, ordinal: Int) =>
           recordConsumer.addBinary(Binary.fromReusedByteArray(row.getBinary(ordinal)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
+import java.time.LocalDateTime
 import java.util.Locale
 
 import scala.collection.JavaConverters._
@@ -116,6 +117,12 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
     // as we store Spark SQL schema in the extra metadata.
     withSQLConf(SQLConf.PARQUET_BINARY_AS_STRING.key -> "false")(checkParquetFile(data))
     withSQLConf(SQLConf.PARQUET_BINARY_AS_STRING.key -> "true")(checkParquetFile(data))
+  }
+
+  test("TimestampNTZ") {
+    val data = Seq("2021-01-01T00:00:00", "1970-07-15T01:02:03.456789")
+      .map(ts => Tuple1(LocalDateTime.parse(ts)))
+    checkParquetFile(data)
   }
 
   testStandardAndLegacyModes("fixed-length decimals") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -156,6 +156,23 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
     }
   }
 
+  test("writing and reading TimestampNTZType column") {
+    withTable("ts") {
+      sql("create table ts (c1 timestamp_ntz) using parquet")
+      sql("insert into ts values (timestamp_ntz'2016-01-01 10:11:12.123456')")
+      sql("insert into ts values (null)")
+      sql("insert into ts values (timestamp_ntz'1965-01-01 10:11:12.123456')")
+      val expectedSchema = new StructType().add(StructField("c1", TimestampNTZType))
+      assert(spark.table("ts").schema == expectedSchema)
+      val expected = Seq(
+        ("2016-01-01 10:11:12.123456"),
+        (null),
+        ("1965-01-01 10:11:12.123456"))
+        .toDS().select($"value".cast("timestamp_ntz"))
+      checkAnswer(sql("select * from ts"), expected)
+    }
+  }
+
   test("SPARK-10365 timestamp written and read as INT64 - TIMESTAMP_MICROS") {
     val data = (1 to 10).map { i =>
       val ts = new java.sql.Timestamp(i)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.execution.datasources.SchemaColumnConvertNotSupportedException
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
@@ -1028,6 +1029,36 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     int96AsTimestamp = false,
     writeLegacyParquetFormat = true,
     outputTimestampType = SQLConf.ParquetOutputTimestampType.TIMESTAMP_MICROS)
+
+  // The behavior of reading/writing TimestampNTZ type is independent of the configurations
+  // SQLConf.PARQUET_INT96_AS_TIMESTAMP and SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE
+  Seq(true, false).foreach { int96AsTimestamp =>
+    Seq(INT96, TIMESTAMP_MILLIS, TIMESTAMP_MICROS).foreach { outputTsType =>
+      testSchema(
+        s"TimestampNTZ written and read as INT64 with TIMESTAMP_MICROS - " +
+          s"int96AsTimestamp as $int96AsTimestamp, outputTimestampType: $outputTsType",
+        StructType(Seq(StructField("f1", TimestampNTZType))),
+        """message root {
+          |  optional INT64 f1 (TIMESTAMP(MICROS,false));
+          |}
+        """.stripMargin,
+        binaryAsString = true,
+        int96AsTimestamp = int96AsTimestamp,
+        writeLegacyParquetFormat = true,
+        outputTimestampType = outputTsType)
+    }
+
+    testParquetToCatalyst(
+      s"TimestampNTZ read as INT64 with TIMESTAMP_MILLIS - " +
+        s"int96AsTimestamp as $int96AsTimestamp",
+      StructType(Seq(StructField("f1", TimestampNTZType))),
+      """message root {
+        |  optional INT64 f1 (TIMESTAMP(MILLIS,false));
+        |}
+        """.stripMargin,
+      binaryAsString = true,
+      int96AsTimestamp = int96AsTimestamp)
+  }
 
   private def testSchemaClipping(
       testName: String,


### PR DESCRIPTION
This is still WIP. I am deciding the behaviors of the Parquet reader for both schema inference and user-provided schema.