### PR TITLE
[SPARK-36199][BUILD] Bump scalatest-maven-plugin to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <scala.version>2.12.14</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <scalatest-maven-plugin.version>2.0.0</scalatest-maven-plugin.version>
+    <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
     <scalafmt.parameters>--test</scalafmt.parameters>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade scalatest-maven-plugin to version 2.0.2.

### Why are the changes needed?
2.0.2 supports build on JDK 11 officially. 
- https://github.com/scalatest/scalatest-maven-plugin/commit/f45ce192f313553efc29c201593950e38f419a80

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the CIs. 
