### PR TITLE
Do not run the 'Build and test Scala 2.13 daily' workflow on forks

### DIFF
--- a/.github/workflows/build_and_test_scala213_daily.yml
+++ b/.github/workflows/build_and_test_scala213_daily.yml
@@ -8,6 +8,7 @@ jobs:
   # Build: build Spark and run the tests for specified modules.
   build:
     name: "${{ matrix.branch }}: ${{ matrix.modules }} ${{ matrix.comment }} (JDK ${{ matrix.java }}, ${{ matrix.hadoop }}, ${{ matrix.hive }})"
+    if: github.repository == 'apache/spark'
     # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disables the daily build and test job introduced in #33358 for fork repos.

### Why are the changes needed?
With #33358 there is a daily build and test job that runs on **all** forks of Spark. This is of little use for fork repos but it will eventually become active on thousands of Spark fork repos and run there every day. Lets save Github some computation resources.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Trivial change, same solution as in #30884.