### PR TITLE
[SPARK-34806][SQL] Add Observation helper for Dataset.observe

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1947,6 +1947,27 @@ class Dataset[T] private[sql](
     CollectMetrics(name, (expr +: exprs).map(_.named), logicalPlan)
   }
 
+  /**
+   * Observe (named) metrics through an [[org.apache.spark.sql.Observation]] instance.
+   * This is equivalent to calling [[Dataset.observe(String, Column, Column*)]] but does
+   * not require adding [[org.apache.spark.sql.util.QueryExecutionListener]] to the spark session.
+   * This method does not support streaming datasets.
+   *
+   * A user can retrieve the metrics by accessing [[org.apache.spark.sql.Observation.get]].
+   *
+   * {{{
+   *   // Observe row count (rows) and highest id (maxid) in the Dataset while writing it
+   *   val observation = Observation("my_metrics")
+   *   val observed_ds = ds.observe(observation, count(lit(1)).as("rows"), max($"id").as("maxid"))
+   *   observed_ds.write.parquet("ds.parquet")
+   *   val metrics = observation.get
+   * }}}
+   *
+   * @throws IllegalArgumentException If this is a streaming Dataset (this.isStreaming == true)
+   *
+   * @group typedrel
+   * @since 3.2.0
+   */
   def observe(observation: Observation, expr: Column, exprs: Column*): Dataset[T] = {
     observation.on(this, expr, exprs: _*)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1948,7 +1948,7 @@ class Dataset[T] private[sql](
   }
 
   def observe(observation: Observation, expr: Column, exprs: Column*): Dataset[T] = {
-    observation.on(this)(expr, exprs: _*)
+    observation.on(this, expr, exprs: _*)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1947,6 +1947,10 @@ class Dataset[T] private[sql](
     CollectMetrics(name, (expr +: exprs).map(_.named), logicalPlan)
   }
 
+  def observe(observation: Observation, expr: Column, exprs: Column*): Dataset[T] = {
+    observation.on(this)(expr, exprs: _*)
+  }
+
   /**
    * Returns a new Dataset by taking the first `n` rows. The difference between this function
    * and `head` is that `head` is an action and returns an array (by triggering query execution)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql
 
 import java.io.{ByteArrayOutputStream, CharArrayWriter, DataOutputStream}
 
+import scala.annotation.varargs
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashSet}
 import scala.reflect.runtime.universe.TypeTag
@@ -1968,6 +1969,7 @@ class Dataset[T] private[sql](
    * @group typedrel
    * @since 3.3.0
    */
+  @varargs
   def observe(observation: Observation, expr: Column, exprs: Column*): Dataset[T] = {
     observation.on(this, expr, exprs: _*)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1966,7 +1966,7 @@ class Dataset[T] private[sql](
    * @throws IllegalArgumentException If this is a streaming Dataset (this.isStreaming == true)
    *
    * @group typedrel
-   * @since 3.2.0
+   * @since 3.3.0
    */
   def observe(observation: Observation, expr: Column, exprs: Column*): Dataset[T] = {
     observation.on(this, expr, exprs: _*)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1948,12 +1948,12 @@ class Dataset[T] private[sql](
   }
 
   /**
-   * Observe (named) metrics through an [[org.apache.spark.sql.Observation]] instance.
-   * This is equivalent to calling [[Dataset.observe(String, Column, Column*)]] but does
-   * not require adding [[org.apache.spark.sql.util.QueryExecutionListener]] to the spark session.
+   * Observe (named) metrics through an `org.apache.spark.sql.Observation` instance.
+   * This is equivalent to calling `observe(String, Column, Column*)` but does not require
+   * adding `org.apache.spark.sql.util.QueryExecutionListener` to the spark session.
    * This method does not support streaming datasets.
    *
-   * A user can retrieve the metrics by accessing [[org.apache.spark.sql.Observation.get]].
+   * A user can retrieve the metrics by accessing `org.apache.spark.sql.Observation.get`.
    *
    * {{{
    *   // Observe row count (rows) and highest id (maxid) in the Dataset while writing it

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -55,7 +55,7 @@ class Observation(name: String) {
 
   private val listener: ObservationListener = ObservationListener(this)
 
-  private var sparkSession: Option[SparkSession] = None
+  @volatile private var sparkSession: Option[SparkSession] = None
 
   @volatile private var row: Option[Row] = None
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.util.QueryExecutionListener
 
 
 /**
- * Helper class to simplify usage of [[Dataset.observe(String, Column, Column*) observe]]:
+ * Helper class to simplify usage of `Dataset.observe(String, Column, Column*)`:
  *
  * {{{
  *   // Observe row count (rows) and highest id (maxid) in the Dataset while writing it
@@ -74,8 +74,9 @@ class Observation(name: String) {
    * Only the result of the first action is available. Subsequent actions do not modify the result.
    *
    * @return the observed metrics as a [[Row]]
-   * @throws java.lang.InterruptedException interrupted while waiting
+   * @throws InterruptedException interrupted while waiting
    */
+  @throws[InterruptedException]
   def get: Row = {
     synchronized {
       // we need to loop as wait might return without us calling notify
@@ -131,6 +132,9 @@ private[sql] case class ObservationListener(observation: Observation)
 
 }
 
+/**
+ * (Scala-specific) Create a named or anonymous instance of Observation.
+ */
 object Observation {
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql
 
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.{Condition, Lock, ReentrantLock}
 
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.util.QueryExecutionListener
@@ -31,17 +30,14 @@ import org.apache.spark.sql.util.QueryExecutionListener
  */
 class Observation(name: String) {
 
-  private val lock: Lock = new ReentrantLock()
-  private val completed: Condition = lock.newCondition()
   private val listener: ObservationListener = ObservationListener(this)
 
   private var sparkSession: Option[SparkSession] = None
 
-  @transient private var row: Option[Row] = None
+  @volatile private var row: Option[Row] = None
 
   /**
    * Attach this observation to the given Dataset.
-   * Remember to call `close()` when the observation is done.
    *
    * @param ds dataset
    * @tparam T dataset type
@@ -71,36 +67,35 @@ class Observation(name: String) {
    * Only the result of the first action is available. Subsequent actions do not modify the result.
    */
   def get: Row = {
-    waitCompleted(None, TimeUnit.SECONDS)
+    assert(waitCompleted(None, TimeUnit.SECONDS), "waitCompleted without timeout returned false")
+    assert(row.isDefined, "waitCompleted without timeout returned while result is still None")
     row.get
   }
 
   private def waitCompleted(time: Option[Long], unit: TimeUnit): Boolean = {
-    lock.lock()
-    try {
+    synchronized {
       if (row.isEmpty) {
         if (time.isDefined) {
-          completed.await(time.get, unit)
+          this.wait(unit.toMillis(time.get))
         } else {
-          completed.await()
+          this.wait()
         }
       }
       row.isDefined
-    } finally {
-      lock.unlock()
     }
   }
 
-  private def getMetricRow(metrics: Map[String, Row]): Option[Row] =
-    metrics
-      .find { case (metricName, _) => metricName.equals(name) }
-      .map { case (_, row) => row }
-
   private def register(sparkSession: SparkSession): Unit = {
-    if (this.sparkSession.isDefined) {
-      throw new IllegalStateException("An Observation can be used with a Dataset only once")
+    // makes this class thread-safe:
+    // only the first thread entering this block can set sparkSession
+    // all other threads will see the exception, because it is only allowed to do this once
+    synchronized {
+      if (this.sparkSession.isDefined) {
+        throw new IllegalStateException("An Observation can be used with a Dataset only once")
+      }
+      this.sparkSession = Some(sparkSession)
     }
-    this.sparkSession = Some(sparkSession)
+
     sparkSession.listenerManager.register(listener)
   }
 
@@ -109,12 +104,9 @@ class Observation(name: String) {
   }
 
   private[spark] def onFinish(funcName: String, qe: QueryExecution): Unit = {
-    lock.lock()
-    try {
-      this.row = getMetricRow(qe.observedMetrics)
-      if (this.row.isDefined) completed.signalAll()
-    } finally {
-      lock.unlock()
+    synchronized {
+      this.row = qe.observedMetrics.get(name)
+      if (this.row.isDefined) this.notifyAll()
     }
     unregister()
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -43,7 +43,7 @@ class Observation(name: String) {
    * @tparam T dataset type
    * @return observed dataset
    */
-  def on[T](ds: Dataset[T])(expr: Column, exprs: Column*): Dataset[T] = {
+  def on[T](ds: Dataset[T], expr: Column, exprs: Column*): Dataset[T] = {
     if (ds.isStreaming) {
       throw new IllegalArgumentException("Observation does not support streaming Datasets")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.util.QueryExecutionListener
 
 
 /**
- * Helper class to simplify usage of [[Dataset.observe(String, Column, Column*)]]:
+ * Helper class to simplify usage of [[Dataset.observe(String, Column, Column*) observe]]:
  *
  * {{{
  *   // Observe row count (rows) and highest id (maxid) in the Dataset while writing it
@@ -52,7 +52,7 @@ class Observation(name: String) {
   @volatile private var row: Option[Row] = None
 
   /**
-   * Attaches this observation to the given [[Dataset]] to observe aggregation expressions.
+   * Attach this observation to the given [[Dataset]] to observe aggregation expressions.
    *
    * @param ds dataset
    * @param expr first aggregation expression
@@ -74,7 +74,7 @@ class Observation(name: String) {
    * Only the result of the first action is available. Subsequent actions do not modify the result.
    *
    * @return the observed metrics as a [[Row]]
-   * @throws InterruptedException interrupted while waiting
+   * @throws java.lang.InterruptedException interrupted while waiting
    */
   def get: Row = {
     synchronized {

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -68,7 +68,6 @@ class Observation(name: String) {
    */
   def get: Row = {
     assert(waitCompleted(None, TimeUnit.SECONDS), "waitCompleted without timeout returned false")
-    assert(row.isDefined, "waitCompleted without timeout returned while result is still None")
     row.get
   }
 
@@ -106,7 +105,8 @@ class Observation(name: String) {
   private[spark] def onFinish(funcName: String, qe: QueryExecution): Unit = {
     synchronized {
       this.row = qe.observedMetrics.get(name)
-      if (this.row.isDefined) this.notifyAll()
+      assert(this.row.isDefined, "No metric provided by QueryExecutionListener")
+      this.notifyAll()
     }
     unregister()
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -45,6 +45,11 @@ import org.apache.spark.sql.util.QueryExecutionListener
  */
 class Observation(name: String) {
 
+  /**
+   * Create an Observation instance without providing a name. This generates a random name.
+   */
+  def this() = this(UUID.randomUUID().toString)
+
   private val listener: ObservationListener = ObservationListener(this)
 
   @volatile private var sparkSession: Option[SparkSession] = None
@@ -133,14 +138,15 @@ private[sql] case class ObservationListener(observation: Observation)
 }
 
 /**
- * (Scala-specific) Create a named or anonymous instance of Observation.
+ * (Scala-specific) Create instances of Observation via Scala `apply`.
+ * @since 3.3.0
  */
 object Observation {
 
   /**
    * Observation constructor for creating an anonymous observation.
    */
-  def apply(): Observation = new Observation(UUID.randomUUID().toString)
+  def apply(): Observation = new Observation()
 
   /**
    * Observation constructor for creating a named observation.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.util.QueryExecutionListener
  * This class does not support streaming datasets.
  *
  * @param name name of the metric
- * @since 3.2.0
+ * @since 3.3.0
  */
 class Observation(name: String) {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -94,7 +94,7 @@ class Observation(name: String) {
     // all other threads will see the exception, as it is only allowed to do this once
     synchronized {
       if (this.sparkSession.isDefined) {
-        throw new IllegalStateException("An Observation can be used with a Dataset only once")
+        throw new IllegalArgumentException("An Observation can be used with a Dataset only once")
       }
       this.sparkSession = Some(sparkSession)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -87,7 +87,7 @@ class Observation(name: String) {
    * @return true if action completed within timeout, false otherwise
    * @throws InterruptedException interrupted while waiting
    */
-  def waitCompleted(time: Long, unit: TimeUnit): Boolean = waitCompleted(Some(time), unit)
+  def waitCompleted(time: Long, unit: TimeUnit): Boolean = waitCompleted(Some(unit.toMillis(time)))
 
   /**
    * Get the observed metrics. This waits until the observed dataset finishes its first action.
@@ -98,15 +98,15 @@ class Observation(name: String) {
    * @throws InterruptedException interrupted while waiting
    */
   def get: Row = {
-    assert(waitCompleted(None, TimeUnit.SECONDS), "waitCompleted without timeout returned false")
+    assert(waitCompleted(None), "waitCompleted without timeout returned false")
     row.get
   }
 
-  private def waitCompleted(time: Option[Long], unit: TimeUnit): Boolean = {
+  private def waitCompleted(millis: Option[Long]): Boolean = {
     synchronized {
       if (row.isEmpty) {
-        if (time.isDefined) {
-          this.wait(unit.toMillis(time.get))
+        if (millis.isDefined) {
+          this.wait(millis.get)
         } else {
           this.wait()
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -102,7 +102,7 @@ class Observation(name: String) {
     this.sparkSession.foreach(_.listenerManager.unregister(listener))
   }
 
-  private[spark] def onFinish(funcName: String, qe: QueryExecution): Unit = {
+  private[spark] def onFinish(qe: QueryExecution): Unit = {
     synchronized {
       this.row = qe.observedMetrics.get(name)
       assert(this.row.isDefined, "No metric provided by QueryExecutionListener")
@@ -117,10 +117,10 @@ private[sql] case class ObservationListener(observation: Observation)
   extends QueryExecutionListener {
 
   override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit =
-    observation.onFinish(funcName, qe)
+    observation.onFinish(qe)
 
   override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit =
-    observation.onFinish(funcName, qe)
+    observation.onFinish(qe)
 
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Observation.scala
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.{Condition, Lock, ReentrantLock}
+
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.util.QueryExecutionListener
+
+/**
+ * Not thread-safe.
+ * @param name
+ * @param expr
+ * @param exprs
+ * @param sparkSession
+ */
+case class Observation(name: String, expr: Column, exprs: Column*)
+                      (implicit sparkSession: SparkSession) {
+
+  val lock: Lock = new ReentrantLock()
+  val completed: Condition = lock.newCondition()
+  val listener: ObservationListener = ObservationListener(this)
+  register()
+
+  @transient var row: Option[Row] = None
+
+  /**
+   * Attach this observation to the given Dataset.
+   * Remember to call `close()` when the observation is done.
+   *
+   * @param ds dataset
+   * @tparam T dataset type
+   * @return observed dataset
+   */
+  def on[T](ds: Dataset[T]): Dataset[T] = {
+    if (ds.isStreaming) {
+      throw new IllegalArgumentException("Observation does not support streaming Datasets")
+    }
+    ds.observe(name, expr, exprs: _*)
+  }
+
+  /**
+   * Get the observation results. Waits for the first action on the observed dataset to complete.
+   * After calling `reset()`, waits for completion of the next action on the observed dataset.
+   */
+  def get: Row = option().get
+
+  /**
+   * Get the observation results. Waits for the first action on the observed dataset to complete.
+   * This method times out waiting for the action after the given amount of time.
+   * After calling `reset()`, waits for completion of the next action on the observed dataset.
+   *
+   * @param time timeout
+   * @param unit timeout time unit
+   * @return observation row as an Option, or None on timeout
+   */
+  def option(time: Long, unit: TimeUnit): Option[Row] = option(Some(time), unit)
+
+  /**
+   * Wait for the first action on the observed dataset to complete.
+   * When the time parameter is given, this method times out waiting for the action.
+   * After calling `reset()`, waits for completion of the next action on the observed dataset.
+   *
+   * @param time timeout
+   * @param unit timeout time unit
+   * @return true if action complete within timeout, false on timeout
+   */
+  def waitCompleted(time: Option[Long] = None, unit: TimeUnit = TimeUnit.MILLISECONDS): Boolean = {
+    lock.lock()
+    try {
+      if (row.isEmpty) {
+        if (time.isDefined) {
+          completed.await(time.get, unit)
+        } else {
+          completed.await()
+        }
+      }
+      row.isDefined
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /**
+   * Wait for the first action on the observed dataset to complete.
+   * After calling `reset()`, waits for completion of the next action on the observed dataset.
+   *
+   * @param time timeout
+   * @param unit timeout time unit
+   * @return true if action complete within timeout, false on timeout
+   */
+  def waitCompleted(time: Long, unit: TimeUnit): Boolean = waitCompleted(Some(time), unit)
+
+  /**
+   * Reset the observation. This deletes the observation and allows to wait for completion
+   * of the next action called on the observed dataset.
+   */
+  def reset(): Unit = {
+    lock.lock()
+    try {
+      row = None
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /**
+   * Terminates the observation. Subsequent calls to actions on the observed dataset
+   * will not update the observation. The current observation persists after calling this method.
+   */
+  def close(): Unit = unregister()
+
+  private def option(time: Option[Long] = None,
+                     unit: TimeUnit = TimeUnit.MILLISECONDS): Option[Row] = {
+    waitCompleted(time, unit)
+    row
+  }
+
+  private[spark] def onFinish(funcName: String, qe: QueryExecution): Unit = {
+    lock.lock()
+    try {
+      this.row = getMetricRow(qe.observedMetrics)
+      if (this.row.isDefined) completed.signalAll()
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  private def getMetricRow(metrics: Map[String, Row]): Option[Row] =
+    metrics
+      .find { case (metricName, _) => metricName.equals(name) }
+      .map { case (_, row) => row }
+
+  private def register(): Unit = sparkSession.listenerManager.register(listener)
+
+  private def unregister(): Unit = sparkSession.listenerManager.unregister(listener)
+
+}
+
+private[sql] case class ObservationListener(observation: Observation)
+  extends QueryExecutionListener {
+
+  override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit =
+    observation.onFinish(funcName, qe)
+
+  override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit =
+    observation.onFinish(funcName, qe)
+
+}
+
+object Observation {
+
+  /**
+   * Observation helper class to simplify calling Dataset.observe().
+   *
+   * This class is not thread-safe. Use it in a single thread or guard access via a lock.
+   *
+   * @param expr metric expression
+   * @param exprs metric expressions
+   */
+  def apply(expr: Column, exprs: Column*)(implicit sparkSession: SparkSession): Observation =
+    new Observation(UUID.randomUUID().toString, expr, exprs: _*)
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -684,6 +684,12 @@ class SparkSession private(
     ret
   }
 
+  def observation(expr: Column, exprs: Column*): Observation =
+    observation(UUID.randomUUID().toString, expr, exprs: _*)
+
+  def observation(name: String, expr: Column, exprs: Column*): Observation =
+    Observation(name, expr, exprs: _*)(this)
+
   // scalastyle:off
   // Disable style checker so "implicits" object can start with lowercase i
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -684,12 +684,6 @@ class SparkSession private(
     ret
   }
 
-  def observation(expr: Column, exprs: Column*): Observation =
-    observation(UUID.randomUUID().toString, expr, exprs: _*)
-
-  def observation(name: String, expr: Column, exprs: Column*): Observation =
-    Observation(name, expr, exprs: _*)(this)
-
   // scalastyle:off
   // Disable style checker so "implicits" object can start with lowercase i
   /**

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -33,7 +33,6 @@ import org.junit.*;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Observation;
 import org.apache.spark.sql.Row;
@@ -539,16 +538,13 @@ public class JavaDataFrameSuite {
       .observe(
         namedObservation,
         min(col("id")).as("min_val"),
-        scala.collection.JavaConverters.asScalaBuffer(Arrays.asList(
-          max(col("id")).as("max_val"),
-          sum(col("id")).as("sum_val"),
-          count(when(pmod(col("id"), lit(2)).$eq$eq$eq(0), 1)).as("num_even")
-        )).toSeq()
+        max(col("id")).as("max_val"),
+        sum(col("id")).as("sum_val"),
+        count(when(pmod(col("id"), lit(2)).$eq$eq$eq(0), 1)).as("num_even")
       )
       .observe(
         unnamedObservation,
-        avg(col("id")).cast("int").as("avg_val"),
-        scala.collection.JavaConverters.asScalaBuffer(Collections.<Column>emptyList()).toSeq()
+        avg(col("id")).cast("int").as("avg_val")
       );
 
     df.collect();

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -551,28 +551,26 @@ public class JavaDataFrameSuite {
       );
 
     df.collect();
-    Row namedMetrics = null;
-    Row unnamedMetrics = null;
+    List<?> namedMetrics = null;
+    List<?> unnamedMetrics = null;
 
     try {
-      // we can get the result multiple times
-      namedMetrics = namedObservation.get();
-      unnamedMetrics = unnamedObservation.get();
+      namedMetrics = JavaConverters.seqAsJavaList(namedObservation.get().toSeq());
+      unnamedMetrics = JavaConverters.seqAsJavaList(unnamedObservation.get().toSeq());
     } catch (InterruptedException e) {
       Assert.fail();
     }
-    Assert.assertEquals(Arrays.asList(0L, 99L, 4950L, 50L), scala.collection.JavaConverters.seqAsJavaList(namedMetrics.toSeq()));
-    Assert.assertEquals(Arrays.asList(49), scala.collection.JavaConverters.seqAsJavaList(unnamedMetrics.toSeq()));
+    Assert.assertEquals(Arrays.asList(0L, 99L, 4950L, 50L), namedMetrics);
+    Assert.assertEquals(Arrays.asList(49), unnamedMetrics);
 
     // we can get the result multiple times
     try {
-      // we can get the result multiple times
-      namedMetrics = namedObservation.get();
-      unnamedMetrics = unnamedObservation.get();
+      namedMetrics = JavaConverters.seqAsJavaList(namedObservation.get().toSeq());
+      unnamedMetrics = JavaConverters.seqAsJavaList(unnamedObservation.get().toSeq());
     } catch (InterruptedException e) {
       Assert.fail();
     }
-    Assert.assertEquals(Arrays.asList(0L, 99L, 4950L, 50L), scala.collection.JavaConverters.seqAsJavaList(namedMetrics.toSeq()));
-    Assert.assertEquals(Arrays.asList(49), scala.collection.JavaConverters.seqAsJavaList(unnamedMetrics.toSeq()));
+    Assert.assertEquals(Arrays.asList(0L, 99L, 4950L, 50L), namedMetrics);
+    Assert.assertEquals(Arrays.asList(49), unnamedMetrics);
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -34,6 +34,7 @@ import org.junit.*;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Observation;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.expressions.UserDefinedFunction;
@@ -533,21 +534,21 @@ public class JavaDataFrameSuite {
     Observation unnamedObservation = new Observation();
 
     Dataset<Long> df = spark
-            .range(100)
-            .observe(
-                    namedObservation,
-                    min(col("id")).as("min_val"),
-                    scala.collection.JavaConverters.asScalaBuffer(Arrays.asList(
-                            max(col("id")).as("max_val"),
-                            sum(col("id")).as("sum_val"),
-                            count(when(pmod(col("id"), lit(2)).$eq$eq$eq(0), 1)).as("num_even")
-                    ))
-            )
-            .observe(
-                    unnamedObservation,
-                    avg(col("id")).cast("int").as("avg_val"),
-                    scala.collection.JavaConverters.asScalaBuffer(Arrays.asList())
-            );
+      .range(100)
+      .observe(
+        namedObservation,
+        min(col("id")).as("min_val"),
+        scala.collection.JavaConverters.asScalaBuffer(Arrays.asList(
+          max(col("id")).as("max_val"),
+          sum(col("id")).as("sum_val"),
+          count(when(pmod(col("id"), lit(2)).$eq$eq$eq(0), 1)).as("num_even")
+        ))
+      )
+      .observe(
+        unnamedObservation,
+        avg(col("id")).cast("int").as("avg_val"),
+        scala.collection.JavaConverters.asScalaBuffer(Arrays.asList())
+      );
 
     df.collect();
     Row namedMetrics = null;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -33,6 +33,7 @@ import org.junit.*;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Observation;
 import org.apache.spark.sql.Row;
@@ -542,12 +543,12 @@ public class JavaDataFrameSuite {
           max(col("id")).as("max_val"),
           sum(col("id")).as("sum_val"),
           count(when(pmod(col("id"), lit(2)).$eq$eq$eq(0), 1)).as("num_even")
-        ))
+        )).toSeq()
       )
       .observe(
         unnamedObservation,
         avg(col("id")).cast("int").as("avg_val"),
-        scala.collection.JavaConverters.asScalaBuffer(Arrays.asList())
+        scala.collection.JavaConverters.asScalaBuffer(Collections.<Column>emptyList()).toSeq()
       );
 
     df.collect();

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2440,6 +2440,14 @@ class DataFrameSuite extends QueryTest
       unnamedObservation.close()
     }
 
+    // an unused observation can be closed
+    Observation().close()
+
+    // an observation can be used only once
+    assertThrows[IllegalStateException] {
+      spark.range(100).observe(namedObservation, sum($"id").as("sum_val"))
+    }
+
     // streaming datasets are not supported
     val streamDf = new MemoryStream[Int](0, sqlContext).toDF()
     val streamObservation = Observation("stream")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2406,10 +2406,9 @@ class DataFrameSuite extends QueryTest
       assert(unnamedMetric === Row(49))
     }
 
-    // First run
     df.collect()
-    checkMetrics(namedObservation.get, unnamedObservation.get)
     // we can get the result multiple times
+    checkMetrics(namedObservation.get, unnamedObservation.get)
     checkMetrics(namedObservation.get, unnamedObservation.get)
 
     // an observation can be used only once

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2413,16 +2413,18 @@ class DataFrameSuite extends QueryTest
     checkMetrics(namedObservation.get, unnamedObservation.get)
 
     // an observation can be used only once
-    assertThrows[IllegalStateException] {
+    val err = intercept[IllegalArgumentException] {
       spark.range(100).observe(namedObservation, sum($"id").as("sum_val"))
     }
+    assert(err.getMessage.contains("An Observation can be used with a Dataset only once"))
 
     // streaming datasets are not supported
     val streamDf = new MemoryStream[Int](0, sqlContext).toDF()
     val streamObservation = Observation("stream")
-    assertThrows[IllegalArgumentException] {
+    val streamErr = intercept[IllegalArgumentException] {
       streamDf.observe(streamObservation, avg($"value").cast("int").as("avg_val"))
     }
+    assert(streamErr.getMessage.contains("Observation does not support streaming Datasets"))
   }
 
   test("SPARK-25159: json schema inference should only trigger one job") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -22,7 +22,6 @@ import java.lang.{Long => JLong}
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 import java.util.{Locale, UUID}
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.reflect.runtime.universe.TypeTag
@@ -2407,14 +2406,8 @@ class DataFrameSuite extends QueryTest
       assert(unnamedMetric === Row(49))
     }
 
-    // Before first run observation times out
-    assert(namedObservation.waitCompleted(100, TimeUnit.MILLISECONDS) === false)
-    assert(unnamedObservation.waitCompleted(100, TimeUnit.MILLISECONDS) === false)
-
     // First run
     df.collect()
-    assert(namedObservation.waitCompleted(1, TimeUnit.SECONDS))
-    assert(unnamedObservation.waitCompleted(1, TimeUnit.SECONDS))
     checkMetrics(namedObservation.get, unnamedObservation.get)
     // we can get the result multiple times
     checkMetrics(namedObservation.get, unnamedObservation.get)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request introduces a helper class that simplifies usage of `Dataset.observe()` for batch datasets:

    val observation = Observation("name")
    val observed = ds.observe(observation, max($"id").as("max_id"))
    observed.count()
    val metrics = observation.get

### Why are the changes needed?
Currently, users are required to implement the `QueryExecutionListener` interface to retrieve the metrics, as well as apply some knowledge on threading and locking to pull the metrics over to the main thread. With the helper class, metrics can be retrieved from batch dataset processing with three lines of code (the action on the observed dataset does not count as a line of code here).

### Does this PR introduce _any_ user-facing change?
Yes, one new class and one `Dataset`` method.

### How was this patch tested?
Adds a unit test to `DataFrameSuite`, similar to `"get observable metrics by callback"` in `DataFrameCallbackSuite`.