### PR TITLE
[SPARK-31907][DOCS][SQL] Adding location of SQL API documentation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -45,8 +45,8 @@ import org.apache.spark.util.Utils
  * Spark also includes more built-in functions that are less common and are not defined here.
  * You can still access them (and all the functions defined here) using the `functions.expr()` API
  * and calling them through a SQL expression string. You can find the entire list of functions
- * at SQL API documentation (https://spark.apache.org/docs/latest/api/sql/index.html or
- * https://spark.apache.org/docs/<version>/api/sql/index.html for older versions).
+ * at SQL API documentation of your Spark version, see also
+ * <a href="https://spark.apache.org/docs/latest/api/sql/index.html">the latest list</a>
  *
  * As an example, `isnan` is a function that is defined here. You can use `isnan(col("myCol"))`
  * to invoke the `isnan` function. This way the programming language's compiler ensures `isnan`

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -45,7 +45,7 @@ import org.apache.spark.util.Utils
  * Spark also includes more built-in functions that are less common and are not defined here.
  * You can still access them (and all the functions defined here) using the `functions.expr()` API
  * and calling them through a SQL expression string. You can find the entire list of functions
- * at SQL API documentation.
+ * at SQL API documentation (https://spark.apache.org/docs/latest/api/sql/index.html).
  *
  * As an example, `isnan` is a function that is defined here. You can use `isnan(col("myCol"))`
  * to invoke the `isnan` function. This way the programming language's compiler ensures `isnan`

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -45,7 +45,8 @@ import org.apache.spark.util.Utils
  * Spark also includes more built-in functions that are less common and are not defined here.
  * You can still access them (and all the functions defined here) using the `functions.expr()` API
  * and calling them through a SQL expression string. You can find the entire list of functions
- * at SQL API documentation (https://spark.apache.org/docs/latest/api/sql/index.html).
+ * at SQL API documentation (https://spark.apache.org/docs/latest/api/sql/index.html or
+ * https://spark.apache.org/docs/<version>/api/sql/index.html for older versions).
  *
  * As an example, `isnan` is a function that is defined here. You can use `isnan(col("myCol"))`
  * to invoke the `isnan` function. This way the programming language's compiler ensures `isnan`


### PR DESCRIPTION

### What changes were proposed in this pull request?
Linking to location of SQL API documentation, making it easier and quicker to find it.


### Why are the changes needed?
documentation clarity


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Only documentation change
