### PR TITLE
[SPARK-36226][PYTHON][DOCS] Improve python docstring links to other classes

### DIFF
--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -208,7 +208,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
     @df_varargs_api
     def sum(self, *cols):
-        """Compute the sum for each numeric columns for each group.
+        """Computes the sum for each numeric columns for each group.
 
         .. versionadded:: 1.3.0
 
@@ -238,7 +238,7 @@ class GroupedData(PandasGroupedOpsMixin):
         ----------
         pivot_col : str
             Name of the column to pivot.
-        values :
+        values : list, optional
             List of values that will be translated to columns in the output DataFrame.
 
         Examples

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -73,7 +73,7 @@ class SparkSession(SparkConversionMixin):
 
     A SparkSession can be used create :class:`DataFrame`, register :class:`DataFrame` as
     tables, execute SQL over tables, cache tables, and read parquet files.
-    To create a SparkSession, use the following builder pattern:
+    To create a :class:`SparkSession`, use the following builder pattern:
 
     .. autoattribute:: builder
        :annotation:
@@ -280,8 +280,8 @@ class SparkSession(SparkConversionMixin):
     @since(2.0)
     def newSession(self):
         """
-        Returns a new SparkSession as new session, that has separate SQLConf,
-        registered temporary views and UDFs, but shared SparkContext and
+        Returns a new :class:`SparkSession` as new session, that has separate SQLConf,
+        registered temporary views and UDFs, but shared :class:`SparkContext` and
         table cache.
         """
         return self.__class__(self._sc, self._jsparkSession.newSession())
@@ -289,7 +289,7 @@ class SparkSession(SparkConversionMixin):
     @classmethod
     def getActiveSession(cls):
         """
-        Returns the active SparkSession for the current thread, returned by the builder
+        Returns the active :class:`SparkSession` for the current thread, returned by the builder
 
         .. versionadded:: 3.0.0
 
@@ -533,9 +533,9 @@ class SparkSession(SparkConversionMixin):
     @staticmethod
     def _create_shell_session():
         """
-        Initialize a SparkSession for a pyspark shell session. This is called from shell.py
-        to make error handling simpler without needing to declare local variables in that
-        script, which would expose those to users.
+        Initialize a :class:`SparkSession` for a pyspark shell session. This is called from
+        shell.py to make error handling simpler without needing to declare local variables in
+        that script, which would expose those to users.
         """
         import py4j
         from pyspark.conf import SparkConf

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -398,9 +398,9 @@ class StructField(DataType):
         name of the field.
     dataType : :class:`DataType`
         :class:`DataType` of the field.
-    nullable : bool
+    nullable : bool, optional
         whether the field can be null (None) or not.
-    metadata : dict
+    metadata : dict, optional
         a dict from string to simple type that can be toInternald to JSON automatically
 
     Examples
@@ -498,20 +498,20 @@ class StructType(DataType):
 
     def add(self, field, data_type=None, nullable=True, metadata=None):
         """
-        Construct a StructType by adding new elements to it, to define the schema.
+        Construct a :class:`StructType` by adding new elements to it, to define the schema.
         The method accepts either:
 
-            a) A single parameter which is a StructField object.
+            a) A single parameter which is a :class:`StructField` object.
             b) Between 2 and 4 parameters as (name, data_type, nullable (optional),
                metadata(optional). The data_type parameter may be either a String or a
-               DataType object.
+               :class:`DataType` object.
 
         Parameters
         ----------
         field : str or :class:`StructField`
-            Either the name of the field or a StructField object
+            Either the name of the field or a :class:`StructField` object
         data_type : :class:`DataType`, optional
-            If present, the DataType of the StructField to create
+            If present, the DataType of the :class:`StructField` to create
         nullable : bool, optional
             Whether the field to add should be nullable (default True)
         metadata : dict, optional


### PR DESCRIPTION

### What changes were proposed in this pull request?
additional links to other classes in python documentation


### Why are the changes needed?
python docstring syntax wasn't fully used everywhere


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Documentation change only
