### PR TITLE
[SPARK-35848][MLLIB] Optimize some treeAggregates in MLlib by delaying allocations

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringMetrics.scala
@@ -298,23 +298,36 @@ private[evaluation] object SquaredEuclideanSilhouette extends Silhouette {
       col(predictionCol).cast(DoubleType), col(featuresCol), col("squaredNorm"), col(weightCol))
       .rdd
       .map { row => (row.getDouble(0), (row.getAs[Vector](1), row.getDouble(2), row.getDouble(3))) }
-      .aggregateByKey
-      [(DenseVector, Double, Double)]((Vectors.zeros(numFeatures).toDense, 0.0, 0.0))(
+      .aggregateByKey[(DenseVector, Double, Double)]((null.asInstanceOf[DenseVector], 0.0, 0.0))(
         seqOp = {
           case (
             (featureSum: DenseVector, squaredNormSum: Double, weightSum: Double),
             (features, squaredNorm, weight)
             ) =>
-            BLAS.axpy(weight, features, featureSum)
-            (featureSum, squaredNormSum + squaredNorm * weight, weightSum + weight)
+            val theFeatureSum =
+              if (featureSum == null) {
+                Vectors.zeros(numFeatures).toDense
+              } else {
+                featureSum
+              }
+            BLAS.axpy(weight, features, theFeatureSum)
+            (theFeatureSum, squaredNormSum + squaredNorm * weight, weightSum + weight)
         },
         combOp = {
           case (
             (featureSum1, squaredNormSum1, weightSum1),
             (featureSum2, squaredNormSum2, weightSum2)
             ) =>
-            BLAS.axpy(1.0, featureSum2, featureSum1)
-            (featureSum1, squaredNormSum1 + squaredNormSum2, weightSum1 + weightSum2)
+            val theFeatureSum =
+              if (featureSum1 == null) {
+                featureSum2
+              } else if (featureSum2 == null) {
+                featureSum1
+              } else {
+                BLAS.axpy(1.0, featureSum2, featureSum1)
+                featureSum1
+              }
+            (theFeatureSum, squaredNormSum1 + squaredNormSum2, weightSum1 + weightSum2)
         }
       )
 
@@ -503,17 +516,31 @@ private[evaluation] object CosineSilhouette extends Silhouette {
       col(predictionCol).cast(DoubleType), col(normalizedFeaturesColName), col(weightCol))
       .rdd
       .map { row => (row.getDouble(0), (row.getAs[Vector](1), row.getDouble(2))) }
-      .aggregateByKey[(DenseVector, Double)]((Vectors.zeros(numFeatures).toDense, 0.0))(
+      .aggregateByKey[(DenseVector, Double)]((null.asInstanceOf[DenseVector], 0.0))(
       seqOp = {
         case ((normalizedFeaturesSum: DenseVector, weightSum: Double),
         (normalizedFeatures, weight)) =>
-          BLAS.axpy(weight, normalizedFeatures, normalizedFeaturesSum)
-          (normalizedFeaturesSum, weightSum + weight)
+          val theNormalizedFeaturesSum =
+            if (normalizedFeaturesSum == null) {
+              Vectors.zeros(numFeatures).toDense
+            } else {
+              normalizedFeaturesSum
+            }
+          BLAS.axpy(weight, normalizedFeatures, theNormalizedFeaturesSum)
+          (theNormalizedFeaturesSum, weightSum + weight)
       },
       combOp = {
         case ((normalizedFeaturesSum1, weightSum1), (normalizedFeaturesSum2, weightSum2)) =>
-          BLAS.axpy(1.0, normalizedFeaturesSum2, normalizedFeaturesSum1)
-          (normalizedFeaturesSum1, weightSum1 + weightSum2)
+          val theNormalizedFeaturesSum =
+            if (normalizedFeaturesSum1 == null) {
+              normalizedFeaturesSum2
+            } else if (normalizedFeaturesSum2 == null) {
+              normalizedFeaturesSum1
+            } else {
+              BLAS.axpy(1.0, normalizedFeaturesSum2, normalizedFeaturesSum1)
+              normalizedFeaturesSum1
+            }
+          (theNormalizedFeaturesSum, weightSum1 + weightSum2)
       }
     )
 

--- a/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/evaluation/ClusteringMetrics.scala
@@ -300,10 +300,9 @@ private[evaluation] object SquaredEuclideanSilhouette extends Silhouette {
       .map { row => (row.getDouble(0), (row.getAs[Vector](1), row.getDouble(2), row.getDouble(3))) }
       .aggregateByKey[(DenseVector, Double, Double)]((null.asInstanceOf[DenseVector], 0.0, 0.0))(
         seqOp = {
-          case (
-            (featureSum: DenseVector, squaredNormSum: Double, weightSum: Double),
-            (features, squaredNorm, weight)
-            ) =>
+          case t: ((DenseVector, Double, Double), (Vector, Double, Double)) =>
+            val ((featureSum, squaredNormSum, weightSum),
+                 (features: Vector, squaredNorm, weight)) = t
             val theFeatureSum =
               if (featureSum == null) {
                 Vectors.zeros(numFeatures).toDense
@@ -314,10 +313,9 @@ private[evaluation] object SquaredEuclideanSilhouette extends Silhouette {
             (theFeatureSum, squaredNormSum + squaredNorm * weight, weightSum + weight)
         },
         combOp = {
-          case (
-            (featureSum1, squaredNormSum1, weightSum1),
-            (featureSum2, squaredNormSum2, weightSum2)
-            ) =>
+          case t: ((DenseVector, Double, Double), (DenseVector, Double, Double)) =>
+            val ((featureSum1, squaredNormSum1, weightSum1),
+                 (featureSum2, squaredNormSum2, weightSum2)) = t
             val theFeatureSum =
               if (featureSum1 == null) {
                 featureSum2
@@ -518,8 +516,8 @@ private[evaluation] object CosineSilhouette extends Silhouette {
       .map { row => (row.getDouble(0), (row.getAs[Vector](1), row.getDouble(2))) }
       .aggregateByKey[(DenseVector, Double)]((null.asInstanceOf[DenseVector], 0.0))(
       seqOp = {
-        case ((normalizedFeaturesSum: DenseVector, weightSum: Double),
-        (normalizedFeatures, weight)) =>
+        case t: ((DenseVector, Double), (Vector, Double)) =>
+          val ((normalizedFeaturesSum, weightSum), (normalizedFeatures, weight)) = t
           val theNormalizedFeaturesSum =
             if (normalizedFeaturesSum == null) {
               Vectors.zeros(numFeatures).toDense
@@ -530,7 +528,8 @@ private[evaluation] object CosineSilhouette extends Silhouette {
           (theNormalizedFeaturesSum, weightSum + weight)
       },
       combOp = {
-        case ((normalizedFeaturesSum1, weightSum1), (normalizedFeaturesSum2, weightSum2)) =>
+        case t: ((DenseVector, Double), (DenseVector, Double)) =>
+          val ((normalizedFeaturesSum1, weightSum1), (normalizedFeaturesSum2, weightSum2)) = t
           val theNormalizedFeaturesSum =
             if (normalizedFeaturesSum1 == null) {
               normalizedFeaturesSum2

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAOptimizer.scala
@@ -490,16 +490,24 @@ final class OnlineLDAOptimizer extends LDAOptimizer with Logging {
         Iterator((stat, logphatPartOption, nonEmptyDocCount))
     }
 
-    val elementWiseSum = (
+    def elementWiseSum(
         u: (BDM[Double], Option[BDV[Double]], Long),
-        v: (BDM[Double], Option[BDV[Double]], Long)) => {
-      u._1 += v._1
+        v: (BDM[Double], Option[BDV[Double]], Long)): (BDM[Double], Option[BDV[Double]], Long) = {
+      val vec =
+        if (u._1 == null) {
+          v._1
+        } else if (v._1 == null) {
+          u._1
+        } else {
+          u._1 += v._1
+          u._1
+        }
       u._2.foreach(_ += v._2.get)
-      (u._1, u._2, u._3 + v._3)
+      (vec, u._2, u._3 + v._3)
     }
 
     val (statsSum: BDM[Double], logphatOption: Option[BDV[Double]], nonEmptyDocsN: Long) = stats
-      .treeAggregate((BDM.zeros[Double](k, vocabSize), logphatPartOptionBase(), 0L))(
+      .treeAggregate((null.asInstanceOf[BDM[Double]], logphatPartOptionBase(), 0L))(
         elementWiseSum, elementWiseSum
       )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Optimize some treeAggregates in MLlib by delaying allocating (thus not sending around) large arrays of zeroes
This uses the same idea as in https://github.com/apache/spark/pull/23600/files

### Why are the changes needed?

Allocating huge arrays of zeroes takes additional memory and network I/O which is unnecessary in some cases. It can cause operations to run out of memory that might otherwise succeed. Specifically, this should prevent the 'zero' value from having to be (pointlessly) checked for serializability, which can fail when passing through the default JavaSerializer; it would also prevent allocating and sending large 'zero' values for an empty partition in the aggregate.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.