### PR TITLE
[SPARK-36215][SHUFFLE] Add logging for slow fetches to diagnose external shuffle service issues

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1214,6 +1214,29 @@ package object config {
       .checkValue(_ > 0, "The max no. of blocks in flight cannot be non-positive.")
       .createWithDefault(Int.MaxValue)
 
+  private[spark] val REDUCER_SHUFFLE_FETCH_SLOW_LOG_THRESHOLD_MS =
+    ConfigBuilder("spark.reducer.shuffleFetchSlowLogThreshold.time")
+      .doc("When fetching blocks from an external shuffle service is slower than expected, the " +
+        "fetch will be logged to allow for subsequent investigation. A fetch is determined " +
+        "to be slow if it has a total duration of at least this value, and a transfer rate " +
+        // cannot reference val REDUCER_SHUFFLE_FETCH_SLOW_LOG_THRESHOLD_BPS since its uninitialized
+        "less than spark.reducer.shuffleFetchSlowLogThreshold.bytesPerSec")
+      .version("3.2.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .checkValue(_ > 0, "The shuffle fetch slow log threshold time must be greater than 0")
+      .createWithDefaultString("1s")
+
+  private[spark] val REDUCER_SHUFFLE_FETCH_SLOW_LOG_THRESHOLD_BPS =
+    ConfigBuilder("spark.reducer.shuffleFetchSlowLogThreshold.bytesPerSec")
+      .doc("When fetching blocks from an external shuffle service is slower than expected, the " +
+        "fetch will be logged to allow for subsequent investigation. A fetch is determined " +
+        "to be slow if it has a total duration of at least " +
+        s"${REDUCER_SHUFFLE_FETCH_SLOW_LOG_THRESHOLD_MS.key}, and a transfer rate less than this")
+      .version("3.2.0")
+      .bytesConf(ByteUnit.BYTE)
+      .checkValue(_ >= 0, "The shuffle fetch slow log threshold rate must non-negative")
+      .createWithDefaultString("1k")
+
   private[spark] val MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM =
     ConfigBuilder("spark.network.maxRemoteBlockSizeFetchToMem")
       .doc("Remote block will be fetched to disk when size of the block is above this threshold " +

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -81,6 +81,8 @@ private[spark] class BlockStoreShuffleReader[K, C](
       SparkEnv.get.conf.get(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS),
       SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
       SparkEnv.get.conf.get(config.SHUFFLE_MAX_ATTEMPTS_ON_NETTY_OOM),
+      SparkEnv.get.conf.get(config.REDUCER_SHUFFLE_FETCH_SLOW_LOG_THRESHOLD_MS),
+      SparkEnv.get.conf.get(config.REDUCER_SHUFFLE_FETCH_SLOW_LOG_THRESHOLD_BPS),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
       SparkEnv.get.conf.get(config.SHUFFLE_CHECKSUM_ENABLED),

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -40,7 +40,7 @@ import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
 import org.apache.spark.network.shuffle._
 import org.apache.spark.network.shuffle.checksum.{Cause, ShuffleChecksumHelper}
 import org.apache.spark.network.util.{NettyUtils, TransportConf}
-import org.apache.spark.shuffle.{FetchFailedException, ShuffleReadMetricsReporter}
+import org.apache.spark.shuffle.ShuffleReadMetricsReporter
 import org.apache.spark.util.{Clock, CompletionIterator, SystemClock, TaskCompletionListener, Utils}
 
 /**

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -1811,17 +1811,17 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         s"durationMs = $elapsedMs , " +
         s"transferBps = ${(totalBytes.toDouble / elapsedMs * 1000).toLong} )"
       assert(1 === appender.loggingEvents.size)
-      assert(1 === appender.loggingEvents.count(_.getRenderedMessage === expectedMessage))
+      assert(expectedMessage === appender.loggingEvents(0).getMessage.getFormattedMessage)
 
       // Fetch with a read that is slightly faster than the threshold
       fetcher.logFetchIfSlow(1000 * totalBytes / thresholdBps - 1, totalBytes, blockCount, bmId)
-      assert(1 === appender.loggingEvents.size)
+      assert(1 === appender.loggingEvents.size) // no new events
 
       // When the number of bytes is too small, even though the transfer rate is slow, the
       // thresholdMillis will not be satisfied
       val smallBytes = 10
       fetcher.logFetchIfSlow(1000 * smallBytes / thresholdBps + 1, smallBytes, blockCount, bmId)
-      assert(1 === appender.loggingEvents.size)
+      assert(1 === appender.loggingEvents.size) // no new events
     }
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2093,6 +2093,28 @@ Apart from these, the following properties are also available, and may be useful
   </td>
   <td>1.2.0</td>
 </tr>
+<tr>
+  <td><code>spark.reducer.shuffleFetchSlowLogThreshold.time</code></td>
+  <td>value of <code>spark.reducer.shuffleFetchSlowLogThreshold.time</code></td>
+  <td>
+    When fetching blocks from an external shuffle service is slower than expected, the
+    fetch will be logged to allow for subsequent investigation. A fetch is determined
+    to be slow if it has a total duration of at least this value, and a transfer rate
+    less than <code>spark.reducer.shuffleFetchSlowLogThreshold.bytesPerSec</code>.
+  </td>
+  <td>3.2.0</td>
+</tr>
+<tr>
+  <td><code>spark.reducer.shuffleFetchSlowLogThreshold.bytesPerSec</code></td>
+  <td>value of <code>spark.reducer.shuffleFetchSlowLogThreshold.bytesPerSec</code></td>
+  <td>
+    When fetching blocks from an external shuffle service is slower than expected, the
+    fetch will be logged to allow for subsequent investigation. A fetch is determined
+    to be slow if it has a total duration of at least <code>spark.reducer.shuffleFetchSlowLogThreshold.time</code>,
+    and a transfer rate less than this.
+  </td>
+  <td>3.2.0</td>
+</tr>
 </table>
 
 ### Scheduling

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2095,25 +2095,25 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.reducer.shuffleFetchSlowLogThreshold.time</code></td>
-  <td>value of <code>spark.reducer.shuffleFetchSlowLogThreshold.time</code></td>
+  <td>1s</td>
   <td>
     When fetching blocks from an external shuffle service is slower than expected, the
     fetch will be logged to allow for subsequent investigation. A fetch is determined
     to be slow if it has a total duration of at least this value, and a transfer rate
     less than <code>spark.reducer.shuffleFetchSlowLogThreshold.bytesPerSec</code>.
   </td>
-  <td>3.2.0</td>
+  <td>3.3.0</td>
 </tr>
 <tr>
   <td><code>spark.reducer.shuffleFetchSlowLogThreshold.bytesPerSec</code></td>
-  <td>value of <code>spark.reducer.shuffleFetchSlowLogThreshold.bytesPerSec</code></td>
+  <td>1k</td>
   <td>
     When fetching blocks from an external shuffle service is slower than expected, the
     fetch will be logged to allow for subsequent investigation. A fetch is determined
     to be slow if it has a total duration of at least <code>spark.reducer.shuffleFetchSlowLogThreshold.time</code>,
     and a transfer rate less than this.
   </td>
-  <td>3.2.0</td>
+  <td>3.3.0</td>
 </tr>
 </table>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add logging to `ShuffleBlockFetcherIterator` to log "slow" fetches, where slow is defined by two confs: `spark.reducer.shuffleFetchSlowLogThreshold.time` and `spark.reducer.shuffleFetchSlowLogThreshold.bytesPerSec`
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Currently we can see from the metrics that a task or stage has slow fetches, and the logs indicate *all* of the shuffle servers those tasks were fetching from, but often this is a big set (dozens or even hundreds) and narrowing down which one caused issues can be very difficult. This change makes it easier to understand which fetch is "slow".
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Adds two configs `spark.reducer.shuffleFetchSlowLogThreshold.time` and `spark.reducer.shuffleFetchSlowLogThreshold.bytesPerSec`


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit test