### PR TITLE
[SPARK-35809][PYTHON] Add `index_col` argument for ps.sql

### DIFF
--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -80,6 +80,7 @@ def sql(
             >>> psdf = ps.DataFrame({"A": [1, 2, 3], "B":[4, 5, 6]}, index=['a', 'b', 'c'])
             >>> psdf_reset_index = psdf.reset_index()
             >>> ps.sql("SELECT * FROM {psdf_reset_index}", index_col="index")
+            ... # doctest: +NORMALIZE_WHITESPACE
                    A  B
             index
             a      1  4
@@ -89,13 +90,14 @@ def sql(
             For MultiIndex,
 
             >>> psdf = ps.DataFrame(
-            >>>     {"A": [1, 2, 3], "B": [4, 5, 6]},
-            >>>     index=pd.MultiIndex.from_tuples(
-            >>>         [("a", "b"), ("c", "d"), ("e", "f")], names=["index1", "index2"]
-            >>>     ),
-            >>> )
+            ...     {"A": [1, 2, 3], "B": [4, 5, 6]},
+            ...     index=pd.MultiIndex.from_tuples(
+            ...         [("a", "b"), ("c", "d"), ("e", "f")], names=["index1", "index2"]
+            ...     ),
+            ... )
             >>> psdf_reset_index = psdf.reset_index()
             >>> ps.sql("SELECT * FROM {psdf_reset_index}", index_col=["index1", "index2"])
+            ... # doctest: +NORMALIZE_WHITESPACE
                            A  B
             index1 index2
             a      b       1  4

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -66,7 +66,7 @@ def sql(
     ----------
     query : str
         the SQL query
-    index_col: str or list of str, optional
+    index_col : str or list of str, optional
         Column names to be used in Spark to represent pandas-on-Spark's index. The index name
         in pandas-on-Spark is ignored. By default, the index is always lost.
     globals : dict, optional

--- a/python/pyspark/pandas/tests/test_sql.py
+++ b/python/pyspark/pandas/tests/test_sql.py
@@ -44,7 +44,8 @@ class SQLTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf = ps.DataFrame(
             {"A": [1, 2, 3], "B": [4, 5, 6]}, index=pd.Index(["a", "b", "c"], name="index")
         )
-        actual = ps.sql("select * from {psdf} where A > 1", index_col="index")
+        psdf_reset_index = psdf.reset_index()
+        actual = ps.sql("select * from {psdf_reset_index} where A > 1", index_col="index")
         expected = psdf.iloc[[1, 2]]
         self.assert_eq(actual, expected)
 
@@ -55,7 +56,10 @@ class SQLTest(PandasOnSparkTestCase, SQLTestUtils):
                 [("a", "b"), ("c", "d"), ("e", "f")], names=["index1", "index2"]
             ),
         )
-        actual = ps.sql("select * from {psdf} where A > 1", index_col=["index1", "index2"])
+        psdf_reset_index = psdf.reset_index()
+        actual = ps.sql(
+            "select * from {psdf_reset_index} where A > 1", index_col=["index1", "index2"]
+        )
         expected = psdf.iloc[[1, 2]]
         self.assert_eq(actual, expected)
 

--- a/python/pyspark/pandas/tests/test_sql.py
+++ b/python/pyspark/pandas/tests/test_sql.py
@@ -37,6 +37,28 @@ class SQLTest(PandasOnSparkTestCase, SQLTestUtils):
         with self.assertRaises(ParseException):
             ps.sql("this is not valid sql")
 
+    def test_sql_with_index_col(self):
+        import pandas as pd
+
+        # Index
+        psdf = ps.DataFrame(
+            {"A": [1, 2, 3], "B": [4, 5, 6]}, index=pd.Index(["a", "b", "c"], name="index")
+        )
+        actual = ps.sql("select * from {psdf} where A > 1", index_col="index")
+        expected = psdf.iloc[[1, 2]]
+        self.assert_eq(actual, expected)
+
+        # MultiIndex
+        psdf = ps.DataFrame(
+            {"A": [1, 2, 3], "B": [4, 5, 6]},
+            index=pd.MultiIndex.from_tuples(
+                [("a", "b"), ("c", "d"), ("e", "f")], names=["index1", "index2"]
+            ),
+        )
+        actual = ps.sql("select * from {psdf} where A > 1", index_col=["index1", "index2"])
+        expected = psdf.iloc[[1, 2]]
+        self.assert_eq(actual, expected)
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes adding an argument `index_col` for `ps.sql` function, to preserve the index when users want.

NOTE that the `reset_index()` have to be performed before using `ps.sql` with `index_col`.

```python
>>> psdf
   A  B
a  1  4
b  2  5
c  3  6
>>> psdf_reset_index = psdf.reset_index()
>>> ps.sql("SELECT * from {psdf_reset_index} WHERE A > 1", index_col="index")
       A  B
index
b      2  5
c      3  6
```

Otherwise, the index is always lost.

```python
>>> ps.sql("SELECT * from {psdf} WHERE A > 1")
   A  B
0  2  5
1  3  6
```


### Why are the changes needed?

Index is one of the key object for the existing pandas users, so we should provide the way to keep the index after computing the `ps.sql`.

### Does this PR introduce _any_ user-facing change?

Yes, the new argument is added.

### How was this patch tested?

Add a unit test and manually check the build pass.