### PR TITLE
[SPARK-36143][PYTHON] Adjust `astype` of fractional Series with missing values to follow pandas

### DIFF
--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -39,11 +39,12 @@ from pyspark.sql import functions as F
 from pyspark.sql.column import Column
 from pyspark.sql.types import (
     BooleanType,
+    DataType,
     StringType,
 )
 
 
-def _non_fractional_astype(index_ops, dtype, spark_type):
+def _non_fractional_astype(index_ops: IndexOpsLike, dtype: Dtype, spark_type: DataType):
     if isinstance(dtype, CategoricalDtype):
         return _as_categorical_type(index_ops, dtype, spark_type)
     elif isinstance(spark_type, BooleanType):

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -34,7 +34,7 @@ from pyspark.pandas.data_type_ops.base import (
     _as_string_type,
 )
 from pyspark.pandas.spark import functions as SF
-from pyspark.pandas.typedef import extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.typedef.typehints import extension_dtypes, pandas_on_spark_type
 from pyspark.sql import functions as F
 from pyspark.sql.column import Column
 from pyspark.sql.types import (

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -328,8 +328,9 @@ class FractionalOps(NumericOps):
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if index_ops.hasnans:
-            if is_integer_dtype(dtype) and not isinstance(dtype, extension_dtypes):
+
+        if is_integer_dtype(dtype) and not isinstance(dtype, extension_dtypes):
+            if index_ops.hasnans:
                 raise ValueError(
                     "Cannot convert %s with missing values to integer" % self.pretty_name
                 )
@@ -405,12 +406,14 @@ class IntegralExtensionOps(IntegralOps):
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)
-        if index_ops.hasnans:
-            if is_integer_dtype(dtype) and not isinstance(dtype, extension_dtypes):
+
+        if is_integer_dtype(dtype) and not isinstance(dtype, extension_dtypes):
+            if index_ops.hasnans:
                 raise ValueError(
                     "Cannot convert %s with missing values to integer" % self.pretty_name
                 )
-            elif is_bool_dtype(dtype) and not isinstance(dtype, extension_dtypes):
+        elif is_bool_dtype(dtype) and not isinstance(dtype, extension_dtypes):
+            if index_ops.hasnans:
                 raise ValueError("Cannot convert %s with missing values to bool" % self.pretty_name)
         return _non_fractional_astype(index_ops, dtype, spark_type)
 

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -333,8 +333,6 @@ class FractionalOps(NumericOps):
                 raise ValueError(
                     "Cannot convert %s with missing values to integer" % self.pretty_name
                 )
-            elif is_bool_dtype(dtype) and not isinstance(dtype, extension_dtypes):
-                raise ValueError("Cannot convert %s with missing values to bool" % self.pretty_name)
 
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -387,6 +387,7 @@ class DecimalOps(FractionalOps):
         )
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
+        # TODO(SPARK-36230): check index_ops.hasnans after fixing SPARK-36230
         dtype, spark_type = pandas_on_spark_type(dtype)
         return _non_fractional_astype(index_ops, dtype, spark_type)
 

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -430,3 +430,34 @@ class FractionalExtensionOps(FractionalOps):
     def restore(self, col: pd.Series) -> pd.Series:
         """Restore column when to_pandas."""
         return col.astype(self.dtype)
+
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+
+        if is_integer_dtype(dtype) and not isinstance(dtype, extension_dtypes):
+            if index_ops.hasnans:
+                raise ValueError(
+                    "Cannot convert %s with missing values to integer" % self.pretty_name
+                )
+        elif is_bool_dtype(dtype) and not isinstance(dtype, extension_dtypes):
+            if index_ops.hasnans:
+                raise ValueError("Cannot convert %s with missing values to bool" % self.pretty_name)
+
+        if isinstance(dtype, CategoricalDtype):
+            return _as_categorical_type(index_ops, dtype, spark_type)
+        elif isinstance(spark_type, BooleanType):
+            if isinstance(dtype, extension_dtypes):
+                scol = index_ops.spark.column.cast(spark_type)
+            else:
+                scol = F.when(
+                    index_ops.spark.column.isNull() | F.isnan(index_ops.spark.column),
+                    SF.lit(True),
+                ).otherwise(index_ops.spark.column.cast(spark_type))
+            return index_ops._with_new_scol(
+                scol.alias(index_ops._internal.data_spark_column_names[0]),
+                field=index_ops._internal.data_fields[0].copy(dtype=dtype, spark_type=spark_type),
+            )
+        elif isinstance(spark_type, StringType):
+            return _as_string_type(index_ops, dtype, null_str=str(np.nan))
+        else:
+            return _as_other_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -44,7 +44,9 @@ from pyspark.sql.types import (
 )
 
 
-def _non_fractional_astype(index_ops: IndexOpsLike, dtype: Dtype, spark_type: DataType):
+def _non_fractional_astype(
+    index_ops: IndexOpsLike, dtype: Dtype, spark_type: DataType
+) -> IndexOpsLike:
     if isinstance(dtype, CategoricalDtype):
         return _as_categorical_type(index_ops, dtype, spark_type)
     elif isinstance(spark_type, BooleanType):

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -3598,8 +3598,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 Window.unboundedPreceding, Window.unboundedFollowing
             )
             scol = stat_func(F.row_number().over(window1)).over(window2)
-        psser = self._with_new_scol(scol)
-        return psser.astype(np.float64)
+        return self._with_new_scol(scol)
 
     def filter(
         self,

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -3598,7 +3598,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 Window.unboundedPreceding, Window.unboundedFollowing
             )
             scol = stat_func(F.row_number().over(window1)).over(window2)
-        return self._with_new_scol(scol)
+        return self._with_new_scol(scol.cast(DoubleType()))
 
     def filter(
         self,

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -335,6 +335,25 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(pser.astype("category"), psser.astype("category"))
             cat_type = CategoricalDtype(categories=[2, 1, 3])
             self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
+        self.assertRaisesRegex(
+            ValueError,
+            "Cannot convert fractions with missing values to integer",
+            lambda: self.float_withnan_psser.astype(int),
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            "Cannot convert fractions with missing values to integer",
+            lambda: self.float_withnan_psser.astype(np.int32),
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            "Cannot convert fractions with missing values to bool",
+            lambda: self.float_withnan_psser.astype(bool),
+        )
+        self.assert_eq(self.float_withnan_psser.astype(str), self.float_withnan_psser.astype(str))
+        self.assert_eq(
+            self.float_withnan_psser.astype("category"), self.float_withnan_psser.astype("category")
+        )
 
     def test_neg(self):
         pdf, psdf = self.pdf, self.psdf
@@ -439,6 +458,24 @@ class IntegralExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                         self.check_extension(pser.astype(dtype), psser.astype(dtype))
                 else:
                     self.check_extension(pser.astype(dtype), psser.astype(dtype))
+        for pser, psser in self.intergral_extension_pser_psser_pairs:
+            self.assert_eq(pser.astype(float), psser.astype(float))
+            self.assert_eq(pser.astype(np.float32), psser.astype(np.float32))
+            self.assertRaisesRegex(
+                ValueError,
+                "Cannot convert integrals with missing values to bool",
+                lambda: psser.astype(bool),
+            )
+            self.assertRaisesRegex(
+                ValueError,
+                "Cannot convert integrals with missing values to integer",
+                lambda: psser.astype(int),
+            )
+            self.assertRaisesRegex(
+                ValueError,
+                "Cannot convert integrals with missing values to integer",
+                lambda: psser.astype(np.int32),
+            )
 
     def test_neg(self):
         for pser, psser in self.intergral_extension_pser_psser_pairs:
@@ -522,6 +559,24 @@ class FractionalExtensionOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         for pser, psser in self.fractional_extension_pser_psser_pairs:
             for dtype in self.extension_dtypes:
                 self.check_extension(pser.astype(dtype), psser.astype(dtype))
+        for pser, psser in self.fractional_extension_pser_psser_pairs:
+            self.assert_eq(pser.astype(float), psser.astype(float))
+            self.assert_eq(pser.astype(np.float32), psser.astype(np.float32))
+            self.assertRaisesRegex(
+                ValueError,
+                "Cannot convert fractions with missing values to bool",
+                lambda: psser.astype(bool),
+            )
+            self.assertRaisesRegex(
+                ValueError,
+                "Cannot convert fractions with missing values to integer",
+                lambda: psser.astype(int),
+            )
+            self.assertRaisesRegex(
+                ValueError,
+                "Cannot convert fractions with missing values to integer",
+                lambda: psser.astype(np.int32),
+            )
 
     def test_neg(self):
         # pandas raises "TypeError: bad operand type for unary -: 'FloatingArray'"

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -345,12 +345,8 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             "Cannot convert fractions with missing values to integer",
             lambda: self.float_withnan_psser.astype(np.int32),
         )
-        self.assertRaisesRegex(
-            ValueError,
-            "Cannot convert fractions with missing values to bool",
-            lambda: self.float_withnan_psser.astype(bool),
-        )
         self.assert_eq(self.float_withnan_psser.astype(str), self.float_withnan_psser.astype(str))
+        self.assert_eq(self.float_withnan_psser.astype(bool), self.float_withnan_psser.astype(bool))
         self.assert_eq(
             self.float_withnan_psser.astype("category"), self.float_withnan_psser.astype("category")
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adjust `astype` of fractional Series with missing values to follow pandas.

Non-goal: Adjust the issue of `astype` of Decimal Series with missing values to follow pandas.

### Why are the changes needed?
`astype` of fractional Series with missing values doesn't behave the same as pandas, for example, float Series returns itself when `astype` integer, while a ValueError is raised in pandas.

We ought to follow pandas.

### Does this PR introduce _any_ user-facing change?
Yes.

From:
```py
>>> import numpy as np
>>> import pyspark.pandas as ps
>>> psser = ps.Series([1, 2, np.nan])
>>> psser.astype(int)
0    1.0
1    2.0
2    NaN
dtype: float64

```

To:
```py
>>> import numpy as np
>>> import pyspark.pandas as ps
>>> psser = ps.Series([1, 2, np.nan])
>>> psser.astype(int)
Traceback (most recent call last):
...
ValueError: Cannot convert fractions with missing values to integer

```

### How was this patch tested?
Unit tests.

Keyword:SPARK-35337