### PR TITLE
[SPARK-36247][SQL] Check string length for char/varchar and apply type coercion in UPDATE/MERGE command

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -168,6 +168,7 @@ case class UnresolvedAttribute(nameParts: Seq[String]) extends Attribute with Un
   override def withName(newName: String): UnresolvedAttribute = UnresolvedAttribute.quoted(newName)
   override def withMetadata(newMetadata: Metadata): Attribute = this
   override def withExprId(newExprId: ExprId): UnresolvedAttribute = this
+  override def withDataType(newType: DataType): Attribute = this
   final override val nodePatterns: Seq[TreePattern] = Seq(UNRESOLVED_ATTRIBUTE)
 
   override def toString: String = s"'$name"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -123,6 +123,7 @@ abstract class Attribute extends LeafExpression with NamedExpression with NullIn
   def withName(newName: String): Attribute
   def withMetadata(newMetadata: Metadata): Attribute
   def withExprId(newExprId: ExprId): Attribute
+  def withDataType(newType: DataType): Attribute
 
   override def toAttribute: Attribute = this
   def newInstance(): Attribute
@@ -339,6 +340,10 @@ case class AttributeReference(
     AttributeReference(name, dataType, nullable, newMetadata)(exprId, qualifier)
   }
 
+  override def withDataType(newType: DataType): Attribute = {
+    AttributeReference(name, newType, nullable, metadata)(exprId, qualifier)
+  }
+
   override protected final def otherCopyArgs: Seq[AnyRef] = {
     exprId :: qualifier :: Nil
   }
@@ -394,6 +399,8 @@ case class PrettyAttribute(
   override def qualifier: Seq[String] = throw new UnsupportedOperationException
   override def exprId: ExprId = throw new UnsupportedOperationException
   override def withExprId(newExprId: ExprId): Attribute =
+    throw new UnsupportedOperationException
+  override def withDataType(newType: DataType): Attribute =
     throw new UnsupportedOperationException
   override def nullable: Boolean = true
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharVarcharUtils.scala
@@ -149,7 +149,7 @@ object CharVarcharUtils extends Logging {
     }.getOrElse(expr)
   }
 
-  private def stringLengthCheck(expr: Expression, dt: DataType): Expression = {
+  def stringLengthCheck(expr: Expression, dt: DataType): Expression = {
     dt match {
       case CharType(length) =>
         StaticInvoke(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -28,7 +28,8 @@ import org.apache.spark.sql.{AnalysisException, SaveMode}
 import org.apache.spark.sql.catalyst.{AliasIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, Analyzer, EmptyFunctionRegistry, NoSuchTableException, ResolvedFieldName, ResolvedTable, ResolveSessionCatalog, UnresolvedAttribute, UnresolvedRelation, UnresolvedSubqueryColumnAliases, UnresolvedTable}
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, CatalogTable, CatalogTableType, InMemoryCatalog, SessionCatalog}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, InSubquery, IntegerLiteral, ListQuery, Literal, StringLiteral}
+import org.apache.spark.sql.catalyst.expressions.{AnsiCast, AttributeReference, EqualTo, Expression, InSubquery, IntegerLiteral, ListQuery, Literal, StringLiteral}
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.catalyst.plans.logical.{AlterTableAlterColumn, AnalysisOnlyCommand, AppendData, Assignment, CreateTableAsSelect, CreateTableStatement, CreateV2Table, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -75,6 +76,13 @@ class PlanResolutionSuite extends AnalysisTest {
     t
   }
 
+  private val charVarcharTable: Table = {
+    val t = mock(classOf[Table])
+    when(t.schema()).thenReturn(new StructType().add("c1", "char(5)").add("c2", "varchar(5)"))
+    when(t.partitioning()).thenReturn(Array.empty[Transform])
+    t
+  }
+
   private val v1Table: V1Table = {
     val t = mock(classOf[CatalogTable])
     when(t.schema).thenReturn(new StructType()
@@ -109,6 +117,7 @@ class PlanResolutionSuite extends AnalysisTest {
         case "tab" => table
         case "tab1" => table1
         case "tab2" => table2
+        case "charvarchar" => charVarcharTable
         case name => throw new NoSuchTableException(name)
       }
     })
@@ -1058,12 +1067,33 @@ class PlanResolutionSuite extends AnalysisTest {
       }
     }
 
-    val sql = "UPDATE non_existing SET id=1"
-    val parsed = parseAndResolve(sql)
-    parsed match {
+    val sql1 = "UPDATE non_existing SET id=1"
+    val parsed1 = parseAndResolve(sql1)
+    parsed1 match {
       case u: UpdateTable =>
         assert(u.table.isInstanceOf[UnresolvedRelation])
-      case _ => fail("Expect UpdateTable, but got:\n" + parsed.treeString)
+      case _ => fail("Expect UpdateTable, but got:\n" + parsed1.treeString)
+    }
+
+    val sql2 = "UPDATE testcat.charvarchar SET c1='a', c2=1"
+    val parsed2 = parseAndResolve(sql2)
+    parsed2 match {
+      case u: UpdateTable =>
+        assert(u.assignments.length == 2)
+        u.assignments(0).value match {
+          case s: StaticInvoke =>
+            assert(s.arguments.length == 2)
+            assert(s.functionName == "charTypeWriteSideCheck")
+          case other => fail("Expect StaticInvoke, but got: " + other)
+        }
+        u.assignments(1).value match {
+          case s: StaticInvoke =>
+            assert(s.arguments.length == 2)
+            assert(s.arguments.head.isInstanceOf[AnsiCast])
+            assert(s.functionName == "varcharTypeWriteSideCheck")
+          case other => fail("Expect StaticInvoke, but got: " + other)
+        }
+      case _ => fail("Expect UpdateTable, but got:\n" + parsed2.treeString)
     }
   }
 
@@ -1568,6 +1598,42 @@ class PlanResolutionSuite extends AnalysisTest {
     val e3 = intercept[AnalysisException](parseAndResolve(sql3))
     assert(e3.message.contains(
       "cannot resolve s in MERGE command given columns [testcat.tab2.i, testcat.tab2.x]"))
+
+    val sql4 =
+      """
+        |MERGE INTO testcat.charvarchar
+        |USING testcat.tab2
+        |ON 1 = 1
+        |WHEN MATCHED THEN UPDATE SET c1='a', c2=1
+        |WHEN NOT MATCHED THEN INSERT (c1, c2) VALUES ('b', 2)
+        |""".stripMargin
+    val parsed4 = parseAndResolve(sql4)
+    parsed4 match {
+      case m: MergeIntoTable =>
+        assert(m.matchedActions.length == 1)
+        m.matchedActions.head match {
+          case UpdateAction(_, Seq(
+          Assignment(_, s1: StaticInvoke), Assignment(_, s2: StaticInvoke))) =>
+            assert(s1.arguments.length == 2)
+            assert(s1.functionName == "charTypeWriteSideCheck")
+            assert(s2.arguments.length == 2)
+            assert(s2.arguments.head.isInstanceOf[AnsiCast])
+            assert(s2.functionName == "varcharTypeWriteSideCheck")
+          case other => fail("Expect UpdateAction, but got: " + other)
+        }
+        assert(m.notMatchedActions.length == 1)
+        m.notMatchedActions.head match {
+          case InsertAction(_, Seq(
+          Assignment(_, s1: StaticInvoke), Assignment(_, s2: StaticInvoke))) =>
+            assert(s1.arguments.length == 2)
+            assert(s1.functionName == "charTypeWriteSideCheck")
+            assert(s2.arguments.length == 2)
+            assert(s2.arguments.head.isInstanceOf[AnsiCast])
+            assert(s2.functionName == "varcharTypeWriteSideCheck")
+          case other => fail("Expect UpdateAction, but got: " + other)
+        }
+      case other => fail("Expect MergeIntoTable, but got:\n" + other.treeString)
+    }
   }
 
   test("MERGE INTO TABLE - skip resolution on v2 tables that accept any schema") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We added the char/varchar support in 3.1, but the string length check is only applied to INSERT, not UPDATE/MERGE. This PR fixes it. This PR also adds the missing type coercion for UPDATE/MERGE.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
complete the char/varchar support and make UPDATE/MERGE easier to use by doing type coercion.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
new UT. No built-in source support UPDATE/MERGE so end-to-end test is not applicable here.