### PR TITLE
[SPARK-36251][INFRA][BUILD][3.2] Cover GitHub Actions runs without SHA in testing script

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -693,15 +693,19 @@ def main():
     included_tags = []
     excluded_tags = []
     if should_only_test_modules:
+        # We're likely in the forked repository
+        is_apache_spark_ref = os.environ.get("APACHE_SPARK_REF", "") != ""
+        # We're likely in the main repo build.
+        is_github_prev_sha = os.environ.get("GITHUB_PREV_SHA", "") != ""
+        # Otherwise, we're in either periodic job in Github Actions or somewhere else.
+
         # If we're running the tests in GitHub Actions, attempt to detect and test
         # only the affected modules.
-        if test_env == "github_actions":
-            if "APACHE_SPARK_REF" in os.environ and os.environ["APACHE_SPARK_REF"] != "":
-                # Fork repository
+        if test_env == "github_actions" and (is_apache_spark_ref or is_github_prev_sha):
+            if is_apache_spark_ref:
                 changed_files = identify_changed_files_from_git_commits(
                     "HEAD", target_ref=os.environ["APACHE_SPARK_REF"])
-            else:
-                # Build for each commit.
+            elif is_github_prev_sha:
                 changed_files = identify_changed_files_from_git_commits(
                     os.environ["GITHUB_SHA"], target_ref=os.environ["GITHUB_PREV_SHA"])
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR partially backports the fix in the script at https://github.com/apache/spark/pull/33410 to make the branch-3.2 build pass at https://github.com/apache/spark/actions/workflows/build_and_test.yml?query=event%3Aschedule

### Why are the changes needed?

To make the Scala 2.13 periodical job pass

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

It is a logically non-conflicting backport.