### PR TITLE
[SPARK-36253][PYTHON][DOCS] Add versionadded to the top of pandas-on-Spark package

### DIFF
--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+.. versionadded:: 3.2.0
+    pandas API on Spark
+"""
+
 import os
 import sys
 from distutils.version import LooseVersion


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the version that added pandas API on Spark in PySpark documentation.

### Why are the changes needed?

To document the version added.

### Does this PR introduce _any_ user-facing change?

No to end user. Spark 3.2 is not released yet.

### How was this patch tested?

Linter and documentation build.