### PR TITLE
[SPARK-36274][PYTHON] Fix equality comparison of unordered Categoricals

### DIFF
--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -22,14 +22,11 @@ import pandas as pd
 import numpy as np
 from pandas.api.types import is_list_like, CategoricalDtype
 
-from pyspark.pandas import DataFrame
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import DataTypeOps
-from pyspark.pandas.series import first_series
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import pandas_on_spark_type
-from pyspark.pandas.utils import combine_frames, same_anchor
 from pyspark.sql import functions as F
 from pyspark.sql.column import Column
 
@@ -126,7 +123,7 @@ def _compare(
         raise TypeError("Cannot compare a Categorical with the given type.")
 
 
-def _to_cat(index_ops):
+def _to_cat(index_ops: IndexOpsLike) -> IndexOpsLike:
     categories = cast(CategoricalDtype, index_ops.dtype).categories
     if len(categories) == 0:
         scol = SF.lit(None)

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -48,6 +48,9 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
                 "that_ordered_string_cat": pd.Categorical(
                     ["z", "y", "x"], categories=["x", "z", "y"], ordered=True
                 ),
+                "this_given_cat_string_cat": pd.Series(
+                    pd.Categorical(["x", "y", "z"], categories=list("zyx"))
+                ),
             }
         )
 
@@ -253,6 +256,18 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             psdf["this_string_cat"] == psdf["that_string_cat"],
         )
 
+        self.assert_eq(
+            pdf["this_string_cat"] == pdf["this_given_cat_string_cat"],
+            psdf["this_string_cat"] == psdf["this_given_cat_string_cat"],
+        )
+
+        pser1 = pd.Series(pd.Categorical(list("abca")))
+        pser2 = pd.Series(pd.Categorical(list("bcaa"), categories=list("bca")))
+        psser1 = ps.from_pandas(pser1)
+        psser2 = ps.from_pandas(pser2)
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(pser1 == pser2, (psser1 == psser2).sort_index())
+
     def test_ne(self):
         pdf, psdf = self.pdf, self.psdf
 
@@ -302,6 +317,17 @@ class CategoricalOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             pdf["this_string_cat"] != pdf["that_string_cat"],
             psdf["this_string_cat"] != psdf["that_string_cat"],
         )
+        self.assert_eq(
+            pdf["this_string_cat"] != pdf["this_given_cat_string_cat"],
+            psdf["this_string_cat"] != psdf["this_given_cat_string_cat"],
+        )
+
+        pser1 = pd.Series(pd.Categorical(list("abca")))
+        pser2 = pd.Series(pd.Categorical(list("bcaa"), categories=list("bca")))
+        psser1 = ps.from_pandas(pser1)
+        psser2 = ps.from_pandas(pser2)
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(pser1 != pser2, (psser1 != psser2).sort_index())
 
     def test_lt(self):
         pdf, psdf = self.pdf, self.psdf


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix equality comparison of unordered Categoricals.

### Why are the changes needed?
Codes of a Categorical Series are used for Series equality comparison. However, that doesn't apply to unordered Categoricals, where the same value can have different codes in two same categories in a different order.

So we should map codes to value respectively and then compare the equality of value.

### Does this PR introduce _any_ user-facing change?
Yes.
From:
```py
>>> psser1 = ps.Series(pd.Categorical(list("abca")))
>>> psser2 = ps.Series(pd.Categorical(list("bcaa"), categories=list("bca")))
>>> with ps.option_context("compute.ops_on_diff_frames", True):
...     (psser1 == psser2).sort_index()
... 
0     True
1     True
2     True
3    False
dtype: bool
```

To:
```py
>>> psser1 = ps.Series(pd.Categorical(list("abca")))
>>> psser2 = ps.Series(pd.Categorical(list("bcaa"), categories=list("bca")))
>>> with ps.option_context("compute.ops_on_diff_frames", True):
...     (psser1 == psser2).sort_index()
... 
0    False
1    False
2    False
3     True
dtype: bool
```

### How was this patch tested?
Unit tests.

Keyword:SPARK-35337
