### PR TITLE
[SPARK-36264][PYTHON] Add reorder_categories to CategoricalAccessor and CategoricalIndex

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/indexing.rst
+++ b/python/docs/source/reference/pyspark.pandas/indexing.rst
@@ -174,6 +174,7 @@ Categorical components
    CategoricalIndex.codes
    CategoricalIndex.categories
    CategoricalIndex.ordered
+   CategoricalIndex.reorder_categories
    CategoricalIndex.add_categories
    CategoricalIndex.remove_categories
    CategoricalIndex.remove_unused_categories

--- a/python/docs/source/reference/pyspark.pandas/series.rst
+++ b/python/docs/source/reference/pyspark.pandas/series.rst
@@ -399,6 +399,7 @@ the ``Series.cat`` accessor.
    Series.cat.categories
    Series.cat.ordered
    Series.cat.codes
+   Series.cat.reorder_categories
    Series.cat.add_categories
    Series.cat.remove_categories
    Series.cat.remove_unused_categories

--- a/python/pyspark/pandas/indexes/category.py
+++ b/python/pyspark/pandas/indexes/category.py
@@ -386,6 +386,58 @@ class CategoricalIndex(Index):
 
         return CategoricalIndex(self.to_series().cat.remove_unused_categories()).rename(self.name)
 
+    def reorder_categories(
+        self,
+        new_categories: Union[pd.Index, Any, List],
+        ordered: Optional[bool] = None,
+        inplace: bool = False,
+    ) -> Optional["CategoricalIndex"]:
+        """
+        Reorder categories as specified in new_categories.
+
+        `new_categories` need to include all old categories and no new category
+        items.
+
+        Parameters
+        ----------
+        new_categories : Index-like
+           The categories in new order.
+        ordered : bool, optional
+           Whether or not the categorical is treated as a ordered categorical.
+           If not given, do not change the ordered information.
+        inplace : bool, default False
+           Whether or not to reorder the categories inplace or return a copy of
+           this categorical with reordered categories.
+
+        Returns
+        -------
+        cat : CategoricalIndex or None
+            Categorical with removed categories or None if ``inplace=True``.
+
+        Raises
+        ------
+        ValueError
+            If the new categories do not contain all old category items or any
+            new ones
+
+        Examples
+        --------
+        >>> idx = ps.CategoricalIndex(list("abbccc"))
+        >>> idx  # doctest: +NORMALIZE_WHITESPACE
+        CategoricalIndex(['a', 'b', 'b', 'c', 'c', 'c'],
+                         categories=['a', 'b', 'c'], ordered=False, dtype='category')
+
+        >>> idx.reorder_categories(['c', 'b', 'a'])  # doctest: +NORMALIZE_WHITESPACE
+        CategoricalIndex(['a', 'b', 'b', 'c', 'c', 'c'],
+                         categories=['c', 'b', 'a'], ordered=False, dtype='category')
+        """
+        if inplace:
+            raise ValueError("cannot use inplace with CategoricalIndex")
+
+        return CategoricalIndex(
+            self.to_series().cat.reorder_categories(new_categories=new_categories, ordered=ordered)
+        ).rename(self.name)
+
     def __getattr__(self, item: str) -> Any:
         if hasattr(MissingPandasLikeCategoricalIndex, item):
             property_or_func = getattr(MissingPandasLikeCategoricalIndex, item)

--- a/python/pyspark/pandas/missing/indexes.py
+++ b/python/pyspark/pandas/missing/indexes.py
@@ -123,7 +123,6 @@ class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
 class MissingPandasLikeCategoricalIndex(MissingPandasLikeIndex):
 
     # Functions
-    reorder_categories = _unsupported_function("reorder_categories", cls="CategoricalIndex")
     set_categories = _unsupported_function("set_categories", cls="CategoricalIndex")
     map = _unsupported_function("map", cls="CategoricalIndex")
 

--- a/python/pyspark/pandas/tests/indexes/test_category.py
+++ b/python/pyspark/pandas/tests/indexes/test_category.py
@@ -130,6 +130,27 @@ class CategoricalIndexTest(PandasOnSparkTestCase, TestUtils):
 
         self.assertRaises(ValueError, lambda: psidx.remove_unused_categories(inplace=True))
 
+    def test_reorder_categories(self):
+        pidx = pd.CategoricalIndex([1, 2, 3])
+        psidx = ps.from_pandas(pidx)
+
+        self.assert_eq(pidx.reorder_categories([1, 2, 3]), psidx.reorder_categories([1, 2, 3]))
+        self.assert_eq(
+            pidx.reorder_categories([1, 2, 3], ordered=True),
+            psidx.reorder_categories([1, 2, 3], ordered=True),
+        )
+        self.assert_eq(pidx.reorder_categories([3, 2, 1]), psidx.reorder_categories([3, 2, 1]))
+        self.assert_eq(
+            pidx.reorder_categories([3, 2, 1], ordered=True),
+            psidx.reorder_categories([3, 2, 1], ordered=True),
+        )
+
+        self.assertRaises(ValueError, lambda: pidx.reorder_categories([1, 2, 3], inplace=True))
+        self.assertRaises(ValueError, lambda: psidx.reorder_categories([1, 2]))
+        self.assertRaises(ValueError, lambda: psidx.reorder_categories([1, 2, 4]))
+        self.assertRaises(ValueError, lambda: psidx.reorder_categories([1, 2, 2]))
+        self.assertRaises(TypeError, lambda: psidx.reorder_categories(1))
+
     def test_as_ordered_unordered(self):
         pidx = pd.CategoricalIndex(["x", "y", "z"], categories=["z", "y", "x"])
         psidx = ps.from_pandas(pidx)

--- a/python/pyspark/pandas/tests/test_categorical.py
+++ b/python/pyspark/pandas/tests/test_categorical.py
@@ -141,6 +141,43 @@ class CategoricalTest(PandasOnSparkTestCase, TestUtils):
         self.assert_eq(pser, psser)
         self.assert_eq(pdf, psdf)
 
+    def test_reorder_categories(self):
+        pdf, psdf = self.df_pair
+
+        pser = pdf.a
+        psser = psdf.a
+
+        self.assert_eq(
+            pser.cat.reorder_categories([1, 2, 3]), psser.cat.reorder_categories([1, 2, 3])
+        )
+        self.assert_eq(
+            pser.cat.reorder_categories([1, 2, 3], ordered=True),
+            psser.cat.reorder_categories([1, 2, 3], ordered=True),
+        )
+        self.assert_eq(
+            pser.cat.reorder_categories([3, 2, 1]), psser.cat.reorder_categories([3, 2, 1])
+        )
+        self.assert_eq(
+            pser.cat.reorder_categories([3, 2, 1], ordered=True),
+            psser.cat.reorder_categories([3, 2, 1], ordered=True),
+        )
+
+        pser.cat.reorder_categories([1, 2, 3], inplace=True)
+        psser.cat.reorder_categories([1, 2, 3], inplace=True)
+        self.assert_eq(pser, psser)
+        self.assert_eq(pdf, psdf)
+
+        pser.cat.reorder_categories([3, 2, 1], ordered=True, inplace=True)
+        psser.cat.reorder_categories([3, 2, 1], ordered=True, inplace=True)
+        self.assert_eq(pser, psser)
+        self.assert_eq(pdf, psdf)
+
+        self.assertRaises(ValueError, lambda: psser.cat.reorder_categories([1, 2]))
+        self.assertRaises(ValueError, lambda: psser.cat.reorder_categories([1, 2, 4]))
+        self.assertRaises(ValueError, lambda: psser.cat.reorder_categories([1, 2, 2]))
+        self.assertRaises(TypeError, lambda: psser.cat.reorder_categories(1))
+        self.assertRaises(TypeError, lambda: psdf.b.cat.reorder_categories("abcd"))
+
     def test_as_ordered_unordered(self):
         pdf, psdf = self.df_pair
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `reorder_categories` to `CategoricalAccessor` and `CategoricalIndex`.

### Why are the changes needed?

We should implement `reorder_categories` in `CategoricalAccessor` and `CategoricalIndex`.

### Does this PR introduce _any_ user-facing change?

Yes, users will be able to use `reorder_categories`.

### How was this patch tested?

Added some tests.