### PR TITLE
[SPARK-36276][BUILD][TESTS] Update maven-checkstyle-plugin to 3.1.2 and checkstyle to 8.43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3090,7 +3090,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.2</version>
         <configuration>
           <failOnViolation>false</failOnViolation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -3110,7 +3110,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.39</version>
+            <version>8.43</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to update maven-checkstyle-plugin to 3.1.2 and checkstyle to 8.43.
### Why are the changes needed?
This will bring the latest bug fixes and improvements from 8.40 to 8.43.
- https://checkstyle.sourceforge.io/releasenotes.html#Release_8.43

Note that 8.44 has a false-positive bug for ArrayType checker.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the GHA. 