### PR TITLE
[SPARK-36213][SQL][FOLLOWUP][3.0] Fix compilation error due to type mismatch

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -692,7 +692,7 @@ case class DescribeTableCommand(
     DDLUtils.verifyPartitionProviderIsHive(spark, metadata, "DESC PARTITION")
     val normalizedPartSpec = PartitioningUtils.normalizePartitionSpec(
       partitionSpec,
-      metadata.partitionSchema,
+      metadata.partitionSchema.fieldNames,
       table.quotedString,
       spark.sessionState.conf.resolver)
     val partition = catalog.getPartition(table, normalizedPartSpec)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch fixes a compilation error of backported PR of SPARK-36213.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To fix compilation error:

```
[error] /spark/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala:695: type mismatch;                             
[error]  found   : org.apache.spark.sql.types.StructType                                                                                                          
[error]  required: Seq[String]                                                                                                                                    
[error] Error occurred in an application involving default arguments.                                                                                             
[error]       metadata.partitionSchema,                                                                                                                           
[error]                ^                                                                                                                                          
```

`PartitioningUtils.normalizePartitionSpec`'s `partColNames` is `Seq[String]` in 3.0.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit test