### PR TITLE
[MINOR][INFRA] Add enabled_merge_buttons to .asf.yaml explicitly

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,3 +27,7 @@ github:
     - jdbc
     - sql
     - spark
+  enabled_merge_buttons:
+    merge: false
+    squash: true
+    rebase: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add the AS-IS `enabled_merge_buttons` policy explicitly. The AS-IS policy was introduced via  https://issues.apache.org/jira/browse/INFRA-18656.

### Why are the changes needed?

Currently, this policy is maintained as a self-serving manner. Here is the official documentation. It would be great if we have this explicitly for new comers.
- https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features#Git.asf.yamlfeatures-Mergebuttons

### Does this PR introduce _any_ user-facing change?

No. This is a committer-only feature and there is no change in terms of the policy.

### How was this patch tested?

N/A