### PR TITLE
[SPARK-36260][PYTHON] Add set_categories to CategoricalAccessor and CategoricalIndex

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/indexing.rst
+++ b/python/docs/source/reference/pyspark.pandas/indexing.rst
@@ -181,6 +181,7 @@ Categorical components
    CategoricalIndex.as_ordered
    CategoricalIndex.as_unordered
    CategoricalIndex.rename_categories
+   CategoricalIndex.set_categories
 
 .. _api.multiindex:
 

--- a/python/docs/source/reference/pyspark.pandas/series.rst
+++ b/python/docs/source/reference/pyspark.pandas/series.rst
@@ -406,6 +406,7 @@ the ``Series.cat`` accessor.
    Series.cat.as_ordered
    Series.cat.as_unordered
    Series.cat.rename_categories
+   Series.cat.set_categories
 
 .. _api.series.plot:
 

--- a/python/pyspark/pandas/categorical.py
+++ b/python/pyspark/pandas/categorical.py
@@ -20,9 +20,8 @@ import pandas as pd
 from pandas.api.types import CategoricalDtype, is_dict_like, is_list_like
 
 from pyspark.pandas.internal import InternalField
-from pyspark.pandas.utils import name_like_string
 from pyspark.sql import functions as F
-from pyspark.sql.types import StructField
+from pyspark.sql.types import IntegerType, StructField
 
 if TYPE_CHECKING:
     import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
@@ -803,7 +802,9 @@ class CategoricalAccessor(object):
             internal = self._data._psdf._internal.with_new_spark_column(
                 self._data._column_label,
                 new_scol,
-                field=self._data._internal.data_fields[0].copy(dtype=new_dtype),
+                field=self._data._internal.data_fields[0].copy(
+                    dtype=new_dtype, spark_type=IntegerType()
+                ),
             )
 
             if inplace:

--- a/python/pyspark/pandas/categorical.py
+++ b/python/pyspark/pandas/categorical.py
@@ -736,6 +736,49 @@ class CategoricalAccessor(object):
         add_categories : Add new categories.
         remove_categories : Remove the specified categories.
         remove_unused_categories : Remove categories which are not used.
+
+        Examples
+        --------
+        >>> s = ps.Series(list("abbccc"), dtype="category")
+        >>> s  # doctest: +SKIP
+        0    a
+        1    b
+        2    b
+        3    c
+        4    c
+        5    c
+        dtype: category
+        Categories (3, object): ['a', 'b', 'c']
+
+        >>> s.cat.set_categories(['b', 'c'])  # doctest: +SKIP
+        0    NaN
+        1      b
+        2      b
+        3      c
+        4      c
+        5      c
+        dtype: category
+        Categories (2, object): ['b', 'c']
+
+        >>> s.cat.set_categories([1, 2, 3], rename=True)  # doctest: +SKIP
+        0    1
+        1    2
+        2    2
+        3    3
+        4    3
+        5    3
+        dtype: category
+        Categories (3, int64): [1, 2, 3]
+
+        >>> s.cat.set_categories([1, 2, 3], rename=True, ordered=True)  # doctest: +SKIP
+        0    1
+        1    2
+        2    2
+        3    3
+        4    3
+        5    3
+        dtype: category
+        Categories (3, int64): [1 < 2 < 3]
         """
         from pyspark.pandas.frame import DataFrame
 

--- a/python/pyspark/pandas/categorical.py
+++ b/python/pyspark/pandas/categorical.py
@@ -20,8 +20,9 @@ import pandas as pd
 from pandas.api.types import CategoricalDtype, is_dict_like, is_list_like
 
 from pyspark.pandas.internal import InternalField
+from pyspark.pandas.spark import functions as SF
 from pyspark.sql import functions as F
-from pyspark.sql.types import IntegerType, StructField
+from pyspark.sql.types import StructField
 
 if TYPE_CHECKING:
     import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
@@ -794,7 +795,7 @@ class CategoricalAccessor(object):
 
         if rename:
             new_scol = (
-                F.when(scol >= len(new_categories), -1)
+                F.when(scol >= len(new_categories), SF.lit(-1).cast(self._data.spark.data_type))
                 .otherwise(scol)
                 .alias(self._data._internal.data_spark_column_names[0])
             )
@@ -802,9 +803,7 @@ class CategoricalAccessor(object):
             internal = self._data._psdf._internal.with_new_spark_column(
                 self._data._column_label,
                 new_scol,
-                field=self._data._internal.data_fields[0].copy(
-                    dtype=new_dtype, spark_type=IntegerType()
-                ),
+                field=self._data._internal.data_fields[0].copy(dtype=new_dtype),
             )
 
             if inplace:

--- a/python/pyspark/pandas/categorical.py
+++ b/python/pyspark/pandas/categorical.py
@@ -683,7 +683,7 @@ class CategoricalAccessor(object):
     def set_categories(
         self,
         new_categories: Union[pd.Index, List],
-        ordered: bool = None,
+        ordered: Optional[bool] = None,
         rename: bool = False,
         inplace: bool = False,
     ) -> Optional["ps.Series"]:
@@ -754,7 +754,7 @@ class CategoricalAccessor(object):
             new_scol = (
                 F.when(scol >= len(new_categories), -1)
                 .otherwise(scol)
-                .alias(name_like_string(self._data._column_label))
+                .alias(self._data._internal.data_spark_column_names[0])
             )
 
             internal = self._data._psdf._internal.with_new_spark_column(

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -42,6 +42,16 @@ class CategoricalOps(DataTypeOps):
 
     def restore(self, col: pd.Series) -> pd.Series:
         """Restore column when to_pandas."""
+        try:
+            pd.Categorical.from_codes(
+                col.replace(np.nan, -1).astype(int),
+                categories=cast(CategoricalDtype, self.dtype).categories,
+                ordered=cast(CategoricalDtype, self.dtype).ordered,
+            )
+        except:
+            print(col)
+            print(self.dtype.categories)
+
         return pd.Series(
             pd.Categorical.from_codes(
                 col.replace(np.nan, -1).astype(int),

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -42,15 +42,11 @@ class CategoricalOps(DataTypeOps):
 
     def restore(self, col: pd.Series) -> pd.Series:
         """Restore column when to_pandas."""
-        try:
-            pd.Categorical.from_codes(
-                col.replace(np.nan, -1).astype(int),
-                categories=cast(CategoricalDtype, self.dtype).categories,
-                ordered=cast(CategoricalDtype, self.dtype).ordered,
-            )
-        except:
-            print(col)
-            print(self.dtype.categories)
+        pd.Categorical.from_codes(
+            col.replace(np.nan, -1).astype(int),
+            categories=cast(CategoricalDtype, self.dtype).categories,
+            ordered=cast(CategoricalDtype, self.dtype).ordered,
+        )
 
         return pd.Series(
             pd.Categorical.from_codes(

--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -42,12 +42,6 @@ class CategoricalOps(DataTypeOps):
 
     def restore(self, col: pd.Series) -> pd.Series:
         """Restore column when to_pandas."""
-        pd.Categorical.from_codes(
-            col.replace(np.nan, -1).astype(int),
-            categories=cast(CategoricalDtype, self.dtype).categories,
-            ordered=cast(CategoricalDtype, self.dtype).ordered,
-        )
-
         return pd.Series(
             pd.Categorical.from_codes(
                 col.replace(np.nan, -1).astype(int),

--- a/python/pyspark/pandas/indexes/category.py
+++ b/python/pyspark/pandas/indexes/category.py
@@ -517,6 +517,70 @@ class CategoricalIndex(Index):
             self.name
         )
 
+    def set_categories(
+        self,
+        new_categories: pd.Index,
+        ordered: bool = None,
+        rename: bool = False,
+        inplace: bool = False,
+    ) -> Optional["CategoricalIndex"]:
+        """
+        Set the categories to the specified new_categories.
+
+        `new_categories` can include new categories (which will result in
+        unused categories) or remove old categories (which results in values
+        set to NaN). If `rename==True`, the categories will simple be renamed
+        (less or more items than in old categories will result in values set to
+        NaN or in unused categories respectively).
+
+        This method can be used to perform more than one action of adding,
+        removing, and reordering simultaneously and is therefore faster than
+        performing the individual steps via the more specialised methods.
+
+        On the other hand this methods does not do checks (e.g., whether the
+        old categories are included in the new categories on a reorder), which
+        can result in surprising changes, for example when using special string
+        dtypes, which does not considers a S1 string equal to a single char
+        python string.
+
+        Parameters
+        ----------
+        new_categories : Index-like
+           The categories in new order.
+        ordered : bool, default False
+           Whether or not the categorical is treated as a ordered categorical.
+           If not given, do not change the ordered information.
+        rename : bool, default False
+           Whether or not the new_categories should be considered as a rename
+           of the old categories or as reordered categories.
+        inplace : bool, default False
+           Whether or not to reorder the categories in-place or return a copy
+           of this categorical with reordered categories.
+
+        Returns
+        -------
+        CategoricalIndex with reordered categories or None if inplace.
+
+        Raises
+        ------
+        ValueError
+            If new_categories does not validate as categories
+
+        See Also
+        --------
+        rename_categories : Rename categories.
+        reorder_categories : Reorder categories.
+        add_categories : Add new categories.
+        remove_categories : Remove the specified categories.
+        remove_unused_categories : Remove categories which are not used.
+        """
+        if inplace:
+            raise ValueError("cannot use inplace with CategoricalIndex")
+
+        return CategoricalIndex(
+            self.to_series().cat.set_categories(new_categories, ordered=ordered, rename=rename)
+        ).rename(self.name)
+
 
 def _test() -> None:
     import os

--- a/python/pyspark/pandas/indexes/category.py
+++ b/python/pyspark/pandas/indexes/category.py
@@ -573,6 +573,23 @@ class CategoricalIndex(Index):
         add_categories : Add new categories.
         remove_categories : Remove the specified categories.
         remove_unused_categories : Remove categories which are not used.
+
+        Examples
+        --------
+        >>> idx = ps.CategoricalIndex(list("abbccc"))
+        >>> idx  # doctest: +NORMALIZE_WHITESPACE
+        CategoricalIndex(['a', 'b', 'b', 'c', 'c', 'c'],
+                         categories=['a', 'b', 'c'], ordered=False, dtype='category')
+
+        >>> idx.set_categories(['b', 'c'])  # doctest: +NORMALIZE_WHITESPACE
+        CategoricalIndex([nan, 'b', 'b', 'c', 'c', 'c'],
+                         categories=['b', 'c'], ordered=False, dtype='category')
+
+        >>> idx.set_categories([1, 2, 3], rename=True)
+        CategoricalIndex([1, 2, 2, 3, 3, 3], categories=[1, 2, 3], ordered=False, dtype='category')
+
+        >>> idx.set_categories([1, 2, 3], rename=True, ordered=True)
+        CategoricalIndex([1, 2, 2, 3, 3, 3], categories=[1, 2, 3], ordered=True, dtype='category')
         """
         if inplace:
             raise ValueError("cannot use inplace with CategoricalIndex")

--- a/python/pyspark/pandas/indexes/category.py
+++ b/python/pyspark/pandas/indexes/category.py
@@ -519,7 +519,7 @@ class CategoricalIndex(Index):
 
     def set_categories(
         self,
-        new_categories: pd.Index,
+        new_categories: Union[pd.Index, List],
         ordered: bool = None,
         rename: bool = False,
         inplace: bool = False,

--- a/python/pyspark/pandas/indexes/category.py
+++ b/python/pyspark/pandas/indexes/category.py
@@ -520,7 +520,7 @@ class CategoricalIndex(Index):
     def set_categories(
         self,
         new_categories: Union[pd.Index, List],
-        ordered: bool = None,
+        ordered: Optional[bool] = None,
         rename: bool = False,
         inplace: bool = False,
     ) -> Optional["CategoricalIndex"]:

--- a/python/pyspark/pandas/missing/indexes.py
+++ b/python/pyspark/pandas/missing/indexes.py
@@ -123,7 +123,6 @@ class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
 class MissingPandasLikeCategoricalIndex(MissingPandasLikeIndex):
 
     # Functions
-    set_categories = _unsupported_function("set_categories", cls="CategoricalIndex")
     map = _unsupported_function("map", cls="CategoricalIndex")
 
 

--- a/python/pyspark/pandas/tests/indexes/test_category.py
+++ b/python/pyspark/pandas/tests/indexes/test_category.py
@@ -316,48 +316,48 @@ class CategoricalIndexTest(PandasOnSparkTestCase, TestUtils):
         psidx = ps.from_pandas(pidx)
 
         self.assert_eq(
-            pidx.set_categories(pd.Index([0, 1, 3, 2])),
-            psidx.set_categories(pd.Index([0, 1, 3, 2])),
+            pidx.set_categories(["a", "c", "b", "o"]),
+            psidx.set_categories(["a", "c", "b", "o"]),
         )
         self.assert_eq(
-            pidx.set_categories(pd.Index([0, 1, 3])),
-            psidx.set_categories(pd.Index([0, 1, 3])),
+            pidx.set_categories(["a", "c", "b"]),
+            psidx.set_categories(["a", "c", "b"]),
         )
         self.assert_eq(
-            pidx.set_categories(pd.Index([0, 1, 3, 2, 4])),
-            psidx.set_categories(pd.Index([0, 1, 3, 2, 4])),
-        )
-
-        self.assert_eq(
-            pidx.set_categories(pd.Index([0, 1, 3, 2]), rename=True),
-            psidx.set_categories(pd.Index([0, 1, 3, 2]), rename=True),
-        )
-        self.assert_eq(
-            pidx.set_categories(pd.Index([0, 1, 3]), rename=True),
-            psidx.set_categories(pd.Index([0, 1, 3]), rename=True),
-        )
-        self.assert_eq(
-            pidx.set_categories(pd.Index([0, 1, 3, 2, 4]), rename=True),
-            psidx.set_categories(pd.Index([0, 1, 3, 2, 4]), rename=True),
+            pidx.set_categories(["a", "c", "b", "d", "e"]),
+            psidx.set_categories(["a", "c", "b", "d", "e"]),
         )
 
         self.assert_eq(
-            pidx.set_categories(pd.Index([0, 1, 3, 2]), ordered=True),
-            psidx.set_categories(pd.Index([0, 1, 3, 2]), ordered=True),
+            pidx.set_categories([0, 1, 3, 2], rename=True),
+            psidx.set_categories([0, 1, 3, 2], rename=True),
         )
         self.assert_eq(
-            pidx.set_categories(pd.Index([0, 1, 3]), ordered=True),
-            psidx.set_categories(pd.Index([0, 1, 3]), ordered=True),
+            pidx.set_categories([0, 1, 3], rename=True),
+            psidx.set_categories([0, 1, 3], rename=True),
         )
         self.assert_eq(
-            pidx.set_categories(pd.Index([0, 1, 3, 2, 4]), ordered=True),
-            psidx.set_categories(pd.Index([0, 1, 3, 2, 4]), ordered=True),
+            pidx.set_categories([0, 1, 3, 2, 4], rename=True),
+            psidx.set_categories([0, 1, 3, 2, 4], rename=True),
+        )
+
+        self.assert_eq(
+            pidx.set_categories(["a", "c", "b", "o"], ordered=True),
+            psidx.set_categories(["a", "c", "b", "o"], ordered=True),
+        )
+        self.assert_eq(
+            pidx.set_categories(["a", "c", "b"], ordered=True),
+            psidx.set_categories(["a", "c", "b"], ordered=True),
+        )
+        self.assert_eq(
+            pidx.set_categories(["a", "c", "b", "d", "e"], ordered=True),
+            psidx.set_categories(["a", "c", "b", "d", "e"], ordered=True),
         )
 
         self.assertRaisesRegex(
             ValueError,
             "cannot use inplace with CategoricalIndex",
-            lambda: psidx.set_categories(pd.Index([0, 1, 3, 2]), inplace=True),
+            lambda: psidx.set_categories(["a", "c", "b", "o"], inplace=True),
         )
 
 

--- a/python/pyspark/pandas/tests/indexes/test_category.py
+++ b/python/pyspark/pandas/tests/indexes/test_category.py
@@ -311,6 +311,55 @@ class CategoricalIndexTest(PandasOnSparkTestCase, TestUtils):
             lambda: psidx.rename_categories("x"),
         )
 
+    def test_set_categories(self):
+        pidx = pd.CategoricalIndex(["a", "b", "c", "d"])
+        psidx = ps.from_pandas(pidx)
+
+        self.assert_eq(
+            pidx.set_categories(pd.Index([0, 1, 3, 2])),
+            psidx.set_categories(pd.Index([0, 1, 3, 2])),
+        )
+        self.assert_eq(
+            pidx.set_categories(pd.Index([0, 1, 3])),
+            psidx.set_categories(pd.Index([0, 1, 3])),
+        )
+        self.assert_eq(
+            pidx.set_categories(pd.Index([0, 1, 3, 2, 4])),
+            psidx.set_categories(pd.Index([0, 1, 3, 2, 4])),
+        )
+
+        self.assert_eq(
+            pidx.set_categories(pd.Index([0, 1, 3, 2]), rename=True),
+            psidx.set_categories(pd.Index([0, 1, 3, 2]), rename=True),
+        )
+        self.assert_eq(
+            pidx.set_categories(pd.Index([0, 1, 3]), rename=True),
+            psidx.set_categories(pd.Index([0, 1, 3]), rename=True),
+        )
+        self.assert_eq(
+            pidx.set_categories(pd.Index([0, 1, 3, 2, 4]), rename=True),
+            psidx.set_categories(pd.Index([0, 1, 3, 2, 4]), rename=True),
+        )
+
+        self.assert_eq(
+            pidx.set_categories(pd.Index([0, 1, 3, 2]), ordered=True),
+            psidx.set_categories(pd.Index([0, 1, 3, 2]), ordered=True),
+        )
+        self.assert_eq(
+            pidx.set_categories(pd.Index([0, 1, 3]), ordered=True),
+            psidx.set_categories(pd.Index([0, 1, 3]), ordered=True),
+        )
+        self.assert_eq(
+            pidx.set_categories(pd.Index([0, 1, 3, 2, 4]), ordered=True),
+            psidx.set_categories(pd.Index([0, 1, 3, 2, 4]), ordered=True),
+        )
+
+        self.assertRaisesRegex(
+            ValueError,
+            "cannot use inplace with CategoricalIndex",
+            lambda: psidx.set_categories(pd.Index([0, 1, 3, 2]), inplace=True),
+        )
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/test_categorical.py
+++ b/python/pyspark/pandas/tests/test_categorical.py
@@ -713,17 +713,76 @@ class CategoricalTest(PandasOnSparkTestCase, TestUtils):
             psser.cat.set_categories(pd.Index([0, 1, 3, 2, 4]), ordered=True),
         )
 
+        pser.cat.set_categories(pd.Index([0, 1, 3, 2]), inplace=True, rename=True)
+        psser.cat.set_categories(pd.Index([0, 1, 3, 2]), inplace=True, rename=True)
+        self.assert_eq(pser, psser)
+        self.assert_eq(pdf, psdf)
+
+        pser.cat.set_categories(pd.Index([2, 3, 1, 0]), inplace=True, rename=False),
+        psser.cat.set_categories(pd.Index([2, 3, 1, 0]), inplace=True, rename=False),
+        self.assert_eq(pser, psser)
+        self.assert_eq(pdf, psdf)
+
+        pdf, psdf = self.df_pair
+
+        pser = pdf.b
+        psser = psdf.b
+
         self.assert_eq(
-            pser.cat.set_categories(pd.Index([0, 1, 3, 2]), inplace=True, rename=True),
-            psser.cat.set_categories(pd.Index([0, 1, 3, 2]), inplace=True, rename=True),
+            pser.cat.set_categories([0, 1, 3, 2]),
+            psser.cat.set_categories([0, 1, 3, 2]),
+        )
+        self.assert_eq(
+            pser.cat.set_categories([0, 1, 3]),
+            psser.cat.set_categories([0, 1, 3]),
+        )
+        self.assert_eq(
+            pser.cat.set_categories([0, 1, 3, 2, 4]),
+            psser.cat.set_categories([0, 1, 3, 2, 4]),
+        )
+
+        self.assert_eq(
+            pser.cat.set_categories([0, 1, 3, 2], rename=True),
+            psser.cat.set_categories([0, 1, 3, 2], rename=True),
+        )
+        self.assert_eq(
+            pser.cat.set_categories([0, 1, 3], rename=True),
+            psser.cat.set_categories([0, 1, 3], rename=True),
+        )
+        self.assert_eq(
+            pser.cat.set_categories([0, 1, 3, 2, 4], rename=True),
+            psser.cat.set_categories([0, 1, 3, 2, 4], rename=True),
+        )
+
+        self.assert_eq(
+            pser.cat.set_categories([0, 1, 3, 2], ordered=True),
+            psser.cat.set_categories([0, 1, 3, 2], ordered=True),
+        )
+        self.assert_eq(
+            pser.cat.set_categories([0, 1, 3], ordered=True),
+            psser.cat.set_categories([0, 1, 3], ordered=True),
+        )
+        self.assert_eq(
+            pser.cat.set_categories([0, 1, 3, 2, 4], ordered=True),
+            psser.cat.set_categories([0, 1, 3, 2, 4], ordered=True),
+        )
+
+        self.assert_eq(
+            pser.cat.set_categories([0, 1, 3, 2], inplace=True, rename=True),
+            psser.cat.set_categories([0, 1, 3, 2], inplace=True, rename=True),
         )
         self.assert_eq(pser, psser)
         self.assert_eq(pdf, psdf)
 
+        pser.cat.set_categories([2, 3, 1, 0], inplace=True, rename=False),
+        psser.cat.set_categories([2, 3, 1, 0], inplace=True, rename=False),
+        self.assert_eq(pser, psser)
+        self.assert_eq(pdf, psdf)
+
         self.assertRaisesRegex(
-            NotImplementedError,
-            "inplace must be False when rename is False",
-            lambda: psser.cat.set_categories(pd.Index([0, 1, 3, 2]), inplace=True, rename=False),
+            TypeError,
+            "Parameter 'new_categories' must be list-like, was",
+            lambda: psser.cat.set_categories(None),
         )
 
 

--- a/python/pyspark/pandas/tests/test_categorical.py
+++ b/python/pyspark/pandas/tests/test_categorical.py
@@ -675,70 +675,16 @@ class CategoricalTest(PandasOnSparkTestCase, TestUtils):
         psser = psdf.b
 
         self.assert_eq(
-            pser.cat.set_categories(pd.Index([0, 1, 3, 2])),
-            psser.cat.set_categories(pd.Index([0, 1, 3, 2])),
+            pser.cat.set_categories(["a", "c", "b", "o"]),
+            psser.cat.set_categories(["a", "c", "b", "o"]),
         )
         self.assert_eq(
-            pser.cat.set_categories(pd.Index([0, 1, 3])),
-            psser.cat.set_categories(pd.Index([0, 1, 3])),
+            pser.cat.set_categories(["a", "c", "b"]),
+            psser.cat.set_categories(["a", "c", "b"]),
         )
         self.assert_eq(
-            pser.cat.set_categories(pd.Index([0, 1, 3, 2, 4])),
-            psser.cat.set_categories(pd.Index([0, 1, 3, 2, 4])),
-        )
-
-        self.assert_eq(
-            pser.cat.set_categories(pd.Index([0, 1, 3, 2]), rename=True),
-            psser.cat.set_categories(pd.Index([0, 1, 3, 2]), rename=True),
-        )
-        self.assert_eq(
-            pser.cat.set_categories(pd.Index([0, 1, 3]), rename=True),
-            psser.cat.set_categories(pd.Index([0, 1, 3]), rename=True),
-        )
-        self.assert_eq(
-            pser.cat.set_categories(pd.Index([0, 1, 3, 2, 4]), rename=True),
-            psser.cat.set_categories(pd.Index([0, 1, 3, 2, 4]), rename=True),
-        )
-
-        self.assert_eq(
-            pser.cat.set_categories(pd.Index([0, 1, 3, 2]), ordered=True),
-            psser.cat.set_categories(pd.Index([0, 1, 3, 2]), ordered=True),
-        )
-        self.assert_eq(
-            pser.cat.set_categories(pd.Index([0, 1, 3]), ordered=True),
-            psser.cat.set_categories(pd.Index([0, 1, 3]), ordered=True),
-        )
-        self.assert_eq(
-            pser.cat.set_categories(pd.Index([0, 1, 3, 2, 4]), ordered=True),
-            psser.cat.set_categories(pd.Index([0, 1, 3, 2, 4]), ordered=True),
-        )
-
-        pser.cat.set_categories(pd.Index([0, 1, 3, 2]), inplace=True, rename=True)
-        psser.cat.set_categories(pd.Index([0, 1, 3, 2]), inplace=True, rename=True)
-        self.assert_eq(pser, psser)
-        self.assert_eq(pdf, psdf)
-
-        pser.cat.set_categories(pd.Index([2, 3, 1, 0]), inplace=True, rename=False),
-        psser.cat.set_categories(pd.Index([2, 3, 1, 0]), inplace=True, rename=False),
-        self.assert_eq(pser, psser)
-        self.assert_eq(pdf, psdf)
-
-        pdf, psdf = self.df_pair
-
-        pser = pdf.b
-        psser = psdf.b
-
-        self.assert_eq(
-            pser.cat.set_categories([0, 1, 3, 2]),
-            psser.cat.set_categories([0, 1, 3, 2]),
-        )
-        self.assert_eq(
-            pser.cat.set_categories([0, 1, 3]),
-            psser.cat.set_categories([0, 1, 3]),
-        )
-        self.assert_eq(
-            pser.cat.set_categories([0, 1, 3, 2, 4]),
-            psser.cat.set_categories([0, 1, 3, 2, 4]),
+            pser.cat.set_categories(["a", "c", "b", "d", "e"]),
+            psser.cat.set_categories(["a", "c", "b", "d", "e"]),
         )
 
         self.assert_eq(
@@ -755,21 +701,21 @@ class CategoricalTest(PandasOnSparkTestCase, TestUtils):
         )
 
         self.assert_eq(
-            pser.cat.set_categories([0, 1, 3, 2], ordered=True),
-            psser.cat.set_categories([0, 1, 3, 2], ordered=True),
+            pser.cat.set_categories(["a", "c", "b", "o"], ordered=True),
+            psser.cat.set_categories(["a", "c", "b", "o"], ordered=True),
         )
         self.assert_eq(
-            pser.cat.set_categories([0, 1, 3], ordered=True),
-            psser.cat.set_categories([0, 1, 3], ordered=True),
+            pser.cat.set_categories(["a", "c", "b"], ordered=True),
+            psser.cat.set_categories(["a", "c", "b"], ordered=True),
         )
         self.assert_eq(
-            pser.cat.set_categories([0, 1, 3, 2, 4], ordered=True),
-            psser.cat.set_categories([0, 1, 3, 2, 4], ordered=True),
+            pser.cat.set_categories(["a", "c", "b", "d", "e"], ordered=True),
+            psser.cat.set_categories(["a", "c", "b", "d", "e"], ordered=True),
         )
 
         self.assert_eq(
-            pser.cat.set_categories([0, 1, 3, 2], inplace=True, rename=True),
-            psser.cat.set_categories([0, 1, 3, 2], inplace=True, rename=True),
+            pser.cat.set_categories(["a", "c", "b", "o"], inplace=True, rename=True),
+            psser.cat.set_categories(["a", "c", "b", "o"], inplace=True, rename=True),
         )
         self.assert_eq(pser, psser)
         self.assert_eq(pdf, psdf)

--- a/python/pyspark/pandas/tests/test_categorical.py
+++ b/python/pyspark/pandas/tests/test_categorical.py
@@ -668,6 +668,64 @@ class CategoricalTest(PandasOnSparkTestCase, TestUtils):
             lambda: psser.cat.rename_categories("x"),
         )
 
+    def test_set_categories(self):
+        pdf, psdf = self.df_pair
+
+        pser = pdf.b
+        psser = psdf.b
+
+        self.assert_eq(
+            pser.cat.set_categories(pd.Index([0, 1, 3, 2])),
+            psser.cat.set_categories(pd.Index([0, 1, 3, 2])),
+        )
+        self.assert_eq(
+            pser.cat.set_categories(pd.Index([0, 1, 3])),
+            psser.cat.set_categories(pd.Index([0, 1, 3])),
+        )
+        self.assert_eq(
+            pser.cat.set_categories(pd.Index([0, 1, 3, 2, 4])),
+            psser.cat.set_categories(pd.Index([0, 1, 3, 2, 4])),
+        )
+
+        self.assert_eq(
+            pser.cat.set_categories(pd.Index([0, 1, 3, 2]), rename=True),
+            psser.cat.set_categories(pd.Index([0, 1, 3, 2]), rename=True),
+        )
+        self.assert_eq(
+            pser.cat.set_categories(pd.Index([0, 1, 3]), rename=True),
+            psser.cat.set_categories(pd.Index([0, 1, 3]), rename=True),
+        )
+        self.assert_eq(
+            pser.cat.set_categories(pd.Index([0, 1, 3, 2, 4]), rename=True),
+            psser.cat.set_categories(pd.Index([0, 1, 3, 2, 4]), rename=True),
+        )
+
+        self.assert_eq(
+            pser.cat.set_categories(pd.Index([0, 1, 3, 2]), ordered=True),
+            psser.cat.set_categories(pd.Index([0, 1, 3, 2]), ordered=True),
+        )
+        self.assert_eq(
+            pser.cat.set_categories(pd.Index([0, 1, 3]), ordered=True),
+            psser.cat.set_categories(pd.Index([0, 1, 3]), ordered=True),
+        )
+        self.assert_eq(
+            pser.cat.set_categories(pd.Index([0, 1, 3, 2, 4]), ordered=True),
+            psser.cat.set_categories(pd.Index([0, 1, 3, 2, 4]), ordered=True),
+        )
+
+        self.assert_eq(
+            pser.cat.set_categories(pd.Index([0, 1, 3, 2]), inplace=True, rename=True),
+            psser.cat.set_categories(pd.Index([0, 1, 3, 2]), inplace=True, rename=True),
+        )
+        self.assert_eq(pser, psser)
+        self.assert_eq(pdf, psdf)
+
+        self.assertRaisesRegex(
+            NotImplementedError,
+            "inplace must be False when rename is False",
+            lambda: psser.cat.set_categories(pd.Index([0, 1, 3, 2]), inplace=True, rename=False),
+        )
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add set_categories to CategoricalAccessor and CategoricalIndex.

### Why are the changes needed?
set_categories is supported in pandas CategoricalAccessor and CategoricalIndex. We ought to follow pandas.

### Does this PR introduce _any_ user-facing change?
Yes, users will be able to use `set_categories`.


### How was this patch tested?
Unit tests.

Keyword:SPARK-35337