### PR TITLE
[MINOR][INFRA] Add build/zinc-x.y.z to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ R/pkg/tests/fulltests/Rplots.pdf
 build/*.jar
 build/apache-maven*
 build/scala*
+build/zinc-*
 cache
 checkpoint
 conf/*.cmd


### PR DESCRIPTION


### What changes were proposed in this pull request?
Add `build/zinc-x.y.z` to .gitignore


### Why are the changes needed?
eg. `build/sbt clean package` will generate `build/zinc-x.y.z`

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested locally.
