### PR TITLE
[SPARK-34619][SQL][DOCS] Describe ANSI interval types at the `Data types` page of the SQL reference

### DIFF
--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -54,6 +54,8 @@ Spark SQL and DataFrames support the following data types:
     - MONTH, months within years `[0..11]`,
     - YEAR, years in the range `[0..178956970]`.
 
+    Individual interval fields are non-negative, but an interval itself can have a sign, and be negative.
+
     `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0(MONTH) and 1(YEAR). Supported year-month interval types are:
       - `YearMonthIntervalType(YEAR, YEAR)` or `YearMonthIntervalType(YEAR)`. For instance, a value of the type is `INTERVAL '2021' YEAR`.
       - `YearMonthIntervalType(YEAR, MONTH)`. For instance, a value of the type is `INTERVAL '2021-07' YEAR TO MONTH`.
@@ -63,6 +65,8 @@ Spark SQL and DataFrames support the following data types:
     - MINUTE, minutes within hours [0..59],
     - HOUR, hours within days [0..23],
     - DAY, days in the range [0..106751991].
+
+    Individual interval fields are non-negative, but an interval itself can have a sign, and be negative.
 
     `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0 (DAY), 1 (HOUR), 2 (MINUTE), 3 (SECOND). Supported day-time interval types are:
       - `DayTimeIntervalType(DAY, DAY)` or `DayTimeIntervalType(DAY)`. For instance, `INTERVAL '100' DAY`.

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -53,26 +53,28 @@ Spark SQL and DataFrames support the following data types:
   - `YearMonthIntervalType(startField, endField)`: Represents a year-month interval which is made up of a contiguous subset of the following fields:
     - MONTH, months within years `[0..11]`,
     - YEAR, years in the range `[0..178956970]`.
-  `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0(MONTH) and 1(YEAR). Supported year-month interval types are:
-    - `YearMonthIntervalType(YEAR, YEAR)` or `YearMonthIntervalType(YEAR)`. For instance, a value of the type is `INTERVAL '2021' YEAR`.
-    - `YearMonthIntervalType(YEAR, MONTH)`. For instance, a value of the type is `INTERVAL '2021-07' YEAR TO MONTH`.
-    - `YearMonthIntervalType(MONTH, MONTH)` or `YearMonthIntervalType(MONTH)`. For example, `INTERVAL '10' MONTH` is a value of the type. 
+
+    `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0(MONTH) and 1(YEAR). Supported year-month interval types are:
+      - `YearMonthIntervalType(YEAR, YEAR)` or `YearMonthIntervalType(YEAR)`. For instance, a value of the type is `INTERVAL '2021' YEAR`.
+      - `YearMonthIntervalType(YEAR, MONTH)`. For instance, a value of the type is `INTERVAL '2021-07' YEAR TO MONTH`.
+      - `YearMonthIntervalType(MONTH, MONTH)` or `YearMonthIntervalType(MONTH)`. For example, `INTERVAL '10' MONTH` is a value of the type.
   - `DayTimeIntervalType(startField, endField)`: Represents a day-time interval which is made up of a contiguous subset of the following fields:
     - SECOND, seconds within minutes and possibly fractions of a second [0..59.999999],
     - MINUTE, minutes within hours [0..59],
     - HOUR, hours within days [0..23],
     - DAY, days in the range [0..106751991].
-  `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0 (DAY), 1 (HOUR), 2 (MINUTE), 3 (SECOND). Supported year-month interval types are:
-    - `DayTimeIntervalType(DAY, DAY)` or `DayTimeIntervalType(DAY)`. For instance, `INTERVAL '100' DAY`.
-    - `DayTimeIntervalType(DAY, HOUR)`. `INTERVAL '100 10' DAY TO HOUR` is a value of the type.
-    - `DayTimeIntervalType(DAY, MINUTE)`. For example, `INTERVAL '100 10:30' DAY TO MINUTE`.
-    - `DayTimeIntervalType(DAY, SECOND)`. For example, `INTERVAL '100 10:30:40.999999' DAY TO SECOND`.
-    - `DayTimeIntervalType(HOUR, HOUR)` or `DayTimeIntervalType(HOUR)`. `INTERVAL '123' HOUR` is a value of the interval type.
-    - `DayTimeIntervalType(HOUR, MINUTE)`. This is a value of the type: `INTERVAL '123:10' HOUR TO MINUTE`.
-    - `DayTimeIntervalType(HOUR, SECOND)`. For instance, `INTERVAL '123:10:59' HOUR TO SECOND`.
-    - `DayTimeIntervalType(MINUTE, MINUTE)` or `DayTimeIntervalType(MINUTE)`. `INTERVAL '1000' MINUTE` is a value of the type.
-    - `DayTimeIntervalType(MINUTE, SECOND)`. For instance, `INTERVAL '1000:01.001' MINUTE TO SECOND`.
-    - `DayTimeIntervalType(SECOND, SECOND)` or `DayTimeIntervalType(SECOND)`. For instance, `INTERVAL '1000.000001' SECOND`.
+
+    `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0 (DAY), 1 (HOUR), 2 (MINUTE), 3 (SECOND). Supported year-month interval types are:
+      - `DayTimeIntervalType(DAY, DAY)` or `DayTimeIntervalType(DAY)`. For instance, `INTERVAL '100' DAY`.
+      - `DayTimeIntervalType(DAY, HOUR)`. `INTERVAL '100 10' DAY TO HOUR` is a value of the type.
+      - `DayTimeIntervalType(DAY, MINUTE)`. For example, `INTERVAL '100 10:30' DAY TO MINUTE`.
+      - `DayTimeIntervalType(DAY, SECOND)`. For example, `INTERVAL '100 10:30:40.999999' DAY TO SECOND`.
+      - `DayTimeIntervalType(HOUR, HOUR)` or `DayTimeIntervalType(HOUR)`. `INTERVAL '123' HOUR` is a value of the interval type.
+      - `DayTimeIntervalType(HOUR, MINUTE)`. This is a value of the type: `INTERVAL '123:10' HOUR TO MINUTE`.
+      - `DayTimeIntervalType(HOUR, SECOND)`. For instance, `INTERVAL '123:10:59' HOUR TO SECOND`.
+      - `DayTimeIntervalType(MINUTE, MINUTE)` or `DayTimeIntervalType(MINUTE)`. `INTERVAL '1000' MINUTE` is a value of the type.
+      - `DayTimeIntervalType(MINUTE, SECOND)`. For instance, `INTERVAL '1000:01.001' MINUTE TO SECOND`.
+      - `DayTimeIntervalType(SECOND, SECOND)` or `DayTimeIntervalType(SECOND)`. For instance, `INTERVAL '1000.000001' SECOND`.
 
 * Complex types
   - `ArrayType(elementType, containsNull)`: Represents values comprising a sequence of

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -58,11 +58,11 @@ Spark SQL and DataFrames support the following data types:
 
     `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0(MONTH) and 1(YEAR). Supported year-month interval types are:
     
-    |Year-Month Interval Type|Short form|An instance of the type|
+    |Year-Month Interval Type|SQL type|An instance of the type|
     |---------|----|-------------------|
-    |`YearMonthIntervalType(YEAR, YEAR)`|`YearMonthIntervalType(YEAR)`|`INTERVAL '2021' YEAR`|
-    |`YearMonthIntervalType(YEAR, MONTH)`||`INTERVAL '2021-07' YEAR TO MONTH`|
-    |`YearMonthIntervalType(MONTH, MONTH)`|`YearMonthIntervalType(MONTH)`|`INTERVAL '10' MONTH`|
+    |`YearMonthIntervalType(YEAR, YEAR)` or `YearMonthIntervalType(YEAR)`|INTERVAL YEAR|`INTERVAL '2021' YEAR`|
+    |`YearMonthIntervalType(YEAR, MONTH)`|INTERVAL YEAR TO MONTH|`INTERVAL '2021-07' YEAR TO MONTH`|
+    |`YearMonthIntervalType(MONTH, MONTH)` or `YearMonthIntervalType(MONTH)`|INTERVAL MONTH|`INTERVAL '10' MONTH`|
 
   - `DayTimeIntervalType(startField, endField)`: Represents a day-time interval which is made up of a contiguous subset of the following fields:
     - SECOND, seconds within minutes and possibly fractions of a second `[0..59.999999]`,
@@ -74,18 +74,18 @@ Spark SQL and DataFrames support the following data types:
 
     `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0 (DAY), 1 (HOUR), 2 (MINUTE), 3 (SECOND). Supported day-time interval types are:
 
-    |Day-Time Interval Type|Short form|An instance of the type|
+    |Day-Time Interval Type|SQL type|An instance of the type|
     |---------|----|-------------------|
-    |`DayTimeIntervalType(DAY, DAY)`|`DayTimeIntervalType(DAY)`|`INTERVAL '100' DAY`|
-    |`DayTimeIntervalType(DAY, HOUR)`||`INTERVAL '100 10' DAY TO HOUR`|
-    |`DayTimeIntervalType(DAY, MINUTE)`||`INTERVAL '100 10:30' DAY TO MINUTE`|
-    |`DayTimeIntervalType(DAY, SECOND)`||`INTERVAL '100 10:30:40.999999' DAY TO SECOND`|
-    |`DayTimeIntervalType(HOUR, HOUR)`|`DayTimeIntervalType(HOUR)`|`INTERVAL '123' HOUR`|
-    |`DayTimeIntervalType(HOUR, MINUTE)`||`INTERVAL '123:10' HOUR TO MINUTE`|
-    |`DayTimeIntervalType(HOUR, SECOND)`||`INTERVAL '123:10:59' HOUR TO SECOND`|
-    |`DayTimeIntervalType(MINUTE, MINUTE)`|`DayTimeIntervalType(MINUTE)`|`INTERVAL '1000' MINUTE`|
-    |`DayTimeIntervalType(MINUTE, SECOND)`||`INTERVAL '1000:01.001' MINUTE TO SECOND`|
-    |`DayTimeIntervalType(SECOND, SECOND)`|`DayTimeIntervalType(SECOND)`|`INTERVAL '1000.000001' SECOND`|
+    |`DayTimeIntervalType(DAY, DAY)` or `DayTimeIntervalType(DAY)`|INTERVAL DAY|`INTERVAL '100' DAY`|
+    |`DayTimeIntervalType(DAY, HOUR)`|INTERVAL DAY TO HOUR|`INTERVAL '100 10' DAY TO HOUR`|
+    |`DayTimeIntervalType(DAY, MINUTE)`|INTERVAL DAY TO MINUTE|`INTERVAL '100 10:30' DAY TO MINUTE`|
+    |`DayTimeIntervalType(DAY, SECOND)`|INTERVAL DAY TO SECOND|`INTERVAL '100 10:30:40.999999' DAY TO SECOND`|
+    |`DayTimeIntervalType(HOUR, HOUR)` or `DayTimeIntervalType(HOUR)`|INTERVAL HOUR|`INTERVAL '123' HOUR`|
+    |`DayTimeIntervalType(HOUR, MINUTE)`|INTERVAL HOUR TO MINUTE|`INTERVAL '123:10' HOUR TO MINUTE`|
+    |`DayTimeIntervalType(HOUR, SECOND)`|INTERVAL HOUR TO SECOND|`INTERVAL '123:10:59' HOUR TO SECOND`|
+    |`DayTimeIntervalType(MINUTE, MINUTE)` or `DayTimeIntervalType(MINUTE)`|INTERVAL MINUTE|`INTERVAL '1000' MINUTE`|
+    |`DayTimeIntervalType(MINUTE, SECOND)`|INTERVAL MINUTE TO SECOND|`INTERVAL '1000:01.001' MINUTE TO SECOND`|
+    |`DayTimeIntervalType(SECOND, SECOND)` or `DayTimeIntervalType(SECOND)`|INTERVAL SECOND|`INTERVAL '1000.000001' SECOND`|
 
 * Complex types
   - `ArrayType(elementType, containsNull)`: Represents values comprising a sequence of

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -57,9 +57,13 @@ Spark SQL and DataFrames support the following data types:
     Individual interval fields are non-negative, but an interval itself can have a sign, and be negative.
 
     `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0(MONTH) and 1(YEAR). Supported year-month interval types are:
-      - `YearMonthIntervalType(YEAR, YEAR)` or `YearMonthIntervalType(YEAR)`. For instance, a value of the type is `INTERVAL '2021' YEAR`.
-      - `YearMonthIntervalType(YEAR, MONTH)`. For instance, a value of the type is `INTERVAL '2021-07' YEAR TO MONTH`.
-      - `YearMonthIntervalType(MONTH, MONTH)` or `YearMonthIntervalType(MONTH)`. For example, `INTERVAL '10' MONTH` is a value of the type.
+    
+    |Year-Month Interval Type|Short form|An instance of the type|
+    |---------|----|-------------------|
+    |`YearMonthIntervalType(YEAR, YEAR)`|`YearMonthIntervalType(YEAR)`|`INTERVAL '2021' YEAR`|
+    |`YearMonthIntervalType(YEAR, MONTH)`||`INTERVAL '2021-07' YEAR TO MONTH`|
+    |`YearMonthIntervalType(MONTH, MONTH)`|`YearMonthIntervalType(MONTH)`|`INTERVAL '10' MONTH`|
+
   - `DayTimeIntervalType(startField, endField)`: Represents a day-time interval which is made up of a contiguous subset of the following fields:
     - SECOND, seconds within minutes and possibly fractions of a second `[0..59.999999]`,
     - MINUTE, minutes within hours `[0..59]`,
@@ -69,16 +73,19 @@ Spark SQL and DataFrames support the following data types:
     Individual interval fields are non-negative, but an interval itself can have a sign, and be negative.
 
     `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0 (DAY), 1 (HOUR), 2 (MINUTE), 3 (SECOND). Supported day-time interval types are:
-      - `DayTimeIntervalType(DAY, DAY)` or `DayTimeIntervalType(DAY)`. For instance, `INTERVAL '100' DAY`.
-      - `DayTimeIntervalType(DAY, HOUR)`. `INTERVAL '100 10' DAY TO HOUR` is a value of the type.
-      - `DayTimeIntervalType(DAY, MINUTE)`. For example, `INTERVAL '100 10:30' DAY TO MINUTE`.
-      - `DayTimeIntervalType(DAY, SECOND)`. For example, `INTERVAL '100 10:30:40.999999' DAY TO SECOND`.
-      - `DayTimeIntervalType(HOUR, HOUR)` or `DayTimeIntervalType(HOUR)`. `INTERVAL '123' HOUR` is a value of the interval type.
-      - `DayTimeIntervalType(HOUR, MINUTE)`. This is a value of the type: `INTERVAL '123:10' HOUR TO MINUTE`.
-      - `DayTimeIntervalType(HOUR, SECOND)`. For instance, `INTERVAL '123:10:59' HOUR TO SECOND`.
-      - `DayTimeIntervalType(MINUTE, MINUTE)` or `DayTimeIntervalType(MINUTE)`. `INTERVAL '1000' MINUTE` is a value of the type.
-      - `DayTimeIntervalType(MINUTE, SECOND)`. For instance, `INTERVAL '1000:01.001' MINUTE TO SECOND`.
-      - `DayTimeIntervalType(SECOND, SECOND)` or `DayTimeIntervalType(SECOND)`. For instance, `INTERVAL '1000.000001' SECOND`.
+
+    |Day-Time Interval Type|Short form|An instance of the type|
+    |---------|----|-------------------|
+    |`DayTimeIntervalType(DAY, DAY)`|`DayTimeIntervalType(DAY)`|`INTERVAL '100' DAY`|
+    |`DayTimeIntervalType(DAY, HOUR)`||`INTERVAL '100 10' DAY TO HOUR`|
+    |`DayTimeIntervalType(DAY, MINUTE)`||`INTERVAL '100 10:30' DAY TO MINUTE`|
+    |`DayTimeIntervalType(DAY, SECOND)`||`INTERVAL '100 10:30:40.999999' DAY TO SECOND`|
+    |`DayTimeIntervalType(HOUR, HOUR)`|`DayTimeIntervalType(HOUR)`|`INTERVAL '123' HOUR`|
+    |`DayTimeIntervalType(HOUR, MINUTE)`||`INTERVAL '123:10' HOUR TO MINUTE`|
+    |`DayTimeIntervalType(HOUR, SECOND)`||`INTERVAL '123:10:59' HOUR TO SECOND`|
+    |`DayTimeIntervalType(MINUTE, MINUTE)`|`DayTimeIntervalType(MINUTE)`|`INTERVAL '1000' MINUTE`|
+    |`DayTimeIntervalType(MINUTE, SECOND)`||`INTERVAL '1000:01.001' MINUTE TO SECOND`|
+    |`DayTimeIntervalType(SECOND, SECOND)`|`DayTimeIntervalType(SECOND)`|`INTERVAL '1000.000001' SECOND`|
 
 * Complex types
   - `ArrayType(elementType, containsNull)`: Represents values comprising a sequence of

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -61,10 +61,10 @@ Spark SQL and DataFrames support the following data types:
       - `YearMonthIntervalType(YEAR, MONTH)`. For instance, a value of the type is `INTERVAL '2021-07' YEAR TO MONTH`.
       - `YearMonthIntervalType(MONTH, MONTH)` or `YearMonthIntervalType(MONTH)`. For example, `INTERVAL '10' MONTH` is a value of the type.
   - `DayTimeIntervalType(startField, endField)`: Represents a day-time interval which is made up of a contiguous subset of the following fields:
-    - SECOND, seconds within minutes and possibly fractions of a second [0..59.999999],
-    - MINUTE, minutes within hours [0..59],
-    - HOUR, hours within days [0..23],
-    - DAY, days in the range [0..106751991].
+    - SECOND, seconds within minutes and possibly fractions of a second `[0..59.999999]`,
+    - MINUTE, minutes within hours `[0..59]`,
+    - HOUR, hours within days `[0..23]`,
+    - DAY, days in the range `[0..106751991]`.
 
     Individual interval fields are non-negative, but an interval itself can have a sign, and be negative.
 

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -64,7 +64,7 @@ Spark SQL and DataFrames support the following data types:
     - HOUR, hours within days [0..23],
     - DAY, days in the range [0..106751991].
 
-    `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0 (DAY), 1 (HOUR), 2 (MINUTE), 3 (SECOND). Supported year-month interval types are:
+    `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0 (DAY), 1 (HOUR), 2 (MINUTE), 3 (SECOND). Supported day-time interval types are:
       - `DayTimeIntervalType(DAY, DAY)` or `DayTimeIntervalType(DAY)`. For instance, `INTERVAL '100' DAY`.
       - `DayTimeIntervalType(DAY, HOUR)`. `INTERVAL '100 10' DAY TO HOUR` is a value of the type.
       - `DayTimeIntervalType(DAY, MINUTE)`. For example, `INTERVAL '100 10:30' DAY TO MINUTE`.

--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -49,6 +49,31 @@ Spark SQL and DataFrames support the following data types:
   absolute point in time.
   - `DateType`: Represents values comprising values of fields year, month and day, without a
   time-zone.
+* Interval types
+  - `YearMonthIntervalType(startField, endField)`: Represents a year-month interval which is made up of a contiguous subset of the following fields:
+    - MONTH, months within years `[0..11]`,
+    - YEAR, years in the range `[0..178956970]`.
+  `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0(MONTH) and 1(YEAR). Supported year-month interval types are:
+    - `YearMonthIntervalType(YEAR, YEAR)` or `YearMonthIntervalType(YEAR)`. For instance, a value of the type is `INTERVAL '2021' YEAR`.
+    - `YearMonthIntervalType(YEAR, MONTH)`. For instance, a value of the type is `INTERVAL '2021-07' YEAR TO MONTH`.
+    - `YearMonthIntervalType(MONTH, MONTH)` or `YearMonthIntervalType(MONTH)`. For example, `INTERVAL '10' MONTH` is a value of the type. 
+  - `DayTimeIntervalType(startField, endField)`: Represents a day-time interval which is made up of a contiguous subset of the following fields:
+    - SECOND, seconds within minutes and possibly fractions of a second [0..59.999999],
+    - MINUTE, minutes within hours [0..59],
+    - HOUR, hours within days [0..23],
+    - DAY, days in the range [0..106751991].
+  `startField` is the leftmost field, and `endField` is the rightmost field of the type. Valid values of `startField` and `endField` are 0 (DAY), 1 (HOUR), 2 (MINUTE), 3 (SECOND). Supported year-month interval types are:
+    - `DayTimeIntervalType(DAY, DAY)` or `DayTimeIntervalType(DAY)`. For instance, `INTERVAL '100' DAY`.
+    - `DayTimeIntervalType(DAY, HOUR)`. `INTERVAL '100 10' DAY TO HOUR` is a value of the type.
+    - `DayTimeIntervalType(DAY, MINUTE)`. For example, `INTERVAL '100 10:30' DAY TO MINUTE`.
+    - `DayTimeIntervalType(DAY, SECOND)`. For example, `INTERVAL '100 10:30:40.999999' DAY TO SECOND`.
+    - `DayTimeIntervalType(HOUR, HOUR)` or `DayTimeIntervalType(HOUR)`. `INTERVAL '123' HOUR` is a value of the interval type.
+    - `DayTimeIntervalType(HOUR, MINUTE)`. This is a value of the type: `INTERVAL '123:10' HOUR TO MINUTE`.
+    - `DayTimeIntervalType(HOUR, SECOND)`. For instance, `INTERVAL '123:10:59' HOUR TO SECOND`.
+    - `DayTimeIntervalType(MINUTE, MINUTE)` or `DayTimeIntervalType(MINUTE)`. `INTERVAL '1000' MINUTE` is a value of the type.
+    - `DayTimeIntervalType(MINUTE, SECOND)`. For instance, `INTERVAL '1000:01.001' MINUTE TO SECOND`.
+    - `DayTimeIntervalType(SECOND, SECOND)` or `DayTimeIntervalType(SECOND)`. For instance, `INTERVAL '1000.000001' SECOND`.
+
 * Complex types
   - `ArrayType(elementType, containsNull)`: Represents values comprising a sequence of
   elements with the type of `elementType`. `containsNull` is used to indicate if


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to update the page https://spark.apache.org/docs/latest/sql-ref-datatypes.html and add information about the year-month and day-time interval types introduced by SPARK-27790.

<img width="932" alt="Screenshot 2021-07-27 at 10 38 23" src="https://user-images.githubusercontent.com/1580697/127115289-e633ca3a-2c18-49a0-a7c0-22421ae5c363.png">


### Why are the changes needed?
To inform users about new ANSI interval types, and improve UX with Spark SQL.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Should be tested by a GitHub action.