### PR TITLE
[SPARK-36289][SQL] Rewrite distinct count case when expressions without Expand node

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1269,6 +1269,20 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val REWRITE_CASE_WHEN_COUNT_DISTINCT_AGGREGATES =
+    buildConf("spark.sql.optimizer.rewriteCaseWhenCountDistinctAggregates")
+      .doc("When true, rewrite case-when count distinct aggregates")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val REWRITE_CASE_WHEN_COUNT_DISTINCT_AGGREGATES_USE_BITVECTOR =
+    buildConf("spark.sql.optimizer.rewriteCaseWhenCountDistinctAggregates.useBitvector")
+      .doc("When true, rewrite case-when count distinct aggregates using bitvectors")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   // Whether to automatically resolve ambiguity in join conditions for self-joins.
   // See SPARK-6231.
   val DATAFRAME_SELF_JOIN_AUTO_RESOLVE_AMBIGUITY =
@@ -3800,6 +3814,12 @@ class SQLConf extends Serializable with Logging {
   def variableSubstituteEnabled: Boolean = getConf(VARIABLE_SUBSTITUTE_ENABLED)
 
   def warehousePath: String = new Path(getConf(StaticSQLConf.WAREHOUSE_PATH)).toString
+
+  def rewriteCaseWhenCountDistinctAggregates: Boolean =
+    getConf(REWRITE_CASE_WHEN_COUNT_DISTINCT_AGGREGATES)
+
+  def rewriteCaseWhenCountDistinctAggregatesUseBitvector: Boolean =
+    getConf(REWRITE_CASE_WHEN_COUNT_DISTINCT_AGGREGATES_USE_BITVECTOR)
 
   def hiveThriftServerSingleSession: Boolean =
     getConf(StaticSQLConf.HIVE_THRIFT_SERVER_SINGLESESSION)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, `RewriteDistinctAggregates` rule will rewrite distinct aggregates with extra Expand node. This causes unnecessary memory waste and performance fallback for some specific aggregates (e.g. count distinct case when).

for query:

```sql
   SELECT
     cat1,
     COUNT(DISTINCT CASE WHEN cond1 THEN cat2 ELSE null end) as cat2_cnt1,
     COUNT(DISTINCT CASE WHEN cond2 THEN cat2 ELSE null end) as cat2_cnt2,
     FROM
       data
     GROUP BY
       key
```


Currently, we rewrite it to :

```
Aggregate(
   key = ['key]
   functions = [count(if (('gid = 1) and 'casewhen1) 'cat2_1 else null),
                count(if (('gid = 2) and 'casewhen2) 'cat2_2 else null)]
   output = ['key, 'cat2_cnt1, 'cat2_cnt2])
   Aggregate(
      key = ['key, 'casewhen1, 'casewhen2, 'gid]
      functions = []
      output = ['key, 'casewhen1, 'casewhen2, 'gid])
     Expand(
        projections = [('key, 'cat1, CASE WHEN cond1 THEN cat2 ELSE null END, null, 1),
                       ('key, 'cat1, 'null, CASE WHEN cond1 THEN cat2 ELSE null END, 2)]
        output = ['key, 'cat1, 'casewhen1, 'casewhen2, 'gid])
       LocalTableScan [...]
```


This PR will improve performance and reduce memory waste. And query will be rewrite to:

- if # of case when expr < 64

    ```
    Aggregate(
       key = ['key]
       functions = [count(if (01 & 'bit_vector != 0) 0 else null),
                    count(if (10 & 'bit_vector != 0) 0 else null)]
       output = ['key, 'cat2_cnt1, 'cat2_cnt2])
       Aggregate(
          key = ['key, 'cat1]
          functions = [bit_or(if (cond1) 01 else 00, if (cond2) 10 else 00)]
          output = ['key, 'cat1, 'bit_vector])
           LocalTableScan [...]
    ```

- if # of case when expr >= 64

    ```
    Aggregate(
       key = ['key]
       functions = [count(if ('sum1 >= 1) 1 else null),
                    count(if ('sum2 >= 1) 1 else null)]
       output = ['key, 'cat1_cnt1, 'cat1_cnt2])
       Aggregate(
          key = ['key, 'cat1]
          functions = [sum(if (cond1) 1 else 0), sum(if (cond2) 1 else 0)]
          output = ['key, 'cat1, 'sum1, 'sum2])
           LocalTableScan [...]
    ```

### Why are the changes needed?
we can rewrite count distinct case when more efficiently

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
UT in `RewriteDistinctAggregatesSuite`