### PR TITLE
[SPARK-36285][INFRA][TESTS] Skip MiMa in PySpark/SparkR/Docker GHA job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -279,6 +279,7 @@ jobs:
       HIVE_PROFILE: hive2.3
       GITHUB_PREV_SHA: ${{ github.event.before }}
       SPARK_LOCAL_IP: localhost
+      SKIP_MIMA: true
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2
@@ -662,6 +663,7 @@ jobs:
       GITHUB_PREV_SHA: ${{ github.event.before }}
       SPARK_LOCAL_IP: localhost
       ORACLE_DOCKER_IMAGE_NAME: oracle/database:18.4.0-xe
+      SKIP_MIMA: true
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -206,6 +206,7 @@ jobs:
       GITHUB_PREV_SHA: ${{ github.event.before }}
       SPARK_LOCAL_IP: localhost
       SKIP_UNIDOC: true
+      SKIP_MIMA: true
       METASPACE_SIZE: 128m
     steps:
     - name: Checkout Spark repository

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -804,7 +804,8 @@ def main():
     # backwards compatibility checks
     if build_tool == "sbt":
         # Note: compatibility tests only supported in sbt for now
-        detect_binary_inop_with_mima(extra_profiles)
+        if not os.environ.get("SKIP_MIMA"):
+            detect_binary_inop_with_mima(extra_profiles)
         # Since we did not build assembly/package before running dev/mima, we need to
         # do it here because the tests still rely on it; see SPARK-13294 for details.
         build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to skip MiMa in PySpark/SparkR/Docker GHA job. 


### Why are the changes needed?
This will save GHA resource because MiMa is irrelevant to Python. 


### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
Pass the GHA. 