### PR TITLE
[SPARK-36321][K8S] Do not fail application in kubernetes if name is too long

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/SparkPiWithoutAppName.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkPiWithoutAppName.scala
@@ -15,33 +15,15 @@
  * limitations under the License.
  */
 
-// scalastyle:off println
 package org.apache.spark.examples
-
-import scala.math.random
 
 import org.apache.spark.sql.SparkSession
 
-/** Computes an approximation to pi */
-object SparkPi {
+/** Computes an approximation to pi but with no app name specified */
+object SparkPiWithoutAppName {
   def main(args: Array[String]): Unit = {
-    val spark = SparkSession
-      .builder
-      .appName("Spark Pi")
-      .getOrCreate()
-    run(args, spark)
+    val spark = SparkSession.builder().getOrCreate()
+    SparkPi.run(args, spark)
     spark.stop()
   }
-
-  def run(args: Array[String], spark: SparkSession): Unit = {
-    val slices = if (args.length > 0) args(0).toInt else 2
-    val n = math.min(100000L * slices, Int.MaxValue).toInt // avoid overflow
-    val count = spark.sparkContext.parallelize(1 until n, slices).map { i =>
-      val x = random * 2 - 1
-      val y = random * 2 - 1
-      if (x*x + y*y <= 1) 1 else 0
-    }.reduce(_ + _)
-    println(s"Pi is roughly ${4.0 * count / (n - 1)}")
-  }
 }
-// scalastyle:on println

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -250,19 +250,6 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
-  // the definition of a label in DNS (RFC 1123).
-  private val dns1123LabelFmt = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
-
-  private val podConfValidator = (s"^$dns1123LabelFmt(\\.$dns1123LabelFmt)*$$").r.pattern
-
-  // The possible longest executor name would be "$prefix-exec-${Int.MaxValue}"
-  def isValidExecutorPodNamePrefix(prefix: String): Boolean = {
-    // 6 is length of '-exec-'
-    val reservedLen = Int.MaxValue.toString.length + 6
-    val validLength = prefix.length + reservedLen <= KUBERNETES_DNSNAME_MAX_LENGTH
-    validLength && podConfValidator.matcher(prefix).matches()
-  }
-
   val KUBERNETES_EXECUTOR_POD_NAME_PREFIX =
     ConfigBuilder("spark.kubernetes.executor.podNamePrefix")
       .doc("Prefix to use in front of the executor pod names. It must conform the rules defined " +
@@ -273,7 +260,7 @@ private[spark] object Config extends Logging {
         "so the length of the `podNamePrefix` needs to be <= 47(= 63 - 10 - 6).")
       .version("2.3.0")
       .stringConf
-      .checkValue(isValidExecutorPodNamePrefix,
+      .checkValue(KubernetesUtils.isValidExecutorPodNamePrefix,
         "must conform https://kubernetes.io/docs/concepts/overview/working-with-objects" +
           "/names/#dns-label-names and the value length <= 47")
       .createOptional

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -256,7 +256,7 @@ private[spark] object Config extends Logging {
   private val podConfValidator = (s"^$dns1123LabelFmt(\\.$dns1123LabelFmt)*$$").r.pattern
 
   // The possible longest executor name would be "$prefix-exec-${Int.MaxValue}"
-  private def isValidExecutorPodNamePrefix(prefix: String): Boolean = {
+  def isValidExecutorPodNamePrefix(prefix: String): Boolean = {
     // 6 is length of '-exec-'
     val reservedLen = Int.MaxValue.toString.length + 6
     val validLength = prefix.length + reservedLen <= KUBERNETES_DNSNAME_MAX_LENGTH

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -604,5 +604,6 @@ private[spark] object Config extends Logging {
 
   val KUBERNETES_DNSNAME_MAX_LENGTH = 63
   // The possible longest executor name would be "$prefix-exec-${Int.MaxValue}"
-  val KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH = 63 - 6 - Int.MaxValue.toString.length
+  val KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH = 
+    KUBERNETES_DNSNAME_MAX_LENGTH - 6 - Int.MaxValue.toString.length
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -603,4 +603,6 @@ private[spark] object Config extends Logging {
   val KUBERNETES_DRIVER_ENV_PREFIX = "spark.kubernetes.driverEnv."
 
   val KUBERNETES_DNSNAME_MAX_LENGTH = 63
+  // The possible longest executor name would be "$prefix-exec-${Int.MaxValue}"
+  val KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH = 63 - 6 - Int.MaxValue.toString.length
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -604,6 +604,6 @@ private[spark] object Config extends Logging {
 
   val KUBERNETES_DNSNAME_MAX_LENGTH = 63
   // The possible longest executor name would be "$prefix-exec-${Int.MaxValue}"
-  val KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH = 
+  val KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH =
     KUBERNETES_DNSNAME_MAX_LENGTH - 6 - Int.MaxValue.toString.length
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.deploy.k8s.Config.{KUBERNETES_DNSNAME_MAX_LENGTH, KUBERNETES_FILE_UPLOAD_PATH}
+import org.apache.spark.deploy.k8s.Config.{KUBERNETES_FILE_UPLOAD_PATH, KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH}
 import org.apache.spark.internal.Logging
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.resource.ResourceUtils
@@ -386,12 +386,9 @@ object KubernetesUtils extends Logging {
   private val dns1123LabelFmt = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
   private val podConfValidator = (s"^$dns1123LabelFmt(\\.$dns1123LabelFmt)*$$").r.pattern
 
-  // The possible longest executor name would be "$prefix-exec-${Int.MaxValue}"
   @Since("3.3.0")
   def isValidExecutorPodNamePrefix(prefix: String): Boolean = {
-    // 6 is length of '-exec-'
-    val reservedLen = Int.MaxValue.toString.length + 6
-    val validLength = prefix.length + reservedLen <= KUBERNETES_DNSNAME_MAX_LENGTH
+    val validLength = prefix.length <= KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH
     validLength && podConfValidator.matcher(prefix).matches()
   }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -74,7 +74,8 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       if (KubernetesUtils.isValidExecutorPodNamePrefix(podNamePrefix)) {
         sc.conf.set(KUBERNETES_EXECUTOR_POD_NAME_PREFIX, podNamePrefix)
       } else {
-        val shortPrefix = "spark-" + KubernetesUtils.uniqueID()
+        val shortPrefix = podNamePrefix.substring(
+          Math.max(0, podNamePrefix.length - KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH))
         logWarning(s"Use $shortPrefix as the executor pod's name prefix due to " +
           s"spark.app.name is too long. Please set '${KUBERNETES_EXECUTOR_POD_NAME_PREFIX.key}' " +
           s"if you need a custom executor pod's name prefix.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -70,19 +70,16 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
     // If/when feature steps are executed in client mode, they should instead take care of this,
     // and this code should be removed.
     if (!sc.conf.contains(KUBERNETES_EXECUTOR_POD_NAME_PREFIX)) {
-      val podNamePrefix = KubernetesConf.getResourceNamePrefix(sc.conf.get("spark.app.name"))
-      if (KubernetesUtils.isValidExecutorPodNamePrefix(podNamePrefix)) {
-        sc.conf.set(KUBERNETES_EXECUTOR_POD_NAME_PREFIX, podNamePrefix)
-      } else {
-        // `KubernetesConf.getResourceNamePrefix` has already formatted the name,
-        //  so here name can only be over the length.
-        val shortPrefix = podNamePrefix.substring(
-          Math.max(0, podNamePrefix.length - KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH))
+      def warnFunc(shortPrefix: String): Unit = {
         logWarning(s"Use $shortPrefix as the executor pod's name prefix due to " +
           s"spark.app.name is too long. Please set '${KUBERNETES_EXECUTOR_POD_NAME_PREFIX.key}' " +
           s"if you need a custom executor pod's name prefix.")
-        sc.conf.set(KUBERNETES_EXECUTOR_POD_NAME_PREFIX, shortPrefix)
       }
+      val appName = sc.conf.get("spark.app.name")
+      val podNamePrefix = KubernetesConf.getResourceNamePrefix(
+        appName, KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH, warnFunc)
+      assert(KubernetesUtils.isValidExecutorPodNamePrefix(podNamePrefix))
+      sc.conf.set(KUBERNETES_EXECUTOR_POD_NAME_PREFIX, podNamePrefix)
     }
 
     val kubernetesClient = SparkKubernetesClientFactory.createKubernetesClient(

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -71,7 +71,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
     // and this code should be removed.
     if (!sc.conf.contains(KUBERNETES_EXECUTOR_POD_NAME_PREFIX)) {
       val podNamePrefix = KubernetesConf.getResourceNamePrefix(sc.conf.get("spark.app.name"))
-      if (org.apache.spark.deploy.k8s.Config.isValidExecutorPodNamePrefix(podNamePrefix)) {
+      if (KubernetesUtils.isValidExecutorPodNamePrefix(podNamePrefix)) {
         sc.conf.set(KUBERNETES_EXECUTOR_POD_NAME_PREFIX, podNamePrefix)
       } else {
         val shortPrefix = "spark-" + KubernetesUtils.uniqueID()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -74,6 +74,8 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       if (KubernetesUtils.isValidExecutorPodNamePrefix(podNamePrefix)) {
         sc.conf.set(KUBERNETES_EXECUTOR_POD_NAME_PREFIX, podNamePrefix)
       } else {
+        // `KubernetesConf.getResourceNamePrefix` has already formatted the name,
+        //  so here name can only be over the length.
         val shortPrefix = podNamePrefix.substring(
           Math.max(0, podNamePrefix.length - KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH))
         logWarning(s"Use $shortPrefix as the executor pod's name prefix due to " +

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -198,4 +198,13 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(driverConf.nodeSelector === CUSTOM_NODE_SELECTOR)
     assert(driverConf.driverNodeSelector === CUSTOM_DRIVER_NODE_SELECTOR)
   }
+
+  test("resourceName prefix") {
+    val name = "a" + "b" * 100 + "c"
+    assert(KubernetesConf.getResourceNamePrefix(name).startsWith(name + "-"))
+
+    val expected = "a" + "b" * (KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH - 1 - 1 - 16)
+    assert(KubernetesConf.getResourceNamePrefix(name, KUBERNETES_POD_NAME_PREFIX_MAX_LENGTH)
+      .startsWith(expected + "-"))
+  }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -194,7 +194,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
       val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf),
         defaultProfile)
       assert(step.configurePod(SparkPod.initialPod()).pod.getSpec.getHostname.length ===
-        KUBERNETES_DNSNAME_MAX_LENGTH)
+        KUBERNETES_DNSNAME_MAX_LENGTH - Int.MaxValue.toString.length + 1)
     }
   }
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -108,11 +108,9 @@ private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
     }
   }
 
-  test("SPARK-36321: Do not fail application in kubernetes if name is too long") {
+  test("SPARK-36321: Do not fail application in kubernetes if name is too long", k8sTestTag) {
     def executorPodCheck(executorPod: Pod): Unit = {
-      assert(executorPod.getMetadata.getName.length == 63)
       assert(executorPod.getMetadata.getName.startsWith("abbbbb"))
-      assert(executorPod.getSpec.getHostname.length == 63)
       assert(executorPod.getSpec.getHostname.startsWith("abbbbb"))
     }
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -569,7 +569,9 @@ private[spark] object KubernetesSuite {
   val pvTestTag = Tag("persistentVolume")
   val rTestTag = Tag("r")
   val MinikubeTag = Tag("minikube")
-  val SPARK_PI_MAIN_CLASS: String = "org.apache.spark.examples.SparkPiWithoutAppName"
+  val SPARK_PI_MAIN_CLASS: String = "org.apache.spark.examples.SparkPi"
+  val SPARK_PI_MAIN_CLASS_WITHOUT_APP_NAME: String =
+    "org.apache.spark.examples.SparkPiWithoutAppName"
   val SPARK_DFS_READ_WRITE_TEST = "org.apache.spark.examples.DFSReadWriteTest"
   val SPARK_REMOTE_MAIN_CLASS: String = "org.apache.spark.examples.SparkRemoteFileTest"
   val SPARK_DRIVER_MAIN_CLASS: String = "org.apache.spark.examples.DriverSubmissionTest"

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -569,7 +569,7 @@ private[spark] object KubernetesSuite {
   val pvTestTag = Tag("persistentVolume")
   val rTestTag = Tag("r")
   val MinikubeTag = Tag("minikube")
-  val SPARK_PI_MAIN_CLASS: String = "org.apache.spark.examples.SparkPi"
+  val SPARK_PI_MAIN_CLASS: String = "org.apache.spark.examples.SparkPiWithoutAppName"
   val SPARK_DFS_READ_WRITE_TEST = "org.apache.spark.examples.DFSReadWriteTest"
   val SPARK_REMOTE_MAIN_CLASS: String = "org.apache.spark.examples.SparkRemoteFileTest"
   val SPARK_DRIVER_MAIN_CLASS: String = "org.apache.spark.examples.DriverSubmissionTest"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Use short string as executor pod name prefix if app name is long.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If we have a long spark app name and start with k8s master, we will get the execption.
```
java.lang.IllegalArgumentException: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-89fe2f7ae71c3570' in spark.kubernetes.executor.podNamePrefix is invalid. must conform https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names and the value length <= 47
	at org.apache.spark.internal.config.TypedConfigBuilder.$anonfun$checkValue$1(ConfigBuilder.scala:108)
	at org.apache.spark.internal.config.TypedConfigBuilder.$anonfun$transform$1(ConfigBuilder.scala:101)
	at scala.Option.map(Option.scala:230)
	at org.apache.spark.internal.config.OptionalConfigEntry.readFrom(ConfigEntry.scala:239)
	at org.apache.spark.internal.config.OptionalConfigEntry.readFrom(ConfigEntry.scala:214)
	at org.apache.spark.SparkConf.get(SparkConf.scala:261)
	at org.apache.spark.deploy.k8s.KubernetesConf.get(KubernetesConf.scala:67)
	at org.apache.spark.deploy.k8s.KubernetesExecutorConf.<init>(KubernetesConf.scala:147)
	at org.apache.spark.deploy.k8s.KubernetesConf$.createExecutorConf(KubernetesConf.scala:231)
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$requestNewExecutors$2(ExecutorPodsAllocator.scala:367)
```
Use app name as the executor pod name is the Spark internal behavior and we should not make application failure.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add test

the new log:
```
21/07/28 09:35:53 INFO SparkEnv: Registering OutputCommitCoordinator
21/07/28 09:35:54 INFO Utils: Successfully started service 'SparkUI' on port 41926.
21/07/28 09:35:54 INFO SparkUI: Bound SparkUI to 0.0.0.0, and started at http://:41926
21/07/28 09:35:54 WARN KubernetesClusterManager: Use spark-c460617aeac0fda9 as the executor pod's name prefix due to spark.app.name is too long. Please set 'spark.kubernetes.executor.podNamePrefix' if you need a custom executor pod's name prefix.
21/07/28 09:35:54 INFO SparkKubernetesClientFactory: Auto-configuring K8S client using current context from users K8S config file
21/07/28 09:35:55 WARN Utils: spark.executor.instances less than spark.dynamicAllocation.minExecutors is invalid, ignoring its setting, please update your configs.
```

verify the config:
![image](https://user-images.githubusercontent.com/12025282/127258223-fbcaaac8-451d-4c55-8c09-e802511a510d.png)

verify the executor pod name
![image](https://user-images.githubusercontent.com/12025282/127258284-be15b862-b826-4440-9a11-023d69c61fc4.png)
