### PR TITLE
[SPARK-36270][BUILD][FOLLOWUP] Fix typo in the sbt memory setting

### DIFF
--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -119,7 +119,7 @@ get_mem_opts () {
   local mem=${1:-$sbt_default_mem}
   local codecache=128
 
-  echo "-Xms$256m -Xmx${mem}m -XX:ReservedCodeCacheSize=${codecache}m"
+  echo "-Xms256m -Xmx${mem}m -XX:ReservedCodeCacheSize=${codecache}m"
 }
 
 require_arg () {


### PR DESCRIPTION
### What changes were proposed in this pull request?
remove the `$` in the `-Xms$256m` memory options


### Why are the changes needed?
fix typo


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
not needed
