### PR TITLE
[SPARK-36326][SQL] Use computeIfAbsent to simplify the process of put a absent value into Map

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/HeapMemoryAllocator.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/HeapMemoryAllocator.java
@@ -104,15 +104,10 @@ public class HeapMemoryAllocator implements MemoryAllocator {
     long alignedSize = ((size + 7) / 8) * 8;
     if (shouldPool(alignedSize)) {
       synchronized (this) {
-        LinkedList<WeakReference<long[]>> pool = bufferPoolsBySize.get(alignedSize);
-        if (pool == null) {
-          pool = new LinkedList<>();
-          bufferPoolsBySize.put(alignedSize, pool);
-        }
+        LinkedList<WeakReference<long[]>> pool =
+          bufferPoolsBySize.computeIfAbsent(alignedSize, k -> new LinkedList<>());
         pool.add(new WeakReference<>(array));
       }
-    } else {
-      // Do nothing
     }
   }
 }

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -269,7 +269,7 @@ abstract class AbstractCommandBuilder {
       effectiveConfig = new HashMap<>(conf);
       Properties p = loadPropertiesFile();
       p.stringPropertyNames().forEach(key ->
-        effectiveConfig.putIfAbsent(key, p.getProperty(key)));
+        effectiveConfig.computeIfAbsent(key, p::getProperty));
     }
     return effectiveConfig;
   }

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
 
 import static org.apache.spark.launcher.CommandBuilderUtils.*;
@@ -267,11 +268,8 @@ abstract class AbstractCommandBuilder {
     if (effectiveConfig == null) {
       effectiveConfig = new HashMap<>(conf);
       Properties p = loadPropertiesFile();
-      for (String key : p.stringPropertyNames()) {
-        if (!effectiveConfig.containsKey(key)) {
-          effectiveConfig.put(key, p.getProperty(key));
-        }
-      }
+      p.stringPropertyNames().forEach(key ->
+        effectiveConfig.putIfAbsent(key, p.getProperty(key)));
     }
     return effectiveConfig;
   }

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
 
 import static org.apache.spark.launcher.CommandBuilderUtils.*;


### PR DESCRIPTION
### What changes were proposed in this pull request?
The main change of this pr is try to use `computeIfAbsent` to simplify the process of put and get missing value in a map.

**Before**

```java
  V oldValue = map.get(key);
  if (oldValue == null) {
    V newValue = functionToProduceMissValue
    map.put(key, newValue);
  }
```

**After**

```java
map.computeIfAbsent(key, functionToProduceMissValue);
```

### Why are the changes needed?
Simplify code use Java 8 API.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass the Jenkins or GitHub Action