### PR TITLE
[SPARK-36333][PYTHON] Reuse isnull where the null check is needed

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -5313,13 +5313,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
                 internal = internal.with_filter(cond)
 
+            psdf = DataFrame(internal)
+
             null_counts = []
             for label in internal.column_labels:
-                scol = internal.spark_column_for(label)
-                if isinstance(internal.spark_type_for(label), (FloatType, DoubleType)):
-                    cond = scol.isNull() | F.isnan(scol)
-                else:
-                    cond = scol.isNull()
+                psser = psdf._psser_for(label)
+                cond = psser.isnull().spark.column
                 null_counts.append(
                     F.sum(F.when(~cond, 1).otherwise(0)).alias(name_like_string(label))
                 )
@@ -8477,7 +8476,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         for label in self._internal.column_labels:
             scol = self._internal.spark_column_for(label)
             spark_type = self._internal.spark_type_for(label)
-            if isinstance(spark_type, DoubleType) or isinstance(spark_type, FloatType):
+            # TODO: Make this work with DataTypeOps.
+            if isinstance(spark_type, (FloatType, DoubleType)):
                 exprs.append(
                     F.nanvl(scol, SF.lit(None)).alias(self._internal.spark_column_name_for(label))
                 )

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -8476,7 +8476,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         for label in self._internal.column_labels:
             scol = self._internal.spark_column_for(label)
             spark_type = self._internal.spark_type_for(label)
-            # TODO: Make this work with DataTypeOps.
+            # TODO(SPARK-36350): Make this work with DataTypeOps.
             if isinstance(spark_type, (FloatType, DoubleType)):
                 exprs.append(
                     F.nanvl(scol, SF.lit(None)).alias(self._internal.spark_column_name_for(label))

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -3180,6 +3180,7 @@ class Frame(object, metaclass=ABCMeta):
     def _count_expr(spark_column: Column, spark_type: DataType) -> Column:
         # Special handle floating point types because Spark's count treats nan as a valid value,
         # whereas pandas count doesn't include nan.
+        # TODO: Make this work with DataTypeOps.
         if isinstance(spark_type, (FloatType, DoubleType)):
             return F.count(F.nanvl(spark_column, SF.lit(None)))
         else:

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -3180,7 +3180,7 @@ class Frame(object, metaclass=ABCMeta):
     def _count_expr(spark_column: Column, spark_type: DataType) -> Column:
         # Special handle floating point types because Spark's count treats nan as a valid value,
         # whereas pandas count doesn't include nan.
-        # TODO: Make this work with DataTypeOps.
+        # TODO(SPARK-36350): Make this work with DataTypeOps.
         if isinstance(spark_type, (FloatType, DoubleType)):
             return F.count(F.nanvl(spark_column, SF.lit(None)))
         else:

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2545,7 +2545,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 # types. Converting the NaNs is used in a few places, it should be in utils.
                 # Special handle floating point types because Spark's count treats nan as a valid
                 # value, whereas pandas count doesn't include nan.
-                if isinstance(spark_type, DoubleType) or isinstance(spark_type, FloatType):
+
+                # TODO: Make this work with DataTypeOps.
+                if isinstance(spark_type, (FloatType, DoubleType)):
                     stat_exprs.append(sfun(F.nanvl(scol, SF.lit(None))).alias(name))
                     data_columns.append(name)
                     column_labels.append(label)

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2546,7 +2546,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 # Special handle floating point types because Spark's count treats nan as a valid
                 # value, whereas pandas count doesn't include nan.
 
-                # TODO: Make this work with DataTypeOps.
+                # TODO(SPARK-36350): Make this work with DataTypeOps.
                 if isinstance(spark_type, (FloatType, DoubleType)):
                     stat_exprs.append(sfun(F.nanvl(scol, SF.lit(None))).alias(name))
                     data_columns.append(name)

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1915,12 +1915,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         scol = self.spark.column
 
-        if isinstance(self.spark.data_type, (FloatType, DoubleType)):
-            cond = scol.isNull() | F.isnan(scol)
-        else:
-            if not self.spark.nullable:
-                return self._psdf.copy()._psser_for(self._column_label)
-            cond = scol.isNull()
+        if not self.spark.nullable and not isinstance(
+            self.spark.data_type, (FloatType, DoubleType)
+        ):
+            return self._psdf.copy()._psser_for(self._column_label)
+
+        cond = self.isnull().spark.column
 
         if value is not None:
             if not isinstance(value, (float, int, str, bool)):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reuse `IndexOpsMixin.isnull()` where the null check is needed.

### Why are the changes needed?

There are some places where we can reuse `IndexOpsMixin.isnull()` instead of directly using Spark `Column`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.