### PR TITLE
[SPARK-36334][K8S] Add a new conf to allow K8s API server-side caching for pod listing

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -395,6 +395,14 @@ private[spark] object Config extends Logging {
         " positive time value.")
       .createWithDefaultString("30s")
 
+  val KUBERNETES_EXECUTOR_API_POLLING_WITH_RESOURCE_VERSION =
+    ConfigBuilder("spark.kubernetes.executor.enablePollingWithResourceVersion")
+      .doc("If true, `resourceVersion` is set with `0` during invoking pod listing APIs " +
+        "in order to allow API Server-side caching. This should be used carefully.")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val KUBERNETES_EXECUTOR_EVENT_PROCESSING_INTERVAL =
     ConfigBuilder("spark.kubernetes.executor.eventProcessingInterval")
       .doc("Interval between successive inspection of executor events sent from the" +


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new config to allow K8s API server-side caching for pod listing.

### Why are the changes needed?

Apache Spark currently requests the most recent data which should be consistent. New configuration looses the restriction to reduce the server-side overhead by allowing K8S API server side caching.

https://kubernetes.io/docs/reference/using-api/api-concepts/#the-resourceversion-parameter

- `resourceVersion`: unset
> Most Recent: Return data at the most recent resource version. The returned data must be consistent (i.e. served from etcd via a quorum read).

- `resourceVersion`: "0"
> Any: Return data at any resource version. The newest available resource version is preferred, but strong consistency is not required; data at any resource version may be served.


### Does this PR introduce _any_ user-facing change?

Yes, this is a new feature to reduce the K8s API server side overhead.

### How was this patch tested?

Pass the CIs.
