### PR TITLE
[SPARK-36341][SQL] Aggregated Metrics by Executor link should wrap <a> with <h4>

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagespage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagespage-template.html
@@ -31,10 +31,10 @@ limitations under the License.
             </tbody>
         </table>
     </div>
-    <a id="aggregatedMetrics" class="collapse-table">
+    <h4 id="aggregatedMetrics" class="collapse-table">
         <span class="expand-input-rate-arrow arrow-closed" id="arrowtoggle2"></span>
-        <h4 class="title-table">Aggregated Metrics by Executor</h4>
-    </a>
+        <a class="title-table">Aggregated Metrics by Executor</a>
+    </h4>
     <br>
     <div class="container-fluid d-none" id="toggle-aggregatedMetrics">
         <table id="summary-executor-table" class="table table-striped compact table-dataTable cell-border">


### PR DESCRIPTION
### What changes were proposed in this pull request?
In current stage page, when we move mouse to the title of `Aggregated Metrics by Executor`, the underline is blocked.
![image](https://user-images.githubusercontent.com/46485123/127449431-8897e648-c7cd-4bff-adb1-f43347c381b1.png)

For completed jobs, the code is
![image](https://user-images.githubusercontent.com/46485123/127449708-d6a7ccea-a1b5-4251-9648-38c5107457f8.png)
 

After this pr
![image](https://user-images.githubusercontent.com/46485123/127449465-6631076e-2eb4-41eb-a5ef-6c3c8be08d87.png)



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
