### PR TITLE
[SPARK-36347][SS] Upgrade the RocksDB version to 6.20.3

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -210,7 +210,7 @@ parquet-jackson/1.12.0//parquet-jackson-1.12.0.jar
 protobuf-java/2.5.0//protobuf-java-2.5.0.jar
 py4j/0.10.9.2//py4j-0.10.9.2.jar
 pyrolite/4.30//pyrolite-4.30.jar
-rocksdbjni/6.2.2//rocksdbjni-6.2.2.jar
+rocksdbjni/6.20.3//rocksdbjni-6.20.3.jar
 scala-collection-compat_2.12/2.1.1//scala-collection-compat_2.12-2.1.1.jar
 scala-compiler/2.12.14//scala-compiler-2.12.14.jar
 scala-library/2.12.14//scala-library-2.12.14.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -181,7 +181,7 @@ parquet-jackson/1.12.0//parquet-jackson-1.12.0.jar
 protobuf-java/2.5.0//protobuf-java-2.5.0.jar
 py4j/0.10.9.2//py4j-0.10.9.2.jar
 pyrolite/4.30//pyrolite-4.30.jar
-rocksdbjni/6.2.2//rocksdbjni-6.2.2.jar
+rocksdbjni/6.20.3//rocksdbjni-6.20.3.jar
 scala-collection-compat_2.12/2.1.1//scala-collection-compat_2.12-2.1.1.jar
 scala-compiler/2.12.14//scala-compiler-2.12.14.jar
 scala-library/2.12.14//scala-library-2.12.14.jar

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.rocksdb</groupId>
       <artifactId>rocksdbjni</artifactId>
-      <version>6.2.2</version>
+      <version>6.20.3</version>
     </dependency>
     <dependency>
       <groupId>com.univocity</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
As the discussion in https://github.com/apache/spark/pull/32928/files#r654049392, after confirming the compatibility, we can use a newer RocksDB version for the state store implementation.

### Why are the changes needed?
For further ARM support and leverage the bug fix for the newer version.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.
