### PR TITLE
[SPARK-36359][SQL] Coalesce drop all expressions after the first non nullable expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.trees.TreePattern.{NULL_CHECK, TreePattern}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{COALESCE, NULL_CHECK, TreePattern}
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.types._
 
@@ -54,6 +54,8 @@ case class Coalesce(children: Seq[Expression]) extends ComplexTypeMergingExpress
 
   // Coalesce is foldable if all children are foldable.
   override def foldable: Boolean = children.forall(_.foldable)
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(COALESCE)
 
   override def checkInputDataTypes(): TypeCheckResult = {
     if (children.length < 1) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -780,10 +780,13 @@ object NullPropagation extends Rule[LogicalPlan] {
           Literal.create(null, e.dataType)
         } else if (newChildren.length == 1) {
           newChildren.head
-        } else if (!newChildren.head.nullable) {
-          newChildren.head // Returns the first expression if it is non nullable.
         } else {
-          Coalesce(newChildren)
+          val nonNullableIndex = newChildren.indexWhere(e => !e.nullable)
+          if (nonNullableIndex > -1) {
+            Coalesce(newChildren.take(nonNullableIndex + 1))
+          } else {
+            Coalesce(newChildren)
+          }
         }
 
       // If the value expression is NULL then transform the In expression to null literal.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -36,6 +36,7 @@ object TreePattern extends Enumeration  {
   val BOOL_AGG: Value = Value
   val CASE_WHEN: Value = Value
   val CAST: Value = Value
+  val COALESCE: Value = Value
   val CONCAT: Value = Value
   val COUNT: Value = Value
   val COUNT_IF: Value = Value

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
@@ -174,11 +174,24 @@ class BinaryComparisonSimplificationSuite extends PlanTest with PredicateHelper 
     }
   }
 
-  test("SPARK-36359: Coalesce returns the first expression if it is non nullable") {
-    val plan = nonNullableRelation
-      .select(Coalesce(Seq('a, 'a + 10)).as("out")).analyze
-    val actual = Optimize.execute(plan)
-    val correctAnswer = nonNullableRelation.select('a.as("out")).analyze
-    comparePlans(actual, correctAnswer)
+  test("SPARK-36359: Coalesce drop all expressions after the first non nullable expression") {
+    val testRelation = LocalRelation(
+      'a.int.withNullability(false),
+      'b.int.withNullability(true),
+      'c.int.withNullability(false),
+      'd.int.withNullability(true))
+
+    comparePlans(
+      Optimize.execute(testRelation.select(Coalesce(Seq('a, 'b, 'c, 'd)).as("out")).analyze),
+      testRelation.select('a.as("out")).analyze)
+    comparePlans(
+      Optimize.execute(testRelation.select(Coalesce(Seq('a, 'c)).as("out")).analyze),
+      testRelation.select('a.as("out")).analyze)
+    comparePlans(
+      Optimize.execute(testRelation.select(Coalesce(Seq('b, 'c, 'd)).as("out")).analyze),
+      testRelation.select(Coalesce(Seq('b, 'c)).as("out")).analyze)
+    comparePlans(
+      Optimize.execute(testRelation.select(Coalesce(Seq('b, 'd)).as("out")).analyze),
+      testRelation.select(Coalesce(Seq('b, 'd)).as("out")).analyze)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
@@ -173,4 +173,12 @@ class BinaryComparisonSimplificationSuite extends PlanTest with PredicateHelper 
       }
     }
   }
+
+  test("SPARK-36359: Coalesce returns the first expression if it is non nullable") {
+    val plan = nonNullableRelation
+      .select(Coalesce(Seq('a, 'a + 10)).as("out")).analyze
+    val actual = Optimize.execute(plan)
+    val correctAnswer = nonNullableRelation.select('a.as("out")).analyze
+    comparePlans(actual, correctAnswer)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -235,8 +235,8 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     val df = sql("select ifnull(id, 'x'), nullif(id, 'x'), nvl(id, 'x'), nvl2(id, 'x', 'y') " +
       "from range(2)")
     checkKeywordsExistsInExplain(df,
-      "Project [coalesce(cast(id#xL as string), x) AS ifnull(id, x)#x, " +
-        "id#xL AS nullif(id, x)#xL, coalesce(cast(id#xL as string), x) AS nvl(id, x)#x, " +
+      "Project [cast(id#xL as string) AS ifnull(id, x)#x, " +
+        "id#xL AS nullif(id, x)#xL, cast(id#xL as string) AS nvl(id, x)#x, " +
         "x AS nvl2(id, x, y)#x]")
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`Coalesce` drop all expressions after the first non nullable expression. For example:
```scala
sql("create table t1(a string, b string) using parquet")
sql("select a, Coalesce(count(b), 0) from t1 group by a").explain(true)
```

Before this pr:
```
== Optimized Logical Plan ==
Aggregate [a#0], [a#0, coalesce(count(b#1), 0) AS coalesce(count(b), 0)#3L]
+- Relation default.t1[a#0,b#1] parquet
```
After this pr:
```
== Optimized Logical Plan ==
Aggregate [a#0], [a#0, count(b#1) AS coalesce(count(b), 0)#3L]
+- Relation default.t1[a#0,b#1] parquet
```

### Why are the changes needed?

Improve query performance.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
