### PR TITLE
[SPARK-36360][Spark Streaming] Remove appName from StreamingSource sourceName

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingSource.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingSource.scala
@@ -24,7 +24,7 @@ import org.apache.spark.streaming.ui.StreamingJobProgressListener
 
 private[streaming] class StreamingSource(ssc: StreamingContext) extends Source {
   override val metricRegistry = new MetricRegistry
-  override val sourceName = "%s.StreamingMetrics".format(ssc.sparkContext.appName)
+  override val sourceName = "StreamingMetrics"
 
   private val streamingListener = ssc.progressListener
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `MetricsSystem` takes care of proper naming of all metrics. By default, the root namespace is the value of `spark.app.id`. A custom namespace can be specified for metrics reporting using `spark.metrics.namespace` configuration property. 

A `StreamingSource` gets registered in the `MetricsSystem`, however, it additionally includes the `appName` in its `sourceName`. This makes it impossible to configure a common namespace excluding the `appName`.

This pull request proposes to exclude the appName from the sourceName in StreamingSource following the example of the other sources, e.g. `ExecutorMetricsSource`.

### Why are the changes needed?
Homogeneous naming scheme across all metrics.

### Does this PR introduce _any_ user-facing change?
The proposed change conforms to the documentation. See [here](https://spark.apache.org/docs/latest/monitoring.html#metrics).

### How was this patch tested?
No tests added.
