### PR TITLE
[SPARK-36362][CORE][SQL][TESTS] Omnibus Java code static analyzer warning fixes

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/ArrayWrappers.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/ArrayWrappers.java
@@ -72,8 +72,8 @@ class ArrayWrappers {
     @Override
     public int hashCode() {
       int code = 0;
-      for (int i = 0; i < array.length; i++) {
-        code = (code * 31) + array[i];
+      for (int j : array) {
+        code = (code * 31) + j;
       }
       return code;
     }
@@ -111,8 +111,8 @@ class ArrayWrappers {
     @Override
     public int hashCode() {
       int code = 0;
-      for (int i = 0; i < array.length; i++) {
-        code = (code * 31) + (int) array[i];
+      for (long l : array) {
+        code = (code * 31) + (int) l;
       }
       return code;
     }
@@ -150,8 +150,8 @@ class ArrayWrappers {
     @Override
     public int hashCode() {
       int code = 0;
-      for (int i = 0; i < array.length; i++) {
-        code = (code * 31) + array[i];
+      for (byte b : array) {
+        code = (code * 31) + b;
       }
       return code;
     }
@@ -189,8 +189,8 @@ class ArrayWrappers {
     @Override
     public int hashCode() {
       int code = 0;
-      for (int i = 0; i < array.length; i++) {
-        code = (code * 31) + array[i].hashCode();
+      for (Object o : array) {
+        code = (code * 31) + o.hashCode();
       }
       return code;
     }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
@@ -130,7 +130,7 @@ public class KVTypeInfo {
     Class<?> getType();
   }
 
-  private class FieldAccessor implements Accessor {
+  private static class FieldAccessor implements Accessor {
 
     private final Field field;
 
@@ -149,7 +149,7 @@ public class KVTypeInfo {
     }
   }
 
-  private class MethodAccessor implements Accessor {
+  private static class MethodAccessor implements Accessor {
 
     private final Method method;
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/DBIteratorSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/DBIteratorSuite.java
@@ -73,9 +73,7 @@ public abstract class DBIteratorSuite {
   private static final BaseComparator NATURAL_ORDER = (t1, t2) -> t1.key.compareTo(t2.key);
   private static final BaseComparator REF_INDEX_ORDER = (t1, t2) -> t1.id.compareTo(t2.id);
   private static final BaseComparator COPY_INDEX_ORDER = (t1, t2) -> t1.name.compareTo(t2.name);
-  private static final BaseComparator NUMERIC_INDEX_ORDER = (t1, t2) -> {
-    return Integer.valueOf(t1.num).compareTo(t2.num);
-  };
+  private static final BaseComparator NUMERIC_INDEX_ORDER = (t1, t2) -> Integer.compare(t1.num, t2.num);
   private static final BaseComparator CHILD_INDEX_ORDER = (t1, t2) -> t1.child.compareTo(t2.child);
 
   /**

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java
@@ -197,7 +197,7 @@ public class LevelDBBenchmark {
       }
     }
 
-    for (; it.hasNext(); ) {
+    while (it.hasNext()) {
       try(Timer.Context ctx = iter.time()) {
         it.next();
       }

--- a/common/network-common/src/test/java/org/apache/spark/network/RpcIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/RpcIntegrationSuite.java
@@ -66,12 +66,15 @@ public class RpcIntegrationSuite {
           RpcResponseCallback callback) {
         String msg = JavaUtils.bytesToString(message);
         String[] parts = msg.split("/");
-        if (parts[0].equals("hello")) {
-          callback.onSuccess(JavaUtils.stringToBytes("Hello, " + parts[1] + "!"));
-        } else if (parts[0].equals("return error")) {
-          callback.onFailure(new RuntimeException("Returned: " + parts[1]));
-        } else if (parts[0].equals("throw error")) {
-          throw new RuntimeException("Thrown: " + parts[1]);
+        switch (parts[0]) {
+          case "hello":
+            callback.onSuccess(JavaUtils.stringToBytes("Hello, " + parts[1] + "!"));
+            break;
+          case "return error":
+            callback.onFailure(new RuntimeException("Returned: " + parts[1]));
+            break;
+          case "throw error":
+            throw new RuntimeException("Thrown: " + parts[1]);
         }
       }
 
@@ -302,8 +305,7 @@ public class RpcIntegrationSuite {
   @Test
   public void sendOneWayMessage() throws Exception {
     final String message = "no reply";
-    TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
-    try {
+    try (TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort())) {
       client.send(JavaUtils.stringToBytes(message));
       assertEquals(0, client.getHandler().numOutstandingRequests());
 
@@ -315,8 +317,6 @@ public class RpcIntegrationSuite {
 
       assertEquals(1, oneWayMsgs.size());
       assertEquals(message, oneWayMsgs.get(0));
-    } finally {
-      client.close();
     }
   }
 
@@ -455,7 +455,7 @@ public class RpcIntegrationSuite {
         byte[] expected = new byte[base.remaining()];
         base.get(expected);
         assertEquals(expected.length, result.length);
-        assertTrue("buffers don't match", Arrays.equals(expected, result));
+        assertArrayEquals("buffers don't match", expected, result);
       }
     }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/StreamSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/StreamSuite.java
@@ -109,49 +109,39 @@ public class StreamSuite {
 
   @Test
   public void testZeroLengthStream() throws Throwable {
-    TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
-    try {
+    try (TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort())) {
       StreamTask task = new StreamTask(client, "emptyBuffer", TimeUnit.SECONDS.toMillis(5));
       task.run();
       task.check();
-    } finally {
-      client.close();
     }
   }
 
   @Test
   public void testSingleStream() throws Throwable {
-    TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
-    try {
+    try (TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort())) {
       StreamTask task = new StreamTask(client, "largeBuffer", TimeUnit.SECONDS.toMillis(5));
       task.run();
       task.check();
-    } finally {
-      client.close();
     }
   }
 
   @Test
   public void testMultipleStreams() throws Throwable {
-    TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
-    try {
+    try (TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort())) {
       for (int i = 0; i < 20; i++) {
         StreamTask task = new StreamTask(client, STREAMS[i % STREAMS.length],
           TimeUnit.SECONDS.toMillis(5));
         task.run();
         task.check();
       }
-    } finally {
-      client.close();
     }
   }
 
   @Test
   public void testConcurrentStreams() throws Throwable {
     ExecutorService executor = Executors.newFixedThreadPool(20);
-    TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
 
-    try {
+    try (TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort())) {
       List<StreamTask> tasks = new ArrayList<>();
       for (int i = 0; i < 20; i++) {
         StreamTask task = new StreamTask(client, STREAMS[i % STREAMS.length],
@@ -167,7 +157,6 @@ public class StreamSuite {
       }
     } finally {
       executor.shutdownNow();
-      client.close();
     }
   }
 
@@ -231,7 +220,7 @@ public class StreamSuite {
           byte[] expected = new byte[base.remaining()];
           base.get(expected);
           assertEquals(expected.length, result.length);
-          assertTrue("buffers don't match", Arrays.equals(expected, result));
+          assertArrayEquals("buffers don't match", expected, result);
         }
       } catch (Throwable t) {
         error = t;

--- a/common/network-common/src/test/java/org/apache/spark/network/StreamTestHelper.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/StreamTestHelper.java
@@ -57,16 +57,13 @@ class StreamTestHelper {
     largeBuffer = createBuffer(100000);
 
     testFile = File.createTempFile("stream-test-file", "txt", tempDir);
-    FileOutputStream fp = new FileOutputStream(testFile);
-    try {
+    try (FileOutputStream fp = new FileOutputStream(testFile)) {
       Random rnd = new Random();
       for (int i = 0; i < 512; i++) {
         byte[] fileContent = new byte[1024];
         rnd.nextBytes(fileContent);
         fp.write(fileContent);
       }
-    } finally {
-      fp.close();
     }
   }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
@@ -52,10 +52,9 @@ public class AuthEngineSuite {
 
   @Test
   public void testAuthEngine() throws Exception {
-    AuthEngine client = new AuthEngine("appId", "secret", conf);
-    AuthEngine server = new AuthEngine("appId", "secret", conf);
 
-    try {
+    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
+         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
       ClientChallenge clientChallenge = client.challenge();
       ServerResponse serverResponse = server.respond(clientChallenge);
       client.validate(serverResponse);
@@ -63,12 +62,9 @@ public class AuthEngineSuite {
       TransportCipher serverCipher = server.sessionCipher();
       TransportCipher clientCipher = client.sessionCipher();
 
-      assertTrue(Arrays.equals(serverCipher.getInputIv(), clientCipher.getOutputIv()));
-      assertTrue(Arrays.equals(serverCipher.getOutputIv(), clientCipher.getInputIv()));
+      assertArrayEquals(serverCipher.getInputIv(), clientCipher.getOutputIv());
+      assertArrayEquals(serverCipher.getOutputIv(), clientCipher.getInputIv());
       assertEquals(serverCipher.getKey(), clientCipher.getKey());
-    } finally {
-      client.close();
-      server.close();
     }
   }
 
@@ -126,17 +122,13 @@ public class AuthEngineSuite {
     try (AuthEngine engine = new AuthEngine("appId", "secret", conf)) {
       engine.challenge();
       fail("Should have failed to create challenge message.");
-
-      // Call close explicitly to make sure it's idempotent.
-      engine.close();
     }
   }
 
   @Test
   public void testEncryptedMessage() throws Exception {
-    AuthEngine client = new AuthEngine("appId", "secret", conf);
-    AuthEngine server = new AuthEngine("appId", "secret", conf);
-    try {
+    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
+         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
       ClientChallenge clientChallenge = client.challenge();
       ServerResponse serverResponse = server.respond(clientChallenge);
       client.validate(serverResponse);
@@ -154,17 +146,13 @@ public class AuthEngineSuite {
         emsg.transferTo(channel, emsg.transferred());
       }
       assertEquals(data.length, channel.length());
-    } finally {
-      client.close();
-      server.close();
     }
   }
 
   @Test
   public void testEncryptedMessageWhenTransferringZeroBytes() throws Exception {
-    AuthEngine client = new AuthEngine("appId", "secret", conf);
-    AuthEngine server = new AuthEngine("appId", "secret", conf);
-    try {
+    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
+         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
       ClientChallenge clientChallenge = client.challenge();
       ServerResponse serverResponse = server.respond(clientChallenge);
       client.validate(serverResponse);
@@ -200,9 +188,6 @@ public class AuthEngineSuite {
       assertEquals(testDataLength, emsg.transferTo(channel, emsg.transferred()));
       assertEquals(emsg.transferred(), emsg.count());
       assertEquals(4, channel.length());
-    } finally {
-      client.close();
-      server.close();
     }
   }
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
@@ -122,6 +122,9 @@ public class AuthEngineSuite {
     try (AuthEngine engine = new AuthEngine("appId", "secret", conf)) {
       engine.challenge();
       fail("Should have failed to create challenge message.");
+
+      // Call close explicitly to make sure it's idempotent.
+      engine.close();
     }
   }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthIntegrationSuite.java
@@ -160,7 +160,7 @@ public class AuthIntegrationSuite {
     }
   }
 
-  private class AuthTestCtx {
+  private static class AuthTestCtx {
 
     private final String appId = "testAppId";
     private final TransportConf conf;

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthMessagesSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthMessagesSuite.java
@@ -37,9 +37,8 @@ public class AuthMessagesSuite {
 
   private static byte[] byteArray() {
     byte[] bytes = new byte[COUNTER++];
-    for (int i = 0; i < bytes.length; i++) {
-      bytes[i] = (byte) COUNTER;
-    } return bytes;
+    Arrays.fill(bytes, (byte) COUNTER);
+    return bytes;
   }
 
   private static int integer() {
@@ -57,18 +56,18 @@ public class AuthMessagesSuite {
     assertEquals(msg.iterations, decoded.iterations);
     assertEquals(msg.cipher, decoded.cipher);
     assertEquals(msg.keyLength, decoded.keyLength);
-    assertTrue(Arrays.equals(msg.nonce, decoded.nonce));
-    assertTrue(Arrays.equals(msg.challenge, decoded.challenge));
+    assertArrayEquals(msg.nonce, decoded.nonce);
+    assertArrayEquals(msg.challenge, decoded.challenge);
   }
 
   @Test
   public void testServerResponse() {
     ServerResponse msg = new ServerResponse(byteArray(), byteArray(), byteArray(), byteArray());
     ServerResponse decoded = ServerResponse.decodeMessage(encode(msg));
-    assertTrue(Arrays.equals(msg.response, decoded.response));
-    assertTrue(Arrays.equals(msg.nonce, decoded.nonce));
-    assertTrue(Arrays.equals(msg.inputIv, decoded.inputIv));
-    assertTrue(Arrays.equals(msg.outputIv, decoded.outputIv));
+    assertArrayEquals(msg.response, decoded.response);
+    assertArrayEquals(msg.nonce, decoded.nonce);
+    assertArrayEquals(msg.inputIv, decoded.inputIv);
+    assertArrayEquals(msg.outputIv, decoded.outputIv);
   }
 
   private ByteBuffer encode(Encodable msg) {

--- a/common/network-common/src/test/java/org/apache/spark/network/protocol/MergedBlockMetaSuccessSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/protocol/MergedBlockMetaSuccessSuite.java
@@ -55,8 +55,8 @@ public class MergedBlockMetaSuccessSuite {
     chunk2.add(4);
     RoaringBitmap[] expectedChunks = new RoaringBitmap[]{chunk1, chunk2};
     try (DataOutputStream metaOutput = new DataOutputStream(new FileOutputStream(chunkMetaFile))) {
-      for (int i = 0; i < expectedChunks.length; i++) {
-        expectedChunks[i].serialize(metaOutput);
+      for (RoaringBitmap expectedChunk : expectedChunks) {
+        expectedChunk.serialize(metaOutput);
       }
     }
     TransportConf conf = mock(TransportConf.class);

--- a/common/network-common/src/test/java/org/apache/spark/network/protocol/MessageWithHeaderSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/protocol/MessageWithHeaderSuite.java
@@ -150,7 +150,7 @@ public class MessageWithHeaderSuite {
 
     @Override
     public long count() {
-      return 8 * writeCount;
+      return 8L * writeCount;
     }
 
     @Override
@@ -160,7 +160,7 @@ public class MessageWithHeaderSuite {
 
     @Override
     public long transferred() {
-      return 8 * written;
+      return 8L * written;
     }
 
     @Override
@@ -174,7 +174,7 @@ public class MessageWithHeaderSuite {
         buf.release();
         written++;
       }
-      return 8 * writesPerCall;
+      return 8L * writesPerCall;
     }
 
     @Override

--- a/common/network-common/src/test/java/org/apache/spark/network/sasl/SparkSaslSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/sasl/SparkSaslSuite.java
@@ -288,7 +288,7 @@ public class SparkSaslSuite {
       verify(callback, never()).onFailure(anyInt(), any(Throwable.class));
 
       byte[] received = ByteStreams.toByteArray(response.get().createInputStream());
-      assertTrue(Arrays.equals(data, received));
+      assertArrayEquals(data, received);
     } finally {
       file.delete();
       if (ctx != null) {

--- a/common/network-common/src/test/java/org/apache/spark/network/util/NettyMemoryMetricsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/NettyMemoryMetricsSuite.java
@@ -108,9 +108,7 @@ public class NettyMemoryMetricsSuite {
     Assert.assertNotNull(clientMetricMap.get(
       MetricRegistry.name("shuffle-client", directMemoryMetric)));
 
-    TransportClient client = null;
-    try {
-      client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
+    try (TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort())) {
       Assert.assertTrue(client.isActive());
 
       Assert.assertTrue(((Gauge<Long>)serverMetricMap.get(
@@ -123,10 +121,6 @@ public class NettyMemoryMetricsSuite {
       Assert.assertTrue(((Gauge<Long>)clientMetricMap.get(
         MetricRegistry.name("shuffle-client", directMemoryMetric))).getValue() >= 0L);
 
-    } finally {
-      if (client != null) {
-        client.close();
-      }
     }
   }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -225,7 +225,7 @@ public class OneForOneBlockFetcher {
   }
 
   /** The reduceIds and blocks in a single mapId */
-  private class BlocksInfo {
+  private static class BlocksInfo {
 
     /**
      * For {@link FetchShuffleBlocks} message, the ids are reduceIds.

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
@@ -216,8 +216,7 @@ public class OneForOneBlockFetcherSuite {
               new long[]{0, 2, 10}, new int[][]{{0}, {1}, {2}}, false),
       conf);
 
-    for (int chunkIndex = 0; chunkIndex < blockIds.length; chunkIndex++) {
-      String blockId = blockIds[chunkIndex];
+    for (String blockId : blockIds) {
       verify(listener).onBlockFetchSuccess(blockId, blocks.get(blockId));
     }
   }
@@ -237,8 +236,7 @@ public class OneForOneBlockFetcherSuite {
               new long[]{0, 2, 10}, new int[][]{{1, 2}, {2, 3}, {3, 4}}, true),
       conf);
 
-    for (int chunkIndex = 0; chunkIndex < blockIds.length; chunkIndex++) {
-      String blockId = blockIds[chunkIndex];
+    for (String blockId : blockIds) {
       verify(listener).onBlockFetchSuccess(blockId, blocks.get(blockId));
     }
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -1138,11 +1138,11 @@ public class RemoteBlockPushResolverSuite {
       String appId,
       int attemptId,
       PushBlock[] blocks) throws IOException {
-    for (int i = 0; i < blocks.length; i++) {
+    for (PushBlock block : blocks) {
       StreamCallbackWithID stream = pushResolver.receiveBlockDataAsStream(
         new PushBlockStream(
-          appId, attemptId, blocks[i].shuffleId, blocks[i].mapIndex, blocks[i].reduceId, 0));
-      stream.onData(stream.getID(), blocks[i].buffer);
+          appId, attemptId, block.shuffleId, block.mapIndex, block.reduceId, 0));
+      stream.onData(stream.getID(), block.buffer);
       stream.onComplete(stream.getID());
     }
   }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/array/ByteArrayMethods.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/array/ByteArrayMethods.java
@@ -49,7 +49,7 @@ public class ByteArrayMethods {
   // Refer to "http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/tip/src/share/classes/java/util/ArrayList.java#l229"
   // This value is word rounded. Use this value if the allocated byte arrays are used to store other
   // types rather than bytes.
-  public static int MAX_ROUNDED_ARRAY_LENGTH = Integer.MAX_VALUE - 15;
+  public static final int MAX_ROUNDED_ARRAY_LENGTH = Integer.MAX_VALUE - 15;
 
   private static final boolean unaligned = Platform.unaligned();
   /**

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/ByteArray.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/ByteArray.java
@@ -80,9 +80,9 @@ public final class ByteArray {
   public static byte[] concat(byte[]... inputs) {
     // Compute the total length of the result
     long totalLength = 0;
-    for (int i = 0; i < inputs.length; i++) {
-      if (inputs[i] != null) {
-        totalLength += (long)inputs[i].length;
+    for (byte[] input : inputs) {
+      if (input != null) {
+        totalLength += input.length;
       } else {
         return null;
       }
@@ -91,10 +91,10 @@ public final class ByteArray {
     // Allocate a new byte array, and copy the inputs one by one into it
     final byte[] result = new byte[Ints.checkedCast(totalLength)];
     int offset = 0;
-    for (int i = 0; i < inputs.length; i++) {
-      int len = inputs[i].length;
+    for (byte[] input : inputs) {
+      int len = input.length;
       Platform.copyMemory(
-        inputs[i], Platform.BYTE_ARRAY_OFFSET,
+        input, Platform.BYTE_ARRAY_OFFSET,
         result, Platform.BYTE_ARRAY_OFFSET + offset,
         len);
       offset += len;

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -483,7 +483,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
   }
 
   private UTF8String toTitleCaseSlow() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     String s = toString();
     sb.append(s);
     sb.setCharAt(0, Character.toTitleCase(sb.charAt(0)));
@@ -906,7 +906,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       // the partial string of the padding
       UTF8String remain = pad.substring(0, spaces - padChars * count);
 
-      int resultSize = Math.toIntExact((long)numBytes + pad.numBytes * count + remain.numBytes);
+      int resultSize = Math.toIntExact((long) numBytes + (long) pad.numBytes * count + remain.numBytes);
       byte[] data = new byte[resultSize];
       copyMemory(this.base, this.offset, data, BYTE_ARRAY_OFFSET, this.numBytes);
       int offset = this.numBytes;
@@ -939,7 +939,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       // the partial string of the padding
       UTF8String remain = pad.substring(0, spaces - padChars * count);
 
-      int resultSize = Math.toIntExact((long)numBytes + pad.numBytes * count + remain.numBytes);
+      int resultSize = Math.toIntExact((long) numBytes + (long) pad.numBytes * count + remain.numBytes);
       byte[] data = new byte[resultSize];
 
       int offset = 0;
@@ -963,21 +963,20 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
   public static UTF8String concat(UTF8String... inputs) {
     // Compute the total length of the result.
     long totalLength = 0;
-    for (int i = 0; i < inputs.length; i++) {
-      if (inputs[i] != null) {
-        totalLength += (long)inputs[i].numBytes;
-      } else {
+    for (UTF8String input : inputs) {
+      if (input == null) {
         return null;
       }
+      totalLength += input.numBytes;
     }
 
     // Allocate a new byte array, and copy the inputs one by one into it.
     final byte[] result = new byte[Math.toIntExact(totalLength)];
     int offset = 0;
-    for (int i = 0; i < inputs.length; i++) {
-      int len = inputs[i].numBytes;
+    for (UTF8String input : inputs) {
+      int len = input.numBytes;
       copyMemory(
-        inputs[i].base, inputs[i].offset,
+        input.base, input.offset,
         result, BYTE_ARRAY_OFFSET + offset,
         len);
       offset += len;
@@ -996,9 +995,9 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
 
     long numInputBytes = 0L;  // total number of bytes from the inputs
     int numInputs = 0;      // number of non-null inputs
-    for (int i = 0; i < inputs.length; i++) {
-      if (inputs[i] != null) {
-        numInputBytes += inputs[i].numBytes;
+    for (UTF8String input : inputs) {
+      if (input != null) {
+        numInputBytes += input.numBytes;
         numInputs++;
       }
     }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -400,12 +400,11 @@ public class UTF8StringSuite {
   public void split() {
     UTF8String[] negativeAndZeroLimitCase =
       new UTF8String[]{fromString("ab"), fromString("def"), fromString("ghi"), fromString("")};
-    assertTrue(Arrays.equals(fromString("ab,def,ghi,").split(fromString(","), 0),
-      negativeAndZeroLimitCase));
-    assertTrue(Arrays.equals(fromString("ab,def,ghi,").split(fromString(","), -1),
-      negativeAndZeroLimitCase));
-    assertTrue(Arrays.equals(fromString("ab,def,ghi,").split(fromString(","), 2),
-      new UTF8String[]{fromString("ab"), fromString("def,ghi,")}));
+      assertArrayEquals(negativeAndZeroLimitCase, fromString("ab,def,ghi,").split(fromString(","), 0));
+    assertArrayEquals(negativeAndZeroLimitCase, fromString("ab,def,ghi,").split(fromString(","), -1));
+    assertArrayEquals(
+      new UTF8String[]{fromString("ab"), fromString("def,ghi,")},
+      fromString("ab,def,ghi,").split(fromString(","), 2));
   }
 
   @Test
@@ -852,8 +851,8 @@ public class UTF8StringSuite {
     };
     byte[] c = new byte[1];
 
-    for (int i = 0; i < wrongFirstBytes.length; ++i) {
-      c[0] = (byte)wrongFirstBytes[i];
+    for (int wrongFirstByte : wrongFirstBytes) {
+      c[0] = (byte) wrongFirstByte;
       assertEquals(1, fromBytes(c).numChars());
     }
   }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -400,7 +400,7 @@ public class UTF8StringSuite {
   public void split() {
     UTF8String[] negativeAndZeroLimitCase =
       new UTF8String[]{fromString("ab"), fromString("def"), fromString("ghi"), fromString("")};
-      assertArrayEquals(negativeAndZeroLimitCase, fromString("ab,def,ghi,").split(fromString(","), 0));
+    assertArrayEquals(negativeAndZeroLimitCase, fromString("ab,def,ghi,").split(fromString(","), 0));
     assertArrayEquals(negativeAndZeroLimitCase, fromString("ab,def,ghi,").split(fromString(","), -1));
     assertArrayEquals(
       new UTF8String[]{fromString("ab"), fromString("def,ghi,")},

--- a/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
@@ -59,8 +59,8 @@ public abstract class GenericFileInputStreamSuite {
   @Test
   public void testReadOneByte() throws IOException {
     for (InputStream inputStream: inputStreams) {
-      for (int i = 0; i < randomBytes.length; i++) {
-        assertEquals(randomBytes[i], (byte) inputStream.read());
+      for (byte randomByte : randomBytes) {
+        assertEquals(randomByte, (byte) inputStream.read());
       }
     }
   }

--- a/core/src/test/java/org/apache/spark/launcher/SparkLauncherSuite.java
+++ b/core/src/test/java/org/apache/spark/launcher/SparkLauncherSuite.java
@@ -281,9 +281,7 @@ public class SparkLauncherSuite extends BaseSuite {
 
   private void restoreSystemProperties(Map<Object, Object> properties) {
     Properties p = new Properties();
-    for (Map.Entry<Object, Object> e : properties.entrySet()) {
-      p.put(e.getKey(), e.getValue());
-    }
+    p.putAll(properties);
     System.setProperties(p);
   }
 

--- a/core/src/test/java/org/apache/spark/shuffle/sort/PackedRecordPointerSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/PackedRecordPointerSuite.java
@@ -29,7 +29,8 @@ import org.apache.spark.unsafe.memory.MemoryBlock;
 import static org.apache.spark.shuffle.sort.PackedRecordPointer.MAXIMUM_PAGE_SIZE_BYTES;
 import static org.apache.spark.shuffle.sort.PackedRecordPointer.MAXIMUM_PARTITION_ID;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PackedRecordPointerSuite {
 
@@ -85,13 +86,16 @@ public class PackedRecordPointerSuite {
   @Test
   public void partitionIdsGreaterThanMaximumPartitionIdWillOverflowOrTriggerError() {
     PackedRecordPointer packedPointer = new PackedRecordPointer();
+    boolean asserted = false;
     try {
       // Pointers greater than the maximum partition ID will overflow or trigger an assertion error
       packedPointer.set(PackedRecordPointer.packPointer(0, MAXIMUM_PARTITION_ID + 1));
-      assertFalse(MAXIMUM_PARTITION_ID  + 1 == packedPointer.getPartitionId());
     } catch (AssertionError e ) {
       // pass
+      asserted = true;
     }
+    assertTrue(asserted);
+    assertNotEquals(MAXIMUM_PARTITION_ID + 1, packedPointer.getPartitionId());
   }
 
   @Test

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -253,7 +253,7 @@ public class UnsafeShuffleWriterSuite implements ShuffleChecksumTestHelper {
   @Test
   public void writeEmptyIterator() throws Exception {
     final UnsafeShuffleWriter<Object, Object> writer = createWriter(true);
-    writer.write(new ArrayList<Product2<Object, Object>>().iterator());
+    writer.write(Collections.emptyIterator());
     final Option<MapStatus> mapStatus = writer.stop(true);
     assertTrue(mapStatus.isDefined());
     assertTrue(mergedOutputFile.exists());

--- a/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
+++ b/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
@@ -217,19 +217,6 @@ public abstract class AbstractBytesToBytesMapSuite {
       Assert.assertArrayEquals(valueData,
         getByteArray(loc.getValueBase(), loc.getValueOffset(), recordLengthBytes));
 
-      try {
-        Assert.assertTrue(loc.append(
-          keyData,
-          Platform.BYTE_ARRAY_OFFSET,
-          recordLengthBytes,
-          valueData,
-          Platform.BYTE_ARRAY_OFFSET,
-          recordLengthBytes
-        ));
-        Assert.fail("Should not be able to set a new value for a key");
-      } catch (AssertionError e) {
-        // Expected exception; do nothing.
-      }
     } finally {
       map.free();
     }
@@ -283,7 +270,7 @@ public abstract class AbstractBytesToBytesMapSuite {
         final long value = Platform.getLong(loc.getValueBase(), loc.getValueOffset());
         final long keyLength = loc.getKeyLength();
         if (keyLength == 0) {
-          Assert.assertTrue("value " + value + " was not divisible by 5", value % 5 == 0);
+          assertEquals("value " + value + " was not divisible by 5", 0, value % 5);
         } else {
           final long key = Platform.getLong(loc.getKeyBase(), loc.getKeyOffset());
           Assert.assertEquals(value, key);

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
@@ -343,12 +343,12 @@ public class UnsafeExternalSorterSuite {
     for (int i = 0; i < n / 3; i++) {
       iter.hasNext();
       iter.loadNext();
-      assertTrue(Platform.getLong(iter.getBaseObject(), iter.getBaseOffset()) == i);
+      assertEquals(i, Platform.getLong(iter.getBaseObject(), iter.getBaseOffset()));
       lastv = i;
     }
     assertTrue(iter.spill() > 0);
     assertEquals(0, iter.spill());
-    assertTrue(Platform.getLong(iter.getBaseObject(), iter.getBaseOffset()) == lastv);
+    assertEquals(lastv, Platform.getLong(iter.getBaseObject(), iter.getBaseOffset()));
     for (int i = n / 3; i < n; i++) {
       iter.hasNext();
       iter.loadNext();
@@ -492,7 +492,7 @@ public class UnsafeExternalSorterSuite {
     // We will have at-least 2 memory pages allocated because of rounding happening due to
     // integer division of pageSizeBytes and recordSize.
     assertTrue(sorter.getNumberOfAllocatedPages() >= 2);
-    assertTrue(taskContext.taskMetrics().diskBytesSpilled() == 0);
+    assertEquals(0, taskContext.taskMetrics().diskBytesSpilled());
     UnsafeExternalSorter.SpillableIterator iter =
             (UnsafeExternalSorter.SpillableIterator) sorter.getSortedIterator();
     assertTrue(iter.spill() > 0);

--- a/external/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaConsumerStrategySuite.java
+++ b/external/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaConsumerStrategySuite.java
@@ -49,9 +49,7 @@ public class JavaConsumerStrategySuite implements Serializable {
     final Map<TopicPartition, Long> offsets = new HashMap<>();
     offsets.put(tp1, 23L);
     final Map<TopicPartition, Object> dummyOffsets = new HashMap<>();
-    for (Map.Entry<TopicPartition, Long> kv : offsets.entrySet()) {
-      dummyOffsets.put(kv.getKey(), kv.getValue());
-    }
+    dummyOffsets.putAll(offsets);
     final scala.collection.Map<TopicPartition, Object> sOffsets =
       JavaConverters.mapAsScalaMap(dummyOffsets);
 

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -120,9 +120,7 @@ abstract class AbstractCommandBuilder {
 
   void addOptionString(List<String> cmd, String options) {
     if (!isEmpty(options)) {
-      for (String opt : parseOptionString(options)) {
-        cmd.add(opt);
-      }
+      cmd.addAll(parseOptionString(options));
     }
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/VariableLengthRowBasedKeyValueBatch.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/VariableLengthRowBasedKeyValueBatch.java
@@ -43,7 +43,7 @@ public final class VariableLengthRowBasedKeyValueBatch extends RowBasedKeyValueB
   public UnsafeRow appendRow(Object kbase, long koff, int klen,
                              Object vbase, long voff, int vlen) {
     int uaoSize = UnsafeAlignedOffset.getUaoSize();
-    final long recordLength = 2 * uaoSize + klen + vlen + 8L;
+    final long recordLength = 2L * uaoSize + klen + vlen + 8L;
     // if run out of max supported rows or page size, return null
     if (numRows >= capacity || page == null || page.size() - pageCursor < recordLength) {
       return null;
@@ -54,7 +54,7 @@ public final class VariableLengthRowBasedKeyValueBatch extends RowBasedKeyValueB
     UnsafeAlignedOffset.putSize(base, offset, klen + vlen + uaoSize);
     UnsafeAlignedOffset.putSize(base, offset + uaoSize, klen);
 
-    offset += 2 * uaoSize;
+    offset += 2L * uaoSize;
     Platform.copyMemory(kbase, koff, base, offset, klen);
     offset += klen;
     Platform.copyMemory(vbase, voff, base, offset, vlen);
@@ -63,11 +63,11 @@ public final class VariableLengthRowBasedKeyValueBatch extends RowBasedKeyValueB
 
     pageCursor += recordLength;
 
-    keyOffsets[numRows] = recordOffset + 2 * uaoSize;
+    keyOffsets[numRows] = recordOffset + 2L * uaoSize;
 
     keyRowId = numRows;
-    keyRow.pointTo(base, recordOffset + 2 * uaoSize, klen);
-    valueRow.pointTo(base, recordOffset + 2 * uaoSize + klen, vlen);
+    keyRow.pointTo(base, recordOffset + 2L * uaoSize, klen);
+    valueRow.pointTo(base, recordOffset + 2L * uaoSize + klen, vlen);
     numRows++;
     return valueRow;
   }
@@ -104,7 +104,7 @@ public final class VariableLengthRowBasedKeyValueBatch extends RowBasedKeyValueB
     int uaoSize = UnsafeAlignedOffset.getUaoSize();
     long offset = keyRow.getBaseOffset();
     int klen = keyRow.getSizeInBytes();
-    int vlen = UnsafeAlignedOffset.getSize(base, offset - uaoSize * 2) - klen - uaoSize;
+    int vlen = UnsafeAlignedOffset.getSize(base, offset - uaoSize * 2L) - klen - uaoSize;
     valueRow.pointTo(base, offset + klen, vlen);
     return valueRow;
   }
@@ -149,10 +149,10 @@ public final class VariableLengthRowBasedKeyValueBatch extends RowBasedKeyValueB
         currentklen = UnsafeAlignedOffset.getSize(base, offsetInPage + uaoSize);
         currentvlen = totalLength - currentklen;
 
-        key.pointTo(base, offsetInPage + 2 * uaoSize, currentklen);
-        value.pointTo(base, offsetInPage + 2 * uaoSize + currentklen, currentvlen);
+        key.pointTo(base, offsetInPage + 2L * uaoSize, currentklen);
+        value.pointTo(base, offsetInPage + 2L * uaoSize + currentklen, currentvlen);
 
-        offsetInPage += 2 * uaoSize + totalLength + 8;
+        offsetInPage += 2L * uaoSize + totalLength + 8;
         recordsInPage -= 1;
         return true;
       }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
@@ -127,30 +127,43 @@ public class RowBasedKeyValueBatchSuite {
     try (RowBasedKeyValueBatch batch = RowBasedKeyValueBatch.allocate(keySchema,
         valueSchema, taskMemoryManager, DEFAULT_CAPACITY)) {
       Assert.assertEquals(0, batch.numRows());
+
+      boolean asserted = false;
       try {
         batch.getKeyRow(-1);
-        Assert.fail("Should not be able to get row -1");
       } catch (AssertionError e) {
         // Expected exception; do nothing.
+        asserted = true;
       }
+      Assert.assertTrue("Should not be able to get row -1", asserted);
+
+      asserted = false;
       try {
         batch.getValueRow(-1);
-        Assert.fail("Should not be able to get row -1");
       } catch (AssertionError e) {
         // Expected exception; do nothing.
+        asserted = true;
       }
+      Assert.assertTrue("Should not be able to get row -1", asserted);
+
+      asserted = false;
       try {
         batch.getKeyRow(0);
-        Assert.fail("Should not be able to get row 0 when batch is empty");
       } catch (AssertionError e) {
         // Expected exception; do nothing.
+        asserted = true;
       }
+      Assert.assertTrue("Should not be able to get row 0 when batch is empty", asserted);
+
+      asserted = false;
       try {
         batch.getValueRow(0);
-        Assert.fail("Should not be able to get row 0 when batch is empty");
       } catch (AssertionError e) {
         // Expected exception; do nothing.
+        asserted = true;
       }
+      Assert.assertTrue("Should not be able to get row 0 when batch is empty", asserted);
+
       Assert.assertFalse(batch.rowIterator().next());
     }
   }
@@ -185,18 +198,24 @@ public class RowBasedKeyValueBatchSuite {
       Assert.assertTrue(checkValue(retrievedValue1, 2, 2));
       UnsafeRow retrievedValue2 = batch.getValueRow(2);
       Assert.assertTrue(checkValue(retrievedValue2, 3, 3));
+
+      boolean asserted = false;
       try {
         batch.getKeyRow(3);
-        Assert.fail("Should not be able to get row 3");
       } catch (AssertionError e) {
         // Expected exception; do nothing.
+        asserted = true;
       }
+      Assert.assertTrue("Should not be able to get row 3", asserted);
+
+      asserted = false;
       try {
         batch.getValueRow(3);
-        Assert.fail("Should not be able to get row 3");
       } catch (AssertionError e) {
         // Expected exception; do nothing.
+        asserted = true;
       }
+      Assert.assertTrue("Should not be able to get row 3", asserted);
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -54,8 +54,8 @@ public abstract class WritableColumnVector extends ColumnVector {
     if (isConstant) return;
 
     if (childColumns != null) {
-      for (ColumnVector c: childColumns) {
-        ((WritableColumnVector) c).reset();
+      for (WritableColumnVector c: childColumns) {
+        c.reset();
       }
     }
     elementsAppended = 0;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaColumnExpressionSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaColumnExpressionSuite.java
@@ -58,18 +58,15 @@ public class JavaColumnExpressionSuite {
       createStructField("b", StringType, false)));
     Dataset<Row> df = spark.createDataFrame(rows, schema);
     // Test with different types of collections
-    Assert.assertTrue(Arrays.equals(
-      (Row[]) df.filter(df.col("a").isInCollection(Arrays.asList(1, 2))).collect(),
-      (Row[]) df.filter((FilterFunction<Row>) r -> r.getInt(0) == 1 || r.getInt(0) == 2).collect()
-    ));
-    Assert.assertTrue(Arrays.equals(
-      (Row[]) df.filter(df.col("a").isInCollection(new HashSet<>(Arrays.asList(1, 2)))).collect(),
-      (Row[]) df.filter((FilterFunction<Row>) r -> r.getInt(0) == 1 || r.getInt(0) == 2).collect()
-    ));
-    Assert.assertTrue(Arrays.equals(
-      (Row[]) df.filter(df.col("a").isInCollection(new ArrayList<>(Arrays.asList(3, 1)))).collect(),
-      (Row[]) df.filter((FilterFunction<Row>) r -> r.getInt(0) == 3 || r.getInt(0) == 1).collect()
-    ));
+    Assert.assertArrayEquals(
+        (Row[]) df.filter(df.col("a").isInCollection(Arrays.asList(1, 2))).collect(),
+        (Row[]) df.filter((FilterFunction<Row>) r -> r.getInt(0) == 1 || r.getInt(0) == 2).collect());
+    Assert.assertArrayEquals(
+        (Row[]) df.filter(df.col("a").isInCollection(new HashSet<>(Arrays.asList(1, 2)))).collect(),
+        (Row[]) df.filter((FilterFunction<Row>) r -> r.getInt(0) == 1 || r.getInt(0) == 2).collect());
+    Assert.assertArrayEquals(
+        (Row[]) df.filter(df.col("a").isInCollection(new ArrayList<>(Arrays.asList(3, 1)))).collect(),
+        (Row[]) df.filter((FilterFunction<Row>) r -> r.getInt(0) == 3 || r.getInt(0) == 1).collect());
   }
 
   @Test

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -1548,7 +1548,7 @@ public class JavaDatasetSuite implements Serializable {
     A("www.elgoog.com"),
     B("www.google.com");
 
-    private String url;
+    private final String url;
 
     MyEnum(String url) {
       this.url = url;
@@ -1556,10 +1556,6 @@ public class JavaDatasetSuite implements Serializable {
 
     public String getUrl() {
       return url;
-    }
-
-    public void setUrl(String url) {
-      this.url = url;
     }
   }
 
@@ -1653,7 +1649,7 @@ public class JavaDatasetSuite implements Serializable {
     }
   }
 
-  public class CircularReference3Bean implements Serializable {
+  public static class CircularReference3Bean implements Serializable {
     private CircularReference3Bean[] child;
 
     public CircularReference3Bean[] getChild() {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaColumnarDataSourceV2.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaColumnarDataSourceV2.java
@@ -35,7 +35,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 public class JavaColumnarDataSourceV2 implements TestingV2Source {
 
-  class MyScanBuilder extends JavaSimpleScanBuilder {
+  static class MyScanBuilder extends JavaSimpleScanBuilder {
 
     @Override
     public InputPartition[] planInputPartitions() {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareDataSource.java
@@ -34,7 +34,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 public class JavaPartitionAwareDataSource implements TestingV2Source {
 
-  class MyScanBuilder extends JavaSimpleScanBuilder implements SupportsReportPartitioning {
+  static class MyScanBuilder extends JavaSimpleScanBuilder implements SupportsReportPartitioning {
 
     @Override
     public InputPartition[] planInputPartitions() {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaReportStatisticsDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaReportStatisticsDataSource.java
@@ -28,7 +28,7 @@ import org.apache.spark.sql.connector.read.SupportsReportStatistics;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 public class JavaReportStatisticsDataSource implements TestingV2Source {
-  class MyScanBuilder extends JavaSimpleScanBuilder implements SupportsReportStatistics {
+  static class MyScanBuilder extends JavaSimpleScanBuilder implements SupportsReportStatistics {
     @Override
     public Statistics estimateStatistics() {
       return new Statistics() {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaSchemaRequiredDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaSchemaRequiredDataSource.java
@@ -29,7 +29,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 public class JavaSchemaRequiredDataSource implements TableProvider {
 
-  class MyScanBuilder extends JavaSimpleScanBuilder {
+  static class MyScanBuilder extends JavaSimpleScanBuilder {
 
     private StructType schema;
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaSimpleDataSourceV2.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaSimpleDataSourceV2.java
@@ -25,7 +25,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 public class JavaSimpleDataSourceV2 implements TestingV2Source {
 
-  class MyScanBuilder extends JavaSimpleScanBuilder {
+  static class MyScanBuilder extends JavaSimpleScanBuilder {
 
     @Override
     public InputPartition[] planInputPartitions() {

--- a/streaming/src/test/java/org/apache/spark/streaming/JavaMapWithStateSuite.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/JavaMapWithStateSuite.java
@@ -95,28 +95,28 @@ public class JavaMapWithStateSuite extends LocalJavaStreamingContext implements 
   @Test
   public void testBasicFunction() {
     List<List<String>> inputData = Arrays.asList(
-        Collections.<String>emptyList(),
+        Collections.emptyList(),
         Arrays.asList("a"),
         Arrays.asList("a", "b"),
         Arrays.asList("a", "b", "c"),
         Arrays.asList("a", "b"),
         Arrays.asList("a"),
-        Collections.<String>emptyList()
+        Collections.emptyList()
     );
 
     List<Set<Integer>> outputData = Arrays.asList(
-        Collections.<Integer>emptySet(),
+        Collections.emptySet(),
         Sets.newHashSet(1),
         Sets.newHashSet(2, 1),
         Sets.newHashSet(3, 2, 1),
         Sets.newHashSet(4, 3),
         Sets.newHashSet(5),
-        Collections.<Integer>emptySet()
+        Collections.emptySet()
     );
 
     @SuppressWarnings("unchecked")
     List<Set<Tuple2<String, Integer>>> stateData = Arrays.asList(
-        Collections.<Tuple2<String, Integer>>emptySet(),
+        Collections.emptySet(),
         Sets.newHashSet(new Tuple2<>("a", 1)),
         Sets.newHashSet(new Tuple2<>("a", 2), new Tuple2<>("b", 1)),
         Sets.newHashSet(new Tuple2<>("a", 3), new Tuple2<>("b", 2), new Tuple2<>("c", 1)),

--- a/streaming/src/test/java/test/org/apache/spark/streaming/Java8APISuite.java
+++ b/streaming/src/test/java/test/org/apache/spark/streaming/Java8APISuite.java
@@ -547,7 +547,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaPairDStream<String, Integer> pairStream = JavaPairDStream.fromJavaDStream(stream);
     JavaDStream<Integer> reversed = pairStream.map(Tuple2::_2);
     JavaTestUtils.attachTestOutputStream(reversed);
-    List<List<Tuple2<Integer, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
+    List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
     Assert.assertEquals(expected, result);
   }
@@ -586,7 +586,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     });
 
     JavaTestUtils.attachTestOutputStream(flatMapped);
-    List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
+    List<List<Tuple2<Integer, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
     Assert.assertEquals(expected, result);
   }
@@ -755,7 +755,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaPairDStream<Integer, Integer> sorted = pairStream.transformToPair(in -> in.sortByKey());
 
     JavaTestUtils.attachTestOutputStream(sorted);
-    List<List<Tuple2<String, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
+    List<List<Tuple2<Integer, Integer>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
     Assert.assertEquals(expected, result);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix up some minor Java issues:

- Some int*int multiplications that widen to long maybe could overflow
- Unnecessarily non-static inner classes
- Some tests "catch (AssertionError)" and do nothing
- Manual array iteration vs very slightly faster/simpler foreach
- Incorrect generic types that just happen to not cause a runtime error
- Missed opportunities for try-close
- Mutable enums
- .. and a few other minor things

### Why are the changes needed?

Some are minor but clear fixes; some may have a marginal perf impact or avoid a bug later. Also: maybe avoid future PRs to address these one by one.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests