### PR TITLE
[SPARK-36381][SQL] Use case sensitive when check column exist for v2 command `Alert Table ` `Add` and `Rename` 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -940,8 +940,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
    * Validates the options used for alter table commands after table and columns are resolved.
    */
   private def checkAlterTableColumnCommand(alter: AlterTableColumnCommand): Unit = {
-    def checkColumnNotExists(op: String, fieldNames: Seq[String], struct: StructType): Unit = {
-      if (struct.findNestedField(fieldNames, includeCollections = true).isDefined) {
+    def checkColumnNotExists(
+      op: String, fieldNames: Seq[String], struct: StructType, r: Resolver): Unit = {
+      if (struct.findNestedField(fieldNames, includeCollections = true, r).isDefined) {
         alter.failAnalysis(s"Cannot $op column, because ${fieldNames.quoted} " +
           s"already exists in ${struct.treeString}")
       }
@@ -950,7 +951,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
     alter match {
       case AlterTableAddColumns(table: ResolvedTable, colsToAdd) =>
         colsToAdd.foreach { colToAdd =>
-          checkColumnNotExists("add", colToAdd.name, table.schema)
+          checkColumnNotExists("add", colToAdd.name, table.schema, alter.conf.resolver)
         }
         SchemaUtils.checkColumnNameDuplication(
           colsToAdd.map(_.name.quoted),
@@ -958,7 +959,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
           alter.conf.resolver)
 
       case AlterTableRenameColumn(table: ResolvedTable, col: ResolvedFieldName, newName) =>
-        checkColumnNotExists("rename", col.path :+ newName, table.schema)
+        checkColumnNotExists("rename", col.path :+ newName, table.schema, alter.conf.resolver)
 
       case a @ AlterTableAlterColumn(table: ResolvedTable, col: ResolvedFieldName, _, _, _, _) =>
         val fieldName = col.name.quoted


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add resolver to `checkColumnNotExists` method for caseSensitive or caseInSensitive

### Why are the changes needed?

[SPARK-36381](https://issues.apache.org/jira/browse/SPARK-36381)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add ut testcase
