### PR TITLE
[SPARK-36382][WEBUI] Remove noisy footer from the summary table for metrics

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -242,6 +242,7 @@ function createDataTableForTaskSummaryMetricsTable(taskSummaryMetricsTable) {
         { "type": "duration", "targets": 5 }
       ],
       "paging": false,
+      "info": false,
       "searching": false,
       "order": [[0, "asc"]],
       "bSort": false,


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR changed `StagePage` to remove a noisy footer from the summary table for metrics.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In the WebUI, some tables are implemented using DataTables (https://datatables.net/).
By default, tables created using DataTables shows footer which says `Showing x to y of z entries`, which is helpful for some tables if table entries can grow
But the summary table for metrics in StagePage cannot grow so it's a little bit noisy.
![summary_metrics_before](https://user-images.githubusercontent.com/4736016/127866960-d2fa23fc-7260-4b99-86cc-b31f85249632.png)

Actually, ExecutorPage has a similar summary table and the footer is from the table.
![executors-no-footer](https://user-images.githubusercontent.com/4736016/127867104-23581e79-de70-49fa-aaef-ab241a8bfa0a.png)

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, appearance will be slightly changed but I don't think this change affects users.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I confirmed that the footer is removed from the table.
![summary_metrics_after](https://user-images.githubusercontent.com/4736016/127867320-097a6f52-7aa8-4fec-9d50-b982165baef7.png)
