### PR TITLE
[SPARK-36367][3.2][PYTHON] Partially backport to avoid unexpected error with pandas 1.3

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -23,7 +23,7 @@ import re
 import inspect
 import sys
 from collections.abc import Mapping
-from functools import partial, wraps, reduce
+from functools import partial, reduce
 from typing import (
     Any,
     Callable,
@@ -3164,7 +3164,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             # Falls back to schema inference if it fails to get signature.
             should_infer_schema = True
 
-        apply_each = wraps(func)(lambda s: s.apply(func, args=args, **kwds))
+        apply_each = lambda s: s.apply(func, args=args, **kwds)
 
         if should_infer_schema:
             return self.pandas_on_spark._transform_batch(apply_each, None)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Partially backport from #33598 to avoid unexpected error caused by pandas 1.3.

### Why are the changes needed?

If uses tries to use pandas 1.3 as the underlying pandas, it will raise unexpected errors caused by removed APIs or behavior change.

Note that pandas API on Spark 3.2 will still follow the pandas 1.2 behavior.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
