### PR TITLE
[SPARK-35548][CORE][SHUFFLE] Handling new attempt has started error message in BlockPushErrorHandler in client

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/server/BlockPushNonFatalFailure.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/BlockPushNonFatalFailure.java
@@ -40,8 +40,8 @@ public class BlockPushNonFatalFailure extends RuntimeException {
     " is received after merged shuffle is finalized";
 
   /**
-   * String constant used for generating exception messages indicating the attempt is not the
-   * latest attempt on the server side. When we get a block push failure because of the too
+   * String constant used for generating exception messages indicating the application attempt is
+   * not the latest attempt on the server side. When we get a block push failure because of the too
    * old attempt, we will not retry pushing the block nor log the exception on the client side.
    */
   public static final String TOO_OLD_ATTEMPT_SUFFIX =
@@ -134,8 +134,8 @@ public class BlockPushNonFatalFailure extends RuntimeException {
      */
     STALE_BLOCK_PUSH(3, STALE_BLOCK_PUSH_MESSAGE_SUFFIX),
     /**
-     * Indicate the attempt is not the latest attempt on the server side. When the client
-     * gets this code, it will not retry pushing the block.
+     * Indicate the application attempt is not the latest attempt on the server side.
+     * When the client gets this code, it will not retry pushing the block.
      */
     TOO_OLD_ATTEMPT_PUSH(4, TOO_OLD_ATTEMPT_SUFFIX);
 
@@ -164,6 +164,12 @@ public class BlockPushNonFatalFailure extends RuntimeException {
     }
   }
 
+  public static boolean shouldNotRetryErrorCode(ReturnCode returnCode) {
+    return returnCode == ReturnCode.TOO_LATE_BLOCK_PUSH ||
+      returnCode == ReturnCode.STALE_BLOCK_PUSH ||
+      returnCode == ReturnCode.TOO_OLD_ATTEMPT_PUSH;
+  }
+
   public static String getErrorMsg(String blockId, ReturnCode errorCode) {
     Preconditions.checkArgument(errorCode != ReturnCode.SUCCESS);
     return "Block " + blockId + errorCode.errorMsgSuffix;
@@ -171,6 +177,6 @@ public class BlockPushNonFatalFailure extends RuntimeException {
 
   public static String getErrorMsg(int attemptId, ReturnCode errorCode) {
     Preconditions.checkArgument(errorCode != ReturnCode.SUCCESS);
-    return "Attempt " + attemptId + errorCode.errorMsgSuffix;
+    return "App Attempt " + attemptId + errorCode.errorMsgSuffix;
   }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/BlockPushNonFatalFailure.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/BlockPushNonFatalFailure.java
@@ -40,6 +40,14 @@ public class BlockPushNonFatalFailure extends RuntimeException {
     " is received after merged shuffle is finalized";
 
   /**
+   * String constant used for generating exception messages indicating the attempt is not the
+   * latest attempt on the server side. When we get a block push failure because of the too
+   * old attempt, we will not retry pushing the block nor log the exception on the client side.
+   */
+  public static final String TOO_OLD_ATTEMPT_SUFFIX =
+    " is a too old app attempt";
+
+  /**
    * String constant used for generating exception messages indicating a block to be merged
    * is a stale block push in the case of indeterminate stage retries on the server side.
    * When we get a block push failure because of the block push being stale, we will not
@@ -124,7 +132,12 @@ public class BlockPushNonFatalFailure extends RuntimeException {
      * indeterminate stage retries. When the client receives this code, it will not retry
      * pushing the block.
      */
-    STALE_BLOCK_PUSH(3, STALE_BLOCK_PUSH_MESSAGE_SUFFIX);
+    STALE_BLOCK_PUSH(3, STALE_BLOCK_PUSH_MESSAGE_SUFFIX),
+    /**
+     * Indicate the attempt is not the latest attempt on the server side. When the client
+     * gets this code, it will not retry pushing the block.
+     */
+    TOO_OLD_ATTEMPT_PUSH(4, TOO_OLD_ATTEMPT_SUFFIX);
 
     private final byte id;
     // Error message suffix used to generate an error message for a given ReturnCode and
@@ -146,6 +159,7 @@ public class BlockPushNonFatalFailure extends RuntimeException {
       case 1: return ReturnCode.TOO_LATE_BLOCK_PUSH;
       case 2: return ReturnCode.BLOCK_APPEND_COLLISION_DETECTED;
       case 3: return ReturnCode.STALE_BLOCK_PUSH;
+      case 4: return ReturnCode.TOO_OLD_ATTEMPT_PUSH;
       default: throw new IllegalArgumentException("Unknown block push return code: " + id);
     }
   }
@@ -153,5 +167,10 @@ public class BlockPushNonFatalFailure extends RuntimeException {
   public static String getErrorMsg(String blockId, ReturnCode errorCode) {
     Preconditions.checkArgument(errorCode != ReturnCode.SUCCESS);
     return "Block " + blockId + errorCode.errorMsgSuffix;
+  }
+
+  public static String getErrorMsg(int attemptId, ReturnCode errorCode) {
+    Preconditions.checkArgument(errorCode != ReturnCode.SUCCESS);
+    return "Attempt " + attemptId + errorCode.errorMsgSuffix;
   }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/BlockPushNonFatalFailure.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/BlockPushNonFatalFailure.java
@@ -45,7 +45,7 @@ public class BlockPushNonFatalFailure extends RuntimeException {
    * old attempt, we will not retry pushing the block nor log the exception on the client side.
    */
   public static final String TOO_OLD_ATTEMPT_SUFFIX =
-    " is a too old app attempt";
+    " is from an older app attempt";
 
   /**
    * String constant used for generating exception messages indicating a block to be merged
@@ -173,10 +173,5 @@ public class BlockPushNonFatalFailure extends RuntimeException {
   public static String getErrorMsg(String blockId, ReturnCode errorCode) {
     Preconditions.checkArgument(errorCode != ReturnCode.SUCCESS);
     return "Block " + blockId + errorCode.errorMsgSuffix;
-  }
-
-  public static String getErrorMsg(int attemptId, ReturnCode errorCode) {
-    Preconditions.checkArgument(errorCode != ReturnCode.SUCCESS);
-    return "App Attempt " + attemptId + errorCode.errorMsgSuffix;
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
@@ -87,9 +87,11 @@ public interface ErrorHandler {
         return false;
       }
 
-      // If the block is too late or stale block push, there is no need to retry it
+      // If the block is too late or the invalid block push or the attempt is not the latest one,
+      // there is no need to retry it
       return !(t instanceof BlockPushNonFatalFailure &&
         (((BlockPushNonFatalFailure) t).getReturnCode() == TOO_LATE_BLOCK_PUSH ||
+          ((BlockPushNonFatalFailure) t).getReturnCode() == TOO_OLD_ATTEMPT_PUSH ||
           ((BlockPushNonFatalFailure) t).getReturnCode() == STALE_BLOCK_PUSH));
     }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
@@ -90,9 +90,8 @@ public interface ErrorHandler {
       // If the block is too late or the invalid block push or the attempt is not the latest one,
       // there is no need to retry it
       return !(t instanceof BlockPushNonFatalFailure &&
-        (((BlockPushNonFatalFailure) t).getReturnCode() == TOO_LATE_BLOCK_PUSH ||
-          ((BlockPushNonFatalFailure) t).getReturnCode() == TOO_OLD_ATTEMPT_PUSH ||
-          ((BlockPushNonFatalFailure) t).getReturnCode() == STALE_BLOCK_PUSH));
+        BlockPushNonFatalFailure.
+          shouldNotRetryErrorCode(((BlockPushNonFatalFailure) t).getReturnCode()));
     }
 
     @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
@@ -90,8 +90,8 @@ public interface ErrorHandler {
       // If the block is too late or the invalid block push or the attempt is not the latest one,
       // there is no need to retry it
       return !(t instanceof BlockPushNonFatalFailure &&
-        BlockPushNonFatalFailure.
-          shouldNotRetryErrorCode(((BlockPushNonFatalFailure) t).getReturnCode()));
+        BlockPushNonFatalFailure
+          .shouldNotRetryErrorCode(((BlockPushNonFatalFailure) t).getReturnCode()));
     }
 
     @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -37,6 +37,7 @@ import org.apache.spark.network.client.TransportClient;
 import org.apache.spark.network.client.TransportClientBootstrap;
 import org.apache.spark.network.crypto.AuthClientBootstrap;
 import org.apache.spark.network.sasl.SecretKeyHolder;
+import org.apache.spark.network.server.BlockPushNonFatalFailure;
 import org.apache.spark.network.server.NoOpRpcHandler;
 import org.apache.spark.network.shuffle.protocol.*;
 import org.apache.spark.network.util.TransportConf;
@@ -193,8 +194,14 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
         }
       });
     } catch (Exception e) {
-      logger.error("Exception while sending finalizeShuffleMerge request to {}:{}",
-        host, port, e);
+      if (e instanceof BlockPushNonFatalFailure) {
+        // It means when we finalizeShuffleMerge, the app attempt is too old.
+        logger.debug("Send too old app attempt finalizeShuffleMerge request to {}:{}",
+          host, port, e);
+      } else {
+        logger.error("Exception while sending finalizeShuffleMerge request to {}:{}",
+          host, port, e);
+      }
       listener.onShuffleMergeFailure(e);
     }
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -37,7 +37,6 @@ import org.apache.spark.network.client.TransportClient;
 import org.apache.spark.network.client.TransportClientBootstrap;
 import org.apache.spark.network.crypto.AuthClientBootstrap;
 import org.apache.spark.network.sasl.SecretKeyHolder;
-import org.apache.spark.network.server.BlockPushNonFatalFailure;
 import org.apache.spark.network.server.NoOpRpcHandler;
 import org.apache.spark.network.shuffle.protocol.*;
 import org.apache.spark.network.util.TransportConf;
@@ -194,14 +193,8 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
         }
       });
     } catch (Exception e) {
-      if (e instanceof BlockPushNonFatalFailure) {
-        // It means when we finalizeShuffleMerge, the app attempt is too old.
-        logger.debug("Send too old app attempt finalizeShuffleMerge request to {}:{}",
-          host, port, e);
-      } else {
-        logger.error("Exception while sending finalizeShuffleMerge request to {}:{}",
-          host, port, e);
-      }
+      logger.error("Exception while sending finalizeShuffleMerge request to {}:{}",
+        host, port, e);
       listener.onShuffleMergeFailure(e);
     }
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -402,9 +402,9 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
     if (appShuffleInfo.attemptId != msg.appAttemptId) {
       // If this Block belongs to a former application attempt, it is considered late,
       // as only the blocks from the current application attempt will be merged
-      throw new BlockPushNonFatalFailure(new BlockPushReturnCode(ReturnCode.TOO_OLD_ATTEMPT_PUSH.id(),
-        streamId).toByteBuffer(),
-        BlockPushNonFatalFailure.getErrorMsg(msg.appAttemptId, ReturnCode.TOO_OLD_ATTEMPT_PUSH));
+      throw new BlockPushNonFatalFailure(new BlockPushReturnCode(ReturnCode
+        .TOO_OLD_ATTEMPT_PUSH.id(), streamId).toByteBuffer(),
+        BlockPushNonFatalFailure.getErrorMsg(streamId, ReturnCode.TOO_OLD_ATTEMPT_PUSH));
     }
     // Retrieve merged shuffle file metadata
     AppShufflePartitionInfo partitionInfoBeforeCheck;
@@ -511,13 +511,19 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       msg.shuffleId, msg.shuffleMergeId, msg.appId, msg.appAttemptId);
     AppShuffleInfo appShuffleInfo = validateAndGetAppShuffleInfo(msg.appId);
     if (appShuffleInfo.attemptId != msg.appAttemptId) {
-      // If this Block belongs to a former application attempt, it is considered late,
-      // as only the blocks from the current application attempt will be merged.
-      // No need use callback to return to client now, because the finalizeShuffleMerge
-      // in DAGScheduler has no retry policy.
-      throw new BlockPushNonFatalFailure(ReturnCode.TOO_OLD_ATTEMPT_PUSH,
-        BlockPushNonFatalFailure.
-          getErrorMsg(msg.appAttemptId, ReturnCode.TOO_OLD_ATTEMPT_PUSH));
+      // If finalizeShuffleMerge from a former application attempt, it is considered late,
+      // as only the finalizeShuffleMerge request from the current application attempt
+      // will be merged. Too old app attempt only being seen by an already failed
+      // app attempt, and no need use callback to return to client now, because
+      // the finalizeShuffleMerge in DAGScheduler has no retry policy, and don't
+      // use the BlockPushNonFatalFailure because it's the finalizeShuffleMerge
+      // related case, not the block push case, just throw it in server side now.
+      // TODO we may use a new exception class to include the finalizeShuffleMerge
+      // related case just as the BlockPushNonFatalFailure contains the block push cases.
+      throw new IllegalArgumentException(
+        String.format("The attempt id %s in this FinalizeShuffleMerge message does not match "
+            + "with the current attempt id %s stored in shuffle service for application %s",
+          msg.appAttemptId, appShuffleInfo.attemptId, msg.appId));
     }
     AtomicReference<Map<Integer, AppShufflePartitionInfo>> shuffleMergePartitionsRef =
       new AtomicReference<>(null);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -402,7 +402,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
     if (appShuffleInfo.attemptId != msg.appAttemptId) {
       // If this Block belongs to a former application attempt, it is considered late,
       // as only the blocks from the current application attempt will be merged
-      throw new BlockPushNonFatalFailure(new BlockPushReturnCode(ReturnCode.STALE_BLOCK_PUSH.id(),
+      throw new BlockPushNonFatalFailure(new BlockPushReturnCode(ReturnCode.TOO_OLD_ATTEMPT_PUSH.id(),
         streamId).toByteBuffer(),
         BlockPushNonFatalFailure.getErrorMsg(msg.appAttemptId, ReturnCode.TOO_OLD_ATTEMPT_PUSH));
     }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ErrorHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ErrorHandlerSuite.java
@@ -37,6 +37,8 @@ public class ErrorHandlerSuite {
     assertFalse(pushHandler.shouldRetryError(new BlockPushNonFatalFailure(
       ReturnCode.TOO_LATE_BLOCK_PUSH, "")));
     assertFalse(pushHandler.shouldRetryError(new BlockPushNonFatalFailure(
+      ReturnCode.TOO_OLD_ATTEMPT_PUSH, "")));
+    assertFalse(pushHandler.shouldRetryError(new BlockPushNonFatalFailure(
       ReturnCode.STALE_BLOCK_PUSH, "")));
     assertFalse(pushHandler.shouldRetryError(new RuntimeException(new ConnectException())));
     assertTrue(pushHandler.shouldRetryError(new BlockPushNonFatalFailure(
@@ -53,6 +55,8 @@ public class ErrorHandlerSuite {
     ErrorHandler.BlockPushErrorHandler pushHandler = new ErrorHandler.BlockPushErrorHandler();
     assertFalse(pushHandler.shouldLogError(new BlockPushNonFatalFailure(
       ReturnCode.TOO_LATE_BLOCK_PUSH, "")));
+    assertFalse(pushHandler.shouldLogError(new BlockPushNonFatalFailure(
+      ReturnCode.TOO_OLD_ATTEMPT_PUSH, "")));
     assertFalse(pushHandler.shouldLogError(new BlockPushNonFatalFailure(
       ReturnCode.STALE_BLOCK_PUSH, "")));
     assertFalse(pushHandler.shouldLogError(new BlockPushNonFatalFailure(

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -1001,7 +1001,11 @@ public class RemoteBlockPushResolverSuite {
       pushResolver.receiveBlockDataAsStream(
         new PushBlockStream(testApp, 1, 0, 0, 1, 0, 0));
     } catch (BlockPushNonFatalFailure re) {
-      assertEquals(re.getMessage(), "Attempt " + ATTEMPT_ID_1 + " is a too old app attempt");
+      BlockPushReturnCode errorCode =
+        (BlockPushReturnCode) BlockTransferMessage.Decoder.fromByteBuffer(re.getResponse());
+      assertEquals(BlockPushNonFatalFailure.ReturnCode.TOO_OLD_ATTEMPT_PUSH.id(),
+        errorCode.returnCode);
+      assertEquals(re.getMessage(), "App Attempt " + ATTEMPT_ID_1 + " is a too old app attempt");
       throw re;
     }
   }
@@ -1031,7 +1035,9 @@ public class RemoteBlockPushResolverSuite {
     try {
       pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(testApp, ATTEMPT_ID_1, 0, 0));
     } catch (BlockPushNonFatalFailure e) {
-      assertEquals(e.getMessage(), "Attempt " + ATTEMPT_ID_1 + " is a too old app attempt");
+      // FinalizeShuffleMerge use TOO_OLD_ATTEMPT_PUSH return code
+      assertEquals(e.getReturnCode(), BlockPushNonFatalFailure.ReturnCode.TOO_OLD_ATTEMPT_PUSH);
+      assertEquals(e.getMessage(), "App Attempt " + ATTEMPT_ID_1 + " is a too old app attempt");
       throw e;
     }
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -1005,12 +1005,12 @@ public class RemoteBlockPushResolverSuite {
         (BlockPushReturnCode) BlockTransferMessage.Decoder.fromByteBuffer(re.getResponse());
       assertEquals(BlockPushNonFatalFailure.ReturnCode.TOO_OLD_ATTEMPT_PUSH.id(),
         errorCode.returnCode);
-      assertEquals(re.getMessage(), "App Attempt " + ATTEMPT_ID_1 + " is a too old app attempt");
+      assertEquals(errorCode.failureBlockId, stream2.getID());
       throw re;
     }
   }
 
-  @Test(expected = BlockPushNonFatalFailure.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testFinalizeShuffleMergeFromPreviousAttemptIsAborted()
     throws IOException, InterruptedException {
     String testApp = "testFinalizeShuffleMergeFromPreviousAttemptIsAborted";
@@ -1034,10 +1034,11 @@ public class RemoteBlockPushResolverSuite {
       MERGE_DIRECTORY_META_2);
     try {
       pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(testApp, ATTEMPT_ID_1, 0, 0));
-    } catch (BlockPushNonFatalFailure e) {
-      // FinalizeShuffleMerge use TOO_OLD_ATTEMPT_PUSH return code
-      assertEquals(e.getReturnCode(), BlockPushNonFatalFailure.ReturnCode.TOO_OLD_ATTEMPT_PUSH);
-      assertEquals(e.getMessage(), "App Attempt " + ATTEMPT_ID_1 + " is a too old app attempt");
+    } catch (IllegalArgumentException e) {
+      assertEquals(e.getMessage(),
+        String.format("The attempt id %s in this FinalizeShuffleMerge message does not " +
+            "match with the current attempt id %s stored in shuffle service for application %s",
+          ATTEMPT_ID_1, ATTEMPT_ID_2, testApp));
       throw e;
     }
   }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
@@ -78,10 +78,13 @@ private[spark] class ShuffleBlockPusher(conf: SparkConf) extends Logging {
         if (t.getCause != null && t.getCause.isInstanceOf[FileNotFoundException]) {
           return false
         }
-        // If the block is too late or the invalid block push, there is no need to retry it
+        // If the block is too late or the invalid block push or the attempt is not the latest one,
+        // there is no need to retry it
         !(t.isInstanceOf[BlockPushNonFatalFailure] &&
           (t.asInstanceOf[BlockPushNonFatalFailure].getReturnCode
             == ReturnCode.TOO_LATE_BLOCK_PUSH ||
+            t.asInstanceOf[BlockPushNonFatalFailure].getReturnCode
+              == ReturnCode.TOO_OLD_ATTEMPT_PUSH ||
             t.asInstanceOf[BlockPushNonFatalFailure].getReturnCode
             == ReturnCode.STALE_BLOCK_PUSH))
       }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
@@ -32,7 +32,6 @@ import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer, NioManagedBuffer}
 import org.apache.spark.network.netty.SparkTransportConf
 import org.apache.spark.network.server.BlockPushNonFatalFailure
-import org.apache.spark.network.server.BlockPushNonFatalFailure.ReturnCode
 import org.apache.spark.network.shuffle.BlockPushingListener
 import org.apache.spark.network.shuffle.ErrorHandler.BlockPushErrorHandler
 import org.apache.spark.network.util.TransportConf

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
@@ -81,12 +81,8 @@ private[spark] class ShuffleBlockPusher(conf: SparkConf) extends Logging {
         // If the block is too late or the invalid block push or the attempt is not the latest one,
         // there is no need to retry it
         !(t.isInstanceOf[BlockPushNonFatalFailure] &&
-          (t.asInstanceOf[BlockPushNonFatalFailure].getReturnCode
-            == ReturnCode.TOO_LATE_BLOCK_PUSH ||
-            t.asInstanceOf[BlockPushNonFatalFailure].getReturnCode
-              == ReturnCode.TOO_OLD_ATTEMPT_PUSH ||
-            t.asInstanceOf[BlockPushNonFatalFailure].getReturnCode
-            == ReturnCode.STALE_BLOCK_PUSH))
+          BlockPushNonFatalFailure.
+            shouldNotRetryErrorCode(t.asInstanceOf[BlockPushNonFatalFailure].getReturnCode));
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/shuffle/ShuffleBlockPusherSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/ShuffleBlockPusherSuite.scala
@@ -224,6 +224,9 @@ class ShuffleBlockPusherSuite extends SparkFunSuite with BeforeAndAfterEach {
         ReturnCode.TOO_LATE_BLOCK_PUSH, "")))
     assert(
       !errorHandler.shouldRetryError(new BlockPushNonFatalFailure(
+        ReturnCode.TOO_OLD_ATTEMPT_PUSH, "")))
+    assert(
+      !errorHandler.shouldRetryError(new BlockPushNonFatalFailure(
         ReturnCode.STALE_BLOCK_PUSH, "")))
     assert(errorHandler.shouldRetryError(new RuntimeException(new ConnectException())))
     assert(
@@ -238,6 +241,9 @@ class ShuffleBlockPusherSuite extends SparkFunSuite with BeforeAndAfterEach {
     assert(
       !errorHandler.shouldLogError(new BlockPushNonFatalFailure(
         ReturnCode.TOO_LATE_BLOCK_PUSH, "")))
+    assert(
+      !errorHandler.shouldLogError(new BlockPushNonFatalFailure(
+        ReturnCode.TOO_OLD_ATTEMPT_PUSH, "")))
     assert(
       !errorHandler.shouldLogError(new BlockPushNonFatalFailure(
         ReturnCode.STALE_BLOCK_PUSH, "")))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add a new type of error message in BlockPushErrorHandler which indicates the PushblockStream message is received after a new application attempt has started. This error message should be correctly handled in client without retrying the block push.


### Why are the changes needed?
When we get a block push failure because of the too old attempt, we will not retry pushing the block nor log the exception on the client side.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add the corresponding unit test.
