### PR TITLE
[SPARK-36381][SQL] Add case sensitive and case insensitive compare for checking column name exist when alter table

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
@@ -249,6 +249,28 @@ class V2CommandsCaseSensitivitySuite extends SharedSparkSession with AnalysisTes
       expectErrorOnCaseSensitive = false)
   }
 
+  test("SPARK-36381: Check column name exist case sensitive and insensitive when add column") {
+    alterTableTest(
+      AddColumns(
+        table,
+        Seq(QualifiedColType(
+          None,
+          "ID",
+          LongType,
+          true,
+          None,
+          Some(UnresolvedFieldPosition(ColumnPosition.after("id")))))),
+      Seq("Cannot add column, because ID already exists in root"),
+      expectErrorOnCaseSensitive = false)
+  }
+
+  test("SPARK-36381: Check column name exist case sensitive and insensitive when rename column") {
+    alterTableTest(
+      RenameColumn(table, UnresolvedFieldName(Array("id")), "DATA"),
+      Seq("Cannot rename column, because DATA already exists in root"),
+      expectErrorOnCaseSensitive = false)
+  }
+
   test("AlterTable: drop column resolution") {
     Seq(Array("ID"), Array("point", "X"), Array("POINT", "X"), Array("POINT", "x")).foreach { ref =>
       alterTableTest(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the Resolver to `checkColumnNotExists` to check name exist in case sensitive.

### Why are the changes needed?
At now the resolver is `_ == _` of `findNestedField`  called by `checkColumnNotExists`
Add `alter.conf.resolver` to it.
[SPARK-36381](https://issues.apache.org/jira/browse/SPARK-36381)
### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add ut tests