### PR TITLE
[WIP][SPARK-36397][PYTHON] Implement DataFrame.mode

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/frame.rst
+++ b/python/docs/source/reference/pyspark.pandas/frame.rst
@@ -137,6 +137,7 @@ Computations / Descriptive Stats
    DataFrame.mean
    DataFrame.min
    DataFrame.median
+   DataFrame.mode
    DataFrame.pct_change
    DataFrame.prod
    DataFrame.product

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3469,6 +3469,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         The mode of a set of values is the value that appears most often.
         It can be multiple values.
 
+        .. note:: the current implementation of mode requires joins
+            multiple times(columns count - 1 times when axis is 0 or 'index'),
+            which is potentially expensive.
+
         Parameters
         ----------
         axis : {0 or 'index', 1 or 'columns'}, default 0

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3473,6 +3473,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             multiple times(columns count - 1 times when axis is 0 or 'index'),
             which is potentially expensive.
 
+        .. note:: the order of multiple modes (within a column when axis is 0 or 'index')
+            is not determined.
+
         Parameters
         ----------
         axis : {0 or 'index', 1 or 'columns'}, default 0
@@ -3509,14 +3512,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         horse       mammal     4    NaN
         spider   arthropod     8    0.0
         ostrich       bird     2    NaN
-        >>> psdf.mode().sort_values(by=list(psdf.columns)).sort_index()
+        >>> psdf.mode()  # doctest: +SKIP
           species  legs  wings
         0    bird   2.0    0.0
         1    None   NaN    2.0
         >>> psdf.mode(dropna=False)
           species  legs  wings
         0    bird     2    NaN
-        >>> psdf.mode(numeric_only=True).sort_values(by='legs')..sort_index()
+        >>> psdf.mode(numeric_only=True)  # doctest: +SKIP
            legs  wings
         0   2.0    0.0
         1   NaN    2.0

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3529,7 +3529,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         new_scol = verify_temp_column_name(data._internal.spark_frame, "__row_index__")
 
-        def scol_mode(col):
+        def scol_mode(col: Column) -> SparkDataFrame:
             if dropna:
                 sdf_dropna = data._internal.spark_frame.select(col).dropna()
             else:
@@ -3551,7 +3551,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         return DataFrame(new_sdf.drop(new_scol))
 
-    def _get_numeric_data(self):
+    def _get_numeric_data(self) -> "DataFrame":
         data = self.copy()
         for label in self._internal.column_labels:
             spark_type = self._internal.spark_type_for(label)

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3509,14 +3509,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         horse       mammal     4    NaN
         spider   arthropod     8    0.0
         ostrich       bird     2    NaN
-        >>> psdf.mode().sort_values(by=list(psdf.columns)).reset_index(drop=True)
+        >>> psdf.mode().sort_values(by=list(psdf.columns)).sort_index()
           species  legs  wings
         0    bird   2.0    0.0
         1    None   NaN    2.0
         >>> psdf.mode(dropna=False)
           species  legs  wings
         0    bird     2    NaN
-        >>> psdf.mode(numeric_only=True).sort_values(by='legs').reset_index(drop=True)
+        >>> psdf.mode(numeric_only=True).sort_values(by='legs')..sort_index()
            legs  wings
         0   2.0    0.0
         1   NaN    2.0

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3511,13 +3511,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         horse       mammal     4    NaN
         spider   arthropod     8    0.0
         ostrich       bird     2    NaN
+
         >>> psdf.mode()  # doctest: +SKIP
           species  legs  wings
         0    bird   2.0    0.0
         1    None   NaN    2.0
+
         >>> psdf.mode(dropna=False)
           species  legs  wings
         0    bird     2    NaN
+
         >>> psdf.mode(numeric_only=True)  # doctest: +SKIP
            legs  wings
         0   2.0    0.0

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3459,14 +3459,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return self.where(cond_inversed, other)
 
     # TODO: Support axis as 1 or 'columns'
-    def mode(
-        self, axis: Union[int, str] = 0, numeric_only: bool = False, dropna: bool = True
-    ) -> "DataFrame":
+    def mode(self, axis: Axis, numeric_only: bool = False, dropna: bool = True) -> "DataFrame":
         """
         Get the mode(s) of each element along the selected axis.
 
         The mode of a set of values is the value that appears most often.
         It can be multiple values.
+
+        Notes
+        -----
+        The current implementation of mode requires joins multiple times
+        (columns count - 1 times when axis is 0 or 'index'), which is potentially expensive.
+
+        The order of multiple modes (within each column when axis is 0 or 'index') is undetermined.
 
         Parameters
         ----------
@@ -3518,13 +3523,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
            legs  wings
         0   2.0    0.0
         1   NaN    2.0
-
-        Notes
-        -----
-        The current implementation of mode requires joins multiple times
-        (columns count - 1 times when axis is 0 or 'index'), which is potentially expensive.
-
-        The order of multiple modes (within each column when axis is 0 or 'index') is undetermined.
         """
         axis = validate_axis(axis)
         if axis == 1:

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -73,7 +73,6 @@ from pyspark.sql.types import (  # noqa: F401 (SPARK-34943)
     BooleanType,
     DataType,
     DoubleType,
-    FloatType,
     NumericType,
     Row,
     StringType,
@@ -3541,9 +3540,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             most_value = count_df.orderBy("count", ascending=False).first()[1]
             sdf_most_value = count_df.filter("count == {}".format(most_value)).select(col)
 
-            return sdf_most_value.withColumn(
-                new_scol, F.row_number().over(Window.orderBy(F.monotonically_increasing_id()))
-            )
+            return InternalFrame.attach_sequence_column(sdf_most_value, new_scol)
 
         new_sdf = None
         for data_scol_name in data._internal.data_spark_column_names:

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3468,13 +3468,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         The mode of a set of values is the value that appears most often.
         It can be multiple values.
 
-        .. note:: the current implementation of mode requires joins
-            multiple times(columns count - 1 times when axis is 0 or 'index'),
-            which is potentially expensive.
-
-        .. note:: the order of multiple modes (within a column when axis is 0 or 'index')
-            is not determined.
-
         Parameters
         ----------
         axis : {0 or 'index', 1 or 'columns'}, default 0
@@ -3525,6 +3518,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
            legs  wings
         0   2.0    0.0
         1   NaN    2.0
+
+        Notes
+        -----
+        The current implementation of mode requires joins multiple times
+        (columns count - 1 times when axis is 0 or 'index'), which is potentially expensive.
+
+        The order of multiple modes (within each column when axis is 0 or 'index') is undetermined.
         """
         axis = validate_axis(axis)
         if axis == 1:

--- a/python/pyspark/pandas/missing/frame.py
+++ b/python/pyspark/pandas/missing/frame.py
@@ -49,7 +49,6 @@ class _MissingPandasLikeDataFrame(object):
     infer_objects = _unsupported_function("infer_objects")
     interpolate = _unsupported_function("interpolate")
     lookup = _unsupported_function("lookup")
-    mode = _unsupported_function("mode")
     reorder_levels = _unsupported_function("reorder_levels")
     resample = _unsupported_function("resample")
     set_axis = _unsupported_function("set_axis")

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1923,6 +1923,8 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
                 pdf.mode(dropna=False),
             )
 
+        self.assert_eq(ps.DataFrame([[]]).mode(), pd.DataFrame([[]]).mode())
+
     def test_merge(self):
         left_pdf = pd.DataFrame(
             {

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1900,6 +1900,29 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         with self.assertRaisesRegex(TypeError, msg):
             psdf.isin(1)
 
+    def test_mode(self):
+        pdf = pd.DataFrame(
+            [("bird", 2, 2), ("mammal", 4, np.nan), ("arthropod", 8, 0), ("bird", 2, np.nan)],
+            index=("falcon", "horse", "spider", "ostrich"),
+            columns=("species", "legs", "wings"),
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(
+            psdf.mode().sort_values(by=list(psdf.columns)).reset_index(drop=True),
+            pdf.mode().sort_values(by=list(pdf.columns)).reset_index(drop=True),
+        )
+        self.assert_eq(
+            psdf.mode(numeric_only=True).sort_values(by="legs").reset_index(drop=True),
+            pdf.mode(numeric_only=True).sort_values(by="legs").reset_index(drop=True),
+        )
+
+        if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
+            # dropna parameter is supported since pandas 0.24
+            self.assert_eq(
+                psdf.mode(dropna=False).sort_values(by=list(psdf.columns)).reset_index(drop=True),
+                pdf.mode(dropna=False).sort_values(by=list(pdf.columns)).reset_index(drop=True),
+            )
+
     def test_merge(self):
         left_pdf = pd.DataFrame(
             {

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1902,25 +1902,25 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
     def test_mode(self):
         pdf = pd.DataFrame(
-            [("bird", 2, 2), ("mammal", 4, np.nan), ("arthropod", 8, 0), ("bird", 2, np.nan)],
+            [("bird", 2, 2), ("mammal", 4, 0), ("arthropod", 8, 0), ("bird", 2, np.nan)],
             index=("falcon", "horse", "spider", "ostrich"),
             columns=("species", "legs", "wings"),
         )
         psdf = ps.from_pandas(pdf)
         self.assert_eq(
-            psdf.mode().sort_values(by=list(psdf.columns)).sort_index(),
-            pdf.mode().sort_values(by=list(pdf.columns)),
+            psdf.mode(),
+            pdf.mode(),
         )
         self.assert_eq(
-            psdf.mode(numeric_only=True).sort_values(by="legs").sort_index(),
-            pdf.mode(numeric_only=True).sort_values(by="legs"),
+            psdf.mode(numeric_only=True),
+            pdf.mode(numeric_only=True),
         )
 
         if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
             # dropna parameter is supported since pandas 0.24
             self.assert_eq(
-                psdf.mode(dropna=False).sort_values(by=list(psdf.columns)).sort_index(),
-                pdf.mode(dropna=False).sort_values(by=list(pdf.columns)),
+                psdf.mode(dropna=False),
+                pdf.mode(dropna=False),
             )
 
     def test_merge(self):

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1908,19 +1908,19 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         )
         psdf = ps.from_pandas(pdf)
         self.assert_eq(
-            psdf.mode().sort_values(by=list(psdf.columns)).reset_index(drop=True),
-            pdf.mode().sort_values(by=list(pdf.columns)).reset_index(drop=True),
+            psdf.mode().sort_values(by=list(psdf.columns)).sort_index(),
+            pdf.mode().sort_values(by=list(pdf.columns)),
         )
         self.assert_eq(
-            psdf.mode(numeric_only=True).sort_values(by="legs").reset_index(drop=True),
-            pdf.mode(numeric_only=True).sort_values(by="legs").reset_index(drop=True),
+            psdf.mode(numeric_only=True).sort_values(by="legs").sort_index(),
+            pdf.mode(numeric_only=True).sort_values(by="legs"),
         )
 
         if LooseVersion(pd.__version__) >= LooseVersion("0.24.0"):
             # dropna parameter is supported since pandas 0.24
             self.assert_eq(
-                psdf.mode(dropna=False).sort_values(by=list(psdf.columns)).reset_index(drop=True),
-                pdf.mode(dropna=False).sort_values(by=list(pdf.columns)).reset_index(drop=True),
+                psdf.mode(dropna=False).sort_values(by=list(psdf.columns)).sort_index(),
+                pdf.mode(dropna=False).sort_values(by=list(pdf.columns)),
             )
 
     def test_merge(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement DataFrame.mode (along index axis).


### Why are the changes needed?
Get the mode(s) of each element along the selected axis is a common functionality, which is supported in pandas. We should support that.

### Does this PR introduce _any_ user-facing change?
Yes. `DataFrame.mode` can be used now.

```py
>>> psdf = ps.DataFrame(
...     [("bird", 2, 2), ("mammal", 4, np.nan), ("arthropod", 8, 0), ("bird", 2, np.nan)],
...     index=("falcon", "horse", "spider", "ostrich"),
...     columns=("species", "legs", "wings"),
... )
>>> psdf
           species  legs  wings                                                 
falcon        bird     2    2.0
horse       mammal     4    NaN
spider   arthropod     8    0.0
ostrich       bird     2    NaN

>>> psdf.mode()
  species  legs  wings
0    bird   2.0    0.0
1    None   NaN    2.0

>>> psdf.mode(dropna=False)
  species  legs  wings
0    bird     2    NaN

>>> psdf.mode(numeric_only=True)
   legs  wings
0   2.0    0.0
1   NaN    2.0
```

### How was this patch tested?
Unit tests.
