### PR TITLE
[SPARK-36405][SQL][TESTS] Check that SQLSTATEs are valid

### DIFF
--- a/core/src/main/resources/error/README.md
+++ b/core/src/main/resources/error/README.md
@@ -98,6 +98,7 @@ Spark only uses the standard-defined classes and subclasses, and does not use im
 
 The following SQLSTATEs are from ISO/IEC CD 9075-2.
 
+[//]: # (SQLSTATE table start)
 |SQLSTATE|Class|Condition                                                   |Subclass|Subcondition                                                   |
 |--------|-----|------------------------------------------------------------|--------|---------------------------------------------------------------|
 |07000   |07   |dynamic SQL error                                           |000     |(no subclass)                                                  |
@@ -253,3 +254,4 @@ The following SQLSTATEs are from ISO/IEC CD 9075-2.
 |42000   |42   |syntax error or access rule violation                       |000     |(no subclass)                                                  |
 |44000   |44   |with check option violation                                 |000     |(no subclass)                                                  |
 |HZ000   |HZ   |remote database access                                      |000     |(no subclass)                                                  |
+[//]: # (SQLSTATE table end)

--- a/core/src/main/resources/error/README.md
+++ b/core/src/main/resources/error/README.md
@@ -98,7 +98,7 @@ Spark only uses the standard-defined classes and subclasses, and does not use im
 
 The following SQLSTATEs are from ISO/IEC CD 9075-2.
 
-[//]: # (SQLSTATE table start)
+<!-- SQLSTATE table start -->
 |SQLSTATE|Class|Condition                                                   |Subclass|Subcondition                                                   |
 |--------|-----|------------------------------------------------------------|--------|---------------------------------------------------------------|
 |07000   |07   |dynamic SQL error                                           |000     |(no subclass)                                                  |
@@ -254,4 +254,4 @@ The following SQLSTATEs are from ISO/IEC CD 9075-2.
 |42000   |42   |syntax error or access rule violation                       |000     |(no subclass)                                                  |
 |44000   |44   |with check option violation                                 |000     |(no subclass)                                                  |
 |HZ000   |HZ   |remote database access                                      |000     |(no subclass)                                                  |
-[//]: # (SQLSTATE table end)
+<!-- SQLSTATE table stop -->

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -76,12 +76,14 @@ class SparkThrowableSuite extends SparkFunSuite {
     val sqlStates = errorClassToInfoMap.values.toSeq.flatMap(_.sqlState)
     val errorClassReadMe = Utils.getSparkClassLoader.getResource("error/README.md")
     val errorClassReadMeContents = IOUtils.toString(errorClassReadMe.openStream())
-    val sqlTableRows = errorClassReadMeContents.split("\\|SQLSTATE\\|")(1)
-      .split("\n").drop(2).filter(_.startsWith("|"))
+    val sqlStateTableRegex =
+      "(?s)\\[//]: # \\(SQLSTATE table start\\)(.+)\\[//]: # \\(SQLSTATE table end\\)".r
+    val sqlTable = sqlStateTableRegex.findFirstIn(errorClassReadMeContents).get
+    val sqlTableRows = sqlTable.split("\n").filter(_.startsWith("|")).drop(2)
     val validSqlStates = sqlTableRows.map(_.slice(1, 6)).toSet
     // Sanity check
     assert(Set("07000", "42000", "HZ000").subsetOf(validSqlStates), validSqlStates)
-    assert(validSqlStates.foreach(_.length == 5))
+    assert(validSqlStates.forall(_.length == 5), validSqlStates)
     checkCondition(sqlStates, s => validSqlStates.contains(s))
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -77,12 +77,12 @@ class SparkThrowableSuite extends SparkFunSuite {
     val errorClassReadMe = Utils.getSparkClassLoader.getResource("error/README.md")
     val errorClassReadMeContents = IOUtils.toString(errorClassReadMe.openStream())
     val sqlStateTableRegex =
-      "(?s)\\[//]: # \\(SQLSTATE table start\\)(.+)\\[//]: # \\(SQLSTATE table end\\)".r
+      "(?s)<!-- SQLSTATE table start -->(.+)<!-- SQLSTATE table stop -->".r
     val sqlTable = sqlStateTableRegex.findFirstIn(errorClassReadMeContents).get
     val sqlTableRows = sqlTable.split("\n").filter(_.startsWith("|")).drop(2)
     val validSqlStates = sqlTableRows.map(_.slice(1, 6)).toSet
     // Sanity check
-    assert(Set("07000", "42000", "HZ000").subsetOf(validSqlStates), validSqlStates)
+    assert(Set("07000", "42000", "HZ000").subsetOf(validSqlStates))
     assert(validSqlStates.forall(_.length == 5), validSqlStates)
     checkCondition(sqlStates, s => validSqlStates.contains(s))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds validation that the SQLSTATEs in the error class JSON are a subset of those provided in the README.

### Why are the changes needed?

Validation of error class JSON

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit test