### PR TITLE
[SPARK-35811][PYTHON][FOLLOWUP] Deprecate DataFrame.to_spark_io

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -4808,7 +4808,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         .. deprecated:: 3.2.0
             Use :func:`DataFrame.spark.to_spark_io` instead.
         """
-        warnings.warn("Deprecated in 3.2, Use spark.to_spark_io instead.", FutureWarning)
+        warnings.warn("Deprecated in 3.2, Use DataFrame.spark.to_spark_io instead.", FutureWarning)
         return self.spark.to_spark_io(path, format, mode, partition_cols, index_col, **options)
 
     to_spark_io.__doc__ = SparkFrameMethods.to_spark_io.__doc__


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is followup for https://github.com/apache/spark/pull/32964, to improve the warning message.

### Why are the changes needed?

To improve the warning message.

### Does this PR introduce _any_ user-facing change?

The warning is changed from "Deprecated in 3.2, Use `spark.to_spark_io` instead." to "Deprecated in 3.2, Use `DataFrame.spark.to_spark_io` instead."

### How was this patch tested?

Manually run `dev/lint-python`