### PR TITLE
[SPARK-36419][CORE]: Optionally move final aggregation in RDD.treeAggregate to executor

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -315,6 +315,12 @@ package object config {
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
+  private[spark] val ENABLE_EXECUTOR_TREE_AGGREGATE = ConfigBuilder("spark.executor.treeAggregate")
+      .doc("If true, last fold operation in the treeAggregate would be computed as a spark " +
+        "task on the executors.")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val CORES_MAX = ConfigBuilder("spark.cores.max")
     .doc("When running on a standalone deploy cluster or a Mesos cluster in coarse-grained " +
       "sharing mode, the maximum amount of CPU cores to request for the application from across " +

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1233,6 +1233,21 @@ abstract class RDD[T: ClassTag](
           (i, iter) => iter.map((i % curNumPartitions, _))
         }.foldByKey(zeroValue, new HashPartitioner(curNumPartitions))(cleanCombOp).values
       }
+      if (conf.get(ENABLE_EXECUTOR_TREE_AGGREGATE) && partiallyAggregated.partitions.length > 1) {
+        // define a new partitioner that results in only 1 partition
+        val constantPartitioner = new Partitioner {
+          override def numPartitions: Int = 1
+
+          override def getPartition(key: Any): Int = 0
+        }
+        // map the partially aggregated rdd into a key-value rdd
+        // do the computation in the single executor with one partition
+        // get the new RDD[U]
+        partiallyAggregated = partiallyAggregated
+          .map(v => (0.toByte, v))
+          .foldByKey(zeroValue, constantPartitioner)(cleanCombOp)
+          .values
+      }
       val copiedZeroValue = Utils.clone(zeroValue, sc.env.closureSerializer.newInstance())
       partiallyAggregated.fold(copiedZeroValue)(cleanCombOp)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Move final iteration of aggregation of RDD.treeAggregate to an executor with one partition and fetch that result to the driver

### Why are the changes needed?
1. RDD.fold pulls all shuffle partitions to the driver to merge the result 
   a. Driver becomes a single point of failure in the case that there are a lot of partitions to do the final aggregation on
2. Shuffle machinery at executors is much more robust/fault tolerant compared to fetching results to driver.


### Does this PR introduce _any_ user-facing change?
The previous behavior always did the final aggregation in the driver. The user can now (optionally) provide a boolean config (default = false) `ENABLE_EXECUTOR_TREE_AGGREGATE` to do that final aggregation in a single partition executor before fetching the results to the driver. The only additional cost is that the user will see an extra stage in their job. 


### How was this patch tested?
This patch was tested via unit tests, and also tested on a cluster. 
The screenshots showing the extra stage on a cluster are attached below (before vs after). 
![before](https://user-images.githubusercontent.com/24758726/128247928-c4f1de8d-b647-4e59-b157-aa50938781b4.png)
![after](https://user-images.githubusercontent.com/24758726/128247941-1fad9ec7-5b22-4b5a-b8c4-8a0b3fe8a91f.png)
