### PR TITLE
[SPARK-36425] [PYSPARK][ML] Support CrossValidatorModel get standard deviation of metrics for each paramMap

### DIFF
--- a/python/pyspark/ml/tests/test_tuning.py
+++ b/python/pyspark/ml/tests/test_tuning.py
@@ -195,14 +195,16 @@ class ValidatorTestUtilsMixin:
 class CrossValidatorTests(SparkSessionTestCase, ValidatorTestUtilsMixin):
 
     def test_gen_avg_and_std_metrics(self):
-        metrics_all = np.array([
+        metrics_all = [
             [1.0, 3.0, 2.0, 4.0],
             [3.0, 2.0, 2.0, 4.0],
             [3.0, 2.5, 2.1, 8.0],
-        ])
+        ]
         avg_metrics, std_metrics = CrossValidator._gen_avg_and_std_metrics(metrics_all)
-        assert np.allclose(avg_metrics, np.array([2.33333333, 2.5, 2.03333333, 5.33333333]))
-        assert np.allclose(std_metrics, np.array([0.94280904, 0.40824829, 0.04714045, 1.88561808]))
+        assert np.allclose(avg_metrics, [2.33333333, 2.5, 2.03333333, 5.33333333])
+        assert np.allclose(std_metrics, [0.94280904, 0.40824829, 0.04714045, 1.88561808])
+        assert isinstance(avg_metrics, list)
+        assert isinstance(std_metrics, list)
 
     def test_copy(self):
         dataset = self.spark.createDataFrame([

--- a/python/pyspark/ml/tests/test_tuning.py
+++ b/python/pyspark/ml/tests/test_tuning.py
@@ -372,6 +372,15 @@ class CrossValidatorTests(SparkSessionTestCase, ValidatorTestUtilsMixin):
             loadedCvModel.isSet(param) for param in loadedCvModel.params
         ))
 
+        # mimic old version CrossValidatorModel (without stdMetrics attribute)
+        # test loading model backwards compatibility
+        cvModel2 = cvModel.copy()
+        cvModel2.stdMetrics = []
+        cvModelPath2 = temp_path + "/cvModel2"
+        cvModel2.save(cvModelPath2)
+        loadedCvModel2 = CrossValidatorModel.load(cvModelPath2)
+        assert loadedCvModel2.stdMetrics == []
+
     def test_save_load_trained_model(self):
         self._run_test_save_load_trained_model(LogisticRegression, LogisticRegressionModel)
         self._run_test_save_load_trained_model(DummyLogisticRegression,

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -499,6 +499,7 @@ class CrossValidatorModelReader(MLReader):
             bestModelPath = os.path.join(path, 'bestModel')
             bestModel = DefaultParamsReader.loadParamsInstance(bestModelPath, self.sc)
             avgMetrics = metadata['avgMetrics']
+            stdMetrics = metadata['stdMetrics']
             persistSubModels = ('persistSubModels' in metadata) and metadata['persistSubModels']
 
             if persistSubModels:
@@ -512,7 +513,9 @@ class CrossValidatorModelReader(MLReader):
             else:
                 subModels = None
 
-            cvModel = CrossValidatorModel(bestModel, avgMetrics=avgMetrics, subModels=subModels)
+            cvModel = CrossValidatorModel(
+                bestModel, avgMetrics=avgMetrics, subModels=subModels, stdMetrics=stdMetrics
+            )
             cvModel = cvModel._resetUid(metadata['uid'])
             cvModel.set(cvModel.estimator, estimator)
             cvModel.set(cvModel.estimatorParamMaps, estimatorParamMaps)
@@ -535,7 +538,8 @@ class CrossValidatorModelWriter(MLWriter):
         persistSubModels = _ValidatorSharedReadWrite \
             .getValidatorModelWriterPersistSubModelsParam(self)
         extraMetadata = {'avgMetrics': instance.avgMetrics,
-                         'persistSubModels': persistSubModels}
+                         'persistSubModels': persistSubModels,
+                         'stdMetrics': instance.stdMetrics}
         _ValidatorSharedReadWrite.saveImpl(path, instance, self.sc, extraMetadata=extraMetadata)
         bestModelPath = os.path.join(path, 'bestModel')
         instance.bestModel.save(bestModelPath)
@@ -710,13 +714,19 @@ class CrossValidator(Estimator, _CrossValidatorParams, HasParallelism, HasCollec
         """
         return self._set(collectSubModels=value)
 
+    @staticmethod
+    def _gen_avg_and_std_metrics(metrics_all):
+        avg_metrics = np.mean(metrics_all, axis=0)
+        std_metrics = np.std(metrics_all, axis=0)
+        return avg_metrics, std_metrics
+
     def _fit(self, dataset):
         est = self.getOrDefault(self.estimator)
         epm = self.getOrDefault(self.estimatorParamMaps)
         numModels = len(epm)
         eva = self.getOrDefault(self.evaluator)
         nFolds = self.getOrDefault(self.numFolds)
-        metrics = [0.0] * numModels
+        metrics_all = [[0.0] * numModels for i in range(nFolds)]
 
         pool = ThreadPool(processes=min(self.getParallelism(), numModels))
         subModels = None
@@ -733,19 +743,21 @@ class CrossValidator(Estimator, _CrossValidatorParams, HasParallelism, HasCollec
                 inheritable_thread_target,
                 _parallelFitTasks(est, train, eva, validation, epm, collectSubModelsParam))
             for j, metric, subModel in pool.imap_unordered(lambda f: f(), tasks):
-                metrics[j] += (metric / nFolds)
+                metrics_all[i][j] = metric
                 if collectSubModelsParam:
                     subModels[i][j] = subModel
 
             validation.unpersist()
             train.unpersist()
 
+        metrics, std_metrics = CrossValidator._gen_avg_and_std_metrics(metrics_all)
+
         if eva.isLargerBetter():
             bestIndex = np.argmax(metrics)
         else:
             bestIndex = np.argmin(metrics)
         bestModel = est.fit(dataset, epm[bestIndex])
-        return self._copyValues(CrossValidatorModel(bestModel, metrics, subModels))
+        return self._copyValues(CrossValidatorModel(bestModel, metrics, subModels, std_metrics))
 
     def _kFold(self, dataset):
         nFolds = self.getOrDefault(self.numFolds)
@@ -883,7 +895,7 @@ class CrossValidatorModel(Model, _CrossValidatorParams, MLReadable, MLWritable):
     .. versionadded:: 1.4.0
     """
 
-    def __init__(self, bestModel, avgMetrics=None, subModels=None):
+    def __init__(self, bestModel, avgMetrics=None, subModels=None, stdMetrics=None):
         super(CrossValidatorModel, self).__init__()
         #: best model from cross validation
         self.bestModel = bestModel
@@ -892,6 +904,9 @@ class CrossValidatorModel(Model, _CrossValidatorParams, MLReadable, MLWritable):
         self.avgMetrics = avgMetrics or []
         #: sub model list from cross validation
         self.subModels = subModels
+        #: standard deviation of metrics for each paramMap in
+        #: CrossValidator.estimatorParamMaps, in the corresponding order.
+        self.stdMetrics = stdMetrics or []
 
     def _transform(self, dataset):
         return self.bestModel.transform(dataset)
@@ -924,7 +939,9 @@ class CrossValidatorModel(Model, _CrossValidatorParams, MLReadable, MLWritable):
             [sub_model.copy() for sub_model in fold_sub_models]
             for fold_sub_models in self.subModels
         ]
-        return self._copyValues(CrossValidatorModel(bestModel, avgMetrics, subModels), extra=extra)
+        stdMetrics = list(self.stdMetrics)
+        return self._copyValues(CrossValidatorModel(bestModel, avgMetrics, subModels, stdMetrics),
+                                extra=extra)
 
     @since("2.3.0")
     def write(self):

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -892,16 +892,17 @@ class CrossValidator(Estimator, _CrossValidatorParams, HasParallelism, HasCollec
 
 class CrossValidatorModel(Model, _CrossValidatorParams, MLReadable, MLWritable):
     """
-
     CrossValidatorModel contains the model with the highest average cross-validation
     metric across folds and uses this model to transform input data. CrossValidatorModel
     also tracks the metrics for each param map evaluated.
 
+    .. versionadded:: 1.4.0
+
+    Notes
+    -----
     Since version 3.3.0, CrossValidatorModel contains a new attribute "stdMetrics",
     which represent standard deviation of metrics for each paramMap in
     CrossValidator.estimatorParamMaps.
-
-    .. versionadded:: 1.4.0
     """
 
     def __init__(self, bestModel, avgMetrics=None, subModels=None, stdMetrics=None):

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -499,7 +499,10 @@ class CrossValidatorModelReader(MLReader):
             bestModelPath = os.path.join(path, 'bestModel')
             bestModel = DefaultParamsReader.loadParamsInstance(bestModelPath, self.sc)
             avgMetrics = metadata['avgMetrics']
-            stdMetrics = metadata['stdMetrics']
+            if 'stdMetrics' in metadata:
+                stdMetrics = metadata['stdMetrics']
+            else:
+                stdMetrics = None
             persistSubModels = ('persistSubModels' in metadata) and metadata['persistSubModels']
 
             if persistSubModels:
@@ -538,8 +541,10 @@ class CrossValidatorModelWriter(MLWriter):
         persistSubModels = _ValidatorSharedReadWrite \
             .getValidatorModelWriterPersistSubModelsParam(self)
         extraMetadata = {'avgMetrics': instance.avgMetrics,
-                         'persistSubModels': persistSubModels,
-                         'stdMetrics': instance.stdMetrics}
+                         'persistSubModels': persistSubModels}
+        if instance.stdMetrics:
+            extraMetadata['stdMetrics'] = instance.stdMetrics
+
         _ValidatorSharedReadWrite.saveImpl(path, instance, self.sc, extraMetadata=extraMetadata)
         bestModelPath = os.path.join(path, 'bestModel')
         instance.bestModel.save(bestModelPath)
@@ -891,6 +896,10 @@ class CrossValidatorModel(Model, _CrossValidatorParams, MLReadable, MLWritable):
     CrossValidatorModel contains the model with the highest average cross-validation
     metric across folds and uses this model to transform input data. CrossValidatorModel
     also tracks the metrics for each param map evaluated.
+
+    Since version 3.2.1, CrossValidatorModel contains a new attribute "stdMetrics",
+    which represent standard deviation of metrics for each paramMap in
+    CrossValidator.estimatorParamMaps.
 
     .. versionadded:: 1.4.0
     """

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -718,7 +718,7 @@ class CrossValidator(Estimator, _CrossValidatorParams, HasParallelism, HasCollec
     def _gen_avg_and_std_metrics(metrics_all):
         avg_metrics = np.mean(metrics_all, axis=0)
         std_metrics = np.std(metrics_all, axis=0)
-        return avg_metrics, std_metrics
+        return list(avg_metrics), list(std_metrics)
 
     def _fit(self, dataset):
         est = self.getOrDefault(self.estimator)

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -897,7 +897,7 @@ class CrossValidatorModel(Model, _CrossValidatorParams, MLReadable, MLWritable):
     metric across folds and uses this model to transform input data. CrossValidatorModel
     also tracks the metrics for each param map evaluated.
 
-    Since version 3.2.1, CrossValidatorModel contains a new attribute "stdMetrics",
+    Since version 3.3.0, CrossValidatorModel contains a new attribute "stdMetrics",
     which represent standard deviation of metrics for each paramMap in
     CrossValidator.estimatorParamMaps.
 


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Support CrossValidatorModel get standard deviation of metrics for each paramMap.

### Why are the changes needed?
So that in mlflow autologging, we can log standard deviation of metrics which is useful.


### Does this PR introduce _any_ user-facing change?
Yes.
`CrossValidatorModel` add a public attribute `stdMetrics` which are the standard deviation of metrics for each paramMap


### How was this patch tested?
Unit test.
