### PR TITLE
[SPARK-36426][INFRA] Pin pyzq to 22.2.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -409,7 +409,7 @@ jobs:
         #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
         # Jinja2 3.0.0+ causes error when building with Sphinx.
         #   See also https://issues.apache.org/jira/browse/SPARK-35375.
-        python3.9 -m pip install flake8 pydata_sphinx_theme 'mypy==0.910' numpydoc 'jinja2<3.0.0' 'black==21.5b2'
+        python3.9 -m pip install flake8 pydata_sphinx_theme 'mypy==0.910' numpydoc 'jinja2<3.0.0' 'black==21.5b2' 'pyzmq==22.2.0'
     - name: Install R linter dependencies and SparkR
       run: |
         apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This  PR recovers GA.
See https://github.com/apache/spark/runs/3250261989#step:11:414 and https://github.com/apache/spark/runs/3250252645?check_suite_focus=true#step:11:417

```
   building 'zmq.libzmq' extension
  creating build/temp.linux-x86_64-3.9/buildutils
  creating build/temp.linux-x86_64-3.9/bundled
  creating build/temp.linux-x86_64-3.9/bundled/zeromq
  creating build/temp.linux-x86_64-3.9/bundled/zeromq/src
  x86_64-linux-gnu-g++ -pthread -std=c++11 -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DZMQ_HAVE_CURVE=1 -DZMQ_USE_TWEETNACL=1 -DZMQ_USE_EPOLL=1 -DZMQ_IOTHREADS_USE_EPOLL=1 -DZMQ_POLL_BASED_ON_POLL=1 -Ibundled/zeromq/include -Ibundled -I/usr/include/python3.9 -c buildutils/initlibzmq.cpp -o build/temp.linux-x86_64-3.9/buildutils/initlibzmq.o
  buildutils/initlibzmq.cpp:10:10: fatal error: Python.h: No such file or directory
     10 | #include "Python.h"
        |          ^~~~~~~~~~
  compilation terminated.
  error: command '/usr/bin/x86_64-linux-gnu-g++' failed with exit code 1
  ----------------------------------------
  ERROR: Failed building wheel for pyzmq
ERROR: Could not build wheels for pyzmq which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 21.1.2; however, version 21.2.2 is available.
You should consider upgrading via the '/usr/bin/python3.9 -m pip install --upgrade pip' command.
  Stored in directory: /tmp/pip-ephem-wheel-cache-3zmzz95t/wheels/d7/2c/f8/55fc25b6130566bdddef382806ceaa33161b39a066c2de5912
  Building wheel for pyzmq (PEP 517): started
  Building wheel for pyzmq (PEP 517): finished with status 'error'
Successfully built ghp-import pandocfilters
Failed to build pyzmq
```

The root cause seems the latest release of `pyzmq`, which is released a few hours ago.
https://pypi.org/project/pyzmq/

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To recover GA

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
GA