### PR TITLE
[SPARK-36433][WEBUI] Fix log message in WebUI

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -142,7 +142,6 @@ private[spark] abstract class WebUI(
   def initServer(): ServerInfo = {
     val host = Option(conf.getenv("SPARK_LOCAL_IP")).getOrElse("0.0.0.0")
     val server = startJettyServer(host, port, sslOptions, conf, name, poolSize)
-    logInfo(s"Bound $className to $host, and started at $webUrl")
     server
   }
 
@@ -150,9 +149,11 @@ private[spark] abstract class WebUI(
   def bind(): Unit = {
     assert(serverInfo.isEmpty, s"Attempted to bind $className more than once!")
     try {
+      val host = Option(conf.getenv("SPARK_LOCAL_IP")).getOrElse("0.0.0.0")
       val server = initServer()
       handlers.foreach(server.addHandler(_, securityManager))
       serverInfo = Some(server)
+      logInfo(s"Bound $className to $host, and started at $webUrl")
     } catch {
       case e: Exception =>
         logError(s"Failed to bind $className", e)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This fixes the info log message output when starting a WebUI server

### Why are the changes needed?
This is needed by the user to go to the right location of the started service
```
21/08/05 14:33:30 INFO HistoryServer: Bound HistoryServer to 0.0.0.0, and started at http://tgudivad-mn1.test.biz:18080
```

### Does this PR introduce _any_ user-facing change?
Yes, fixes the URL displayed in the logs when starting the service.

### How was this patch tested?
Tested by running an instance of HistoryServer
