### PR TITLE
[Spark-36328][CORE][SQL] Reuse the FileSystem delegation token while querying partitioned hive table.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -146,8 +146,8 @@ private[spark] class SparkHadoopUtil extends Logging {
    * @param conf a map/reduce job configuration.
    * @param partitionedTableUUID UUID for current partitioned table.
    */
-  def addCurrentHivePartitionedTableCredentials(conf: JobConf,
-                                                partitionedTableUUID: String): Unit = {
+  def addCurrentPartitionedTableCredentials(conf: JobConf,
+                                            partitionedTableUUID: String): Unit = {
     val jobCreds = conf.getCredentials()
     if(credentialsMapForPartitionedTable.contains(partitionedTableUUID)) {
       jobCreds.addAll(credentialsMapForPartitionedTable.get(partitionedTableUUID))

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -54,7 +54,7 @@ private[spark] class SparkHadoopUtil extends Logging {
    * SPARK-36328: Save Credentials for each partitioned table to reuse the FileSystem
    * Delegation Token.
    */
-  val credentialsMapForPartitionedTable = new ConcurrentHashMap[String, Credentials]()
+  private[this] val credentialsMapForPartitionedTable = new ConcurrentHashMap[String, Credentials]()
 
   /**
    * Runs the given function with a Hadoop UserGroupInformation as a thread local variable

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -54,7 +54,7 @@ private[spark] class SparkHadoopUtil extends Logging {
    * SPARK-36328: Save Credentials for each partitioned table to reuse the FileSystem
    * Delegation Token.
    */
-  private[this] val credentialsMapForPartitionedTable = new ConcurrentHashMap[String, Credentials]()
+  private[spark] val credentialsMapForPartitionedTable = new ConcurrentHashMap[String, Credentials]()
 
   /**
    * Runs the given function with a Hadoop UserGroupInformation as a thread local variable

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -54,7 +54,7 @@ private[spark] class SparkHadoopUtil extends Logging {
    * SPARK-36328: Save Credentials for each partitioned table to reuse the FileSystem
    * Delegation Token.
    */
-  private[spark] val credentialsMapForPartitionedTable = new ConcurrentHashMap[String, Credentials]()
+  val credentialsMapForPartitionedTable = new ConcurrentHashMap[String, Credentials]()
 
   /**
    * Runs the given function with a Hadoop UserGroupInformation as a thread local variable

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -89,6 +89,7 @@ private[spark] class HadoopPartition(rddId: Int, override val index: Int, s: Inp
  * @param keyClass Class of the key associated with the inputFormatClass.
  * @param valueClass Class of the value associated with the inputFormatClass.
  * @param minPartitions Minimum number of HadoopRDD partitions (Hadoop Splits) to generate.
+ * @param partitionedTableUUID UUID for partitioned table.
  *
  * @note Instantiating this class directly is not recommended, please use
  * `org.apache.spark.SparkContext.hadoopRDD()`
@@ -202,6 +203,8 @@ class HadoopRDD[K, V](
   override def getPartitions: Array[Partition] = {
     val jobConf = getJobConf()
     // add the credentials here as this can be called before SparkContext initialized
+    // SPARK-36328: Add the credentials from previous JobConf into the new JobConf to reuse the
+    // FileSystem Delegation Token.
     if(partitionedTableUUID == null) SparkHadoopUtil.get.addCredentials(jobConf)
     else SparkHadoopUtil.get.
       addCurrentHivePartitionedTableCredentials(jobConf, partitionedTableUUID)

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -207,7 +207,7 @@ class HadoopRDD[K, V](
     // FileSystem Delegation Token.
     if(partitionedTableUUID == null) SparkHadoopUtil.get.addCredentials(jobConf)
     else SparkHadoopUtil.get.
-      addCurrentHivePartitionedTableCredentials(jobConf, partitionedTableUUID)
+      addCurrentPartitionedTableCredentials(jobConf, partitionedTableUUID)
     try {
       val allInputSplits = getInputFormat(jobConf).getSplits(jobConf, minPartitions)
       val inputSplits = if (ignoreEmptySplits) {

--- a/core/src/main/scala/org/apache/spark/util/SerializableCredentials.scala
+++ b/core/src/main/scala/org/apache/spark/util/SerializableCredentials.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.util
+
+import java.io.{ObjectInputStream, ObjectOutputStream}
+
+import org.apache.hadoop.security.Credentials
+
+/**
+ * SPARK-36328: A wrapper around a org.apache.hadoop.security.Credentials that is serializable
+ * through Java serialization, to make it easier to pass Credentials between jobs on distributed
+ * Executors.
+ *
+ * @param value provide the facilities of reading and writing secret keys and Tokens.
+ */
+private[spark]
+class SerializableCredentials(@transient var value: Credentials) extends Serializable {
+  private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
+    out.defaultWriteObject()
+    value.write(out)
+  }
+
+  private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
+    value = new Credentials()
+    value.readFields(in)
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -387,9 +387,6 @@ class HadoopTableReader(
   private def createNewHadoopRDD(partDesc: PartitionDesc, path: String): RDD[Writable] = {
     val newJobConf = new JobConf(hadoopConf)
     HadoopTableReader.initializeLocalJobConfFunc(path, partDesc.getTableDesc)(newJobConf)
-    // SPARK-36328: Reuse the FileSystem delegation token while querying partitioned hive table.
-    SparkHadoopUtil.get.addCurrentCredentials(newJobConf,
-      _broadcastedCredentials.value.value)
     val inputFormatClass = partDesc.getInputFileFormatClass
       .asInstanceOf[Class[newInputClass[Writable, Writable]]]
     createNewHadoopRDD(inputFormatClass, newJobConf)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -388,7 +388,7 @@ class HadoopTableReader(
     HadoopTableReader.initializeLocalJobConfFunc(path, partDesc.getTableDesc)(newJobConf)
     // SPARK-36328: Add the credentials from previous JobConf into the new JobConf to reuse the
     // FileSystem Delegation Token.
-    SparkHadoopUtil.get.addCurrentHivePartitionedTableCredentials(newJobConf, partitionedTableUUID)
+    SparkHadoopUtil.get.addCurrentPartitionedTableCredentials(newJobConf, partitionedTableUUID)
     val inputFormatClass = partDesc.getInputFileFormatClass
       .asInstanceOf[Class[newInputClass[Writable, Writable]]]
     createNewHadoopRDD(inputFormatClass, newJobConf)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/security/HivePartitionedTableCredentialsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/security/HivePartitionedTableCredentialsSuite.scala
@@ -26,8 +26,6 @@ import com.google.common.base.Charsets
 import com.google.common.io.Files
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
-import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito
 
 import org.apache.spark.rdd.HadoopRDD
 import org.apache.spark.sql.{QueryTest, Row}
@@ -44,10 +42,6 @@ object HivePartitionedTableCredentialsSuite extends QueryTest
     " while querying partitioned hive table.") {
     // The suite is based on the repro provided in SPARK-36328
     val hadoopKeytabFile = writeCredentials("hadoop.keytab", "hadoop-keytab")
-    // mock
-    val mockStatic = Mockito.mockStatic(classOf[UserGroupInformation])
-    Mockito.doNothing().when(
-      UserGroupInformation.loginUserFromKeytabAndReturnUGI(anyString(), anyString()))
     // scalastyle:off hadoopconfiguration
     spark.sparkContext.hadoopConfiguration.set("hadoop.security.authorization", "true")
     spark.sparkContext.hadoopConfiguration.set("hadoop.security.authentication", "kerberos")
@@ -79,8 +73,6 @@ object HivePartitionedTableCredentialsSuite extends QueryTest
         if (credentials != null) credentialsBuffer += credentials
       })
     }
-    // Release this static mock and avoid impact on subsequent check
-    mockStatic.close()
     // Check
     assert(UserGroupInformation.isSecurityEnabled)
     // Token map buffer from SparkEnv's cache

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/security/HivePartitionedTableCredentialsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/security/HivePartitionedTableCredentialsSuite.scala
@@ -26,7 +26,7 @@ object HivePartitionedTableCredentialsSuite extends QueryTest
   with SQLTestUtils with TestHiveSingleton {
   test("SPARK-36328:  Add the credentials from previous JobConf into the new JobConf" +
     " to reuse the FileSystem Delegation Token ") {
-    // The test is based on the repro provided in SPARK-36328
+    // The suite is based on the repro provided in SPARK-36328
     // scalastyle:off hadoopconfiguration
     spark.sparkContext.hadoopConfiguration.set("hive.server2.authentication", "KERBEROS")
     // scalastyle:on hadoopconfiguration


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the credentials from previous JobConf into the new JobConf to reuse the FileSystem Delegation Token.

### Why are the changes needed?

Spark Job creates a new JobConf (which will have a new Credentials) for every hive table partition, the token is not reused and gets fetched for every partition. This is slowing down the query as each delegation token has to go through KDC and SSL handshake on Secure Clusters.

### Does this PR introduce _any_ user-facing change?

Yes, while user querying partitioned hive table.

### How was this patch tested?

new test added.
