### PR TITLE
[SPARK-36370][PYTHON] _builtin_table directly imported from pandas instead of being redefined

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -26,6 +26,7 @@ from collections import OrderedDict, namedtuple
 from distutils.version import LooseVersion
 from functools import partial
 from itertools import product
+from packaging import version
 from typing import (
     Any,
     Callable,
@@ -46,12 +47,11 @@ from typing import (
 import pandas as pd
 from pandas.api.types import is_hashable, is_list_like
 
-try:
-    from pandas.core.base import SelectionMixin
-
-    _builtin_table = SelectionMixin._builtin_table
-except AttributeError:
+if version.parse(pd.__version__) >= version.parse("1.3.0"):
     from pandas.core.common import _builtin_table
+else:
+    from pandas.core.base import SelectionMixin
+    _builtin_table = SelectionMixin._builtin_table
 
 from pyspark.sql import Column, DataFrame as SparkDataFrame, Window, functions as F
 from pyspark.sql.types import (  # noqa: F401

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -20,7 +20,6 @@ A wrapper for GroupedData to behave similar to pandas GroupBy.
 """
 
 from abc import ABCMeta, abstractmethod
-import builtins
 import sys
 import inspect
 from collections import OrderedDict, namedtuple
@@ -44,9 +43,13 @@ from typing import (
     TYPE_CHECKING,
 )
 
-import numpy as np
 import pandas as pd
 from pandas.api.types import is_hashable, is_list_like
+try:
+    from pandas.core.base import SelectionMixin
+    _builtin_table = SelectionMixin._builtin_table
+except AttributeError:
+    from pandas.core.common import _builtin_table
 
 from pyspark.sql import Column, DataFrame as SparkDataFrame, Window, functions as F
 from pyspark.sql.types import (  # noqa: F401
@@ -96,12 +99,6 @@ if TYPE_CHECKING:
 
 # to keep it the same as pandas
 NamedAgg = namedtuple("NamedAgg", ["column", "aggfunc"])
-
-_builtin_table = {
-    builtins.sum: np.sum,
-    builtins.max: np.max,
-    builtins.min: np.min,
-}  # type: Dict[Callable, Callable]
 
 
 class GroupBy(Generic[FrameLike], metaclass=ABCMeta):

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -45,8 +45,10 @@ from typing import (
 
 import pandas as pd
 from pandas.api.types import is_hashable, is_list_like
+
 try:
     from pandas.core.base import SelectionMixin
+
     _builtin_table = SelectionMixin._builtin_table
 except AttributeError:
     from pandas.core.common import _builtin_table

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -26,7 +26,7 @@ from collections import OrderedDict, namedtuple
 from distutils.version import LooseVersion
 from functools import partial
 from itertools import product
-from packaging import version
+from pkg_resources import parse_version
 from typing import (
     Any,
     Callable,
@@ -47,7 +47,7 @@ from typing import (
 import pandas as pd
 from pandas.api.types import is_hashable, is_list_like
 
-if version.parse(pd.__version__) >= version.parse("1.3.0"):
+if parse_version(pd.__version__) >= parse_version("1.3.0"):
     from pandas.core.common import _builtin_table
 else:
     from pandas.core.base import SelectionMixin

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -51,6 +51,7 @@ if version.parse(pd.__version__) >= version.parse("1.3.0"):
     from pandas.core.common import _builtin_table
 else:
     from pandas.core.base import SelectionMixin
+
     _builtin_table = SelectionMixin._builtin_table
 
 from pyspark.sql import Column, DataFrame as SparkDataFrame, Window, functions as F

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -26,7 +26,7 @@ from collections import OrderedDict, namedtuple
 from distutils.version import LooseVersion
 from functools import partial
 from itertools import product
-from pkg_resources import parse_version
+from pkg_resources import parse_version  # type: ignore
 from typing import (
     Any,
     Callable,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Suggesting to refactor the way the _builtin_table is defined in the `python/pyspark/pandas/groupby.py` module.
Pandas has recently refactored the way we import the _builtin_table and is now part of the pandas.core.common module instead of being an attribute of the pandas.core.base.SelectionMixin class.

### Why are the changes needed?
This change is not fully needed but the current implementation redefines this table within pyspark, so any changes of this table from the pandas library would need to be updated in the pyspark repository as well.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Ran the following command successfully :
```sh
python/run-tests --testnames 'pyspark.pandas.tests.test_groupby'
```
Tests passed in 327 seconds
