### PR TITLE
[SPARK-36478][SQL]Removes outer join if all grouping and aggregate expressions are from the streamed side

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -126,7 +126,7 @@ object ReorderJoin extends Rule[LogicalPlan] with PredicateHelper {
  * - full outer -> left outer if only the left side has such predicates
  * - full outer -> right outer if only the right side has such predicates
  *
- * 2. Removes outer join if it only has distinct on streamed side
+ * 2. Removes outer join if all grouping and aggregate expressions are from the streamed side
  * {{{
  *   SELECT DISTINCT f1 FROM t1 LEFT JOIN t2 ON t1.id = t2.id  ==>  SELECT DISTINCT f1 FROM t1
  *   SELECT f1, max(f2) FROM t1 LEFT JOIN t2 ON t1.id = t2.id GROUP BY f1

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
@@ -1,453 +1,367 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * HashAggregate (69)
-   +- Exchange (68)
-      +- * HashAggregate (67)
-         +- * Project (66)
-            +- * SortMergeJoin LeftOuter (65)
-               :- * Sort (58)
-               :  +- Exchange (57)
-               :     +- * Project (56)
-               :        +- * BroadcastHashJoin LeftOuter BuildRight (55)
-               :           :- * Project (50)
-               :           :  +- * SortMergeJoin Inner (49)
-               :           :     :- * Sort (37)
-               :           :     :  +- Exchange (36)
-               :           :     :     +- * Project (35)
-               :           :     :        +- * BroadcastHashJoin Inner BuildRight (34)
-               :           :     :           :- * Project (32)
-               :           :     :           :  +- * SortMergeJoin Inner (31)
-               :           :     :           :     :- * Sort (25)
-               :           :     :           :     :  +- Exchange (24)
-               :           :     :           :     :     +- * Project (23)
-               :           :     :           :     :        +- * BroadcastHashJoin Inner BuildRight (22)
-               :           :     :           :     :           :- * Project (17)
-               :           :     :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (16)
-               :           :     :           :     :           :     :- * Project (10)
-               :           :     :           :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-               :           :     :           :     :           :     :     :- * Filter (3)
-               :           :     :           :     :           :     :     :  +- * ColumnarToRow (2)
-               :           :     :           :     :           :     :     :     +- Scan parquet default.catalog_sales (1)
-               :           :     :           :     :           :     :     +- BroadcastExchange (8)
-               :           :     :           :     :           :     :        +- * Project (7)
-               :           :     :           :     :           :     :           +- * Filter (6)
-               :           :     :           :     :           :     :              +- * ColumnarToRow (5)
-               :           :     :           :     :           :     :                 +- Scan parquet default.household_demographics (4)
-               :           :     :           :     :           :     +- BroadcastExchange (15)
-               :           :     :           :     :           :        +- * Project (14)
-               :           :     :           :     :           :           +- * Filter (13)
-               :           :     :           :     :           :              +- * ColumnarToRow (12)
-               :           :     :           :     :           :                 +- Scan parquet default.customer_demographics (11)
-               :           :     :           :     :           +- BroadcastExchange (21)
-               :           :     :           :     :              +- * Filter (20)
-               :           :     :           :     :                 +- * ColumnarToRow (19)
-               :           :     :           :     :                    +- Scan parquet default.date_dim (18)
-               :           :     :           :     +- * Sort (30)
-               :           :     :           :        +- Exchange (29)
-               :           :     :           :           +- * Filter (28)
-               :           :     :           :              +- * ColumnarToRow (27)
-               :           :     :           :                 +- Scan parquet default.item (26)
-               :           :     :           +- ReusedExchange (33)
-               :           :     +- * Sort (48)
-               :           :        +- Exchange (47)
-               :           :           +- * Project (46)
-               :           :              +- * BroadcastHashJoin Inner BuildRight (45)
-               :           :                 :- * Filter (40)
-               :           :                 :  +- * ColumnarToRow (39)
-               :           :                 :     +- Scan parquet default.inventory (38)
-               :           :                 +- BroadcastExchange (44)
-               :           :                    +- * Filter (43)
-               :           :                       +- * ColumnarToRow (42)
-               :           :                          +- Scan parquet default.warehouse (41)
-               :           +- BroadcastExchange (54)
-               :              +- * Filter (53)
-               :                 +- * ColumnarToRow (52)
-               :                    +- Scan parquet default.promotion (51)
-               +- * Sort (64)
-                  +- Exchange (63)
-                     +- * Project (62)
-                        +- * Filter (61)
-                           +- * ColumnarToRow (60)
-                              +- Scan parquet default.catalog_returns (59)
+TakeOrderedAndProject (54)
++- * HashAggregate (53)
+   +- Exchange (52)
+      +- * HashAggregate (51)
+         +- * Project (50)
+            +- * SortMergeJoin Inner (49)
+               :- * Sort (37)
+               :  +- Exchange (36)
+               :     +- * Project (35)
+               :        +- * BroadcastHashJoin Inner BuildRight (34)
+               :           :- * Project (32)
+               :           :  +- * SortMergeJoin Inner (31)
+               :           :     :- * Sort (25)
+               :           :     :  +- Exchange (24)
+               :           :     :     +- * Project (23)
+               :           :     :        +- * BroadcastHashJoin Inner BuildRight (22)
+               :           :     :           :- * Project (17)
+               :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (16)
+               :           :     :           :     :- * Project (10)
+               :           :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+               :           :     :           :     :     :- * Filter (3)
+               :           :     :           :     :     :  +- * ColumnarToRow (2)
+               :           :     :           :     :     :     +- Scan parquet default.catalog_sales (1)
+               :           :     :           :     :     +- BroadcastExchange (8)
+               :           :     :           :     :        +- * Project (7)
+               :           :     :           :     :           +- * Filter (6)
+               :           :     :           :     :              +- * ColumnarToRow (5)
+               :           :     :           :     :                 +- Scan parquet default.household_demographics (4)
+               :           :     :           :     +- BroadcastExchange (15)
+               :           :     :           :        +- * Project (14)
+               :           :     :           :           +- * Filter (13)
+               :           :     :           :              +- * ColumnarToRow (12)
+               :           :     :           :                 +- Scan parquet default.customer_demographics (11)
+               :           :     :           +- BroadcastExchange (21)
+               :           :     :              +- * Filter (20)
+               :           :     :                 +- * ColumnarToRow (19)
+               :           :     :                    +- Scan parquet default.date_dim (18)
+               :           :     +- * Sort (30)
+               :           :        +- Exchange (29)
+               :           :           +- * Filter (28)
+               :           :              +- * ColumnarToRow (27)
+               :           :                 +- Scan parquet default.item (26)
+               :           +- ReusedExchange (33)
+               +- * Sort (48)
+                  +- Exchange (47)
+                     +- * Project (46)
+                        +- * BroadcastHashJoin Inner BuildRight (45)
+                           :- * Filter (40)
+                           :  +- * ColumnarToRow (39)
+                           :     +- Scan parquet default.inventory (38)
+                           +- BroadcastExchange (44)
+                              +- * Filter (43)
+                                 +- * ColumnarToRow (42)
+                                    +- Scan parquet default.warehouse (41)
 
 
 (1) Scan parquet default.catalog_sales
-Output [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
+Output [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#8), dynamicpruningexpression(cs_sold_date_sk#8 IN dynamicpruning#9)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#6), dynamicpruningexpression(cs_sold_date_sk#6 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(cs_quantity), IsNotNull(cs_item_sk), IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_hdemo_sk), IsNotNull(cs_ship_date_sk)]
-ReadSchema: struct<cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_quantity:int>
+ReadSchema: struct<cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_quantity:int>
 
 (2) ColumnarToRow [codegen id : 4]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
+Input [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
 
 (3) Filter [codegen id : 4]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Condition : ((((isnotnull(cs_quantity#7) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
+Input [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
+Condition : ((((isnotnull(cs_quantity#5) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
 
 (4) Scan parquet default.household_demographics
-Output [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [2]: [hd_demo_sk#8, hd_buy_potential#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_buy_potential), EqualTo(hd_buy_potential,>10000         ), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Input [2]: [hd_demo_sk#8, hd_buy_potential#9]
 
 (6) Filter [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
-Condition : ((isnotnull(hd_buy_potential#11) AND (hd_buy_potential#11 = >10000         )) AND isnotnull(hd_demo_sk#10))
+Input [2]: [hd_demo_sk#8, hd_buy_potential#9]
+Condition : ((isnotnull(hd_buy_potential#9) AND (hd_buy_potential#9 = >10000         )) AND isnotnull(hd_demo_sk#8))
 
 (7) Project [codegen id : 1]
-Output [1]: [hd_demo_sk#10]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [1]: [hd_demo_sk#8]
+Input [2]: [hd_demo_sk#8, hd_buy_potential#9]
 
 (8) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Input [1]: [hd_demo_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_hdemo_sk#3]
-Right keys [1]: [hd_demo_sk#10]
+Right keys [1]: [hd_demo_sk#8]
 Join condition: None
 
 (10) Project [codegen id : 4]
-Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, hd_demo_sk#10]
+Output [5]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
+Input [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, hd_demo_sk#8]
 
 (11) Scan parquet default.customer_demographics
-Output [2]: [cd_demo_sk#13, cd_marital_status#14]
+Output [2]: [cd_demo_sk#11, cd_marital_status#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_marital_status), EqualTo(cd_marital_status,D), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
 (12) ColumnarToRow [codegen id : 2]
-Input [2]: [cd_demo_sk#13, cd_marital_status#14]
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
 
 (13) Filter [codegen id : 2]
-Input [2]: [cd_demo_sk#13, cd_marital_status#14]
-Condition : ((isnotnull(cd_marital_status#14) AND (cd_marital_status#14 = D)) AND isnotnull(cd_demo_sk#13))
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
+Condition : ((isnotnull(cd_marital_status#12) AND (cd_marital_status#12 = D)) AND isnotnull(cd_demo_sk#11))
 
 (14) Project [codegen id : 2]
-Output [1]: [cd_demo_sk#13]
-Input [2]: [cd_demo_sk#13, cd_marital_status#14]
+Output [1]: [cd_demo_sk#11]
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
 
 (15) BroadcastExchange
-Input [1]: [cd_demo_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Input [1]: [cd_demo_sk#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
 
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#13]
+Right keys [1]: [cd_demo_sk#11]
 Join condition: None
 
 (17) Project [codegen id : 4]
-Output [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, cd_demo_sk#13]
+Output [4]: [cs_ship_date_sk#1, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
+Input [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, cd_demo_sk#11]
 
 (18) Scan parquet default.date_dim
-Output [2]: [d_date_sk#16, d_date#17]
+Output [2]: [d_date_sk#14, d_date#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (19) ColumnarToRow [codegen id : 3]
-Input [2]: [d_date_sk#16, d_date#17]
+Input [2]: [d_date_sk#14, d_date#15]
 
 (20) Filter [codegen id : 3]
-Input [2]: [d_date_sk#16, d_date#17]
-Condition : (isnotnull(d_date#17) AND isnotnull(d_date_sk#16))
+Input [2]: [d_date_sk#14, d_date#15]
+Condition : (isnotnull(d_date#15) AND isnotnull(d_date_sk#14))
 
 (21) BroadcastExchange
-Input [2]: [d_date_sk#16, d_date#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Input [2]: [d_date_sk#14, d_date#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_ship_date_sk#1]
-Right keys [1]: [d_date_sk#16]
+Right keys [1]: [d_date_sk#14]
 Join condition: None
 
 (23) Project [codegen id : 4]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
-Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date_sk#16, d_date#17]
+Output [4]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15]
+Input [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date_sk#14, d_date#15]
 
 (24) Exchange
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
-Arguments: hashpartitioning(cs_item_sk#4, 5), ENSURE_REQUIREMENTS, [id=#19]
+Input [4]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15]
+Arguments: hashpartitioning(cs_item_sk#4, 5), ENSURE_REQUIREMENTS, [id=#17]
 
 (25) Sort [codegen id : 5]
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
+Input [4]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15]
 Arguments: [cs_item_sk#4 ASC NULLS FIRST], false, 0
 
 (26) Scan parquet default.item
-Output [2]: [i_item_sk#20, i_item_desc#21]
+Output [2]: [i_item_sk#18, i_item_desc#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string>
 
 (27) ColumnarToRow [codegen id : 6]
-Input [2]: [i_item_sk#20, i_item_desc#21]
+Input [2]: [i_item_sk#18, i_item_desc#19]
 
 (28) Filter [codegen id : 6]
-Input [2]: [i_item_sk#20, i_item_desc#21]
-Condition : isnotnull(i_item_sk#20)
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Condition : isnotnull(i_item_sk#18)
 
 (29) Exchange
-Input [2]: [i_item_sk#20, i_item_desc#21]
-Arguments: hashpartitioning(i_item_sk#20, 5), ENSURE_REQUIREMENTS, [id=#22]
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Arguments: hashpartitioning(i_item_sk#18, 5), ENSURE_REQUIREMENTS, [id=#20]
 
 (30) Sort [codegen id : 7]
-Input [2]: [i_item_sk#20, i_item_desc#21]
-Arguments: [i_item_sk#20 ASC NULLS FIRST], false, 0
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Arguments: [i_item_sk#18 ASC NULLS FIRST], false, 0
 
 (31) SortMergeJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
-Right keys [1]: [i_item_sk#20]
+Right keys [1]: [i_item_sk#18]
 Join condition: None
 
 (32) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_desc#21]
-Input [8]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_sk#20, i_item_desc#21]
+Output [5]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15, i_item_desc#19]
+Input [6]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15, i_item_sk#18, i_item_desc#19]
 
-(33) ReusedExchange [Reuses operator id: 81]
-Output [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26]
+(33) ReusedExchange [Reuses operator id: 65]
+Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#24]
 
 (34) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_sold_date_sk#8]
-Right keys [1]: [d_date_sk#23]
-Join condition: (d_date#17 > date_add(d_date#24, 5))
+Left keys [1]: [cs_sold_date_sk#6]
+Right keys [1]: [d_date_sk#21]
+Join condition: (d_date#15 > date_add(d_date#22, 5))
 
 (35) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#21, d_week_seq#25, d_date_sk#26]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_desc#21, d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26]
+Output [5]: [cs_item_sk#4, cs_quantity#5, i_item_desc#19, d_week_seq#23, d_date_sk#24]
+Input [9]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15, i_item_desc#19, d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#24]
 
 (36) Exchange
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#21, d_week_seq#25, d_date_sk#26]
-Arguments: hashpartitioning(cs_item_sk#4, d_date_sk#26, 5), ENSURE_REQUIREMENTS, [id=#27]
+Input [5]: [cs_item_sk#4, cs_quantity#5, i_item_desc#19, d_week_seq#23, d_date_sk#24]
+Arguments: hashpartitioning(cs_item_sk#4, d_date_sk#24, 5), ENSURE_REQUIREMENTS, [id=#25]
 
 (37) Sort [codegen id : 11]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#21, d_week_seq#25, d_date_sk#26]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, d_date_sk#26 ASC NULLS FIRST], false, 0
+Input [5]: [cs_item_sk#4, cs_quantity#5, i_item_desc#19, d_week_seq#23, d_date_sk#24]
+Arguments: [cs_item_sk#4 ASC NULLS FIRST, d_date_sk#24 ASC NULLS FIRST], false, 0
 
 (38) Scan parquet default.inventory
-Output [4]: [inv_item_sk#28, inv_warehouse_sk#29, inv_quantity_on_hand#30, inv_date_sk#31]
+Output [4]: [inv_item_sk#26, inv_warehouse_sk#27, inv_quantity_on_hand#28, inv_date_sk#29]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(inv_date_sk#31), dynamicpruningexpression(true)]
+PartitionFilters: [isnotnull(inv_date_sk#29), dynamicpruningexpression(true)]
 PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
 (39) ColumnarToRow [codegen id : 13]
-Input [4]: [inv_item_sk#28, inv_warehouse_sk#29, inv_quantity_on_hand#30, inv_date_sk#31]
+Input [4]: [inv_item_sk#26, inv_warehouse_sk#27, inv_quantity_on_hand#28, inv_date_sk#29]
 
 (40) Filter [codegen id : 13]
-Input [4]: [inv_item_sk#28, inv_warehouse_sk#29, inv_quantity_on_hand#30, inv_date_sk#31]
-Condition : ((isnotnull(inv_quantity_on_hand#30) AND isnotnull(inv_item_sk#28)) AND isnotnull(inv_warehouse_sk#29))
+Input [4]: [inv_item_sk#26, inv_warehouse_sk#27, inv_quantity_on_hand#28, inv_date_sk#29]
+Condition : ((isnotnull(inv_quantity_on_hand#28) AND isnotnull(inv_item_sk#26)) AND isnotnull(inv_warehouse_sk#27))
 
 (41) Scan parquet default.warehouse
-Output [2]: [w_warehouse_sk#32, w_warehouse_name#33]
+Output [2]: [w_warehouse_sk#30, w_warehouse_name#31]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
 (42) ColumnarToRow [codegen id : 12]
-Input [2]: [w_warehouse_sk#32, w_warehouse_name#33]
+Input [2]: [w_warehouse_sk#30, w_warehouse_name#31]
 
 (43) Filter [codegen id : 12]
-Input [2]: [w_warehouse_sk#32, w_warehouse_name#33]
-Condition : isnotnull(w_warehouse_sk#32)
+Input [2]: [w_warehouse_sk#30, w_warehouse_name#31]
+Condition : isnotnull(w_warehouse_sk#30)
 
 (44) BroadcastExchange
-Input [2]: [w_warehouse_sk#32, w_warehouse_name#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#34]
+Input [2]: [w_warehouse_sk#30, w_warehouse_name#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#32]
 
 (45) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [inv_warehouse_sk#29]
-Right keys [1]: [w_warehouse_sk#32]
+Left keys [1]: [inv_warehouse_sk#27]
+Right keys [1]: [w_warehouse_sk#30]
 Join condition: None
 
 (46) Project [codegen id : 13]
-Output [4]: [inv_item_sk#28, inv_quantity_on_hand#30, inv_date_sk#31, w_warehouse_name#33]
-Input [6]: [inv_item_sk#28, inv_warehouse_sk#29, inv_quantity_on_hand#30, inv_date_sk#31, w_warehouse_sk#32, w_warehouse_name#33]
+Output [4]: [inv_item_sk#26, inv_quantity_on_hand#28, inv_date_sk#29, w_warehouse_name#31]
+Input [6]: [inv_item_sk#26, inv_warehouse_sk#27, inv_quantity_on_hand#28, inv_date_sk#29, w_warehouse_sk#30, w_warehouse_name#31]
 
 (47) Exchange
-Input [4]: [inv_item_sk#28, inv_quantity_on_hand#30, inv_date_sk#31, w_warehouse_name#33]
-Arguments: hashpartitioning(inv_item_sk#28, inv_date_sk#31, 5), ENSURE_REQUIREMENTS, [id=#35]
+Input [4]: [inv_item_sk#26, inv_quantity_on_hand#28, inv_date_sk#29, w_warehouse_name#31]
+Arguments: hashpartitioning(inv_item_sk#26, inv_date_sk#29, 5), ENSURE_REQUIREMENTS, [id=#33]
 
 (48) Sort [codegen id : 14]
-Input [4]: [inv_item_sk#28, inv_quantity_on_hand#30, inv_date_sk#31, w_warehouse_name#33]
-Arguments: [inv_item_sk#28 ASC NULLS FIRST, inv_date_sk#31 ASC NULLS FIRST], false, 0
+Input [4]: [inv_item_sk#26, inv_quantity_on_hand#28, inv_date_sk#29, w_warehouse_name#31]
+Arguments: [inv_item_sk#26 ASC NULLS FIRST, inv_date_sk#29 ASC NULLS FIRST], false, 0
 
-(49) SortMergeJoin [codegen id : 16]
-Left keys [2]: [cs_item_sk#4, d_date_sk#26]
-Right keys [2]: [inv_item_sk#28, inv_date_sk#31]
-Join condition: (inv_quantity_on_hand#30 < cs_quantity#7)
+(49) SortMergeJoin [codegen id : 15]
+Left keys [2]: [cs_item_sk#4, d_date_sk#24]
+Right keys [2]: [inv_item_sk#26, inv_date_sk#29]
+Join condition: (inv_quantity_on_hand#28 < cs_quantity#5)
 
-(50) Project [codegen id : 16]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#21, d_week_seq#25, d_date_sk#26, inv_item_sk#28, inv_quantity_on_hand#30, inv_date_sk#31, w_warehouse_name#33]
+(50) Project [codegen id : 15]
+Output [3]: [w_warehouse_name#31, i_item_desc#19, d_week_seq#23]
+Input [9]: [cs_item_sk#4, cs_quantity#5, i_item_desc#19, d_week_seq#23, d_date_sk#24, inv_item_sk#26, inv_quantity_on_hand#28, inv_date_sk#29, w_warehouse_name#31]
 
-(51) Scan parquet default.promotion
-Output [1]: [p_promo_sk#36]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/promotion]
-PushedFilters: [IsNotNull(p_promo_sk)]
-ReadSchema: struct<p_promo_sk:int>
-
-(52) ColumnarToRow [codegen id : 15]
-Input [1]: [p_promo_sk#36]
-
-(53) Filter [codegen id : 15]
-Input [1]: [p_promo_sk#36]
-Condition : isnotnull(p_promo_sk#36)
-
-(54) BroadcastExchange
-Input [1]: [p_promo_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#37]
-
-(55) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [cs_promo_sk#5]
-Right keys [1]: [p_promo_sk#36]
-Join condition: None
-
-(56) Project [codegen id : 16]
-Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25, p_promo_sk#36]
-
-(57) Exchange
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [id=#38]
-
-(58) Sort [codegen id : 17]
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, cs_order_number#6 ASC NULLS FIRST], false, 0
-
-(59) Scan parquet default.catalog_returns
-Output [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/catalog_returns]
-PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
-ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
-
-(60) ColumnarToRow [codegen id : 18]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-
-(61) Filter [codegen id : 18]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-Condition : (isnotnull(cr_item_sk#39) AND isnotnull(cr_order_number#40))
-
-(62) Project [codegen id : 18]
-Output [2]: [cr_item_sk#39, cr_order_number#40]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-
-(63) Exchange
-Input [2]: [cr_item_sk#39, cr_order_number#40]
-Arguments: hashpartitioning(cr_item_sk#39, cr_order_number#40, 5), ENSURE_REQUIREMENTS, [id=#42]
-
-(64) Sort [codegen id : 19]
-Input [2]: [cr_item_sk#39, cr_order_number#40]
-Arguments: [cr_item_sk#39 ASC NULLS FIRST, cr_order_number#40 ASC NULLS FIRST], false, 0
-
-(65) SortMergeJoin [codegen id : 20]
-Left keys [2]: [cs_item_sk#4, cs_order_number#6]
-Right keys [2]: [cr_item_sk#39, cr_order_number#40]
-Join condition: None
-
-(66) Project [codegen id : 20]
-Output [3]: [w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25, cr_item_sk#39, cr_order_number#40]
-
-(67) HashAggregate [codegen id : 20]
-Input [3]: [w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Keys [3]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25]
+(51) HashAggregate [codegen id : 15]
+Input [3]: [w_warehouse_name#31, i_item_desc#19, d_week_seq#23]
+Keys [3]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#43]
-Results [4]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, count#44]
+Aggregate Attributes [1]: [count#34]
+Results [4]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, count#35]
 
-(68) Exchange
-Input [4]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, count#44]
-Arguments: hashpartitioning(i_item_desc#21, w_warehouse_name#33, d_week_seq#25, 5), ENSURE_REQUIREMENTS, [id=#45]
+(52) Exchange
+Input [4]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, count#35]
+Arguments: hashpartitioning(i_item_desc#19, w_warehouse_name#31, d_week_seq#23, 5), ENSURE_REQUIREMENTS, [id=#36]
 
-(69) HashAggregate [codegen id : 21]
-Input [4]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, count#44]
-Keys [3]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25]
+(53) HashAggregate [codegen id : 16]
+Input [4]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, count#35]
+Keys [3]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#46]
-Results [6]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, count(1)#46 AS no_promo#47, count(1)#46 AS promo#48, count(1)#46 AS total_cnt#49]
+Aggregate Attributes [1]: [count(1)#37]
+Results [6]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, count(1)#37 AS no_promo#38, count(1)#37 AS promo#39, count(1)#37 AS total_cnt#40]
 
-(70) TakeOrderedAndProject
-Input [6]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, no_promo#47, promo#48, total_cnt#49]
-Arguments: 100, [total_cnt#49 DESC NULLS LAST, i_item_desc#21 ASC NULLS FIRST, w_warehouse_name#33 ASC NULLS FIRST, d_week_seq#25 ASC NULLS FIRST], [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, no_promo#47, promo#48, total_cnt#49]
+(54) TakeOrderedAndProject
+Input [6]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, no_promo#38, promo#39, total_cnt#40]
+Arguments: 100, [total_cnt#40 DESC NULLS LAST, i_item_desc#19 ASC NULLS FIRST, w_warehouse_name#31 ASC NULLS FIRST, d_week_seq#23 ASC NULLS FIRST], [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, no_promo#38, promo#39, total_cnt#40]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (81)
-+- * Project (80)
-   +- * BroadcastHashJoin Inner BuildLeft (79)
-      :- BroadcastExchange (75)
-      :  +- * Project (74)
-      :     +- * Filter (73)
-      :        +- * ColumnarToRow (72)
-      :           +- Scan parquet default.date_dim (71)
-      +- * Filter (78)
-         +- * ColumnarToRow (77)
-            +- Scan parquet default.date_dim (76)
+Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#6 IN dynamicpruning#7
+BroadcastExchange (65)
++- * Project (64)
+   +- * BroadcastHashJoin Inner BuildLeft (63)
+      :- BroadcastExchange (59)
+      :  +- * Project (58)
+      :     +- * Filter (57)
+      :        +- * ColumnarToRow (56)
+      :           +- Scan parquet default.date_dim (55)
+      +- * Filter (62)
+         +- * ColumnarToRow (61)
+            +- Scan parquet default.date_dim (60)
 
 
-(71) Scan parquet default.date_dim
-Output [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_year#50]
+(55) Scan parquet default.date_dim
+Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk), IsNotNull(d_week_seq), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_week_seq:int,d_year:int>
 
-(72) ColumnarToRow [codegen id : 1]
-Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_year#50]
+(56) ColumnarToRow [codegen id : 1]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#41]
 
-(73) Filter [codegen id : 1]
-Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_year#50]
-Condition : ((((isnotnull(d_year#50) AND (d_year#50 = 1999)) AND isnotnull(d_date_sk#23)) AND isnotnull(d_week_seq#25)) AND isnotnull(d_date#24))
+(57) Filter [codegen id : 1]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#41]
+Condition : ((((isnotnull(d_year#41) AND (d_year#41 = 1999)) AND isnotnull(d_date_sk#21)) AND isnotnull(d_week_seq#23)) AND isnotnull(d_date#22))
 
-(74) Project [codegen id : 1]
-Output [3]: [d_date_sk#23, d_date#24, d_week_seq#25]
-Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_year#50]
+(58) Project [codegen id : 1]
+Output [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#41]
 
-(75) BroadcastExchange
-Input [3]: [d_date_sk#23, d_date#24, d_week_seq#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#51]
+(59) BroadcastExchange
+Input [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#42]
 
-(76) Scan parquet default.date_dim
-Output [2]: [d_date_sk#26, d_week_seq#52]
+(60) Scan parquet default.date_dim
+Output [2]: [d_date_sk#24, d_week_seq#43]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(77) ColumnarToRow
-Input [2]: [d_date_sk#26, d_week_seq#52]
+(61) ColumnarToRow
+Input [2]: [d_date_sk#24, d_week_seq#43]
 
-(78) Filter
-Input [2]: [d_date_sk#26, d_week_seq#52]
-Condition : (isnotnull(d_week_seq#52) AND isnotnull(d_date_sk#26))
+(62) Filter
+Input [2]: [d_date_sk#24, d_week_seq#43]
+Condition : (isnotnull(d_week_seq#43) AND isnotnull(d_date_sk#24))
 
-(79) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [d_week_seq#25]
-Right keys [1]: [d_week_seq#52]
+(63) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [d_week_seq#23]
+Right keys [1]: [d_week_seq#43]
 Join condition: None
 
-(80) Project [codegen id : 2]
-Output [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26]
-Input [5]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26, d_week_seq#52]
+(64) Project [codegen id : 2]
+Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#24]
+Input [5]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#24, d_week_seq#43]
 
-(81) BroadcastExchange
-Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#53]
+(65) BroadcastExchange
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#44]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/simplified.txt
@@ -1,134 +1,106 @@
 TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_promo,promo]
-  WholeStageCodegen (21)
+  WholeStageCodegen (16)
     HashAggregate [i_item_desc,w_warehouse_name,d_week_seq,count] [count(1),no_promo,promo,total_cnt,count]
       InputAdapter
         Exchange [i_item_desc,w_warehouse_name,d_week_seq] #1
-          WholeStageCodegen (20)
+          WholeStageCodegen (15)
             HashAggregate [i_item_desc,w_warehouse_name,d_week_seq] [count,count]
               Project [w_warehouse_name,i_item_desc,d_week_seq]
-                SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
+                SortMergeJoin [cs_item_sk,d_date_sk,inv_item_sk,inv_date_sk,inv_quantity_on_hand,cs_quantity]
                   InputAdapter
-                    WholeStageCodegen (17)
-                      Sort [cs_item_sk,cs_order_number]
+                    WholeStageCodegen (11)
+                      Sort [cs_item_sk,d_date_sk]
                         InputAdapter
-                          Exchange [cs_item_sk,cs_order_number] #2
-                            WholeStageCodegen (16)
-                              Project [cs_item_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
-                                BroadcastHashJoin [cs_promo_sk,p_promo_sk]
-                                  Project [cs_item_sk,cs_promo_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
-                                    SortMergeJoin [cs_item_sk,d_date_sk,inv_item_sk,inv_date_sk,inv_quantity_on_hand,cs_quantity]
+                          Exchange [cs_item_sk,d_date_sk] #2
+                            WholeStageCodegen (10)
+                              Project [cs_item_sk,cs_quantity,i_item_desc,d_week_seq,d_date_sk]
+                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk,d_date,d_date]
+                                  Project [cs_item_sk,cs_quantity,cs_sold_date_sk,d_date,i_item_desc]
+                                    SortMergeJoin [cs_item_sk,i_item_sk]
                                       InputAdapter
-                                        WholeStageCodegen (11)
-                                          Sort [cs_item_sk,d_date_sk]
+                                        WholeStageCodegen (5)
+                                          Sort [cs_item_sk]
                                             InputAdapter
-                                              Exchange [cs_item_sk,d_date_sk] #3
-                                                WholeStageCodegen (10)
-                                                  Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,i_item_desc,d_week_seq,d_date_sk]
-                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk,d_date,d_date]
-                                                      Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk,d_date,i_item_desc]
-                                                        SortMergeJoin [cs_item_sk,i_item_sk]
-                                                          InputAdapter
-                                                            WholeStageCodegen (5)
-                                                              Sort [cs_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [cs_item_sk] #4
-                                                                    WholeStageCodegen (4)
-                                                                      Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk,d_date]
-                                                                        BroadcastHashJoin [cs_ship_date_sk,d_date_sk]
-                                                                          Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
-                                                                            BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
-                                                                              Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
-                                                                                BroadcastHashJoin [cs_bill_hdemo_sk,hd_demo_sk]
-                                                                                  Filter [cs_quantity,cs_item_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_ship_date_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
-                                                                                          SubqueryBroadcast [d_date_sk] #1
-                                                                                            BroadcastExchange #5
-                                                                                              WholeStageCodegen (2)
-                                                                                                Project [d_date_sk,d_date,d_week_seq,d_date_sk]
-                                                                                                  BroadcastHashJoin [d_week_seq,d_week_seq]
-                                                                                                    InputAdapter
-                                                                                                      BroadcastExchange #6
-                                                                                                        WholeStageCodegen (1)
-                                                                                                          Project [d_date_sk,d_date,d_week_seq]
-                                                                                                            Filter [d_year,d_date_sk,d_week_seq,d_date]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
-                                                                                                    Filter [d_week_seq,d_date_sk]
-                                                                                                      ColumnarToRow
-                                                                                                        InputAdapter
-                                                                                                          Scan parquet default.date_dim [d_date_sk,d_week_seq]
-                                                                                  InputAdapter
-                                                                                    BroadcastExchange #7
-                                                                                      WholeStageCodegen (1)
-                                                                                        Project [hd_demo_sk]
-                                                                                          Filter [hd_buy_potential,hd_demo_sk]
-                                                                                            ColumnarToRow
-                                                                                              InputAdapter
-                                                                                                Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential]
-                                                                              InputAdapter
-                                                                                BroadcastExchange #8
-                                                                                  WholeStageCodegen (2)
-                                                                                    Project [cd_demo_sk]
-                                                                                      Filter [cd_marital_status,cd_demo_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.customer_demographics [cd_demo_sk,cd_marital_status]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #9
-                                                                              WholeStageCodegen (3)
-                                                                                Filter [d_date,d_date_sk]
+                                              Exchange [cs_item_sk] #3
+                                                WholeStageCodegen (4)
+                                                  Project [cs_item_sk,cs_quantity,cs_sold_date_sk,d_date]
+                                                    BroadcastHashJoin [cs_ship_date_sk,d_date_sk]
+                                                      Project [cs_ship_date_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
+                                                        BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                                          Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
+                                                            BroadcastHashJoin [cs_bill_hdemo_sk,hd_demo_sk]
+                                                              Filter [cs_quantity,cs_item_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_ship_date_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
+                                                                      SubqueryBroadcast [d_date_sk] #1
+                                                                        BroadcastExchange #4
+                                                                          WholeStageCodegen (2)
+                                                                            Project [d_date_sk,d_date,d_week_seq,d_date_sk]
+                                                                              BroadcastHashJoin [d_week_seq,d_week_seq]
+                                                                                InputAdapter
+                                                                                  BroadcastExchange #5
+                                                                                    WholeStageCodegen (1)
+                                                                                      Project [d_date_sk,d_date,d_week_seq]
+                                                                                        Filter [d_year,d_date_sk,d_week_seq,d_date]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
+                                                                                Filter [d_week_seq,d_date_sk]
                                                                                   ColumnarToRow
                                                                                     InputAdapter
-                                                                                      Scan parquet default.date_dim [d_date_sk,d_date]
-                                                          InputAdapter
-                                                            WholeStageCodegen (7)
-                                                              Sort [i_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [i_item_sk] #10
-                                                                    WholeStageCodegen (6)
-                                                                      Filter [i_item_sk]
+                                                                                      Scan parquet default.date_dim [d_date_sk,d_week_seq]
+                                                              InputAdapter
+                                                                BroadcastExchange #6
+                                                                  WholeStageCodegen (1)
+                                                                    Project [hd_demo_sk]
+                                                                      Filter [hd_buy_potential,hd_demo_sk]
                                                                         ColumnarToRow
                                                                           InputAdapter
-                                                                            Scan parquet default.item [i_item_sk,i_item_desc]
-                                                      InputAdapter
-                                                        ReusedExchange [d_date_sk,d_date,d_week_seq,d_date_sk] #5
-                                      InputAdapter
-                                        WholeStageCodegen (14)
-                                          Sort [inv_item_sk,inv_date_sk]
-                                            InputAdapter
-                                              Exchange [inv_item_sk,inv_date_sk] #11
-                                                WholeStageCodegen (13)
-                                                  Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
-                                                    BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
-                                                      Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
-                                                        ColumnarToRow
+                                                                            Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential]
                                                           InputAdapter
-                                                            Scan parquet default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
+                                                            BroadcastExchange #7
+                                                              WholeStageCodegen (2)
+                                                                Project [cd_demo_sk]
+                                                                  Filter [cd_marital_status,cd_demo_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.customer_demographics [cd_demo_sk,cd_marital_status]
                                                       InputAdapter
-                                                        BroadcastExchange #12
-                                                          WholeStageCodegen (12)
-                                                            Filter [w_warehouse_sk]
+                                                        BroadcastExchange #8
+                                                          WholeStageCodegen (3)
+                                                            Filter [d_date,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
-                                                                  Scan parquet default.warehouse [w_warehouse_sk,w_warehouse_name]
+                                                                  Scan parquet default.date_dim [d_date_sk,d_date]
+                                      InputAdapter
+                                        WholeStageCodegen (7)
+                                          Sort [i_item_sk]
+                                            InputAdapter
+                                              Exchange [i_item_sk] #9
+                                                WholeStageCodegen (6)
+                                                  Filter [i_item_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet default.item [i_item_sk,i_item_desc]
                                   InputAdapter
-                                    BroadcastExchange #13
-                                      WholeStageCodegen (15)
-                                        Filter [p_promo_sk]
+                                    ReusedExchange [d_date_sk,d_date,d_week_seq,d_date_sk] #4
+                  InputAdapter
+                    WholeStageCodegen (14)
+                      Sort [inv_item_sk,inv_date_sk]
+                        InputAdapter
+                          Exchange [inv_item_sk,inv_date_sk] #10
+                            WholeStageCodegen (13)
+                              Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
+                                BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
+                                  Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
+                                  InputAdapter
+                                    BroadcastExchange #11
+                                      WholeStageCodegen (12)
+                                        Filter [w_warehouse_sk]
                                           ColumnarToRow
                                             InputAdapter
-                                              Scan parquet default.promotion [p_promo_sk]
-                  InputAdapter
-                    WholeStageCodegen (19)
-                      Sort [cr_item_sk,cr_order_number]
-                        InputAdapter
-                          Exchange [cr_item_sk,cr_order_number] #14
-                            WholeStageCodegen (18)
-                              Project [cr_item_sk,cr_order_number]
-                                Filter [cr_item_sk,cr_order_number]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_returned_date_sk]
+                                              Scan parquet default.warehouse [w_warehouse_sk,w_warehouse_name]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/explain.txt
@@ -1,423 +1,337 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * HashAggregate (69)
-   +- Exchange (68)
-      +- * HashAggregate (67)
-         +- * Project (66)
-            +- * SortMergeJoin LeftOuter (65)
-               :- * Sort (58)
-               :  +- Exchange (57)
-               :     +- * Project (56)
-               :        +- * BroadcastHashJoin LeftOuter BuildRight (55)
-               :           :- * Project (50)
-               :           :  +- * BroadcastHashJoin Inner BuildRight (49)
-               :           :     :- * Project (44)
-               :           :     :  +- * BroadcastHashJoin Inner BuildRight (43)
-               :           :     :     :- * Project (38)
-               :           :     :     :  +- * BroadcastHashJoin Inner BuildRight (37)
-               :           :     :     :     :- * Project (35)
-               :           :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (34)
-               :           :     :     :     :     :- * Project (28)
-               :           :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (27)
-               :           :     :     :     :     :     :- * Project (21)
-               :           :     :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (20)
-               :           :     :     :     :     :     :     :- * Project (15)
-               :           :     :     :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (14)
-               :           :     :     :     :     :     :     :     :- * Project (9)
-               :           :     :     :     :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (8)
-               :           :     :     :     :     :     :     :     :     :- * Filter (3)
-               :           :     :     :     :     :     :     :     :     :  +- * ColumnarToRow (2)
-               :           :     :     :     :     :     :     :     :     :     +- Scan parquet default.catalog_sales (1)
-               :           :     :     :     :     :     :     :     :     +- BroadcastExchange (7)
-               :           :     :     :     :     :     :     :     :        +- * Filter (6)
-               :           :     :     :     :     :     :     :     :           +- * ColumnarToRow (5)
-               :           :     :     :     :     :     :     :     :              +- Scan parquet default.inventory (4)
-               :           :     :     :     :     :     :     :     +- BroadcastExchange (13)
-               :           :     :     :     :     :     :     :        +- * Filter (12)
-               :           :     :     :     :     :     :     :           +- * ColumnarToRow (11)
-               :           :     :     :     :     :     :     :              +- Scan parquet default.warehouse (10)
-               :           :     :     :     :     :     :     +- BroadcastExchange (19)
-               :           :     :     :     :     :     :        +- * Filter (18)
-               :           :     :     :     :     :     :           +- * ColumnarToRow (17)
-               :           :     :     :     :     :     :              +- Scan parquet default.item (16)
-               :           :     :     :     :     :     +- BroadcastExchange (26)
-               :           :     :     :     :     :        +- * Project (25)
-               :           :     :     :     :     :           +- * Filter (24)
-               :           :     :     :     :     :              +- * ColumnarToRow (23)
-               :           :     :     :     :     :                 +- Scan parquet default.customer_demographics (22)
-               :           :     :     :     :     +- BroadcastExchange (33)
-               :           :     :     :     :        +- * Project (32)
-               :           :     :     :     :           +- * Filter (31)
-               :           :     :     :     :              +- * ColumnarToRow (30)
-               :           :     :     :     :                 +- Scan parquet default.household_demographics (29)
-               :           :     :     :     +- ReusedExchange (36)
-               :           :     :     +- BroadcastExchange (42)
-               :           :     :        +- * Filter (41)
-               :           :     :           +- * ColumnarToRow (40)
-               :           :     :              +- Scan parquet default.date_dim (39)
-               :           :     +- BroadcastExchange (48)
-               :           :        +- * Filter (47)
-               :           :           +- * ColumnarToRow (46)
-               :           :              +- Scan parquet default.date_dim (45)
-               :           +- BroadcastExchange (54)
-               :              +- * Filter (53)
-               :                 +- * ColumnarToRow (52)
-               :                    +- Scan parquet default.promotion (51)
-               +- * Sort (64)
-                  +- Exchange (63)
-                     +- * Project (62)
-                        +- * Filter (61)
-                           +- * ColumnarToRow (60)
-                              +- Scan parquet default.catalog_returns (59)
+TakeOrderedAndProject (54)
++- * HashAggregate (53)
+   +- Exchange (52)
+      +- * HashAggregate (51)
+         +- * Project (50)
+            +- * BroadcastHashJoin Inner BuildRight (49)
+               :- * Project (44)
+               :  +- * BroadcastHashJoin Inner BuildRight (43)
+               :     :- * Project (38)
+               :     :  +- * BroadcastHashJoin Inner BuildRight (37)
+               :     :     :- * Project (35)
+               :     :     :  +- * BroadcastHashJoin Inner BuildRight (34)
+               :     :     :     :- * Project (28)
+               :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (27)
+               :     :     :     :     :- * Project (21)
+               :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (20)
+               :     :     :     :     :     :- * Project (15)
+               :     :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (14)
+               :     :     :     :     :     :     :- * Project (9)
+               :     :     :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (8)
+               :     :     :     :     :     :     :     :- * Filter (3)
+               :     :     :     :     :     :     :     :  +- * ColumnarToRow (2)
+               :     :     :     :     :     :     :     :     +- Scan parquet default.catalog_sales (1)
+               :     :     :     :     :     :     :     +- BroadcastExchange (7)
+               :     :     :     :     :     :     :        +- * Filter (6)
+               :     :     :     :     :     :     :           +- * ColumnarToRow (5)
+               :     :     :     :     :     :     :              +- Scan parquet default.inventory (4)
+               :     :     :     :     :     :     +- BroadcastExchange (13)
+               :     :     :     :     :     :        +- * Filter (12)
+               :     :     :     :     :     :           +- * ColumnarToRow (11)
+               :     :     :     :     :     :              +- Scan parquet default.warehouse (10)
+               :     :     :     :     :     +- BroadcastExchange (19)
+               :     :     :     :     :        +- * Filter (18)
+               :     :     :     :     :           +- * ColumnarToRow (17)
+               :     :     :     :     :              +- Scan parquet default.item (16)
+               :     :     :     :     +- BroadcastExchange (26)
+               :     :     :     :        +- * Project (25)
+               :     :     :     :           +- * Filter (24)
+               :     :     :     :              +- * ColumnarToRow (23)
+               :     :     :     :                 +- Scan parquet default.customer_demographics (22)
+               :     :     :     +- BroadcastExchange (33)
+               :     :     :        +- * Project (32)
+               :     :     :           +- * Filter (31)
+               :     :     :              +- * ColumnarToRow (30)
+               :     :     :                 +- Scan parquet default.household_demographics (29)
+               :     :     +- ReusedExchange (36)
+               :     +- BroadcastExchange (42)
+               :        +- * Filter (41)
+               :           +- * ColumnarToRow (40)
+               :              +- Scan parquet default.date_dim (39)
+               +- BroadcastExchange (48)
+                  +- * Filter (47)
+                     +- * ColumnarToRow (46)
+                        +- Scan parquet default.date_dim (45)
 
 
 (1) Scan parquet default.catalog_sales
-Output [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
+Output [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#8), dynamicpruningexpression(cs_sold_date_sk#8 IN dynamicpruning#9)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#6), dynamicpruningexpression(cs_sold_date_sk#6 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(cs_quantity), IsNotNull(cs_item_sk), IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_hdemo_sk), IsNotNull(cs_ship_date_sk)]
-ReadSchema: struct<cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_quantity:int>
+ReadSchema: struct<cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_quantity:int>
 
-(2) ColumnarToRow [codegen id : 10]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
+(2) ColumnarToRow [codegen id : 9]
+Input [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
 
-(3) Filter [codegen id : 10]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Condition : ((((isnotnull(cs_quantity#7) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
+(3) Filter [codegen id : 9]
+Input [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
+Condition : ((((isnotnull(cs_quantity#5) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
 
 (4) Scan parquet default.inventory
-Output [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
+Output [4]: [inv_item_sk#8, inv_warehouse_sk#9, inv_quantity_on_hand#10, inv_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(inv_date_sk#13)]
+PartitionFilters: [isnotnull(inv_date_sk#11)]
 PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
+Input [4]: [inv_item_sk#8, inv_warehouse_sk#9, inv_quantity_on_hand#10, inv_date_sk#11]
 
 (6) Filter [codegen id : 1]
-Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
-Condition : ((isnotnull(inv_quantity_on_hand#12) AND isnotnull(inv_item_sk#10)) AND isnotnull(inv_warehouse_sk#11))
+Input [4]: [inv_item_sk#8, inv_warehouse_sk#9, inv_quantity_on_hand#10, inv_date_sk#11]
+Condition : ((isnotnull(inv_quantity_on_hand#10) AND isnotnull(inv_item_sk#8)) AND isnotnull(inv_warehouse_sk#9))
 
 (7) BroadcastExchange
-Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Input [4]: [inv_item_sk#8, inv_warehouse_sk#9, inv_quantity_on_hand#10, inv_date_sk#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
 
-(8) BroadcastHashJoin [codegen id : 10]
+(8) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_item_sk#4]
-Right keys [1]: [inv_item_sk#10]
-Join condition: (inv_quantity_on_hand#12 < cs_quantity#7)
+Right keys [1]: [inv_item_sk#8]
+Join condition: (inv_quantity_on_hand#10 < cs_quantity#5)
 
-(9) Project [codegen id : 10]
-Output [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_warehouse_sk#11, inv_date_sk#13]
-Input [12]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
+(9) Project [codegen id : 9]
+Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_sold_date_sk#6, inv_warehouse_sk#9, inv_date_sk#11]
+Input [10]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, inv_item_sk#8, inv_warehouse_sk#9, inv_quantity_on_hand#10, inv_date_sk#11]
 
 (10) Scan parquet default.warehouse
-Output [2]: [w_warehouse_sk#15, w_warehouse_name#16]
+Output [2]: [w_warehouse_sk#13, w_warehouse_name#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
 (11) ColumnarToRow [codegen id : 2]
-Input [2]: [w_warehouse_sk#15, w_warehouse_name#16]
+Input [2]: [w_warehouse_sk#13, w_warehouse_name#14]
 
 (12) Filter [codegen id : 2]
-Input [2]: [w_warehouse_sk#15, w_warehouse_name#16]
-Condition : isnotnull(w_warehouse_sk#15)
+Input [2]: [w_warehouse_sk#13, w_warehouse_name#14]
+Condition : isnotnull(w_warehouse_sk#13)
 
 (13) BroadcastExchange
-Input [2]: [w_warehouse_sk#15, w_warehouse_name#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Input [2]: [w_warehouse_sk#13, w_warehouse_name#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
 
-(14) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [inv_warehouse_sk#11]
-Right keys [1]: [w_warehouse_sk#15]
+(14) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [inv_warehouse_sk#9]
+Right keys [1]: [w_warehouse_sk#13]
 Join condition: None
 
-(15) Project [codegen id : 10]
-Output [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16]
-Input [11]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_warehouse_sk#11, inv_date_sk#13, w_warehouse_sk#15, w_warehouse_name#16]
+(15) Project [codegen id : 9]
+Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14]
+Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_sold_date_sk#6, inv_warehouse_sk#9, inv_date_sk#11, w_warehouse_sk#13, w_warehouse_name#14]
 
 (16) Scan parquet default.item
-Output [2]: [i_item_sk#18, i_item_desc#19]
+Output [2]: [i_item_sk#16, i_item_desc#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string>
 
 (17) ColumnarToRow [codegen id : 3]
-Input [2]: [i_item_sk#18, i_item_desc#19]
+Input [2]: [i_item_sk#16, i_item_desc#17]
 
 (18) Filter [codegen id : 3]
-Input [2]: [i_item_sk#18, i_item_desc#19]
-Condition : isnotnull(i_item_sk#18)
+Input [2]: [i_item_sk#16, i_item_desc#17]
+Condition : isnotnull(i_item_sk#16)
 
 (19) BroadcastExchange
-Input [2]: [i_item_sk#18, i_item_desc#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
+Input [2]: [i_item_sk#16, i_item_desc#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
 
-(20) BroadcastHashJoin [codegen id : 10]
+(20) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_item_sk#4]
-Right keys [1]: [i_item_sk#18]
+Right keys [1]: [i_item_sk#16]
 Join condition: None
 
-(21) Project [codegen id : 10]
-Output [10]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19]
-Input [11]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_sk#18, i_item_desc#19]
+(21) Project [codegen id : 9]
+Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17]
+Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_sk#16, i_item_desc#17]
 
 (22) Scan parquet default.customer_demographics
-Output [2]: [cd_demo_sk#21, cd_marital_status#22]
+Output [2]: [cd_demo_sk#19, cd_marital_status#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_marital_status), EqualTo(cd_marital_status,D), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
 (23) ColumnarToRow [codegen id : 4]
-Input [2]: [cd_demo_sk#21, cd_marital_status#22]
+Input [2]: [cd_demo_sk#19, cd_marital_status#20]
 
 (24) Filter [codegen id : 4]
-Input [2]: [cd_demo_sk#21, cd_marital_status#22]
-Condition : ((isnotnull(cd_marital_status#22) AND (cd_marital_status#22 = D)) AND isnotnull(cd_demo_sk#21))
+Input [2]: [cd_demo_sk#19, cd_marital_status#20]
+Condition : ((isnotnull(cd_marital_status#20) AND (cd_marital_status#20 = D)) AND isnotnull(cd_demo_sk#19))
 
 (25) Project [codegen id : 4]
-Output [1]: [cd_demo_sk#21]
-Input [2]: [cd_demo_sk#21, cd_marital_status#22]
+Output [1]: [cd_demo_sk#19]
+Input [2]: [cd_demo_sk#19, cd_marital_status#20]
 
 (26) BroadcastExchange
-Input [1]: [cd_demo_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Input [1]: [cd_demo_sk#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
 
-(27) BroadcastHashJoin [codegen id : 10]
+(27) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#21]
+Right keys [1]: [cd_demo_sk#19]
 Join condition: None
 
-(28) Project [codegen id : 10]
-Output [9]: [cs_ship_date_sk#1, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19]
-Input [11]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19, cd_demo_sk#21]
+(28) Project [codegen id : 9]
+Output [6]: [cs_ship_date_sk#1, cs_bill_hdemo_sk#3, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17]
+Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17, cd_demo_sk#19]
 
 (29) Scan parquet default.household_demographics
-Output [2]: [hd_demo_sk#24, hd_buy_potential#25]
+Output [2]: [hd_demo_sk#22, hd_buy_potential#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_buy_potential), EqualTo(hd_buy_potential,>10000         ), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
 
 (30) ColumnarToRow [codegen id : 5]
-Input [2]: [hd_demo_sk#24, hd_buy_potential#25]
+Input [2]: [hd_demo_sk#22, hd_buy_potential#23]
 
 (31) Filter [codegen id : 5]
-Input [2]: [hd_demo_sk#24, hd_buy_potential#25]
-Condition : ((isnotnull(hd_buy_potential#25) AND (hd_buy_potential#25 = >10000         )) AND isnotnull(hd_demo_sk#24))
+Input [2]: [hd_demo_sk#22, hd_buy_potential#23]
+Condition : ((isnotnull(hd_buy_potential#23) AND (hd_buy_potential#23 = >10000         )) AND isnotnull(hd_demo_sk#22))
 
 (32) Project [codegen id : 5]
-Output [1]: [hd_demo_sk#24]
-Input [2]: [hd_demo_sk#24, hd_buy_potential#25]
+Output [1]: [hd_demo_sk#22]
+Input [2]: [hd_demo_sk#22, hd_buy_potential#23]
 
 (33) BroadcastExchange
-Input [1]: [hd_demo_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Input [1]: [hd_demo_sk#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#24]
 
-(34) BroadcastHashJoin [codegen id : 10]
+(34) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_bill_hdemo_sk#3]
-Right keys [1]: [hd_demo_sk#24]
+Right keys [1]: [hd_demo_sk#22]
 Join condition: None
 
-(35) Project [codegen id : 10]
-Output [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19]
-Input [10]: [cs_ship_date_sk#1, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19, hd_demo_sk#24]
+(35) Project [codegen id : 9]
+Output [5]: [cs_ship_date_sk#1, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17]
+Input [7]: [cs_ship_date_sk#1, cs_bill_hdemo_sk#3, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17, hd_demo_sk#22]
 
-(36) ReusedExchange [Reuses operator id: 75]
-Output [3]: [d_date_sk#27, d_date#28, d_week_seq#29]
+(36) ReusedExchange [Reuses operator id: 59]
+Output [3]: [d_date_sk#25, d_date#26, d_week_seq#27]
 
-(37) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_sold_date_sk#8]
-Right keys [1]: [d_date_sk#27]
+(37) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_sold_date_sk#6]
+Right keys [1]: [d_date_sk#25]
 Join condition: None
 
-(38) Project [codegen id : 10]
-Output [9]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19, d_date#28, d_week_seq#29]
-Input [11]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19, d_date_sk#27, d_date#28, d_week_seq#29]
+(38) Project [codegen id : 9]
+Output [6]: [cs_ship_date_sk#1, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17, d_date#26, d_week_seq#27]
+Input [8]: [cs_ship_date_sk#1, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17, d_date_sk#25, d_date#26, d_week_seq#27]
 
 (39) Scan parquet default.date_dim
-Output [2]: [d_date_sk#30, d_week_seq#31]
+Output [2]: [d_date_sk#28, d_week_seq#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (40) ColumnarToRow [codegen id : 7]
-Input [2]: [d_date_sk#30, d_week_seq#31]
+Input [2]: [d_date_sk#28, d_week_seq#29]
 
 (41) Filter [codegen id : 7]
-Input [2]: [d_date_sk#30, d_week_seq#31]
-Condition : (isnotnull(d_week_seq#31) AND isnotnull(d_date_sk#30))
+Input [2]: [d_date_sk#28, d_week_seq#29]
+Condition : (isnotnull(d_week_seq#29) AND isnotnull(d_date_sk#28))
 
 (42) BroadcastExchange
-Input [2]: [d_date_sk#30, d_week_seq#31]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, false] as bigint), 32) | (cast(input[0, int, false] as bigint) & 4294967295))),false), [id=#32]
+Input [2]: [d_date_sk#28, d_week_seq#29]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, false] as bigint), 32) | (cast(input[0, int, false] as bigint) & 4294967295))),false), [id=#30]
 
-(43) BroadcastHashJoin [codegen id : 10]
-Left keys [2]: [d_week_seq#29, inv_date_sk#13]
-Right keys [2]: [d_week_seq#31, d_date_sk#30]
+(43) BroadcastHashJoin [codegen id : 9]
+Left keys [2]: [d_week_seq#27, inv_date_sk#11]
+Right keys [2]: [d_week_seq#29, d_date_sk#28]
 Join condition: None
 
-(44) Project [codegen id : 10]
-Output [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_date#28, d_week_seq#29]
-Input [11]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19, d_date#28, d_week_seq#29, d_date_sk#30, d_week_seq#31]
+(44) Project [codegen id : 9]
+Output [5]: [cs_ship_date_sk#1, w_warehouse_name#14, i_item_desc#17, d_date#26, d_week_seq#27]
+Input [8]: [cs_ship_date_sk#1, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17, d_date#26, d_week_seq#27, d_date_sk#28, d_week_seq#29]
 
 (45) Scan parquet default.date_dim
-Output [2]: [d_date_sk#33, d_date#34]
+Output [2]: [d_date_sk#31, d_date#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (46) ColumnarToRow [codegen id : 8]
-Input [2]: [d_date_sk#33, d_date#34]
+Input [2]: [d_date_sk#31, d_date#32]
 
 (47) Filter [codegen id : 8]
-Input [2]: [d_date_sk#33, d_date#34]
-Condition : (isnotnull(d_date#34) AND isnotnull(d_date_sk#33))
+Input [2]: [d_date_sk#31, d_date#32]
+Condition : (isnotnull(d_date#32) AND isnotnull(d_date_sk#31))
 
 (48) BroadcastExchange
-Input [2]: [d_date_sk#33, d_date#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#35]
+Input [2]: [d_date_sk#31, d_date#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#33]
 
-(49) BroadcastHashJoin [codegen id : 10]
+(49) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_ship_date_sk#1]
-Right keys [1]: [d_date_sk#33]
-Join condition: (d_date#34 > date_add(d_date#28, 5))
+Right keys [1]: [d_date_sk#31]
+Join condition: (d_date#32 > date_add(d_date#26, 5))
 
-(50) Project [codegen id : 10]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Input [10]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_date#28, d_week_seq#29, d_date_sk#33, d_date#34]
+(50) Project [codegen id : 9]
+Output [3]: [w_warehouse_name#14, i_item_desc#17, d_week_seq#27]
+Input [7]: [cs_ship_date_sk#1, w_warehouse_name#14, i_item_desc#17, d_date#26, d_week_seq#27, d_date_sk#31, d_date#32]
 
-(51) Scan parquet default.promotion
-Output [1]: [p_promo_sk#36]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/promotion]
-PushedFilters: [IsNotNull(p_promo_sk)]
-ReadSchema: struct<p_promo_sk:int>
-
-(52) ColumnarToRow [codegen id : 9]
-Input [1]: [p_promo_sk#36]
-
-(53) Filter [codegen id : 9]
-Input [1]: [p_promo_sk#36]
-Condition : isnotnull(p_promo_sk#36)
-
-(54) BroadcastExchange
-Input [1]: [p_promo_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#37]
-
-(55) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_promo_sk#5]
-Right keys [1]: [p_promo_sk#36]
-Join condition: None
-
-(56) Project [codegen id : 10]
-Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29, p_promo_sk#36]
-
-(57) Exchange
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [id=#38]
-
-(58) Sort [codegen id : 11]
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, cs_order_number#6 ASC NULLS FIRST], false, 0
-
-(59) Scan parquet default.catalog_returns
-Output [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/catalog_returns]
-PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
-ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
-
-(60) ColumnarToRow [codegen id : 12]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-
-(61) Filter [codegen id : 12]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-Condition : (isnotnull(cr_item_sk#39) AND isnotnull(cr_order_number#40))
-
-(62) Project [codegen id : 12]
-Output [2]: [cr_item_sk#39, cr_order_number#40]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-
-(63) Exchange
-Input [2]: [cr_item_sk#39, cr_order_number#40]
-Arguments: hashpartitioning(cr_item_sk#39, cr_order_number#40, 5), ENSURE_REQUIREMENTS, [id=#42]
-
-(64) Sort [codegen id : 13]
-Input [2]: [cr_item_sk#39, cr_order_number#40]
-Arguments: [cr_item_sk#39 ASC NULLS FIRST, cr_order_number#40 ASC NULLS FIRST], false, 0
-
-(65) SortMergeJoin [codegen id : 14]
-Left keys [2]: [cs_item_sk#4, cs_order_number#6]
-Right keys [2]: [cr_item_sk#39, cr_order_number#40]
-Join condition: None
-
-(66) Project [codegen id : 14]
-Output [3]: [w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29, cr_item_sk#39, cr_order_number#40]
-
-(67) HashAggregate [codegen id : 14]
-Input [3]: [w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Keys [3]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29]
+(51) HashAggregate [codegen id : 9]
+Input [3]: [w_warehouse_name#14, i_item_desc#17, d_week_seq#27]
+Keys [3]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#43]
-Results [4]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, count#44]
+Aggregate Attributes [1]: [count#34]
+Results [4]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, count#35]
 
-(68) Exchange
-Input [4]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, count#44]
-Arguments: hashpartitioning(i_item_desc#19, w_warehouse_name#16, d_week_seq#29, 5), ENSURE_REQUIREMENTS, [id=#45]
+(52) Exchange
+Input [4]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, count#35]
+Arguments: hashpartitioning(i_item_desc#17, w_warehouse_name#14, d_week_seq#27, 5), ENSURE_REQUIREMENTS, [id=#36]
 
-(69) HashAggregate [codegen id : 15]
-Input [4]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, count#44]
-Keys [3]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29]
+(53) HashAggregate [codegen id : 10]
+Input [4]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, count#35]
+Keys [3]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#46]
-Results [6]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, count(1)#46 AS no_promo#47, count(1)#46 AS promo#48, count(1)#46 AS total_cnt#49]
+Aggregate Attributes [1]: [count(1)#37]
+Results [6]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, count(1)#37 AS no_promo#38, count(1)#37 AS promo#39, count(1)#37 AS total_cnt#40]
 
-(70) TakeOrderedAndProject
-Input [6]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, no_promo#47, promo#48, total_cnt#49]
-Arguments: 100, [total_cnt#49 DESC NULLS LAST, i_item_desc#19 ASC NULLS FIRST, w_warehouse_name#16 ASC NULLS FIRST, d_week_seq#29 ASC NULLS FIRST], [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, no_promo#47, promo#48, total_cnt#49]
+(54) TakeOrderedAndProject
+Input [6]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, no_promo#38, promo#39, total_cnt#40]
+Arguments: 100, [total_cnt#40 DESC NULLS LAST, i_item_desc#17 ASC NULLS FIRST, w_warehouse_name#14 ASC NULLS FIRST, d_week_seq#27 ASC NULLS FIRST], [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, no_promo#38, promo#39, total_cnt#40]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (75)
-+- * Project (74)
-   +- * Filter (73)
-      +- * ColumnarToRow (72)
-         +- Scan parquet default.date_dim (71)
+Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#6 IN dynamicpruning#7
+BroadcastExchange (59)
++- * Project (58)
+   +- * Filter (57)
+      +- * ColumnarToRow (56)
+         +- Scan parquet default.date_dim (55)
 
 
-(71) Scan parquet default.date_dim
-Output [4]: [d_date_sk#27, d_date#28, d_week_seq#29, d_year#50]
+(55) Scan parquet default.date_dim
+Output [4]: [d_date_sk#25, d_date#26, d_week_seq#27, d_year#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk), IsNotNull(d_week_seq), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_week_seq:int,d_year:int>
 
-(72) ColumnarToRow [codegen id : 1]
-Input [4]: [d_date_sk#27, d_date#28, d_week_seq#29, d_year#50]
+(56) ColumnarToRow [codegen id : 1]
+Input [4]: [d_date_sk#25, d_date#26, d_week_seq#27, d_year#41]
 
-(73) Filter [codegen id : 1]
-Input [4]: [d_date_sk#27, d_date#28, d_week_seq#29, d_year#50]
-Condition : ((((isnotnull(d_year#50) AND (d_year#50 = 1999)) AND isnotnull(d_date_sk#27)) AND isnotnull(d_week_seq#29)) AND isnotnull(d_date#28))
+(57) Filter [codegen id : 1]
+Input [4]: [d_date_sk#25, d_date#26, d_week_seq#27, d_year#41]
+Condition : ((((isnotnull(d_year#41) AND (d_year#41 = 1999)) AND isnotnull(d_date_sk#25)) AND isnotnull(d_week_seq#27)) AND isnotnull(d_date#26))
 
-(74) Project [codegen id : 1]
-Output [3]: [d_date_sk#27, d_date#28, d_week_seq#29]
-Input [4]: [d_date_sk#27, d_date#28, d_week_seq#29, d_year#50]
+(58) Project [codegen id : 1]
+Output [3]: [d_date_sk#25, d_date#26, d_week_seq#27]
+Input [4]: [d_date_sk#25, d_date#26, d_week_seq#27, d_year#41]
 
-(75) BroadcastExchange
-Input [3]: [d_date_sk#27, d_date#28, d_week_seq#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#51]
+(59) BroadcastExchange
+Input [3]: [d_date_sk#25, d_date#26, d_week_seq#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/simplified.txt
@@ -1,116 +1,88 @@
 TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_promo,promo]
-  WholeStageCodegen (15)
+  WholeStageCodegen (10)
     HashAggregate [i_item_desc,w_warehouse_name,d_week_seq,count] [count(1),no_promo,promo,total_cnt,count]
       InputAdapter
         Exchange [i_item_desc,w_warehouse_name,d_week_seq] #1
-          WholeStageCodegen (14)
+          WholeStageCodegen (9)
             HashAggregate [i_item_desc,w_warehouse_name,d_week_seq] [count,count]
               Project [w_warehouse_name,i_item_desc,d_week_seq]
-                SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
-                  InputAdapter
-                    WholeStageCodegen (11)
-                      Sort [cs_item_sk,cs_order_number]
-                        InputAdapter
-                          Exchange [cs_item_sk,cs_order_number] #2
-                            WholeStageCodegen (10)
-                              Project [cs_item_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
-                                BroadcastHashJoin [cs_promo_sk,p_promo_sk]
-                                  Project [cs_item_sk,cs_promo_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
-                                    BroadcastHashJoin [cs_ship_date_sk,d_date_sk,d_date,d_date]
-                                      Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,w_warehouse_name,i_item_desc,d_date,d_week_seq]
-                                        BroadcastHashJoin [d_week_seq,inv_date_sk,d_week_seq,d_date_sk]
-                                          Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,inv_date_sk,w_warehouse_name,i_item_desc,d_date,d_week_seq]
-                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                              Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
-                                                BroadcastHashJoin [cs_bill_hdemo_sk,hd_demo_sk]
-                                                  Project [cs_ship_date_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
-                                                    BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
-                                                      Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
-                                                        BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                          Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,inv_date_sk,w_warehouse_name]
-                                                            BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
-                                                              Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,inv_warehouse_sk,inv_date_sk]
-                                                                BroadcastHashJoin [cs_item_sk,inv_item_sk,inv_quantity_on_hand,cs_quantity]
-                                                                  Filter [cs_quantity,cs_item_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_ship_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
-                                                                          SubqueryBroadcast [d_date_sk] #1
-                                                                            BroadcastExchange #3
-                                                                              WholeStageCodegen (1)
-                                                                                Project [d_date_sk,d_date,d_week_seq]
-                                                                                  Filter [d_year,d_date_sk,d_week_seq,d_date]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
-                                                                  InputAdapter
-                                                                    BroadcastExchange #4
-                                                                      WholeStageCodegen (1)
-                                                                        Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
-                                                              InputAdapter
-                                                                BroadcastExchange #5
-                                                                  WholeStageCodegen (2)
-                                                                    Filter [w_warehouse_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet default.warehouse [w_warehouse_sk,w_warehouse_name]
-                                                          InputAdapter
-                                                            BroadcastExchange #6
-                                                              WholeStageCodegen (3)
-                                                                Filter [i_item_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.item [i_item_sk,i_item_desc]
-                                                      InputAdapter
-                                                        BroadcastExchange #7
-                                                          WholeStageCodegen (4)
-                                                            Project [cd_demo_sk]
-                                                              Filter [cd_marital_status,cd_demo_sk]
+                BroadcastHashJoin [cs_ship_date_sk,d_date_sk,d_date,d_date]
+                  Project [cs_ship_date_sk,w_warehouse_name,i_item_desc,d_date,d_week_seq]
+                    BroadcastHashJoin [d_week_seq,inv_date_sk,d_week_seq,d_date_sk]
+                      Project [cs_ship_date_sk,inv_date_sk,w_warehouse_name,i_item_desc,d_date,d_week_seq]
+                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                          Project [cs_ship_date_sk,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
+                            BroadcastHashJoin [cs_bill_hdemo_sk,hd_demo_sk]
+                              Project [cs_ship_date_sk,cs_bill_hdemo_sk,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
+                                BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                  Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
+                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                      Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_sold_date_sk,inv_date_sk,w_warehouse_name]
+                                        BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
+                                          Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_sold_date_sk,inv_warehouse_sk,inv_date_sk]
+                                            BroadcastHashJoin [cs_item_sk,inv_item_sk,inv_quantity_on_hand,cs_quantity]
+                                              Filter [cs_quantity,cs_item_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_ship_date_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
+                                                      SubqueryBroadcast [d_date_sk] #1
+                                                        BroadcastExchange #2
+                                                          WholeStageCodegen (1)
+                                                            Project [d_date_sk,d_date,d_week_seq]
+                                                              Filter [d_year,d_date_sk,d_week_seq,d_date]
                                                                 ColumnarToRow
                                                                   InputAdapter
-                                                                    Scan parquet default.customer_demographics [cd_demo_sk,cd_marital_status]
-                                                  InputAdapter
-                                                    BroadcastExchange #8
-                                                      WholeStageCodegen (5)
-                                                        Project [hd_demo_sk]
-                                                          Filter [hd_buy_potential,hd_demo_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential]
+                                                                    Scan parquet default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
                                               InputAdapter
-                                                ReusedExchange [d_date_sk,d_date,d_week_seq] #3
+                                                BroadcastExchange #3
+                                                  WholeStageCodegen (1)
+                                                    Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
                                           InputAdapter
-                                            BroadcastExchange #9
-                                              WholeStageCodegen (7)
-                                                Filter [d_week_seq,d_date_sk]
+                                            BroadcastExchange #4
+                                              WholeStageCodegen (2)
+                                                Filter [w_warehouse_sk]
                                                   ColumnarToRow
                                                     InputAdapter
-                                                      Scan parquet default.date_dim [d_date_sk,d_week_seq]
+                                                      Scan parquet default.warehouse [w_warehouse_sk,w_warehouse_name]
                                       InputAdapter
-                                        BroadcastExchange #10
-                                          WholeStageCodegen (8)
-                                            Filter [d_date,d_date_sk]
+                                        BroadcastExchange #5
+                                          WholeStageCodegen (3)
+                                            Filter [i_item_sk]
                                               ColumnarToRow
                                                 InputAdapter
-                                                  Scan parquet default.date_dim [d_date_sk,d_date]
+                                                  Scan parquet default.item [i_item_sk,i_item_desc]
                                   InputAdapter
-                                    BroadcastExchange #11
-                                      WholeStageCodegen (9)
-                                        Filter [p_promo_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet default.promotion [p_promo_sk]
+                                    BroadcastExchange #6
+                                      WholeStageCodegen (4)
+                                        Project [cd_demo_sk]
+                                          Filter [cd_marital_status,cd_demo_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet default.customer_demographics [cd_demo_sk,cd_marital_status]
+                              InputAdapter
+                                BroadcastExchange #7
+                                  WholeStageCodegen (5)
+                                    Project [hd_demo_sk]
+                                      Filter [hd_buy_potential,hd_demo_sk]
+                                        ColumnarToRow
+                                          InputAdapter
+                                            Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential]
+                          InputAdapter
+                            ReusedExchange [d_date_sk,d_date,d_week_seq] #2
+                      InputAdapter
+                        BroadcastExchange #8
+                          WholeStageCodegen (7)
+                            Filter [d_week_seq,d_date_sk]
+                              ColumnarToRow
+                                InputAdapter
+                                  Scan parquet default.date_dim [d_date_sk,d_week_seq]
                   InputAdapter
-                    WholeStageCodegen (13)
-                      Sort [cr_item_sk,cr_order_number]
-                        InputAdapter
-                          Exchange [cr_item_sk,cr_order_number] #12
-                            WholeStageCodegen (12)
-                              Project [cr_item_sk,cr_order_number]
-                                Filter [cr_item_sk,cr_order_number]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_returned_date_sk]
+                    BroadcastExchange #9
+                      WholeStageCodegen (8)
+                        Filter [d_date,d_date_sk]
+                          ColumnarToRow
+                            InputAdapter
+                              Scan parquet default.date_dim [d_date_sk,d_date]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
@@ -1,453 +1,367 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * HashAggregate (69)
-   +- Exchange (68)
-      +- * HashAggregate (67)
-         +- * Project (66)
-            +- * SortMergeJoin LeftOuter (65)
-               :- * Sort (58)
-               :  +- Exchange (57)
-               :     +- * Project (56)
-               :        +- * BroadcastHashJoin LeftOuter BuildRight (55)
-               :           :- * Project (50)
-               :           :  +- * SortMergeJoin Inner (49)
-               :           :     :- * Sort (37)
-               :           :     :  +- Exchange (36)
-               :           :     :     +- * Project (35)
-               :           :     :        +- * BroadcastHashJoin Inner BuildRight (34)
-               :           :     :           :- * Project (32)
-               :           :     :           :  +- * SortMergeJoin Inner (31)
-               :           :     :           :     :- * Sort (25)
-               :           :     :           :     :  +- Exchange (24)
-               :           :     :           :     :     +- * Project (23)
-               :           :     :           :     :        +- * BroadcastHashJoin Inner BuildRight (22)
-               :           :     :           :     :           :- * Project (17)
-               :           :     :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (16)
-               :           :     :           :     :           :     :- * Project (10)
-               :           :     :           :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-               :           :     :           :     :           :     :     :- * Filter (3)
-               :           :     :           :     :           :     :     :  +- * ColumnarToRow (2)
-               :           :     :           :     :           :     :     :     +- Scan parquet default.catalog_sales (1)
-               :           :     :           :     :           :     :     +- BroadcastExchange (8)
-               :           :     :           :     :           :     :        +- * Project (7)
-               :           :     :           :     :           :     :           +- * Filter (6)
-               :           :     :           :     :           :     :              +- * ColumnarToRow (5)
-               :           :     :           :     :           :     :                 +- Scan parquet default.household_demographics (4)
-               :           :     :           :     :           :     +- BroadcastExchange (15)
-               :           :     :           :     :           :        +- * Project (14)
-               :           :     :           :     :           :           +- * Filter (13)
-               :           :     :           :     :           :              +- * ColumnarToRow (12)
-               :           :     :           :     :           :                 +- Scan parquet default.customer_demographics (11)
-               :           :     :           :     :           +- BroadcastExchange (21)
-               :           :     :           :     :              +- * Filter (20)
-               :           :     :           :     :                 +- * ColumnarToRow (19)
-               :           :     :           :     :                    +- Scan parquet default.date_dim (18)
-               :           :     :           :     +- * Sort (30)
-               :           :     :           :        +- Exchange (29)
-               :           :     :           :           +- * Filter (28)
-               :           :     :           :              +- * ColumnarToRow (27)
-               :           :     :           :                 +- Scan parquet default.item (26)
-               :           :     :           +- ReusedExchange (33)
-               :           :     +- * Sort (48)
-               :           :        +- Exchange (47)
-               :           :           +- * Project (46)
-               :           :              +- * BroadcastHashJoin Inner BuildRight (45)
-               :           :                 :- * Filter (40)
-               :           :                 :  +- * ColumnarToRow (39)
-               :           :                 :     +- Scan parquet default.inventory (38)
-               :           :                 +- BroadcastExchange (44)
-               :           :                    +- * Filter (43)
-               :           :                       +- * ColumnarToRow (42)
-               :           :                          +- Scan parquet default.warehouse (41)
-               :           +- BroadcastExchange (54)
-               :              +- * Filter (53)
-               :                 +- * ColumnarToRow (52)
-               :                    +- Scan parquet default.promotion (51)
-               +- * Sort (64)
-                  +- Exchange (63)
-                     +- * Project (62)
-                        +- * Filter (61)
-                           +- * ColumnarToRow (60)
-                              +- Scan parquet default.catalog_returns (59)
+TakeOrderedAndProject (54)
++- * HashAggregate (53)
+   +- Exchange (52)
+      +- * HashAggregate (51)
+         +- * Project (50)
+            +- * SortMergeJoin Inner (49)
+               :- * Sort (37)
+               :  +- Exchange (36)
+               :     +- * Project (35)
+               :        +- * BroadcastHashJoin Inner BuildRight (34)
+               :           :- * Project (32)
+               :           :  +- * SortMergeJoin Inner (31)
+               :           :     :- * Sort (25)
+               :           :     :  +- Exchange (24)
+               :           :     :     +- * Project (23)
+               :           :     :        +- * BroadcastHashJoin Inner BuildRight (22)
+               :           :     :           :- * Project (17)
+               :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (16)
+               :           :     :           :     :- * Project (10)
+               :           :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+               :           :     :           :     :     :- * Filter (3)
+               :           :     :           :     :     :  +- * ColumnarToRow (2)
+               :           :     :           :     :     :     +- Scan parquet default.catalog_sales (1)
+               :           :     :           :     :     +- BroadcastExchange (8)
+               :           :     :           :     :        +- * Project (7)
+               :           :     :           :     :           +- * Filter (6)
+               :           :     :           :     :              +- * ColumnarToRow (5)
+               :           :     :           :     :                 +- Scan parquet default.household_demographics (4)
+               :           :     :           :     +- BroadcastExchange (15)
+               :           :     :           :        +- * Project (14)
+               :           :     :           :           +- * Filter (13)
+               :           :     :           :              +- * ColumnarToRow (12)
+               :           :     :           :                 +- Scan parquet default.customer_demographics (11)
+               :           :     :           +- BroadcastExchange (21)
+               :           :     :              +- * Filter (20)
+               :           :     :                 +- * ColumnarToRow (19)
+               :           :     :                    +- Scan parquet default.date_dim (18)
+               :           :     +- * Sort (30)
+               :           :        +- Exchange (29)
+               :           :           +- * Filter (28)
+               :           :              +- * ColumnarToRow (27)
+               :           :                 +- Scan parquet default.item (26)
+               :           +- ReusedExchange (33)
+               +- * Sort (48)
+                  +- Exchange (47)
+                     +- * Project (46)
+                        +- * BroadcastHashJoin Inner BuildRight (45)
+                           :- * Filter (40)
+                           :  +- * ColumnarToRow (39)
+                           :     +- Scan parquet default.inventory (38)
+                           +- BroadcastExchange (44)
+                              +- * Filter (43)
+                                 +- * ColumnarToRow (42)
+                                    +- Scan parquet default.warehouse (41)
 
 
 (1) Scan parquet default.catalog_sales
-Output [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
+Output [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#8), dynamicpruningexpression(cs_sold_date_sk#8 IN dynamicpruning#9)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#6), dynamicpruningexpression(cs_sold_date_sk#6 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(cs_quantity), IsNotNull(cs_item_sk), IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_hdemo_sk), IsNotNull(cs_ship_date_sk)]
-ReadSchema: struct<cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_quantity:int>
+ReadSchema: struct<cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_quantity:int>
 
 (2) ColumnarToRow [codegen id : 4]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
+Input [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
 
 (3) Filter [codegen id : 4]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Condition : ((((isnotnull(cs_quantity#7) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
+Input [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
+Condition : ((((isnotnull(cs_quantity#5) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
 
 (4) Scan parquet default.household_demographics
-Output [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [2]: [hd_demo_sk#8, hd_buy_potential#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_buy_potential), EqualTo(hd_buy_potential,1001-5000      ), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Input [2]: [hd_demo_sk#8, hd_buy_potential#9]
 
 (6) Filter [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
-Condition : ((isnotnull(hd_buy_potential#11) AND (hd_buy_potential#11 = 1001-5000      )) AND isnotnull(hd_demo_sk#10))
+Input [2]: [hd_demo_sk#8, hd_buy_potential#9]
+Condition : ((isnotnull(hd_buy_potential#9) AND (hd_buy_potential#9 = 1001-5000      )) AND isnotnull(hd_demo_sk#8))
 
 (7) Project [codegen id : 1]
-Output [1]: [hd_demo_sk#10]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [1]: [hd_demo_sk#8]
+Input [2]: [hd_demo_sk#8, hd_buy_potential#9]
 
 (8) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Input [1]: [hd_demo_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_hdemo_sk#3]
-Right keys [1]: [hd_demo_sk#10]
+Right keys [1]: [hd_demo_sk#8]
 Join condition: None
 
 (10) Project [codegen id : 4]
-Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, hd_demo_sk#10]
+Output [5]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
+Input [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, hd_demo_sk#8]
 
 (11) Scan parquet default.customer_demographics
-Output [2]: [cd_demo_sk#13, cd_marital_status#14]
+Output [2]: [cd_demo_sk#11, cd_marital_status#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_marital_status), EqualTo(cd_marital_status,M), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
 (12) ColumnarToRow [codegen id : 2]
-Input [2]: [cd_demo_sk#13, cd_marital_status#14]
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
 
 (13) Filter [codegen id : 2]
-Input [2]: [cd_demo_sk#13, cd_marital_status#14]
-Condition : ((isnotnull(cd_marital_status#14) AND (cd_marital_status#14 = M)) AND isnotnull(cd_demo_sk#13))
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
+Condition : ((isnotnull(cd_marital_status#12) AND (cd_marital_status#12 = M)) AND isnotnull(cd_demo_sk#11))
 
 (14) Project [codegen id : 2]
-Output [1]: [cd_demo_sk#13]
-Input [2]: [cd_demo_sk#13, cd_marital_status#14]
+Output [1]: [cd_demo_sk#11]
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
 
 (15) BroadcastExchange
-Input [1]: [cd_demo_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Input [1]: [cd_demo_sk#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
 
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#13]
+Right keys [1]: [cd_demo_sk#11]
 Join condition: None
 
 (17) Project [codegen id : 4]
-Output [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, cd_demo_sk#13]
+Output [4]: [cs_ship_date_sk#1, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
+Input [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, cd_demo_sk#11]
 
 (18) Scan parquet default.date_dim
-Output [2]: [d_date_sk#16, d_date#17]
+Output [2]: [d_date_sk#14, d_date#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (19) ColumnarToRow [codegen id : 3]
-Input [2]: [d_date_sk#16, d_date#17]
+Input [2]: [d_date_sk#14, d_date#15]
 
 (20) Filter [codegen id : 3]
-Input [2]: [d_date_sk#16, d_date#17]
-Condition : (isnotnull(d_date#17) AND isnotnull(d_date_sk#16))
+Input [2]: [d_date_sk#14, d_date#15]
+Condition : (isnotnull(d_date#15) AND isnotnull(d_date_sk#14))
 
 (21) BroadcastExchange
-Input [2]: [d_date_sk#16, d_date#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Input [2]: [d_date_sk#14, d_date#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_ship_date_sk#1]
-Right keys [1]: [d_date_sk#16]
+Right keys [1]: [d_date_sk#14]
 Join condition: None
 
 (23) Project [codegen id : 4]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
-Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date_sk#16, d_date#17]
+Output [4]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15]
+Input [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date_sk#14, d_date#15]
 
 (24) Exchange
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
-Arguments: hashpartitioning(cs_item_sk#4, 5), ENSURE_REQUIREMENTS, [id=#19]
+Input [4]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15]
+Arguments: hashpartitioning(cs_item_sk#4, 5), ENSURE_REQUIREMENTS, [id=#17]
 
 (25) Sort [codegen id : 5]
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
+Input [4]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15]
 Arguments: [cs_item_sk#4 ASC NULLS FIRST], false, 0
 
 (26) Scan parquet default.item
-Output [2]: [i_item_sk#20, i_item_desc#21]
+Output [2]: [i_item_sk#18, i_item_desc#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string>
 
 (27) ColumnarToRow [codegen id : 6]
-Input [2]: [i_item_sk#20, i_item_desc#21]
+Input [2]: [i_item_sk#18, i_item_desc#19]
 
 (28) Filter [codegen id : 6]
-Input [2]: [i_item_sk#20, i_item_desc#21]
-Condition : isnotnull(i_item_sk#20)
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Condition : isnotnull(i_item_sk#18)
 
 (29) Exchange
-Input [2]: [i_item_sk#20, i_item_desc#21]
-Arguments: hashpartitioning(i_item_sk#20, 5), ENSURE_REQUIREMENTS, [id=#22]
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Arguments: hashpartitioning(i_item_sk#18, 5), ENSURE_REQUIREMENTS, [id=#20]
 
 (30) Sort [codegen id : 7]
-Input [2]: [i_item_sk#20, i_item_desc#21]
-Arguments: [i_item_sk#20 ASC NULLS FIRST], false, 0
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Arguments: [i_item_sk#18 ASC NULLS FIRST], false, 0
 
 (31) SortMergeJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
-Right keys [1]: [i_item_sk#20]
+Right keys [1]: [i_item_sk#18]
 Join condition: None
 
 (32) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_desc#21]
-Input [8]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_sk#20, i_item_desc#21]
+Output [5]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15, i_item_desc#19]
+Input [6]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15, i_item_sk#18, i_item_desc#19]
 
-(33) ReusedExchange [Reuses operator id: 81]
-Output [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26]
+(33) ReusedExchange [Reuses operator id: 65]
+Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#24]
 
 (34) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_sold_date_sk#8]
-Right keys [1]: [d_date_sk#23]
-Join condition: (d_date#17 > date_add(d_date#24, 5))
+Left keys [1]: [cs_sold_date_sk#6]
+Right keys [1]: [d_date_sk#21]
+Join condition: (d_date#15 > date_add(d_date#22, 5))
 
 (35) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#21, d_week_seq#25, d_date_sk#26]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_desc#21, d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26]
+Output [5]: [cs_item_sk#4, cs_quantity#5, i_item_desc#19, d_week_seq#23, d_date_sk#24]
+Input [9]: [cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, d_date#15, i_item_desc#19, d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#24]
 
 (36) Exchange
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#21, d_week_seq#25, d_date_sk#26]
-Arguments: hashpartitioning(cs_item_sk#4, d_date_sk#26, 5), ENSURE_REQUIREMENTS, [id=#27]
+Input [5]: [cs_item_sk#4, cs_quantity#5, i_item_desc#19, d_week_seq#23, d_date_sk#24]
+Arguments: hashpartitioning(cs_item_sk#4, d_date_sk#24, 5), ENSURE_REQUIREMENTS, [id=#25]
 
 (37) Sort [codegen id : 11]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#21, d_week_seq#25, d_date_sk#26]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, d_date_sk#26 ASC NULLS FIRST], false, 0
+Input [5]: [cs_item_sk#4, cs_quantity#5, i_item_desc#19, d_week_seq#23, d_date_sk#24]
+Arguments: [cs_item_sk#4 ASC NULLS FIRST, d_date_sk#24 ASC NULLS FIRST], false, 0
 
 (38) Scan parquet default.inventory
-Output [4]: [inv_item_sk#28, inv_warehouse_sk#29, inv_quantity_on_hand#30, inv_date_sk#31]
+Output [4]: [inv_item_sk#26, inv_warehouse_sk#27, inv_quantity_on_hand#28, inv_date_sk#29]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(inv_date_sk#31), dynamicpruningexpression(true)]
+PartitionFilters: [isnotnull(inv_date_sk#29), dynamicpruningexpression(true)]
 PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
 (39) ColumnarToRow [codegen id : 13]
-Input [4]: [inv_item_sk#28, inv_warehouse_sk#29, inv_quantity_on_hand#30, inv_date_sk#31]
+Input [4]: [inv_item_sk#26, inv_warehouse_sk#27, inv_quantity_on_hand#28, inv_date_sk#29]
 
 (40) Filter [codegen id : 13]
-Input [4]: [inv_item_sk#28, inv_warehouse_sk#29, inv_quantity_on_hand#30, inv_date_sk#31]
-Condition : ((isnotnull(inv_quantity_on_hand#30) AND isnotnull(inv_item_sk#28)) AND isnotnull(inv_warehouse_sk#29))
+Input [4]: [inv_item_sk#26, inv_warehouse_sk#27, inv_quantity_on_hand#28, inv_date_sk#29]
+Condition : ((isnotnull(inv_quantity_on_hand#28) AND isnotnull(inv_item_sk#26)) AND isnotnull(inv_warehouse_sk#27))
 
 (41) Scan parquet default.warehouse
-Output [2]: [w_warehouse_sk#32, w_warehouse_name#33]
+Output [2]: [w_warehouse_sk#30, w_warehouse_name#31]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
 (42) ColumnarToRow [codegen id : 12]
-Input [2]: [w_warehouse_sk#32, w_warehouse_name#33]
+Input [2]: [w_warehouse_sk#30, w_warehouse_name#31]
 
 (43) Filter [codegen id : 12]
-Input [2]: [w_warehouse_sk#32, w_warehouse_name#33]
-Condition : isnotnull(w_warehouse_sk#32)
+Input [2]: [w_warehouse_sk#30, w_warehouse_name#31]
+Condition : isnotnull(w_warehouse_sk#30)
 
 (44) BroadcastExchange
-Input [2]: [w_warehouse_sk#32, w_warehouse_name#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#34]
+Input [2]: [w_warehouse_sk#30, w_warehouse_name#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#32]
 
 (45) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [inv_warehouse_sk#29]
-Right keys [1]: [w_warehouse_sk#32]
+Left keys [1]: [inv_warehouse_sk#27]
+Right keys [1]: [w_warehouse_sk#30]
 Join condition: None
 
 (46) Project [codegen id : 13]
-Output [4]: [inv_item_sk#28, inv_quantity_on_hand#30, inv_date_sk#31, w_warehouse_name#33]
-Input [6]: [inv_item_sk#28, inv_warehouse_sk#29, inv_quantity_on_hand#30, inv_date_sk#31, w_warehouse_sk#32, w_warehouse_name#33]
+Output [4]: [inv_item_sk#26, inv_quantity_on_hand#28, inv_date_sk#29, w_warehouse_name#31]
+Input [6]: [inv_item_sk#26, inv_warehouse_sk#27, inv_quantity_on_hand#28, inv_date_sk#29, w_warehouse_sk#30, w_warehouse_name#31]
 
 (47) Exchange
-Input [4]: [inv_item_sk#28, inv_quantity_on_hand#30, inv_date_sk#31, w_warehouse_name#33]
-Arguments: hashpartitioning(inv_item_sk#28, inv_date_sk#31, 5), ENSURE_REQUIREMENTS, [id=#35]
+Input [4]: [inv_item_sk#26, inv_quantity_on_hand#28, inv_date_sk#29, w_warehouse_name#31]
+Arguments: hashpartitioning(inv_item_sk#26, inv_date_sk#29, 5), ENSURE_REQUIREMENTS, [id=#33]
 
 (48) Sort [codegen id : 14]
-Input [4]: [inv_item_sk#28, inv_quantity_on_hand#30, inv_date_sk#31, w_warehouse_name#33]
-Arguments: [inv_item_sk#28 ASC NULLS FIRST, inv_date_sk#31 ASC NULLS FIRST], false, 0
+Input [4]: [inv_item_sk#26, inv_quantity_on_hand#28, inv_date_sk#29, w_warehouse_name#31]
+Arguments: [inv_item_sk#26 ASC NULLS FIRST, inv_date_sk#29 ASC NULLS FIRST], false, 0
 
-(49) SortMergeJoin [codegen id : 16]
-Left keys [2]: [cs_item_sk#4, d_date_sk#26]
-Right keys [2]: [inv_item_sk#28, inv_date_sk#31]
-Join condition: (inv_quantity_on_hand#30 < cs_quantity#7)
+(49) SortMergeJoin [codegen id : 15]
+Left keys [2]: [cs_item_sk#4, d_date_sk#24]
+Right keys [2]: [inv_item_sk#26, inv_date_sk#29]
+Join condition: (inv_quantity_on_hand#28 < cs_quantity#5)
 
-(50) Project [codegen id : 16]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#21, d_week_seq#25, d_date_sk#26, inv_item_sk#28, inv_quantity_on_hand#30, inv_date_sk#31, w_warehouse_name#33]
+(50) Project [codegen id : 15]
+Output [3]: [w_warehouse_name#31, i_item_desc#19, d_week_seq#23]
+Input [9]: [cs_item_sk#4, cs_quantity#5, i_item_desc#19, d_week_seq#23, d_date_sk#24, inv_item_sk#26, inv_quantity_on_hand#28, inv_date_sk#29, w_warehouse_name#31]
 
-(51) Scan parquet default.promotion
-Output [1]: [p_promo_sk#36]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/promotion]
-PushedFilters: [IsNotNull(p_promo_sk)]
-ReadSchema: struct<p_promo_sk:int>
-
-(52) ColumnarToRow [codegen id : 15]
-Input [1]: [p_promo_sk#36]
-
-(53) Filter [codegen id : 15]
-Input [1]: [p_promo_sk#36]
-Condition : isnotnull(p_promo_sk#36)
-
-(54) BroadcastExchange
-Input [1]: [p_promo_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#37]
-
-(55) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [cs_promo_sk#5]
-Right keys [1]: [p_promo_sk#36]
-Join condition: None
-
-(56) Project [codegen id : 16]
-Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25, p_promo_sk#36]
-
-(57) Exchange
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [id=#38]
-
-(58) Sort [codegen id : 17]
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, cs_order_number#6 ASC NULLS FIRST], false, 0
-
-(59) Scan parquet default.catalog_returns
-Output [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/catalog_returns]
-PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
-ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
-
-(60) ColumnarToRow [codegen id : 18]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-
-(61) Filter [codegen id : 18]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-Condition : (isnotnull(cr_item_sk#39) AND isnotnull(cr_order_number#40))
-
-(62) Project [codegen id : 18]
-Output [2]: [cr_item_sk#39, cr_order_number#40]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-
-(63) Exchange
-Input [2]: [cr_item_sk#39, cr_order_number#40]
-Arguments: hashpartitioning(cr_item_sk#39, cr_order_number#40, 5), ENSURE_REQUIREMENTS, [id=#42]
-
-(64) Sort [codegen id : 19]
-Input [2]: [cr_item_sk#39, cr_order_number#40]
-Arguments: [cr_item_sk#39 ASC NULLS FIRST, cr_order_number#40 ASC NULLS FIRST], false, 0
-
-(65) SortMergeJoin [codegen id : 20]
-Left keys [2]: [cs_item_sk#4, cs_order_number#6]
-Right keys [2]: [cr_item_sk#39, cr_order_number#40]
-Join condition: None
-
-(66) Project [codegen id : 20]
-Output [3]: [w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#33, i_item_desc#21, d_week_seq#25, cr_item_sk#39, cr_order_number#40]
-
-(67) HashAggregate [codegen id : 20]
-Input [3]: [w_warehouse_name#33, i_item_desc#21, d_week_seq#25]
-Keys [3]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25]
+(51) HashAggregate [codegen id : 15]
+Input [3]: [w_warehouse_name#31, i_item_desc#19, d_week_seq#23]
+Keys [3]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#43]
-Results [4]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, count#44]
+Aggregate Attributes [1]: [count#34]
+Results [4]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, count#35]
 
-(68) Exchange
-Input [4]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, count#44]
-Arguments: hashpartitioning(i_item_desc#21, w_warehouse_name#33, d_week_seq#25, 5), ENSURE_REQUIREMENTS, [id=#45]
+(52) Exchange
+Input [4]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, count#35]
+Arguments: hashpartitioning(i_item_desc#19, w_warehouse_name#31, d_week_seq#23, 5), ENSURE_REQUIREMENTS, [id=#36]
 
-(69) HashAggregate [codegen id : 21]
-Input [4]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, count#44]
-Keys [3]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25]
+(53) HashAggregate [codegen id : 16]
+Input [4]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, count#35]
+Keys [3]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#46]
-Results [6]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, count(1)#46 AS no_promo#47, count(1)#46 AS promo#48, count(1)#46 AS total_cnt#49]
+Aggregate Attributes [1]: [count(1)#37]
+Results [6]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, count(1)#37 AS no_promo#38, count(1)#37 AS promo#39, count(1)#37 AS total_cnt#40]
 
-(70) TakeOrderedAndProject
-Input [6]: [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, no_promo#47, promo#48, total_cnt#49]
-Arguments: 100, [total_cnt#49 DESC NULLS LAST, i_item_desc#21 ASC NULLS FIRST, w_warehouse_name#33 ASC NULLS FIRST, d_week_seq#25 ASC NULLS FIRST], [i_item_desc#21, w_warehouse_name#33, d_week_seq#25, no_promo#47, promo#48, total_cnt#49]
+(54) TakeOrderedAndProject
+Input [6]: [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, no_promo#38, promo#39, total_cnt#40]
+Arguments: 100, [total_cnt#40 DESC NULLS LAST, i_item_desc#19 ASC NULLS FIRST, w_warehouse_name#31 ASC NULLS FIRST, d_week_seq#23 ASC NULLS FIRST], [i_item_desc#19, w_warehouse_name#31, d_week_seq#23, no_promo#38, promo#39, total_cnt#40]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (81)
-+- * Project (80)
-   +- * BroadcastHashJoin Inner BuildLeft (79)
-      :- BroadcastExchange (75)
-      :  +- * Project (74)
-      :     +- * Filter (73)
-      :        +- * ColumnarToRow (72)
-      :           +- Scan parquet default.date_dim (71)
-      +- * Filter (78)
-         +- * ColumnarToRow (77)
-            +- Scan parquet default.date_dim (76)
+Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#6 IN dynamicpruning#7
+BroadcastExchange (65)
++- * Project (64)
+   +- * BroadcastHashJoin Inner BuildLeft (63)
+      :- BroadcastExchange (59)
+      :  +- * Project (58)
+      :     +- * Filter (57)
+      :        +- * ColumnarToRow (56)
+      :           +- Scan parquet default.date_dim (55)
+      +- * Filter (62)
+         +- * ColumnarToRow (61)
+            +- Scan parquet default.date_dim (60)
 
 
-(71) Scan parquet default.date_dim
-Output [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_year#50]
+(55) Scan parquet default.date_dim
+Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk), IsNotNull(d_week_seq), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_week_seq:int,d_year:int>
 
-(72) ColumnarToRow [codegen id : 1]
-Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_year#50]
+(56) ColumnarToRow [codegen id : 1]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#41]
 
-(73) Filter [codegen id : 1]
-Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_year#50]
-Condition : ((((isnotnull(d_year#50) AND (d_year#50 = 2001)) AND isnotnull(d_date_sk#23)) AND isnotnull(d_week_seq#25)) AND isnotnull(d_date#24))
+(57) Filter [codegen id : 1]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#41]
+Condition : ((((isnotnull(d_year#41) AND (d_year#41 = 2001)) AND isnotnull(d_date_sk#21)) AND isnotnull(d_week_seq#23)) AND isnotnull(d_date#22))
 
-(74) Project [codegen id : 1]
-Output [3]: [d_date_sk#23, d_date#24, d_week_seq#25]
-Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_year#50]
+(58) Project [codegen id : 1]
+Output [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#41]
 
-(75) BroadcastExchange
-Input [3]: [d_date_sk#23, d_date#24, d_week_seq#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#51]
+(59) BroadcastExchange
+Input [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#42]
 
-(76) Scan parquet default.date_dim
-Output [2]: [d_date_sk#26, d_week_seq#52]
+(60) Scan parquet default.date_dim
+Output [2]: [d_date_sk#24, d_week_seq#43]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(77) ColumnarToRow
-Input [2]: [d_date_sk#26, d_week_seq#52]
+(61) ColumnarToRow
+Input [2]: [d_date_sk#24, d_week_seq#43]
 
-(78) Filter
-Input [2]: [d_date_sk#26, d_week_seq#52]
-Condition : (isnotnull(d_week_seq#52) AND isnotnull(d_date_sk#26))
+(62) Filter
+Input [2]: [d_date_sk#24, d_week_seq#43]
+Condition : (isnotnull(d_week_seq#43) AND isnotnull(d_date_sk#24))
 
-(79) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [d_week_seq#25]
-Right keys [1]: [d_week_seq#52]
+(63) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [d_week_seq#23]
+Right keys [1]: [d_week_seq#43]
 Join condition: None
 
-(80) Project [codegen id : 2]
-Output [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26]
-Input [5]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26, d_week_seq#52]
+(64) Project [codegen id : 2]
+Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#24]
+Input [5]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#24, d_week_seq#43]
 
-(81) BroadcastExchange
-Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#53]
+(65) BroadcastExchange
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#44]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/simplified.txt
@@ -1,134 +1,106 @@
 TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_promo,promo]
-  WholeStageCodegen (21)
+  WholeStageCodegen (16)
     HashAggregate [i_item_desc,w_warehouse_name,d_week_seq,count] [count(1),no_promo,promo,total_cnt,count]
       InputAdapter
         Exchange [i_item_desc,w_warehouse_name,d_week_seq] #1
-          WholeStageCodegen (20)
+          WholeStageCodegen (15)
             HashAggregate [i_item_desc,w_warehouse_name,d_week_seq] [count,count]
               Project [w_warehouse_name,i_item_desc,d_week_seq]
-                SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
+                SortMergeJoin [cs_item_sk,d_date_sk,inv_item_sk,inv_date_sk,inv_quantity_on_hand,cs_quantity]
                   InputAdapter
-                    WholeStageCodegen (17)
-                      Sort [cs_item_sk,cs_order_number]
+                    WholeStageCodegen (11)
+                      Sort [cs_item_sk,d_date_sk]
                         InputAdapter
-                          Exchange [cs_item_sk,cs_order_number] #2
-                            WholeStageCodegen (16)
-                              Project [cs_item_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
-                                BroadcastHashJoin [cs_promo_sk,p_promo_sk]
-                                  Project [cs_item_sk,cs_promo_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
-                                    SortMergeJoin [cs_item_sk,d_date_sk,inv_item_sk,inv_date_sk,inv_quantity_on_hand,cs_quantity]
+                          Exchange [cs_item_sk,d_date_sk] #2
+                            WholeStageCodegen (10)
+                              Project [cs_item_sk,cs_quantity,i_item_desc,d_week_seq,d_date_sk]
+                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk,d_date,d_date]
+                                  Project [cs_item_sk,cs_quantity,cs_sold_date_sk,d_date,i_item_desc]
+                                    SortMergeJoin [cs_item_sk,i_item_sk]
                                       InputAdapter
-                                        WholeStageCodegen (11)
-                                          Sort [cs_item_sk,d_date_sk]
+                                        WholeStageCodegen (5)
+                                          Sort [cs_item_sk]
                                             InputAdapter
-                                              Exchange [cs_item_sk,d_date_sk] #3
-                                                WholeStageCodegen (10)
-                                                  Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,i_item_desc,d_week_seq,d_date_sk]
-                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk,d_date,d_date]
-                                                      Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk,d_date,i_item_desc]
-                                                        SortMergeJoin [cs_item_sk,i_item_sk]
-                                                          InputAdapter
-                                                            WholeStageCodegen (5)
-                                                              Sort [cs_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [cs_item_sk] #4
-                                                                    WholeStageCodegen (4)
-                                                                      Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk,d_date]
-                                                                        BroadcastHashJoin [cs_ship_date_sk,d_date_sk]
-                                                                          Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
-                                                                            BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
-                                                                              Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
-                                                                                BroadcastHashJoin [cs_bill_hdemo_sk,hd_demo_sk]
-                                                                                  Filter [cs_quantity,cs_item_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_ship_date_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
-                                                                                          SubqueryBroadcast [d_date_sk] #1
-                                                                                            BroadcastExchange #5
-                                                                                              WholeStageCodegen (2)
-                                                                                                Project [d_date_sk,d_date,d_week_seq,d_date_sk]
-                                                                                                  BroadcastHashJoin [d_week_seq,d_week_seq]
-                                                                                                    InputAdapter
-                                                                                                      BroadcastExchange #6
-                                                                                                        WholeStageCodegen (1)
-                                                                                                          Project [d_date_sk,d_date,d_week_seq]
-                                                                                                            Filter [d_year,d_date_sk,d_week_seq,d_date]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
-                                                                                                    Filter [d_week_seq,d_date_sk]
-                                                                                                      ColumnarToRow
-                                                                                                        InputAdapter
-                                                                                                          Scan parquet default.date_dim [d_date_sk,d_week_seq]
-                                                                                  InputAdapter
-                                                                                    BroadcastExchange #7
-                                                                                      WholeStageCodegen (1)
-                                                                                        Project [hd_demo_sk]
-                                                                                          Filter [hd_buy_potential,hd_demo_sk]
-                                                                                            ColumnarToRow
-                                                                                              InputAdapter
-                                                                                                Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential]
-                                                                              InputAdapter
-                                                                                BroadcastExchange #8
-                                                                                  WholeStageCodegen (2)
-                                                                                    Project [cd_demo_sk]
-                                                                                      Filter [cd_marital_status,cd_demo_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.customer_demographics [cd_demo_sk,cd_marital_status]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #9
-                                                                              WholeStageCodegen (3)
-                                                                                Filter [d_date,d_date_sk]
+                                              Exchange [cs_item_sk] #3
+                                                WholeStageCodegen (4)
+                                                  Project [cs_item_sk,cs_quantity,cs_sold_date_sk,d_date]
+                                                    BroadcastHashJoin [cs_ship_date_sk,d_date_sk]
+                                                      Project [cs_ship_date_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
+                                                        BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                                          Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
+                                                            BroadcastHashJoin [cs_bill_hdemo_sk,hd_demo_sk]
+                                                              Filter [cs_quantity,cs_item_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_ship_date_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
+                                                                      SubqueryBroadcast [d_date_sk] #1
+                                                                        BroadcastExchange #4
+                                                                          WholeStageCodegen (2)
+                                                                            Project [d_date_sk,d_date,d_week_seq,d_date_sk]
+                                                                              BroadcastHashJoin [d_week_seq,d_week_seq]
+                                                                                InputAdapter
+                                                                                  BroadcastExchange #5
+                                                                                    WholeStageCodegen (1)
+                                                                                      Project [d_date_sk,d_date,d_week_seq]
+                                                                                        Filter [d_year,d_date_sk,d_week_seq,d_date]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
+                                                                                Filter [d_week_seq,d_date_sk]
                                                                                   ColumnarToRow
                                                                                     InputAdapter
-                                                                                      Scan parquet default.date_dim [d_date_sk,d_date]
-                                                          InputAdapter
-                                                            WholeStageCodegen (7)
-                                                              Sort [i_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [i_item_sk] #10
-                                                                    WholeStageCodegen (6)
-                                                                      Filter [i_item_sk]
+                                                                                      Scan parquet default.date_dim [d_date_sk,d_week_seq]
+                                                              InputAdapter
+                                                                BroadcastExchange #6
+                                                                  WholeStageCodegen (1)
+                                                                    Project [hd_demo_sk]
+                                                                      Filter [hd_buy_potential,hd_demo_sk]
                                                                         ColumnarToRow
                                                                           InputAdapter
-                                                                            Scan parquet default.item [i_item_sk,i_item_desc]
-                                                      InputAdapter
-                                                        ReusedExchange [d_date_sk,d_date,d_week_seq,d_date_sk] #5
-                                      InputAdapter
-                                        WholeStageCodegen (14)
-                                          Sort [inv_item_sk,inv_date_sk]
-                                            InputAdapter
-                                              Exchange [inv_item_sk,inv_date_sk] #11
-                                                WholeStageCodegen (13)
-                                                  Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
-                                                    BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
-                                                      Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
-                                                        ColumnarToRow
+                                                                            Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential]
                                                           InputAdapter
-                                                            Scan parquet default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
+                                                            BroadcastExchange #7
+                                                              WholeStageCodegen (2)
+                                                                Project [cd_demo_sk]
+                                                                  Filter [cd_marital_status,cd_demo_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.customer_demographics [cd_demo_sk,cd_marital_status]
                                                       InputAdapter
-                                                        BroadcastExchange #12
-                                                          WholeStageCodegen (12)
-                                                            Filter [w_warehouse_sk]
+                                                        BroadcastExchange #8
+                                                          WholeStageCodegen (3)
+                                                            Filter [d_date,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
-                                                                  Scan parquet default.warehouse [w_warehouse_sk,w_warehouse_name]
+                                                                  Scan parquet default.date_dim [d_date_sk,d_date]
+                                      InputAdapter
+                                        WholeStageCodegen (7)
+                                          Sort [i_item_sk]
+                                            InputAdapter
+                                              Exchange [i_item_sk] #9
+                                                WholeStageCodegen (6)
+                                                  Filter [i_item_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet default.item [i_item_sk,i_item_desc]
                                   InputAdapter
-                                    BroadcastExchange #13
-                                      WholeStageCodegen (15)
-                                        Filter [p_promo_sk]
+                                    ReusedExchange [d_date_sk,d_date,d_week_seq,d_date_sk] #4
+                  InputAdapter
+                    WholeStageCodegen (14)
+                      Sort [inv_item_sk,inv_date_sk]
+                        InputAdapter
+                          Exchange [inv_item_sk,inv_date_sk] #10
+                            WholeStageCodegen (13)
+                              Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
+                                BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
+                                  Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
+                                  InputAdapter
+                                    BroadcastExchange #11
+                                      WholeStageCodegen (12)
+                                        Filter [w_warehouse_sk]
                                           ColumnarToRow
                                             InputAdapter
-                                              Scan parquet default.promotion [p_promo_sk]
-                  InputAdapter
-                    WholeStageCodegen (19)
-                      Sort [cr_item_sk,cr_order_number]
-                        InputAdapter
-                          Exchange [cr_item_sk,cr_order_number] #14
-                            WholeStageCodegen (18)
-                              Project [cr_item_sk,cr_order_number]
-                                Filter [cr_item_sk,cr_order_number]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_returned_date_sk]
+                                              Scan parquet default.warehouse [w_warehouse_sk,w_warehouse_name]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/explain.txt
@@ -1,423 +1,337 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * HashAggregate (69)
-   +- Exchange (68)
-      +- * HashAggregate (67)
-         +- * Project (66)
-            +- * SortMergeJoin LeftOuter (65)
-               :- * Sort (58)
-               :  +- Exchange (57)
-               :     +- * Project (56)
-               :        +- * BroadcastHashJoin LeftOuter BuildRight (55)
-               :           :- * Project (50)
-               :           :  +- * BroadcastHashJoin Inner BuildRight (49)
-               :           :     :- * Project (44)
-               :           :     :  +- * BroadcastHashJoin Inner BuildRight (43)
-               :           :     :     :- * Project (38)
-               :           :     :     :  +- * BroadcastHashJoin Inner BuildRight (37)
-               :           :     :     :     :- * Project (35)
-               :           :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (34)
-               :           :     :     :     :     :- * Project (28)
-               :           :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (27)
-               :           :     :     :     :     :     :- * Project (21)
-               :           :     :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (20)
-               :           :     :     :     :     :     :     :- * Project (15)
-               :           :     :     :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (14)
-               :           :     :     :     :     :     :     :     :- * Project (9)
-               :           :     :     :     :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (8)
-               :           :     :     :     :     :     :     :     :     :- * Filter (3)
-               :           :     :     :     :     :     :     :     :     :  +- * ColumnarToRow (2)
-               :           :     :     :     :     :     :     :     :     :     +- Scan parquet default.catalog_sales (1)
-               :           :     :     :     :     :     :     :     :     +- BroadcastExchange (7)
-               :           :     :     :     :     :     :     :     :        +- * Filter (6)
-               :           :     :     :     :     :     :     :     :           +- * ColumnarToRow (5)
-               :           :     :     :     :     :     :     :     :              +- Scan parquet default.inventory (4)
-               :           :     :     :     :     :     :     :     +- BroadcastExchange (13)
-               :           :     :     :     :     :     :     :        +- * Filter (12)
-               :           :     :     :     :     :     :     :           +- * ColumnarToRow (11)
-               :           :     :     :     :     :     :     :              +- Scan parquet default.warehouse (10)
-               :           :     :     :     :     :     :     +- BroadcastExchange (19)
-               :           :     :     :     :     :     :        +- * Filter (18)
-               :           :     :     :     :     :     :           +- * ColumnarToRow (17)
-               :           :     :     :     :     :     :              +- Scan parquet default.item (16)
-               :           :     :     :     :     :     +- BroadcastExchange (26)
-               :           :     :     :     :     :        +- * Project (25)
-               :           :     :     :     :     :           +- * Filter (24)
-               :           :     :     :     :     :              +- * ColumnarToRow (23)
-               :           :     :     :     :     :                 +- Scan parquet default.customer_demographics (22)
-               :           :     :     :     :     +- BroadcastExchange (33)
-               :           :     :     :     :        +- * Project (32)
-               :           :     :     :     :           +- * Filter (31)
-               :           :     :     :     :              +- * ColumnarToRow (30)
-               :           :     :     :     :                 +- Scan parquet default.household_demographics (29)
-               :           :     :     :     +- ReusedExchange (36)
-               :           :     :     +- BroadcastExchange (42)
-               :           :     :        +- * Filter (41)
-               :           :     :           +- * ColumnarToRow (40)
-               :           :     :              +- Scan parquet default.date_dim (39)
-               :           :     +- BroadcastExchange (48)
-               :           :        +- * Filter (47)
-               :           :           +- * ColumnarToRow (46)
-               :           :              +- Scan parquet default.date_dim (45)
-               :           +- BroadcastExchange (54)
-               :              +- * Filter (53)
-               :                 +- * ColumnarToRow (52)
-               :                    +- Scan parquet default.promotion (51)
-               +- * Sort (64)
-                  +- Exchange (63)
-                     +- * Project (62)
-                        +- * Filter (61)
-                           +- * ColumnarToRow (60)
-                              +- Scan parquet default.catalog_returns (59)
+TakeOrderedAndProject (54)
++- * HashAggregate (53)
+   +- Exchange (52)
+      +- * HashAggregate (51)
+         +- * Project (50)
+            +- * BroadcastHashJoin Inner BuildRight (49)
+               :- * Project (44)
+               :  +- * BroadcastHashJoin Inner BuildRight (43)
+               :     :- * Project (38)
+               :     :  +- * BroadcastHashJoin Inner BuildRight (37)
+               :     :     :- * Project (35)
+               :     :     :  +- * BroadcastHashJoin Inner BuildRight (34)
+               :     :     :     :- * Project (28)
+               :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (27)
+               :     :     :     :     :- * Project (21)
+               :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (20)
+               :     :     :     :     :     :- * Project (15)
+               :     :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (14)
+               :     :     :     :     :     :     :- * Project (9)
+               :     :     :     :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (8)
+               :     :     :     :     :     :     :     :- * Filter (3)
+               :     :     :     :     :     :     :     :  +- * ColumnarToRow (2)
+               :     :     :     :     :     :     :     :     +- Scan parquet default.catalog_sales (1)
+               :     :     :     :     :     :     :     +- BroadcastExchange (7)
+               :     :     :     :     :     :     :        +- * Filter (6)
+               :     :     :     :     :     :     :           +- * ColumnarToRow (5)
+               :     :     :     :     :     :     :              +- Scan parquet default.inventory (4)
+               :     :     :     :     :     :     +- BroadcastExchange (13)
+               :     :     :     :     :     :        +- * Filter (12)
+               :     :     :     :     :     :           +- * ColumnarToRow (11)
+               :     :     :     :     :     :              +- Scan parquet default.warehouse (10)
+               :     :     :     :     :     +- BroadcastExchange (19)
+               :     :     :     :     :        +- * Filter (18)
+               :     :     :     :     :           +- * ColumnarToRow (17)
+               :     :     :     :     :              +- Scan parquet default.item (16)
+               :     :     :     :     +- BroadcastExchange (26)
+               :     :     :     :        +- * Project (25)
+               :     :     :     :           +- * Filter (24)
+               :     :     :     :              +- * ColumnarToRow (23)
+               :     :     :     :                 +- Scan parquet default.customer_demographics (22)
+               :     :     :     +- BroadcastExchange (33)
+               :     :     :        +- * Project (32)
+               :     :     :           +- * Filter (31)
+               :     :     :              +- * ColumnarToRow (30)
+               :     :     :                 +- Scan parquet default.household_demographics (29)
+               :     :     +- ReusedExchange (36)
+               :     +- BroadcastExchange (42)
+               :        +- * Filter (41)
+               :           +- * ColumnarToRow (40)
+               :              +- Scan parquet default.date_dim (39)
+               +- BroadcastExchange (48)
+                  +- * Filter (47)
+                     +- * ColumnarToRow (46)
+                        +- Scan parquet default.date_dim (45)
 
 
 (1) Scan parquet default.catalog_sales
-Output [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
+Output [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#8), dynamicpruningexpression(cs_sold_date_sk#8 IN dynamicpruning#9)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#6), dynamicpruningexpression(cs_sold_date_sk#6 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(cs_quantity), IsNotNull(cs_item_sk), IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_hdemo_sk), IsNotNull(cs_ship_date_sk)]
-ReadSchema: struct<cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_quantity:int>
+ReadSchema: struct<cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_quantity:int>
 
-(2) ColumnarToRow [codegen id : 10]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
+(2) ColumnarToRow [codegen id : 9]
+Input [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
 
-(3) Filter [codegen id : 10]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Condition : ((((isnotnull(cs_quantity#7) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
+(3) Filter [codegen id : 9]
+Input [6]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6]
+Condition : ((((isnotnull(cs_quantity#5) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
 
 (4) Scan parquet default.inventory
-Output [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
+Output [4]: [inv_item_sk#8, inv_warehouse_sk#9, inv_quantity_on_hand#10, inv_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(inv_date_sk#13)]
+PartitionFilters: [isnotnull(inv_date_sk#11)]
 PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
+Input [4]: [inv_item_sk#8, inv_warehouse_sk#9, inv_quantity_on_hand#10, inv_date_sk#11]
 
 (6) Filter [codegen id : 1]
-Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
-Condition : ((isnotnull(inv_quantity_on_hand#12) AND isnotnull(inv_item_sk#10)) AND isnotnull(inv_warehouse_sk#11))
+Input [4]: [inv_item_sk#8, inv_warehouse_sk#9, inv_quantity_on_hand#10, inv_date_sk#11]
+Condition : ((isnotnull(inv_quantity_on_hand#10) AND isnotnull(inv_item_sk#8)) AND isnotnull(inv_warehouse_sk#9))
 
 (7) BroadcastExchange
-Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Input [4]: [inv_item_sk#8, inv_warehouse_sk#9, inv_quantity_on_hand#10, inv_date_sk#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
 
-(8) BroadcastHashJoin [codegen id : 10]
+(8) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_item_sk#4]
-Right keys [1]: [inv_item_sk#10]
-Join condition: (inv_quantity_on_hand#12 < cs_quantity#7)
+Right keys [1]: [inv_item_sk#8]
+Join condition: (inv_quantity_on_hand#10 < cs_quantity#5)
 
-(9) Project [codegen id : 10]
-Output [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_warehouse_sk#11, inv_date_sk#13]
-Input [12]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
+(9) Project [codegen id : 9]
+Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_sold_date_sk#6, inv_warehouse_sk#9, inv_date_sk#11]
+Input [10]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_quantity#5, cs_sold_date_sk#6, inv_item_sk#8, inv_warehouse_sk#9, inv_quantity_on_hand#10, inv_date_sk#11]
 
 (10) Scan parquet default.warehouse
-Output [2]: [w_warehouse_sk#15, w_warehouse_name#16]
+Output [2]: [w_warehouse_sk#13, w_warehouse_name#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
 (11) ColumnarToRow [codegen id : 2]
-Input [2]: [w_warehouse_sk#15, w_warehouse_name#16]
+Input [2]: [w_warehouse_sk#13, w_warehouse_name#14]
 
 (12) Filter [codegen id : 2]
-Input [2]: [w_warehouse_sk#15, w_warehouse_name#16]
-Condition : isnotnull(w_warehouse_sk#15)
+Input [2]: [w_warehouse_sk#13, w_warehouse_name#14]
+Condition : isnotnull(w_warehouse_sk#13)
 
 (13) BroadcastExchange
-Input [2]: [w_warehouse_sk#15, w_warehouse_name#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Input [2]: [w_warehouse_sk#13, w_warehouse_name#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
 
-(14) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [inv_warehouse_sk#11]
-Right keys [1]: [w_warehouse_sk#15]
+(14) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [inv_warehouse_sk#9]
+Right keys [1]: [w_warehouse_sk#13]
 Join condition: None
 
-(15) Project [codegen id : 10]
-Output [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16]
-Input [11]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_warehouse_sk#11, inv_date_sk#13, w_warehouse_sk#15, w_warehouse_name#16]
+(15) Project [codegen id : 9]
+Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14]
+Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_sold_date_sk#6, inv_warehouse_sk#9, inv_date_sk#11, w_warehouse_sk#13, w_warehouse_name#14]
 
 (16) Scan parquet default.item
-Output [2]: [i_item_sk#18, i_item_desc#19]
+Output [2]: [i_item_sk#16, i_item_desc#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string>
 
 (17) ColumnarToRow [codegen id : 3]
-Input [2]: [i_item_sk#18, i_item_desc#19]
+Input [2]: [i_item_sk#16, i_item_desc#17]
 
 (18) Filter [codegen id : 3]
-Input [2]: [i_item_sk#18, i_item_desc#19]
-Condition : isnotnull(i_item_sk#18)
+Input [2]: [i_item_sk#16, i_item_desc#17]
+Condition : isnotnull(i_item_sk#16)
 
 (19) BroadcastExchange
-Input [2]: [i_item_sk#18, i_item_desc#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
+Input [2]: [i_item_sk#16, i_item_desc#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
 
-(20) BroadcastHashJoin [codegen id : 10]
+(20) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_item_sk#4]
-Right keys [1]: [i_item_sk#18]
+Right keys [1]: [i_item_sk#16]
 Join condition: None
 
-(21) Project [codegen id : 10]
-Output [10]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19]
-Input [11]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_sk#18, i_item_desc#19]
+(21) Project [codegen id : 9]
+Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17]
+Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_sk#16, i_item_desc#17]
 
 (22) Scan parquet default.customer_demographics
-Output [2]: [cd_demo_sk#21, cd_marital_status#22]
+Output [2]: [cd_demo_sk#19, cd_marital_status#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_marital_status), EqualTo(cd_marital_status,M), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
 (23) ColumnarToRow [codegen id : 4]
-Input [2]: [cd_demo_sk#21, cd_marital_status#22]
+Input [2]: [cd_demo_sk#19, cd_marital_status#20]
 
 (24) Filter [codegen id : 4]
-Input [2]: [cd_demo_sk#21, cd_marital_status#22]
-Condition : ((isnotnull(cd_marital_status#22) AND (cd_marital_status#22 = M)) AND isnotnull(cd_demo_sk#21))
+Input [2]: [cd_demo_sk#19, cd_marital_status#20]
+Condition : ((isnotnull(cd_marital_status#20) AND (cd_marital_status#20 = M)) AND isnotnull(cd_demo_sk#19))
 
 (25) Project [codegen id : 4]
-Output [1]: [cd_demo_sk#21]
-Input [2]: [cd_demo_sk#21, cd_marital_status#22]
+Output [1]: [cd_demo_sk#19]
+Input [2]: [cd_demo_sk#19, cd_marital_status#20]
 
 (26) BroadcastExchange
-Input [1]: [cd_demo_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Input [1]: [cd_demo_sk#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
 
-(27) BroadcastHashJoin [codegen id : 10]
+(27) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#21]
+Right keys [1]: [cd_demo_sk#19]
 Join condition: None
 
-(28) Project [codegen id : 10]
-Output [9]: [cs_ship_date_sk#1, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19]
-Input [11]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19, cd_demo_sk#21]
+(28) Project [codegen id : 9]
+Output [6]: [cs_ship_date_sk#1, cs_bill_hdemo_sk#3, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17]
+Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17, cd_demo_sk#19]
 
 (29) Scan parquet default.household_demographics
-Output [2]: [hd_demo_sk#24, hd_buy_potential#25]
+Output [2]: [hd_demo_sk#22, hd_buy_potential#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_buy_potential), EqualTo(hd_buy_potential,1001-5000      ), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
 
 (30) ColumnarToRow [codegen id : 5]
-Input [2]: [hd_demo_sk#24, hd_buy_potential#25]
+Input [2]: [hd_demo_sk#22, hd_buy_potential#23]
 
 (31) Filter [codegen id : 5]
-Input [2]: [hd_demo_sk#24, hd_buy_potential#25]
-Condition : ((isnotnull(hd_buy_potential#25) AND (hd_buy_potential#25 = 1001-5000      )) AND isnotnull(hd_demo_sk#24))
+Input [2]: [hd_demo_sk#22, hd_buy_potential#23]
+Condition : ((isnotnull(hd_buy_potential#23) AND (hd_buy_potential#23 = 1001-5000      )) AND isnotnull(hd_demo_sk#22))
 
 (32) Project [codegen id : 5]
-Output [1]: [hd_demo_sk#24]
-Input [2]: [hd_demo_sk#24, hd_buy_potential#25]
+Output [1]: [hd_demo_sk#22]
+Input [2]: [hd_demo_sk#22, hd_buy_potential#23]
 
 (33) BroadcastExchange
-Input [1]: [hd_demo_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Input [1]: [hd_demo_sk#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#24]
 
-(34) BroadcastHashJoin [codegen id : 10]
+(34) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_bill_hdemo_sk#3]
-Right keys [1]: [hd_demo_sk#24]
+Right keys [1]: [hd_demo_sk#22]
 Join condition: None
 
-(35) Project [codegen id : 10]
-Output [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19]
-Input [10]: [cs_ship_date_sk#1, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19, hd_demo_sk#24]
+(35) Project [codegen id : 9]
+Output [5]: [cs_ship_date_sk#1, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17]
+Input [7]: [cs_ship_date_sk#1, cs_bill_hdemo_sk#3, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17, hd_demo_sk#22]
 
-(36) ReusedExchange [Reuses operator id: 75]
-Output [3]: [d_date_sk#27, d_date#28, d_week_seq#29]
+(36) ReusedExchange [Reuses operator id: 59]
+Output [3]: [d_date_sk#25, d_date#26, d_week_seq#27]
 
-(37) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_sold_date_sk#8]
-Right keys [1]: [d_date_sk#27]
+(37) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_sold_date_sk#6]
+Right keys [1]: [d_date_sk#25]
 Join condition: None
 
-(38) Project [codegen id : 10]
-Output [9]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19, d_date#28, d_week_seq#29]
-Input [11]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19, d_date_sk#27, d_date#28, d_week_seq#29]
+(38) Project [codegen id : 9]
+Output [6]: [cs_ship_date_sk#1, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17, d_date#26, d_week_seq#27]
+Input [8]: [cs_ship_date_sk#1, cs_sold_date_sk#6, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17, d_date_sk#25, d_date#26, d_week_seq#27]
 
 (39) Scan parquet default.date_dim
-Output [2]: [d_date_sk#30, d_week_seq#31]
+Output [2]: [d_date_sk#28, d_week_seq#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (40) ColumnarToRow [codegen id : 7]
-Input [2]: [d_date_sk#30, d_week_seq#31]
+Input [2]: [d_date_sk#28, d_week_seq#29]
 
 (41) Filter [codegen id : 7]
-Input [2]: [d_date_sk#30, d_week_seq#31]
-Condition : (isnotnull(d_week_seq#31) AND isnotnull(d_date_sk#30))
+Input [2]: [d_date_sk#28, d_week_seq#29]
+Condition : (isnotnull(d_week_seq#29) AND isnotnull(d_date_sk#28))
 
 (42) BroadcastExchange
-Input [2]: [d_date_sk#30, d_week_seq#31]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, false] as bigint), 32) | (cast(input[0, int, false] as bigint) & 4294967295))),false), [id=#32]
+Input [2]: [d_date_sk#28, d_week_seq#29]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, false] as bigint), 32) | (cast(input[0, int, false] as bigint) & 4294967295))),false), [id=#30]
 
-(43) BroadcastHashJoin [codegen id : 10]
-Left keys [2]: [d_week_seq#29, inv_date_sk#13]
-Right keys [2]: [d_week_seq#31, d_date_sk#30]
+(43) BroadcastHashJoin [codegen id : 9]
+Left keys [2]: [d_week_seq#27, inv_date_sk#11]
+Right keys [2]: [d_week_seq#29, d_date_sk#28]
 Join condition: None
 
-(44) Project [codegen id : 10]
-Output [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_date#28, d_week_seq#29]
-Input [11]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, inv_date_sk#13, w_warehouse_name#16, i_item_desc#19, d_date#28, d_week_seq#29, d_date_sk#30, d_week_seq#31]
+(44) Project [codegen id : 9]
+Output [5]: [cs_ship_date_sk#1, w_warehouse_name#14, i_item_desc#17, d_date#26, d_week_seq#27]
+Input [8]: [cs_ship_date_sk#1, inv_date_sk#11, w_warehouse_name#14, i_item_desc#17, d_date#26, d_week_seq#27, d_date_sk#28, d_week_seq#29]
 
 (45) Scan parquet default.date_dim
-Output [2]: [d_date_sk#33, d_date#34]
+Output [2]: [d_date_sk#31, d_date#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (46) ColumnarToRow [codegen id : 8]
-Input [2]: [d_date_sk#33, d_date#34]
+Input [2]: [d_date_sk#31, d_date#32]
 
 (47) Filter [codegen id : 8]
-Input [2]: [d_date_sk#33, d_date#34]
-Condition : (isnotnull(d_date#34) AND isnotnull(d_date_sk#33))
+Input [2]: [d_date_sk#31, d_date#32]
+Condition : (isnotnull(d_date#32) AND isnotnull(d_date_sk#31))
 
 (48) BroadcastExchange
-Input [2]: [d_date_sk#33, d_date#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#35]
+Input [2]: [d_date_sk#31, d_date#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#33]
 
-(49) BroadcastHashJoin [codegen id : 10]
+(49) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_ship_date_sk#1]
-Right keys [1]: [d_date_sk#33]
-Join condition: (d_date#34 > date_add(d_date#28, 5))
+Right keys [1]: [d_date_sk#31]
+Join condition: (d_date#32 > date_add(d_date#26, 5))
 
-(50) Project [codegen id : 10]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Input [10]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_date#28, d_week_seq#29, d_date_sk#33, d_date#34]
+(50) Project [codegen id : 9]
+Output [3]: [w_warehouse_name#14, i_item_desc#17, d_week_seq#27]
+Input [7]: [cs_ship_date_sk#1, w_warehouse_name#14, i_item_desc#17, d_date#26, d_week_seq#27, d_date_sk#31, d_date#32]
 
-(51) Scan parquet default.promotion
-Output [1]: [p_promo_sk#36]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/promotion]
-PushedFilters: [IsNotNull(p_promo_sk)]
-ReadSchema: struct<p_promo_sk:int>
-
-(52) ColumnarToRow [codegen id : 9]
-Input [1]: [p_promo_sk#36]
-
-(53) Filter [codegen id : 9]
-Input [1]: [p_promo_sk#36]
-Condition : isnotnull(p_promo_sk#36)
-
-(54) BroadcastExchange
-Input [1]: [p_promo_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#37]
-
-(55) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_promo_sk#5]
-Right keys [1]: [p_promo_sk#36]
-Join condition: None
-
-(56) Project [codegen id : 10]
-Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29, p_promo_sk#36]
-
-(57) Exchange
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [id=#38]
-
-(58) Sort [codegen id : 11]
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, cs_order_number#6 ASC NULLS FIRST], false, 0
-
-(59) Scan parquet default.catalog_returns
-Output [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/catalog_returns]
-PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
-ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
-
-(60) ColumnarToRow [codegen id : 12]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-
-(61) Filter [codegen id : 12]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-Condition : (isnotnull(cr_item_sk#39) AND isnotnull(cr_order_number#40))
-
-(62) Project [codegen id : 12]
-Output [2]: [cr_item_sk#39, cr_order_number#40]
-Input [3]: [cr_item_sk#39, cr_order_number#40, cr_returned_date_sk#41]
-
-(63) Exchange
-Input [2]: [cr_item_sk#39, cr_order_number#40]
-Arguments: hashpartitioning(cr_item_sk#39, cr_order_number#40, 5), ENSURE_REQUIREMENTS, [id=#42]
-
-(64) Sort [codegen id : 13]
-Input [2]: [cr_item_sk#39, cr_order_number#40]
-Arguments: [cr_item_sk#39 ASC NULLS FIRST, cr_order_number#40 ASC NULLS FIRST], false, 0
-
-(65) SortMergeJoin [codegen id : 14]
-Left keys [2]: [cs_item_sk#4, cs_order_number#6]
-Right keys [2]: [cr_item_sk#39, cr_order_number#40]
-Join condition: None
-
-(66) Project [codegen id : 14]
-Output [3]: [w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#16, i_item_desc#19, d_week_seq#29, cr_item_sk#39, cr_order_number#40]
-
-(67) HashAggregate [codegen id : 14]
-Input [3]: [w_warehouse_name#16, i_item_desc#19, d_week_seq#29]
-Keys [3]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29]
+(51) HashAggregate [codegen id : 9]
+Input [3]: [w_warehouse_name#14, i_item_desc#17, d_week_seq#27]
+Keys [3]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#43]
-Results [4]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, count#44]
+Aggregate Attributes [1]: [count#34]
+Results [4]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, count#35]
 
-(68) Exchange
-Input [4]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, count#44]
-Arguments: hashpartitioning(i_item_desc#19, w_warehouse_name#16, d_week_seq#29, 5), ENSURE_REQUIREMENTS, [id=#45]
+(52) Exchange
+Input [4]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, count#35]
+Arguments: hashpartitioning(i_item_desc#17, w_warehouse_name#14, d_week_seq#27, 5), ENSURE_REQUIREMENTS, [id=#36]
 
-(69) HashAggregate [codegen id : 15]
-Input [4]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, count#44]
-Keys [3]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29]
+(53) HashAggregate [codegen id : 10]
+Input [4]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, count#35]
+Keys [3]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#46]
-Results [6]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, count(1)#46 AS no_promo#47, count(1)#46 AS promo#48, count(1)#46 AS total_cnt#49]
+Aggregate Attributes [1]: [count(1)#37]
+Results [6]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, count(1)#37 AS no_promo#38, count(1)#37 AS promo#39, count(1)#37 AS total_cnt#40]
 
-(70) TakeOrderedAndProject
-Input [6]: [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, no_promo#47, promo#48, total_cnt#49]
-Arguments: 100, [total_cnt#49 DESC NULLS LAST, i_item_desc#19 ASC NULLS FIRST, w_warehouse_name#16 ASC NULLS FIRST, d_week_seq#29 ASC NULLS FIRST], [i_item_desc#19, w_warehouse_name#16, d_week_seq#29, no_promo#47, promo#48, total_cnt#49]
+(54) TakeOrderedAndProject
+Input [6]: [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, no_promo#38, promo#39, total_cnt#40]
+Arguments: 100, [total_cnt#40 DESC NULLS LAST, i_item_desc#17 ASC NULLS FIRST, w_warehouse_name#14 ASC NULLS FIRST, d_week_seq#27 ASC NULLS FIRST], [i_item_desc#17, w_warehouse_name#14, d_week_seq#27, no_promo#38, promo#39, total_cnt#40]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (75)
-+- * Project (74)
-   +- * Filter (73)
-      +- * ColumnarToRow (72)
-         +- Scan parquet default.date_dim (71)
+Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#6 IN dynamicpruning#7
+BroadcastExchange (59)
++- * Project (58)
+   +- * Filter (57)
+      +- * ColumnarToRow (56)
+         +- Scan parquet default.date_dim (55)
 
 
-(71) Scan parquet default.date_dim
-Output [4]: [d_date_sk#27, d_date#28, d_week_seq#29, d_year#50]
+(55) Scan parquet default.date_dim
+Output [4]: [d_date_sk#25, d_date#26, d_week_seq#27, d_year#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk), IsNotNull(d_week_seq), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_week_seq:int,d_year:int>
 
-(72) ColumnarToRow [codegen id : 1]
-Input [4]: [d_date_sk#27, d_date#28, d_week_seq#29, d_year#50]
+(56) ColumnarToRow [codegen id : 1]
+Input [4]: [d_date_sk#25, d_date#26, d_week_seq#27, d_year#41]
 
-(73) Filter [codegen id : 1]
-Input [4]: [d_date_sk#27, d_date#28, d_week_seq#29, d_year#50]
-Condition : ((((isnotnull(d_year#50) AND (d_year#50 = 2001)) AND isnotnull(d_date_sk#27)) AND isnotnull(d_week_seq#29)) AND isnotnull(d_date#28))
+(57) Filter [codegen id : 1]
+Input [4]: [d_date_sk#25, d_date#26, d_week_seq#27, d_year#41]
+Condition : ((((isnotnull(d_year#41) AND (d_year#41 = 2001)) AND isnotnull(d_date_sk#25)) AND isnotnull(d_week_seq#27)) AND isnotnull(d_date#26))
 
-(74) Project [codegen id : 1]
-Output [3]: [d_date_sk#27, d_date#28, d_week_seq#29]
-Input [4]: [d_date_sk#27, d_date#28, d_week_seq#29, d_year#50]
+(58) Project [codegen id : 1]
+Output [3]: [d_date_sk#25, d_date#26, d_week_seq#27]
+Input [4]: [d_date_sk#25, d_date#26, d_week_seq#27, d_year#41]
 
-(75) BroadcastExchange
-Input [3]: [d_date_sk#27, d_date#28, d_week_seq#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#51]
+(59) BroadcastExchange
+Input [3]: [d_date_sk#25, d_date#26, d_week_seq#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/simplified.txt
@@ -1,116 +1,88 @@
 TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_promo,promo]
-  WholeStageCodegen (15)
+  WholeStageCodegen (10)
     HashAggregate [i_item_desc,w_warehouse_name,d_week_seq,count] [count(1),no_promo,promo,total_cnt,count]
       InputAdapter
         Exchange [i_item_desc,w_warehouse_name,d_week_seq] #1
-          WholeStageCodegen (14)
+          WholeStageCodegen (9)
             HashAggregate [i_item_desc,w_warehouse_name,d_week_seq] [count,count]
               Project [w_warehouse_name,i_item_desc,d_week_seq]
-                SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
-                  InputAdapter
-                    WholeStageCodegen (11)
-                      Sort [cs_item_sk,cs_order_number]
-                        InputAdapter
-                          Exchange [cs_item_sk,cs_order_number] #2
-                            WholeStageCodegen (10)
-                              Project [cs_item_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
-                                BroadcastHashJoin [cs_promo_sk,p_promo_sk]
-                                  Project [cs_item_sk,cs_promo_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
-                                    BroadcastHashJoin [cs_ship_date_sk,d_date_sk,d_date,d_date]
-                                      Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,w_warehouse_name,i_item_desc,d_date,d_week_seq]
-                                        BroadcastHashJoin [d_week_seq,inv_date_sk,d_week_seq,d_date_sk]
-                                          Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,inv_date_sk,w_warehouse_name,i_item_desc,d_date,d_week_seq]
-                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                              Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
-                                                BroadcastHashJoin [cs_bill_hdemo_sk,hd_demo_sk]
-                                                  Project [cs_ship_date_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
-                                                    BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
-                                                      Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
-                                                        BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                          Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,inv_date_sk,w_warehouse_name]
-                                                            BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
-                                                              Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,inv_warehouse_sk,inv_date_sk]
-                                                                BroadcastHashJoin [cs_item_sk,inv_item_sk,inv_quantity_on_hand,cs_quantity]
-                                                                  Filter [cs_quantity,cs_item_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_ship_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
-                                                                          SubqueryBroadcast [d_date_sk] #1
-                                                                            BroadcastExchange #3
-                                                                              WholeStageCodegen (1)
-                                                                                Project [d_date_sk,d_date,d_week_seq]
-                                                                                  Filter [d_year,d_date_sk,d_week_seq,d_date]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
-                                                                  InputAdapter
-                                                                    BroadcastExchange #4
-                                                                      WholeStageCodegen (1)
-                                                                        Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
-                                                              InputAdapter
-                                                                BroadcastExchange #5
-                                                                  WholeStageCodegen (2)
-                                                                    Filter [w_warehouse_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet default.warehouse [w_warehouse_sk,w_warehouse_name]
-                                                          InputAdapter
-                                                            BroadcastExchange #6
-                                                              WholeStageCodegen (3)
-                                                                Filter [i_item_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.item [i_item_sk,i_item_desc]
-                                                      InputAdapter
-                                                        BroadcastExchange #7
-                                                          WholeStageCodegen (4)
-                                                            Project [cd_demo_sk]
-                                                              Filter [cd_marital_status,cd_demo_sk]
+                BroadcastHashJoin [cs_ship_date_sk,d_date_sk,d_date,d_date]
+                  Project [cs_ship_date_sk,w_warehouse_name,i_item_desc,d_date,d_week_seq]
+                    BroadcastHashJoin [d_week_seq,inv_date_sk,d_week_seq,d_date_sk]
+                      Project [cs_ship_date_sk,inv_date_sk,w_warehouse_name,i_item_desc,d_date,d_week_seq]
+                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                          Project [cs_ship_date_sk,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
+                            BroadcastHashJoin [cs_bill_hdemo_sk,hd_demo_sk]
+                              Project [cs_ship_date_sk,cs_bill_hdemo_sk,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
+                                BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                  Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_sold_date_sk,inv_date_sk,w_warehouse_name,i_item_desc]
+                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                      Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_sold_date_sk,inv_date_sk,w_warehouse_name]
+                                        BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
+                                          Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_sold_date_sk,inv_warehouse_sk,inv_date_sk]
+                                            BroadcastHashJoin [cs_item_sk,inv_item_sk,inv_quantity_on_hand,cs_quantity]
+                                              Filter [cs_quantity,cs_item_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_ship_date_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
+                                                      SubqueryBroadcast [d_date_sk] #1
+                                                        BroadcastExchange #2
+                                                          WholeStageCodegen (1)
+                                                            Project [d_date_sk,d_date,d_week_seq]
+                                                              Filter [d_year,d_date_sk,d_week_seq,d_date]
                                                                 ColumnarToRow
                                                                   InputAdapter
-                                                                    Scan parquet default.customer_demographics [cd_demo_sk,cd_marital_status]
-                                                  InputAdapter
-                                                    BroadcastExchange #8
-                                                      WholeStageCodegen (5)
-                                                        Project [hd_demo_sk]
-                                                          Filter [hd_buy_potential,hd_demo_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential]
+                                                                    Scan parquet default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
                                               InputAdapter
-                                                ReusedExchange [d_date_sk,d_date,d_week_seq] #3
+                                                BroadcastExchange #3
+                                                  WholeStageCodegen (1)
+                                                    Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
                                           InputAdapter
-                                            BroadcastExchange #9
-                                              WholeStageCodegen (7)
-                                                Filter [d_week_seq,d_date_sk]
+                                            BroadcastExchange #4
+                                              WholeStageCodegen (2)
+                                                Filter [w_warehouse_sk]
                                                   ColumnarToRow
                                                     InputAdapter
-                                                      Scan parquet default.date_dim [d_date_sk,d_week_seq]
+                                                      Scan parquet default.warehouse [w_warehouse_sk,w_warehouse_name]
                                       InputAdapter
-                                        BroadcastExchange #10
-                                          WholeStageCodegen (8)
-                                            Filter [d_date,d_date_sk]
+                                        BroadcastExchange #5
+                                          WholeStageCodegen (3)
+                                            Filter [i_item_sk]
                                               ColumnarToRow
                                                 InputAdapter
-                                                  Scan parquet default.date_dim [d_date_sk,d_date]
+                                                  Scan parquet default.item [i_item_sk,i_item_desc]
                                   InputAdapter
-                                    BroadcastExchange #11
-                                      WholeStageCodegen (9)
-                                        Filter [p_promo_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet default.promotion [p_promo_sk]
+                                    BroadcastExchange #6
+                                      WholeStageCodegen (4)
+                                        Project [cd_demo_sk]
+                                          Filter [cd_marital_status,cd_demo_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet default.customer_demographics [cd_demo_sk,cd_marital_status]
+                              InputAdapter
+                                BroadcastExchange #7
+                                  WholeStageCodegen (5)
+                                    Project [hd_demo_sk]
+                                      Filter [hd_buy_potential,hd_demo_sk]
+                                        ColumnarToRow
+                                          InputAdapter
+                                            Scan parquet default.household_demographics [hd_demo_sk,hd_buy_potential]
+                          InputAdapter
+                            ReusedExchange [d_date_sk,d_date,d_week_seq] #2
+                      InputAdapter
+                        BroadcastExchange #8
+                          WholeStageCodegen (7)
+                            Filter [d_week_seq,d_date_sk]
+                              ColumnarToRow
+                                InputAdapter
+                                  Scan parquet default.date_dim [d_date_sk,d_week_seq]
                   InputAdapter
-                    WholeStageCodegen (13)
-                      Sort [cr_item_sk,cr_order_number]
-                        InputAdapter
-                          Exchange [cr_item_sk,cr_order_number] #12
-                            WholeStageCodegen (12)
-                              Project [cr_item_sk,cr_order_number]
-                                Filter [cr_item_sk,cr_order_number]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet default.catalog_returns [cr_item_sk,cr_order_number,cr_returned_date_sk]
+                    BroadcastExchange #9
+                      WholeStageCodegen (8)
+                        Filter [d_date,d_date_sk]
+                          ColumnarToRow
+                            InputAdapter
+                              Scan parquet default.date_dim [d_date_sk,d_date]

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1314,7 +1314,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       }
 
       // Test output partitioning is preserved
-      Seq("INNER", "LEFT OUTER", "RIGHT OUTER", "LEFT SEMI", "LEFT ANTI").foreach {
+      Seq("INNER", "LEFT SEMI", "LEFT ANTI").foreach {
         joinType =>
           val selectExpr = if (joinType == "RIGHT OUTER") {
             "/*+ BROADCAST(t1) */ t2.k AS k"
@@ -1328,7 +1328,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       }
 
       // Test output partitioning is not preserved
-      Seq("LEFT OUTER", "RIGHT OUTER", "LEFT SEMI", "LEFT ANTI", "FULL OUTER").foreach {
+      Seq("LEFT SEMI", "LEFT ANTI", "FULL OUTER").foreach {
         joinType =>
           val selectExpr = if (joinType == "RIGHT OUTER") {
             "/*+ BROADCAST(t2) */ t1.k AS k"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -254,7 +254,7 @@ class AdaptiveQueryExecSuite
       val df2 = spark.range(10).withColumn("b", 'id)
       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
         val testDf = df1.where('a > 10).join(df2.where('b > 10), Seq("id"), "left_outer")
-          .groupBy('a).count()
+          .groupBy('a).agg(count('b))
         checkAnswer(testDf, Seq())
         val plan = testDf.queryExecution.executedPlan
         assert(find(plan)(_.isInstanceOf[SortMergeJoinExec]).isDefined)
@@ -267,7 +267,7 @@ class AdaptiveQueryExecSuite
 
       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1") {
         val testDf = df1.where('a > 10).join(df2.where('b > 10), Seq("id"), "left_outer")
-          .groupBy('a).count()
+          .groupBy('a).agg(count('b))
         checkAnswer(testDf, Seq())
         val plan = testDf.queryExecution.executedPlan
         assert(find(plan)(_.isInstanceOf[BroadcastHashJoinExec]).isDefined)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes outer join if all grouping and aggregate expressions are from the streamed side.

For example:

```java
spark.range(200L).selectExpr("id AS a", "id as b", "id as c").createTempView("t1")
spark.range(300L).selectExpr("id AS a").createTempView("t2")
spark.sql("SELECT t1.b, max(t1.c) as c FROM t1 LEFT JOIN t2 ON t1.a = t2.a GROUP BY t1.b").explain(true)
```

Current optimized plan:

```
== Optimized Logical Plan ==
Aggregate [b#3L], [b#3L, max(c#4L) AS c#20L]
+- Project [b#3L, c#4L]
   +- Join LeftOuter, (a#2L = a#10L)
      :- Project [id#0L AS a#2L, id#0L AS b#3L, id#0L AS c#4L]
      :  +- Range (0, 200, step=1, splits=Some(1))
      +- Project [id#8L AS a#10L]
         +- Range (0, 300, step=1, splits=Some(1))
```

Expected optimized plan:
```
== Optimized Logical Plan ==
Aggregate [b#277L], [b#277L, max(c#278L) AS c#290L]
+- Project [id#274L AS b#277L, id#274L AS c#278L]
   +- Range (0, 200, step=1, splits=Some(2))
```


### Why are the changes needed?

`Enhance EliminateOuterJoin` rule

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

Add UTs

