### PR TITLE
[SPARK-36481][ML] Expose LogisticRegression.setInitialModel, like KMeans et al do

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -486,7 +486,8 @@ class LogisticRegression @Since("1.2.0") (
 
   private var optInitialModel: Option[LogisticRegressionModel] = None
 
-  private[spark] def setInitialModel(model: LogisticRegressionModel): this.type = {
+  @Since("3.3.0")
+  def setInitialModel(model: LogisticRegressionModel): this.type = {
     this.optInitialModel = Some(model)
     this
   }


### PR DESCRIPTION
### Why are the changes needed?

Several Spark ML components already allow setting of an initial model, including KMeans, LogisticRegression, and GaussianMixture. This is useful to begin training from a known reasonably good model.

However, the method in LogisticRegression is private to Spark. I don't see a good reason why it should be as the others in KMeans et al are not.

None of these are exposed in Pyspark, which I don't necessarily want to question or deal with now; there are other places one could arguably set an initial model too, but, here just interested in exposing the existing, tested functionality to callers.


### Does this PR introduce _any_ user-facing change?

Other than the new API method, no.

### How was this patch tested?

Existing tests

