### PR TITLE
[SPARK-36399][PYTHON] Implement DataFrame.combine_first

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/frame.rst
+++ b/python/docs/source/reference/pyspark.pandas/frame.rst
@@ -100,6 +100,7 @@ Binary operator functions
    DataFrame.ne
    DataFrame.eq
    DataFrame.dot
+   DataFrame.combine_first
 
 Function application, GroupBy & Window
 --------------------------------------

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -7920,7 +7920,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df1 = ps.DataFrame({'A': [None, 0], 'B': [None, 4]})
         >>> df2 = ps.DataFrame({'A': [1, 1], 'B': [3, 3]})
 
-        >>> df1.combine_first(df2)
+        >>> df1.combine_first(df2).sort_index()
              A    B
         0  1.0  3.0
         1  0.0  4.0
@@ -7930,7 +7930,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df1 = ps.DataFrame({'A': [None, 0], 'B': [4, None]})
         >>> df2 = ps.DataFrame({'B': [3, 3], 'C': [1, 1]}, index=[1, 2])
 
-        >>> df1.combine_first(df2)
+        >>> df1.combine_first(df2).sort_index()
              A    B    C
         0  NaN  4.0  NaN
         1  0.0  3.0  1.0

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -7913,6 +7913,29 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         Returns
         -------
         DataFrame
+
+        Examples
+        --------
+        >>> ps.set_option("compute.ops_on_diff_frames", True)
+        >>> df1 = ps.DataFrame({'A': [None, 0], 'B': [None, 4]})
+        >>> df2 = ps.DataFrame({'A': [1, 1], 'B': [3, 3]})
+
+        >>> df1.combine_first(df2)
+             A    B
+        0  1.0  3.0
+        1  0.0  4.0
+
+        Null values still persist if the location of that null value does not exist in other
+
+        >>> df1 = ps.DataFrame({'A': [None, 0], 'B': [4, None]})
+        >>> df2 = ps.DataFrame({'B': [3, 3], 'C': [1, 1]}, index=[1, 2])
+
+        >>> df1.combine_first(df2)
+             A    B    C
+        0  NaN  4.0  NaN
+        1  0.0  3.0  1.0
+        2  NaN  3.0  1.0
+        >>> ps.reset_option("compute.ops_on_diff_frames")
         """
         if not isinstance(other, DataFrame):
             raise TypeError("`combine_first` only allows `DataFrame` for parameter `other`")

--- a/python/pyspark/pandas/missing/frame.py
+++ b/python/pyspark/pandas/missing/frame.py
@@ -40,7 +40,6 @@ class _MissingPandasLikeDataFrame(object):
     asof = _unsupported_function("asof")
     boxplot = _unsupported_function("boxplot")
     combine = _unsupported_function("combine")
-    combine_first = _unsupported_function("combine_first")
     compare = _unsupported_function("compare")
     convert_dtypes = _unsupported_function("convert_dtypes")
     corrwith = _unsupported_function("corrwith")

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -5760,6 +5760,22 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
         self.assertRaises(TypeError, lambda: psdf1.combine_first(ps.Series([1, 2])))
 
+    def test_combine_first(self):
+        pdf = pd.DataFrame(
+            {("X", "A"): [None, 0], ("X", "B"): [4, None], ("Y", "C"): [3, 3], ("Y", "B"): [1, 1]}
+        )
+        pdf1, pdf2 = pdf["X"], pdf["Y"]
+        psdf = ps.from_pandas(pdf)
+        psdf1, psdf2 = psdf["X"], psdf["Y"]
+
+        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
+            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
+        else:
+            # pandas < 1.2.0 returns unexpected dtypes,
+            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
+            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
+            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
+
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.test_dataframe import *  # noqa: F401

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -5727,40 +5727,6 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             self.assert_eq(value_psdf, value_pdf)
 
     def test_combine_first(self):
-        pdf1 = pd.DataFrame({"A": [None, 0], "B": [4, None]})
-        psdf1 = ps.from_pandas(pdf1)
-        pdf2 = pd.DataFrame({"C": [3, 3], "B": [1, 1]})
-        psdf2 = ps.from_pandas(pdf2)
-
-        with option_context("compute.ops_on_diff_frames", True):
-            if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-                self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
-            else:
-                # pandas < 1.2.0 returns unexpected dtypes,
-                # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
-                expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
-                self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
-
-        pdf1.columns = pd.MultiIndex.from_tuples([("A", "willow"), ("B", "pine")])
-        psdf1 = ps.from_pandas(pdf1)
-        pdf2.columns = pd.MultiIndex.from_tuples([("C", "oak"), ("B", "pine")])
-        psdf2 = ps.from_pandas(pdf2)
-
-        with option_context("compute.ops_on_diff_frames", True):
-            if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-                self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
-            else:
-                # pandas < 1.2.0 returns unexpected dtypes,
-                # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
-                expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
-                expected_pdf.columns = pd.MultiIndex.from_tuples(
-                    [("A", "willow"), ("B", "pine"), ("C", "oak")]
-                )
-                self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
-
-        self.assertRaises(TypeError, lambda: psdf1.combine_first(ps.Series([1, 2])))
-
-    def test_combine_first(self):
         pdf = pd.DataFrame(
             {("X", "A"): [None, 0], ("X", "B"): [4, None], ("Y", "C"): [3, 3], ("Y", "B"): [1, 1]}
         )

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -709,6 +709,23 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
             )
             self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
 
+        pdf = pd.DataFrame(
+            {("X", "A"): [None, 0], ("X", "B"): [4, None], ("Y", "C"): [3, 3], ("Y", "B"): [1, 1]}
+        )
+        pdf1 = pdf["X"]
+        pdf2 = pdf["Y"]
+        psdf = ps.from_pandas(pdf)
+        psdf1 = psdf["X"]
+        psdf2 = psdf["Y"]
+
+        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
+            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
+        else:
+            # pandas < 1.2.0 returns unexpected dtypes,
+            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
+            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
+            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
+
     def test_insert(self):
         #
         # Basic DataFrame
@@ -1990,23 +2007,6 @@ class OpsOnDiffFramesDisabledTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf1 = ps.from_pandas(pdf1)
 
         self.assertRaises(TypeError, lambda: psdf1.combine_first(ps.Series([1, 2])))
-
-        pdf = pd.DataFrame(
-            {("X", "A"): [None, 0], ("X", "B"): [4, None], ("Y", "C"): [3, 3], ("Y", "B"): [1, 1]}
-        )
-        pdf1 = pdf["X"]
-        pdf2 = pdf["Y"]
-        psdf = ps.from_pandas(pdf)
-        psdf1 = psdf["X"]
-        psdf2 = psdf["Y"]
-
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
-        else:
-            # pandas < 1.2.0 returns unexpected dtypes,
-            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
-            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
-            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -1961,46 +1961,24 @@ class OpsOnDiffFramesDisabledTest(PandasOnSparkTestCase, SQLTestUtils):
             psser.rpow(psser_other)
 
     def test_combine_first(self):
-        pdf = pd.DataFrame(
-            {
-                "A": {"falcon": 330.0, "eagle": 160.0},
-                "B": {"falcon": 345.0, "eagle": 200.0, "duck": 30.0},
-            }
-        )
-        pser1, pser2 = pdf.A, pdf.B
-        psdf = ps.from_pandas(pdf)
-        psser1, psser2 = psdf.A, psdf.B
-
-        self.assert_eq(
-            psser1.combine_first(psser2).sort_index(), pser1.combine_first(pser2).sort_index()
-        )
-
-        psser1.name = pser1.name = ("X", "A")
-        psser2.name = pser2.name = ("Y", "B")
-
-        self.assert_eq(
-            psser1.combine_first(psser2).sort_index(), pser1.combine_first(pser2).sort_index()
-        )
-
-        pdf = pd.DataFrame(
-            {("X", "A"): [None, 0], ("X", "B"): [4, None], ("Y", "C"): [3, 3], ("Y", "B"): [1, 1]}
-        )
-        pdf1, pdf2 = pdf["X"], pdf["Y"]
-        psdf = ps.from_pandas(pdf)
-        psdf1, psdf2 = psdf["X"], psdf["Y"]
-
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
-        else:
-            # pandas < 1.2.0 returns unexpected dtypes,
-            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
-            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
-            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
-
         pdf1 = pd.DataFrame({"A": [None, 0], "B": [4, None]})
         psdf1 = ps.from_pandas(pdf1)
 
         self.assertRaises(TypeError, lambda: psdf1.combine_first(ps.Series([1, 2])))
+
+        pser1 = pd.Series({"falcon": 330.0, "eagle": 160.0})
+        pser2 = pd.Series({"falcon": 345.0, "eagle": 200.0, "duck": 30.0})
+        psser1 = ps.from_pandas(pser1)
+        psser2 = ps.from_pandas(pser2)
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            psser1.combine_first(psser2)
+
+        pdf1 = pd.DataFrame({"A": [None, 0], "B": [4, None]})
+        psdf1 = ps.from_pandas(pdf1)
+        pdf2 = pd.DataFrame({"C": [3, 3], "B": [1, 1]})
+        psdf2 = ps.from_pandas(pdf2)
+        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+            psdf1.combine_first(psdf2)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -661,12 +661,12 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf2 = ps.from_pandas(pdf2)
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
+            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2).sort_index())
         else:
             # pandas < 1.2.0 returns unexpected dtypes,
             # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
             expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
-            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
+            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2).sort_index())
 
         pdf1.columns = pd.MultiIndex.from_tuples([("A", "willow"), ("B", "pine")])
         psdf1 = ps.from_pandas(pdf1)
@@ -674,7 +674,7 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf2 = ps.from_pandas(pdf2)
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
+            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2).sort_index())
         else:
             # pandas < 1.2.0 returns unexpected dtypes,
             # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
@@ -682,7 +682,7 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
             expected_pdf.columns = pd.MultiIndex.from_tuples(
                 [("A", "willow"), ("B", "pine"), ("C", "oak")]
             )
-            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
+            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2).sort_index())
 
     def test_insert(self):
         #

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -679,6 +679,36 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
             psser1.combine_first(psser2).sort_index(), pser1.combine_first(pser2).sort_index()
         )
 
+        # DataFrame
+        pdf1 = pd.DataFrame({"A": [None, 0], "B": [4, None]})
+        psdf1 = ps.from_pandas(pdf1)
+        pdf2 = pd.DataFrame({"C": [3, 3], "B": [1, 1]})
+        psdf2 = ps.from_pandas(pdf2)
+
+        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
+            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
+        else:
+            # pandas < 1.2.0 returns unexpected dtypes,
+            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
+            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
+            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
+
+        pdf1.columns = pd.MultiIndex.from_tuples([("A", "willow"), ("B", "pine")])
+        psdf1 = ps.from_pandas(pdf1)
+        pdf2.columns = pd.MultiIndex.from_tuples([("C", "oak"), ("B", "pine")])
+        psdf2 = ps.from_pandas(pdf2)
+
+        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
+            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
+        else:
+            # pandas < 1.2.0 returns unexpected dtypes,
+            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
+            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
+            expected_pdf.columns = pd.MultiIndex.from_tuples(
+                [("A", "willow"), ("B", "pine"), ("C", "oak")]
+            )
+            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
+
     def test_insert(self):
         #
         # Basic DataFrame
@@ -1788,36 +1818,6 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
             pdf["Col2"].rank().loc[pdf["Col1"] == 20], psdf["Col2"].rank().loc[psdf["Col1"] == 20]
         )
 
-    def test_combine_first(self):
-        pdf1 = pd.DataFrame({"A": [None, 0], "B": [4, None]})
-        psdf1 = ps.from_pandas(pdf1)
-        pdf2 = pd.DataFrame({"C": [3, 3], "B": [1, 1]})
-        psdf2 = ps.from_pandas(pdf2)
-
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
-        else:
-            # pandas < 1.2.0 returns unexpected dtypes,
-            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
-            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
-            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
-
-        pdf1.columns = pd.MultiIndex.from_tuples([("A", "willow"), ("B", "pine")])
-        psdf1 = ps.from_pandas(pdf1)
-        pdf2.columns = pd.MultiIndex.from_tuples([("C", "oak"), ("B", "pine")])
-        psdf2 = ps.from_pandas(pdf2)
-
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
-        else:
-            # pandas < 1.2.0 returns unexpected dtypes,
-            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
-            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
-            expected_pdf.columns = pd.MultiIndex.from_tuples(
-                [("A", "willow"), ("B", "pine"), ("C", "oak")]
-            )
-            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
-
 
 class OpsOnDiffFramesDisabledTest(PandasOnSparkTestCase, SQLTestUtils):
     @classmethod
@@ -1990,6 +1990,23 @@ class OpsOnDiffFramesDisabledTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf1 = ps.from_pandas(pdf1)
 
         self.assertRaises(TypeError, lambda: psdf1.combine_first(ps.Series([1, 2])))
+
+        pdf = pd.DataFrame(
+            {("X", "A"): [None, 0], ("X", "B"): [4, None], ("Y", "C"): [3, 3], ("Y", "B"): [1, 1]}
+        )
+        pdf1 = pdf["X"]
+        pdf2 = pdf["Y"]
+        psdf = ps.from_pandas(pdf)
+        psdf1 = psdf["X"]
+        psdf2 = psdf["Y"]
+
+        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
+            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
+        else:
+            # pandas < 1.2.0 returns unexpected dtypes,
+            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
+            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
+            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -654,31 +654,6 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
             psser1.combine_first(psser2).sort_index(), pser1.combine_first(pser2).sort_index()
         )
 
-        # Series come from same DataFrame
-        pdf = pd.DataFrame(
-            {
-                "A": {"falcon": 330.0, "eagle": 160.0},
-                "B": {"falcon": 345.0, "eagle": 200.0, "duck": 30.0},
-            }
-        )
-        pser1 = pdf.A
-        pser2 = pdf.B
-        psser1 = ps.from_pandas(pser1)
-        psser2 = ps.from_pandas(pser2)
-
-        self.assert_eq(
-            psser1.combine_first(psser2).sort_index(), pser1.combine_first(pser2).sort_index()
-        )
-
-        psser1.name = ("X", "A")
-        psser2.name = ("Y", "B")
-        pser1.name = ("X", "A")
-        pser2.name = ("Y", "B")
-
-        self.assert_eq(
-            psser1.combine_first(psser2).sort_index(), pser1.combine_first(pser2).sort_index()
-        )
-
         # DataFrame
         pdf1 = pd.DataFrame({"A": [None, 0], "B": [4, None]})
         psdf1 = ps.from_pandas(pdf1)
@@ -707,23 +682,6 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
             expected_pdf.columns = pd.MultiIndex.from_tuples(
                 [("A", "willow"), ("B", "pine"), ("C", "oak")]
             )
-            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
-
-        pdf = pd.DataFrame(
-            {("X", "A"): [None, 0], ("X", "B"): [4, None], ("Y", "C"): [3, 3], ("Y", "B"): [1, 1]}
-        )
-        pdf1 = pdf["X"]
-        pdf2 = pdf["Y"]
-        psdf = ps.from_pandas(pdf)
-        psdf1 = psdf["X"]
-        psdf2 = psdf["Y"]
-
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
-        else:
-            # pandas < 1.2.0 returns unexpected dtypes,
-            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
-            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
             self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
 
     def test_insert(self):
@@ -2003,6 +1961,42 @@ class OpsOnDiffFramesDisabledTest(PandasOnSparkTestCase, SQLTestUtils):
             psser.rpow(psser_other)
 
     def test_combine_first(self):
+        pdf = pd.DataFrame(
+            {
+                "A": {"falcon": 330.0, "eagle": 160.0},
+                "B": {"falcon": 345.0, "eagle": 200.0, "duck": 30.0},
+            }
+        )
+        pser1, pser2 = pdf.A, pdf.B
+        psdf = ps.from_pandas(pdf)
+        psser1, psser2 = psdf.A, psdf.B
+
+        self.assert_eq(
+            psser1.combine_first(psser2).sort_index(), pser1.combine_first(pser2).sort_index()
+        )
+
+        psser1.name = pser1.name = ("X", "A")
+        psser2.name = pser2.name = ("Y", "B")
+
+        self.assert_eq(
+            psser1.combine_first(psser2).sort_index(), pser1.combine_first(pser2).sort_index()
+        )
+
+        pdf = pd.DataFrame(
+            {("X", "A"): [None, 0], ("X", "B"): [4, None], ("Y", "C"): [3, 3], ("Y", "B"): [1, 1]}
+        )
+        pdf1, pdf2 = pdf["X"], pdf["Y"]
+        psdf = ps.from_pandas(pdf)
+        psdf1, psdf2 = psdf["X"], psdf["Y"]
+
+        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
+            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
+        else:
+            # pandas < 1.2.0 returns unexpected dtypes,
+            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
+            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
+            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
+
         pdf1 = pd.DataFrame({"A": [None, 0], "B": [4, None]})
         psdf1 = ps.from_pandas(pdf1)
 

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2887,6 +2887,24 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             psser.at_time("0:20").sort_index(),
         )
 
+    def test_combine_first(self):
+        pdf = pd.DataFrame(
+            {
+                "A": {"falcon": 330.0, "eagle": 160.0},
+                "B": {"falcon": 345.0, "eagle": 200.0, "duck": 30.0},
+            }
+        )
+        pser1, pser2 = pdf.A, pdf.B
+        psdf = ps.from_pandas(pdf)
+        psser1, psser2 = psdf.A, psdf.B
+
+        self.assert_eq(psser1.combine_first(psser2), pser1.combine_first(pser2))
+
+        psser1.name = pser1.name = ("X", "A")
+        psser2.name = pser2.name = ("Y", "B")
+
+        self.assert_eq(psser1.combine_first(psser2), pser1.combine_first(pser2))
+
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.test_series import *  # noqa: F401


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `DataFrame.combine_first`.

The PR is based on https://github.com/databricks/koalas/pull/1950. Thanks @AishwaryaKalloli for the prototype.

### Why are the changes needed?
Update null elements with value in the same location in another is a common use case.
That is supported in pandas. We should support that as well.

### Does this PR introduce _any_ user-facing change?
Yes. `DataFrame.combine_first` can be used.

```py
>>> ps.set_option("compute.ops_on_diff_frames", True)
>>> df1 = ps.DataFrame({'A': [None, 0], 'B': [None, 4]})
>>> df2 = ps.DataFrame({'A': [1, 1], 'B': [3, 3]})
>>> df1.combine_first(df2).sort_index()
     A    B
0  1.0  3.0
1  0.0  4.0

# Null values still persist if the location of that null value does not exist in other

>>> df1 = ps.DataFrame({'A': [None, 0], 'B': [4, None]})
>>> df2 = ps.DataFrame({'B': [3, 3], 'C': [1, 1]}, index=[1, 2])
>>> df1.combine_first(df2).sort_index()
     A    B    C
0  NaN  4.0  NaN
1  0.0  3.0  1.0
2  NaN  3.0  1.0
>>> ps.reset_option("compute.ops_on_diff_frames")
```

### How was this patch tested?
Unit tests.