### PR TITLE
[SPARK-36487][CORE] Modify exit executor log logic

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -276,7 +276,11 @@ private[spark] class CoarseGrainedExecutorBackend(
       if (throwable != null) {
         logError(message, throwable)
       } else {
+        if (code == 0) {
+          logInfo(message)
+        } else {
         logError(message)
+        }
       }
 
       if (notifyDriver && driver.nonEmpty) {

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -279,7 +279,7 @@ private[spark] class CoarseGrainedExecutorBackend(
         if (code == 0) {
           logInfo(message)
         } else {
-        logError(message)
+          logError(message)
         }
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adjust the log logic of CoarseGrainedExecutorBackend


### Why are the changes needed?
When exit executor with system code 0, coarseGrainedExecutorBackend will print ERROR log.
That doesn't make sense, because it seems to me that executor's normal decommission is not caused by an exception.

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
local
