### PR TITLE
[SPARK-36492][SQL] Add hive-thriftserver module to parent maven pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
     <module>sql/catalyst</module>
     <module>sql/core</module>
     <module>sql/hive</module>
+    <module>sql/hive-thriftserver</module>
     <module>assembly</module>
     <module>examples</module>
     <module>repl</module>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add hive-thriftserver module to parent maven pom file

### Why are the changes needed?
hive-thriftserver module does not exist in the parent pom file, it's not friendly to developers.
IDE can not check syntax errors on runtime code patching.
IDE can not support grammar prompt

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass all current tests
