### PR TITLE
[SPARK-32210][CORE] Fix NegativeArraySizeException in MapOutputTracker with large spark.default.parallelism

### DIFF
--- a/core/benchmarks/MapStatusesSerDeserBenchmark-jdk11-results.txt
+++ b/core/benchmarks/MapStatusesSerDeserBenchmark-jdk11-results.txt
@@ -1,64 +1,64 @@
 OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 200000 MapOutputs, 10 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Serialization                                        166            176           6          1.2         830.5       1.0X
-Deserialization                                      202            300          63          1.0        1011.8       0.8X
+Serialization                                        148            164           8          1.4         739.6       1.0X
+Deserialization                                      202            303          72          1.0        1009.9       0.7X
 
 Compressed Serialized MapStatus sizes: 412 bytes
 Compressed Serialized Broadcast MapStatus sizes: 2 MB
 
 
 OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 200000 MapOutputs, 10 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         130            139          11          1.5         650.5       1.0X
-Deserialization                                       220            307          81          0.9        1099.7       0.6X
+Serialization                                         125            132           9          1.6         623.4       1.0X
+Deserialization                                       197            277          76          1.0         984.4       0.6X
 
 Compressed Serialized MapStatus sizes: 2 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
 
 
 OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 200000 MapOutputs, 100 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         274            298          14          0.7        1371.5       1.0X
-Deserialization                                       255            353         130          0.8        1274.9       1.1X
+Serialization                                         260            286          17          0.8        1302.0       1.0X
+Deserialization                                       224            344         128          0.9        1121.0       1.2X
 
-Compressed Serialized MapStatus sizes: 428 bytes
+Compressed Serialized MapStatus sizes: 427 bytes
 Compressed Serialized Broadcast MapStatus sizes: 13 MB
 
 
 OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 200000 MapOutputs, 100 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                          238            248          14          0.8        1189.7       1.0X
-Deserialization                                        291            402         147          0.7        1455.4       0.8X
+Serialization                                          253            272          14          0.8        1262.9       1.0X
+Deserialization                                        240            409         150          0.8        1201.0       1.1X
 
 Compressed Serialized MapStatus sizes: 13 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
 
 
 OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 200000 MapOutputs, 1000 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                         1247           1261          20          0.2        6235.2       1.0X
-Deserialization                                        865            915          44          0.2        4326.0       1.4X
+Serialization                                         1361           1378          24          0.1        6805.0       1.0X
+Deserialization                                        830           1022         272          0.2        4150.1       1.6X
 
-Compressed Serialized MapStatus sizes: 556 bytes
+Compressed Serialized MapStatus sizes: 562 bytes
 Compressed Serialized Broadcast MapStatus sizes: 121 MB
 
 
 OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 200000 MapOutputs, 1000 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Serialization                                          1005           1023          25          0.2        5027.2       1.0X
-Deserialization                                         541            790         217          0.4        2706.6       1.9X
+Serialization                                          1216           1251          51          0.2        6078.3       1.0X
+Deserialization                                         821            968         138          0.2        4105.8       1.5X
 
 Compressed Serialized MapStatus sizes: 121 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes

--- a/core/benchmarks/MapStatusesSerDeserBenchmark-jdk11-results.txt
+++ b/core/benchmarks/MapStatusesSerDeserBenchmark-jdk11-results.txt
@@ -1,64 +1,64 @@
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 10 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Serialization                                        179            194           9          1.1         897.4       1.0X
-Deserialization                                      254            321          74          0.8        1271.0       0.7X
+Serialization                                        166            176           6          1.2         830.5       1.0X
+Deserialization                                      202            300          63          1.0        1011.8       0.8X
 
-Compressed Serialized MapStatus sizes: 409 bytes
+Compressed Serialized MapStatus sizes: 412 bytes
 Compressed Serialized Broadcast MapStatus sizes: 2 MB
 
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 10 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         160            166           7          1.2         801.2       1.0X
-Deserialization                                       256            323          69          0.8        1278.9       0.6X
+Serialization                                         130            139          11          1.5         650.5       1.0X
+Deserialization                                       220            307          81          0.9        1099.7       0.6X
 
 Compressed Serialized MapStatus sizes: 2 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
 
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 100 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         341            349           7          0.6        1707.3       1.0X
-Deserialization                                       286            370          84          0.7        1431.4       1.2X
+Serialization                                         274            298          14          0.7        1371.5       1.0X
+Deserialization                                       255            353         130          0.8        1274.9       1.1X
 
-Compressed Serialized MapStatus sizes: 426 bytes
+Compressed Serialized MapStatus sizes: 428 bytes
 Compressed Serialized Broadcast MapStatus sizes: 13 MB
 
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 100 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                          309            319          11          0.6        1543.6       1.0X
-Deserialization                                        286            373         117          0.7        1429.5       1.1X
+Serialization                                          238            248          14          0.8        1189.7       1.0X
+Deserialization                                        291            402         147          0.7        1455.4       0.8X
 
 Compressed Serialized MapStatus sizes: 13 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
 
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 1000 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                         1619           1627          12          0.1        8092.6       1.0X
-Deserialization                                        864            883          26          0.2        4319.9       1.9X
+Serialization                                         1247           1261          20          0.2        6235.2       1.0X
+Deserialization                                        865            915          44          0.2        4326.0       1.4X
 
-Compressed Serialized MapStatus sizes: 557 bytes
+Compressed Serialized MapStatus sizes: 556 bytes
 Compressed Serialized Broadcast MapStatus sizes: 121 MB
 
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 1000 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Serialization                                          1449           1456           9          0.1        7246.8       1.0X
-Deserialization                                         853            888          46          0.2        4263.7       1.7X
+Serialization                                          1005           1023          25          0.2        5027.2       1.0X
+Deserialization                                         541            790         217          0.4        2706.6       1.9X
 
 Compressed Serialized MapStatus sizes: 121 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes

--- a/core/benchmarks/MapStatusesSerDeserBenchmark-results.txt
+++ b/core/benchmarks/MapStatusesSerDeserBenchmark-results.txt
@@ -2,8 +2,8 @@ OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 10 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Serialization                                        164            178          13          1.2         818.7       1.0X
-Deserialization                                      233            261          27          0.9        1166.0       0.7X
+Serialization                                        143            164          55          1.4         716.5       1.0X
+Deserialization                                      252            300          43          0.8        1262.4       0.6X
 
 Compressed Serialized MapStatus sizes: 412 bytes
 Compressed Serialized Broadcast MapStatus sizes: 2 MB
@@ -13,8 +13,8 @@ OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 10 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         139            146           7          1.4         693.6       1.0X
-Deserialization                                       264            271          12          0.8        1318.4       0.5X
+Serialization                                         137            139           1          1.5         684.2       1.0X
+Deserialization                                       252            259          13          0.8        1259.5       0.5X
 
 Compressed Serialized MapStatus sizes: 2 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
@@ -24,10 +24,10 @@ OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 100 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         277            331          80          0.7        1384.3       1.0X
-Deserialization                                       257            269          21          0.8        1284.5       1.1X
+Serialization                                         279            322         116          0.7        1394.6       1.0X
+Deserialization                                       275            287          28          0.7        1372.7       1.0X
 
-Compressed Serialized MapStatus sizes: 428 bytes
+Compressed Serialized MapStatus sizes: 427 bytes
 Compressed Serialized Broadcast MapStatus sizes: 13 MB
 
 
@@ -35,8 +35,8 @@ OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 100 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                          248            253           9          0.8        1242.1       1.0X
-Deserialization                                        250            273          18          0.8        1252.1       1.0X
+Serialization                                          262            263           1          0.8        1310.3       1.0X
+Deserialization                                        274            288          22          0.7        1370.5       1.0X
 
 Compressed Serialized MapStatus sizes: 13 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
@@ -46,10 +46,10 @@ OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 1000 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                         1434           1640         292          0.1        7167.8       1.0X
-Deserialization                                        505            570          74          0.4        2524.1       2.8X
+Serialization                                         1208           1208           1          0.2        6038.4       1.0X
+Deserialization                                        555            783         394          0.4        2774.2       2.2X
 
-Compressed Serialized MapStatus sizes: 557 bytes
+Compressed Serialized MapStatus sizes: 562 bytes
 Compressed Serialized Broadcast MapStatus sizes: 121 MB
 
 
@@ -57,8 +57,8 @@ OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 1000 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Serialization                                          1116           1117           1          0.2        5580.4       1.0X
-Deserialization                                         564            620          62          0.4        2821.4       2.0X
+Serialization                                          1097           1097           1          0.2        5484.2       1.0X
+Deserialization                                         554            596          48          0.4        2771.3       2.0X
 
 Compressed Serialized MapStatus sizes: 121 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes

--- a/core/benchmarks/MapStatusesSerDeserBenchmark-results.txt
+++ b/core/benchmarks/MapStatusesSerDeserBenchmark-results.txt
@@ -1,64 +1,64 @@
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 10 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Serialization                                        135            161          56          1.5         673.9       1.0X
-Deserialization                                      213            235          26          0.9        1065.6       0.6X
+Serialization                                        164            178          13          1.2         818.7       1.0X
+Deserialization                                      233            261          27          0.9        1166.0       0.7X
 
-Compressed Serialized MapStatus sizes: 409 bytes
+Compressed Serialized MapStatus sizes: 412 bytes
 Compressed Serialized Broadcast MapStatus sizes: 2 MB
 
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 10 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         130            137           5          1.5         650.8       1.0X
-Deserialization                                       211            230          20          0.9        1056.5       0.6X
+Serialization                                         139            146           7          1.4         693.6       1.0X
+Deserialization                                       264            271          12          0.8        1318.4       0.5X
 
 Compressed Serialized MapStatus sizes: 2 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
 
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 100 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         281            324          86          0.7        1406.7       1.0X
-Deserialization                                       240            267          32          0.8        1200.5       1.2X
+Serialization                                         277            331          80          0.7        1384.3       1.0X
+Deserialization                                       257            269          21          0.8        1284.5       1.1X
 
-Compressed Serialized MapStatus sizes: 426 bytes
+Compressed Serialized MapStatus sizes: 428 bytes
 Compressed Serialized Broadcast MapStatus sizes: 13 MB
 
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 100 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                          265            273           6          0.8        1324.5       1.0X
-Deserialization                                        247            276          33          0.8        1236.1       1.1X
+Serialization                                          248            253           9          0.8        1242.1       1.0X
+Deserialization                                        250            273          18          0.8        1252.1       1.0X
 
 Compressed Serialized MapStatus sizes: 13 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
 
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 1000 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                         1333           1592         366          0.2        6666.0       1.0X
-Deserialization                                        560            585          22          0.4        2799.1       2.4X
+Serialization                                         1434           1640         292          0.1        7167.8       1.0X
+Deserialization                                        505            570          74          0.4        2524.1       2.8X
 
-Compressed Serialized MapStatus sizes: 558 bytes
+Compressed Serialized MapStatus sizes: 557 bytes
 Compressed Serialized Broadcast MapStatus sizes: 121 MB
 
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 1000 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Serialization                                          1222           1260          54          0.2        6111.7       1.0X
-Deserialization                                         539            568          42          0.4        2695.3       2.3X
+Serialization                                          1116           1117           1          0.2        5580.4       1.0X
+Deserialization                                         564            620          62          0.4        2821.4       2.0X
 
 Compressed Serialized MapStatus sizes: 121 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark
 
-import java.io.{ByteArrayInputStream, IOException, ObjectInputStream, ObjectOutputStream}
+import java.io.{InputStream, IOException, ObjectInputStream, ObjectOutputStream}
+import java.nio.ByteBuffer
 import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
@@ -28,7 +29,6 @@ import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
-import org.apache.commons.io.output.{ByteArrayOutputStream => ApacheByteArrayOutputStream}
 import org.roaringbitmap.RoaringBitmap
 
 import org.apache.spark.broadcast.{Broadcast, BroadcastManager}
@@ -40,6 +40,7 @@ import org.apache.spark.scheduler.{MapStatus, MergeStatus, ShuffleOutputStatus}
 import org.apache.spark.shuffle.MetadataFetchFailedException
 import org.apache.spark.storage.{BlockId, BlockManagerId, ShuffleBlockId, ShuffleMergedBlockId}
 import org.apache.spark.util._
+import org.apache.spark.util.io.{ChunkedByteBuffer, ChunkedByteBufferOutputStream}
 
 /**
  * Helper class used by the [[MapOutputTrackerMaster]] to perform bookkeeping for a single
@@ -111,7 +112,7 @@ private class ShuffleStatus(
    * The cached result of serializing the map statuses array. This cache is lazily populated when
    * [[serializedMapStatus]] is called. The cache is invalidated when map outputs are removed.
    */
-  private[this] var cachedSerializedMapStatus: Array[Byte] = _
+  private[this] var cachedSerializedMapStatus: Array[Array[Byte]] = _
 
   /**
    * Broadcast variable holding serialized map output statuses array. When [[serializedMapStatus]]
@@ -121,14 +122,14 @@ private class ShuffleStatus(
    * broadcast variable in order to keep it from being garbage collected and to allow for it to be
    * explicitly destroyed later on when the ShuffleMapStage is garbage-collected.
    */
-  private[spark] var cachedSerializedBroadcast: Broadcast[Array[Byte]] = _
+  private[spark] var cachedSerializedBroadcast: Broadcast[Array[Array[Byte]]] = _
 
   /**
    * Similar to cachedSerializedMapStatus and cachedSerializedBroadcast, but for MergeStatus.
    */
-  private[this] var cachedSerializedMergeStatus: Array[Byte] = _
+  private[this] var cachedSerializedMergeStatus: Array[Array[Byte]] = _
 
-  private[this] var cachedSerializedBroadcastMergeStatus: Broadcast[Array[Byte]] = _
+  private[this] var cachedSerializedBroadcastMergeStatus: Broadcast[Array[Array[Byte]]] = _
 
   /**
    * Counter tracking the number of partitions that have output. This is a performance optimization
@@ -310,8 +311,8 @@ private class ShuffleStatus(
       broadcastManager: BroadcastManager,
       isLocal: Boolean,
       minBroadcastSize: Int,
-      conf: SparkConf): Array[Byte] = {
-    var result: Array[Byte] = null
+      conf: SparkConf): Array[Array[Byte]] = {
+    var result: Array[Array[Byte]] = null
     withReadLock {
       if (cachedSerializedMapStatus != null) {
         result = cachedSerializedMapStatus
@@ -346,10 +347,10 @@ private class ShuffleStatus(
       broadcastManager: BroadcastManager,
       isLocal: Boolean,
       minBroadcastSize: Int,
-      conf: SparkConf): (Array[Byte], Array[Byte]) = {
-    val mapStatusesBytes: Array[Byte] =
+      conf: SparkConf): (Array[Array[Byte]], Array[Array[Byte]]) = {
+    val mapStatusesBytes: Array[Array[Byte]] =
       serializedMapStatus(broadcastManager, isLocal, minBroadcastSize, conf)
-    var mergeStatusesBytes: Array[Byte] = null
+    var mergeStatusesBytes: Array[Array[Byte]] = null
 
     withReadLock {
       if (cachedSerializedMergeStatus != null) {
@@ -1223,8 +1224,8 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
           var fetchedMergeStatuses = mergeStatuses.get(shuffleId).orNull
           if (fetchedMapStatuses == null || fetchedMergeStatuses == null) {
             logInfo("Doing the fetch; tracker endpoint = " + trackerEndpoint)
-            val fetchedBytes =
-              askTracker[(Array[Byte], Array[Byte])](GetMapAndMergeResultStatuses(shuffleId))
+            val fetchedBytes = askTracker[(Array[Array[Byte]], Array[Array[Byte]])](
+              GetMapAndMergeResultStatuses(shuffleId))
             try {
               fetchedMapStatuses =
                 MapOutputTracker.deserializeOutputStatuses[MapStatus](fetchedBytes._1, conf)
@@ -1256,7 +1257,7 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
           var fetchedStatuses = mapStatuses.get(shuffleId).orNull
           if (fetchedStatuses == null) {
             logInfo("Doing the fetch; tracker endpoint = " + trackerEndpoint)
-            val fetchedBytes = askTracker[Array[Byte]](GetMapOutputStatuses(shuffleId))
+            val fetchedBytes = askTracker[Array[Array[Byte]]](GetMapOutputStatuses(shuffleId))
             try {
               fetchedStatuses =
                 MapOutputTracker.deserializeOutputStatuses[MapStatus](fetchedBytes, conf)
@@ -1318,12 +1319,10 @@ private[spark] object MapOutputTracker extends Logging {
       broadcastManager: BroadcastManager,
       isLocal: Boolean,
       minBroadcastSize: Int,
-      conf: SparkConf): (Array[Byte], Broadcast[Array[Byte]]) = {
-    // Using `org.apache.commons.io.output.ByteArrayOutputStream` instead of the standard one
-    // This implementation doesn't reallocate the whole memory block but allocates
-    // additional buffers. This way no buffers need to be garbage collected and
-    // the contents don't have to be copied to the new buffer.
-    val out = new ApacheByteArrayOutputStream()
+      conf: SparkConf): (Array[Array[Byte]], Broadcast[Array[Array[Byte]]]) = {
+    val chunkSize = conf.get(MAP_STATUS_OUTPUT_CHUNK_SIZE)
+    // ByteArrayOutputStream has the 2GB limit so use ChunkedByteBufferOutputStream instead
+    val out = new ChunkedByteBufferOutputStream(chunkSize, ByteBuffer.allocate _)
     out.write(DIRECT)
     val codec = CompressionCodec.createCodec(conf, conf.get(MAP_STATUS_COMPRESSION_CODEC))
     val objOut = new ObjectOutputStream(codec.compressedOutputStream(out))
@@ -1335,13 +1334,14 @@ private[spark] object MapOutputTracker extends Logging {
     } {
       objOut.close()
     }
-    val arr = out.toByteArray
-    if (arr.length >= minBroadcastSize) {
+    // create a nested Array so that it can handle over 2GB serialized data
+    val arr = out.toChunkedByteBuffer.getChunks().map(_.array())
+    val arrSize = out.size
+    if (arrSize >= minBroadcastSize) {
       // Use broadcast instead.
       // Important arr(0) is the tag == DIRECT, ignore that while deserializing !
       val bcast = broadcastManager.newBroadcast(arr, isLocal)
-      // toByteArray creates copy, so we can reuse out
-      out.reset()
+      val out = new ChunkedByteBufferOutputStream(chunkSize, ByteBuffer.allocate _)
       out.write(BROADCAST)
       val oos = new ObjectOutputStream(codec.compressedOutputStream(out))
       Utils.tryWithSafeFinally {
@@ -1349,8 +1349,8 @@ private[spark] object MapOutputTracker extends Logging {
       } {
         oos.close()
       }
-      val outArr = out.toByteArray
-      logInfo("Broadcast outputstatuses size = " + outArr.length + ", actual size = " + arr.length)
+      val outArr = out.toChunkedByteBuffer.getChunks().map(_.array())
+      logInfo("Broadcast outputstatuses size = " + out.size + ", actual size = " + arrSize)
       (outArr, bcast)
     } else {
       (arr, null)
@@ -1359,16 +1359,15 @@ private[spark] object MapOutputTracker extends Logging {
 
   // Opposite of serializeOutputStatuses.
   def deserializeOutputStatuses[T <: ShuffleOutputStatus](
-      bytes: Array[Byte], conf: SparkConf): Array[T] = {
-    assert (bytes.length > 0)
+      bytes: Array[Array[Byte]], conf: SparkConf): Array[T] = {
+    assert (bytes.length > 0 && bytes(0).length > 0)
 
-    def deserializeObject(arr: Array[Byte], off: Int, len: Int): AnyRef = {
+    def deserializeObject(in: InputStream): AnyRef = {
       val codec = CompressionCodec.createCodec(conf, conf.get(MAP_STATUS_COMPRESSION_CODEC))
       // The ZStd codec is wrapped in a `BufferedInputStream` which avoids overhead excessive
       // of JNI call while trying to decompress small amount of data for each element
       // of `MapStatuses`
-      val objIn = new ObjectInputStream(codec.compressedInputStream(
-        new ByteArrayInputStream(arr, off, len)))
+      val objIn = new ObjectInputStream(codec.compressedInputStream(in))
       Utils.tryWithSafeFinally {
         objIn.readObject()
       } {
@@ -1376,18 +1375,21 @@ private[spark] object MapOutputTracker extends Logging {
       }
     }
 
-    bytes(0) match {
+    val in = new ChunkedByteBuffer(bytes.map(ByteBuffer.wrap)).toInputStream()
+    val tag = in.read()
+    tag match {
       case DIRECT =>
-        deserializeObject(bytes, 1, bytes.length - 1).asInstanceOf[Array[T]]
+        deserializeObject(in).asInstanceOf[Array[T]]
       case BROADCAST =>
         try {
           // deserialize the Broadcast, pull .value array out of it, and then deserialize that
-          val bcast = deserializeObject(bytes, 1, bytes.length - 1).
-            asInstanceOf[Broadcast[Array[Byte]]]
-          logInfo("Broadcast outputstatuses size = " + bytes.length +
-            ", actual size = " + bcast.value.length)
+          val bcast = deserializeObject(in).asInstanceOf[Broadcast[Array[Array[Byte]]]]
+          logInfo("Broadcast outputstatuses size = " + bytes.foldLeft(0L)(_ + _.length) +
+            ", actual size = " + bcast.value.foldLeft(0L)(_ + _.length))
+          val bcastIn = new ChunkedByteBuffer(bcast.value.map(ByteBuffer.wrap)).toInputStream()
           // Important - ignore the DIRECT tag ! Start from offset 1
-          deserializeObject(bcast.value, 1, bcast.value.length - 1).asInstanceOf[Array[T]]
+          bcastIn.skip(1)
+          deserializeObject(bcastIn).asInstanceOf[Array[T]]
         } catch {
           case e: IOException =>
             logWarning("Exception encountered during deserializing broadcasted" +
@@ -1395,7 +1397,7 @@ private[spark] object MapOutputTracker extends Logging {
             throw new SparkException("Unable to deserialize broadcasted" +
               " output statuses", e)
         }
-      case _ => throw new IllegalArgumentException("Unexpected byte tag = " + bytes(0))
+      case _ => throw new IllegalArgumentException("Unexpected byte tag = " + tag)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -1321,9 +1321,8 @@ private[spark] object MapOutputTracker extends Logging {
       isLocal: Boolean,
       minBroadcastSize: Int,
       conf: SparkConf): (Array[Byte], Broadcast[Array[Array[Byte]]]) = {
-    val chunkSize = conf.get(MAP_STATUS_OUTPUT_CHUNK_SIZE)
     // ByteArrayOutputStream has the 2GB limit so use ChunkedByteBufferOutputStream instead
-    val out = new ChunkedByteBufferOutputStream(chunkSize, ByteBuffer.allocate)
+    val out = new ChunkedByteBufferOutputStream(1024 * 1024, ByteBuffer.allocate)
     out.write(DIRECT)
     val codec = CompressionCodec.createCodec(conf, conf.get(MAP_STATUS_COMPRESSION_CODEC))
     val objOut = new ObjectOutputStream(codec.compressedOutputStream(out))

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1416,17 +1416,6 @@ package object config {
       .stringConf
       .createWithDefault("zstd")
 
-  private[spark] val MAP_STATUS_OUTPUT_CHUNK_SIZE =
-    ConfigBuilder("spark.shuffle.mapStatus.output.chunkSize")
-      .internal()
-      .doc("The chunk size in bytes for writing out the bytes of serialized status output.")
-      .version("3.3.0")
-      .intConf
-      .checkValue(v => v > 0 && v <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH,
-        "The chunk size must be greater than 0 and less than or equal to " +
-          s"${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH}.")
-      .createWithDefault(64 * 1024 * 1024)
-
   private[spark] val SHUFFLE_SPILL_INITIAL_MEM_THRESHOLD =
     ConfigBuilder("spark.shuffle.spill.initialMemoryThreshold")
       .internal()

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1416,6 +1416,17 @@ package object config {
       .stringConf
       .createWithDefault("zstd")
 
+  private[spark] val MAP_STATUS_OUTPUT_CHUNK_SIZE =
+    ConfigBuilder("spark.shuffle.mapStatus.output.chunkSize")
+      .internal()
+      .doc("The chunk size in bytes for writing out the bytes of serialized status output.")
+      .version("3.3.0")
+      .intConf
+      .checkValue(v => v > 0 && v <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH,
+        "The chunk size must be greater than 0 and less than or equal to " +
+          s"${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH}.")
+      .createWithDefault(64 * 1024 * 1024)
+
   private[spark] val SHUFFLE_SPILL_INITIAL_MEM_THRESHOLD =
     ConfigBuilder("spark.shuffle.spill.initialMemoryThreshold")
       .internal()

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -573,8 +573,8 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
         mapWorkerRpcEnv.setupEndpointRef(rpcEnv.address, MapOutputTracker.ENDPOINT_NAME)
 
       val fetchedBytes = mapWorkerTracker.trackerEndpoint
-        .askSync[Array[Array[Byte]]](GetMapOutputStatuses(20))
-      assert(fetchedBytes(0)(0) == 1)
+        .askSync[Array[Byte]](GetMapOutputStatuses(20))
+      assert(fetchedBytes(0) == 1)
 
       // Normally `unregisterMapOutput` triggers the destroy of broadcasted value.
       // But the timing of destroying broadcasted value is indeterminate, we manually destroy
@@ -621,7 +621,7 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
         mapWorkerRpcEnv.setupEndpointRef(rpcEnv.address, MapOutputTracker.ENDPOINT_NAME)
 
       val fetchedBytes = mapWorkerTracker.trackerEndpoint
-        .askSync[(Array[Array[Byte]], Array[Array[Byte]])](GetMapAndMergeResultStatuses(20))
+        .askSync[(Array[Byte], Array[Byte])](GetMapAndMergeResultStatuses(20))
       assert(masterTracker.getNumAvailableMergeResults(20) == 1)
       assert(masterTracker.getNumAvailableOutputs(20) == 100)
 

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -697,7 +697,6 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
 
       tracker.unregisterShuffle(shuffleId)
       tracker.stop()
-      rpcEnv.shutdown()
     }
   }
 
@@ -733,7 +732,6 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
 
       tracker.unregisterShuffle(shuffleId)
       tracker.stop()
-      rpcEnv.shutdown()
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/MapStatusesSerDeserBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/MapStatusesSerDeserBenchmark.scala
@@ -63,15 +63,15 @@ object MapStatusesSerDeserBenchmark extends BenchmarkBase {
 
     val shuffleStatus = tracker.shuffleStatuses.get(shuffleId).head
 
-    var serializedMapStatusSizes = 0
-    var serializedBroadcastSizes = 0
+    var serializedMapStatusSizes = 0L
+    var serializedBroadcastSizes = 0L
 
     val (serializedMapStatus, serializedBroadcast) = MapOutputTracker.serializeOutputStatuses(
       shuffleStatus.mapStatuses, tracker.broadcastManager, tracker.isLocal, minBroadcastSize,
       sc.getConf)
-    serializedMapStatusSizes = serializedMapStatus.length
+    serializedMapStatusSizes = serializedMapStatus.foldLeft(0L)(_ + _.length)
     if (serializedBroadcast != null) {
-      serializedBroadcastSizes = serializedBroadcast.value.length
+      serializedBroadcastSizes = serializedBroadcast.value.foldLeft(0L)(_ + _.length)
     }
 
     benchmark.addCase("Serialization") { _ =>

--- a/core/src/test/scala/org/apache/spark/MapStatusesSerDeserBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/MapStatusesSerDeserBenchmark.scala
@@ -63,13 +63,13 @@ object MapStatusesSerDeserBenchmark extends BenchmarkBase {
 
     val shuffleStatus = tracker.shuffleStatuses.get(shuffleId).head
 
-    var serializedMapStatusSizes = 0L
+    var serializedMapStatusSizes = 0
     var serializedBroadcastSizes = 0L
 
     val (serializedMapStatus, serializedBroadcast) = MapOutputTracker.serializeOutputStatuses(
       shuffleStatus.mapStatuses, tracker.broadcastManager, tracker.isLocal, minBroadcastSize,
       sc.getConf)
-    serializedMapStatusSizes = serializedMapStatus.foldLeft(0L)(_ + _.length)
+    serializedMapStatusSizes = serializedMapStatus.length
     if (serializedBroadcast != null) {
       serializedBroadcastSizes = serializedBroadcast.value.foldLeft(0L)(_ + _.length)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current `MapOutputTracker` class may throw `NegativeArraySizeException` with a large number of partitions. Within the serializeOutputStatuses() method, it is trying to compress an array of mapStatuses and outputting the binary data into (Apache)ByteArrayOutputStream . Inside the (Apache)ByteArrayOutputStream.toByteArray(), negative index exception happens because the index is int and overflows (2GB limit) when the output binary size is too large.

This PR proposes two high-level ideas:
  1. Use `org.apache.spark.util.io.ChunkedByteBufferOutputStream`, which has a way to output the underlying buffer as `Array[Array[Byte]]`.
  2. Change the signatures from `Array[Byte]` to `Array[Array[Byte]]` in order to handle over 2GB compressed data.


### Why are the changes needed?
This issue seems to be missed out in the earlier effort of addressing 2GB limitations [SPARK-6235](https://issues.apache.org/jira/browse/SPARK-6235)

Without this fix, `spark.default.parallelism` needs to be kept at the low number. The drawback of setting smaller spark.default.parallelism is that it requires more executor memory (more data per partition). Setting `spark.io.compression.zstd.level` to higher number (default 1) hardly helps.

That essentially means we have the data size limit that for shuffling and does not scale.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Passed existing tests
```
build/sbt "core/testOnly org.apache.spark.MapOutputTrackerSuite"
```
Also added a new unit test
```
build/sbt "core/testOnly org.apache.spark.MapOutputTrackerSuite  -- -z SPARK-32210"
```
Ran the benchmark using GitHub Actions and didn't not observe any performance penalties. The results are attached in this PR
```
core/benchmarks/MapStatusesSerDeserBenchmark-jdk11-results.txt
core/benchmarks/MapStatusesSerDeserBenchmark-results.txt
```