### PR TITLE
[SPARK-36495][SQL] Use type match to simplify methods in CatalystTypeConverter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -98,20 +98,13 @@ object CatalystTypeConverters {
      * Converts a Scala type to its Catalyst equivalent while automatically handling nulls
      * and Options.
      */
-    final def toCatalyst(@Nullable maybeScalaValue: Any): CatalystType = {
-      if (maybeScalaValue == null) {
-        null.asInstanceOf[CatalystType]
-      } else if (maybeScalaValue.isInstanceOf[Option[ScalaInputType]]) {
-        val opt = maybeScalaValue.asInstanceOf[Option[ScalaInputType]]
-        if (opt.isDefined) {
-          toCatalystImpl(opt.get)
-        } else {
-          null.asInstanceOf[CatalystType]
-        }
-      } else {
-        toCatalystImpl(maybeScalaValue.asInstanceOf[ScalaInputType])
+    final def toCatalyst(@Nullable maybeScalaValue: Any): CatalystType =
+      maybeScalaValue match {
+        case null | None => null.asInstanceOf[CatalystType]
+        case opt: Some[ScalaInputType] => toCatalystImpl(opt.get)
+        case other => toCatalystImpl(other.asInstanceOf[ScalaInputType])
       }
-    }
+
 
     /**
      * Given a Catalyst row, convert the value at column `column` to its Scala equivalent.
@@ -473,10 +466,9 @@ object CatalystTypeConverters {
       // a measurable performance impact. Note that this optimization will be unnecessary if we
       // use code generation to construct Scala Row -> Catalyst Row converters.
       def convert(maybeScalaValue: Any): Any = {
-        if (maybeScalaValue.isInstanceOf[Option[Any]]) {
-          maybeScalaValue.asInstanceOf[Option[Any]].orNull
-        } else {
-          maybeScalaValue
+        maybeScalaValue match {
+          case opt: Option[Any] => opt.orNull
+          case _ => maybeScalaValue
         }
       }
       convert

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -98,13 +98,13 @@ object CatalystTypeConverters {
      * Converts a Scala type to its Catalyst equivalent while automatically handling nulls
      * and Options.
      */
-    final def toCatalyst(@Nullable maybeScalaValue: Any): CatalystType =
+    final def toCatalyst(@Nullable maybeScalaValue: Any): CatalystType = {
       maybeScalaValue match {
         case null | None => null.asInstanceOf[CatalystType]
         case opt: Some[ScalaInputType] => toCatalystImpl(opt.get)
         case other => toCatalystImpl(other.asInstanceOf[ScalaInputType])
       }
-
+    }
 
     /**
      * Given a Catalyst row, convert the value at column `column` to its Scala equivalent.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -325,6 +325,13 @@ class ScalaReflectionSuite extends SparkFunSuite {
     assert(CatalystTypeConverters.createToCatalystConverter(dataType)(data) === convertedData)
   }
 
+  test("convert None to catalyst") {
+    val data = OptionalData(None, None, None, None, None, None, None, None, None)
+    val dataType = schemaFor[OptionalData].dataType
+    val convertedData = InternalRow(null, null, null, null, null, null, null, null, null)
+    assert(CatalystTypeConverters.createToCatalystConverter(dataType)(data) === convertedData)
+  }
+
   test("infer schema from case class with multiple constructors") {
     val dataType = schemaFor[MultipleConstructorsData].dataType
     dataType match {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CatalystTypeConverter.toCatalyst` method use `isInstanceOf  + asInstanceOf` for type conversion, the main change of this pr is use  type match to simplify this process.

`CatalystTypeConverters.createToCatalystConverter` method has a similar pattern.

### Why are the changes needed?
Code simplification

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass the Jenkins or GitHub Action
- Add a new case to `ScalaReflectionSuite` to add the coverage of the `case None` branch of `CatalystTypeConverter#toCatalyst` method
