### PR TITLE
[SPARK-36445][SQL][FollowUp] ANSI type coercion: revisit promoting string literals in datetime expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
@@ -296,8 +296,12 @@ object AnsiTypeCoercion extends TypeCoercionBase {
 
       case d @ DateAdd(left @ StringType(), _) if left.foldable =>
         d.copy(startDate = Cast(d.startDate, DateType))
+      case d @ DateAdd(_, right @ StringType()) if right.foldable =>
+        d.copy(days = Cast(right, IntegerType))
       case d @ DateSub(left @ StringType(), _) if left.foldable =>
         d.copy(startDate = Cast(d.startDate, DateType))
+      case d @ DateSub(_, right @ StringType()) if right.foldable =>
+        d.copy(days = Cast(right, IntegerType))
 
       case s @ SubtractDates(left @ StringType(), _, _) if left.foldable =>
         s.copy(left = Cast(s.left, DateType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
@@ -91,7 +91,6 @@ object AnsiTypeCoercion extends TypeCoercionBase {
       ImplicitTypeCasts ::
       DateTimeOperations ::
       WindowFrameCoercion ::
-      StringLiteralCoercion ::
       GetDateFieldOperations:: Nil) :: Nil
 
   val findTightestCommonType: (DataType, DataType) => Option[DataType] = {
@@ -297,12 +296,22 @@ object AnsiTypeCoercion extends TypeCoercionBase {
 
       case d @ DateAdd(left @ StringType(), _) if left.foldable =>
         d.copy(startDate = Cast(d.startDate, DateType))
+      case d @ DateAdd(_, right @ StringType()) if right.foldable =>
+        d.copy(days = Cast(right, IntegerType))
       case d @ DateSub(left @ StringType(), _) if left.foldable =>
         d.copy(startDate = Cast(d.startDate, DateType))
+      case d @ DateSub(_, right @ StringType()) if right.foldable =>
+        d.copy(days = Cast(right, IntegerType))
+      case s @ SubtractDates(left @ StringType(), _, _) if left.foldable =>
+        s.copy(left = Cast(s.left, DateType))
+      case s @ SubtractDates(_, right @ StringType(), _) if right.foldable =>
+        s.copy(right = Cast(s.right, DateType))
       case t @ TimeAdd(left @ StringType(), _, _) if left.foldable =>
         t.copy(start = Cast(t.start, TimestampType))
       case t @ SubtractTimestamps(left @ StringType(), _, _, _) if left.foldable =>
         t.copy(left = Cast(t.left, TimestampType))
+      case t @ SubtractTimestamps(_, right @ StringType(), _, _) if right.foldable =>
+        t.copy(right = Cast(right, TimestampType))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
@@ -296,12 +296,9 @@ object AnsiTypeCoercion extends TypeCoercionBase {
 
       case d @ DateAdd(left @ StringType(), _) if left.foldable =>
         d.copy(startDate = Cast(d.startDate, DateType))
-      case d @ DateAdd(_, right @ StringType()) if right.foldable =>
-        d.copy(days = Cast(right, IntegerType))
       case d @ DateSub(left @ StringType(), _) if left.foldable =>
         d.copy(startDate = Cast(d.startDate, DateType))
-      case d @ DateSub(_, right @ StringType()) if right.foldable =>
-        d.copy(days = Cast(right, IntegerType))
+
       case s @ SubtractDates(left @ StringType(), _, _) if left.foldable =>
         s.copy(left = Cast(s.left, DateType))
       case s @ SubtractDates(_, right @ StringType(), _) if right.foldable =>
@@ -309,9 +306,9 @@ object AnsiTypeCoercion extends TypeCoercionBase {
       case t @ TimeAdd(left @ StringType(), _, _) if left.foldable =>
         t.copy(start = Cast(t.start, TimestampType))
       case t @ SubtractTimestamps(left @ StringType(), _, _, _) if left.foldable =>
-        t.copy(left = Cast(t.left, TimestampType))
+        t.copy(left = Cast(t.left, t.right.dataType))
       case t @ SubtractTimestamps(_, right @ StringType(), _, _) if right.foldable =>
-        t.copy(right = Cast(right, TimestampType))
+        t.copy(right = Cast(right, t.left.dataType))
     }
   }
 

--- a/sql/core/src/test/resources/sql-tests/inputs/date.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/date.sql
@@ -120,9 +120,11 @@ select null - date '2019-10-06';
 select date_str - date '2001-09-28' from date_view;
 select date '2001-09-28' - date_str from date_view;
 
--- invalid: date + string/null literal
+-- invalid: date + string literal
 select date'2011-11-11' + '1';
 select '1' + date'2011-11-11';
+
+-- null result: date + null
 select date'2011-11-11' + null;
 select null + date'2011-11-11';
 

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp.sql
@@ -108,9 +108,11 @@ create temporary view ts_view as select '2011-11-11 11:11:11' str;
 select str - timestamp'2011-11-11 11:11:11' from ts_view;
 select timestamp'2011-11-11 11:11:11' - str from ts_view;
 
--- invalid: timestamp + string/null literal
+-- invalid: timestamp + string literal
 select timestamp'2011-11-11 11:11:11' + '1';
 select '1' + timestamp'2011-11-11 11:11:11';
+
+-- null result: timestamp + null
 select timestamp'2011-11-11 11:11:11' + null;
 select null + timestamp'2011-11-11 11:11:11';
 

--- a/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
@@ -331,8 +331,8 @@ select date_add('2011-11-11', '1.2')
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
-The second argument of 'date_add' function needs to be an integer.
+java.lang.NumberFormatException
+invalid input syntax for type numeric: 1.2
 
 
 -- !query
@@ -441,8 +441,8 @@ select date_sub(date'2011-11-11', '1.2')
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
-The second argument of 'date_sub' function needs to be an integer.
+java.lang.NumberFormatException
+invalid input syntax for type numeric: 1.2
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
@@ -321,9 +321,10 @@ cannot resolve 'date_add(CAST('2011-11-11' AS DATE), 10.0D)' due to data type mi
 -- !query
 select date_add('2011-11-11', '1')
 -- !query schema
-struct<date_add(2011-11-11, 1):date>
+struct<>
 -- !query output
-2011-11-12
+org.apache.spark.sql.AnalysisException
+cannot resolve 'date_add(CAST('2011-11-11' AS DATE), '1')' due to data type mismatch: argument 2 requires (int or smallint or tinyint) type, however, ''1'' is of string type.; line 1 pos 7
 
 
 -- !query
@@ -331,8 +332,8 @@ select date_add('2011-11-11', '1.2')
 -- !query schema
 struct<>
 -- !query output
-java.lang.NumberFormatException
-invalid input syntax for type numeric: 1.2
+org.apache.spark.sql.AnalysisException
+cannot resolve 'date_add(CAST('2011-11-11' AS DATE), '1.2')' due to data type mismatch: argument 2 requires (int or smallint or tinyint) type, however, ''1.2'' is of string type.; line 1 pos 7
 
 
 -- !query
@@ -431,9 +432,10 @@ cannot resolve 'date_sub(CAST('2011-11-11' AS DATE), 10.0D)' due to data type mi
 -- !query
 select date_sub(date'2011-11-11', '1')
 -- !query schema
-struct<date_sub(DATE '2011-11-11', 1):date>
+struct<>
 -- !query output
-2011-11-10
+org.apache.spark.sql.AnalysisException
+cannot resolve 'date_sub(DATE '2011-11-11', '1')' due to data type mismatch: argument 2 requires (int or smallint or tinyint) type, however, ''1'' is of string type.; line 1 pos 7
 
 
 -- !query
@@ -441,8 +443,8 @@ select date_sub(date'2011-11-11', '1.2')
 -- !query schema
 struct<>
 -- !query output
-java.lang.NumberFormatException
-invalid input syntax for type numeric: 1.2
+org.apache.spark.sql.AnalysisException
+cannot resolve 'date_sub(DATE '2011-11-11', '1.2')' due to data type mismatch: argument 2 requires (int or smallint or tinyint) type, however, ''1.2'' is of string type.; line 1 pos 7
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
@@ -321,10 +321,9 @@ cannot resolve 'date_add(CAST('2011-11-11' AS DATE), 10.0D)' due to data type mi
 -- !query
 select date_add('2011-11-11', '1')
 -- !query schema
-struct<>
+struct<date_add(2011-11-11, 1):date>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'date_add(CAST('2011-11-11' AS DATE), '1')' due to data type mismatch: argument 2 requires (int or smallint or tinyint) type, however, ''1'' is of string type.; line 1 pos 7
+2011-11-12
 
 
 -- !query
@@ -332,8 +331,8 @@ select date_add('2011-11-11', '1.2')
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'date_add(CAST('2011-11-11' AS DATE), '1.2')' due to data type mismatch: argument 2 requires (int or smallint or tinyint) type, however, ''1.2'' is of string type.; line 1 pos 7
+java.lang.NumberFormatException
+invalid input syntax for type numeric: 1.2
 
 
 -- !query
@@ -432,10 +431,9 @@ cannot resolve 'date_sub(CAST('2011-11-11' AS DATE), 10.0D)' due to data type mi
 -- !query
 select date_sub(date'2011-11-11', '1')
 -- !query schema
-struct<>
+struct<date_sub(DATE '2011-11-11', 1):date>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'date_sub(DATE '2011-11-11', '1')' due to data type mismatch: argument 2 requires (int or smallint or tinyint) type, however, ''1'' is of string type.; line 1 pos 7
+2011-11-10
 
 
 -- !query
@@ -443,8 +441,8 @@ select date_sub(date'2011-11-11', '1.2')
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'date_sub(DATE '2011-11-11', '1.2')' due to data type mismatch: argument 2 requires (int or smallint or tinyint) type, however, ''1.2'' is of string type.; line 1 pos 7
+java.lang.NumberFormatException
+invalid input syntax for type numeric: 1.2
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/timestamp.sql.out
@@ -559,10 +559,9 @@ struct<(TIMESTAMP '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):interval day
 -- !query
 select timestamp'2011-11-11 11:11:11' - '2011-11-11 11:11:10'
 -- !query schema
-struct<>
+struct<(TIMESTAMP '2011-11-11 11:11:11' - 2011-11-11 11:11:10):interval day to second>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve '(TIMESTAMP '2011-11-11 11:11:11' - '2011-11-11 11:11:10')' due to data type mismatch: argument 2 requires (timestamp or timestamp without time zone) type, however, ''2011-11-11 11:11:10'' is of string type.; line 1 pos 7
+0 00:00:01.000000000
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
@@ -559,10 +559,9 @@ struct<(TIMESTAMP_NTZ '2019-10-06 10:11:12.345678' - DATE '2020-01-01'):interval
 -- !query
 select timestamp'2011-11-11 11:11:11' - '2011-11-11 11:11:10'
 -- !query schema
-struct<>
+struct<(TIMESTAMP_NTZ '2011-11-11 11:11:11' - 2011-11-11 11:11:10):interval day to second>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve '(TIMESTAMP_NTZ '2011-11-11 11:11:11' - '2011-11-11 11:11:10')' due to data type mismatch: argument 2 requires (timestamp or timestamp without time zone) type, however, ''2011-11-11 11:11:10'' is of string type.; line 1 pos 7
+0 00:00:01.000000000
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1. Promote more string literal in subtractions. In the ANSI type coercion rule, we already promoted 
```
string - timestamp => cast(string as timestamp) - timestamp
```
This PR is to promote the following string literals:
```
string - date => cast(string as date) - date
date - string => date - cast(date as string)
timestamp - string => timestamp
```
It is very straightforward to cast the string literal as the data type of the other side in the subtraction.

2. Merge the string promotion logic from the rule `StringLiteralCoercion`:
```
date_sub(date, string) => date_sub(date, cast(string as int))
date_add(date, string) => date_add(date, cast(string as int))
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. Promote the string literal in the subtraction as the data type of the other side. This is straightforward and consistent with PostgreSQL
2. Certerize all the string literal promotion in the ANSI type coercion rule

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the new ANSI type coercion rules are not released yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing UT