### PR TITLE
[SPARK-36503][SQL] Add RowToColumnConverter for BinaryType

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -256,6 +256,7 @@ private object RowToColumnConverter {
 
   private def getConverterForType(dataType: DataType, nullable: Boolean): TypeConverter = {
     val core = dataType match {
+      case BinaryType => BinaryConverter
       case BooleanType => BooleanConverter
       case ByteType => ByteConverter
       case ShortType => ShortConverter
@@ -282,6 +283,13 @@ private object RowToColumnConverter {
       }
     } else {
       core
+    }
+  }
+
+  private object BinaryConverter extends TypeConverter {
+    override def append(row: SpecializedGetters, column: Int, cv: WritableColumnVector): Unit = {
+      val bytes = row.getBinary(column)
+      cv.appendByteArray(bytes, 0, bytes.length)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -1387,6 +1387,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
             Nil
         )) ::
         StructField("int_to_int", MapType(IntegerType, IntegerType)) ::
+        StructField("binary", BinaryType) ::
         Nil)
     var mapBuilder = new ArrayBasedMapBuilder(IntegerType, IntegerType)
     mapBuilder.put(1, 10)
@@ -1406,7 +1407,8 @@ class ColumnarBatchSuite extends SparkFunSuite {
       new CalendarInterval(1, 0, 0),
       new GenericArrayData(Array(1, 2, 3, 4, null)),
       new GenericInternalRow(Array[Any](5.asInstanceOf[Any], 10)),
-      mapBuilder.build()
+      mapBuilder.build(),
+      "Spark SQL".getBytes()
     ))
 
     mapBuilder = new ArrayBasedMapBuilder(IntegerType, IntegerType)
@@ -1427,10 +1429,12 @@ class ColumnarBatchSuite extends SparkFunSuite {
       new CalendarInterval(-10, -50, -100),
       new GenericArrayData(Array(5, 10, -100)),
       new GenericInternalRow(Array[Any](20.asInstanceOf[Any], null)),
-      mapBuilder.build()
+      mapBuilder.build(),
+      "Parquet".getBytes()
     ))
 
     val row3 = new GenericInternalRow(Array[Any](
+      null,
       null,
       null,
       null,
@@ -1564,8 +1568,12 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(map2.valueArray().isNullAt(0))
       assert(map2.keyArray().getInt(1) == 40)
       assert(map2.valueArray().getInt(1) == 50)
-
       assert(columns(14).isNullAt(2))
+
+      assert(columns(15).dataType() == BinaryType)
+      assert(columns(15).getBinary(0).deep == "Spark SQL".getBytes.deep)
+      assert(columns(15).getBinary(1).deep == "Parquet".getBytes.deep)
+      assert(columns(15).isNullAt(2))
     } finally {
       batch.close()
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -24,7 +24,9 @@ import java.nio.charset.StandardCharsets
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Random
+
 import org.apache.arrow.vector.IntVector
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.{RandomDataGenerator, Row}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -24,9 +24,7 @@ import java.nio.charset.StandardCharsets
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Random
-
 import org.apache.arrow.vector.IntVector
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.{RandomDataGenerator, Row}
@@ -1571,8 +1569,8 @@ class ColumnarBatchSuite extends SparkFunSuite {
       assert(columns(14).isNullAt(2))
 
       assert(columns(15).dataType() == BinaryType)
-      assert(columns(15).getBinary(0).deep == "Spark SQL".getBytes.deep)
-      assert(columns(15).getBinary(1).deep == "Parquet".getBytes.deep)
+      assert(new String(columns(15).getBinary(0)) == "Spark SQL")
+      assert(new String(columns(15).getBinary(1)) == "Parquet")
       assert(columns(15).isNullAt(2))
     } finally {
       batch.close()


### PR DESCRIPTION


### What changes were proposed in this pull request?
Add RowToColumnConverter for BinaryType


### Why are the changes needed?
currently, we have RowToColumnConverter for all data types except BinaryType
```
  private def getConverterForType(dataType: DataType, nullable: Boolean): TypeConverter = {
    val core = dataType match {
      case BooleanType => BooleanConverter
      case ByteType => ByteConverter
      case ShortType => ShortConverter
      case IntegerType | DateType => IntConverter
      case FloatType => FloatConverter
      case LongType | TimestampType => LongConverter
      case DoubleType => DoubleConverter
      case StringType => StringConverter
      case CalendarIntervalType => CalendarConverter
      case at: ArrayType => ArrayConverter(getConverterForType(at.elementType, at.containsNull))
      case st: StructType => new StructConverter(st.fields.map(
        (f) => getConverterForType(f.dataType, f.nullable)))
      case dt: DecimalType => new DecimalConverter(dt)
      case mt: MapType => MapConverter(getConverterForType(mt.keyType, nullable = false),
        getConverterForType(mt.valueType, mt.valueContainsNull))
      case unknown => throw QueryExecutionErrors.unsupportedDataTypeError(unknown.toString)
    }
```
so add one for BinaryType

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
modify existing test
