### PR TITLE
[SPARK-36403][PYTHON] Implement `Index.putmask` 

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/indexing.rst
+++ b/python/docs/source/reference/pyspark.pandas/indexing.rst
@@ -83,6 +83,7 @@ Modifying and computations
    Index.min
    Index.max
    Index.map
+   Index.putmask
    Index.rename
    Index.repeat
    Index.take

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -1236,6 +1236,13 @@ class MultiIndex(Index):
     ) -> "Index":
         return MissingPandasLikeMultiIndex.map(self, mapper, na_action)
 
+    def putmask(
+        self,
+        mask: Union[Series, "Index", List, Tuple] = None,
+        value: Union[Series, "Index", List, Tuple] = None,
+    ) -> "Index":
+        return MissingPandasLikeMultiIndex.putmask(self, mask, value)
+
 
 def _test() -> None:
     import os

--- a/python/pyspark/pandas/missing/indexes.py
+++ b/python/pyspark/pandas/missing/indexes.py
@@ -53,7 +53,6 @@ class MissingPandasLikeIndex(object):
     groupby = _unsupported_function("groupby")
     is_ = _unsupported_function("is_")
     join = _unsupported_function("join")
-    putmask = _unsupported_function("putmask")
     ravel = _unsupported_function("ravel")
     reindex = _unsupported_function("reindex")
     searchsorted = _unsupported_function("searchsorted")

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -2388,6 +2388,41 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
             lambda: psidx.map({1: 1, 2: 2.0, 3: "three"}),
         )
 
+    def test_putmask(self):
+        pidx = pd.Index(["a", "b", "c", "d", "e"])
+        psidx = ps.from_pandas(pidx)
+
+        self.assert_eq(
+            psidx.putmask(psidx < "c", "k").sort_values(),
+            pidx.putmask(pidx < "c", "k").sort_values(),
+        )
+        self.assert_eq(
+            psidx.putmask(psidx < "c", ["g", "h", "i", "j", "k"]).sort_values(),
+            pidx.putmask(pidx < "c", ["g", "h", "i", "j", "k"]).sort_values(),
+        )
+        self.assert_eq(
+            psidx.putmask(psidx < "c", ("g", "h", "i", "j", "k")).sort_values(),
+            pidx.putmask(pidx < "c", ("g", "h", "i", "j", "k")).sort_values(),
+        )
+        self.assert_eq(
+            psidx.putmask(psidx < "c", ps.Index(["g", "h", "i", "j", "k"])).sort_values(),
+            pidx.putmask(pidx < "c", pd.Index(["g", "h", "i", "j", "k"])).sort_values(),
+        )
+        self.assert_eq(
+            psidx.putmask(psidx < "c", ps.Series(["g", "h", "i", "j", "k"])).sort_values(),
+            pidx.putmask(pidx < "c", pd.Series(["g", "h", "i", "j", "k"])).sort_values(),
+        )
+
+        self.assertRaises(
+            ValueError,
+            lambda: psidx.putmask(psidx < "c", ps.Series(["g", "h"])),
+        )
+
+        self.assertRaises(
+            ValueError,
+            lambda: psidx.putmask([True, False], ps.Series(["g", "h", "i", "j", "k"])),
+        )
+
     def test_multiindex_equal_levels(self):
         pmidx1 = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
         pmidx2 = pd.MultiIndex.from_tuples([("b", "y"), ("a", "x"), ("c", "z")])

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -356,7 +356,7 @@ def infer_pd_series_spark_type(
     if dtype == np.dtype("object"):
         if len(pser) == 0 or pser.isnull().all():
             return types.NullType()
-        elif hasattr(pser.iloc[0], "__UDT__"):
+        elif hasattr(pser, "iloc") and hasattr(pser.iloc[0], "__UDT__"):
             return pser.iloc[0].__UDT__
         else:
             return from_arrow_type(pa.Array.from_pandas(pser).type, prefer_timestamp_ntz)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Implement `Index.putmask`

This pull request is based on https://github.com/databricks/koalas/pull/1560


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`putmask` returns a new Index of the values set with the mask.
`putmask` is supported in pandas. PySpark should support that as well.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. `Index.putmask` can be used.
```python
>>> pidx = pd.Index(["a", "b", "c", "d", "e"])
>>> psidx = ps.from_pandas(pidx)
>>> psidx.putmask(psidx < "c", "k").sort_values()
Index(['c', 'd', 'e', 'k', 'k'], dtype='object')
>>> psidx.putmask(psidx < "c", ["g", "h", "i", "j", "k"]).sort_values()
Index(['c', 'd', 'e', 'g', 'h'], dtype='object')
>>> psidx.putmask(psidx < "c", ("g", "h", "i", "j", "k")).sort_values()
Index(['c', 'd', 'e', 'g', 'h'], dtype='object')
>>> psidx.putmask(psidx < "c", ps.Index(["g", "h", "i", "j", "k"])).sort_values()
Index(['c', 'd', 'e', 'g', 'h'], dtype='object')
>>> psidx.putmask(psidx < "c", "MASKED").sort_values()
Index(['MASKED', 'MASKED', 'c', 'd', 'e'], dtype='object')
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Unit tests.
