### PR TITLE
[MINOR][DOCS] More correct results for GitHub Actions build link at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and Structured Streaming for stream processing.
 
 <https://spark.apache.org/>
 
-[![GitHub Action Build](https://github.com/apache/spark/actions/workflows/build_and_test.yml/badge.svg?branch=master)](https://github.com/apache/spark/actions/workflows/build_and_test.yml?query=branch%3Amaster)
+[![GitHub Action Build](https://github.com/apache/spark/actions/workflows/build_and_test.yml/badge.svg?branch=master&event=push)](https://github.com/apache/spark/actions/workflows/build_and_test.yml?query=branch%3Amaster+event%3Apush)
 [![Jenkins Build](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-3.2/badge/icon)](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-3.2)
 [![AppVeyor Build](https://img.shields.io/appveyor/ci/ApacheSoftwareFoundation/spark/master.svg?style=plastic&logo=appveyor)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark)
 [![PySpark Coverage](https://codecov.io/gh/apache/spark/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/spark)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use more correct link for GitHub Actions build to only show the full builds at the commits in the master branch.

Current link includes scheduled builds (https://github.com/apache/spark/actions/workflows/build_and_test.yml?query=branch%3Amaster+event%3Aschedule).

### Why are the changes needed?

To show the full builds at the commits in the master branch only.

### Does this PR introduce _any_ user-facing change?

No, dev only.

Before:

![Screen Shot 2021-08-15 at 11 11 19 AM](https://user-images.githubusercontent.com/6477701/129464841-7207865e-3f94-4e18-8db6-e8fa36a926bf.png)


After:

![Screen Shot 2021-08-15 at 11 12 01 AM](https://user-images.githubusercontent.com/6477701/129464842-887d121e-88d3-4342-b11a-3048df88856d.png)


### How was this patch tested?

Manually checked by clicking these links.