### PR TITLE
[SPARK-36519][SS]Store RocksDB format version in the checkpoint for streaming queries

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1594,13 +1594,8 @@ object SQLConf {
     buildConf("spark.sql.streaming.stateStore.rocksdb.formatVersion")
       .internal()
       .doc("Set the RocksDB format version. This will be stored in the checkpoint when starting " +
-        "a streaming query. If this configuration is not set, we will use the value in the " +
-        "checkpoint when restarting a streaming query. This behavior ensures that if a query is " +
-        "created in an old Spark version and upgraded to a new Spark version, the user can still" +
-        "rollback their Spark version if they hit any regressions. This config can be set to " +
-        "overwrite the RocksDB format version in the checkpoint, but it may prevent users from " +
-        "rollbacking to an old Spark version that doesn't support the user provided RocksDB " +
-        "format version.")
+        "a streaming query. The checkpoint will use this RocksDB format version in the entire " +
+        "lifetime of the query.")
       .version("3.2.0")
       .intConf
       .checkValue(_ >= 0, "Must not be negative")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1595,10 +1595,16 @@ object SQLConf {
       .internal()
       .doc("Set the RocksDB format version. This will be stored in the checkpoint when starting " +
         "a streaming query. If this configuration is not set, we will use the value in the " +
-        "checkpoint when restarting a streaming query.")
+        "checkpoint when restarting a streaming query. This behavior ensures that if a query is " +
+        "created in an old Spark version and upgraded to a new Spark version, the user can still" +
+        "rollback their Spark version if they hit any regressions. This config can be set to " +
+        "overwrite the RocksDB format version in the checkpoint, but it may prevent users from " +
+        "rollbacking to an old Spark version that doesn't support the user provided RocksDB " +
+        "format version.")
       .version("3.2.0")
       .intConf
       .checkValue(_ >= 0, "Must not be negative")
+      // 5 is the default table format version for RocksDB 6.20.3.
       .createWithDefault(5)
 
   val STREAMING_AGGREGATION_STATE_FORMAT_VERSION =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1586,6 +1586,21 @@ object SQLConf {
       .stringConf
       .createWithDefault("lz4")
 
+  /**
+   * Note: this is defined in `RocksDBConf.FORMAT_VERSION`. These two places should be updated
+   * together.
+   */
+  val STATE_STORE_ROCKSDB_FORMAT_VERSION =
+    buildConf("spark.sql.streaming.stateStore.rocksdb.formatVersion")
+      .internal()
+      .doc("Set the RocksDB format version. This will be stored in the checkpoint when starting " +
+        "a streaming query. If this configuration is not set, we will use the value in the " +
+        "checkpoint when restarting a streaming query.")
+      .version("3.2.0")
+      .intConf
+      .checkValue(_ >= 0, "Must not be negative")
+      .createWithDefault(5)
+
   val STREAMING_AGGREGATION_STATE_FORMAT_VERSION =
     buildConf("spark.sql.streaming.aggregation.stateFormatVersion")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -519,11 +519,9 @@ object RocksDBConf {
   // Configuration to set the RocksDB format version. When upgrading the RocksDB version in Spark,
   // it may introduce a new table format version that can not be supported by an old RocksDB version
   // used by an old Spark version. Hence, we store the table format version in the checkpoint when
-  // a query starts, and when restarting a query from a checkpoint, we will use the format version
-  // in the checkpoint. This will ensure the user can still rollback their Spark version for an
-  // existing query when RocksDB changes its default table format in a new version. The user can
-  // still use this config to ignore the table format version in the checkpoint if they don't need
-  // to rollback the Spark version. See
+  // a query starts and use it in the entire lifetime of the query. This will ensure the user can
+  // still rollback their Spark version for an existing query when RocksDB changes its default
+  // table format in a new version. See
   // https://github.com/facebook/rocksdb/wiki/RocksDB-Compatibility-Between-Different-Releases
   // for the RocksDB compatibility guarantee.
   //

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.streaming.state
 
 import java.io.File
+import java.util.Locale
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.{mutable, Map}
@@ -504,16 +505,16 @@ object RocksDBConf {
   /** Common prefix of all confs in SQLConf that affects RocksDB */
   val ROCKSDB_CONF_NAME_PREFIX = "spark.sql.streaming.stateStore.rocksdb"
 
-  case class ConfEntry(name: String, default: String) {
-    def fullName: String = s"$ROCKSDB_CONF_NAME_PREFIX.${name}"
+  private case class ConfEntry(name: String, default: String) {
+    def fullName: String = s"$ROCKSDB_CONF_NAME_PREFIX.${name}".toLowerCase(Locale.ROOT)
   }
 
   // Configuration that specifies whether to compact the RocksDB data every time data is committed
-  val COMPACT_ON_COMMIT_CONF = ConfEntry("compactOnCommit", "false")
+  private val COMPACT_ON_COMMIT_CONF = ConfEntry("compactOnCommit", "false")
   private val PAUSE_BG_WORK_FOR_COMMIT_CONF = ConfEntry("pauseBackgroundWorkForCommit", "true")
   private val BLOCK_SIZE_KB_CONF = ConfEntry("blockSizeKB", "4")
   private val BLOCK_CACHE_SIZE_MB_CONF = ConfEntry("blockCacheSizeMB", "8")
-  val LOCK_ACQUIRE_TIMEOUT_MS_CONF = ConfEntry("lockAcquireTimeoutMs", "60000")
+  private val LOCK_ACQUIRE_TIMEOUT_MS_CONF = ConfEntry("lockAcquireTimeoutMs", "60000")
   private val RESET_STATS_ON_LOAD = ConfEntry("resetStatsOnLoad", "true")
   // Configuration to set the RocksDB format version. When upgrading the RocksDB version in Spark,
   // it may introduce a new table format version that can not be supported by an old RocksDB version
@@ -526,7 +527,7 @@ object RocksDBConf {
   // https://github.com/facebook/rocksdb/wiki/RocksDB-Compatibility-Between-Different-Releases
   // for the RocksDB compatibility guarantee.
   //
-  // Note: this is also defined in `SQLConf.STREAMING_AGGREGATION_STATE_FORMAT_VERSION`. These two
+  // Note: this is also defined in `SQLConf.STATE_STORE_ROCKSDB_FORMAT_VERSION`. These two
   // places should be updated together.
   private val FORMAT_VERSION = ConfEntry("formatVersion", "5")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -23,12 +23,13 @@ import scala.collection.JavaConverters
 
 import org.scalatest.time.{Minute, Span}
 
-import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.{MemoryStream, StreamingQueryWrapper}
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming._
 
 class RocksDBStateStoreIntegrationSuite extends StreamTest {
+
   import testImplicits._
 
   test("RocksDBStateStore") {
@@ -101,6 +102,76 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest {
           query.stop()
         }
       }
+    }
+  }
+
+  testQuietly("SPARK-36519: store RocksDB format version in the checkpoint") {
+    def getFormatVersion(query: StreamingQuery): Int = {
+      query.asInstanceOf[StreamingQueryWrapper].streamingQuery.lastExecution.sparkSession
+        .sessionState.conf.getConf(SQLConf.STATE_STORE_ROCKSDB_FORMAT_VERSION)
+    }
+
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName) {
+      withTempDir { dir =>
+        val inputData = MemoryStream[Int]
+
+        def startQuery(): StreamingQuery = {
+          inputData.toDS().toDF("value")
+            .select('value)
+            .groupBy($"value")
+            .agg(count("*"))
+            .writeStream
+            .format("console")
+            .option("checkpointLocation", dir.getCanonicalPath)
+            .outputMode("complete")
+            .start()
+        }
+
+        // The format version should be 5 by default
+        var query = startQuery()
+        inputData.addData(1, 2)
+        query.processAllAvailable()
+        assert(getFormatVersion(query) == 5)
+        query.stop()
+
+        // Setting the format version manually should overwrite the value in the checkpoint
+        withSQLConf(SQLConf.STATE_STORE_ROCKSDB_FORMAT_VERSION.key -> "4") {
+          query = startQuery()
+          inputData.addData(1, 2)
+          query.processAllAvailable()
+          assert(getFormatVersion(query) == 4)
+          query.stop()
+        }
+
+        // Use the format version in the checkpoint when the config is not set
+        query = startQuery()
+        inputData.addData(1, 2)
+        query.processAllAvailable()
+        assert(getFormatVersion(query) == 4)
+        query.stop()
+      }
+    }
+  }
+
+  testQuietly("SPARK-36519: RocksDB format version can be set by the SQL conf") {
+    withSQLConf(
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName,
+      // Set an unsupported RocksDB format version and the query should fail if it's passed down
+      // into RocksDB
+      SQLConf.STATE_STORE_ROCKSDB_FORMAT_VERSION.key -> "100") {
+      val inputData = MemoryStream[Int]
+      val query = inputData.toDS().toDF("value")
+        .select('value)
+        .groupBy($"value")
+        .agg(count("*"))
+        .writeStream
+        .format("console")
+        .outputMode("complete")
+        .start()
+      inputData.addData(1, 2)
+      val e = intercept[StreamingQueryException](query.processAllAvailable())
+      assert(e.getCause.getCause.getMessage.contains("Unsupported BlockBasedTable format_version"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming._
 
 class RocksDBStateStoreIntegrationSuite extends StreamTest {
-
   import testImplicits._
 
   test("RocksDBStateStore") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -134,21 +134,14 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest {
         assert(getFormatVersion(query) == 5)
         query.stop()
 
-        // Setting the format version manually should overwrite the value in the checkpoint
+        // Setting the format version manually should not overwrite the value in the checkpoint
         withSQLConf(SQLConf.STATE_STORE_ROCKSDB_FORMAT_VERSION.key -> "4") {
           query = startQuery()
           inputData.addData(1, 2)
           query.processAllAvailable()
-          assert(getFormatVersion(query) == 4)
+          assert(getFormatVersion(query) == 5)
           query.stop()
         }
-
-        // Use the format version in the checkpoint when the config is not set
-        query = startQuery()
-        inputData.addData(1, 2)
-        query.processAllAvailable()
-        assert(getFormatVersion(query) == 4)
-        query.stop()
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -62,8 +62,9 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       val testConfs = Seq(
         ("spark.sql.streaming.stateStore.providerClass",
           classOf[RocksDBStateStoreProvider].getName),
-        (RocksDBConf.ROCKSDB_CONF_NAME_PREFIX + ".compactOnCommit", "true"),
-        (RocksDBConf.ROCKSDB_CONF_NAME_PREFIX + ".lockAcquireTimeoutMs", "10")
+        (RocksDBConf.COMPACT_ON_COMMIT_CONF.fullName, "true"),
+        (RocksDBConf.LOCK_ACQUIRE_TIMEOUT_MS_CONF.fullName, "10"),
+        (SQLConf.STATE_STORE_ROCKSDB_FORMAT_VERSION.key, "4")
       )
       testConfs.foreach { case (k, v) => spark.conf.set(k, v) }
 
@@ -87,6 +88,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       // Verify the confs are same as those configured in the session conf
       assert(rocksDBConfInTask.compactOnCommit == true)
       assert(rocksDBConfInTask.lockAcquireTimeoutMs == 10L)
+      assert(rocksDBConfInTask.formatVersion == 4)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -62,8 +62,8 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       val testConfs = Seq(
         ("spark.sql.streaming.stateStore.providerClass",
           classOf[RocksDBStateStoreProvider].getName),
-        (RocksDBConf.COMPACT_ON_COMMIT_CONF.fullName, "true"),
-        (RocksDBConf.LOCK_ACQUIRE_TIMEOUT_MS_CONF.fullName, "10"),
+        (RocksDBConf.ROCKSDB_CONF_NAME_PREFIX + ".compactOnCommit", "true"),
+        (RocksDBConf.ROCKSDB_CONF_NAME_PREFIX + ".lockAcquireTimeoutMs", "10"),
         (SQLConf.STATE_STORE_ROCKSDB_FORMAT_VERSION.key, "4")
       )
       testConfs.foreach { case (k, v) => spark.conf.set(k, v) }


### PR DESCRIPTION
### What changes were proposed in this pull request?

RocksDB provides backward compatibility but it doesn't always provide forward compatibility. It's better to store the RocksDB format version in the checkpoint so that it would give us more information to provide the rollback guarantee when we upgrade the RocksDB version that may introduce incompatible change in a new Spark version.

A typical case is when a user upgrades their query to a new Spark version, and this new Spark version has a new RocksDB version which may use a new format. But the user hits some bug and decide to rollback. But in the old Spark version, the old RocksDB version cannot read the new format.

In order to handle this case, we will write the RocksDB format version to the checkpoint. When restarting from a checkpoint, we will force RocksDB to use the format version stored in the checkpoint. This will ensure the user can rollback their Spark version if needed.

We also provide a config `spark.sql.streaming.stateStore.rocksdb.formatVersion` for users who don't need to rollback their Spark versions to overwrite the format version specified in the checkpoint.

### Why are the changes needed?

Provide the Spark version rollback guarantee for streaming queries when a new RocksDB introduces an incompatible format change.

### Does this PR introduce _any_ user-facing change?

No. RocksDB state store is a new feature in Spark 3.2, which has not yet released.

### How was this patch tested?

The new unit tests.