### PR TITLE
[SPARK-36526][SQL] DSV2 Index Support: Add supportsIndex interface

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/Index.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/Index.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog.index;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * An Index in a table
+ *
+ * @since 3.3.0
+ */
+@Evolving
+public class Index {
+  private String indexName;
+  private FieldReference[] columns;
+  private Identifier table;
+  private String indexType;
+  private Map<String, String> properties = Collections.emptyMap();
+
+  public Index(
+      String indexName,
+      FieldReference[] columns,
+      Identifier table,
+      String indexType,
+      Map<String, String> properties) {
+    this.indexName = indexName;
+    this.columns = columns;
+    this.table = table;
+    this.indexType = indexType;
+    this.properties = properties;
+  }
+
+  /**
+   * @return the Index name.
+   */
+  String indexName() { return indexName; }
+
+  /**
+   * @return the column(s) this Index is on. Could be multi columns (a multi-column index).
+   */
+  FieldReference[] columns() { return columns; }
+
+  /**
+   * @return the table this Index is on.
+   */
+  Identifier table() { return table; }
+
+  /**
+   * @return the indexType of this Index.
+   */
+  String indexType() { return indexType; }
+
+  /**
+   * Returns the string map of index properties.
+   */
+  Map<String, String> properties() {
+    return Collections.emptyMap();
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/Index.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/Index.java
@@ -17,12 +17,12 @@
 
 package org.apache.spark.sql.connector.catalog.index;
 
+import java.util.Collections;
+import java.util.Map;
+
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.expressions.FieldReference;
-
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * An Index in a table
@@ -32,21 +32,21 @@ import java.util.Map;
 @Evolving
 public class Index {
   private String indexName;
-  private FieldReference[] columns;
-  private Identifier table;
   private String indexType;
+  private Identifier table;
+  private FieldReference[] columns;
   private Map<String, String> properties = Collections.emptyMap();
 
   public Index(
       String indexName,
-      FieldReference[] columns,
-      Identifier table,
       String indexType,
+      Identifier table,
+      FieldReference[] columns,
       Map<String, String> properties) {
     this.indexName = indexName;
-    this.columns = columns;
-    this.table = table;
     this.indexType = indexType;
+    this.table = table;
+    this.columns = columns;
     this.properties = properties;
   }
 
@@ -56,9 +56,9 @@ public class Index {
   String indexName() { return indexName; }
 
   /**
-   * @return the column(s) this Index is on. Could be multi columns (a multi-column index).
+   * @return the indexType of this Index.
    */
-  FieldReference[] columns() { return columns; }
+  String indexType() { return indexType; }
 
   /**
    * @return the table this Index is on.
@@ -66,9 +66,9 @@ public class Index {
   Identifier table() { return table; }
 
   /**
-   * @return the indexType of this Index.
+   * @return the column(s) this Index is on. Could be multi columns (a multi-column index).
    */
-  String indexType() { return indexType; }
+  FieldReference[] columns() { return columns; }
 
   /**
    * Returns the string map of index properties.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchIndexException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
  * Catalog methods for working with index
@@ -43,7 +43,7 @@ public interface SupportsIndex extends CatalogPlugin {
    * @param indexType the IndexType of the index to be created
    * @param table the table on which index to be created
    * @param columns the columns on which index to be created
-   * @param columnPropertyList the properties of the columns on which index to be created
+   * @param columnProperties the properties of the columns on which index to be created
    * @param properties the properties of the index to be created
    * @throws IndexAlreadyExistsException If the index already exists (optional)
    * @throws UnsupportedOperationException If create index is not a supported operation
@@ -51,24 +51,20 @@ public interface SupportsIndex extends CatalogPlugin {
   void createIndex(String indexName,
       String indexType,
       Identifier table,
-      FieldReference[] columns,
-      Map<String, String>[] columnPropertyList,
-      Map<String, String> properties)
+      NamedReference[] columns,
+      Map<NamedReference, Properties>[] columnProperties,
+      Properties properties)
       throws IndexAlreadyExistsException, UnsupportedOperationException;
 
   /**
-   * Soft deletes the index with the given name.
-   * Deleted index can be restored by calling restoreIndex.
+   * drops the index with the given name.
    *
-   * @param indexName the name of the index to be deleted
-   * @return true if the index is deleted
+   * @param indexName the name of the index to be dropped.
+   * @return true if the index is dropped
    * @throws NoSuchIndexException If the index does not exist (optional)
-   * @throws UnsupportedOperationException If delete index is not a supported operation
+   * @throws UnsupportedOperationException If drop index is not a supported operation
    */
-  default boolean deleteIndex(String indexName)
-      throws NoSuchIndexException, UnsupportedOperationException {
-    throw new UnsupportedOperationException("Delete index is not supported.");
-  }
+  boolean dropIndex(String indexName) throws NoSuchIndexException, UnsupportedOperationException;
 
   /**
    * Checks whether an index exists.
@@ -84,56 +80,5 @@ public interface SupportsIndex extends CatalogPlugin {
    * @param table the table to be checked on for indexes
    * @throws NoSuchTableException
    */
-  Index[] listIndexes(Identifier table) throws NoSuchTableException;
-
-  /**
-   * Hard deletes the index with the given name.
-   * The Index can't be restored once dropped.
-   *
-   * @param indexName the name of the index to be dropped.
-   * @return true if the index is dropped
-   * @throws NoSuchIndexException If the index does not exist (optional)
-   * @throws UnsupportedOperationException If drop index is not a supported operation
-   */
-  boolean dropIndex(String indexName) throws NoSuchIndexException, UnsupportedOperationException;
-
-  /**
-   * Restores the index with the given name.
-   * Deleted index can be restored by calling restoreIndex, but dropped index can't be restored.
-   *
-   * @param indexName the name of the index to be restored
-   * @return true if the index is restored
-   * @throws NoSuchIndexException If the index does not exist (optional)
-   * @throws UnsupportedOperationException
-   */
-  default boolean restoreIndex(String indexName)
-      throws NoSuchIndexException, UnsupportedOperationException {
-    throw new UnsupportedOperationException("Restore index is not supported.");
-  }
-
-  /**
-   * Refreshes index using the latest data. This causes the index to be rebuilt.
-   *
-   * @param indexName the name of the index to be rebuilt
-   * @return true if the index is rebuilt
-   * @throws NoSuchIndexException If the index does not exist (optional)
-   * @throws UnsupportedOperationException
-   */
-  default boolean refreshIndex(String indexName)
-      throws NoSuchIndexException, UnsupportedOperationException {
-    throw new UnsupportedOperationException("Refresh index is not supported.");
-  }
-
-  /**
-   * Alter Index using the new property. This causes the index to be rebuilt.
-   *
-   * @param indexName the name of the index to be altered
-   * @return true if the index is altered
-   * @throws NoSuchIndexException If the index does not exist (optional)
-   * @throws UnsupportedOperationException
-   */
-  default boolean alterIndex(String indexName, Properties properties)
-      throws NoSuchIndexException, UnsupportedOperationException {
-    throw new UnsupportedOperationException("Alter index is not supported.");
-  }
+  TableIndex[] listIndexes(Identifier table) throws NoSuchTableException;
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
@@ -43,6 +43,7 @@ public interface SupportsIndex extends CatalogPlugin {
    * @param indexType the IndexType of the index to be created
    * @param table the table on which index to be created
    * @param columns the columns on which index to be created
+   * @param columnPropertyList the properties of the columns on which index to be created
    * @param properties the properties of the index to be created
    * @throws IndexAlreadyExistsException If the index already exists (optional)
    * @throws UnsupportedOperationException If create index is not a supported operation
@@ -51,6 +52,7 @@ public interface SupportsIndex extends CatalogPlugin {
       String indexType,
       Identifier table,
       FieldReference[] columns,
+      Map<String, String>[] columnPropertyList,
       Map<String, String> properties)
       throws IndexAlreadyExistsException, UnsupportedOperationException;
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
@@ -23,9 +23,7 @@ import java.util.Properties;
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.catalyst.analysis.IndexAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchIndexException;
-import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.apache.spark.sql.connector.catalog.CatalogPlugin;
-import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
@@ -34,14 +32,13 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
  * @since 3.3.0
  */
 @Evolving
-public interface SupportsIndex extends CatalogPlugin {
+public interface SupportsIndex extends Table {
 
   /**
    * Creates an index.
    *
    * @param indexName the name of the index to be created
    * @param indexType the IndexType of the index to be created
-   * @param table the table on which index to be created
    * @param columns the columns on which index to be created
    * @param columnProperties the properties of the columns on which index to be created
    * @param properties the properties of the index to be created
@@ -50,7 +47,6 @@ public interface SupportsIndex extends CatalogPlugin {
    */
   void createIndex(String indexName,
       String indexType,
-      Identifier table,
       NamedReference[] columns,
       Map<NamedReference, Properties>[] columnProperties,
       Properties properties)
@@ -75,10 +71,7 @@ public interface SupportsIndex extends CatalogPlugin {
   boolean indexExists(String indexName);
 
   /**
-   * Lists all the indexes in a table.
-   *
-   * @param table the table to be checked on for indexes
-   * @throws NoSuchTableException
+   * Lists all the indexes in this table.
    */
-  TableIndex[] listIndexes(Identifier table) throws NoSuchTableException;
+  TableIndex[] listIndexes();
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
@@ -27,7 +27,7 @@ import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
- * Catalog methods for working with index
+ * Table methods for working with index
  *
  * @since 3.3.0
  */
@@ -43,27 +43,25 @@ public interface SupportsIndex extends Table {
    * @param columnProperties the properties of the columns on which index to be created
    * @param properties the properties of the index to be created
    * @throws IndexAlreadyExistsException If the index already exists (optional)
-   * @throws UnsupportedOperationException If create index is not a supported operation
    */
   void createIndex(String indexName,
       String indexType,
       NamedReference[] columns,
       Map<NamedReference, Properties>[] columnProperties,
       Properties properties)
-      throws IndexAlreadyExistsException, UnsupportedOperationException;
+      throws IndexAlreadyExistsException;
 
   /**
-   * drops the index with the given name.
+   * Drops the index with the given name.
    *
    * @param indexName the name of the index to be dropped.
    * @return true if the index is dropped
    * @throws NoSuchIndexException If the index does not exist (optional)
-   * @throws UnsupportedOperationException If drop index is not a supported operation
    */
-  boolean dropIndex(String indexName) throws NoSuchIndexException, UnsupportedOperationException;
+  boolean dropIndex(String indexName) throws NoSuchIndexException;
 
   /**
-   * Checks whether an index exists.
+   * Checks whether an index exists in this table.
    *
    * @param indexName the name of the index
    * @return true if the index exists, false otherwise

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog.index;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.catalyst.analysis.IndexAlreadyExistsException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchIndexException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Catalog methods for working with index
+ *
+ * @since 3.3.0
+ */
+@Evolving
+public interface SupportsIndex extends CatalogPlugin {
+
+  /**
+   * Creates an index.
+   *
+   * @param indexName the name of the index to be created
+   * @param indexType the IndexType of the index to be created
+   * @param table the table on which index to be created
+   * @param columns the columns on which index to be created
+   * @param properties the properties of the index to be created
+   * @throws IndexAlreadyExistsException If the index already exists (optional)
+   * @throws UnsupportedOperationException If create index is not a supported operation
+   */
+  void createIndex(String indexName,
+                   String indexType,
+                   Identifier table,
+                   FieldReference[] columns,
+                   Map<String, String> properties)
+      throws IndexAlreadyExistsException, UnsupportedOperationException;
+
+  /**
+   * Soft deletes the index with the given name.
+   * Deleted index can be restored by calling restoreIndex.
+   *
+   * @param indexName the name of the index to be deleted
+   * @return true if the index is deleted
+   * @throws NoSuchIndexException If the index does not exist (optional)
+   * @throws UnsupportedOperationException If delete index is not a supported operation
+   */
+  default boolean deleteIndex(String indexName) throws UnsupportedOperationException {
+    throw new UnsupportedOperationException("Delete index is not supported.");
+  }
+
+  /**
+   * Checks whether an index exists.
+   *
+   * @param indexName the name of the index
+   * @return true if the index exists, false otherwise
+   */
+  boolean indexExists(String indexName);
+
+  /**
+   * Lists all the indexes in a table.
+   *
+   * @param table the table to be checked on for indexes
+   * @throws NoSuchTableException
+   */
+  Index[] listIndexes(Identifier table) throws NoSuchTableException;
+
+  /**
+   * Hard deletes the index with the given name.
+   * The Index can't be restored once dropped.
+   *
+   * @param indexName the name of the index to be dropped.
+   * @return true if the index is dropped
+   * @throws NoSuchIndexException If the index does not exist (optional)
+   * @throws UnsupportedOperationException If drop index is not a supported operation
+   */
+  boolean dropIndex(String indexName) throws NoSuchIndexException, UnsupportedOperationException;
+
+  /**
+   * Restores the index with the given name.
+   * Deleted index can be restored by calling restoreIndex, but dropped index can't be restored.
+   *
+   * @param indexName the name of the index to be restored
+   * @return true if the index is restored
+   * @throws NoSuchIndexException If the index does not exist (optional)
+   * @throws UnsupportedOperationException
+   */
+  default boolean restoreIndex(String indexName)
+      throws NoSuchIndexException, UnsupportedOperationException {
+    throw new UnsupportedOperationException("Restore index is not supported.");
+  }
+
+  /**
+   * Refreshes index using the latest data. This causes the index to be rebuilt.
+   *
+   * @param indexName the name of the index to be rebuilt
+   * @return true if the index is rebuilt
+   * @throws NoSuchIndexException If the index does not exist (optional)
+   * @throws UnsupportedOperationException
+   */
+  default boolean refreshIndex(String indexName)
+      throws NoSuchIndexException, UnsupportedOperationException {
+    throw new UnsupportedOperationException("Refresh index is not supported.");
+  }
+
+  /**
+   * Alter Index using the new property. This causes the index to be rebuilt.
+   *
+   * @param indexName the name of the index to be altered
+   * @return true if the index is altered
+   * @throws NoSuchIndexException If the index does not exist (optional)
+   * @throws UnsupportedOperationException
+   */
+  default boolean alterIndex(String indexName, Properties properties)
+      throws NoSuchIndexException, UnsupportedOperationException {
+    throw new UnsupportedOperationException("Alter index is not supported.");
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.connector.catalog.index;
 
+import java.util.Map;
+import java.util.Properties;
+
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.catalyst.analysis.IndexAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchIndexException;
@@ -24,9 +27,6 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.expressions.FieldReference;
-
-import java.util.Map;
-import java.util.Properties;
 
 /**
  * Catalog methods for working with index
@@ -63,7 +63,8 @@ public interface SupportsIndex extends CatalogPlugin {
    * @throws NoSuchIndexException If the index does not exist (optional)
    * @throws UnsupportedOperationException If delete index is not a supported operation
    */
-  default boolean deleteIndex(String indexName) throws UnsupportedOperationException {
+  default boolean deleteIndex(String indexName)
+      throws NoSuchIndexException, UnsupportedOperationException {
     throw new UnsupportedOperationException("Delete index is not supported.");
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/SupportsIndex.java
@@ -48,10 +48,10 @@ public interface SupportsIndex extends CatalogPlugin {
    * @throws UnsupportedOperationException If create index is not a supported operation
    */
   void createIndex(String indexName,
-                   String indexType,
-                   Identifier table,
-                   FieldReference[] columns,
-                   Map<String, String> properties)
+      String indexType,
+      Identifier table,
+      FieldReference[] columns,
+      Map<String, String> properties)
       throws IndexAlreadyExistsException, UnsupportedOperationException;
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/TableIndex.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/TableIndex.java
@@ -76,6 +76,4 @@ public final class TableIndex {
   Properties properties() {
     return properties;
   }
-
-  Properties columnProperties(NamedReference column) { return columnProperties.get(column); }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/TableIndex.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/TableIndex.java
@@ -17,13 +17,12 @@
 
 package org.apache.spark.sql.connector.catalog.index;
 
-import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.expressions.NamedReference;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
  * Index in a table
@@ -34,7 +33,6 @@ import java.util.Properties;
 public final class TableIndex {
   private String indexName;
   private String indexType;
-  private Identifier table;
   private NamedReference[] columns;
   private Map<NamedReference, Properties> columnProperties = Collections.emptyMap();
   private Properties properties;
@@ -42,13 +40,11 @@ public final class TableIndex {
   public TableIndex(
       String indexName,
       String indexType,
-      Identifier table,
       NamedReference[] columns,
       Map<NamedReference, Properties> columnProperties,
       Properties properties) {
     this.indexName = indexName;
     this.indexType = indexType;
-    this.table = table;
     this.columns = columns;
     this.columnProperties = columnProperties;
     this.properties = properties;
@@ -63,11 +59,6 @@ public final class TableIndex {
    * @return the indexType of this Index.
    */
   String indexType() { return indexType; }
-
-  /**
-   * @return the table this Index is on.
-   */
-  Identifier table() { return table; }
 
   /**
    * @return the column(s) this Index is on. Could be multi columns (a multi-column index).

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/TableIndex.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/index/TableIndex.java
@@ -17,36 +17,40 @@
 
 package org.apache.spark.sql.connector.catalog.index;
 
-import java.util.Collections;
-import java.util.Map;
-
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
 
 /**
- * An Index in a table
+ * Index in a table
  *
  * @since 3.3.0
  */
 @Evolving
-public class Index {
+public final class TableIndex {
   private String indexName;
   private String indexType;
   private Identifier table;
-  private FieldReference[] columns;
-  private Map<String, String> properties = Collections.emptyMap();
+  private NamedReference[] columns;
+  private Map<NamedReference, Properties> columnProperties = Collections.emptyMap();
+  private Properties properties;
 
-  public Index(
+  public TableIndex(
       String indexName,
       String indexType,
       Identifier table,
-      FieldReference[] columns,
-      Map<String, String> properties) {
+      NamedReference[] columns,
+      Map<NamedReference, Properties> columnProperties,
+      Properties properties) {
     this.indexName = indexName;
     this.indexType = indexType;
     this.table = table;
     this.columns = columns;
+    this.columnProperties = columnProperties;
     this.properties = properties;
   }
 
@@ -68,12 +72,19 @@ public class Index {
   /**
    * @return the column(s) this Index is on. Could be multi columns (a multi-column index).
    */
-  FieldReference[] columns() { return columns; }
+  NamedReference[] columns() { return columns; }
 
   /**
-   * Returns the string map of index properties.
+   * @return the map of column and column property map.
    */
-  Map<String, String> properties() {
-    return Collections.emptyMap();
+  Map<NamedReference, Properties> columnProperties() { return columnProperties; }
+
+  /**
+   * Returns the index properties.
+   */
+  Properties properties() {
+    return properties;
   }
+
+  Properties columnProperties(NamedReference column) { return columnProperties.get(column); }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AlreadyExistException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AlreadyExistException.scala
@@ -79,5 +79,5 @@ class PartitionsAlreadyExistException(message: String) extends AnalysisException
 class FunctionAlreadyExistsException(db: String, func: String)
   extends AnalysisException(s"Function '$func' already exists in database '$db'")
 
-class IndexAlreadyExistsException(indexName: String)
-  extends AnalysisException(s"Index '$indexName' already exists")
+class IndexAlreadyExistsException(indexName: String, table: Identifier)
+  extends AnalysisException(s"Index '$indexName' already exists in table ${table.quoted}")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AlreadyExistException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AlreadyExistException.scala
@@ -78,3 +78,6 @@ class PartitionsAlreadyExistException(message: String) extends AnalysisException
 
 class FunctionAlreadyExistsException(db: String, func: String)
   extends AnalysisException(s"Function '$func' already exists in database '$db'")
+
+class IndexAlreadyExistsException(indexName: String)
+  extends AnalysisException(s"Index '$indexName' already exists")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NoSuchItemException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NoSuchItemException.scala
@@ -95,3 +95,6 @@ class NoSuchPartitionsException(message: String) extends AnalysisException(messa
 
 class NoSuchTempFunctionException(func: String)
   extends AnalysisException(s"Temporary function '$func' not found")
+
+class NoSuchIndexException(indexName: String)
+  extends AnalysisException(s"Index '$indexName' not found")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Indexes are database objects created on one or more columns of a table. Indexes are used to improve query performance. A detailed explanation of database index is here https://en.wikipedia.org/wiki/Database_index

 This PR adds `supportsIndex` interface that provides APIs to work with indexes.


### Why are the changes needed?
Many data sources support index to improvement query performance. In order to take advantage of the index support in data source, this `supportsIndex` interface is added to let user to create/drop an index, list indexes, etc.


### Does this PR introduce _any_ user-facing change?
yes, the following new APIs are added:

- createIndex
- dropIndex
- indexExists
- listIndexes

New SQL syntax:
```

CREATE [index_type] INDEX [index_name] ON [TABLE] table_name (column_index_property_list)[OPTIONS indexPropertyList]

    column_index_property_list: column_name [OPTIONS(indexPropertyList)]  [ ,  . . . ]
    indexPropertyList: index_property_name = index_property_value [ ,  . . . ]

DROP INDEX index_name

```
### How was this patch tested?
only interface is added for now. Tests will be added when doing the implementation
