### PR TITLE
[SPARK-36052][K8S][FOLLOWUP] Update config version to 3.2.0

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -601,7 +601,7 @@ private[spark] object Config extends Logging {
         "also counted into this limit as they will change into pending PODs by time. " +
         "This limit is independent from the resource profiles as it limits the sum of all " +
         "allocation for all the used resource profiles.")
-      .version("3.3.0")
+      .version("3.2.0")
       .intConf
       .checkValue(value => value > 0, "Maximum number of pending pods should be a positive integer")
       .createWithDefault(Int.MaxValue)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up to update the version of config, `spark.kubernetes.allocation.maxPendingPods`, from 3.3.0 to 3.2.0.

### Why are the changes needed?

SPARK-36052 landed at branch-3.2 to fix a bug.

### Does this PR introduce _any_ user-facing change?

Yes, but this is a new configuration to fix a bug.

### How was this patch tested?

Pass the CIs.