### PR TITLE
[SPARK-36518][Deploy] Spark should support distribute directory to cluster

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/DependencyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/DependencyUtils.scala
@@ -316,7 +316,7 @@ private[spark] object DependencyUtils extends Logging {
       case _ =>
         val fs = FileSystem.get(uri, hadoopConf)
         Option(fs.globStatus(new Path(uri))).map { status =>
-          status.filter(_.isFile).map(_.getPath.toUri.toString)
+          status.map(_.getPath.toUri.toString)
         }.getOrElse(Array(uri.toString))
     }
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
support distribute directory to cluster via --files
before:
[root@kwephispra41893 spark]# ll /opt/ygh/testdir/
total 8
drwxr-xr-x 2 root root 4096 Aug 17 16:07 dd1
drwxr-xr-x 2 root root 4096 Aug 17 16:07 dd2
-rw-r--r-- 1 root root    0 Aug 17 16:07 t1.txt
-rw-r--r-- 1 root root    0 Aug 17 16:07 t2.txt
-rw-r--r-- 1 root root    0 Aug 17 16:07 t3.conf

spark-shell --master yarn --files file:///opt/ygh/testdir
![image](https://user-images.githubusercontent.com/25889738/129689226-d63cc7f6-c529-4c6f-a94d-d48c062dbf29.png)

after:
spark-shell --master yarn --files file:///opt/ygh/testdir
![image](https://user-images.githubusercontent.com/25889738/129689406-432c796c-52e5-49c1-8016-9eec151257fb.png)


### Why are the changes needed?
when we submit spark application we can't directly distribute a directory to cluster


### Does this PR introduce _any_ user-facing change?
No, user do not need change any code


### How was this patch tested?
tested by existing UT
