### PR TITLE
Increasing performance of upper case operation for non-ascii-only strings

### DIFF
--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -124,6 +124,38 @@ public class UTF8StringSuite {
     testUpperandLower("ЀЁЂѺΏỀ", "ѐёђѻώề");
     testUpperandLower("大千世界 数据砖头", "大千世界 数据砖头");
   }
+  
+  @Test
+  public void newUpper() {
+    for (int i = 0;i <= 0x10ffff;i++) {
+      StringBuilder sb = new StringBuilder();
+      for (int j = 0;j < 20;j++) {
+        try {
+          sb.append(Character.toChars(i + j));
+        } catch (IllegalArgumentException r) {}
+      }
+      String s = sb.toString();
+      byte[] arr1 = UTF8String.fromString(s).toUpperCase().getBytes();
+      byte[] arr2 = s.toUpperCase().getBytes(StandardCharsets.UTF_8);
+      assertArrayEquals(arr1, arr2);
+    }
+    Random r = new Random(1000);
+    int testStrLen = 128;
+    for (int i = 0;i < 40;i++) {
+      StringBuilder sb = new StringBuilder();
+      for (int j = 0;j < testStrLen;j++) {
+        try {
+          sb.append(Character.toChars(r.nextInt(0x10ffff + 1)));
+        } catch (IllegalArgumentException e) {
+          j--;
+        }
+      }
+      String s = sb.toString();
+      byte[] arr1 = UTF8String.fromString(s).toUpperCase().getBytes();
+      byte[] arr2 = s.toUpperCase().getBytes(StandardCharsets.UTF_8);
+      assertArrayEquals(arr1, arr2);
+    }
+  }
 
   @Test
   public void titleCase() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Using extra uppercase map as uppercase operation for non-ascii character instead of using toUpperCaseSlow method, which increase performance of uppercase operation for non-ascii character.

### Why are the changes needed?
Make upper case faster for non-ascii-only strings.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unittest
