### PR TITLE
[SPARK-36370][PYTHON][FOLLOWUP] Use LooseVersion instead of pkg_resources.parse_version

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -26,7 +26,6 @@ from collections import OrderedDict, namedtuple
 from distutils.version import LooseVersion
 from functools import partial
 from itertools import product
-from pkg_resources import parse_version  # type: ignore
 from typing import (
     Any,
     Callable,
@@ -47,7 +46,7 @@ from typing import (
 import pandas as pd
 from pandas.api.types import is_hashable, is_list_like
 
-if parse_version(pd.__version__) >= parse_version("1.3.0"):
+if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
     from pandas.core.common import _builtin_table
 else:
     from pandas.core.base import SelectionMixin


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #33687.

Use `LooseVersion` instead of `pkg_resources.parse_version`.

### Why are the changes needed?

In the previous PR, `pkg_resources.parse_version` was used, but we should use `LooseVersion` instead to be consistent in the code base.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.