### PR TITLE
Spark 36303

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,6 +1,59 @@
 {
+  "ADD_FILES_WITH_ABSOLUTE_PATH_UNSUPPORTED_ERROR" : {
+    "message" : [ "%s does not support adding files with an absolute path" ],
+    "sqlState" : "42000"
+  },
   "AMBIGUOUS_FIELD_NAME" : {
     "message" : [ "Field name %s is ambiguous and has %s matching fields in the struct." ],
+    "sqlState" : "42000"
+  },
+  "BATCH_METADATA_FILE_NOT_FOUND_ERROR" : {
+    "message" : [ "Unable to find batch %s" ]
+  },
+  "CANNOT_CLONE_OR_COPY_READ_ONLY_SQL_CONF_ERROR" : {
+    "message" : [ "Cannot clone/copy ReadOnlySQLConf." ],
+    "sqlState" : "42000"
+  },
+  "CANNOT_EXECUTE_STREAMING_RELATION_EXEC_ERROR" : {
+    "message" : [ "StreamingRelationExec cannot be executed" ],
+    "sqlState" : "42000"
+  },
+  "CANNOT_GET_EVENT_TIME_WATERMARK_ERROR" : {
+    "message" : [ "Cannot get event time watermark timestamp without setting watermark before [map|flatMap]GroupsWithState" ],
+    "sqlState" : "42000"
+  },
+  "CANNOT_GET_SQL_CONF_IN_SCHEDULER_EVENT_LOOP_THREAD_ERROR" : {
+    "message" : [ "Cannot get SQLConf inside scheduler event loop thread." ],
+    "sqlState" : "42000"
+  },
+  "CANNOT_INSTANTIATE_ABSTRACT_CATALOG_PLUGIN_CLASS_ERROR" : {
+    "message" : [ "Cannot instantiate abstract catalog plugin class for catalog '%s': %s" ],
+    "sqlState" : "42000"
+  },
+  "CANNOT_MUTATE_READ_ONLY_SQL_CONF_ERROR" : {
+    "message" : [ "Cannot mutate ReadOnlySQLConf." ],
+    "sqlState" : "42000"
+  },
+  "CANNOT_SET_TIMEOUT_TIMESTAMP_ERROR" : {
+    "message" : [ "Cannot set timeout timestamp without enabling event time timeout in [map|flatMapGroupsWithState" ],
+    "sqlState" : "42000"
+  },
+  "CATALOG_FAIL_TO_CALL_PUBLIC_NO_ARG_CONSTRUCTOR_ERROR" : {
+    "message" : [ "Failed to call public no-arg constructor for catalog '%s': %s" ]
+  },
+  "CATALOG_FAIL_TO_FIND_PUBLIC_NO_ARG_CONSTRUCTOR_ERROR" : {
+    "message" : [ "Failed to find public no-arg constructor for catalog '%s': %s" ]
+  },
+  "CATALOG_PLUGIN_CLASS_NOT_FOUND_ERROR" : {
+    "message" : [ "Catalog '%s' plugin class not found: spark.sql.catalog.%s is not defined" ],
+    "sqlState" : "42000"
+  },
+  "CATALOG_PLUGIN_CLASS_NOT_FOUND_FOR_CATALOG_ERROR" : {
+    "message" : [ "Cannot find catalog plugin class for catalog '%s': %s" ],
+    "sqlState" : "42000"
+  },
+  "CATALOG_PLUGIN_CLASS_NOT_IMPLEMENTED_ERROR" : {
+    "message" : [ "Plugin class for catalog '%s' does not implement CatalogPlugin: %s" ],
     "sqlState" : "42000"
   },
   "DIVIDE_BY_ZERO" : {
@@ -10,6 +63,10 @@
   "DUPLICATE_KEY" : {
     "message" : [ "Found duplicate keys '%s'" ],
     "sqlState" : "23000"
+  },
+  "FAILED_TO_INSTANTIATE_CONSTRUCTOR_FOR_CATALOG_ERROR" : {
+    "message" : [ "Failed during instantiating constructor for catalog '%s': %S" ],
+    "sqlState" : "42000"
   },
   "GROUPING_COLUMN_MISMATCH" : {
     "message" : [ "Column of grouping (%s) can't be found in grouping columns %s" ],
@@ -36,12 +93,24 @@
   "INVALID_JSON_SCHEMA_MAPTYPE" : {
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
   },
+  "INVALID_STREAMING_OUTPUT_MODE_ERROR" : {
+    "message" : [ "Invalid output mode: %s" ],
+    "sqlState" : "42000"
+  },
+  "MICRO_BATCH_UNSUPPORTED_BY_DATA_SOURCE_ERROR" : {
+    "message" : [ "Data source %s does not support microbatch processing." ],
+    "sqlState" : "42000"
+  },
   "MISSING_COLUMN" : {
     "message" : [ "cannot resolve '%s' given input columns: [%s]" ],
     "sqlState" : "42000"
   },
   "MISSING_STATIC_PARTITION_COLUMN" : {
     "message" : [ "Unknown static partition column: %s" ],
+    "sqlState" : "42000"
+  },
+  "MULTI_STREAMING_QUERIES_USING_PATH_CONCURRENTLY_ERROR" : {
+    "message" : [ "Multiple streaming queries are concurrently using %s" ],
     "sqlState" : "42000"
   },
   "NON_LITERAL_PIVOT_VALUES" : {
@@ -51,6 +120,9 @@
   "NON_PARTITION_COLUMN" : {
     "message" : [ "PARTITION clause cannot contain a non-partition column name: %s" ],
     "sqlState" : "42000"
+  },
+  "NO_SUCH_ELEMENT_EXCEPTION_ERROR" : {
+    "message" : [ "" ]
   },
   "PIVOT_VALUE_DATA_TYPE_MISMATCH" : {
     "message" : [ "Invalid pivot value '%s': value data type %s does not match pivot column data type %s" ],

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -124,18 +124,6 @@ class SparkConcurrentModificationException(
 }
 
 /**
- * Catalog not found exception thrown from Spark with an error class.
- */
-class SparkCatalogNotFoundException(errorClass: String, messageParameters: Array[String])
-  extends SparkException(
-    SparkThrowableHelper.getMessage(errorClass, messageParameters))
-    with SparkThrowable {
-
-  override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-}
-
-/**
  * Runtime exception thrown from Spark with an error class
  */
 class SparkRuntimeException(errorClass: String, messageParameters: Array[String])

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -17,6 +17,10 @@
 
 package org.apache.spark
 
+import java.io.FileNotFoundException
+import java.util.ConcurrentModificationException
+
+
 class SparkException(
     message: String,
     cause: Throwable,
@@ -74,6 +78,81 @@ private[spark] class SparkUpgradeException(version: String, message: String, cau
  */
 class SparkArithmeticException(errorClass: String, messageParameters: Array[String])
   extends ArithmeticException(SparkThrowableHelper.getMessage(errorClass, messageParameters))
+    with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * Unsupported Operation exception thrown from Spark with an error class.
+ */
+class SparkUnsupportedOperationException(errorClass: String, messageParameters: Array[String])
+  extends UnsupportedOperationException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters))
+    with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * File doesn't be found exception thrown from Spark with an error class.
+ */
+class SparkFileNotFoundException(errorClass: String, messageParameters: Array[String])
+  extends FileNotFoundException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters))
+    with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * Concurrent modification exception thrown from Spark with an error class.
+ */
+class SparkConcurrentModificationException(
+      errorClass: String,
+      messageParameters: Array[String],
+      cause: Throwable)
+  extends ConcurrentModificationException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters))
+    with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * Catalog not found exception thrown from Spark with an error class.
+ */
+class SparkCatalogNotFoundException(errorClass: String, messageParameters: Array[String])
+  extends SparkException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters))
+    with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * Runtime exception thrown from Spark with an error class
+ */
+class SparkRuntimeException(errorClass: String, messageParameters: Array[String])
+  extends RuntimeException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters))
+    with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * NoSuch element exception thrown form Spark with an error class.
+ */
+class SparkNoSuchElementException(errorClass: String, messageParameters: Array[String])
+  extends NoSuchElementException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters))
     with SparkThrowable {
 
   override def getErrorClass: String = errorClass

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogNotFoundException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogNotFoundException.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.catalog
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkThrowable, SparkThrowableHelper}
 import org.apache.spark.annotation.Experimental
 
 @Experimental
@@ -25,4 +25,13 @@ class CatalogNotFoundException(message: String, cause: Throwable)
   extends SparkException(message, cause) {
 
   def this(message: String) = this(message, null)
+}
+
+class SparkCatalogNotFoundException(errorClass: String, messageParameters: Array[String])
+  extends CatalogNotFoundException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters))
+    with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -32,7 +32,7 @@ import org.apache.hadoop.fs.permission.FsPermission
 import org.codehaus.commons.compiler.CompileException
 import org.codehaus.janino.InternalCompilerException
 
-import org.apache.spark.{Partition, SparkArithmeticException, SparkCatalogNotFoundException, SparkConcurrentModificationException, SparkException, SparkFileNotFoundException, SparkNoSuchElementException, SparkRuntimeException, SparkUnsupportedOperationException, SparkUpgradeException}
+import org.apache.spark.{Partition, SparkArithmeticException, SparkConcurrentModificationException, SparkException, SparkFileNotFoundException, SparkNoSuchElementException, SparkRuntimeException, SparkUnsupportedOperationException, SparkUpgradeException}
 import org.apache.spark.executor.CommitDeniedException
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.memory.SparkOutOfMemoryError
@@ -47,7 +47,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{DomainJoin, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.ValueInterval
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.{sideBySide, BadRecordException, FailFastMode}
-import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableProvider}
+import org.apache.spark.sql.connector.catalog.{Identifier, SparkCatalogNotFoundException, Table, TableProvider}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.QueryExecutionException

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -32,7 +32,7 @@ import org.apache.hadoop.fs.permission.FsPermission
 import org.codehaus.commons.compiler.CompileException
 import org.codehaus.janino.InternalCompilerException
 
-import org.apache.spark.{Partition, SparkArithmeticException, SparkException, SparkUpgradeException}
+import org.apache.spark.{Partition, SparkArithmeticException, SparkCatalogNotFoundException, SparkConcurrentModificationException, SparkException, SparkFileNotFoundException, SparkNoSuchElementException, SparkRuntimeException, SparkUnsupportedOperationException, SparkUpgradeException}
 import org.apache.spark.executor.CommitDeniedException
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.memory.SparkOutOfMemoryError
@@ -47,7 +47,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{DomainJoin, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.ValueInterval
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.{sideBySide, BadRecordException, FailFastMode}
-import org.apache.spark.sql.connector.catalog.{CatalogNotFoundException, Identifier, Table, TableProvider}
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableProvider}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.QueryExecutionException
@@ -1406,59 +1406,76 @@ object QueryExecutionErrors {
   }
 
   def cannotGetEventTimeWatermarkError(): Throwable = {
-    new UnsupportedOperationException(
-      "Cannot get event time watermark timestamp without setting watermark before " +
-        "[map|flatMap]GroupsWithState")
+    new SparkUnsupportedOperationException(
+      errorClass = "CANNOT_GET_EVENT_TIME_WATERMARK_ERROR",
+      messageParameters = Array.empty
+    )
   }
 
   def cannotSetTimeoutTimestampError(): Throwable = {
-    new UnsupportedOperationException(
-      "Cannot set timeout timestamp without enabling event time timeout in " +
-        "[map|flatMapGroupsWithState")
+    new SparkUnsupportedOperationException(
+      errorClass = "CANNOT_SET_TIMEOUT_TIMESTAMP_ERROR",
+      messageParameters = Array.empty)
   }
 
   def batchMetadataFileNotFoundError(batchMetadataFile: Path): Throwable = {
-    new FileNotFoundException(s"Unable to find batch $batchMetadataFile")
+    new SparkFileNotFoundException(
+      errorClass = "BATCH_METADATA_FILE_NOT_FOUND_ERROR",
+      messageParameters = Array(batchMetadataFile.toString)
+    )
   }
 
   def multiStreamingQueriesUsingPathConcurrentlyError(
       path: String, e: FileAlreadyExistsException): Throwable = {
-    new ConcurrentModificationException(
-      s"Multiple streaming queries are concurrently using $path", e)
+    new SparkConcurrentModificationException(
+      errorClass = "MULTI_STREAMING_QUERIES_USING_PATH_CONCURRENTLY_ERROR",
+      messageParameters = Array(path.toString), e)
   }
 
   def addFilesWithAbsolutePathUnsupportedError(commitProtocol: String): Throwable = {
-    new UnsupportedOperationException(
-      s"$commitProtocol does not support adding files with an absolute path")
+    new SparkUnsupportedOperationException(
+      errorClass = "ADD_FILES_WITH_ABSOLUTE_PATH_UNSUPPORTED_ERROR",
+      messageParameters = Array(commitProtocol))
   }
 
   def microBatchUnsupportedByDataSourceError(srcName: String): Throwable = {
-    new UnsupportedOperationException(
-      s"Data source $srcName does not support microbatch processing.")
+    new SparkUnsupportedOperationException(
+      errorClass = "MICRO_BATCH_UNSUPPORTED_BY_DATA_SOURCE_ERROR",
+      messageParameters = Array(srcName))
   }
 
   def cannotExecuteStreamingRelationExecError(): Throwable = {
-    new UnsupportedOperationException("StreamingRelationExec cannot be executed")
+    new SparkUnsupportedOperationException(
+      errorClass = "CANNOT_EXECUTE_STREAMING_RELATION_EXEC_ERROR",
+      messageParameters = Array.empty
+    )
   }
 
   def invalidStreamingOutputModeError(outputMode: Option[OutputMode]): Throwable = {
-    new UnsupportedOperationException(s"Invalid output mode: $outputMode")
+    new SparkUnsupportedOperationException(
+      errorClass = "INVALID_STREAMING_OUTPUT_MODE_ERROR",
+      messageParameters = Array(outputMode.toString)
+    )
   }
 
   def catalogPluginClassNotFoundError(name: String): Throwable = {
-    new CatalogNotFoundException(
-      s"Catalog '$name' plugin class not found: spark.sql.catalog.$name is not defined")
+    new SparkCatalogNotFoundException(
+      errorClass = "CATALOG_PLUGIN_CLASS_NOT_FOUND_ERROR",
+      messageParameters = Array(name, name))
   }
 
   def catalogPluginClassNotImplementedError(name: String, pluginClassName: String): Throwable = {
     new SparkException(
-      s"Plugin class for catalog '$name' does not implement CatalogPlugin: $pluginClassName")
+      errorClass = "CATALOG_PLUGIN_CLASS_NOT_IMPLEMENTED_ERROR",
+      messageParameters = Array(name, pluginClassName), null)
   }
 
   def catalogPluginClassNotFoundForCatalogError(
       name: String,
       pluginClassName: String): Throwable = {
-    new SparkException(s"Cannot find catalog plugin class for catalog '$name': $pluginClassName")
+    new SparkException(
+      errorClass = "CATALOG_PLUGIN_CLASS_NOT_FOUND_FOR_CATALOG_ERROR",
+      messageParameters = Array(name, pluginClassName), null)
   }
 
   def catalogFailToFindPublicNoArgConstructorError(
@@ -1466,7 +1483,8 @@ object QueryExecutionErrors {
       pluginClassName: String,
       e: Exception): Throwable = {
     new SparkException(
-      s"Failed to find public no-arg constructor for catalog '$name': $pluginClassName)", e)
+      errorClass = "CATALOG_FAIL_TO_FIND_PUBLIC_NO_ARG_CONSTRUCTOR_ERROR",
+      messageParameters = Array(name, pluginClassName), e)
   }
 
   def catalogFailToCallPublicNoArgConstructorError(
@@ -1474,27 +1492,33 @@ object QueryExecutionErrors {
       pluginClassName: String,
       e: Exception): Throwable = {
     new SparkException(
-      s"Failed to call public no-arg constructor for catalog '$name': $pluginClassName)", e)
+      errorClass = "CATALOG_FAIL_TO_CALL_PUBLIC_NO_ARG_CONSTRUCTOR_ERROR",
+      messageParameters = Array(name, pluginClassName), e)
   }
 
   def cannotInstantiateAbstractCatalogPluginClassError(
       name: String,
       pluginClassName: String,
       e: Exception): Throwable = {
-    new SparkException("Cannot instantiate abstract catalog plugin class for " +
-      s"catalog '$name': $pluginClassName", e.getCause)
+    new SparkException(
+      errorClass = "CANNOT_INSTANTIATE_ABSTRACT_CATALOG_PLUGIN_CLASS_ERROR",
+      messageParameters = Array(name, pluginClassName), e.getCause)
   }
 
   def failedToInstantiateConstructorForCatalogError(
       name: String,
       pluginClassName: String,
       e: Exception): Throwable = {
-    new SparkException("Failed during instantiating constructor for catalog " +
-      s"'$name': $pluginClassName", e.getCause)
+    new SparkException(
+      errorClass = "FAILED_TO_INSTANTIATE_CONSTRUCTOR_FOR_CATALOG_ERROR",
+      messageParameters = Array(name, pluginClassName), e.getCause)
   }
 
   def noSuchElementExceptionError(): Throwable = {
-    new NoSuchElementException
+    new SparkNoSuchElementException(
+      errorClass = "NO_SUCH_ELEMENT_EXCEPTION_ERROR",
+      messageParameters = Array.empty
+    )
   }
 
   def noSuchElementExceptionError(key: String): Throwable = {
@@ -1502,15 +1526,24 @@ object QueryExecutionErrors {
   }
 
   def cannotMutateReadOnlySQLConfError(): Throwable = {
-    new UnsupportedOperationException("Cannot mutate ReadOnlySQLConf.")
+    new SparkUnsupportedOperationException(
+      errorClass = "CANNOT_MUTATE_READ_ONLY_SQL_CONF_ERROR",
+      messageParameters = Array.empty
+    )
   }
 
   def cannotCloneOrCopyReadOnlySQLConfError(): Throwable = {
-    new UnsupportedOperationException("Cannot clone/copy ReadOnlySQLConf.")
+    new SparkUnsupportedOperationException(
+      errorClass = "CANNOT_CLONE_OR_COPY_READ_ONLY_SQL_CONF_ERROR",
+      messageParameters = Array.empty
+    )
   }
 
   def cannotGetSQLConfInSchedulerEventLoopThreadError(): Throwable = {
-    new RuntimeException("Cannot get SQLConf inside scheduler event loop thread.")
+    new SparkRuntimeException(
+      errorClass = "CANNOT_GET_SQL_CONF_IN_SCHEDULER_EVENT_LOOP_THREAD_ERROR",
+      messageParameters = Array.empty
+    )
   }
 
   def unsupportedOperationExceptionError(): Throwable = {

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
@@ -66,7 +66,7 @@ public class CatalogLoadingSuite {
   public void testLoadWithoutConfig() {
     SQLConf conf = new SQLConf();
 
-    SparkException exc = intercept(CatalogNotFoundException.class,
+    SparkException exc = intercept(SparkCatalogNotFoundException.class,
         () -> Catalogs.load("missing", conf));
 
     Assert.assertTrue("Should complain that implementation is not configured",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Adds error classes to some of the exceptions in QueryExecutionErrors.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
--> Fills in missing error class and SQLSTATE fields.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->Existing tests
