### PR TITLE
[SPARK-36388][SPARK-36386][PYTHON][FOLLOWUP] Fix DataFrame groupby-rolling and groupby-expanding to follow pandas 1.3

### DIFF
--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames_groupby_expanding.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames_groupby_expanding.py
@@ -52,13 +52,16 @@ class OpsOnDiffFramesGroupByExpandingTest(PandasOnSparkTestCase, TestUtils):
         psdf = ps.from_pandas(pdf)
         kkey = ps.from_pandas(pkey)
 
+        # The behavior of GroupBy.expanding is changed from pandas 1.3.
         if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            # TODO(SPARK-36367): Fix the behavior to follow pandas >= 1.3
-            pass
-        else:
             self.assert_eq(
                 getattr(psdf.groupby(kkey).expanding(2), f)().sort_index(),
                 getattr(pdf.groupby(pkey).expanding(2), f)().sort_index(),
+            )
+        else:
+            self.assert_eq(
+                getattr(psdf.groupby(kkey).expanding(2), f)().sort_index(),
+                getattr(pdf.groupby(pkey).expanding(2), f)().drop("a", axis=1).sort_index(),
             )
 
         self.assert_eq(

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames_groupby_rolling.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames_groupby_rolling.py
@@ -50,13 +50,16 @@ class OpsOnDiffFramesGroupByRollingTest(PandasOnSparkTestCase, TestUtils):
         psdf = ps.from_pandas(pdf)
         kkey = ps.from_pandas(pkey)
 
+        # The behavior of GroupBy.rolling is changed from pandas 1.3.
         if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            # TODO(SPARK-36367): Fix the behavior to follow pandas >= 1.3
-            pass
-        else:
             self.assert_eq(
                 getattr(psdf.groupby(kkey).rolling(2), f)().sort_index(),
                 getattr(pdf.groupby(pkey).rolling(2), f)().sort_index(),
+            )
+        else:
+            self.assert_eq(
+                getattr(psdf.groupby(kkey).rolling(2), f)().sort_index(),
+                getattr(pdf.groupby(pkey).rolling(2), f)().drop("a", axis=1).sort_index(),
             )
 
         self.assert_eq(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is followup for https://github.com/apache/spark/pull/33646 to add missing tests.

### Why are the changes needed?

Some tests are missing

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unittest