### PR TITLE
[SPARK-36539][SQL] trimNonTopLevelAlias should not change StructType inner alias

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -78,14 +78,10 @@ trait AliasHelper {
   }
 
   protected def trimAliases(e: Expression): Expression = {
-    e.transformDown {
+    val trimAlias = e.transformDown {
       case Alias(child, _) => child
       case MultiAlias(child, _) => child
     }
-  }
-
-  protected def trimAliasesKeepSchema(e: Expression): Expression = {
-    val trimAlias = trimAliases(e)
     if (DataType.equalsIgnoreNullability(trimAlias.dataType, e.dataType)) {
       trimAlias
     } else {
@@ -96,14 +92,14 @@ trait AliasHelper {
   protected def trimNonTopLevelAliases[T <: Expression](e: T): T = {
     val res = e match {
       case a: Alias =>
-        a.copy(child = trimAliasesKeepSchema(a.child))(
+        a.copy(child = trimAliases(a.child))(
           exprId = a.exprId,
           qualifier = a.qualifier,
           explicitMetadata = Some(a.metadata),
           nonInheritableMetadataKeys = a.nonInheritableMetadataKeys)
       case a: MultiAlias =>
-        a.copy(child = trimAliasesKeepSchema(a.child))
-      case other => trimAliasesKeepSchema(other)
+        a.copy(child = trimAliases(a.child))
+      case other => trimAliases(other)
     }
 
     res.asInstanceOf[T]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -78,10 +78,14 @@ trait AliasHelper {
   }
 
   protected def trimAliases(e: Expression): Expression = {
-    val trimAlias = e.transformDown {
+    e.transformDown {
       case Alias(child, _) => child
       case MultiAlias(child, _) => child
     }
+  }
+
+  protected def trimAliasesKeepSchema(e: Expression): Expression = {
+    val trimAlias = trimAliases(e)
     if (DataType.equalsIgnoreNullability(trimAlias.dataType, e.dataType)) {
       trimAlias
     } else {
@@ -92,14 +96,14 @@ trait AliasHelper {
   protected def trimNonTopLevelAliases[T <: Expression](e: T): T = {
     val res = e match {
       case a: Alias =>
-        a.copy(child = trimAliases(a.child))(
+        a.copy(child = trimAliasesKeepSchema(a.child))(
           exprId = a.exprId,
           qualifier = a.qualifier,
           explicitMetadata = Some(a.metadata),
           nonInheritableMetadataKeys = a.nonInheritableMetadataKeys)
       case a: MultiAlias =>
-        a.copy(child = trimAliases(a.child))
-      case other => trimAliases(other)
+        a.copy(child = trimAliasesKeepSchema(a.child))
+      case other => trimAliasesKeepSchema(other)
     }
 
     res.asInstanceOf[T]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -82,7 +82,7 @@ trait AliasHelper {
       case Alias(child, _) => child
       case MultiAlias(child, _) => child
     }
-    if (DataType.equalsIgnoreNullability(trimAlias.dataType, e.dataType)) {
+    if (!e.resolved || DataType.equalsIgnoreNullability(trimAlias.dataType, e.dataType)) {
       trimAlias
     } else {
       e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -84,11 +84,12 @@ trait AliasHelper {
     }
   }
 
-  protected def trimAliasesExceptContainsStructTypeSchema(e: Expression): Expression = {
-    if (e.resolved && DataType.containsStructType(e.dataType)) {
-      e
+  protected def trimAliasesKeepSchema(e: Expression): Expression = {
+    val trimAlias = trimAliases(e)
+    if (DataType.equalsIgnoreNullability(trimAlias.dataType, e.dataType)) {
+      trimAlias
     } else {
-      trimAliases(e)
+      e
     }
   }
 
@@ -111,14 +112,14 @@ trait AliasHelper {
   protected def trimNonTopLevelAliasesExceptStruct[T <: Expression](e: T): T = {
     val res = e match {
       case a: Alias =>
-        a.copy(child = trimAliasesExceptContainsStructTypeSchema(a.child))(
+        a.copy(child = trimAliasesKeepSchema(a.child))(
           exprId = a.exprId,
           qualifier = a.qualifier,
           explicitMetadata = Some(a.metadata),
           nonInheritableMetadataKeys = a.nonInheritableMetadataKeys)
       case a: MultiAlias =>
-        a.copy(child = trimAliasesExceptContainsStructTypeSchema(a.child))
-      case other => trimAliasesExceptContainsStructTypeSchema(other)
+        a.copy(child = trimAliasesKeepSchema(a.child))
+      case other => trimAliasesKeepSchema(other)
     }
 
     res.asInstanceOf[T]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -72,7 +72,7 @@ trait AliasHelper {
      aliasMap: AttributeMap[Alias]): NamedExpression = {
     // Use transformUp to prevent infinite recursion when the replacement expression
     // redefines the same ExprId,
-    trimNonTopLevelAliasesExceptStruct(expr.transformUp {
+    trimNonTopLevelAliasesKeepSchema(expr.transformUp {
       case a: Attribute => aliasMap.get(a).map(_.withName(a.name)).getOrElse(a)
     }).asInstanceOf[NamedExpression]
   }
@@ -109,7 +109,7 @@ trait AliasHelper {
     res.asInstanceOf[T]
   }
 
-  protected def trimNonTopLevelAliasesExceptStruct[T <: Expression](e: T): T = {
+  protected def trimNonTopLevelAliasesKeepSchema[T <: Expression](e: T): T = {
     val res = e match {
       case a: Alias =>
         a.copy(child = trimAliasesKeepSchema(a.child))(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -72,7 +72,7 @@ trait AliasHelper {
      aliasMap: AttributeMap[Alias]): NamedExpression = {
     // Use transformUp to prevent infinite recursion when the replacement expression
     // redefines the same ExprId,
-    trimNonTopLevelAliasesKeepSchema(expr.transformUp {
+    trimNonTopLevelAliases(expr.transformUp {
       case a: Attribute => aliasMap.get(a).map(_.withName(a.name)).getOrElse(a)
     }).asInstanceOf[NamedExpression]
   }
@@ -94,22 +94,6 @@ trait AliasHelper {
   }
 
   protected def trimNonTopLevelAliases[T <: Expression](e: T): T = {
-    val res = e match {
-      case a: Alias =>
-        a.copy(child = trimAliases(a.child))(
-          exprId = a.exprId,
-          qualifier = a.qualifier,
-          explicitMetadata = Some(a.metadata),
-          nonInheritableMetadataKeys = a.nonInheritableMetadataKeys)
-      case a: MultiAlias =>
-        a.copy(child = trimAliases(a.child))
-      case other => trimAliases(other)
-    }
-
-    res.asInstanceOf[T]
-  }
-
-  protected def trimNonTopLevelAliasesKeepSchema[T <: Expression](e: T): T = {
     val res = e match {
       case a: Alias =>
         a.copy(child = trimAliasesKeepSchema(a.child))(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -82,7 +82,7 @@ trait AliasHelper {
       case Alias(child, _) => child
       case MultiAlias(child, _) => child
     }
-    if (!e.resolved || DataType.equalsIgnoreNullability(trimAlias.dataType, e.dataType)) {
+    if (DataType.equalsIgnoreNullability(trimAlias.dataType, e.dataType)) {
       trimAlias
     } else {
       e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -86,7 +86,7 @@ trait AliasHelper {
 
   protected def trimAliasesKeepSchema(e: Expression): Expression = {
     val trimAlias = trimAliases(e)
-    if (DataType.equalsIgnoreNullability(trimAlias.dataType, e.dataType)) {
+    if (!e.resolved || DataType.equalsIgnoreNullability(trimAlias.dataType, e.dataType)) {
       trimAlias
     } else {
       e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -562,4 +562,14 @@ object DataType {
         false
     }
   }
+
+  private[sql] def containsStructType(dataType: DataType): Boolean = {
+    dataType match {
+      case StructType(_) => true
+      case ArrayType(elementType, _) => containsStructType(elementType)
+      case MapType(keyType, valueType, _) =>
+        containsStructType(keyType) || containsStructType(valueType)
+      case _ => false
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -562,14 +562,4 @@ object DataType {
         false
     }
   }
-
-  private[sql] def containsStructType(dataType: DataType): Boolean = {
-    dataType match {
-      case StructType(_) => true
-      case ArrayType(elementType, _) => containsStructType(elementType)
-      case MapType(keyType, valueType, _) =>
-        containsStructType(keyType) || containsStructType(valueType)
-      case _ => false
-    }
-  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
trimNonTopLevelAlias should not change StructType inner alias, since it may impact output schema


### Why are the changes needed?
Keep schema consistence after Optimization


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existed UT