### PR TITLE
 [SPARK-36428][TESTS][FOLLOWUP] Revert mistake change to DateExpressionsSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -1161,7 +1161,7 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       withSQLConf(SQLConf.TIMESTAMP_TYPE.key -> tsType.toString) {
         val expected = expectedAnswer("2013-07-15 08:15:23.5")
 
-        Seq(true).foreach { ansi =>
+        Seq(true, false).foreach { ansi =>
           withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi.toString) {
             var makeTimestampExpr = MakeTimestamp(
               Literal(2013), Literal(7), Literal(15), Literal(8), Literal(15),


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/33775 commits the debug code mistakely.
This PR revert the test path.


### Why are the changes needed?
Revoke debug code.


### Does this PR introduce _any_ user-facing change?
 'No'.
Just adjust test.


### How was this patch tested?
Revert non-ansi test path.
