### PR TITLE
[MINOR] Fixes typo on javadoc for LogicalPlan#sameOutput

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -145,7 +145,7 @@ abstract class LogicalPlan
   def outputOrdering: Seq[SortOrder] = Nil
 
   /**
-   * Returns true iff `other`'s output is semantically the same, i.e.:
+   * Returns true if `other`'s output is semantically the same, i.e.:
    *  - it contains the same number of `Attribute`s;
    *  - references are the same;
    *  - the order is equal too.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replaces `iff` with `if`

### Why are the changes needed?

Have less typos in the codebase

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Code still compiles