### PR TITLE
Revert "[SPARK-35083][FOLLOW-UP][CORE] Add migration guide for the re…

### DIFF
--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -24,8 +24,6 @@ license: |
 
 ## Upgrading from Core 3.1 to 3.2
 
-- Since Spark 3.2, the fair scheduler also supports reading a configuration file from a remote node. `spark.scheduler.allocation.file` can either be a local file path or HDFS file path.
-
 - Since Spark 3.2, `spark.hadoopRDD.ignoreEmptySplits` is set to `true` by default which means Spark will not create empty partitions for empty input splits. To restore the behavior before Spark 3.2, you can set `spark.hadoopRDD.ignoreEmptySplits` to `false`.
 
 - Since Spark 3.2, `spark.eventLog.compression.codec` is set to `zstd` by default which means Spark will not fallback to use `spark.io.compression.codec` anymore.


### PR DESCRIPTION
…mote scheduler pool files support"

This reverts commit e3902d1975ee6a6a6f672eb6b4f318bcdd237e3f. The feature is improvement instead of behavior change.
