### PR TITLE
[SPARK-36550][SQL] Propagation cause when UDF reflection fails

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hive
 
+import java.lang.reflect.InvocationTargetException
 import java.util.Locale
 
 import scala.util.{Failure, Success, Try}
@@ -87,7 +88,11 @@ private[sql] class HiveSessionCatalog(
         udfExpr.get.asInstanceOf[HiveGenericUDTF].elementSchema
       }
     } catch {
-      case NonFatal(e) =>
+      case NonFatal(exception) =>
+        val e = exception match {
+          case i: InvocationTargetException => i.getCause
+          case o => o
+        }
         val errorMsg = s"No handler for UDF/UDAF/UDTF '${clazz.getCanonicalName}': $e"
         val analysisException = new AnalysisException(errorMsg)
         analysisException.setStackTrace(e.getStackTrace)


### PR DESCRIPTION
### What changes were proposed in this pull request?
When the exception is InvocationTargetException, get cause and stack trace.

### Why are the changes needed?
Now when UDF reflection fails, InvocationTargetException is thrown, but it is not a specific exception.
```
Error in query: No handler for Hive UDF 'XXX': java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
```

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
manual test
