### PR TITLE
[WIP][SPARK-34415][ML][FOLLOWUP] Choose random grid points in search actually randomly each time

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
@@ -29,7 +29,7 @@ import org.apache.spark.ml.param._
 @Since("1.2.0")
 class ParamGridBuilder @Since("1.2.0") {
 
-  private val paramGrid = mutable.Map.empty[Param[_], Iterable[_]]
+  protected val paramGrid = mutable.Map.empty[Param[_], Iterable[_]]
 
   /**
    * Sets the given parameters in this grid to fixed values.

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/ParamRandomBuilderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/ParamRandomBuilderSuite.scala
@@ -120,4 +120,19 @@ class ParamRandomBuilderSuite extends SparkFunSuite with ScalaCheckDrivenPropert
     }
   }
 
+  val dummyParams = new TestParams() {
+    val dParam = new DoubleParam(this, "d", "doc")
+    val iParam = new IntParam(this, "i", "doc")
+  }
+  import dummyParams._
+
+  test("Parameters are randomly chosen independently") {
+    val result = new ParamRandomBuilder().
+      addRandom(iParam, -5, 2000, 5).
+      addRandom(dParam, -100.0, -0.5, 7).
+      build()
+    assert(35 === result.map(_.get(dParam).get).distinct.size)
+    assert(35 === result.map(_.get(iParam).get).distinct.size)
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the new ParamRandomBuilder, choose each grid point's values randomly each time, rather than choosing the _grid_ randomly and performing grid search.


### Why are the changes needed?

This is probably what callers actually expect it to do, and is more effective than a grid search (whose coordinates happen to be random)

### Does this PR introduce _any_ user-facing change?

If merged for 3.2.0:
No, this is new functionality in 3.2.0 anyway
If after:
Yes, but, the API is the same, the results still match the 'contract', and this is if anything a behavior improvement.

### How was this patch tested?

Existing and new test cases.