### PR TITLE
[SPARK-36560][PYTHON][INFRA] Deflake PySpark coverage job

### DIFF
--- a/python/pyspark/mllib/tests/test_streaming_algorithms.py
+++ b/python/pyspark/mllib/tests/test_streaming_algorithms.py
@@ -226,7 +226,7 @@ class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
             self.assertAlmostEqual(rel, 0.1, 1)
             return True
 
-        eventually(condition, timeout=60.0, catch_assertions=True)
+        eventually(condition, timeout=120.0, catch_assertions=True)
 
     def test_convergence(self):
         """

--- a/python/pyspark/sql/tests/test_streaming.py
+++ b/python/pyspark/sql/tests/test_streaming.py
@@ -588,7 +588,7 @@ class StreamingTests(ReusedSQLTestCase):
             df = self.spark.readStream.format("rate").option("rowsPerSecond", 10).load()
             q = df.writeStream.toTable("output_table", format='parquet', checkpointLocation=tmpdir)
             self.assertTrue(q.isActive)
-            time.sleep(3)
+            time.sleep(10)
             q.stop()
             result = self.spark.sql("SELECT value FROM output_table").collect()
             self.assertTrue(len(result) > 0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to increase timeouts for:
- `pyspark.sql.tests.test_streaming.StreamingTests.test_parameter_accuracy`
- `pyspark.mllib.tests.test_streaming_algorithms.StreamingLogisticRegressionWithSGDTests. test_parameter_accuracy`

to deflake PySpark coverage build:

- https://github.com/apache/spark/runs/3392972609?check_suite_focus=true
- https://github.com/apache/spark/runs/3388727798?check_suite_focus=true
- https://github.com/apache/spark/runs/3359880048?check_suite_focus=true
- https://github.com/apache/spark/runs/3338876122?check_suite_focus=true

### Why are the changes needed?

To have more stable PySpark coverage report: https://app.codecov.io/gh/apache/spark

### Does this PR introduce _any_ user-facing change?

Spark developers will be able to see more stable results in https://app.codecov.io/gh/apache/spark

### How was this patch tested?

GitHub Actions' scheduled jobs will test them out.