### PR TITLE
 [SPARK-36563][SQL] dynamicPartitionOverwrite can direct rename to targetPath instead of partition path one by one when targetPath is empty

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/HadoopMapReduceCommitProtocol.scala
@@ -207,7 +207,7 @@ class HadoopMapReduceCommitProtocol(
         val pathExisted = fs.exists(targetPath)
         if (!pathExisted || fs.listStatus(targetPath).isEmpty) {
           if ((!pathExisted || (pathExisted && fs.delete(targetPath, true))) &&
-            !fs.rename(stagingDir, targetPath)) {
+              !fs.rename(stagingDir, targetPath)) {
             throw new IOException(s"Failed to rename $stagingDir to $targetPath when " +
               s"committing files staged for overwriting dynamic partitions")
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1226,6 +1226,9 @@ object SQLConf {
 
   val FILE_STAGING_DIR =
     buildConf("spark.sql.source.stagingDir")
+      .doc("The staging directory of Spark job. Spark uses it to deal with files with " +
+        "absolute output path, or writing data into partitioned directory when " +
+        "dynamic partition overwrite mode.")
       .version("3.3.0")
       .internal()
       .stringConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1224,6 +1224,13 @@ object SQLConf {
     .stringConf
     .createOptional
 
+  val FILE_STAGING_DIR =
+    buildConf("spark.sql.source.stagingDir")
+      .version("3.3.0")
+      .internal()
+      .stringConf
+      .createWithDefault(".spark-staging")
+
   val FILE_COMMIT_PROTOCOL_CLASS =
     buildConf("spark.sql.sources.commitProtocolClass")
       .version("2.1.1")
@@ -3823,6 +3830,8 @@ class SQLConf extends Serializable with Logging {
 
   def partitionColumnTypeInferenceEnabled: Boolean =
     getConf(SQLConf.PARTITION_COLUMN_TYPE_INFERENCE)
+
+  def fileStagingDir: String = getConf(SQLConf.FILE_STAGING_DIR)
 
   def fileCommitProtocolClass: String = getConf(SQLConf.FILE_COMMIT_PROTOCOL_CLASS)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
@@ -36,6 +36,10 @@ class SQLHadoopMapReduceCommitProtocol(
   extends HadoopMapReduceCommitProtocol(jobId, path, dynamicPartitionOverwrite)
     with Serializable with Logging {
 
+  override def stagingDir: Path = {
+    new Path(path, SQLConf.get.fileStagingDir + "-" + jobId)
+  }
+
   override protected def setupCommitter(context: TaskAttemptContext): OutputCommitter = {
     var committer = super.setupCommitter(context)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -190,7 +190,7 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("dynamic partition overwrite can rename table path when reasonable") {
+  test("SPARK-36563: dynamic partition overwrite can rename table path when reasonable") {
     withTempDir { stagingDir =>
       withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key ->
         SQLConf.PartitionOverwriteMode.DYNAMIC.toString,

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -199,9 +199,9 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
           withTable("t") {
             sql(
               s"""
-                 | create table t(c1 int, p1 int) using parquet partitioned by (p1)
-                 | location '${d.getAbsolutePath}'
-            """.stripMargin)
+                 | CREATE TABLE t(c1 int, p1 int) USING PARQUET PARTITIONED BY(p1)
+                 | LOCATION '${d.getAbsolutePath}'
+               """.stripMargin)
 
             val df = Seq((1, 2), (3, 4)).toDF("c1", "p1")
             df.write


### PR DESCRIPTION
### What changes were proposed in this pull request?
When target path is empty, we can directly rename stagingDir to targetPath avoid to rename path one by one


### Why are the changes needed?
Optimize file commit logic


### Does this PR introduce _any_ user-facing change?
User can set `spark.sql.source.stagingDir` to enable  direct rename to targetPath instead of partition path one by one when targetPath is empty for dynamicPartitionOverWrite


### How was this patch tested?
Added UT
