### PR TITLE
[SPARK-35991][SQL][FOLLOWUP] Add back protected modifier of sparkConf to TPCBase

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCBase.scala
@@ -25,7 +25,7 @@ trait TPCBase extends SharedSparkSession {
 
   protected def injectStats: Boolean = false
 
-  override def sparkConf: SparkConf = {
+  override protected def sparkConf: SparkConf = {
     if (injectStats) {
       super.sparkConf
         .set(SQLConf.MAX_TO_STRING_FIELDS, Int.MaxValue)

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
@@ -73,6 +73,6 @@ class TPCDSQueryWithStatsSuite extends TPCDSQuerySuite {
 
 @ExtendedSQLTest
 class TPCDSQueryANSISuite extends TPCDSQuerySuite {
-  override def sparkConf: SparkConf =
+  override protected def sparkConf: SparkConf =
     super.sparkConf.set(SQLConf.ANSI_ENABLED, true)
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
@@ -57,7 +57,7 @@ class TPCDSQueryTestSuite extends QueryTest with TPCDSBase with SQLQueryTestHelp
   private val regenerateGoldenFiles = sys.env.get("SPARK_GENERATE_GOLDEN_FILES").exists(_ == "1")
 
   // To make output results deterministic
-  override def sparkConf: SparkConf = super.sparkConf
+  override protected def sparkConf: SparkConf = super.sparkConf
     .set(SQLConf.SHUFFLE_PARTITIONS.key, "1")
 
   protected override def createSparkSession: TestSparkSession = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add back protected modifier of sparkConf to TPCBase according to https://github.com/apache/spark/pull/33736/files#r694054229

### Why are the changes needed?
Add back protected modifier of sparkConf to TPCBase


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Not need
