### PR TITLE
[SPARK-36396][PYTHON] Implement DataFrame.cov

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/frame.rst
+++ b/python/docs/source/reference/pyspark.pandas/frame.rst
@@ -148,6 +148,7 @@ Computations / Descriptive Stats
    DataFrame.clip
    DataFrame.corr
    DataFrame.count
+   DataFrame.cov
    DataFrame.describe
    DataFrame.kurt
    DataFrame.kurtosis

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -8119,15 +8119,18 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def cov(self, min_periods: Optional[int] = None) -> "DataFrame":
         """
         Compute pairwise covariance of columns, excluding NA/null values.
+
         Compute the pairwise covariance among the series of a DataFrame.
         The returned data frame is the `covariance matrix
         <https://en.wikipedia.org/wiki/Covariance_matrix>`__ of the columns
         of the DataFrame.
+
         Both NA and null values are automatically excluded from the
         calculation. (See the note below about bias from missing values.)
         A threshold can be set for the minimum number of
         observations for each value created. Comparisons with observations
         below this threshold will be returned as ``NaN``.
+
         This method is generally used for the analysis of time series data to
         understand the relationship between different measures
         across time.
@@ -8157,6 +8160,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                   dogs      cats
         dogs  0.666667 -1.000000
         cats -1.000000  1.666667
+
         >>> np.random.seed(42)
         >>> df = ps.DataFrame(np.random.randn(1000, 5),
         ...                   columns=['a', 'b', 'c', 'd', 'e'])
@@ -8169,9 +8173,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         e  0.014144  0.009826 -0.000271 -0.013692  0.977795
 
         **Minimum number of periods**
+
         This method also supports an optional ``min_periods`` keyword
         that specifies the required minimum number of non-NA observations for
         each column pair in order to have a valid result:
+
         >>> np.random.seed(42)
         >>> df = pd.DataFrame(np.random.randn(20, 3),
         ...                   columns=['a', 'b', 'c'])

--- a/python/pyspark/pandas/missing/frame.py
+++ b/python/pyspark/pandas/missing/frame.py
@@ -39,7 +39,6 @@ class _MissingPandasLikeDataFrame(object):
     compare = _unsupported_function("compare")
     convert_dtypes = _unsupported_function("convert_dtypes")
     corrwith = _unsupported_function("corrwith")
-    cov = _unsupported_function("cov")
     ewm = _unsupported_function("ewm")
     infer_objects = _unsupported_function("infer_objects")
     interpolate = _unsupported_function("interpolate")

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import decimal
 from datetime import datetime
 from distutils.version import LooseVersion
 import inspect
@@ -5756,12 +5756,43 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
 
     def test_cov(self):
+        # int
         pdf = pd.DataFrame([(1, 2), (0, 3), (2, 0), (1, 1)], columns=["a", "b"])
         psdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.cov(), psdf.cov(), almost=True)
         self.assert_eq(pdf.cov(min_periods=4), psdf.cov(min_periods=4), almost=True)
         self.assert_eq(pdf.cov(min_periods=5), psdf.cov(min_periods=5), almost=True)
 
+        # bool
+        pdf = pd.DataFrame(
+            {
+                "a": [1, np.nan, 3, 4],
+                "b": [True, False, False, True],
+                "c": [True, True, False, True],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(pdf.cov(), psdf.cov(), almost=True)
+        self.assert_eq(pdf.cov(min_periods=4), psdf.cov(min_periods=4), almost=True)
+        self.assert_eq(pdf.cov(min_periods=5), psdf.cov(min_periods=5), almost=True)
+
+        # extension dtype
+        numeric_dtypes = ["Int8", "Int16", "Int32", "Int64", "Float32", "Float64", "float"]
+        boolean_dtypes = ["boolean", "bool"]
+
+        sers = [pd.Series([1, 2, 3, None], dtype=dtype) for dtype in numeric_dtypes]
+        sers += [pd.Series([True, False, True, None], dtype=dtype) for dtype in boolean_dtypes]
+        sers.append(pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(3), None]))
+
+        pdf = pd.concat(sers, axis=1)
+        pdf.columns = [dtype for dtype in numeric_dtypes + boolean_dtypes] + ["decimal"]
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(pdf.cov(), psdf.cov(), almost=True)
+        self.assert_eq(pdf.cov(min_periods=3), psdf.cov(min_periods=3), almost=True)
+        self.assert_eq(pdf.cov(min_periods=4), psdf.cov(min_periods=4), almost=True)
+
+        # string column
         pdf = pd.DataFrame(
             [(1, 2, "a", 1), (0, 3, "b", 1), (2, 0, "c", 9), (1, 1, "d", 1)],
             columns=["a", "b", "c", "d"],
@@ -5771,6 +5802,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(pdf.cov(min_periods=4), psdf.cov(min_periods=4), almost=True)
         self.assert_eq(pdf.cov(min_periods=5), psdf.cov(min_periods=5), almost=True)
 
+        # nan
         np.random.seed(42)
         pdf = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
         pdf.loc[pdf.index[:5], "a"] = np.nan

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -5755,6 +5755,30 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
             self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
 
+    def test_cov(self):
+        pdf = pd.DataFrame([(1, 2), (0, 3), (2, 0), (1, 1)], columns=["a", "b"])
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(pdf.cov(), psdf.cov(), almost=True)
+        self.assert_eq(pdf.cov(min_periods=4), psdf.cov(min_periods=4), almost=True)
+        self.assert_eq(pdf.cov(min_periods=5), psdf.cov(min_periods=5), almost=True)
+
+        pdf = pd.DataFrame(
+            [(1, 2, "a", 1), (0, 3, "b", 1), (2, 0, "c", 9), (1, 1, "d", 1)],
+            columns=["a", "b", "c", "d"],
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(pdf.cov(), psdf.cov(), almost=True)
+        self.assert_eq(pdf.cov(min_periods=4), psdf.cov(min_periods=4), almost=True)
+        self.assert_eq(pdf.cov(min_periods=5), psdf.cov(min_periods=5), almost=True)
+
+        np.random.seed(42)
+        pdf = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+        pdf.loc[pdf.index[:5], "a"] = np.nan
+        pdf.loc[pdf.index[5:10], "b"] = np.nan
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(pdf.cov(min_periods=11), psdf.cov(min_periods=11), almost=True)
+        self.assert_eq(pdf.cov(min_periods=10), psdf.cov(min_periods=10), almost=True)
+
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.test_dataframe import *  # noqa: F401


### PR DESCRIPTION
### What changes were proposed in this pull request?

implement DataFrame.cov

### Why are the changes needed?

Increase pandas API coverage in PySpark

### Does this PR introduce _any_ user-facing change?
User can use

``` python
>>> psdf = ps.DataFrame([(1, 2), (0, 3), (2, 0), (1, 1)],
...                   columns=['dogs', 'cats'])
>>> psdf.cov()
       dogs      cats
dogs  0.666667 -1.000000
cats -1.000000  1.666667

>>> pdf = pd.DataFrame(
...     {
...         "a": [1, np.nan, 3, 4],
...         "b": [True, False, False, True],
...         "c": [True, True, False, True],
...     }
... )
>>> psdf = ps.from_pandas(pdf)
>>> psdf.cov()
          a         b         c
a  2.333333 -0.166667 -0.166667
b -0.166667  0.333333  0.166667
c -0.166667  0.166667  0.250000
```

### How was this patch tested?

unit tests