### PR TITLE
[SPARK-36567][SQL] Support foldable special datetime strings by `CAST`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -158,7 +158,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
       RewriteNonCorrelatedExists,
       PullOutGroupingExpressions,
       ComputeCurrentTime,
-      ReplaceCurrentLike(catalogManager)) ::
+      ReplaceCurrentLike(catalogManager),
+      SpecialDatetimeValues) ::
     //////////////////////////////////////////////////////////////////////////////////////////
     // Optimizer rules start here
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -266,6 +267,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       EliminateView.ruleName ::
       ReplaceExpressions.ruleName ::
       ComputeCurrentTime.ruleName ::
+      SpecialDatetimeValues.ruleName ::
       ReplaceCurrentLike(catalogManager).ruleName ::
       RewriteDistinctAggregates.ruleName ::
       ReplaceDeduplicateWithAggregate.ruleName ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -126,19 +126,18 @@ case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[Logic
  * if the input strings are foldable.
  */
 object SpecialDatetimeValues extends Rule[LogicalPlan] {
+  private val conv = Map[DataType, (String, java.time.ZoneId) => Option[Any]](
+    DateType -> convertSpecialDate,
+    TimestampType -> convertSpecialTimestamp,
+    TimestampNTZType -> ((s: String, _: java.time.ZoneId) => convertSpecialTimestampNTZ(s))
+  )
   def apply(plan: LogicalPlan): LogicalPlan = {
     plan.transformAllExpressionsWithPruning(_.containsPattern(CAST)) {
-      case cast @ Cast(e, DateType, _, _) if e.foldable && e.dataType == StringType =>
-        convertSpecialDate(e.eval().toString, cast.zoneId)
-          .map(Literal(_, DateType))
-          .getOrElse(cast)
-      case cast @ Cast(e, TimestampType, _, _) if e.foldable && e.dataType == StringType =>
-        convertSpecialTimestamp(e.eval().toString, cast.zoneId)
-          .map(Literal(_, TimestampType))
-          .getOrElse(cast)
-      case cast @ Cast(e, TimestampNTZType, _, _) if e.foldable && e.dataType == StringType =>
-        convertSpecialTimestampNTZ(e.eval().toString)
-          .map(Literal(_, TimestampNTZType))
+      case cast @ Cast(e, dt @ (DateType | TimestampType | TimestampNTZType), _, _)
+        if e.foldable && e.dataType == StringType =>
+        Option(e.eval())
+          .flatMap(s => conv(dt)(s.toString, cast.zoneId))
+          .map(Literal(_, dt))
           .getOrElse(cast)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SpecialDatetimeValuesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SpecialDatetimeValuesSuite.scala
@@ -17,14 +17,16 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import java.time.LocalDate
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, ZoneId}
 
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, Literal}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
-import org.apache.spark.sql.types.DateType
+import org.apache.spark.sql.catalyst.util.DateTimeConstants.MICROS_PER_MINUTE
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{instantToMicros, localDateTimeToMicros}
+import org.apache.spark.sql.types.{AtomicType, DateType, TimestampNTZType, TimestampType}
 
 class SpecialDatetimeValuesSuite extends PlanTest {
   object Optimize extends RuleExecutor[LogicalPlan] {
@@ -53,6 +55,47 @@ class SpecialDatetimeValuesSuite extends PlanTest {
         e
       }
       assert(expected === lits.toSet)
+    }
+  }
+
+  private def testSpecialTs(tsType: AtomicType, expected: Set[Long], zoneId: ZoneId): Unit = {
+    val in = Project(Seq(
+      Alias(Cast(Literal("epoch"), tsType, Some(zoneId.getId)), "epoch")(),
+      Alias(Cast(Literal("now"), tsType, Some(zoneId.getId)), "now")(),
+      Alias(Cast(Literal("tomorrow"), tsType, Some(zoneId.getId)), "tomorrow")(),
+      Alias(Cast(Literal("yesterday"), tsType, Some(zoneId.getId)), "yesterday")()),
+      LocalRelation())
+
+    val plan = Optimize.execute(in.analyze).asInstanceOf[Project]
+    val lits = new scala.collection.mutable.ArrayBuffer[Long]
+    plan.transformAllExpressions { case e: Literal if e.dataType == tsType =>
+      lits += e.value.asInstanceOf[Long]
+      e
+    }
+    assert(lits.forall(ts => expected.exists(ets => Math.abs(ets -ts) <= MICROS_PER_MINUTE)))
+  }
+
+  test("special timestamp_ltz values") {
+    testSpecialDatetimeValues { zoneId =>
+      val expected = Set(
+        Instant.ofEpochSecond(0),
+        Instant.now(),
+        Instant.now().atZone(zoneId).`with`(LocalTime.MIDNIGHT).plusDays(1).toInstant,
+        Instant.now().atZone(zoneId).`with`(LocalTime.MIDNIGHT).minusDays(1).toInstant
+      ).map(instantToMicros)
+      testSpecialTs(TimestampType, expected, zoneId)
+    }
+  }
+
+  test("special timestamp_ntz values") {
+    testSpecialDatetimeValues { zoneId =>
+      val expected = Set(
+        LocalDateTime.of(1970, 1, 1, 0, 0),
+        LocalDateTime.now(),
+        LocalDateTime.now().`with`(LocalTime.MIDNIGHT).plusDays(1),
+        LocalDateTime.now().`with`(LocalTime.MIDNIGHT).minusDays(1)
+      ).map(localDateTimeToMicros)
+      testSpecialTs(TimestampNTZType, expected, zoneId)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SpecialDatetimeValuesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SpecialDatetimeValuesSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import java.time.LocalDate
+
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, Literal}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types.DateType
+
+class SpecialDatetimeValuesSuite extends PlanTest {
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches = Seq(Batch("SpecialDatetimeValues", Once, SpecialDatetimeValues))
+  }
+
+  test("special date values") {
+    testSpecialDatetimeValues { zoneId =>
+      val expected = Set(
+        LocalDate.ofEpochDay(0),
+        LocalDate.now(zoneId),
+        LocalDate.now(zoneId).minusDays(1),
+        LocalDate.now(zoneId).plusDays(1)
+      ).map(_.toEpochDay.toInt)
+      val in = Project(Seq(
+        Alias(Cast(Literal("epoch"), DateType, Some(zoneId.getId)), "epoch")(),
+        Alias(Cast(Literal("today"), DateType, Some(zoneId.getId)), "today")(),
+        Alias(Cast(Literal("yesterday"), DateType, Some(zoneId.getId)), "yesterday")(),
+        Alias(Cast(Literal("tomorrow"), DateType, Some(zoneId.getId)), "tomorrow")()),
+        LocalRelation())
+
+      val plan = Optimize.execute(in.analyze).asInstanceOf[Project]
+      val lits = new scala.collection.mutable.ArrayBuffer[Int]
+      plan.transformAllExpressions { case e: Literal if e.dataType == DateType =>
+        lits += e.value.asInstanceOf[Int]
+        e
+      }
+      assert(expected === lits.toSet)
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to add new correctness rule `SpecialDatetimeValues` to the final analysis phase. It replaces casts of strings to date/timestamp_ltz/timestamp_ntz by literals of such types if the strings contain special datetime values like `today`, `yesterday` and `tomorrow`, and the input strings are foldable.

### Why are the changes needed?
1. To avoid a breaking change.
2. To improve user experience with Spark SQL. After the PR https://github.com/apache/spark/pull/32714, users have to use typed literals instead of implicit casts. For instance,
at Spark 3.1:
```sql
select ts_col > 'now';
```
but the query fails at the moment, and users have to use typed timestamp literal:
```sql
select ts_col > timestamp'now';
```

### Does this PR introduce _any_ user-facing change?
No. Previous release 3.1 has supported the feature already till it was removed by https://github.com/apache/spark/pull/32714.

### How was this patch tested?
1. Manually tested via the sql command line:
```sql
spark-sql> select cast('today' as date);
2021-08-24
spark-sql> select timestamp('today');
2021-08-24 00:00:00
spark-sql> select timestamp'tomorrow' > 'today';
true
```
2. By running new test suite:
```
$ build/sbt "sql/testOnly org.apache.spark.sql.catalyst.optimizer.SpecialDatetimeValuesSuite"
```
