### PR TITLE
[SPARK-36582][UI] Spark HistoryPage show 'NotFound' in not logged multiple attempts

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
@@ -34,13 +34,11 @@
           App Name
         </span>
       </th>
-      {{#hasMultipleAttempts}}
       <th>
         <span data-toggle="tooltip" data-placement="top" title="The attempt ID of this application since one application might be launched several times">
           Attempt ID
         </span>
       </th>
-      {{/hasMultipleAttempts}}
       <th>
         <span data-toggle="tooltip" data-placement="top" title="Started time of this application.">
           Started

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -119,7 +119,6 @@ $(document).ready(function() {
 
   $.getJSON(uiRoot + "/api/v1/applications", appParams, function(response, _ignored_status, _ignored_jqXHR) {
     var array = [];
-    var hasMultipleAttempts = false;
     for (var i in response) {
       var app = response[i];
       if (app["attempts"][0]["completed"] == requestedIncomplete) {
@@ -131,9 +130,6 @@ $(document).ready(function() {
       }
       var id = app["id"];
       var name = app["name"];
-      if (app["attempts"].length > 1) {
-        hasMultipleAttempts = true;
-      }
 
       // TODO: Replace hasOwnProperty with prototype.hasOwnProperty after we find it's safe to do.
       /* eslint-disable no-prototype-builtins */
@@ -162,7 +158,6 @@ $(document).ready(function() {
     var data = {
       "uiroot": uiRoot,
       "applications": array,
-      "hasMultipleAttempts": hasMultipleAttempts,
       "showCompletedColumns": !requestedIncomplete,
     };
 
@@ -205,25 +200,19 @@ $(document).ready(function() {
           {
             aTargets: [0, 1, 2],
             fnCreatedCell: (nTd, _ignored_sData, _ignored_oData, _ignored_iRow, _ignored_iCol) => {
-              if (hasMultipleAttempts) {
-                $(nTd).css('background-color', '#fff');
-              }
+              $(nTd).css('background-color', '#fff');
             }
           },
+        ],
+        "rowsGroup": [
+          'appId:name',
+          'version:name',
+          'appName:name'
         ],
         "autoWidth": false,
         "deferRender": true
       };
 
-      if (hasMultipleAttempts) {
-        conf.rowsGroup = [
-          'appId:name',
-          'version:name',
-          'appName:name'
-        ];
-      } else {
-        conf.columns = removeColumnByName(conf.columns, attemptIdColumnName);
-      }
 
       var defaultSortColumn = completedColumnName;
       if (requestedIncomplete) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`attemptId` should be always, so deleted `hasMultipleAttempts`

### Why are the changes needed?

Described in https://issues.apache.org/jira/browse/SPARK-36582


### Does this PR introduce _any_ user-facing change?

#### before change

When all applications in spark history had an attempt only, it doesn't show attemptId

![Screen Shot 2021-08-26 at 10 47 23 AM](https://user-images.githubusercontent.com/13159599/130886943-36666846-4dca-4687-9e3f-9c6d339207bd.png)

Now it shows a attemptId column regardless of hasMultipleAttempts.

![Screen Shot 2021-08-26 at 10 04 43 AM](https://user-images.githubusercontent.com/13159599/130883769-b10916ef-ccaa-4811-8e70-fa27e8a8fceb.png)


### How was this patch tested?

I checked chrome developer tool's console in changed web ui. (History Server's home page)
