### PR TITLE
[SPARK-36583][BUILD] Upgrade Apache commons-pool2 from 2.6.2 to 2.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <!-- org.apache.commons/commons-lang3/-->
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <!-- org.apache.commons/commons-pool2/-->
-    <commons-pool2.version>2.6.2</commons-pool2.version>
+    <commons-pool2.version>2.11.1</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>
     <guava.version>14.0.1</guava.version>
     <janino.version>3.0.16</janino.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr upgrade Apache `commons-pool2` from `2.6.2` to `2.11.1`, `2.11.1` is a Java 8 build version and `2.6.2` is still a Java 7 build version.


### Why are the changes needed?
Bring some bug fix like `DefaultPooledObject.getIdleTime() drops nanoseconds on Java 9 and greater`
Other changes: [RELEASE-NOTES](https://gitbox.apache.org/repos/asf?p=commons-pool.git;a=blob;f=RELEASE-NOTES.txt)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass the Jenkins or GitHub Action

