### PR TITLE
[SPARK-36293][SQL] Refactor fourth set of 20 query execution errors to use error classes

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -18,10 +18,10 @@
   "CANNOT_CREATE_OBJECT_DUE_TO_FAILED_DIRECTORY_CREATION" : {
     "message" : [ "Unable to CREATE %s %s as failed to create its directory %s." ]
   },
-  "CANNOT_CREATE_PARTITION" : {
+  "CANNOT_CREATE_PARTITION_PATH" : {
     "message" : [ "Unable to create partition path %s" ]
   },
-  "CANNOT_DELETE_PARTITION" : {
+  "CANNOT_DELETE_PARTITION_PATH" : {
     "message" : [ "Unable to delete partition path %s" ]
   },
   "CANNOT_DROP_OBJECT_DUE_TO_FAILED_DIRECTORY_DELETION" : {
@@ -37,7 +37,7 @@
     "message" : [ "Cannot parse decimal" ],
     "sqlState" : "42000"
   },
-  "CANNOT_RENAME_PARTITION" : {
+  "CANNOT_RENAME_PARTITION_PATH" : {
     "message" : [ "Unable to rename partition path %s" ]
   },
   "CANNOT_RENAME_TABLE_DUE_TO_FAILED_DIRECTORY_RENAMING" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -3,6 +3,10 @@
     "message" : [ "Field name %s is ambiguous and has %s matching fields in the struct." ],
     "sqlState" : "42000"
   },
+  "BINARY_ARITHMETIC_OVERFLOW" : {
+    "message" : [ "%s %s %s caused overflow." ],
+    "sqlState" : "22003"
+  },
   "CANNOT_CAST_DATATYPE" : {
     "message" : [ "Cannot cast %s to %s." ],
     "sqlState" : "22005"
@@ -10,6 +14,18 @@
   "CANNOT_CHANGE_DECIMAL_PRECISION" : {
     "message" : [ "%s cannot be represented as Decimal(%s, %s)." ],
     "sqlState" : "22005"
+  },
+  "CANNOT_CREATE_OBJECT_DUE_TO_FAILED_DIRECTORY_CREATION" : {
+    "message" : [ "Unable to CREATE %s %s as failed to create its directory %s." ]
+  },
+  "CANNOT_CREATE_PARTITION" : {
+    "message" : [ "Unable to create partition path %s" ]
+  },
+  "CANNOT_DELETE_PARTITION" : {
+    "message" : [ "Unable to delete partition path %s" ]
+  },
+  "CANNOT_DROP_OBJECT_DUE_TO_FAILED_DIRECTORY_DELETION" : {
+    "message" : [ "Unable to DROP %s %s as failed to delete its directory %s." ]
   },
   "CANNOT_EVALUATE_EXPRESSION" : {
     "message" : [ "Cannot evaluate expression: %s" ]
@@ -21,6 +37,12 @@
     "message" : [ "Cannot parse decimal" ],
     "sqlState" : "42000"
   },
+  "CANNOT_RENAME_PARTITION" : {
+    "message" : [ "Unable to rename partition path %s" ]
+  },
+  "CANNOT_RENAME_TABLE_DUE_TO_FAILED_DIRECTORY_RENAMING" : {
+    "message" : [ "Unable to rename table %s to %s as failed to rename its directory %s" ]
+  },
   "CANNOT_TERMINATE_GENERATOR" : {
     "message" : [ "Cannot terminate expression: %s" ]
   },
@@ -28,8 +50,15 @@
     "message" : [ "Casting %s to %s causes overflow" ],
     "sqlState" : "22005"
   },
+  "COMPILATION_FAILED" : {
+    "message" : [ "failed to compile: %s" ]
+  },
   "CONCURRENT_QUERY" : {
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
+  },
+  "DATA_PATH_NOT_SPECIFIED" : {
+    "message" : [ "'path' is not specified" ],
+    "sqlState" : "42000"
   },
   "DIVIDE_BY_ZERO" : {
     "message" : [ "divide by zero" ],
@@ -48,6 +77,9 @@
   },
   "FAILED_SET_ORIGINAL_PERMISSION_BACK" : {
     "message" : [ "Failed to set original permission %s back to the created path: %s. Exception: %s" ]
+  },
+  "FAILED_SPLIT_SUBEXPRESSION" : {
+    "message" : [ "Failed to split subexpression code into small functions because the parameter length of at least one split function went over the JVM limit: %s" ]
   },
   "GROUPING_COLUMN_MISMATCH" : {
     "message" : [ "Column of grouping (%s) can't be found in grouping columns %s" ],
@@ -98,6 +130,10 @@
   "MAP_KEY_DOES_NOT_EXIST" : {
     "message" : [ "Key %s does not exist." ]
   },
+  "METHOD_NOT_IMPLEMENTED" : {
+    "message" : [ "%s is not implemented" ],
+    "sqlState" : "0A000"
+  },
   "MISSING_COLUMN" : {
     "message" : [ "cannot resolve '%s' given input columns: [%s]" ],
     "sqlState" : "42000"
@@ -118,6 +154,9 @@
     "message" : [ "PARTITION clause cannot contain a non-partition column name: %s" ],
     "sqlState" : "42000"
   },
+  "NOT_A_DATA_SOURCE_RDD_PARTITION" : {
+    "message" : [ "[BUG] Not a DataSourceRDDPartition: %s" ]
+  },
   "PIVOT_VALUE_DATA_TYPE_MISMATCH" : {
     "message" : [ "Invalid pivot value '%s': value data type %s does not match pivot column data type %s" ],
     "sqlState" : "42000"
@@ -134,8 +173,16 @@
     "message" : [ "The second argument of '%s' function needs to be an integer." ],
     "sqlState" : "22023"
   },
+  "TABLE_STATISTICS_NOT_SPECIFIED" : {
+    "message" : [ "table stats must be specified." ],
+    "sqlState" : "42000"
+  },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
+  },
+  "UNARY_MINUS_OVERFLOW" : {
+    "message" : [ "- %s caused overflow." ],
+    "sqlState" : "22003"
   },
   "UNRECOGNIZED_SQL_TYPE" : {
     "message" : [ "Unrecognized SQL type %s" ],
@@ -155,6 +202,10 @@
   },
   "UNSUPPORTED_SIMPLE_STRING_WITH_NODE_ID" : {
     "message" : [ "%s does not implement simpleStringWithNodeId" ]
+  },
+  "UNSUPPORTED_TABLE_CHANGE" : {
+    "message" : [ "Unsupported table change: %s" ],
+    "sqlState" : "0A000"
   },
   "UNSUPPORTED_TRANSACTION_BY_JDBC_SERVER" : {
     "message" : [ "The target JDBC server does not support transaction and can only support ALTER TABLE with a single action." ],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql
 
+import org.codehaus.commons.compiler.{CompileException, Location}
+import org.codehaus.janino.InternalCompilerException
+
 import org.apache.spark.{SparkThrowable, SparkThrowableHelper}
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -93,4 +96,24 @@ class AnalysisException protected[sql] (
 
   override def getErrorClass: String = errorClass.orNull
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass.orNull)
+}
+
+private[spark] class SparkInternalCompilerException(
+    errorClass: String,
+    messageParameters: Array[String])
+  extends InternalCompilerException(SparkThrowableHelper.getMessage(errorClass, messageParameters))
+    with SparkThrowable {
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+private[spark] class SparkCompileException(
+    errorClass: String,
+    messageParameters: Array[String],
+    location: Location)
+  extends CompileException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters),
+    location) with SparkThrowable {
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -359,7 +359,7 @@ object QueryExecutionErrors {
   }
 
   def unableToDeletePartitionPathError(partitionPath: Path, e: IOException): Throwable = {
-    new SparkException("CANNOT_DELETE_PARTITION", Array(partitionPath.toString), e)
+    new SparkException("CANNOT_DELETE_PARTITION_PATH", Array(partitionPath.toString), e)
   }
 
   def unableToDropTableAsFailedToDeleteDirectoryError(
@@ -375,11 +375,11 @@ object QueryExecutionErrors {
   }
 
   def unableToCreatePartitionPathError(partitionPath: Path, e: IOException): Throwable = {
-    new SparkException("CANNOT_CREATE_PARTITION", Array(partitionPath.toString), e)
+    new SparkException("CANNOT_CREATE_PARTITION_PATH", Array(partitionPath.toString), e)
   }
 
   def unableToRenamePartitionPathError(oldPartPath: Path, e: IOException): Throwable = {
-    new SparkException("CANNOT_RENAME_PARTITION", Array(oldPartPath.toString), e)
+    new SparkException("CANNOT_RENAME_PARTITION_PATH", Array(oldPartPath.toString), e)
   }
 
   def methodNotImplementedError(methodName: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -32,10 +32,11 @@ import org.apache.hadoop.fs.permission.FsPermission
 import org.codehaus.commons.compiler.CompileException
 import org.codehaus.janino.InternalCompilerException
 
-import org.apache.spark.{Partition, SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkClassNotFoundException, SparkConcurrentModificationException, SparkDateTimeException, SparkException, SparkFileAlreadyExistsException, SparkFileNotFoundException, SparkIllegalArgumentException, SparkIllegalStateException, SparkIndexOutOfBoundsException, SparkNoSuchElementException, SparkNoSuchMethodException, SparkNumberFormatException, SparkRuntimeException, SparkSecurityException, SparkSQLException, SparkSQLFeatureNotSupportedException, SparkUnsupportedOperationException, SparkUpgradeException}
+import org.apache.spark.{Partition, SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkClassNotFoundException, SparkConcurrentModificationException, SparkDateTimeException, SparkException, SparkFileAlreadyExistsException, SparkFileNotFoundException, SparkIllegalArgumentException, SparkIllegalStateException, SparkIndexOutOfBoundsException, SparkNoSuchElementException, SparkNoSuchMethodException, SparkNumberFormatException, SparkRuntimeException, SparkSecurityException, SparkSQLException, SparkSQLFeatureNotSupportedException, SparkThrowableHelper, SparkUnsupportedOperationException, SparkUpgradeException}
 import org.apache.spark.executor.CommitDeniedException
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.memory.SparkOutOfMemoryError
+import org.apache.spark.sql.{SparkCompileException, SparkInternalCompilerException}
 import org.apache.spark.sql.catalyst.ScalaReflection.Schema
 import org.apache.spark.sql.catalyst.WalkedTypePath
 import org.apache.spark.sql.catalyst.analysis.UnresolvedGenerator
@@ -341,94 +342,94 @@ object QueryExecutionErrors {
 
   def unableToCreateDatabaseAsFailedToCreateDirectoryError(
       dbDefinition: CatalogDatabase, e: IOException): Throwable = {
-    new SparkException(s"Unable to create database ${dbDefinition.name} as failed " +
-      s"to create its directory ${dbDefinition.locationUri}", e)
+    new SparkException("CANNOT_CREATE_OBJECT_DUE_TO_FAILED_DIRECTORY_CREATION",
+      Array("DATABASE", dbDefinition.name, dbDefinition.locationUri.toString), e)
   }
 
   def unableToDropDatabaseAsFailedToDeleteDirectoryError(
       dbDefinition: CatalogDatabase, e: IOException): Throwable = {
-    new SparkException(s"Unable to drop database ${dbDefinition.name} as failed " +
-      s"to delete its directory ${dbDefinition.locationUri}", e)
+    new SparkException("CANNOT_DROP_OBJECT_DUE_TO_FAILED_DIRECTORY_DELETION",
+      Array("DATABASE", dbDefinition.name, dbDefinition.locationUri.toString), e)
   }
 
   def unableToCreateTableAsFailedToCreateDirectoryError(
       table: String, defaultTableLocation: Path, e: IOException): Throwable = {
-    new SparkException(s"Unable to create table $table as failed " +
-      s"to create its directory $defaultTableLocation", e)
+    new SparkException("CANNOT_CREATE_OBJECT_DUE_TO_FAILED_DIRECTORY_CREATION",
+      Array("TABLE", table, defaultTableLocation.toString), e)
   }
 
   def unableToDeletePartitionPathError(partitionPath: Path, e: IOException): Throwable = {
-    new SparkException(s"Unable to delete partition path $partitionPath", e)
+    new SparkException("CANNOT_DELETE_PARTITION", Array(partitionPath.toString), e)
   }
 
   def unableToDropTableAsFailedToDeleteDirectoryError(
       table: String, dir: Path, e: IOException): Throwable = {
-    new SparkException(s"Unable to drop table $table as failed " +
-      s"to delete its directory $dir", e)
+    new SparkException("CANNOT_DROP_OBJECT_DUE_TO_FAILED_DIRECTORY_DELETION",
+      Array("TABLE", table, dir.toString), e)
   }
 
   def unableToRenameTableAsFailedToRenameDirectoryError(
       oldName: String, newName: String, oldDir: Path, e: IOException): Throwable = {
-    new SparkException(s"Unable to rename table $oldName to $newName as failed " +
-      s"to rename its directory $oldDir", e)
+    new SparkException("CANNOT_RENAME_TABLE_DUE_TO_FAILED_DIRECTORY_RENAMING",
+      Array(oldName, newName, oldDir.toString), e)
   }
 
   def unableToCreatePartitionPathError(partitionPath: Path, e: IOException): Throwable = {
-    new SparkException(s"Unable to create partition path $partitionPath", e)
+    new SparkException("CANNOT_CREATE_PARTITION", Array(partitionPath.toString), e)
   }
 
   def unableToRenamePartitionPathError(oldPartPath: Path, e: IOException): Throwable = {
-    new SparkException(s"Unable to rename partition path $oldPartPath", e)
+    new SparkException("CANNOT_RENAME_PARTITION", Array(oldPartPath.toString), e)
   }
 
   def methodNotImplementedError(methodName: String): Throwable = {
-    new UnsupportedOperationException(s"$methodName is not implemented")
+    new SparkUnsupportedOperationException("METHOD_NOT_IMPLEMENTED", Array(methodName))
   }
 
   def tableStatsNotSpecifiedError(): Throwable = {
-    new IllegalStateException("table stats must be specified.")
+    new SparkIllegalStateException("TABLE_STATISTICS_NOT_SPECIFIED", Array.empty)
   }
 
   def unaryMinusCauseOverflowError(originValue: AnyVal): ArithmeticException = {
-    new ArithmeticException(s"- $originValue caused overflow.")
+    new SparkArithmeticException("UNARY_MINUS_OVERFLOW", Array(originValue.toString))
   }
 
   def binaryArithmeticCauseOverflowError(
       eval1: Short, symbol: String, eval2: Short): ArithmeticException = {
-    new ArithmeticException(s"$eval1 $symbol $eval2 caused overflow.")
+    new SparkArithmeticException("BINARY_ARITHMETIC_OVERFLOW",
+      Array(eval1.toString, symbol, eval2.toString))
   }
 
   def failedSplitSubExpressionMsg(length: Int): String = {
-    "Failed to split subexpression code into small functions because " +
-      s"the parameter length of at least one split function went over the JVM limit: $length"
+    SparkThrowableHelper.getMessage("FAILED_SPLIT_SUBEXPRESSION", Array(length.toString))
   }
 
   def failedSplitSubExpressionError(length: Int): Throwable = {
-    new IllegalStateException(failedSplitSubExpressionMsg(length))
+    new SparkIllegalStateException("FAILED_SPLIT_SUBEXPRESSION", Array(length.toString))
   }
 
   def failedToCompileMsg(e: Exception): String = {
-    s"failed to compile: $e"
+    SparkThrowableHelper.getMessage("COMPILATION_FAILED", Array(e.toString))
   }
 
   def internalCompilerError(e: InternalCompilerException): Throwable = {
-    new InternalCompilerException(failedToCompileMsg(e), e)
+    new SparkInternalCompilerException("COMPILATION_FAILED", Array(e.toString))
   }
 
   def compilerError(e: CompileException): Throwable = {
-    new CompileException(failedToCompileMsg(e), e.getLocation)
+    new SparkCompileException("COMPILATION_FAILED", Array(e.toString), e.getLocation)
   }
 
   def unsupportedTableChangeError(e: IllegalArgumentException): Throwable = {
-    new SparkException(s"Unsupported table change: ${e.getMessage}", e)
+    new SparkException("UNSUPPORTED_TABLE_CHANGE", Array(e.getMessage), e)
   }
 
   def notADatasourceRDDPartitionError(split: Partition): Throwable = {
-    new SparkException(s"[BUG] Not a DataSourceRDDPartition: $split")
+    new SparkException("NOT_A_DATA_SOURCE_RDD_PARTITION", Array(split.toString), null)
   }
 
   def dataPathNotSpecifiedError(): Throwable = {
-    new IllegalArgumentException("'path' is not specified")
+    new SparkIllegalArgumentException("DATA_PATH_NOT_SPECIFIED", Array.empty)
   }
 
   def createStreamingSourceNotSpecifySchemaError(): Throwable = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Refactor some exceptions in QueryExecutionErrors to use error classes.
There are currently ~350 exceptions in this file; so this PR only focuses on the fourth set of 20.

> unableToCreateDatabaseAsFailedToCreateDirectoryError
> unableToDropDatabaseAsFailedToDeleteDirectoryError
> unableToCreateTableAsFailedToCreateDirectoryError
> unableToDeletePartitionPathError
> unableToDropTableAsFailedToDeleteDirectoryError
> unableToRenameTableAsFailedToRenameDirectoryError
> unableToCreatePartitionPathError
> unableToRenamePartitionPathError
> methodNotImplementedError
> tableStatsNotSpecifiedError
> unaryMinusCauseOverflowError
> binaryArithmeticCauseOverflowError
> failedSplitSubExpressionMsg
> failedSplitSubExpressionError
> failedToCompileMsg
> internalCompilerError
> compilerError
> unsupportedTableChangeError
> notADatasourceRDDPartitionError
> dataPathNotSpecifiedError

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
https://issues.apache.org/jira/browse/SPARK-36094

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass all current tests