### PR TITLE
[SPARK-36291][SQL] Refactor second set of 20 in QueryExecutionErrors to use error classes

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -31,6 +31,9 @@
   "CONCURRENT_QUERY" : {
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
   },
+  "COPY_NULL_FIELD" : {
+    "message" : [ "Do not attempt to copy a null field" ]
+  },
   "DIVIDE_BY_ZERO" : {
     "message" : [ "divide by zero" ],
     "sqlState" : "22012"
@@ -38,6 +41,9 @@
   "DUPLICATE_KEY" : {
     "message" : [ "Found duplicate keys '%s'" ],
     "sqlState" : "23000"
+  },
+  "EXCEED_ARRAY_SIZE_WHEN_ZIP_MAP" : {
+    "message" : [ "Unsuccessful try to zip maps with %s unique keys due to exceeding the array size limit %s." ]
   },
   "FAILED_EXECUTE_UDF" : {
     "message" : [ "Failed to execute user defined function (%s: (%s) => %s)" ]
@@ -48,6 +54,15 @@
   },
   "FAILED_SET_ORIGINAL_PERMISSION_BACK" : {
     "message" : [ "Failed to set original permission %s back to the created path: %s. Exception: %s" ]
+  },
+  "FOUND_NEGATIVE_VALUES" : {
+    "message" : [ "Negative values found in %s" ]
+  },
+  "GROUP_INDEX_LESS_THAN_ZERO" : {
+    "message" : [ "The specified group index cannot be less than zero" ]
+  },
+  "GROUP_INDEX_EXCEED_GROUP_COUNT" : {
+    "message" : [ "Regex group count is %s, but the specified group index is %s" ]
   },
   "GROUPING_COLUMN_MISMATCH" : {
     "message" : [ "Column of grouping (%s) can't be found in grouping columns %s" ],
@@ -67,12 +82,18 @@
     "message" : [ "Invalid pivot column '%s'. Pivot columns must be comparable." ],
     "sqlState" : "42000"
   },
+  "INCOMPARABLE_TYPE" : {
+    "message" : [ "cannot generate %s code for un-comparable type: %s" ]
+  },
   "INCOMPATIBLE_DATASOURCE_REGISTER" : {
     "message" : [ "Detected an incompatible DataSourceRegister. Please remove the incompatible library from classpath or upgrade it. Error: %s" ]
   },
   "INDEX_OUT_OF_BOUNDS" : {
     "message" : [ "Index %s must be between 0 and the length of the ArrayData." ],
     "sqlState" : "22023"
+  },
+  "INTEGRAL_DIVIDE_OVERFLOW" : {
+    "message" : [ "Overflow in integral divide." ]
   },
   "INVALID_ARRAY_INDEX" : {
     "message" : [ "Invalid index: %s, numElements: %s" ]
@@ -92,7 +113,10 @@
   "INVALID_JSON_SCHEMA_MAPTYPE" : {
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
   },
-  "LOGICAL_HINT_OPERATOR_NOT_REMOVED_DURING_ANALYSIS" : {
+  "INVALID_URL" : {
+    "message" : [ "Find an invalid url string %s" ]
+  },
+    "LOGICAL_HINT_OPERATOR_NOT_REMOVED_DURING_ANALYSIS" : {
     "message" : [ "Internal error: logical hint operator should have been removed during analysis" ]
   },
   "MAP_KEY_DOES_NOT_EXIST" : {
@@ -110,6 +134,9 @@
     "message" : [ "Unknown static partition column: %s" ],
     "sqlState" : "42000"
   },
+  "NO_DEFAULT_FOR_TYPE" : {
+    "message" : [ "no default for type %s" ]
+  },
   "NON_LITERAL_PIVOT_VALUES" : {
     "message" : [ "Literal expressions required for pivot values, found '%s'" ],
     "sqlState" : "42000"
@@ -117,6 +144,12 @@
   "NON_PARTITION_COLUMN" : {
     "message" : [ "PARTITION clause cannot contain a non-partition column name: %s" ],
     "sqlState" : "42000"
+  },
+  "NOT_MATCH_FUNCTION_NAME" : {
+    "message" : [ "%s is not matched at addNewFunction"]
+  },
+  "NOT_SUPPORT_ORDERED_OPERATIONS" : {
+    "message" : [ "Type %s does not support ordered operations"]
   },
   "PIVOT_VALUE_DATA_TYPE_MISMATCH" : {
     "message" : [ "Invalid pivot value '%s': value data type %s does not match pivot column data type %s" ],
@@ -134,8 +167,20 @@
     "message" : [ "The second argument of '%s' function needs to be an integer." ],
     "sqlState" : "22023"
   },
+  "SHOULD_NOT_CALL_ALIAS_DO_GEN_CODE" : {
+    "message" : [ "Alias.doGenCode should not be called." ]
+  },
+  "SUM_OF_DECIMAL_OVERFLOW" : {
+    "message" : [ "Overflow in sum of decimals." ]
+  },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
+  },
+  "UNEXPECTED_DATATYPE" : {
+    "message" : [ "Unexpected data type %s" ]
+  },
+  "UNEXPECTED_TYPE" : {
+    "message" : [ "Unexpected type %s" ]
   },
   "UNRECOGNIZED_SQL_TYPE" : {
     "message" : [ "Unrecognized SQL type %s" ],
@@ -149,6 +194,13 @@
     "message" : [ "Unsupported data type %s" ],
     "sqlState" : "0A000"
   },
+  "UNSUPPORTED_DATA_TYPE" : {
+    "message" : [ "dataType" ],
+    "sqlState": "0A000"
+  },
+  "UNSUPPORTED_INPUT_TYPE" : {
+    "message" : [ "Unsupported input type %s" ]
+  },
   "UNSUPPORTED_LITERAL_TYPE" : {
     "message" : [ "Unsupported literal type %s %s" ],
     "sqlState" : "0A000"
@@ -159,6 +211,9 @@
   "UNSUPPORTED_TRANSACTION_BY_JDBC_SERVER" : {
     "message" : [ "The target JDBC server does not support transaction and can only support ALTER TABLE with a single action." ],
     "sqlState" : "0A000"
+  },
+  "WINDOW_NOT_SUPPORT_MERGING" : {
+    "message" : [ "Window Functions do not support merging." ]
   },
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -122,7 +122,7 @@
     "message" : [ "Window Functions do not support merging." ],
     "sqlState" : "0A000"
   },
-    "LOGICAL_HINT_OPERATOR_NOT_REMOVED_DURING_ANALYSIS" : {
+  "LOGICAL_HINT_OPERATOR_NOT_REMOVED_DURING_ANALYSIS" : {
     "message" : [ "Internal error: logical hint operator should have been removed during analysis" ]
   },
   "MAP_KEY_DOES_NOT_EXIST" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -186,10 +186,6 @@
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
   },
-  "UNEXPECTED_DATATYPE" : {
-    "message" : [ "Unexpected data type %s" ],
-    "sqlState" : "42000"
-  },
   "UNEXPECTED_TYPE" : {
     "message" : [ "Unexpected type %s" ],
     "sqlState" : "42000"

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -17,6 +17,10 @@
   "CANNOT_GENERATE_CODE_FOR_EXPRESSION" : {
     "message" : [ "Cannot generate code for expression: %s" ]
   },
+  "CANNOT_GENERATE_CODE_FOR_UNCOMPARABLE_TYPE" : {
+    "message" : [ "cannot generate %s code for un-comparable type: %s" ],
+    "sqlState" : "0A000"
+  },
   "CANNOT_PARSE_DECIMAL" : {
     "message" : [ "Cannot parse decimal" ],
     "sqlState" : "42000"
@@ -32,8 +36,7 @@
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
   },
   "COPY_NULL_FIELD" : {
-    "message" : [ "Do not attempt to copy a null field" ],
-    "sqlState" : "39004"
+    "message" : [ "Do not attempt to copy a null field" ]
   },
   "DIVIDE_BY_ZERO" : {
     "message" : [ "divide by zero" ],
@@ -44,8 +47,7 @@
     "sqlState" : "23000"
   },
   "EXCEED_ARRAY_SIZE_WHEN_ZIP_MAP" : {
-    "message" : [ "Unsuccessful try to zip maps with %s unique keys due to exceeding the array size limit %s." ],
-    "sqlState" : "22026"
+    "message" : [ "Unsuccessful try to zip maps with %s unique keys due to exceeding the array size limit %s." ]
   },
   "FAILED_EXECUTE_UDF" : {
     "message" : [ "Failed to execute user defined function (%s: (%s) => %s)" ]
@@ -74,7 +76,7 @@
   },
   "GROUP_INDEX_EXCEED_GROUP_COUNT" : {
     "message" : [ "Regex group count is %s, but the specified group index is %s" ],
-    "sqlState" : "07009"
+    "sqlState" : "42000"
   },
   "GROUP_INDEX_LESS_THAN_ZERO" : {
     "message" : [ "The specified group index cannot be less than zero" ],
@@ -86,10 +88,6 @@
   "INCOMPARABLE_PIVOT_COLUMN" : {
     "message" : [ "Invalid pivot column '%s'. Pivot columns must be comparable." ],
     "sqlState" : "42000"
-  },
-  "INCOMPARABLE_TYPE" : {
-    "message" : [ "cannot generate %s code for un-comparable type: %s" ],
-    "sqlState" : "07006"
   },
   "INCOMPATIBLE_DATASOURCE_REGISTER" : {
     "message" : [ "Detected an incompatible DataSourceRegister. Please remove the incompatible library from classpath or upgrade it. Error: %s" ]
@@ -122,7 +120,11 @@
   },
   "INVALID_URL" : {
     "message" : [ "Find an invalid url string %s" ],
-    "sqlState" : "22000"
+    "sqlState" : "42000"
+  },
+  "MERGE_UNSUPPORTED_BY_WINDOW_FUNCTIONS" : {
+    "message" : [ "Window Functions do not support merging." ],
+    "sqlState" : "0A000"
   },
     "LOGICAL_HINT_OPERATOR_NOT_REMOVED_DURING_ANALYSIS" : {
     "message" : [ "Internal error: logical hint operator should have been removed during analysis" ]
@@ -152,11 +154,7 @@
   },
   "NOT_MATCH_FUNCTION_NAME" : {
     "message" : [ "%s is not matched at addNewFunction" ],
-    "sqlState" : "07000"
-  },
-  "NOT_SUPPORT_ORDERED_OPERATIONS" : {
-    "message" : [ "Type %s does not support ordered operations" ],
-    "sqlState" : "07006"
+    "sqlState" : "42000"
   },
   "NO_DEFAULT_FOR_TYPE" : {
     "message" : [ "no default for type %s" ],
@@ -179,23 +177,22 @@
     "sqlState" : "22023"
   },
   "SHOULD_NOT_CALL_ALIAS_DO_GEN_CODE" : {
-    "message" : [ "Alias.doGenCode should not be called." ],
-    "sqlState" : "42000"
+    "message" : [ "Alias.doGenCode should not be called." ]
   },
   "SUM_OF_DECIMAL_OVERFLOW" : {
     "message" : [ "Overflow in sum of decimals." ],
-    "sqlState" : "22015"
+    "sqlState" : "22003"
   },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
   },
   "UNEXPECTED_DATATYPE" : {
     "message" : [ "Unexpected data type %s" ],
-    "sqlState" : "22000"
+    "sqlState" : "42000"
   },
   "UNEXPECTED_TYPE" : {
     "message" : [ "Unexpected type %s" ],
-    "sqlState" : "22000"
+    "sqlState" : "42000"
   },
   "UNRECOGNIZED_SQL_TYPE" : {
     "message" : [ "Unrecognized SQL type %s" ],
@@ -221,6 +218,10 @@
     "message" : [ "Unsupported literal type %s %s" ],
     "sqlState" : "0A000"
   },
+  "UNSUPPORTED_ORDERED_OPERATIONS" : {
+    "message" : [ "Type %s does not support ordered operations" ],
+    "sqlState" : "0A000"
+  },
   "UNSUPPORTED_SIMPLE_STRING_WITH_NODE_ID" : {
     "message" : [ "%s does not implement simpleStringWithNodeId" ]
   },
@@ -228,8 +229,8 @@
     "message" : [ "The target JDBC server does not support transaction and can only support ALTER TABLE with a single action." ],
     "sqlState" : "0A000"
   },
-  "WINDOW_NOT_SUPPORT_MERGING" : {
-    "message" : [ "Window Functions do not support merging." ],
+  "UNSUPPORTED_TRANSACTION_BY_JDBC_SERVER" : {
+    "message" : [ "The target JDBC server does not support transaction and can only support ALTER TABLE with a single action." ],
     "sqlState" : "0A000"
   },
   "WRITING_JOB_ABORTED" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -32,7 +32,8 @@
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
   },
   "COPY_NULL_FIELD" : {
-    "message" : [ "Do not attempt to copy a null field" ]
+    "message" : [ "Do not attempt to copy a null field" ],
+    "sqlState" : "39004"
   },
   "DIVIDE_BY_ZERO" : {
     "message" : [ "divide by zero" ],
@@ -43,7 +44,8 @@
     "sqlState" : "23000"
   },
   "EXCEED_ARRAY_SIZE_WHEN_ZIP_MAP" : {
-    "message" : [ "Unsuccessful try to zip maps with %s unique keys due to exceeding the array size limit %s." ]
+    "message" : [ "Unsuccessful try to zip maps with %s unique keys due to exceeding the array size limit %s." ],
+    "sqlState" : "22026"
   },
   "FAILED_EXECUTE_UDF" : {
     "message" : [ "Failed to execute user defined function (%s: (%s) => %s)" ]
@@ -56,7 +58,8 @@
     "message" : [ "Failed to set original permission %s back to the created path: %s. Exception: %s" ]
   },
   "FOUND_NEGATIVE_VALUES" : {
-    "message" : [ "Negative values found in %s" ]
+    "message" : [ "Negative values found in %s" ],
+    "sqlState" : "22003"
   },
   "GROUPING_COLUMN_MISMATCH" : {
     "message" : [ "Column of grouping (%s) can't be found in grouping columns %s" ],
@@ -70,10 +73,12 @@
     "message" : [ "Grouping sets size cannot be greater than %s" ]
   },
   "GROUP_INDEX_EXCEED_GROUP_COUNT" : {
-    "message" : [ "Regex group count is %s, but the specified group index is %s" ]
+    "message" : [ "Regex group count is %s, but the specified group index is %s" ],
+    "sqlState" : "07009"
   },
   "GROUP_INDEX_LESS_THAN_ZERO" : {
-    "message" : [ "The specified group index cannot be less than zero" ]
+    "message" : [ "The specified group index cannot be less than zero" ],
+    "sqlState" : "07009"
   },
   "IF_PARTITION_NOT_EXISTS_UNSUPPORTED" : {
     "message" : [ "Cannot write, IF NOT EXISTS is not supported for table: %s" ]
@@ -83,7 +88,8 @@
     "sqlState" : "42000"
   },
   "INCOMPARABLE_TYPE" : {
-    "message" : [ "cannot generate %s code for un-comparable type: %s" ]
+    "message" : [ "cannot generate %s code for un-comparable type: %s" ],
+    "sqlState" : "07006"
   },
   "INCOMPATIBLE_DATASOURCE_REGISTER" : {
     "message" : [ "Detected an incompatible DataSourceRegister. Please remove the incompatible library from classpath or upgrade it. Error: %s" ]
@@ -93,7 +99,8 @@
     "sqlState" : "22023"
   },
   "INTEGRAL_DIVIDE_OVERFLOW" : {
-    "message" : [ "Overflow in integral divide." ]
+    "message" : [ "Overflow in integral divide." ],
+    "sqlState" : "22015"
   },
   "INVALID_ARRAY_INDEX" : {
     "message" : [ "Invalid index: %s, numElements: %s" ]
@@ -114,7 +121,8 @@
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
   },
   "INVALID_URL" : {
-    "message" : [ "Find an invalid url string %s" ]
+    "message" : [ "Find an invalid url string %s" ],
+    "sqlState" : "22000"
   },
     "LOGICAL_HINT_OPERATOR_NOT_REMOVED_DURING_ANALYSIS" : {
     "message" : [ "Internal error: logical hint operator should have been removed during analysis" ]
@@ -143,13 +151,16 @@
     "sqlState" : "42000"
   },
   "NOT_MATCH_FUNCTION_NAME" : {
-    "message" : [ "%s is not matched at addNewFunction" ]
+    "message" : [ "%s is not matched at addNewFunction" ],
+    "sqlState" : "07000"
   },
   "NOT_SUPPORT_ORDERED_OPERATIONS" : {
-    "message" : [ "Type %s does not support ordered operations" ]
+    "message" : [ "Type %s does not support ordered operations" ],
+    "sqlState" : "07006"
   },
   "NO_DEFAULT_FOR_TYPE" : {
-    "message" : [ "no default for type %s" ]
+    "message" : [ "no default for type %s" ],
+    "sqlState" : "0700C"
   },
   "PIVOT_VALUE_DATA_TYPE_MISMATCH" : {
     "message" : [ "Invalid pivot value '%s': value data type %s does not match pivot column data type %s" ],
@@ -168,19 +179,23 @@
     "sqlState" : "22023"
   },
   "SHOULD_NOT_CALL_ALIAS_DO_GEN_CODE" : {
-    "message" : [ "Alias.doGenCode should not be called." ]
+    "message" : [ "Alias.doGenCode should not be called." ],
+    "sqlState" : "42000"
   },
   "SUM_OF_DECIMAL_OVERFLOW" : {
-    "message" : [ "Overflow in sum of decimals." ]
+    "message" : [ "Overflow in sum of decimals." ],
+    "sqlState" : "22015"
   },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
   },
   "UNEXPECTED_DATATYPE" : {
-    "message" : [ "Unexpected data type %s" ]
+    "message" : [ "Unexpected data type %s" ],
+    "sqlState" : "22000"
   },
   "UNEXPECTED_TYPE" : {
-    "message" : [ "Unexpected type %s" ]
+    "message" : [ "Unexpected type %s" ],
+    "sqlState" : "22000"
   },
   "UNRECOGNIZED_SQL_TYPE" : {
     "message" : [ "Unrecognized SQL type %s" ],
@@ -199,7 +214,8 @@
     "sqlState": "0A000"
   },
   "UNSUPPORTED_INPUT_TYPE" : {
-    "message" : [ "Unsupported input type %s" ]
+    "message" : [ "Unsupported input type %s" ],
+    "sqlState" : "0A000"
   },
   "UNSUPPORTED_LITERAL_TYPE" : {
     "message" : [ "Unsupported literal type %s %s" ],
@@ -213,7 +229,8 @@
     "sqlState" : "0A000"
   },
   "WINDOW_NOT_SUPPORT_MERGING" : {
-    "message" : [ "Window Functions do not support merging." ]
+    "message" : [ "Window Functions do not support merging." ],
+    "sqlState" : "0A000"
   },
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -58,12 +58,6 @@
   "FOUND_NEGATIVE_VALUES" : {
     "message" : [ "Negative values found in %s" ]
   },
-  "GROUP_INDEX_LESS_THAN_ZERO" : {
-    "message" : [ "The specified group index cannot be less than zero" ]
-  },
-  "GROUP_INDEX_EXCEED_GROUP_COUNT" : {
-    "message" : [ "Regex group count is %s, but the specified group index is %s" ]
-  },
   "GROUPING_COLUMN_MISMATCH" : {
     "message" : [ "Column of grouping (%s) can't be found in grouping columns %s" ],
     "sqlState" : "42000"
@@ -74,6 +68,12 @@
   },
   "GROUPING_SIZE_LIMIT_EXCEEDED" : {
     "message" : [ "Grouping sets size cannot be greater than %s" ]
+  },
+  "GROUP_INDEX_EXCEED_GROUP_COUNT" : {
+    "message" : [ "Regex group count is %s, but the specified group index is %s" ]
+  },
+  "GROUP_INDEX_LESS_THAN_ZERO" : {
+    "message" : [ "The specified group index cannot be less than zero" ]
   },
   "IF_PARTITION_NOT_EXISTS_UNSUPPORTED" : {
     "message" : [ "Cannot write, IF NOT EXISTS is not supported for table: %s" ]
@@ -134,9 +134,6 @@
     "message" : [ "Unknown static partition column: %s" ],
     "sqlState" : "42000"
   },
-  "NO_DEFAULT_FOR_TYPE" : {
-    "message" : [ "no default for type %s" ]
-  },
   "NON_LITERAL_PIVOT_VALUES" : {
     "message" : [ "Literal expressions required for pivot values, found '%s'" ],
     "sqlState" : "42000"
@@ -146,10 +143,13 @@
     "sqlState" : "42000"
   },
   "NOT_MATCH_FUNCTION_NAME" : {
-    "message" : [ "%s is not matched at addNewFunction"]
+    "message" : [ "%s is not matched at addNewFunction" ]
   },
   "NOT_SUPPORT_ORDERED_OPERATIONS" : {
-    "message" : [ "Type %s does not support ordered operations"]
+    "message" : [ "Type %s does not support ordered operations" ]
+  },
+  "NO_DEFAULT_FOR_TYPE" : {
+    "message" : [ "no default for type %s" ]
   },
   "PIVOT_VALUE_DATA_TYPE_MISMATCH" : {
     "message" : [ "Invalid pivot value '%s': value data type %s does not match pivot column data type %s" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -70,7 +70,7 @@
   "GROUPING_SIZE_LIMIT_EXCEEDED" : {
     "message" : [ "Grouping sets size cannot be greater than %s" ]
   },
-  "GROUP_INDEX_EXCEED_GROUP_COUNT" : {
+  "GROUP_INDEX_EXCEEDS_GROUP_COUNT" : {
     "message" : [ "Regex group count is %s, but the specified group index is %s" ],
     "sqlState" : "42000"
   },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -118,15 +118,15 @@
     "message" : [ "Find an invalid url string %s" ],
     "sqlState" : "42000"
   },
-  "MERGE_UNSUPPORTED_BY_WINDOW_FUNCTIONS" : {
-    "message" : [ "Window Functions do not support merging." ],
-    "sqlState" : "0A000"
-  },
   "LOGICAL_HINT_OPERATOR_NOT_REMOVED_DURING_ANALYSIS" : {
     "message" : [ "Internal error: logical hint operator should have been removed during analysis" ]
   },
   "MAP_KEY_DOES_NOT_EXIST" : {
     "message" : [ "Key %s does not exist." ]
+  },
+  "MERGE_UNSUPPORTED_BY_WINDOW_FUNCTIONS" : {
+    "message" : [ "Window Functions do not support merging." ],
+    "sqlState" : "0A000"
   },
   "MISSING_COLUMN" : {
     "message" : [ "cannot resolve '%s' given input columns: [%s]" ],
@@ -204,7 +204,7 @@
   },
   "UNSUPPORTED_DATA_TYPE" : {
     "message" : [ "dataType" ],
-    "sqlState": "0A000"
+    "sqlState" : "0A000"
   },
   "UNSUPPORTED_INPUT_TYPE" : {
     "message" : [ "Unsupported input type %s" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,4 +1,7 @@
 {
+  "ADD_NEW_FUNCTION_NAME_MISMATCHED" : {
+    "message" : [ "%s is not matched at addNewFunction" ]
+  },
   "AMBIGUOUS_FIELD_NAME" : {
     "message" : [ "Field name %s is ambiguous and has %s matching fields in the struct." ],
     "sqlState" : "42000"
@@ -35,7 +38,7 @@
   "CONCURRENT_QUERY" : {
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
   },
-  "COPY_NULL_FIELD" : {
+  "COPY_NULL_FIELD_NOT_ALLOWED" : {
     "message" : [ "Do not attempt to copy a null field" ]
   },
   "DIVIDE_BY_ZERO" : {
@@ -46,9 +49,6 @@
     "message" : [ "Found duplicate keys '%s'" ],
     "sqlState" : "23000"
   },
-  "EXCEED_ARRAY_SIZE_WHEN_ZIP_MAP" : {
-    "message" : [ "Unsuccessful try to zip maps with %s unique keys due to exceeding the array size limit %s." ]
-  },
   "FAILED_EXECUTE_UDF" : {
     "message" : [ "Failed to execute user defined function (%s: (%s) => %s)" ]
   },
@@ -58,10 +58,6 @@
   },
   "FAILED_SET_ORIGINAL_PERMISSION_BACK" : {
     "message" : [ "Failed to set original permission %s back to the created path: %s. Exception: %s" ]
-  },
-  "FOUND_NEGATIVE_VALUES" : {
-    "message" : [ "Negative values found in %s" ],
-    "sqlState" : "22003"
   },
   "GROUPING_COLUMN_MISMATCH" : {
     "message" : [ "Column of grouping (%s) can't be found in grouping columns %s" ],
@@ -80,7 +76,7 @@
   },
   "GROUP_INDEX_LESS_THAN_ZERO" : {
     "message" : [ "The specified group index cannot be less than zero" ],
-    "sqlState" : "07009"
+    "sqlState" : "42000"
   },
   "IF_PARTITION_NOT_EXISTS_UNSUPPORTED" : {
     "message" : [ "Cannot write, IF NOT EXISTS is not supported for table: %s" ]
@@ -98,7 +94,7 @@
   },
   "INTEGRAL_DIVIDE_OVERFLOW" : {
     "message" : [ "Overflow in integral divide." ],
-    "sqlState" : "22015"
+    "sqlState" : "22003"
   },
   "INVALID_ARRAY_INDEX" : {
     "message" : [ "Invalid index: %s, numElements: %s" ]
@@ -152,13 +148,13 @@
     "message" : [ "PARTITION clause cannot contain a non-partition column name: %s" ],
     "sqlState" : "42000"
   },
-  "NOT_MATCH_FUNCTION_NAME" : {
-    "message" : [ "%s is not matched at addNewFunction" ],
-    "sqlState" : "42000"
-  },
   "NO_DEFAULT_FOR_TYPE" : {
     "message" : [ "no default for type %s" ],
     "sqlState" : "0700C"
+  },
+  "ORDERED_OPERATIONS_UNSUPPORTED_BY_DATA_TYPE" : {
+    "message" : [ "Type %s does not support ordered operations" ],
+    "sqlState" : "0A000"
   },
   "PIVOT_VALUE_DATA_TYPE_MISMATCH" : {
     "message" : [ "Invalid pivot value '%s': value data type %s does not match pivot column data type %s" ],
@@ -185,6 +181,10 @@
   },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
+  },
+  "UNEXPECTED_NEGATIVE_VALUES" : {
+    "message" : [ "Negative values found in %s" ],
+    "sqlState" : "22003"
   },
   "UNEXPECTED_TYPE" : {
     "message" : [ "Unexpected type %s" ],
@@ -214,16 +214,8 @@
     "message" : [ "Unsupported literal type %s %s" ],
     "sqlState" : "0A000"
   },
-  "UNSUPPORTED_ORDERED_OPERATIONS" : {
-    "message" : [ "Type %s does not support ordered operations" ],
-    "sqlState" : "0A000"
-  },
   "UNSUPPORTED_SIMPLE_STRING_WITH_NODE_ID" : {
     "message" : [ "%s does not implement simpleStringWithNodeId" ]
-  },
-  "UNSUPPORTED_TRANSACTION_BY_JDBC_SERVER" : {
-    "message" : [ "The target JDBC server does not support transaction and can only support ALTER TABLE with a single action." ],
-    "sqlState" : "0A000"
   },
   "UNSUPPORTED_TRANSACTION_BY_JDBC_SERVER" : {
     "message" : [ "The target JDBC server does not support transaction and can only support ALTER TABLE with a single action." ],
@@ -232,5 +224,8 @@
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],
     "sqlState" : "40000"
+  },
+  "ZIPPED_MAPS_EXCEED_SIZE_LIMIT" : {
+    "message" : [ "Unsuccessful try to zip maps with %s unique keys due to exceeding the array size limit %s." ]
   }
 }

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -318,3 +318,69 @@ private[spark] class SparkSQLFeatureNotSupportedException(
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
 }
+
+/**
+ * Unsupported operation exception thrown from Spark with an error class.
+ */
+class SparkUnsupportedOperationException(errorClass: String, messageParameters: Array[String])
+  extends UnsupportedOperationException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * Illegal state exception thrown from Spark with an error class.
+ */
+class SparkIllegalStateException(errorClass: String, messageParameters: Array[String])
+  extends IllegalStateException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * Number format exception thrown from Spark with an error class.
+ */
+class SparkNumberFormatException(errorClass: String, messageParameters: Array[String])
+  extends NumberFormatException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * Illegal argument exception thrown from Spark with an error class.
+ */
+class SparkIllegalArgumentException(errorClass: String, messageParameters: Array[String])
+  extends IllegalArgumentException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * Array index out of bounds exception thrown from Spark with an error class.
+ */
+class SparkArrayIndexOutOfBoundsException(errorClass: String, messageParameters: Array[String])
+  extends ArrayIndexOutOfBoundsException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}
+
+/**
+ * No such element exception thrown from Spark with an error class.
+ */
+class SparkNoSuchElementException(errorClass: String, messageParameters: Array[String])
+  extends NoSuchElementException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+}

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -209,9 +209,10 @@ private[spark] class SparkNoSuchMethodException(
  */
 private[spark] class SparkIllegalArgumentException(
     errorClass: String,
-    messageParameters: Array[String])
+    messageParameters: Array[String],
+    cause: Throwable = null)
   extends IllegalArgumentException(
-    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
+    SparkThrowableHelper.getMessage(errorClass, messageParameters), cause) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
@@ -313,72 +314,6 @@ private[spark] class SparkSQLFeatureNotSupportedException(
     errorClass: String,
     messageParameters: Array[String])
   extends SQLFeatureNotSupportedException(
-    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
-
-  override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-}
-
-/**
- * Unsupported operation exception thrown from Spark with an error class.
- */
-class SparkUnsupportedOperationException(errorClass: String, messageParameters: Array[String])
-  extends UnsupportedOperationException(
-    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
-
-  override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-}
-
-/**
- * Illegal state exception thrown from Spark with an error class.
- */
-class SparkIllegalStateException(errorClass: String, messageParameters: Array[String])
-  extends IllegalStateException(
-    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
-
-  override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-}
-
-/**
- * Number format exception thrown from Spark with an error class.
- */
-class SparkNumberFormatException(errorClass: String, messageParameters: Array[String])
-  extends NumberFormatException(
-    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
-
-  override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-}
-
-/**
- * Illegal argument exception thrown from Spark with an error class.
- */
-class SparkIllegalArgumentException(errorClass: String, messageParameters: Array[String])
-  extends IllegalArgumentException(
-    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
-
-  override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-}
-
-/**
- * Array index out of bounds exception thrown from Spark with an error class.
- */
-class SparkArrayIndexOutOfBoundsException(errorClass: String, messageParameters: Array[String])
-  extends ArrayIndexOutOfBoundsException(
-    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
-
-  override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-}
-
-/**
- * No such element exception thrown from Spark with an error class.
- */
-class SparkNoSuchElementException(errorClass: String, messageParameters: Array[String])
-  extends NoSuchElementException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -628,7 +628,7 @@ class CodegenContext extends Logging {
     case udt: UserDefinedType[_] => genEqual(udt.sqlType, c1, c2)
     case NullType => "false"
     case _ =>
-      throw QueryExecutionErrors.cannotGenerateCodeForUncomparableTypeError(
+      throw QueryExecutionErrors.cannotGenerateCodeForIncomparableTypeError(
         "equality", dataType)
   }
 
@@ -719,7 +719,7 @@ class CodegenContext extends Logging {
     case other if other.isInstanceOf[AtomicType] => s"$c1.compare($c2)"
     case udt: UserDefinedType[_] => genComp(udt.sqlType, c1, c2)
     case _ =>
-      throw QueryExecutionErrors.cannotGenerateCodeForUncomparableTypeError("compare", dataType)
+      throw QueryExecutionErrors.cannotGenerateCodeForIncomparableTypeError("compare", dataType)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -628,7 +628,7 @@ class CodegenContext extends Logging {
     case udt: UserDefinedType[_] => genEqual(udt.sqlType, c1, c2)
     case NullType => "false"
     case _ =>
-      throw QueryExecutionErrors.cannotGenerateCodeForIncomparableTypeError(
+      throw QueryExecutionErrors.cannotGenerateCodeForUncomparableTypeError(
         "equality", dataType)
   }
 
@@ -719,7 +719,7 @@ class CodegenContext extends Logging {
     case other if other.isInstanceOf[AtomicType] => s"$c1.compare($c2)"
     case udt: UserDefinedType[_] => genComp(udt.sqlType, c1, c2)
     case _ =>
-      throw QueryExecutionErrors.cannotGenerateCodeForIncomparableTypeError("compare", dataType)
+      throw QueryExecutionErrors.cannotGenerateCodeForUncomparableTypeError("compare", dataType)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -217,7 +217,7 @@ object QueryExecutionErrors {
 
   def regexGroupIndexExceedGroupCountError(
       groupCount: Int, groupIndex: Int): Throwable = {
-    new SparkIllegalArgumentException("GROUP_INDEX_EXCEED_GROUP_COUNT",
+    new SparkIllegalArgumentException("GROUP_INDEX_EXCEEDS_GROUP_COUNT",
       Array(groupCount.toString, groupIndex.toString))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -186,12 +186,12 @@ object QueryExecutionErrors {
   }
 
   def mapSizeExceedArraySizeWhenZipMapError(size: Int): RuntimeException = {
-    new SparkRuntimeException("EXCEED_ARRAY_SIZE_WHEN_ZIP_MAP",
+    new SparkRuntimeException("ZIPPED_MAPS_EXCEED_SIZE_LIMIT",
       Array(size.toString, ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toString))
   }
 
   def copyNullFieldNotAllowedError(): Throwable = {
-    new SparkIllegalStateException("COPY_NULL_FIELD", Array.empty)
+    new SparkIllegalStateException("COPY_NULL_FIELD_NOT_ALLOWED", Array.empty)
   }
 
   def literalTypeUnsupportedError(v: Any): RuntimeException = {
@@ -207,7 +207,8 @@ object QueryExecutionErrors {
   }
 
   def orderedOperationUnsupportedByDataTypeError(dataType: DataType): Throwable = {
-    new SparkIllegalArgumentException("UNSUPPORTED_ORDERED_OPERATIONS", Array(dataType.toString))
+    new SparkIllegalArgumentException("ORDERED_OPERATIONS_UNSUPPORTED_BY_DATA_TYPE",
+      Array(dataType.toString))
   }
 
   def regexGroupIndexLessThanZeroError(): Throwable = {
@@ -241,12 +242,12 @@ object QueryExecutionErrors {
   }
 
   def negativeValueUnexpectedError(frequencyExpression : Expression): Throwable = {
-    new SparkException(errorClass = "FOUND_NEGATIVE_VALUES",
+    new SparkException(errorClass = "UNEXPECTED_NEGATIVE_VALUES",
       messageParameters = Array(frequencyExpression.sql), cause = null)
   }
 
   def addNewFunctionMismatchedWithFunctionError(funcName: String): Throwable = {
-    new SparkIllegalArgumentException("NOT_MATCH_FUNCTION_NAME", Array(funcName))
+    new SparkIllegalArgumentException("ADD_NEW_FUNCTION_NAME_MISMATCHED", Array(funcName))
   }
 
   def cannotGenerateCodeForUncomparableTypeError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -207,7 +207,7 @@ object QueryExecutionErrors {
   }
 
   def orderedOperationUnsupportedByDataTypeError(dataType: DataType): Throwable = {
-    new SparkIllegalArgumentException("NOT_SUPPORT_ORDERED_OPERATIONS", Array(dataType.toString))
+    new SparkIllegalArgumentException("UNSUPPORTED_ORDERED_OPERATIONS", Array(dataType.toString))
   }
 
   def regexGroupIndexLessThanZeroError(): Throwable = {
@@ -229,7 +229,7 @@ object QueryExecutionErrors {
   }
 
   def mergeUnsupportedByWindowFunctionError(): Throwable = {
-    new SparkUnsupportedOperationException("WINDOW_NOT_SUPPORT_MERGING", Array.empty)
+    new SparkUnsupportedOperationException("MERGE_UNSUPPORTED_BY_WINDOW_FUNCTIONS", Array.empty)
   }
 
   def dataTypeUnexpectedError(dataType: DataType): Throwable = {
@@ -249,9 +249,10 @@ object QueryExecutionErrors {
     new SparkIllegalArgumentException("NOT_MATCH_FUNCTION_NAME", Array(funcName))
   }
 
-  def cannotGenerateCodeForIncomparableTypeError(
+  def cannotGenerateCodeForUncomparableTypeError(
       codeType: String, dataType: DataType): Throwable = {
-    new SparkIllegalArgumentException("INCOMPARABLE_TYPE", Array(codeType, dataType.catalogString))
+    new SparkIllegalArgumentException("CANNOT_GENERATE_CODE_FOR_UNCOMPARABLE_TYPE",
+      Array(codeType, dataType.catalogString))
   }
 
   def cannotGenerateCodeForUnsupportedTypeError(dataType: DataType): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -233,7 +233,7 @@ object QueryExecutionErrors {
   }
 
   def dataTypeUnexpectedError(dataType: DataType): Throwable = {
-    new SparkUnsupportedOperationException("UNEXPECTED_DATATYPE", Array(dataType.catalogString))
+    new SparkUnsupportedOperationException("UNEXPECTED_TYPE", Array(dataType.catalogString))
   }
 
   def typeUnsupportedError(dataType: DataType): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -170,90 +170,88 @@ object QueryExecutionErrors {
   }
 
   def inputTypeUnsupportedError(dataType: DataType): Throwable = {
-    new IllegalArgumentException(s"Unsupported input type ${dataType.catalogString}")
+    new SparkIllegalArgumentException("UNSUPPORTED_INPUT_TYPE", Array(dataType.catalogString))
   }
 
   def invalidFractionOfSecondError(): DateTimeException = {
-    new SparkDateTimeException(errorClass = "INVALID_FRACTION_OF_SECOND", Array.empty)
+    new SparkDateTimeException("INVALID_FRACTION_OF_SECOND", Array.empty)
   }
 
   def overflowInSumOfDecimalError(): ArithmeticException = {
-    new ArithmeticException("Overflow in sum of decimals.")
+    new SparkArithmeticException("SUM_OF_DECIMAL_OVERFLOW", Array.empty)
   }
 
   def overflowInIntegralDivideError(): ArithmeticException = {
-    new ArithmeticException("Overflow in integral divide.")
+    new SparkArithmeticException("INTEGRAL_DIVIDE_OVERFLOW", Array.empty)
   }
 
   def mapSizeExceedArraySizeWhenZipMapError(size: Int): RuntimeException = {
-    new RuntimeException(s"Unsuccessful try to zip maps with $size " +
-      "unique keys due to exceeding the array size limit " +
-      s"${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH}.")
+    new SparkRuntimeException("EXCEED_ARRAY_SIZE_WHEN_ZIP_MAP",
+      Array(size.toString, ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toString))
   }
 
   def copyNullFieldNotAllowedError(): Throwable = {
-    new IllegalStateException("Do not attempt to copy a null field")
+    new SparkIllegalStateException("COPY_NULL_FIELD", Array.empty)
   }
 
   def literalTypeUnsupportedError(v: Any): RuntimeException = {
-    new SparkRuntimeException("UNSUPPORTED_LITERAL_TYPE",
-      Array(v.getClass.toString, v.toString))
+    new SparkRuntimeException("UNSUPPORTED_LITERAL_TYPE", Array(v.getClass.toString, v.toString))
   }
 
   def noDefaultForDataTypeError(dataType: DataType): RuntimeException = {
-    new RuntimeException(s"no default for type $dataType")
+    new SparkRuntimeException("NO_DEFAULT_FOR_TYPE", Array(dataType.toString))
   }
 
   def doGenCodeOfAliasShouldNotBeCalledError(): Throwable = {
-    new IllegalStateException("Alias.doGenCode should not be called.")
+    new SparkIllegalStateException("SHOULD_NOT_CALL_ALIAS_DO_GEN_CODE", Array.empty)
   }
 
   def orderedOperationUnsupportedByDataTypeError(dataType: DataType): Throwable = {
-    new IllegalArgumentException(s"Type $dataType does not support ordered operations")
+    new SparkIllegalArgumentException("NOT_SUPPORT_ORDERED_OPERATIONS", Array(dataType.toString))
   }
 
   def regexGroupIndexLessThanZeroError(): Throwable = {
-    new IllegalArgumentException("The specified group index cannot be less than zero")
+    new SparkIllegalArgumentException("GROUP_INDEX_LESS_THAN_ZERO", Array.empty)
   }
 
   def regexGroupIndexExceedGroupCountError(
       groupCount: Int, groupIndex: Int): Throwable = {
-    new IllegalArgumentException(
-      s"Regex group count is $groupCount, but the specified group index is $groupIndex")
+    new SparkIllegalArgumentException("GROUP_INDEX_EXCEED_GROUP_COUNT",
+      Array(groupCount.toString, groupIndex.toString))
   }
 
   def invalidUrlError(url: UTF8String, e: URISyntaxException): Throwable = {
-    new IllegalArgumentException(s"Find an invaild url string ${url.toString}", e)
+    new SparkIllegalArgumentException("INVALID_URL", Array(url.toString), cause = e)
   }
 
   def dataTypeOperationUnsupportedError(): Throwable = {
-    new UnsupportedOperationException("dataType")
+    new SparkUnsupportedOperationException("UNSUPPORTED_DATA_TYPE_OPERATION", Array.empty)
   }
 
   def mergeUnsupportedByWindowFunctionError(): Throwable = {
-    new UnsupportedOperationException("Window Functions do not support merging.")
+    new SparkUnsupportedOperationException("WINDOW_NOT_SUPPORT_MERGING", Array.empty)
   }
 
   def dataTypeUnexpectedError(dataType: DataType): Throwable = {
-    new UnsupportedOperationException(s"Unexpected data type ${dataType.catalogString}")
+    new SparkUnsupportedOperationException("UNEXPECTED_DATATYPE", Array(dataType.catalogString))
   }
 
   def typeUnsupportedError(dataType: DataType): Throwable = {
-    new IllegalArgumentException(s"Unexpected type $dataType")
+    new SparkIllegalArgumentException("UNEXPECTED_TYPE", Array(dataType.toString))
   }
 
   def negativeValueUnexpectedError(frequencyExpression : Expression): Throwable = {
-    new SparkException(s"Negative values found in ${frequencyExpression.sql}")
+    new SparkException(errorClass = "FOUND_NEGATIVE_VALUES",
+      messageParameters = Array(frequencyExpression.sql), cause = null)
   }
 
   def addNewFunctionMismatchedWithFunctionError(funcName: String): Throwable = {
-    new IllegalArgumentException(s"$funcName is not matched at addNewFunction")
+    new SparkIllegalArgumentException("NOT_MATCH_FUNCTION_NAME", Array(funcName))
   }
 
-  def cannotGenerateCodeForUncomparableTypeError(
+  def cannotGenerateCodeForIncomparableTypeError(
       codeType: String, dataType: DataType): Throwable = {
-    new IllegalArgumentException(
-      s"cannot generate $codeType code for un-comparable type: ${dataType.catalogString}")
+    new SparkIllegalArgumentException("INCOMPARABLE_TYPE", Array(codeType, dataType.catalogString))
   }
 
   def cannotGenerateCodeForUnsupportedTypeError(dataType: DataType): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -956,7 +956,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         evaluateWithoutCodegen(
           ParseUrl(Seq("https://a.b.c/index.php?params1=a|b&params2=x", "HOST")))
       }.getMessage
-      assert(msg.contains("Find an invaild url string"))
+      assert(msg.contains("Find an invalid url string"))
     }
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
       checkEvaluation(

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1900,7 +1900,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
+org.apache.spark.SparkArithmeticException
 Overflow in integral divide.
 
 
@@ -1909,7 +1909,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1L
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
+org.apache.spark.SparkArithmeticException
 Overflow in integral divide.
 
 
@@ -1952,7 +1952,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
+org.apache.spark.SparkArithmeticException
 Overflow in integral divide.
 
 
@@ -1961,7 +1961,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1L
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
+org.apache.spark.SparkArithmeticException
 Overflow in integral divide.
 
 

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1889,7 +1889,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
+org.apache.spark.SparkArithmeticException
 Overflow in integral divide.
 
 
@@ -1898,7 +1898,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1L
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
+org.apache.spark.SparkArithmeticException
 Overflow in integral divide.
 
 
@@ -1941,7 +1941,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
+org.apache.spark.SparkArithmeticException
 Overflow in integral divide.
 
 
@@ -1950,7 +1950,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1L
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
+org.apache.spark.SparkArithmeticException
 Overflow in integral divide.
 
 

--- a/sql/core/src/test/resources/sql-tests/results/regexp-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/regexp-functions.sql.out
@@ -7,7 +7,7 @@ SELECT regexp_extract('1a 2b 14m', '\\d+')
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 Regex group count is 0, but the specified group index is 1
 
 
@@ -24,7 +24,7 @@ SELECT regexp_extract('1a 2b 14m', '\\d+', 1)
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 Regex group count is 0, but the specified group index is 1
 
 
@@ -33,7 +33,7 @@ SELECT regexp_extract('1a 2b 14m', '\\d+', 2)
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 Regex group count is 0, but the specified group index is 2
 
 
@@ -42,7 +42,7 @@ SELECT regexp_extract('1a 2b 14m', '\\d+', -1)
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 The specified group index cannot be less than zero
 
 
@@ -99,7 +99,7 @@ SELECT regexp_extract('1a 2b 14m', '(\\d+)([a-z]+)', 3)
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 Regex group count is 2, but the specified group index is 3
 
 
@@ -108,7 +108,7 @@ SELECT regexp_extract('1a 2b 14m', '(\\d+)([a-z]+)', -1)
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 The specified group index cannot be less than zero
 
 
@@ -133,7 +133,7 @@ SELECT regexp_extract_all('1a 2b 14m', '\\d+')
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 Regex group count is 0, but the specified group index is 1
 
 
@@ -150,7 +150,7 @@ SELECT regexp_extract_all('1a 2b 14m', '\\d+', 1)
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 Regex group count is 0, but the specified group index is 1
 
 
@@ -159,7 +159,7 @@ SELECT regexp_extract_all('1a 2b 14m', '\\d+', 2)
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 Regex group count is 0, but the specified group index is 2
 
 
@@ -168,7 +168,7 @@ SELECT regexp_extract_all('1a 2b 14m', '\\d+', -1)
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 The specified group index cannot be less than zero
 
 
@@ -225,7 +225,7 @@ SELECT regexp_extract_all('1a 2b 14m', '(\\d+)([a-z]+)', 3)
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 Regex group count is 2, but the specified group index is 3
 
 
@@ -234,7 +234,7 @@ SELECT regexp_extract_all('1a 2b 14m', '(\\d+)([a-z]+)', -1)
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
+org.apache.spark.SparkIllegalArgumentException
 The specified group index cannot be less than zero
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactor some exceptions in QueryExecutionErrors to use error classes.

```
inputTypeUnsupportedError
invalidFractionOfSecondError
overflowInSumOfDecimalError
overflowInIntegralDivideError
mapSizeExceedArraySizeWhenZipMapError
copyNullFieldNotAllowedError
literalTypeUnsupportedError
noDefaultForDataTypeError
doGenCodeOfAliasShouldNotBeCalledError
orderedOperationUnsupportedByDataTypeError
regexGroupIndexLessThanZeroError
regexGroupIndexExceedGroupCountError
invalidUrlError
dataTypeOperationUnsupportedError
mergeUnsupportedByWindowFunctionError
dataTypeUnexpectedError
typeUnsupportedError
negativeValueUnexpectedError
addNewFunctionMismatchedWithFunctionError
cannotGenerateCodeForUncomparableTypeError
```
### Why are the changes needed?

There are currently ~350 exceptions in this file; so this PR only focuses on the second set of 20.

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
Existed UT Testcase