### PR TITLE
[SPARK-36402][PYTHON] Implement Series.combine

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/series.rst
+++ b/python/docs/source/reference/pyspark.pandas/series.rst
@@ -243,6 +243,7 @@ Combining / joining / merging
    :toctree: api/
 
    Series.append
+   Series.combine
    Series.compare
    Series.replace
    Series.update

--- a/python/pyspark/pandas/missing/series.py
+++ b/python/pyspark/pandas/missing/series.py
@@ -34,7 +34,6 @@ class MissingPandasLikeSeries(object):
     # Functions
     asfreq = _unsupported_function("asfreq")
     autocorr = _unsupported_function("autocorr")
-    combine = _unsupported_function("combine")
     convert_dtypes = _unsupported_function("convert_dtypes")
     ewm = _unsupported_function("ewm")
     infer_objects = _unsupported_function("infer_objects")

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4587,9 +4587,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         def wrapped_func(x: pd.Series, y: pd.Series) -> pd.Series:
             return x.combine(y, func)
 
+        scol = wrapped_func(*combined._internal.data_spark_columns)
         combined_sdf = combined._internal.spark_frame.select(
             *combined._internal.index_spark_columns,
-            wrapped_func(*combined._internal.data_spark_columns),
+            scol.alias(self._internal.spark_column_name_for(self.spark.column)),
             NATURAL_ORDER_COLUMN_NAME
         )
         internal = InternalFrame(

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4604,10 +4604,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def _combine_frame_with_fill_value(self, other: "Series", fill_value: Any) -> DataFrame:
         this = self.to_frame()
-        this_col = this.columns[0]
+        this_col = this._internal.column_labels[0]
 
         that = other.to_frame()
-        that_col = that.columns[0]
+        that_col = that._internal.column_labels[0]
 
         tmp_col = "__tmp_check_missing_index__"
         verify_temp_column_name(this, tmp_col)
@@ -4616,10 +4616,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         combined = combine_frames(this, that)
 
-        combined.loc[combined[("this", tmp_col)].isnull(), ("this", this_col)] = fill_value
-        combined.loc[combined[("that", tmp_col)].isnull(), ("that", that_col)] = fill_value
+        combined.loc[combined[("this", tmp_col)].isnull(), ("this",) + this_col] = fill_value
+        combined.loc[combined[("that", tmp_col)].isnull(), ("that",) + that_col] = fill_value
 
-        return combined[[("this", this_col), ("that", that_col)]]
+        return combined[[("this",) + this_col, ("that",) + that_col]]
 
     def update(self, other: "Series") -> None:
         """

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -1863,6 +1863,10 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         pser2 = pd.Series({"falcon": 345.0, "eagle": 200.0, "duck": 30.0}, name="same-name")
         run_test_combine(pser1, pser2)
 
+        pser1 = pd.Series({"falcon": 330.0, "eagle": 160.0}, name=("x", "s1"))
+        pser2 = pd.Series({"falcon": 345.0, "eagle": 200.0, "duck": 30.0}, name=("y", "s2"))
+        run_test_combine(pser1, pser2)
+
         psser1 = ps.from_pandas(pser1)
         with self.assertRaisesRegex(TypeError, "unsupported type: <class 'list'>"):
             psser1.combine([345.0, 200.0, 30.0], max)

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2982,6 +2982,59 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         pscov = psdf["s1"].cov(psdf["s2"], min_periods=4)
         self.assert_eq(pcov, pscov, almost=True)
 
+    def test_combine(self):
+        pdf = pd.DataFrame(
+            {"s1": [330.0, 160.0, np.nan], "s2": [345.0, 0.0, 30.0], "s3": [345.0, 0.0, 30.0]}
+        )
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(
+            pdf["s1"].combine(pdf["s2"], max),
+            psdf["s1"].combine(psdf["s2"], max),
+        )
+        self.assert_eq(
+            pdf["s1"].combine(pdf["s2"], max, fill_value=100),
+            psdf["s1"].combine(psdf["s2"], max, fill_value=100),
+        )
+        self.assert_eq(
+            pdf["s1"].combine(100, max),
+            psdf["s1"].combine(100, max),
+        )
+        self.assert_eq(
+            pdf["s1"].combine(100, max, fill_value=100),
+            psdf["s1"].combine(100, max, fill_value=100),
+        )
+
+        pdf = pd.DataFrame({"s1": ["a a", "b", ""], "s2": [345.0, np.nan, 30.0]})
+        psdf = ps.from_pandas(pdf)
+
+        def concat_strings(s1: str, s2: str) -> str:
+            return s1 + ": " + str(s2)
+
+        self.assert_eq(
+            pdf["s1"].combine(pdf["s2"], concat_strings),
+            psdf["s1"].combine(psdf["s2"], concat_strings),
+        )
+        self.assert_eq(
+            pdf["s1"].combine(pdf["s2"], concat_strings, fill_value=10.0),
+            psdf["s1"].combine(psdf["s2"], concat_strings, fill_value=10.0),
+        )
+        self.assert_eq(
+            pdf["s1"].combine(100, concat_strings),
+            psdf["s1"].combine(100, concat_strings),
+        )
+
+        pdf = pd.DataFrame({"s1": [1, 2, 3], "s2": [4, 5, 6]})
+        psdf = ps.from_pandas(pdf)
+
+        def true_div(s1: int, s2: int) -> float:
+            return s1 / s2
+
+        self.assert_eq(
+            pdf["s1"].combine(pdf["s2"], true_div),
+            psdf["s1"].combine(psdf["s2"], true_div),
+        )
+
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.test_series import *  # noqa: F401

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -3005,6 +3005,14 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             psdf["s1"].combine(100, max, fill_value=100),
         )
 
+        pdf = pd.DataFrame({("x", "s1"): [1, 2, 3], ("y", "s2"): [4, 5, 6]})
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(
+            pdf[("x", "s1")].combine(pdf[("y", "s2")], max),
+            psdf[("x", "s1")].combine(psdf[("y", "s2")], max),
+        )
+
         pdf = pd.DataFrame({"s1": ["a a", "b", ""], "s2": [345.0, np.nan, 30.0]})
         psdf = ps.from_pandas(pdf)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Implement Series.combine

### Why are the changes needed?

Increase pandas API coverage in PySpark
### Does this PR introduce _any_ user-facing change?

User can use

```python
>>> s1 = ps.Series({'falcon': 330.0, 'eagle': 160.0})
>>> s1
falcon    330.0
eagle     160.0
dtype: float64

>>> s2 = ps.Series({'falcon': 345.0, 'eagle': 200.0, 'duck': 30.0})
>>> s2
falcon    345.0
eagle     200.0
duck       30.0
dtype: float64

>>> s1.combine(s2, max)
duck        NaN
eagle     200.0
falcon    345.0
dtype: float64
```
### How was this patch tested?

unit tests and docstest