### PR TITLE
[SPARK-36624][YARN] In yarn client mode, when ApplicationMaster failed with KILLED/FAILED, driver should exit with code not 0

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2045,7 +2045,7 @@ class SparkContext(config: SparkConf) extends Logging {
   /**
    * Shut down the SparkContext.
    */
-  def stop(): Unit = {
+  def stop(callBack: Option[() => Unit] = None): Unit = {
     if (LiveListenerBus.withinListenerThread.value) {
       throw new SparkException(s"Cannot stop SparkContext within listener bus thread.")
     }
@@ -2137,6 +2137,9 @@ class SparkContext(config: SparkConf) extends Logging {
     // Unset YARN mode system env variable, to allow switching between cluster types.
     SparkContext.clearActiveContext()
     logInfo("Successfully stopped SparkContext")
+    callBack.foreach { call =>
+      call()
+    }
   }
 
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2045,7 +2045,7 @@ class SparkContext(config: SparkConf) extends Logging {
   /**
    * Shut down the SparkContext.
    */
-  def stop(callBack: Option[() => Unit] = None): Unit = {
+  def stop(): Unit = {
     if (LiveListenerBus.withinListenerThread.value) {
       throw new SparkException(s"Cannot stop SparkContext within listener bus thread.")
     }
@@ -2137,9 +2137,6 @@ class SparkContext(config: SparkConf) extends Logging {
     // Unset YARN mode system env variable, to allow switching between cluster types.
     SparkContext.clearActiveContext()
     logInfo("Successfully stopped SparkContext")
-    callBack.foreach { call =>
-      call()
-    }
   }
 
 

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -442,6 +442,16 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>1.6.0</td>
 </tr>
 <tr>
+  <td><code>spark.yarn.am.clientModeExitOnErro</code></td>
+  <td>false</td>
+  <td>
+  In yarn-client mode when this is true, if driver got application report with final status of KILLED or FAILED,
+  driver will stop corresponding SparkContext and exit program with code 1.
+  Note that if this is true can called from another application and it will terminate the parent application as well.
+  </td>
+  <td>3.3.0</td>
+</tr>
+<tr>
   <td><code>spark.yarn.executor.failuresValidityInterval</code></td>
   <td>(none)</td>
   <td>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -442,12 +442,12 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>1.6.0</td>
 </tr>
 <tr>
-  <td><code>spark.yarn.am.clientModeExitOnErro</code></td>
+  <td><code>spark.yarn.am.clientModeExitOnError</code></td>
   <td>false</td>
   <td>
-  In yarn-client mode when this is true, if driver got application report with final status of KILLED or FAILED,
+  In yarn-client mode, when this is true, if driver got application report with final status of KILLED or FAILED,
   driver will stop corresponding SparkContext and exit program with code 1.
-  Note that if this is true can called from another application and it will terminate the parent application as well.
+  Note, if this is true and called from another application, it will terminate the parent application as well.
   </td>
   <td>3.3.0</td>
 </tr>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -52,6 +52,14 @@ package object config extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
+  private[spark] val AM_CLIENT_MODE_EXIT_DIRECTLY =
+    ConfigBuilder("spark.yarn.am.clientModeExitDirectly")
+      .doc("When ture, if YarnClientSchedulerBackend.MonitorThread got report with " +
+        "KILLED or FAILED status, driver will stop SparkContext and exit program with code 1.")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val EXECUTOR_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS =
     ConfigBuilder("spark.yarn.executor.failuresValidityInterval")
       .doc("Interval after which Executor failures will be considered independent and not " +

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -52,10 +52,13 @@ package object config extends Logging {
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
-  private[spark] val AM_CLIENT_MODE_EXIT_DIRECTLY =
-    ConfigBuilder("spark.yarn.am.clientModeExitDirectly")
-      .doc("When ture, if YarnClientSchedulerBackend.MonitorThread got report with " +
-        "KILLED or FAILED status, driver will stop SparkContext and exit program with code 1.")
+  private[spark] val AM_CLIENT_MODE_EXIT_ON_ERROR =
+    ConfigBuilder("spark.yarn.am.clientModeExitOnError")
+      .doc("In yarn-client mode when this is true, if driver got " +
+        "application report with final status of KILLED or FAILED, driver " +
+        "will stop corresponding SparkContext and exit program with code 1." +
+        "Note that if this is true can called from another application and " +
+        "it will terminate the parent application as well.")
       .version("3.3.0")
       .booleanConf
       .createWithDefault(false)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -54,11 +54,11 @@ package object config extends Logging {
 
   private[spark] val AM_CLIENT_MODE_EXIT_ON_ERROR =
     ConfigBuilder("spark.yarn.am.clientModeExitOnError")
-      .doc("In yarn-client mode when this is true, if driver got " +
-        "application report with final status of KILLED or FAILED, driver " +
-        "will stop corresponding SparkContext and exit program with code 1." +
-        "Note that if this is true can called from another application and " +
-        "it will terminate the parent application as well.")
+      .doc("In yarn-client mode, when this is true, if driver got " +
+        "application report with final status of KILLED or FAILED, " +
+        "driver will stop corresponding SparkContext and exit program with code 1. " +
+        "Note, if this is true and called from another application, it will terminate " +
+        "the parent application as well.")
       .version("3.3.0")
       .booleanConf
       .createWithDefault(false)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -123,7 +123,8 @@ private[spark] class YarnClientSchedulerBackend(
         allowInterrupt = false
         sc.stop()
         state match {
-          case FinalApplicationStatus.FAILED | FinalApplicationStatus.KILLED =>
+          case FinalApplicationStatus.FAILED | FinalApplicationStatus.KILLED
+            if conf.get(AM_CLIENT_MODE_EXIT_DIRECTLY) =>
             logWarning(s"ApplicationMaster finished with status ${state}, " +
               s"SparkContext should exit with code 1.")
             System.exit(1)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -121,15 +121,15 @@ private[spark] class YarnClientSchedulerBackend(
           logError(s"Diagnostics message: $err")
         }
         allowInterrupt = false
-        sc.stop()
-        state match {
-          case FinalApplicationStatus.FAILED | FinalApplicationStatus.KILLED
-            if conf.get(AM_CLIENT_MODE_EXIT_DIRECTLY) =>
-            logWarning(s"ApplicationMaster finished with status ${state}, " +
-              s"SparkContext should exit with code 1.")
-            System.exit(1)
-          case _ =>
-        }
+        sc.stop(Some(() =>
+          state match {
+            case FinalApplicationStatus.FAILED | FinalApplicationStatus.KILLED
+              if conf.get(AM_CLIENT_MODE_EXIT_DIRECTLY) =>
+              logWarning(s"ApplicationMaster finished with status $state, " +
+                s"Application should exit with code 1.")
+              System.exit(1)
+            case _ =>
+          }))
       } catch {
         case _: InterruptedException | _: InterruptedIOException =>
           logInfo("Interrupting monitor thread")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -125,8 +125,8 @@ private[spark] class YarnClientSchedulerBackend(
         state match {
           case FinalApplicationStatus.FAILED | FinalApplicationStatus.KILLED =>
             logWarning(s"ApplicationMaster finished with status ${state}, " +
-              s"SparkContext should exit with code -1.")
-            System.exit(-1)
+              s"SparkContext should exit with code 1.")
+            System.exit(1)
           case _ =>
         }
       } catch {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -124,7 +124,7 @@ private[spark] class YarnClientSchedulerBackend(
         sc.stop()
         state match {
           case FinalApplicationStatus.FAILED | FinalApplicationStatus.KILLED
-            if conf.get(AM_CLIENT_MODE_EXIT_DIRECTLY) =>
+            if conf.get(AM_CLIENT_MODE_EXIT_ON_ERROR) =>
             logWarning(s"ApplicationMaster finished with status ${state}, " +
               s"SparkContext should exit with code 1.")
             System.exit(1)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -121,15 +121,15 @@ private[spark] class YarnClientSchedulerBackend(
           logError(s"Diagnostics message: $err")
         }
         allowInterrupt = false
-        sc.stop(Some(() =>
-          state match {
-            case FinalApplicationStatus.FAILED | FinalApplicationStatus.KILLED
-              if conf.get(AM_CLIENT_MODE_EXIT_DIRECTLY) =>
-              logWarning(s"ApplicationMaster finished with status $state, " +
-                s"Application should exit with code 1.")
-              System.exit(1)
-            case _ =>
-          }))
+        sc.stop()
+        state match {
+          case FinalApplicationStatus.FAILED | FinalApplicationStatus.KILLED
+            if conf.get(AM_CLIENT_MODE_EXIT_DIRECTLY) =>
+            logWarning(s"ApplicationMaster finished with status ${state}, " +
+              s"SparkContext should exit with code 1.")
+            System.exit(1)
+          case _ =>
+        }
       } catch {
         case _: InterruptedException | _: InterruptedIOException =>
           logInfo("Interrupting monitor thread")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -21,7 +21,7 @@ import java.io.InterruptedIOException
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.hadoop.yarn.api.records.YarnApplicationState
+import org.apache.hadoop.yarn.api.records.{FinalApplicationStatus, YarnApplicationState}
 
 import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.deploy.yarn.{Client, ClientArguments, YarnAppReport}
@@ -122,6 +122,13 @@ private[spark] class YarnClientSchedulerBackend(
         }
         allowInterrupt = false
         sc.stop()
+        state match {
+          case FinalApplicationStatus.FAILED | FinalApplicationStatus.KILLED =>
+            logWarning(s"ApplicationMaster finished with status ${state}, " +
+              s"SparkContext should exit with code -1.")
+            System.exit(-1)
+          case _ =>
+        }
       } catch {
         case _: InterruptedException | _: InterruptedIOException =>
           logInfo("Interrupting monitor thread")


### PR DESCRIPTION
### What changes were proposed in this pull request?
In current code for yarn client mode, even when use use `yarn application -kill` to kill the application, driver side still exit with code 0. This behavior make job scheduler can't know the job is not success. and user don't know too.

In this case we should exit program with a non 0 code.

### Why are the changes needed?
Make scheduler/user more clear about application's status

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

