### PR TITLE
[SPARK-35624][CORE]Support reading inputbytes and inputrecords of the…

### DIFF
--- a/core/src/main/java/org/apache/spark/SparkStageInfo.java
+++ b/core/src/main/java/org/apache/spark/SparkStageInfo.java
@@ -34,4 +34,6 @@ public interface SparkStageInfo extends Serializable {
   int numActiveTasks();
   int numCompletedTasks();
   int numFailedTasks();
+  long inputBytes();
+  long inputRecords();
 }

--- a/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
+++ b/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
@@ -93,7 +93,9 @@ class SparkStatusTracker private[spark] (sc: SparkContext, store: AppStatusStore
         stage.numTasks,
         stage.numActiveTasks,
         stage.numCompleteTasks,
-        stage.numFailedTasks)
+        stage.numFailedTasks,
+        stage.inputBytes,
+        stage.inputRecords)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/StatusAPIImpl.scala
+++ b/core/src/main/scala/org/apache/spark/StatusAPIImpl.scala
@@ -31,7 +31,9 @@ private class SparkStageInfoImpl(
     val numTasks: Int,
     val numActiveTasks: Int,
     val numCompletedTasks: Int,
-    val numFailedTasks: Int)
+    val numFailedTasks: Int,
+    val inputBytes: Long,
+    val inputRecords: Long)
   extends SparkStageInfo
 
 private class SparkExecutorInfoImpl(

--- a/examples/src/main/java/org/apache/spark/examples/JavaStatusTrackerDemo.java
+++ b/examples/src/main/java/org/apache/spark/examples/JavaStatusTrackerDemo.java
@@ -66,6 +66,8 @@ public final class JavaStatusTrackerDemo {
       SparkStageInfo stageInfo = jsc.statusTracker().getStageInfo(jobInfo.stageIds()[0]);
       System.out.println(stageInfo.numTasks() + " tasks total: " + stageInfo.numActiveTasks() +
           " active, " + stageInfo.numCompletedTasks() + " complete");
+      System.out.println(stageInfo.inputBytes() + " input bytes");
+      System.out.println(stageInfo.inputRecords() + " input records");
     }
 
     System.out.println("Job results are: " + jobFuture.get());

--- a/examples/src/main/python/status_api_demo.py
+++ b/examples/src/main/python/status_api_demo.py
@@ -56,8 +56,10 @@ def main():
             for sid in job.stageIds:
                 info = status.getStageInfo(sid)
                 if info:
-                    print("Stage %d: %d tasks total (%d active, %d complete)" %
-                          (sid, info.numTasks, info.numActiveTasks, info.numCompletedTasks))
+                    print("Stage %d: %d tasks total (%d active, %d complete), "
+                          "%s inputBytes %s inputRecords" %
+                          (sid, info.numTasks, info.numActiveTasks, info.numCompletedTasks,
+                           info.inputBytes, info.inputRecords))
         time.sleep(1)
 
     print("Job results are:", result.get())

--- a/python/pyspark/status.py
+++ b/python/pyspark/status.py
@@ -28,7 +28,7 @@ class SparkJobInfo(namedtuple("SparkJobInfo", "jobId stageIds status")):
 
 class SparkStageInfo(namedtuple("SparkStageInfo",
                                 "stageId currentAttemptId name numTasks numActiveTasks "
-                                "numCompletedTasks numFailedTasks")):
+                                "numCompletedTasks numFailedTasks inputBytes inputRecords")):
     """
     Exposes information about Spark Stages.
     """

--- a/python/pyspark/status.pyi
+++ b/python/pyspark/status.pyi
@@ -32,6 +32,8 @@ class SparkStageInfo(NamedTuple):
     numActiveTasks: int
     numCompletedTasks: int
     numFailedTasks: int
+    inputBytes: long
+    inputRecords: long
 
 class StatusTracker:
     def __init__(self, jtracker: JavaObject) -> None: ...

--- a/python/pyspark/tests/test_context.py
+++ b/python/pyspark/tests/test_context.py
@@ -239,6 +239,8 @@ class ContextTests(unittest.TestCase):
             self.assertEqual(1, len(job.stageIds))
             stage = tracker.getStageInfo(job.stageIds[0])
             self.assertEqual(rdd.getNumPartitions(), stage.numTasks)
+            self.assertGreater(0, stage.inputBytes)
+            self.assertEqual(10, stage.inputRecords)
 
             sc.cancelAllJobs()
             t.join()


### PR DESCRIPTION
What changes were proposed in this pull request?
add inputBytes and inputRecords interface in SparkStageInfo

Why are the changes needed?
One of our projects needs to count the amount of data scanned and the number of scanned data rows during the execution of sparksql statements, but the current version of spark does not provide an interface to view these data, so I want to obtain this type of data through the spark context interface

Does this PR introduce any user-facing change?
expose new interface in spark context

How was this patch tested?
Manual test
