### PR TITLE
[SPARK-36625][SPARK-36661][PYTHON] Support TimestampNTZ in pandas API on Spark

### DIFF
--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -40,6 +40,7 @@ from pyspark.sql.types import (
     StringType,
     StructType,
     TimestampType,
+    TimestampNTZType,
     UserDefinedType,
 )
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
@@ -203,7 +204,7 @@ class DataTypeOps(object, metaclass=ABCMeta):
         from pyspark.pandas.data_type_ops.categorical_ops import CategoricalOps
         from pyspark.pandas.data_type_ops.complex_ops import ArrayOps, MapOps, StructOps
         from pyspark.pandas.data_type_ops.date_ops import DateOps
-        from pyspark.pandas.data_type_ops.datetime_ops import DatetimeOps
+        from pyspark.pandas.data_type_ops.datetime_ops import DatetimeOps, DatetimeNTZOps
         from pyspark.pandas.data_type_ops.null_ops import NullOps
         from pyspark.pandas.data_type_ops.num_ops import (
             DecimalOps,
@@ -246,6 +247,8 @@ class DataTypeOps(object, metaclass=ABCMeta):
                 return object.__new__(BooleanOps)
         elif isinstance(spark_type, TimestampType):
             return object.__new__(DatetimeOps)
+        elif isinstance(spark_type, TimestampNTZType):
+            return object.__new__(DatetimeNTZOps)
         elif isinstance(spark_type, DateType):
             return object.__new__(DateOps)
         elif isinstance(spark_type, BinaryType):

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -23,8 +23,16 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
+from pyspark import SparkContext
 from pyspark.sql import Column
-from pyspark.sql.types import BooleanType, LongType, StringType, TimestampType
+from pyspark.sql.types import (
+    BooleanType,
+    LongType,
+    StringType,
+    TimestampType,
+    TimestampNTZType,
+    NumericType,
+)
 
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import IndexOpsMixin
@@ -58,7 +66,9 @@ class DatetimeOps(DataTypeOps):
             "The timestamp subtraction returns an integer in seconds, "
             "whereas pandas returns 'timedelta64[ns]'."
         )
-        if isinstance(right, IndexOpsMixin) and isinstance(right.spark.data_type, TimestampType):
+        if isinstance(right, IndexOpsMixin) and isinstance(
+            right.spark.data_type, (TimestampType, TimestampNTZType)
+        ):
             warnings.warn(msg, UserWarning)
             return left.astype("long") - right.astype("long")
         elif isinstance(right, datetime.datetime):
@@ -66,7 +76,8 @@ class DatetimeOps(DataTypeOps):
             return cast(
                 SeriesOrIndex,
                 left._with_new_scol(
-                    left.spark.column.cast(LongType()) - SF.lit(right).cast(LongType()),
+                    left.astype("long").spark.column
+                    - self._cast_spark_column_timestamp_to_long(SF.lit(right)),
                     field=left._internal.data_fields[0].copy(
                         dtype=np.dtype("int64"), spark_type=LongType()
                     ),
@@ -89,7 +100,8 @@ class DatetimeOps(DataTypeOps):
             return cast(
                 SeriesOrIndex,
                 left._with_new_scol(
-                    SF.lit(right).cast(LongType()) - left.spark.column.cast(LongType()),
+                    self._cast_spark_column_timestamp_to_long(SF.lit(right))
+                    - left.astype("long").spark.column,
                     field=left._internal.data_fields[0].copy(
                         dtype=np.dtype("int64"), spark_type=LongType()
                     ),
@@ -137,3 +149,32 @@ class DatetimeOps(DataTypeOps):
             return _as_string_type(index_ops, dtype, null_str=str(pd.NaT))
         else:
             return _as_other_type(index_ops, dtype, spark_type)
+
+    def _cast_spark_column_timestamp_to_long(self, scol: Column) -> Column:
+        return scol.cast(LongType())
+
+
+class DatetimeNTZOps(DatetimeOps):
+    """
+    The class for binary operations of pandas-on-Spark objects with spark type:
+    TimestampNTZType.
+    """
+
+    def _cast_spark_column_timestamp_to_long(self, scol: Column) -> Column:
+        jvm = SparkContext._active_spark_context._jvm  # type: ignore
+        return Column(jvm.PythonSQLUtils.castTimestampNTZToLong(scol._jc))
+
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+
+        if isinstance(dtype, CategoricalDtype):
+            return _as_categorical_type(index_ops, dtype, spark_type)
+        elif isinstance(spark_type, NumericType):
+            from pyspark.pandas.internal import InternalField
+
+            scol = self._cast_spark_column_timestamp_to_long(index_ops.spark.column).cast(
+                spark_type
+            )
+            return index_ops._with_new_scol(scol, field=InternalField(dtype=dtype))
+        else:
+            return super(DatetimeNTZOps, self).astype(index_ops, dtype)

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -24,7 +24,7 @@ import numpy as np  # noqa: F401 (SPARK-34943)
 import pandas as pd  # noqa: F401
 from pandas.tseries.offsets import DateOffset
 import pyspark.sql.functions as F
-from pyspark.sql.types import DateType, TimestampType, LongType
+from pyspark.sql.types import DateType, TimestampType, TimestampNTZType, LongType
 
 if TYPE_CHECKING:
     import pyspark.pandas as ps  # noqa: F401 (SPARK-34943)
@@ -34,7 +34,7 @@ class DatetimeMethods(object):
     """Date/Time methods for pandas-on-Spark Series"""
 
     def __init__(self, series: "ps.Series"):
-        if not isinstance(series.spark.data_type, (DateType, TimestampType)):
+        if not isinstance(series.spark.data_type, (DateType, TimestampType, TimestampNTZType)):
             raise ValueError(
                 "Cannot call DatetimeMethods on type {}".format(series.spark.data_type)
             )

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -37,7 +37,7 @@ from pandas.api.types import CategoricalDtype, is_hashable
 from pandas._libs import lib
 
 from pyspark.sql import functions as F, Column
-from pyspark.sql.types import FractionalType, IntegralType, TimestampType
+from pyspark.sql.types import FractionalType, IntegralType, TimestampType, TimestampNTZType
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import Dtype, Label, Name, Scalar
@@ -191,7 +191,8 @@ class Index(IndexOpsMixin):
         ):
             instance = object.__new__(Float64Index)
         elif isinstance(
-            anchor._internal.spark_type_for(anchor._internal.index_spark_columns[0]), TimestampType
+            anchor._internal.spark_type_for(anchor._internal.index_spark_columns[0]),
+            (TimestampType, TimestampNTZType),
         ):
             instance = object.__new__(DatetimeIndex)
         else:
@@ -617,7 +618,7 @@ class Index(IndexOpsMixin):
         warnings.warn("We recommend using `{}.to_numpy()` instead.".format(type(self).__name__))
         if isinstance(self.spark.data_type, IntegralType):
             return self.to_numpy()
-        elif isinstance(self.spark.data_type, TimestampType):
+        elif isinstance(self.spark.data_type, (TimestampType, TimestampNTZType)):
             return np.array(list(map(lambda x: x.astype(np.int64), self.to_numpy())))
         else:
             return None
@@ -2123,7 +2124,7 @@ class Index(IndexOpsMixin):
         >>> idx.is_all_dates
         False
         """
-        return isinstance(self.spark.data_type, TimestampType)
+        return isinstance(self.spark.data_type, (TimestampType, TimestampNTZType))
 
     def repeat(self, repeats: int) -> "Index":
         """

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -58,6 +58,7 @@ from pyspark.sql.types import (
     DoubleType,
     BooleanType,
     TimestampType,
+    TimestampNTZType,
     DecimalType,
     StringType,
     DateType,
@@ -2977,6 +2978,7 @@ _get_dummies_acceptable_types = _get_dummies_default_accept_types + (
     DoubleType,
     BooleanType,
     TimestampType,
+    TimestampNTZType,
 )
 
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_base.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_base.py
@@ -26,7 +26,7 @@ from pyspark.pandas.data_type_ops.boolean_ops import BooleanOps, BooleanExtensio
 from pyspark.pandas.data_type_ops.categorical_ops import CategoricalOps
 from pyspark.pandas.data_type_ops.complex_ops import ArrayOps, MapOps, StructOps
 from pyspark.pandas.data_type_ops.date_ops import DateOps
-from pyspark.pandas.data_type_ops.datetime_ops import DatetimeOps
+from pyspark.pandas.data_type_ops.datetime_ops import DatetimeOps, DatetimeNTZOps
 from pyspark.pandas.data_type_ops.null_ops import NullOps
 from pyspark.pandas.data_type_ops.num_ops import IntegralOps, FractionalOps, DecimalOps
 from pyspark.pandas.data_type_ops.string_ops import StringOps
@@ -45,6 +45,7 @@ from pyspark.sql.types import (
     StringType,
     StructType,
     TimestampType,
+    TimestampNTZType,
     UserDefinedType,
 )
 
@@ -61,6 +62,7 @@ class BaseTest(unittest.TestCase):
             (_mock_dtype, StringType(), StringOps),
             (_mock_dtype, BooleanType(), BooleanOps),
             (_mock_dtype, TimestampType(), DatetimeOps),
+            (_mock_dtype, TimestampNTZType(), DatetimeNTZOps),
             (_mock_dtype, DateType(), DateOps),
             (_mock_dtype, BinaryType(), BinaryOps),
             (_mock_dtype, ArrayType(StringType()), ArrayOps),

--- a/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
@@ -235,6 +235,13 @@ class DatetimeOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assert_eq(pdf["this"] >= pdf["this"], psdf["this"] >= psdf["this"])
 
 
+class DatetimeNTZOpsTest(DatetimeOpsTest):
+    @classmethod
+    def setUpClass(cls):
+        super(DatetimeOpsTest, cls).setUpClass()
+        cls.spark.conf.set("spark.sql.timestampType", "timestamp_ntz")
+
+
 if __name__ == "__main__":
     import unittest
     from pyspark.pandas.tests.data_type_ops.test_datetime_ops import *  # noqa: F401

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2427,7 +2427,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         with self.assertRaisesRegex(TypeError, "Could not convert object \\(string\\) to numeric"):
             ps.Series(["a", "b", "c"]).prod()
         with self.assertRaisesRegex(
-            TypeError, "Could not convert datetime64\\[ns\\] \\(timestamp\\) to numeric"
+            TypeError, "Could not convert datetime64\\[ns\\] \\(timestamp.*\\) to numeric"
         ):
             ps.Series([pd.Timestamp("2016-01-01") for _ in range(3)]).prod()
 

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -23,6 +23,7 @@ from pyspark.sql.pandas.serializers import ArrowCollectSerializer
 from pyspark.sql.types import IntegralType
 from pyspark.sql.types import ByteType, ShortType, IntegerType, LongType, FloatType, \
     DoubleType, BooleanType, MapType, TimestampType, TimestampNTZType, StructType, DataType
+from pyspark.sql.utils import is_timestamp_ntz_preferred
 from pyspark.traceback_utils import SCCallSiteSync
 
 
@@ -372,7 +373,7 @@ class SparkConversionMixin(object):
                                 copied = True
                             pdf[field.name] = s
             else:
-                should_localize = not self._is_timestamp_ntz_preferred()
+                should_localize = not is_timestamp_ntz_preferred()
                 for column, series in pdf.iteritems():
                     s = series
                     if should_localize and is_datetime64tz_dtype(s.dtype) and s.dt.tz is not None:
@@ -455,7 +456,7 @@ class SparkConversionMixin(object):
         if isinstance(schema, (list, tuple)):
             arrow_schema = pa.Schema.from_pandas(pdf, preserve_index=False)
             struct = StructType()
-            prefer_timestamp_ntz = self._is_timestamp_ntz_preferred()
+            prefer_timestamp_ntz = is_timestamp_ntz_preferred()
             for name, field in zip(schema, arrow_schema):
                 struct.add(
                     name,

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -30,7 +30,7 @@ from pyspark.sql.streaming import DataStreamReader
 from pyspark.sql.types import DataType, StructType, \
     _make_type_verifier, _infer_schema, _has_nulltype, _merge_type, _create_converter, \
     _parse_datatype_string
-from pyspark.sql.utils import install_exception_handler
+from pyspark.sql.utils import install_exception_handler, is_timestamp_ntz_preferred
 
 __all__ = ["SparkSession"]
 
@@ -419,9 +419,6 @@ class SparkSession(SparkConversionMixin):
 
         return DataFrame(jdf, self._wrapped)
 
-    def _is_timestamp_ntz_preferred(self):
-        return self._wrapped._conf.timestampType().typeName() == "timestamp_ntz"
-
     def _inferSchemaFromList(self, data, names=None):
         """
         Infer schema from list of Row, dict, or tuple.
@@ -440,7 +437,7 @@ class SparkSession(SparkConversionMixin):
         if not data:
             raise ValueError("can not infer schema from empty dataset")
         infer_dict_as_struct = self._wrapped._conf.inferDictAsStruct()
-        prefer_timestamp_ntz = self._is_timestamp_ntz_preferred()
+        prefer_timestamp_ntz = is_timestamp_ntz_preferred()
         schema = reduce(_merge_type, (
             _infer_schema(row, names, infer_dict_as_struct, prefer_timestamp_ntz)
                         for row in data))
@@ -470,7 +467,7 @@ class SparkSession(SparkConversionMixin):
                              "can not infer schema")
 
         infer_dict_as_struct = self._wrapped._conf.inferDictAsStruct()
-        prefer_timestamp_ntz = self._is_timestamp_ntz_preferred()
+        prefer_timestamp_ntz = is_timestamp_ntz_preferred()
         if samplingRatio is None:
             schema = _infer_schema(
                 first,

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -210,3 +210,14 @@ def to_str(value):
         return value
     else:
         return str(value)
+
+
+def is_timestamp_ntz_preferred():
+    """
+    Return a bool if TimestampNTZType is preferred according to the SQL configuration set.
+    """
+    jvm = SparkContext._jvm
+    return jvm is not None and getattr(
+        getattr(jvm.org.apache.spark.sql.internal, "SQLConf$"),
+        "MODULE$"
+    ).get().timestampType().typeName() == "timestamp_ntz"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -708,6 +708,19 @@ case class UnixSeconds(child: Expression) extends TimestampToLongBase {
     copy(child = newChild)
 }
 
+// Internal expression used to get the raw UTC timestamp in pandas API on Spark.
+// This is to work around casting timestamp_ntz to long disallowed by ANSI.
+case class CastTimestampNTZToLong(child: Expression) extends TimestampToLongBase {
+  override def inputTypes: Seq[AbstractDataType] = Seq(TimestampNTZType)
+
+  override def scaleFactor: Long = MICROS_PER_SECOND
+
+  override def prettyName: String = "cast_timestamp_ntz_to_long"
+
+  override protected def withNewChildInternal(newChild: Expression): CastTimestampNTZToLong =
+    copy(child = newChild)
+}
+
 // scalastyle:off line.size.limit
 @ExpressionDescription(
   usage = "_FUNC_(timestamp) - Returns the number of milliseconds since 1970-01-01 00:00:00 UTC. Truncates higher levels of precision.",

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -24,9 +24,9 @@ import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.api.python.PythonRDDServer
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.{Column, DataFrame, SQLContext}
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
-import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
+import org.apache.spark.sql.catalyst.expressions.{CastTimestampNTZToLong, ExpressionInfo}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.execution.{ExplainMode, QueryExecution}
 import org.apache.spark.sql.execution.arrow.ArrowConverters
@@ -77,6 +77,8 @@ private[sql] object PythonSQLUtils extends Logging {
   def explainString(queryExecution: QueryExecution, mode: String): String = {
     queryExecution.explainString(ExplainMode.fromString(mode))
   }
+
+  def castTimestampNTZToLong(c: Column): Column = Column(CastTimestampNTZToLong(c.expr))
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds:
- the support of `TimestampNTZType` in pandas API on Spark.
- the support of Py4J handling of `spark.sql.timestampType` configuration

### Why are the changes needed?

To complete `TimestampNTZ` support.

In more details:

- ([#33876](https://github.com/apache/spark/pull/33876)) For `TimestampNTZType` in Spark SQL at PySpark, we can successfully ser/de `TimestampNTZType` instances to naive `datetime` (see also https://docs.python.org/3/library/datetime.html#aware-and-naive-objects). This naive `datetime` interpretation is up to the program to decide how to interpret, e.g.) whether a local time vs UTC time as an example. Although some Python built-in APIs assume they are local time in general (see also https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp):

    > Because naive datetime objects are treated by many datetime methods as local times ...

  semantically it is legitimate to assume:
    - that naive `datetime` is mapped to `TimestampNTZType` (unknown timezone).
    - if you want to handle them as if a local timezone, this interpretation is matched to `TimestamType` (local time)

- ([#33875](https://github.com/apache/spark/pull/33875)) For `TimestampNTZType` in Arrow, they provide the same semantic (see also https://github.com/apache/arrow/blob/master/format/Schema.fbs#L240-L278):
    - `Timestamp(..., timezone=sparkLocalTimezone)` ->  `TimestamType`
    - `Timestamp(..., timezone=null)` ->  `TimestampNTZType`

- (this PR) For `TimestampNTZType` in pandas API on Spark, it follows Python side in general - pandas implements APIs based on the assumption of time (e.g., naive `datetime` is a local time or a UTC time).

    One example is that pandas allows to convert these naive `datetime` as if they are in UTC by default:

    ```python
    >>> pd.Series(datetime.datetime(1970, 1, 1)).astype("int")
    0    0
    ```

    whereas in Spark:

    ```python
    >>> spark.createDataFrame([[datetime.datetime(1970, 1, 1, 0, 0, 0)]]).selectExpr("CAST(_1 as BIGINT)").show()
    +------+
    |    _1|
    +------+
    |-32400|
    +------+

    >>> spark.createDataFrame([[datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)]]).selectExpr("CAST(_1 as BIGINT)").show()
    +---+
    | _1|
    +---+
    |  0|
    +---+
    ```

    In contrast, some APIs like `pandas.fromtimestamp` assume they are local times:

    ```python
    >>> pd.Timestamp.fromtimestamp(pd.Series(datetime(1970, 1, 1, 0, 0, 0)).astype("int").iloc[0])
    Timestamp('1970-01-01 09:00:00')
    ```

    For native Python, users can decide how to interpret native `datetime` so it's fine. The problem is that pandas API on Spark case would require to have two implementations of the same pandas behavior for `TimestampType` and `TimestampNTZType` respectively, which might be non-trivial overhead and work. 

    As far as I know, pandas API on Spark has not yet implemented such ambiguous APIs so they are left as future work.

### Does this PR introduce _any_ user-facing change?

Yes, now pandas API on Spark can handle `TimestampNTZType`. 

```python
import datetime
spark.createDataFrame([(datetime.datetime.now(),)], schema="dt timestamp_ntz").to_pandas_on_spark()
```

```
                          dt
0 2021-08-31 19:58:55.024410
```

This PR also adds the support of Py4J handling with `spark.sql.timestampType` configuration:

```python
>>> lit(datetime.datetime.now())
Column<'TIMESTAMP '2021-09-03 19:34:03.949998''>
```
```python
>>> spark.conf.set("spark.sql.timestampType", "TIMESTAMP_NTZ")
>>> lit(datetime.datetime.now())
Column<'TIMESTAMP_NTZ '2021-09-03 19:34:24.864632''>
```

### How was this patch tested?

Unittests were added.