### PR TITLE
[SPARK-36628][PYTHON] Implement `__getitem__`  of label-based MultiIndex select

### DIFF
--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -429,6 +429,139 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
         """Select columns by other type key."""
         pass
 
+    @abstractmethod
+    def _extract_rows_sel_cols_sel(self, key: Any) -> Tuple[Any, Any]:
+        """Extract rows selection key and columns selection key against a DataFrame."""
+        pass
+
+    @abstractmethod
+    def _return_psdf_or_psser(
+        self, remaining_index: Optional[int], psdf_or_psser: Union["Series", "DataFrame"], key: Any
+    ) -> Optional[Union["Series", "DataFrame"]]:
+        pass
+
+    def __getitem__(self, key: Any) -> Union["Series", "DataFrame"]:
+        from pyspark.pandas.frame import DataFrame
+        from pyspark.pandas.series import Series, first_series
+
+        if self._is_series:
+            if isinstance(key, Series) and not same_anchor(key, self._psdf_or_psser):
+                psdf = self._psdf_or_psser.to_frame()
+                temp_col = verify_temp_column_name(psdf, "__temp_col__")
+
+                psdf[temp_col] = key
+                return type(self)(psdf[self._psdf_or_psser.name])[psdf[temp_col]]
+
+            cond, limit, remaining_index = self._select_rows(key)
+            if cond is None and limit is None:
+                return self._psdf_or_psser
+
+            column_label = self._psdf_or_psser._column_label
+            column_labels = [column_label]
+            data_spark_columns = [self._internal.spark_column_for(column_label)]
+            data_fields = [self._internal.field_for(column_label)]
+            returns_series = True
+            series_name = self._psdf_or_psser.name
+        else:
+            assert self._is_df
+            cols_sel, rows_sel = self._extract_rows_sel_cols_sel(key)
+
+            if isinstance(rows_sel, Series) and not same_anchor(rows_sel, self._psdf_or_psser):
+                psdf = self._psdf_or_psser.copy()
+                temp_col = verify_temp_column_name(cast("DataFrame", psdf), "__temp_col__")
+
+                psdf[temp_col] = rows_sel
+                return type(self)(psdf)[psdf[temp_col], cols_sel][list(self._psdf_or_psser.columns)]
+
+            cond, limit, remaining_index = self._select_rows(rows_sel)
+            (
+                column_labels,
+                data_spark_columns,
+                data_fields,
+                returns_series,
+                series_name,
+            ) = self._select_cols(cols_sel)
+
+            if cond is None and limit is None and returns_series:
+                psser = self._psdf_or_psser._psser_for(column_labels[0])
+                if series_name is not None and series_name != psser.name:
+                    psser = psser.rename(series_name)
+                return psser
+
+        if remaining_index is not None:
+            index_spark_columns = self._internal.index_spark_columns[-remaining_index:]
+            index_names = self._internal.index_names[-remaining_index:]
+            index_fields = self._internal.index_fields[-remaining_index:]
+        else:
+            index_spark_columns = self._internal.index_spark_columns
+            index_names = self._internal.index_names
+            index_fields = self._internal.index_fields
+
+        if len(column_labels) > 0:
+            column_labels = column_labels.copy()
+            column_labels_level = max(
+                len(label) if label is not None else 1 for label in column_labels
+            )
+            none_column = 0
+            for i, label in enumerate(column_labels):
+                if label is None:
+                    label = (none_column,)
+                    none_column += 1
+                if len(label) < column_labels_level:
+                    label = tuple(list(label) + ([""]) * (column_labels_level - len(label)))
+                column_labels[i] = label
+
+            if i == 0 and none_column == 1:
+                column_labels = [None]
+
+            column_label_names = self._internal.column_label_names[-column_labels_level:]
+        else:
+            column_label_names = self._internal.column_label_names
+
+        try:
+            sdf = self._internal.spark_frame
+
+            if cond is not None:
+                index_columns = sdf.select(index_spark_columns).columns
+                data_columns = sdf.select(data_spark_columns).columns
+                sdf = sdf.filter(cond).select(index_spark_columns + data_spark_columns)
+                index_spark_columns = [scol_for(sdf, col) for col in index_columns]
+                data_spark_columns = [scol_for(sdf, col) for col in data_columns]
+
+            if limit is not None:
+                if limit >= 0:
+                    sdf = sdf.limit(limit)
+                else:
+                    sdf = sdf.limit(sdf.count() + limit)
+                sdf = sdf.drop(NATURAL_ORDER_COLUMN_NAME)
+        except AnalysisException:
+            raise KeyError(
+                "[{}] don't exist in columns".format(
+                    [col._jc.toString() for col in data_spark_columns]  # type: ignore
+                )
+            )
+
+        internal = InternalFrame(
+            spark_frame=sdf,
+            index_spark_columns=index_spark_columns,
+            index_names=index_names,
+            index_fields=index_fields,
+            column_labels=column_labels,
+            data_spark_columns=data_spark_columns,
+            data_fields=data_fields,
+            column_label_names=column_label_names,
+        )
+        psdf = DataFrame(internal)
+
+        if returns_series:
+            psdf_or_psser = first_series(psdf)
+            if series_name is not None and series_name != psdf_or_psser.name:
+                psdf_or_psser = psdf_or_psser.rename(series_name)
+        else:
+            psdf_or_psser = psdf
+
+        return self._return_psdf_or_psser(remaining_index, psdf_or_psser, key)
+
     def __setitem__(self, key: Any, value: Any) -> None:
         from pyspark.pandas.frame import DataFrame
         from pyspark.pandas.series import Series, first_series
@@ -847,151 +980,6 @@ class LocIndexer(LocIndexerLike):
             spark_target_function="select, where",
         )
 
-    def __getitem__(self, key: Any) -> Union["Series", "DataFrame"]:
-        from pyspark.pandas.frame import DataFrame
-        from pyspark.pandas.series import Series, first_series
-        from pyspark.pandas.indexes import MultiIndex
-
-        if self._is_series:
-            if isinstance(key, Series) and not same_anchor(key, self._psdf_or_psser):
-                psdf = self._psdf_or_psser.to_frame()
-                temp_col = verify_temp_column_name(psdf, "__temp_col__")
-
-                psdf[temp_col] = key
-                return type(self)(psdf[self._psdf_or_psser.name])[psdf[temp_col]]
-
-            cond, limit, remaining_index = self._select_rows(key)
-            if cond is None and limit is None:
-                return self._psdf_or_psser
-
-            column_label = self._psdf_or_psser._column_label
-            column_labels = [column_label]
-            data_spark_columns = [self._internal.spark_column_for(column_label)]
-            data_fields = [self._internal.field_for(column_label)]
-            returns_series = True
-            series_name = self._psdf_or_psser.name
-        else:
-            assert self._is_df
-            if isinstance(key, tuple):
-                if len(key) != 2:
-                    raise SparkPandasIndexingError("Only accepts pairs of candidates")
-                if isinstance(self._psdf.index, MultiIndex) and not isinstance(key[0], slice):
-                    rows_sel, cols_sel = key, None
-                else:
-                    rows_sel, cols_sel = key
-            else:
-                rows_sel = key
-                cols_sel = None
-
-            if isinstance(rows_sel, Series) and not same_anchor(rows_sel, self._psdf_or_psser):
-                psdf = self._psdf_or_psser.copy()
-                temp_col = verify_temp_column_name(cast("DataFrame", psdf), "__temp_col__")
-
-                psdf[temp_col] = rows_sel
-                return type(self)(psdf)[psdf[temp_col], cols_sel][list(self._psdf_or_psser.columns)]
-
-            cond, limit, remaining_index = self._select_rows(rows_sel)
-            (
-                column_labels,
-                data_spark_columns,
-                data_fields,
-                returns_series,
-                series_name,
-            ) = self._select_cols(cols_sel)
-
-            if cond is None and limit is None and returns_series:
-                psser = self._psdf_or_psser._psser_for(column_labels[0])
-                if series_name is not None and series_name != psser.name:
-                    psser = psser.rename(series_name)
-                return psser
-
-        if remaining_index is not None:
-            index_spark_columns = self._internal.index_spark_columns[-remaining_index:]
-            index_names = self._internal.index_names[-remaining_index:]
-            index_fields = self._internal.index_fields[-remaining_index:]
-        else:
-            index_spark_columns = self._internal.index_spark_columns
-            index_names = self._internal.index_names
-            index_fields = self._internal.index_fields
-
-        if len(column_labels) > 0:
-            column_labels = column_labels.copy()
-            column_labels_level = max(
-                len(label) if label is not None else 1 for label in column_labels
-            )
-            none_column = 0
-            for i, label in enumerate(column_labels):
-                if label is None:
-                    label = (none_column,)
-                    none_column += 1
-                if len(label) < column_labels_level:
-                    label = tuple(list(label) + ([""]) * (column_labels_level - len(label)))
-                column_labels[i] = label
-
-            if i == 0 and none_column == 1:
-                column_labels = [None]
-
-            column_label_names = self._internal.column_label_names[-column_labels_level:]
-        else:
-            column_label_names = self._internal.column_label_names
-
-        try:
-            sdf = self._internal.spark_frame
-
-            if cond is not None:
-                index_columns = sdf.select(index_spark_columns).columns
-                data_columns = sdf.select(data_spark_columns).columns
-                sdf = sdf.filter(cond).select(index_spark_columns + data_spark_columns)
-                index_spark_columns = [scol_for(sdf, col) for col in index_columns]
-                data_spark_columns = [scol_for(sdf, col) for col in data_columns]
-
-            if limit is not None:
-                if limit >= 0:
-                    sdf = sdf.limit(limit)
-                else:
-                    sdf = sdf.limit(sdf.count() + limit)
-                sdf = sdf.drop(NATURAL_ORDER_COLUMN_NAME)
-        except AnalysisException:
-            raise KeyError(
-                "[{}] don't exist in columns".format(
-                    [col._jc.toString() for col in data_spark_columns]  # type: ignore
-                )
-            )
-
-        internal = InternalFrame(
-            spark_frame=sdf,
-            index_spark_columns=index_spark_columns,
-            index_names=index_names,
-            index_fields=index_fields,
-            column_labels=column_labels,
-            data_spark_columns=data_spark_columns,
-            data_fields=data_fields,
-            column_label_names=column_label_names,
-        )
-        psdf = DataFrame(internal)
-
-        if returns_series:
-            psdf_or_psser = first_series(psdf)
-            if series_name is not None and series_name != psdf_or_psser.name:
-                psdf_or_psser = psdf_or_psser.rename(series_name)
-        else:
-            psdf_or_psser = psdf
-
-        if remaining_index is not None and remaining_index == 0:
-            pdf_or_pser = psdf_or_psser.head(2).to_pandas()
-            length = len(pdf_or_pser)
-            if length == 0:
-                raise KeyError(name_like_string(key))
-            elif length == 1:
-                if isinstance(self._psdf.index, MultiIndex):
-                    return pdf_or_pser
-                else:
-                    return pdf_or_pser.iloc[0]
-            else:
-                return psdf_or_psser
-        else:
-            return psdf_or_psser
-
     def _select_rows_by_series(
         self, rows_sel: "Series"
     ) -> Tuple[Optional[Column], Optional[int], Optional[int]]:
@@ -1377,6 +1365,41 @@ class LocIndexer(LocIndexerLike):
             cols_sel = (cols_sel,)
         return self._get_from_multiindex_column(cols_sel, missing_keys)
 
+    def _extract_rows_sel_cols_sel(self, key: Any) -> Tuple[Any, Any]:
+        from pyspark.pandas.indexes import MultiIndex
+
+        if isinstance(key, tuple):
+            if len(key) != 2:
+                raise SparkPandasIndexingError("Only accepts pairs of candidates")
+            if isinstance(self._psdf.index, MultiIndex) and not isinstance(key[0], slice):
+                rows_sel, cols_sel = key, None
+            else:
+                rows_sel, cols_sel = key
+        else:
+            rows_sel = key
+            cols_sel = None
+        return cols_sel, rows_sel
+
+    def _return_psdf_or_psser(
+        self, remaining_index: Optional[int], psdf_or_psser: Union["Series", "DataFrame"], key: Any
+    ) -> Optional[Union["Series", "DataFrame"]]:
+        from pyspark.pandas.indexes import MultiIndex
+
+        if remaining_index is not None and remaining_index == 0:
+            pdf_or_pser = psdf_or_psser.head(2).to_pandas()
+            length = len(pdf_or_pser)
+            if length == 0:
+                raise KeyError(name_like_string(key))
+            elif length == 1:
+                if isinstance(self._psdf.index, MultiIndex) and not isinstance(key[0], slice):
+                    return pdf_or_pser
+                else:
+                    return pdf_or_pser.iloc[0]
+            else:
+                return psdf_or_psser
+        else:
+            return psdf_or_psser
+
 
 class iLocIndexer(LocIndexerLike):
     """
@@ -1553,145 +1576,6 @@ class iLocIndexer(LocIndexerLike):
         # Use resolved_copy to fix the natural order.
         internal = super()._internal.resolved_copy
         return verify_temp_column_name(internal.spark_frame, "__distributed_sequence_column__")
-
-    def __getitem__(self, key: Any) -> Union["Series", "DataFrame"]:
-        from pyspark.pandas.frame import DataFrame
-        from pyspark.pandas.series import Series, first_series
-
-        if self._is_series:
-            if isinstance(key, Series) and not same_anchor(key, self._psdf_or_psser):
-                psdf = self._psdf_or_psser.to_frame()
-                temp_col = verify_temp_column_name(psdf, "__temp_col__")
-
-                psdf[temp_col] = key
-                return type(self)(psdf[self._psdf_or_psser.name])[psdf[temp_col]]
-
-            cond, limit, remaining_index = self._select_rows(key)
-            if cond is None and limit is None:
-                return self._psdf_or_psser
-
-            column_label = self._psdf_or_psser._column_label
-            column_labels = [column_label]
-            data_spark_columns = [self._internal.spark_column_for(column_label)]
-            data_fields = [self._internal.field_for(column_label)]
-            returns_series = True
-            series_name = self._psdf_or_psser.name
-        else:
-            assert self._is_df
-            if isinstance(key, tuple):
-                if len(key) != 2:
-                    raise SparkPandasIndexingError("Only accepts pairs of candidates")
-                else:
-                    rows_sel, cols_sel = key
-            else:
-                rows_sel = key
-                cols_sel = None
-
-            if isinstance(rows_sel, Series) and not same_anchor(rows_sel, self._psdf_or_psser):
-                psdf = self._psdf_or_psser.copy()
-                temp_col = verify_temp_column_name(cast("DataFrame", psdf), "__temp_col__")
-
-                psdf[temp_col] = rows_sel
-                return type(self)(psdf)[psdf[temp_col], cols_sel][list(self._psdf_or_psser.columns)]
-
-            cond, limit, remaining_index = self._select_rows(rows_sel)
-            (
-                column_labels,
-                data_spark_columns,
-                data_fields,
-                returns_series,
-                series_name,
-            ) = self._select_cols(cols_sel)
-
-            if cond is None and limit is None and returns_series:
-                psser = self._psdf_or_psser._psser_for(column_labels[0])
-                if series_name is not None and series_name != psser.name:
-                    psser = psser.rename(series_name)
-                return psser
-
-        if remaining_index is not None:
-            index_spark_columns = self._internal.index_spark_columns[-remaining_index:]
-            index_names = self._internal.index_names[-remaining_index:]
-            index_fields = self._internal.index_fields[-remaining_index:]
-        else:
-            index_spark_columns = self._internal.index_spark_columns
-            index_names = self._internal.index_names
-            index_fields = self._internal.index_fields
-
-        if len(column_labels) > 0:
-            column_labels = column_labels.copy()
-            column_labels_level = max(
-                len(label) if label is not None else 1 for label in column_labels
-            )
-            none_column = 0
-            for i, label in enumerate(column_labels):
-                if label is None:
-                    label = (none_column,)
-                    none_column += 1
-                if len(label) < column_labels_level:
-                    label = tuple(list(label) + ([""]) * (column_labels_level - len(label)))
-                column_labels[i] = label
-
-            if i == 0 and none_column == 1:
-                column_labels = [None]
-
-            column_label_names = self._internal.column_label_names[-column_labels_level:]
-        else:
-            column_label_names = self._internal.column_label_names
-
-        try:
-            sdf = self._internal.spark_frame
-
-            if cond is not None:
-                index_columns = sdf.select(index_spark_columns).columns
-                data_columns = sdf.select(data_spark_columns).columns
-                sdf = sdf.filter(cond).select(index_spark_columns + data_spark_columns)
-                index_spark_columns = [scol_for(sdf, col) for col in index_columns]
-                data_spark_columns = [scol_for(sdf, col) for col in data_columns]
-
-            if limit is not None:
-                if limit >= 0:
-                    sdf = sdf.limit(limit)
-                else:
-                    sdf = sdf.limit(sdf.count() + limit)
-                sdf = sdf.drop(NATURAL_ORDER_COLUMN_NAME)
-        except AnalysisException:
-            raise KeyError(
-                "[{}] don't exist in columns".format(
-                    [col._jc.toString() for col in data_spark_columns]  # type: ignore
-                )
-            )
-
-        internal = InternalFrame(
-            spark_frame=sdf,
-            index_spark_columns=index_spark_columns,
-            index_names=index_names,
-            index_fields=index_fields,
-            column_labels=column_labels,
-            data_spark_columns=data_spark_columns,
-            data_fields=data_fields,
-            column_label_names=column_label_names,
-        )
-        psdf = DataFrame(internal)
-
-        if returns_series:
-            psdf_or_psser = first_series(psdf)
-            if series_name is not None and series_name != psdf_or_psser.name:
-                psdf_or_psser = psdf_or_psser.rename(series_name)
-        else:
-            psdf_or_psser = psdf
-
-        if remaining_index is not None and remaining_index == 0:
-            pdf_or_pser = psdf_or_psser.head(2).to_pandas()
-            length = len(pdf_or_pser)
-            if length == 0:
-                raise KeyError(name_like_string(key))
-            elif length == 1:
-                return pdf_or_pser.iloc[0]
-            else:
-                return psdf_or_psser
-        else:
-            return psdf_or_psser
 
     def _select_rows_by_series(
         self, rows_sel: "Series"
@@ -1925,6 +1809,32 @@ class iLocIndexer(LocIndexerLike):
                 "Location based indexing can only have [integer, integer slice, "
                 "listlike of integers, boolean array] types, got {}".format(cols_sel)
             )
+
+    def _extract_rows_sel_cols_sel(self, key: Any) -> Tuple[Any, Any]:
+        if isinstance(key, tuple):
+            if len(key) != 2:
+                raise SparkPandasIndexingError("Only accepts pairs of candidates")
+            else:
+                rows_sel, cols_sel = key
+        else:
+            rows_sel = key
+            cols_sel = None
+        return cols_sel, rows_sel
+
+    def _return_psdf_or_psser(
+        self, remaining_index: Optional[int], psdf_or_psser: Union["Series", "DataFrame"], key: Any
+    ) -> Optional[Union["Series", "DataFrame"]]:
+        if remaining_index is not None and remaining_index == 0:
+            pdf_or_pser = psdf_or_psser.head(2).to_pandas()
+            length = len(pdf_or_pser)
+            if length == 0:
+                raise KeyError(name_like_string(key))
+            elif length == 1:
+                return pdf_or_pser.iloc[0]
+            else:
+                return psdf_or_psser
+        else:
+            return psdf_or_psser
 
     def __setitem__(self, key: Any, value: Any) -> None:
         if is_list_like(value) and not isinstance(value, Column):

--- a/python/pyspark/pandas/tests/test_indexing.py
+++ b/python/pyspark/pandas/tests/test_indexing.py
@@ -466,8 +466,8 @@ class IndexingTest(PandasOnSparkTestCase):
 
         self.assert_eq(psdf.loc[5], pdf.loc[5])
         self.assert_eq(psdf.loc[9], pdf.loc[9])
-        # TODO: self.assert_eq(psdf.loc[(5, 3)], pdf.loc[(5, 3)])
-        # TODO: self.assert_eq(psdf.loc[(9, 0)], pdf.loc[(9, 0)])
+        self.assert_eq(psdf.loc[(5, 3)], pdf.loc[(5, 3)])
+        self.assert_eq(psdf.loc[(9, 0)], pdf.loc[(9, 0)])
         self.assert_eq(psdf.a.loc[5], pdf.a.loc[5])
         self.assert_eq(psdf.a.loc[9], pdf.a.loc[9])
         self.assertTrue((psdf.a.loc[(5, 3)] == pdf.a.loc[(5, 3)]).all())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `__getitem__`  of label-based MultiIndex select


### Why are the changes needed?
Increase pandas API coverage


### Does this PR introduce _any_ user-facing change?
Yes, reading values by label-based MultiIndex select is supported now.

```py
>>> psdf = ps.DataFrame(
...             {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
...             index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
...         )
>>> psdf = psdf.set_index("b", append=True)
>>> psdf
     a
  b   
0 4  1
1 5  2
3 6  3
5 3  4
6 2  5
8 1  6
9 0  7
  0  8
  0  9
>>> psdf.loc[6, 2]
     a
  b   
6 2  5
```

### How was this patch tested?
Unit tests.
