### PR TITLE
[SPARK-36609][PYTHON] Add `errors` argument for `ps.to_numeric`.

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2760,7 +2760,7 @@ def to_numeric(arg, errors="raise"):
         * If 'raise', then invalid parsing will raise an exception.
         * If 'ignore', then invalid parsing will return the input.
 
-        .. note:: 'ignore' doesn't work for pandas-on-Spark Series.
+        .. note:: 'ignore' doesn't work yet when `arg` is pandas-on-Spark Series.
 
     Returns
     -------

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2762,8 +2762,8 @@ def to_numeric(arg, errors="coerce"):
 
     Notes
     -----
-    Unlike pandas, the default value for `errors` is 'coerce', since 'raise' is not supported yet
-    when the `arg` is Series.
+    Unlike pandas, the default value for `errors` is 'coerce', since 'raise' and 'ignore'
+    are not supported yet when the `arg` is Series.
 
     Returns
     -------
@@ -2825,13 +2825,11 @@ def to_numeric(arg, errors="coerce"):
     """
     if isinstance(arg, Series):
         if errors == "coerce":
-            return arg._with_new_scol(arg.spark.column.cast("int"))
-        elif errors == "ignore":
-            scol = arg.spark.column
-            casted_scol = scol.cast("int")
-            return arg._with_new_scol(F.when(casted_scol.isNull(), scol).otherwise(casted_scol))
+            return arg._with_new_scol(arg.spark.column.cast("float"))
         elif errors == "raise":
             raise NotImplementedError("'raise' is not implemented yet, when the `arg` is Series.")
+        elif errors == "ignore":
+            raise NotImplementedError("'ignore' is not implemented yet, when the `arg` is Series.")
         else:
             raise ValueError("invalid error value specified")
     else:

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2755,12 +2755,11 @@ def to_numeric(arg, errors="raise"):
     ----------
     arg : scalar, list, tuple, 1-d array, or Series
         Argument to be converted.
-    errors : {'ignore', 'raise', 'coerce'}, default 'coerce'
-        Note that 'ignore' are not supported yet when the `arg` is Series.
-
+    errors : {'raise', 'coerce'}, default 'coerce'
         * If 'coerce', then invalid parsing will be set as NaN.
-        * If 'ignore', then invalid parsing will return the input.
         * If 'raise', then invalid parsing will raise an exception.
+        
+        .. note:: pandas support 'ignore' but this is not implemented yet.
 
     Returns
     -------

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2755,10 +2755,10 @@ def to_numeric(arg, errors="raise"):
     ----------
     arg : scalar, list, tuple, 1-d array, or Series
         Argument to be converted.
-    errors : {'raise', 'coerce'}, default 'coerce'
+    errors : {'raise', 'coerce'}, default 'raise'
         * If 'coerce', then invalid parsing will be set as NaN.
         * If 'raise', then invalid parsing will raise an exception.
-        
+
         .. note:: pandas support 'ignore' but this is not implemented yet.
 
     Returns

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -340,33 +340,52 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
         pser = pd.Series(["1", "2", None, "4", "hello"])
         psser = ps.from_pandas(pser)
 
+        # "coerce" and "raise" with Series that contains un-parsable data.
         self.assert_eq(
             pd.to_numeric(pser, errors="coerce"), ps.to_numeric(psser, errors="coerce"), almost=True
         )
+        self.assertRaisesRegex(
+            ValueError,
+            'Unable to parse string "hello"',
+            lambda: ps.to_numeric(psser, errors="raise"),
+        )
+        # "raise" with Series that contains parsable data only.
+        pser = pd.Series(["1", "2", None, "4", "5.0"])
+        psser = ps.from_pandas(pser)
 
+        self.assert_eq(
+            pd.to_numeric(pser, errors="raise"), ps.to_numeric(psser, errors="raise"), almost=True
+        )
+
+        # "coerce", "ignore" and "raise" with non-Series.
         data = ["1", "2", None, "4", "hello"]
         self.assert_eq(pd.to_numeric(data, errors="coerce"), ps.to_numeric(data, errors="coerce"))
         self.assert_eq(pd.to_numeric(data, errors="ignore"), ps.to_numeric(data, errors="ignore"))
 
         self.assertRaisesRegex(
             ValueError,
-            'Unable to parse string "hello" at position 4',
+            'Unable to parse string "hello"',
             lambda: ps.to_numeric(data, errors="raise"),
         )
-        self.assertRaisesRegex(
-            NotImplementedError,
-            "'raise' is not implemented yet, when the `arg` is Series.",
-            lambda: ps.to_numeric(psser, errors="raise"),
+
+        # "raise" with non-Series that contains parsable data only.
+        data = ["1", "2", None, "4", "5.0"]
+
+        self.assert_eq(
+            pd.to_numeric(data, errors="raise"), ps.to_numeric(data, errors="raise"), almost=True
         )
-        self.assertRaisesRegex(
-            NotImplementedError,
-            "'ignore' is not implemented yet, when the `arg` is Series.",
-            lambda: ps.to_numeric(psser, errors="ignore"),
-        )
+
+        # Wrong string for `errors` parameter.
         self.assertRaisesRegex(
             ValueError,
             "invalid error value specified",
             lambda: ps.to_numeric(psser, errors="errors"),
+        )
+        # NotImplementedError
+        self.assertRaisesRegex(
+            NotImplementedError,
+            "'ignore' is not implemented yet, when the `arg` is Series.",
+            lambda: ps.to_numeric(psser, errors="ignore"),
         )
 
 

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -357,6 +357,11 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
             'Unable to parse string "hello" at position 4',
             lambda: ps.to_numeric(data, errors="raise"),
         )
+        self.assertRaisesRegex(
+            ValueError,
+            "invalid error value specified",
+            lambda: ps.to_numeric(psser, errors="errors"),
+        )
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -344,11 +344,7 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(
             pd.to_numeric(pser, errors="coerce"), ps.to_numeric(psser, errors="coerce"), almost=True
         )
-        self.assertRaisesRegex(
-            ValueError,
-            'Unable to parse string "hello"',
-            lambda: ps.to_numeric(psser, errors="raise"),
-        )
+
         # "raise" with Series that contains parsable data only.
         pser = pd.Series(["1", "2", None, "4", "5.0"])
         psser = ps.from_pandas(pser)

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -336,6 +336,28 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
             lambda: read_delta("fake_path", version="0", timestamp="2021-06-22"),
         )
 
+    def test_to_numeric(self):
+        pser = pd.Series(["1", "2", None, "4", "hello"])
+        psser = ps.from_pandas(pser)
+
+        self.assert_eq(pd.to_numeric(pser, errors="coerce"), ps.to_numeric(psser, errors="coerce"))
+        self.assert_eq(pd.to_numeric(pser, errors="ignore"), ps.to_numeric(psser, errors="ignore"))
+
+        data = ["1", "2", None, "4", "hello"]
+        self.assert_eq(pd.to_numeric(data, errors="coerce"), ps.to_numeric(data, errors="coerce"))
+        self.assert_eq(pd.to_numeric(data, errors="ignore"), ps.to_numeric(data, errors="ignore"))
+
+        self.assertRaisesRegex(
+            NotImplementedError,
+            "'raise' is not implemented yet, when the `arg` is Series.",
+            lambda: ps.to_numeric(psser, errors="raise"),
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            'Unable to parse string "hello" at position 4',
+            lambda: ps.to_numeric(data, errors="raise"),
+        )
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -340,22 +340,28 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
         pser = pd.Series(["1", "2", None, "4", "hello"])
         psser = ps.from_pandas(pser)
 
-        self.assert_eq(pd.to_numeric(pser, errors="coerce"), ps.to_numeric(psser, errors="coerce"))
-        self.assert_eq(pd.to_numeric(pser, errors="ignore"), ps.to_numeric(psser, errors="ignore"))
+        self.assert_eq(
+            pd.to_numeric(pser, errors="coerce"), ps.to_numeric(psser, errors="coerce"), almost=True
+        )
 
         data = ["1", "2", None, "4", "hello"]
         self.assert_eq(pd.to_numeric(data, errors="coerce"), ps.to_numeric(data, errors="coerce"))
         self.assert_eq(pd.to_numeric(data, errors="ignore"), ps.to_numeric(data, errors="ignore"))
 
         self.assertRaisesRegex(
+            ValueError,
+            'Unable to parse string "hello" at position 4',
+            lambda: ps.to_numeric(data, errors="raise"),
+        )
+        self.assertRaisesRegex(
             NotImplementedError,
             "'raise' is not implemented yet, when the `arg` is Series.",
             lambda: ps.to_numeric(psser, errors="raise"),
         )
         self.assertRaisesRegex(
-            ValueError,
-            'Unable to parse string "hello" at position 4',
-            lambda: ps.to_numeric(data, errors="raise"),
+            NotImplementedError,
+            "'ignore' is not implemented yet, when the `arg` is Series.",
+            lambda: ps.to_numeric(psser, errors="ignore"),
         )
         self.assertRaisesRegex(
             ValueError,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to support `errors` argument for `ps.to_numeric` such as pandas does.

Note that we don't support the `ignore` when the `arg` is pandas-on-Spark Series for now.

### Why are the changes needed?

We should match the behavior to pandas' as much as possible.

Also in the [recent blog post](https://medium.com/@chuck.connell.3/pandas-on-databricks-via-koalas-a-review-9876b0a92541), the author pointed out we're missing this feature.

Seems like it's the kind of feature that commonly used in data science.

### Does this PR introduce _any_ user-facing change?

Now the `errors` argument is available for `ps.to_numeric`.

### How was this patch tested?

Unittests.