### PR TITLE
[SPARK-36339] Add the option to use physicalStats in AQE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -626,6 +626,13 @@ object SQLConf {
       .checkValue(_ >= 0, "The non-empty partition ratio must be positive number.")
       .createWithDefault(0.2)
 
+  val USE_PHYSICAL_STATS_TO_SELECT_JOIN_ENABLED =
+    buildConf("spark.sql.adaptive.broadcastJoin.usePhysicalStats.enabled")
+      .doc("When true, we only use physical statistics from shuffle blocks, a.k.a stats in " +
+        "`LogicalQueryStage`, to decide whether to use broadcast join or not.")
+      .booleanConf
+      .createWithDefault(false)
+
   val ADAPTIVE_OPTIMIZER_EXCLUDED_RULES =
     buildConf("spark.sql.adaptive.optimizer.excludedRules")
       .doc("Configures a list of rules to be disabled in the adaptive optimizer, in which the " +
@@ -3637,6 +3644,9 @@ class SQLConf extends Serializable with Logging {
 
   def nonEmptyPartitionRatioForBroadcastJoin: Double =
     getConf(NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN)
+
+  def usePhysicalStatsToSelectJoinEnabled: Boolean =
+    getConf(USE_PHYSICAL_STATS_TO_SELECT_JOIN_ENABLED)
 
   def coalesceShufflePartitionsEnabled: Boolean = getConf(COALESCE_PARTITIONS_ENABLED)
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add the option to use physicalStats in AQE

### Why are the changes needed?

Currently when AQE's queryStage is not materialized, it uses the stats of the logical plan to estimate whether the plan can be converted to BHJ, and in some scenarios the estimated value is several orders of magnitude larger than the actual broadcast data, which can lead to large tables being broadcast


### Does this PR introduce _any_ user-facing change?
Yes, a new config spark.sql.adaptive.broadcastJoin.usePhysicalStats.enabled added.



### How was this patch tested?
(TODO)
