### PR TITLE
[SPARK-36400][TEST][FOLLOWUP] Add test for redacting sensitive information in UI by config

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
@@ -126,4 +126,49 @@ class UISeleniumSuite
       }
     }
   }
+
+  test("SPARK-36400: Redact sensitive information in UI by config") {
+    withJdbcStatement("test_tbl1", "test_tbl2") { statement =>
+      val baseURL = s"http://localhost:$uiPort"
+
+      val Seq(nonMaskedQuery, maskedQuery) = Seq("test_tbl1", "test_tbl2").map (tblName =>
+        s"CREATE TABLE $tblName(a int) " +
+          s"OPTIONS(url='jdbc:postgresql://localhost:5432/$tblName', " +
+          "user='test_user', password='abcde')")
+      statement.execute(nonMaskedQuery)
+
+      statement.execute("SET spark.sql.redaction.string.regex=((?i)(?<=password=))('.*')")
+      statement.execute(maskedQuery)
+
+      eventually(timeout(10.seconds), interval(50.milliseconds)) {
+        go to (baseURL + "/sqlserver")
+        val statements = findAll(
+          cssSelector("span.description-input")).map(_.text).filter(_.startsWith("CREATE")).toSeq
+        statements.size should be (2)
+
+        val nonMaskedStatement = statements.filter(_.contains("test_tbl1"))
+        nonMaskedStatement.size should be (1)
+        nonMaskedStatement.head should be (nonMaskedQuery)
+        val maskedStatement = statements.filter(_.contains("test_tbl2"))
+        maskedStatement.size should be (1)
+        maskedStatement.head should be (maskedQuery.replace("'abcde'", "*********(redacted)"))
+      }
+
+      val sessionLink =
+        find(cssSelector("table#sessionstat td a")).head.underlying.getAttribute("href")
+      eventually(timeout(10.seconds), interval(50.milliseconds)) {
+        go to sessionLink
+        val statements = findAll(
+          cssSelector("span.description-input")).map(_.text).filter(_.startsWith("CREATE")).toSeq
+        statements.size should be (2)
+
+        val nonMaskedStatement = statements.filter(_.contains("test_tbl1"))
+        nonMaskedStatement.size should be (1)
+        nonMaskedStatement.head should be (nonMaskedQuery)
+        val maskedStatement = statements.filter(_.contains("test_tbl2"))
+        maskedStatement.size should be (1)
+        maskedStatement.head should be (maskedQuery.replace("'abcde'", "*********(redacted)"))
+      }
+    }
+  }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
@@ -142,9 +142,9 @@ class UISeleniumSuite
 
       eventually(timeout(10.seconds), interval(50.milliseconds)) {
         go to (baseURL + "/sqlserver")
-        val statements = findAll(
-          cssSelector("span.description-input")).map(_.text).filter(_.startsWith("CREATE")).toSeq
-        statements.size should be (2)
+        // Take description of 2 statements executed within this test.
+        val statements = findAll(cssSelector("span.description-input"))
+          .map(_.text).filter(_.startsWith("CREATE")).take(2).toSeq
 
         val nonMaskedStatement = statements.filter(_.contains("test_tbl1"))
         nonMaskedStatement.size should be (1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a test for SPARK-36400 (#33743).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
SPARK-36512 (#33741) was fixed so we can add this test now.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New test.