### PR TITLE
[SPARK-36604][SQL] timestamp type column stats result consistent with the time zone

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import java.net.URI
-import java.time.ZoneOffset
 import java.util.Date
 
 import scala.collection.mutable
@@ -657,7 +656,7 @@ object CatalogColumnStat extends Logging {
   private def getTimestampFormatter(isParsing: Boolean): TimestampFormatter = {
     TimestampFormatter(
       format = "yyyy-MM-dd HH:mm:ss.SSSSSS",
-      zoneId = ZoneOffset.UTC,
+      zoneId = DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone),
       isParsing = isParsing)
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
timestamp type column stats result should consistent with time zone


### Why are the changes needed?
for now timestamp type column stats result is based on UTC TimeZone，independent from the time zone. Thus the stats result may not correct


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add new test
