### PR TITLE
[SPARK-36634][SQL] Support access and read parquet file by column ordinal

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3724,6 +3724,8 @@ class SQLConf extends Serializable with Logging {
 
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)
 
+  def parquetAccessByIndex: Boolean = getConf(PARQUET_ACCESS_BY_INDEX)
+
   def constraintPropagationEnabled: Boolean = getConf(CONSTRAINT_PROPAGATION_ENABLED)
 
   def escapedStringLiterals: Boolean = getConf(ESCAPED_STRING_LITERALS)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -903,6 +903,13 @@ object SQLConf {
     .intConf
     .createWithDefault(4096)
 
+  val PARQUET_COLUMN_INDEX_ACCESS = buildConf("spark.sql.parquet.columnIndexAccess")
+    .doc("When true, we access the parquet files by column index instead of catalyst schema" +
+      " mapping at the executor side.")
+    .version("3.3.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val ORC_COMPRESSION = buildConf("spark.sql.orc.compression.codec")
     .doc("Sets the compression codec used when writing ORC files. If either `compression` or " +
       "`orc.compress` is specified in the table-specific options/properties, the precedence " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -904,7 +904,7 @@ object SQLConf {
     .createWithDefault(4096)
 
   val PARQUET_ACCESS_BY_ORDINAL = buildConf("spark.sql.parquet.accessByColumnOrdinal")
-    .doc("When true, we access the Parquet files by column index instead of catalyst schema" +
+    .doc("When true, we access the Parquet files by column ordinal instead of catalyst schema" +
       " mapping at the executor side.")
     .version("3.3.0")
     .booleanConf
@@ -3724,7 +3724,7 @@ class SQLConf extends Serializable with Logging {
 
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)
 
-  def parquetAccessByIndex: Boolean = getConf(PARQUET_ACCESS_BY_ORDINAL)
+  def parquetAccessByOrdinal: Boolean = getConf(PARQUET_ACCESS_BY_ORDINAL)
 
   def constraintPropagationEnabled: Boolean = getConf(CONSTRAINT_PROPAGATION_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -903,8 +903,8 @@ object SQLConf {
     .intConf
     .createWithDefault(4096)
 
-  val PARQUET_COLUMN_INDEX_ACCESS = buildConf("spark.sql.parquet.columnIndexAccess")
-    .doc("When true, we access the parquet files by column index instead of catalyst schema" +
+  val PARQUET_ACCESS_BY_INDEX = buildConf("spark.sql.parquet.accessByIndex")
+    .doc("When true, we access the Parquet files by column index instead of catalyst schema" +
       " mapping at the executor side.")
     .version("3.3.0")
     .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -903,7 +903,7 @@ object SQLConf {
     .intConf
     .createWithDefault(4096)
 
-  val PARQUET_ACCESS_BY_INDEX = buildConf("spark.sql.parquet.accessByIndex")
+  val PARQUET_ACCESS_BY_ORDINAL = buildConf("spark.sql.parquet.accessByColumnOrdinal")
     .doc("When true, we access the Parquet files by column index instead of catalyst schema" +
       " mapping at the executor side.")
     .version("3.3.0")
@@ -3724,7 +3724,7 @@ class SQLConf extends Serializable with Logging {
 
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)
 
-  def parquetAccessByIndex: Boolean = getConf(PARQUET_ACCESS_BY_INDEX)
+  def parquetAccessByIndex: Boolean = getConf(PARQUET_ACCESS_BY_ORDINAL)
 
   def constraintPropagationEnabled: Boolean = getConf(CONSTRAINT_PROPAGATION_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -219,7 +219,7 @@ class ParquetFileFormat
       sparkSession.sessionState.conf.caseSensitiveAnalysis)
     hadoopConf.setBoolean(
       SQLConf.PARQUET_ACCESS_BY_INDEX.key,
-      sparkSession.sessionState.conf.getConf(SQLConf.PARQUET_ACCESS_BY_INDEX))
+      sparkSession.sessionState.conf.parquetAccessByIndex)
 
     ParquetWriteSupport.setSchema(requiredSchema, hadoopConf)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -218,8 +218,8 @@ class ParquetFileFormat
       SQLConf.CASE_SENSITIVE.key,
       sparkSession.sessionState.conf.caseSensitiveAnalysis)
     hadoopConf.setBoolean(
-      SQLConf.PARQUET_COLUMN_INDEX_ACCESS.key,
-      sparkSession.sessionState.conf.getConf(SQLConf.PARQUET_COLUMN_INDEX_ACCESS))
+      SQLConf.PARQUET_ACCESS_BY_INDEX.key,
+      sparkSession.sessionState.conf.getConf(SQLConf.PARQUET_ACCESS_BY_INDEX))
 
     ParquetWriteSupport.setSchema(requiredSchema, hadoopConf)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -217,6 +217,9 @@ class ParquetFileFormat
     hadoopConf.setBoolean(
       SQLConf.CASE_SENSITIVE.key,
       sparkSession.sessionState.conf.caseSensitiveAnalysis)
+    hadoopConf.setBoolean(
+      SQLConf.PARQUET_COLUMN_INDEX_ACCESS.key,
+      sparkSession.sessionState.conf.getConf(SQLConf.PARQUET_COLUMN_INDEX_ACCESS))
 
     ParquetWriteSupport.setSchema(requiredSchema, hadoopConf)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -219,7 +219,7 @@ class ParquetFileFormat
       sparkSession.sessionState.conf.caseSensitiveAnalysis)
     hadoopConf.setBoolean(
       SQLConf.PARQUET_ACCESS_BY_ORDINAL.key,
-      sparkSession.sessionState.conf.parquetAccessByIndex)
+      sparkSession.sessionState.conf.parquetAccessByOrdinal)
 
     ParquetWriteSupport.setSchema(requiredSchema, hadoopConf)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -218,7 +218,7 @@ class ParquetFileFormat
       SQLConf.CASE_SENSITIVE.key,
       sparkSession.sessionState.conf.caseSensitiveAnalysis)
     hadoopConf.setBoolean(
-      SQLConf.PARQUET_ACCESS_BY_INDEX.key,
+      SQLConf.PARQUET_ACCESS_BY_ORDINAL.key,
       sparkSession.sessionState.conf.parquetAccessByIndex)
 
     ParquetWriteSupport.setSchema(requiredSchema, hadoopConf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
@@ -121,7 +121,7 @@ class ParquetReadSupport(
          |Catalyst requested schema:
          |${catalystRequestedSchema.treeString}
        """.stripMargin)
-    new ReadContext(parquetClippedSchema, Map.empty[String, String].asJava)
+    new ReadContext(parquetRequestedSchema, Map.empty[String, String].asJava)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
@@ -88,8 +88,8 @@ class ParquetReadSupport(
       SQLConf.CASE_SENSITIVE.defaultValue.get)
     val schemaPruningEnabled = conf.getBoolean(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key,
       SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.defaultValue.get)
-    val columnIndexAccess = conf.getBoolean(SQLConf.PARQUET_COLUMN_INDEX_ACCESS.key,
-      SQLConf.PARQUET_COLUMN_INDEX_ACCESS.defaultValue.get)
+    val columnIndexAccess = conf.getBoolean(SQLConf.PARQUET_ACCESS_BY_INDEX.key,
+      SQLConf.PARQUET_ACCESS_BY_INDEX.defaultValue.get)
     val parquetFileSchema = context.getFileSchema
     val parquetClippedSchema = ParquetReadSupport.clipParquetSchema(parquetFileSchema,
       catalystRequestedSchema, caseSensitive, columnIndexAccess)
@@ -158,7 +158,7 @@ object ParquetReadSupport {
       parquetSchema: MessageType,
       catalystSchema: StructType,
       caseSensitive: Boolean = true,
-      columnIndexAccess: Boolean = true): MessageType = {
+      columnIndexAccess: Boolean = false): MessageType = {
     val clippedParquetFields = clipParquetGroupFields(
       parquetSchema.asGroupType(), catalystSchema, caseSensitive, columnIndexAccess)
     if (clippedParquetFields.isEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
@@ -88,8 +88,8 @@ class ParquetReadSupport(
       SQLConf.CASE_SENSITIVE.defaultValue.get)
     val schemaPruningEnabled = conf.getBoolean(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key,
       SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.defaultValue.get)
-    val columnIndexAccess = conf.getBoolean(SQLConf.PARQUET_ACCESS_BY_INDEX.key,
-      SQLConf.PARQUET_ACCESS_BY_INDEX.defaultValue.get)
+    val columnIndexAccess = conf.getBoolean(SQLConf.PARQUET_ACCESS_BY_ORDINAL.key,
+      SQLConf.PARQUET_ACCESS_BY_ORDINAL.defaultValue.get)
     val parquetFileSchema = context.getFileSchema
     val parquetClippedSchema = ParquetReadSupport.clipParquetSchema(parquetFileSchema,
       catalystRequestedSchema, caseSensitive, columnIndexAccess)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRecordMaterializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRecordMaterializer.scala
@@ -44,7 +44,8 @@ private[parquet] class ParquetRecordMaterializer(
     schemaConverter: ParquetToSparkSchemaConverter,
     convertTz: Option[ZoneId],
     datetimeRebaseMode: LegacyBehaviorPolicy.Value,
-    int96RebaseMode: LegacyBehaviorPolicy.Value)
+    int96RebaseMode: LegacyBehaviorPolicy.Value,
+    accessByColumnOrdinal: Boolean)
   extends RecordMaterializer[InternalRow] {
 
   private val rootConverter = new ParquetRowConverter(
@@ -54,7 +55,8 @@ private[parquet] class ParquetRecordMaterializer(
     convertTz,
     datetimeRebaseMode,
     int96RebaseMode,
-    NoopUpdater)
+    NoopUpdater,
+    accessByColumnOrdinal)
 
   override def getCurrentRecord: InternalRow = rootConverter.currentRecord
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRecordMaterializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRecordMaterializer.scala
@@ -37,6 +37,8 @@ import org.apache.spark.sql.types.StructType
  *                           calendar
  * @param int96RebaseMode the mode of rebasing INT96 timestamp from Julian to Proleptic Gregorian
  *                           calendar
+ * @param accessByColumnOrdinal when true, mapping parquet schema with catalyst schema by column
+ *                              ordinals; otherwise, by column names
  */
 private[parquet] class ParquetRecordMaterializer(
     parquetSchema: MessageType,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -200,7 +200,7 @@ private[parquet] class ParquetRowConverter(
 
   // Converters for each field.
   private[this] val fieldConverters: Array[Converter with HasParentContainerUpdater] = {
-    if (SQLConf.get.parquetAccessByIndex) {
+    if (SQLConf.get.parquetAccessByOrdinal) {
       // SPARK-36634: When access parquet file by the idx of columns, we can not ensure 2 types
       // matched
       parquetType.getFields.asScala.zip(catalystType).zipWithIndex.map {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -139,7 +139,8 @@ private[parquet] class ParquetRowConverter(
     convertTz: Option[ZoneId],
     datetimeRebaseMode: LegacyBehaviorPolicy.Value,
     int96RebaseMode: LegacyBehaviorPolicy.Value,
-    updater: ParentContainerUpdater)
+    updater: ParentContainerUpdater,
+    parquetAccessByOrdinal: Boolean)
   extends ParquetGroupConverter(updater) with Logging {
 
   assert(
@@ -200,7 +201,7 @@ private[parquet] class ParquetRowConverter(
 
   // Converters for each field.
   private[this] val fieldConverters: Array[Converter with HasParentContainerUpdater] = {
-    if (SQLConf.get.parquetAccessByOrdinal) {
+    if (parquetAccessByOrdinal) {
       // SPARK-36634: When access parquet file by the idx of columns, we can not ensure 2 types
       // matched
       parquetType.getFields.asScala.zip(catalystType).zipWithIndex.map {
@@ -435,7 +436,8 @@ private[parquet] class ParquetRowConverter(
           convertTz,
           datetimeRebaseMode,
           int96RebaseMode,
-          wrappedUpdater)
+          wrappedUpdater,
+          parquetAccessByOrdinal)
 
       case t =>
         throw QueryExecutionErrors.cannotCreateParquetConverterForDataTypeError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4223,6 +4223,52 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     checkAnswer(sql("""SELECT from_json(r'{"a": "\\"}', 'a string')"""), Row(Row("\\")))
     checkAnswer(sql("""SELECT from_json(R'{"a": "\\"}', 'a string')"""), Row(Row("\\")))
   }
+
+  test("SPARK-36634: Support access and read parquet file by column index") {
+    withTempDir { dir =>
+      val loc = s"file:///$dir/t"
+
+      withTable("t1", "t2", "t3") {
+        sql(s"create table t1 (my_id int, my_name string) using parquet location '$loc'")
+        sql(s"create table t2 (myid int, myName string) using parquet location '$loc'")
+        sql("insert into t1 select 1, 'kent'")
+        sql("insert into t2 select 2, 'yao'")
+        sql("insert into t2 select 3, 'kyuubi'")
+        sql(s"create table t3 (myid int, myname string, myage int) using parquet location '$loc'")
+
+        withSQLConf((SQLConf.PARQUET_COLUMN_INDEX_ACCESS.key, "false")) {
+          checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(null), Row(null)))
+          checkAnswer(sql("select my_id, my_name from t1"),
+            Seq(Row(1, "kent"), Row(null, null), Row(null, null)))
+          assert(sql("select my_id, my_name from t1 where my_id=2").isEmpty)
+          checkAnswer(sql("select myid, myname, myage from t3"),
+            Seq(Row(2, "yao", null),
+              Row(3, "kyuubi", null),
+              Row(null, null, null)))
+        }
+
+        withSQLConf((SQLConf.PARQUET_COLUMN_INDEX_ACCESS.key, "true")) {
+          checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(2), Row(3)))
+          val e1 = {
+            intercept[SparkException](sql("select my_name from t1").collect())
+          }
+          assert(e1.getCause.getMessage.contains("Parquet column cannot be converted in"))
+
+          checkAnswer(sql("select my_id, my_name from t1"),
+            Seq(Row(1, "kent"), Row(2, "yao"), Row(3, "kyuubi")))
+          checkAnswer(sql("select my_id, my_name from t1 where my_id=2"), Row(2, "yao"))
+
+          sql("insert into t3 select 4, 'spark', 11")
+          checkAnswer(sql("select myid, myname, myage from t3"),
+            Seq(Row(1, "kent", null),
+              Row(2, "yao", null),
+              Row(3, "kyuubi", null),
+              Row(4, "spark", 11)))
+
+        }
+      }
+    }
+  }
 }
 
 case class Foo(bar: Option[String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4236,7 +4236,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         sql("insert into t2 select 3, 'foundation'")
         sql(s"create table t3 (myid int, myname string, myage int) using parquet location '$loc'")
 
-        withSQLConf((SQLConf.PARQUET_ACCESS_BY_INDEX.key, "false")) {
+        withSQLConf((SQLConf.PARQUET_ACCESS_BY_ORDINAL.key, "false")) {
           checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(null), Row(null)))
           checkAnswer(sql("select my_id, my_name from t1"),
             Seq(Row(1, "apache"), Row(null, null), Row(null, null)))
@@ -4250,7 +4250,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         sql("insert into t3 select 4, 'spark', 11")
 
         Seq("true", "false").foreach { vectorized =>
-          withSQLConf((SQLConf.PARQUET_ACCESS_BY_INDEX.key, "true"),
+          withSQLConf((SQLConf.PARQUET_ACCESS_BY_ORDINAL.key, "true"),
             (SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key, vectorized)) {
             checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(2), Row(3)))
             val e1 = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4231,40 +4231,43 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       withTable("t1", "t2", "t3") {
         sql(s"create table t1 (my_id int, my_name string) using parquet location '$loc'")
         sql(s"create table t2 (myid int, myName string) using parquet location '$loc'")
-        sql("insert into t1 select 1, 'kent'")
-        sql("insert into t2 select 2, 'yao'")
-        sql("insert into t2 select 3, 'kyuubi'")
+        sql("insert into t1 select 1, 'apache'")
+        sql("insert into t2 select 2, 'software'")
+        sql("insert into t2 select 3, 'foundation'")
         sql(s"create table t3 (myid int, myname string, myage int) using parquet location '$loc'")
 
         withSQLConf((SQLConf.PARQUET_ACCESS_BY_INDEX.key, "false")) {
           checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(null), Row(null)))
           checkAnswer(sql("select my_id, my_name from t1"),
-            Seq(Row(1, "kent"), Row(null, null), Row(null, null)))
+            Seq(Row(1, "apache"), Row(null, null), Row(null, null)))
           assert(sql("select my_id, my_name from t1 where my_id=2").isEmpty)
           checkAnswer(sql("select myid, myname, myage from t3"),
-            Seq(Row(2, "yao", null),
-              Row(3, "kyuubi", null),
+            Seq(Row(2, "software", null),
+              Row(3, "foundation", null),
               Row(null, null, null)))
         }
 
-        withSQLConf((SQLConf.PARQUET_ACCESS_BY_INDEX.key, "true")) {
-          checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(2), Row(3)))
-          val e1 = {
-            intercept[SparkException](sql("select my_name from t1").collect())
+        sql("insert into t3 select 4, 'spark', 11")
+
+        Seq("true", "false").foreach { vectorized =>
+          withSQLConf((SQLConf.PARQUET_ACCESS_BY_INDEX.key, "true"),
+            (SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key, vectorized)) {
+            checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(2), Row(3)))
+            val e1 = {
+              intercept[SparkException](sql("select my_name from t1").collect())
+            }
+            assert(e1.getCause.getMessage.contains("Parquet column cannot be converted in"))
+
+            checkAnswer(sql("select my_id, my_name from t1"),
+              Seq(Row(1, "apache"), Row(2, "software"), Row(3, "foundation")))
+            checkAnswer(sql("select my_id, my_name from t1 where my_id=2"), Row(2, "software"))
+
+            checkAnswer(sql("select myid, myname, myage from t3"),
+              Seq(Row(1, "apache", null),
+                Row(2, "software", null),
+                Row(3, "foundation", null),
+                Row(4, "spark", 11)))
           }
-          assert(e1.getCause.getMessage.contains("Parquet column cannot be converted in"))
-
-          checkAnswer(sql("select my_id, my_name from t1"),
-            Seq(Row(1, "kent"), Row(2, "yao"), Row(3, "kyuubi")))
-          checkAnswer(sql("select my_id, my_name from t1 where my_id=2"), Row(2, "yao"))
-
-          sql("insert into t3 select 4, 'spark', 11")
-          checkAnswer(sql("select myid, myname, myage from t3"),
-            Seq(Row(1, "kent", null),
-              Row(2, "yao", null),
-              Row(3, "kyuubi", null),
-              Row(4, "spark", 11)))
-
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4236,7 +4236,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         sql("insert into t2 select 3, 'kyuubi'")
         sql(s"create table t3 (myid int, myname string, myage int) using parquet location '$loc'")
 
-        withSQLConf((SQLConf.PARQUET_COLUMN_INDEX_ACCESS.key, "false")) {
+        withSQLConf((SQLConf.PARQUET_ACCESS_BY_INDEX.key, "false")) {
           checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(null), Row(null)))
           checkAnswer(sql("select my_id, my_name from t1"),
             Seq(Row(1, "kent"), Row(null, null), Row(null, null)))
@@ -4247,7 +4247,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
               Row(null, null, null)))
         }
 
-        withSQLConf((SQLConf.PARQUET_COLUMN_INDEX_ACCESS.key, "true")) {
+        withSQLConf((SQLConf.PARQUET_ACCESS_BY_INDEX.key, "true")) {
           checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(2), Row(3)))
           val e1 = {
             intercept[SparkException](sql("select my_name from t1").collect())

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4223,55 +4223,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     checkAnswer(sql("""SELECT from_json(r'{"a": "\\"}', 'a string')"""), Row(Row("\\")))
     checkAnswer(sql("""SELECT from_json(R'{"a": "\\"}', 'a string')"""), Row(Row("\\")))
   }
-
-  test("SPARK-36634: Support access and read parquet file by column index") {
-    withTempDir { dir =>
-      val loc = s"file:///$dir/t"
-
-      withTable("t1", "t2", "t3") {
-        sql(s"create table t1 (my_id int, my_name string) using parquet location '$loc'")
-        sql(s"create table t2 (myid int, myName string) using parquet location '$loc'")
-        sql("insert into t1 select 1, 'apache'")
-        sql("insert into t2 select 2, 'software'")
-        sql("insert into t2 select 3, 'foundation'")
-        sql(s"create table t3 (myid int, myname string, myage int) using parquet location '$loc'")
-
-        withSQLConf((SQLConf.PARQUET_ACCESS_BY_ORDINAL.key, "false")) {
-          checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(null), Row(null)))
-          checkAnswer(sql("select my_id, my_name from t1"),
-            Seq(Row(1, "apache"), Row(null, null), Row(null, null)))
-          assert(sql("select my_id, my_name from t1 where my_id=2").isEmpty)
-          checkAnswer(sql("select myid, myname, myage from t3"),
-            Seq(Row(2, "software", null),
-              Row(3, "foundation", null),
-              Row(null, null, null)))
-        }
-
-        sql("insert into t3 select 4, 'spark', 11")
-
-        Seq("true", "false").foreach { vectorized =>
-          withSQLConf((SQLConf.PARQUET_ACCESS_BY_ORDINAL.key, "true"),
-            (SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key, vectorized)) {
-            checkAnswer(sql("select my_id from t1"), Seq(Row(1), Row(2), Row(3)))
-            val e1 = {
-              intercept[SparkException](sql("select my_name from t1").collect())
-            }
-            assert(e1.getCause.getMessage.contains("Parquet column cannot be converted in"))
-
-            checkAnswer(sql("select my_id, my_name from t1"),
-              Seq(Row(1, "apache"), Row(2, "software"), Row(3, "foundation")))
-            checkAnswer(sql("select my_id, my_name from t1 where my_id=2"), Row(2, "software"))
-
-            checkAnswer(sql("select myid, myname, myage from t3"),
-              Seq(Row(1, "apache", null),
-                Row(2, "software", null),
-                Row(3, "foundation", null),
-                Row(4, "spark", 11)))
-          }
-        }
-      }
-    }
-  }
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add a config `spark.sql.parquet.accessByColumnOrdinal` 

When true, we access the parquet files by column original instead of catalyst schema mapping at the executor side. 

This is useful when the parquet file meta is inconsistent with those in Metastore, e.g. creating a table with existing parquet files with column names renamed, the column names are changed by external systems.

- What if the number of columns/inner fields does not match?
  - if the number of requests columns (M)is greater than the one(N) in the parquet file, the [M, N-1] of the outputs will be filled with nulls, which is also the same as the current name-based mapping
  - if the number of requests columns (M)is less than or equal to the one(N) in the parquet file, the [0, M-1] of fields will be token in order.
- What if the types are not compatible?
  - In this case, it throws unsupportedSchemaColumnConvertError 

By default, it is off

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- What's the concrete use case that requires this feature?

Parquet's schema evolution is implementation-dependent and may causes inconsistency from file to file or file to metastore. Sometimes, 1) the table Spark's processing might be produced by other systems, e.g. renamed by hive https://issues.apache.org/jira/browse/HIVE-6938, 2)some operations that do not introduce a force schema checking, e.g. `set location, `add partition`. With this feature, the users as data consumers can still read those data produced by different providers.

See also, https://issues.apache.org/jira/browse/IMPALA-2835


better data accessibility 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

newly added test