### PR TITLE
[SPARK-36632][SQL] DivideYMInterval and DivideDTInterval should throw the same exception when divide by zero.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -426,7 +426,7 @@ class Analyzer(override val catalogManager: CatalogManager)
         case d @ Divide(l, r, f) if d.childrenResolved => (l.dataType, r.dataType) match {
           case (CalendarIntervalType, _) => DivideInterval(l, r, f)
           case (_: YearMonthIntervalType, _) => DivideYMInterval(l, r, f)
-          case (_: DayTimeIntervalType, _) => DivideDTInterval(l, r, f)
+          case (_: DayTimeIntervalType, _) => DivideDTInterval(l, r)
           case _ => d
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -425,7 +425,7 @@ class Analyzer(override val catalogManager: CatalogManager)
         }
         case d @ Divide(l, r, f) if d.childrenResolved => (l.dataType, r.dataType) match {
           case (CalendarIntervalType, _) => DivideInterval(l, r, f)
-          case (_: YearMonthIntervalType, _) => DivideYMInterval(l, r, f)
+          case (_: YearMonthIntervalType, _) => DivideYMInterval(l, r)
           case (_: DayTimeIntervalType, _) => DivideDTInterval(l, r)
           case _ => d
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -425,8 +425,8 @@ class Analyzer(override val catalogManager: CatalogManager)
         }
         case d @ Divide(l, r, f) if d.childrenResolved => (l.dataType, r.dataType) match {
           case (CalendarIntervalType, _) => DivideInterval(l, r, f)
-          case (_: YearMonthIntervalType, _) => DivideYMInterval(l, r)
-          case (_: DayTimeIntervalType, _) => DivideDTInterval(l, r)
+          case (_: YearMonthIntervalType, _) => DivideYMInterval(l, r, f)
+          case (_: DayTimeIntervalType, _) => DivideDTInterval(l, r, f)
           case _ => d
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -630,9 +630,14 @@ case class DivideYMInterval(
 
   @transient
   private lazy val evalExactFunc: (Int, Any) => Any = if (failOnError) {
-    (months: Int, num) =>
-      if (num == 0) throw QueryExecutionErrors.divideByZeroError()
-      evalFunc(months, num)
+    right.dataType match {
+      case _: DecimalType => (months: Int, num) =>
+        if (num.asInstanceOf[Decimal].isZero) throw QueryExecutionErrors.divideByZeroError()
+        evalFunc(months, num)
+      case _ => (months: Int, num) =>
+        if (num == 0) throw QueryExecutionErrors.divideByZeroError()
+        evalFunc(months, num)
+    }
   } else {
     (months: Int, num) => evalFunc(months, num)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -666,7 +666,7 @@ case class DivideYMInterval(
            |${divideByZeroCheckCodegen(right, n)}
            |$checkIntegralDivideOverflow
            |${ev.value} = ($javaType)$math.divide($m, $n, java.math.RoundingMode.HALF_UP);
-         """.stripMargin)
+        """.stripMargin)
     case _: DecimalType =>
       nullSafeCodeGen(ctx, ev, (m, n) =>
         s"""
@@ -742,7 +742,7 @@ case class DivideDTInterval(
            |${divideByZeroCheckCodegen(right, n)}
            |$checkIntegralDivideOverflow
            |${ev.value} = $math.divide($m, $n, java.math.RoundingMode.HALF_UP);
-         """.stripMargin)
+        """.stripMargin)
     case _: DecimalType =>
       nullSafeCodeGen(ctx, ev, (m, n) =>
         s"""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -656,8 +656,8 @@ case class DivideYMInterval(
            |  throw QueryExecutionErrors.overflowInIntegralDivideError();
            |""".stripMargin
       nullSafeCodeGen(ctx, ev, (m, n) =>
-        // Similarly to non-codegen code. The result of `divide(Int, Long, ...)` must fit
-        // to `Int`. Casting to `Int` is safe here.
+        // Similarly to non-codegen code. The result of `divide(Int, Long, ...)` must fit to `Int`.
+        // Casting to `Int` is safe here.
         s"""
            |$checkDivideByZero
            |$checkIntegralDivideOverflow

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -603,7 +603,8 @@ trait IntervalDivide {
 // Divide an year-month interval by a numeric
 case class DivideYMInterval(
     interval: Expression,
-    num: Expression)
+    num: Expression,
+    failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with ImplicitCastInputTypes with IntervalDivide
     with NullIntolerant with Serializable {
   override def left: Expression = interval
@@ -627,40 +628,64 @@ case class DivideYMInterval(
       DoubleMath.roundToInt(months / num.asInstanceOf[Number].doubleValue(), RoundingMode.HALF_UP)
   }
 
-  override def nullSafeEval(interval: Any, num: Any): Any = {
-    checkDivideOverflow(interval.asInstanceOf[Int], Int.MinValue, right, num)
-    evalFunc(interval.asInstanceOf[Int], num)
+  @transient
+  private lazy val evalExactFunc: (Int, Any) => Any = if (failOnError) {
+    (months: Int, num) =>
+      if (num == 0) throw QueryExecutionErrors.divideByZeroError()
+      evalFunc(months, num)
+  } else {
+    (months: Int, num) => evalFunc(months, num)
   }
 
-  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = right.dataType match {
-    case t: IntegralType =>
-      val math = t match {
-        case LongType => classOf[LongMath].getName
-        case _ => classOf[IntMath].getName
-      }
-      val javaType = CodeGenerator.javaType(dataType)
-      val months = left.genCode(ctx)
-      val num = right.genCode(ctx)
-      val checkIntegralDivideOverflow =
-        s"""
-           |if (${months.value} == ${Int.MinValue} && ${num.value} == -1)
-           |  throw QueryExecutionErrors.overflowInIntegralDivideError();
-           |""".stripMargin
-      nullSafeCodeGen(ctx, ev, (m, n) =>
-        // Similarly to non-codegen code. The result of `divide(Int, Long, ...)` must fit to `Int`.
-        // Casting to `Int` is safe here.
-        s"""
-           |$checkIntegralDivideOverflow
-           |${ev.value} = ($javaType)$math.divide($m, $n, java.math.RoundingMode.HALF_UP);
+  override def nullSafeEval(interval: Any, num: Any): Any = {
+    checkDivideOverflow(interval.asInstanceOf[Int], Int.MinValue, right, num)
+    evalExactFunc(interval.asInstanceOf[Int], num)
+  }
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val num = right.genCode(ctx)
+    val checkDivideByZero = if (failOnError) {
+      s"""
+         |if (${num.value} == 0)
+         |  throw QueryExecutionErrors.divideByZeroError();
+         """.stripMargin
+    } else ""
+    right.dataType match {
+      case t: IntegralType =>
+        val math = t match {
+          case LongType => classOf[LongMath].getName
+          case _ => classOf[IntMath].getName
+        }
+        val javaType = CodeGenerator.javaType(dataType)
+        val months = left.genCode(ctx)
+        val checkIntegralDivideOverflow =
+          s"""
+             |if (${months.value} == ${Int.MinValue} && ${num.value} == -1)
+             |  throw QueryExecutionErrors.overflowInIntegralDivideError();
+             |""".stripMargin
+        nullSafeCodeGen(ctx, ev, (m, n) =>
+          // Similarly to non-codegen code. The result of `divide(Int, Long, ...)` must fit
+          // to `Int`. Casting to `Int` is safe here.
+          s"""
+             |$checkIntegralDivideOverflow
+             |$checkDivideByZero
+             |${ev.value} = ($javaType)$math.divide($m, $n, java.math.RoundingMode.HALF_UP);
         """.stripMargin)
-    case _: DecimalType =>
-      defineCodeGen(ctx, ev, (m, n) =>
-        s"((new Decimal()).set($m).$$div($n)).toJavaBigDecimal()" +
-        ".setScale(0, java.math.RoundingMode.HALF_UP).intValueExact()")
-    case _: FractionalType =>
-      val math = classOf[DoubleMath].getName
-      defineCodeGen(ctx, ev, (m, n) =>
-        s"$math.roundToInt($m / (double)$n, java.math.RoundingMode.HALF_UP)")
+      case _: DecimalType =>
+        nullSafeCodeGen(ctx, ev, (m, n) =>
+          s"""
+             |$checkDivideByZero
+             |${ev.value} = ((new Decimal()).set($m).$$div($n)).toJavaBigDecimal()
+             |  .setScale(0, java.math.RoundingMode.HALF_UP).intValueExact();
+        """.stripMargin)
+      case _: FractionalType =>
+        val math = classOf[DoubleMath].getName
+        nullSafeCodeGen(ctx, ev, (m, n) =>
+          s"""
+             |$checkDivideByZero
+             |${ev.value} = $math.roundToInt($m / (double)$n, java.math.RoundingMode.HALF_UP);
+        """.stripMargin)
+    }
   }
 
   override def toString: String = s"($left / $right)"
@@ -674,7 +699,8 @@ case class DivideYMInterval(
 // Divide a day-time interval by a numeric
 case class DivideDTInterval(
     interval: Expression,
-    num: Expression)
+    num: Expression,
+    failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with ImplicitCastInputTypes with IntervalDivide
     with NullIntolerant with Serializable {
   override def left: Expression = interval

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -672,9 +672,15 @@ case class DivideYMInterval(
              |${ev.value} = ($javaType)$math.divide($m, $n, java.math.RoundingMode.HALF_UP);
         """.stripMargin)
       case _: DecimalType =>
+        val checkDecimalDivideByZero = if (failOnError) {
+          s"""
+             |if (${num.value}.isZero())
+             |  throw QueryExecutionErrors.divideByZeroError();
+         """.stripMargin
+        } else ""
         nullSafeCodeGen(ctx, ev, (m, n) =>
           s"""
-             |$checkDivideByZero
+             |$checkDecimalDivideByZero
              |${ev.value} = ((new Decimal()).set($m).$$div($n)).toJavaBigDecimal()
              |  .setScale(0, java.math.RoundingMode.HALF_UP).intValueExact();
         """.stripMargin)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -421,6 +421,12 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         expectedErrMsg)
     }
 
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      checkExceptionInExpression[ArithmeticException](
+        DivideYMInterval(Literal(Period.ofMonths(1)), Literal(0)),
+        "divide by zero")
+    }
+
     numericTypes.foreach { numType =>
       yearMonthIntervalTypes.foreach { it =>
         checkConsistencyBetweenInterpretedAndCodegenAllowingException(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -412,8 +412,8 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
 
     Seq(
-//      (Period.ofMonths(1), 0) -> "divide by zero",
-//      (Period.ofMonths(Int.MinValue), 0d) -> "divide by zero",
+      (Period.ofMonths(1), 0) -> "divide by zero",
+      (Period.ofMonths(Int.MinValue), 0d) -> "divide by zero",
       (Period.ofMonths(-100), Float.NaN) -> "input is infinite or NaN"
     ).foreach { case ((period, num), expectedErrMsg) =>
       checkExceptionInExpression[ArithmeticException](

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -447,8 +447,8 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
 
     Seq(
-      (Duration.ofDays(1), 0) -> "/ by zero",
-      (Duration.ofMillis(Int.MinValue), 0d) -> "input is infinite or NaN",
+      (Duration.ofDays(1), 0) -> "divide by zero",
+      (Duration.ofMillis(Int.MinValue), 0d) -> "divide by zero",
       (Duration.ofSeconds(-100), Float.NaN) -> "input is infinite or NaN"
     ).foreach { case ((period, num), expectedErrMsg) =>
       checkExceptionInExpression[ArithmeticException](

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -412,8 +412,8 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
 
     Seq(
-      (Period.ofMonths(1), 0) -> "/ by zero",
-      (Period.ofMonths(Int.MinValue), 0d) -> "input is infinite or NaN",
+//      (Period.ofMonths(1), 0) -> "divide by zero",
+//      (Period.ofMonths(Int.MinValue), 0d) -> "divide by zero",
       (Period.ofMonths(-100), Float.NaN) -> "input is infinite or NaN"
     ).foreach { case ((period, num), expectedErrMsg) =>
       checkExceptionInExpression[ArithmeticException](

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -421,12 +421,6 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         expectedErrMsg)
     }
 
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      checkExceptionInExpression[ArithmeticException](
-        DivideYMInterval(Literal(Period.ofMonths(1)), Literal(0)),
-        "divide by zero")
-    }
-
     numericTypes.foreach { numType =>
       yearMonthIntervalTypes.foreach { it =>
         checkConsistencyBetweenInterpretedAndCodegenAllowingException(

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -242,8 +242,8 @@ select interval '2' year / 0
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
-/ by zero
+org.apache.spark.SparkArithmeticException
+divide by zero
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -209,8 +209,8 @@ select interval '2 seconds' / 0
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
-/ by zero
+org.apache.spark.SparkArithmeticException
+divide by zero
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -236,8 +236,8 @@ select interval '2' year / 0
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
-/ by zero
+org.apache.spark.SparkArithmeticException
+divide by zero
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -203,8 +203,8 @@ select interval '2 seconds' / 0
 -- !query schema
 struct<>
 -- !query output
-java.lang.ArithmeticException
-/ by zero
+org.apache.spark.SparkArithmeticException
+divide by zero
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2737,15 +2737,19 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       Seq((Period.ofYears(9999), 0)).toDF("i", "n").select($"i" / $"n").collect()
     }.getCause
     assert(e.isInstanceOf[ArithmeticException])
-    assert(e.getMessage.contains("/ by zero"))
+    assert(e.getMessage.contains("divide by zero"))
 
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      val e = intercept[SparkException] {
-        Seq((Period.ofYears(9999), 0)).toDF("i", "n").select($"i" / $"n").collect()
-      }.getCause
-      assert(e.isInstanceOf[ArithmeticException])
-      assert(e.getMessage.contains("divide by zero"))
-    }
+    val e2 = intercept[SparkException] {
+      Seq((Period.ofYears(9999), 0d)).toDF("i", "n").select($"i" / $"n").collect()
+    }.getCause
+    assert(e2.isInstanceOf[ArithmeticException])
+    assert(e2.getMessage.contains("divide by zero"))
+
+    val e3 = intercept[SparkException] {
+      Seq((Period.ofYears(9999), BigDecimal(0))).toDF("i", "n").select($"i" / $"n").collect()
+    }.getCause
+    assert(e3.isInstanceOf[ArithmeticException])
+    assert(e3.getMessage.contains("divide by zero"))
   }
 
   test("SPARK-34875: divide day-time interval by numeric") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2784,7 +2784,19 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       Seq((Duration.ofDays(9999), 0)).toDF("i", "n").select($"i" / $"n").collect()
     }.getCause
     assert(e.isInstanceOf[ArithmeticException])
-    assert(e.getMessage.contains("/ by zero"))
+    assert(e.getMessage.contains("divide by zero"))
+
+    val e2 = intercept[SparkException] {
+      Seq((Duration.ofDays(9999), 0d)).toDF("i", "n").select($"i" / $"n").collect()
+    }.getCause
+    assert(e2.isInstanceOf[ArithmeticException])
+    assert(e2.getMessage.contains("divide by zero"))
+
+    val e3 = intercept[SparkException] {
+      Seq((Duration.ofDays(9999), BigDecimal(0))).toDF("i", "n").select($"i" / $"n").collect()
+    }.getCause
+    assert(e3.isInstanceOf[ArithmeticException])
+    assert(e3.getMessage.contains("divide by zero"))
   }
 
   test("SPARK-34896: return day-time interval from dates subtraction") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2738,6 +2738,14 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
     }.getCause
     assert(e.isInstanceOf[ArithmeticException])
     assert(e.getMessage.contains("/ by zero"))
+
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      val e = intercept[SparkException] {
+        Seq((Period.ofYears(9999), 0)).toDF("i", "n").select($"i" / $"n").collect()
+      }.getCause
+      assert(e.isInstanceOf[ArithmeticException])
+      assert(e.getMessage.contains("divide by zero"))
+    }
   }
 
   test("SPARK-34875: divide day-time interval by numeric") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When dividing by zero, `DivideYMInterval` and `DivideDTInterval` output
```
java.lang.ArithmeticException
/ by zero
```
But, in ansi mode, `select 2 / 0` will output
```
org.apache.spark.SparkArithmeticException
divide by zero
```
The behavior looks not inconsistent.


### Why are the changes needed?
Make consistent behavior.


### Does this PR introduce _any_ user-facing change?
'Yes'.


### How was this patch tested?
New tests.
