### PR TITLE
[SPARK-36638][SQL] Generalize OptimizeSkewedJoin

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -704,16 +704,6 @@ object SQLConf {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("256MB")
 
-  val SKEW_JOIN_MAX_JOINS =
-    buildConf("spark.sql.adaptive.skewJoin.maxJoins")
-      .doc(s"When '${ADAPTIVE_EXECUTION_ENABLED.key}' and '${SKEW_JOIN_ENABLED.key}' " +
-        s"are true, the max number (inclusive) of shuffled joins in a stage that general " +
-        s"skew algorithm can handle.")
-      .version("3.3.0")
-      .intConf
-      .checkValue(_ > 0, "The max joins must be positive.")
-      .createWithDefault(5)
-
   val SKEW_JOIN_MAX_SPLITS_PER_PARTITION =
     buildConf("spark.sql.adaptive.skewJoin.maxSplitsPerPartition")
       .doc(s"When '${ADAPTIVE_EXECUTION_ENABLED.key}' and '${SKEW_JOIN_ENABLED.key}' " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -708,7 +708,7 @@ object SQLConf {
     buildConf("spark.sql.adaptive.skewJoin.maxSplitsPerPartition")
       .doc(s"When '${ADAPTIVE_EXECUTION_ENABLED.key}' and '${SKEW_JOIN_ENABLED.key}' " +
         s"are true, the max number (inclusive) of splits from a partition.")
-      .version("3.3.0")
+      .version("3.4.0")
       .intConf
       .checkValue(_ >= 10, "The max splits must be no less than 10.")
       .createWithDefault(1000)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -704,6 +704,25 @@ object SQLConf {
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("256MB")
 
+  val SKEW_JOIN_MAX_JOINS =
+    buildConf("spark.sql.adaptive.skewJoin.maxJoins")
+      .doc(s"When '${ADAPTIVE_EXECUTION_ENABLED.key}' and '${SKEW_JOIN_ENABLED.key}' " +
+        s"are true, the max number (inclusive) of shuffled joins in a stage that general " +
+        s"skew algorithm can handle.")
+      .version("3.3.0")
+      .intConf
+      .checkValue(_ > 0, "The max joins must be positive.")
+      .createWithDefault(5)
+
+  val SKEW_JOIN_MAX_SPLITS_PER_PARTITION =
+    buildConf("spark.sql.adaptive.skewJoin.maxSplitsPerPartition")
+      .doc(s"When '${ADAPTIVE_EXECUTION_ENABLED.key}' and '${SKEW_JOIN_ENABLED.key}' " +
+        s"are true, the max number (inclusive) of splits from a partition.")
+      .version("3.3.0")
+      .intConf
+      .checkValue(_ >= 10, "The max splits must be no less than 10.")
+      .createWithDefault(1000)
+
   val NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN =
     buildConf("spark.sql.adaptive.nonEmptyPartitionRatioForBroadcastJoin")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -377,15 +377,11 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
 
     val optimized = optimize(plan)
     if (optimized.collectFirst { case s: ShuffledJoin if s.isSkewJoin => s }.isEmpty) return plan
-
     val requirementSatisfied = if (ensureRequirements.requiredDistribution.isDefined) {
       ValidateRequirements.validate(optimized, ensureRequirements.requiredDistribution.get)
     } else {
       ValidateRequirements.validate(optimized)
     }
-    // Two cases we will apply the skewed join optimization:
-    //   1. optimize the skew join without extra shuffle
-    //   2. optimize the skew join with extra shuffle but the force-apply config is true.
     if (requirementSatisfied) {
       optimized.transform {
         case SkewJoinChildWrapper(child) => child

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -353,7 +353,6 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
     }
   }
 
-  // try to optimize at top join in each stage
   private def optimize(plan: SparkPlan): SparkPlan = {
     plan transformDown {
       case join: ShuffledJoin if !join.isSkewJoin => optimizeShuffledJoin(join)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -28,8 +28,11 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, EnsureRequirements, ValidateRequirements}
-import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.execution.joins._
+import org.apache.spark.sql.execution.python.{ArrowEvalPythonExec, BatchEvalPythonExec, MapInPandasExec}
+import org.apache.spark.sql.execution.window.{WindowExec, WindowExecBase}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
@@ -98,123 +101,280 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
 
   /*
    * This method aim to optimize the skewed join with the following steps:
-   * 1. Check whether the shuffle partition is skewed based on the median size
-   *    and the skewed partition threshold in origin shuffled join (smj and shj).
-   * 2. Assuming partition0 is skewed in left side, and it has 5 mappers (Map0, Map1...Map4).
-   *    And we may split the 5 Mappers into 3 mapper ranges [(Map0, Map1), (Map2, Map3), (Map4)]
-   *    based on the map size and the max split number.
-   * 3. Wrap the join left child with a special shuffle read that loads each mapper range with one
-   *    task, so total 3 tasks.
-   * 4. Wrap the join right child with a special shuffle read that loads partition0 3 times by
-   *    3 tasks separately.
+   * 0. Collect all ShuffledJoin in this plan. Find the top level ShuffledJoin as the root
+   *    for following steps;
+   * 1. Check whether this plan satisfy the required pattern of optimization algorithm:
+   *    all the nodes under the top level ShuffledJoin MUST have types in a whitelist including:
+   *    JoinExec/AggExec/WindowExec/SortExec/etc;
+   * 2. Collect all ShuffleQueryStages under the top level ShuffledJoin;
+   * 3. Collect all splittable ShuffleQueryStages by the semantics of internal nodes.
+   *    A ShuffleQueryStages is splittable if it can be split into specs, each spec can be
+   *    processed independently, and the original data result can be obtained by union all
+   *    the outputs of specs.
+   *    Splittable ShuffleQueryStages are collected in this way:
+   *      0, start at the top level ShuffledJoin;
+   *      1, at a Join node, select the splittable paths according to its JoinType;
+   *      2, at a Agg/Window node, skip all its descendants;
+   *      3, all the reached leave are splittable;
+   *    For example, in the following stage, ShuffleQueryStages s6/s7/s8 are splittable.
+   *                       cross
+   *                 /              \
+   *               agg               \
+   *               /                  \
+   *            left                 cross
+   *          /      \            /           \
+   *        inner    s3        agg          inner
+   *      /      \              /          /       \
+   *     s0    right         inner      inner     left
+   *           /   \         /   \      /   \     /   \
+   *          s1   s2       s4   s5    s6   s7   s8   s9
+   *
+   * 4. Precompute skewThreshold and targetSize for each splittable ShuffleQueryStageExec;
+   * 5. For each splittable ShuffleQueryStageExec, check whether skew partitions exists, if true,
+   *    split them into specs. This step also detects and handles Combinatorial Explosion: for
+   *    each skew partition, check whether the combination number is too large, if so, re-split the
+   *    ShuffleQueryStageExecs.
+   *    For example, for partition 0, stage s6/s7/s8 are split into 100/100/100 specs,
+   *    respectively. Then there are 1M combinations, which is too large, and will cause
+   *    performance regression. Given a threshold (1k by default), the numbers of specs will
+   *    be optimized to 10/10/10.
+   * 6. Generate final specs. Suppose above splittable ShuffleQueryStages s6/s7/s8 are finally
+   *    split into 2/2/3 specs, then there will be following 2X2X3=12 combinations:
+   *      [s0, s1, s2, s3, s4, s5, s6_spec0, s7_spec0, s8_spec0, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec0, s7_spec0, s8_spec1, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec0, s7_spec0, s8_spec2, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec0, s7_spec1, s8_spec0, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec0, s7_spec1, s8_spec1, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec0, s7_spec1, s8_spec2, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec1, s7_spec0, s8_spec0, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec1, s7_spec0, s8_spec1, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec1, s7_spec0, s8_spec2, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec1, s7_spec1, s8_spec0, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec1, s7_spec1, s8_spec1, s9]
+   *      [s0, s1, s2, s3, s4, s5, s6_spec1, s7_spec1, s8_spec2, s9]
+   * 7. Generate optimized plan by attaching new specs to ShuffleQueryStageExecs;
    */
-  private def tryOptimizeJoinChildren(
-      left: ShuffleQueryStageExec,
-      right: ShuffleQueryStageExec,
-      joinType: JoinType): Option[(SparkPlan, SparkPlan)] = {
-    val canSplitLeft = canSplitLeftSide(joinType)
-    val canSplitRight = canSplitRightSide(joinType)
-    if (!canSplitLeft && !canSplitRight) return None
+  private def optimize(plan: SparkPlan): SparkPlan = {
+    import OptimizeSkewedJoin._
+    val logPrefix = s"Optimizing ${plan.nodeName} #${plan.id}"
 
-    val leftSizes = left.mapStats.get.bytesByPartitionId
-    val rightSizes = right.mapStats.get.bytesByPartitionId
-    assert(leftSizes.length == rightSizes.length)
-    val numPartitions = leftSizes.length
-    // We use the median size of the original shuffle partitions to detect skewed partitions.
-    val leftMedSize = Utils.median(leftSizes, false)
-    val rightMedSize = Utils.median(rightSizes, false)
-    logDebug(
-      s"""
-         |Optimizing skewed join.
-         |Left side partitions size info:
-         |${getSizeInfo(leftMedSize, leftSizes)}
-         |Right side partitions size info:
-         |${getSizeInfo(rightMedSize, rightSizes)}
-      """.stripMargin)
+    // Step 0: Collect all ShuffledJoins (SMJ/SHJ)
+    def collectShuffledJoins(plan: SparkPlan): Seq[ShuffledJoin] = plan match {
+      case join: ShuffledJoin => Seq(join) ++ join.children.flatMap(collectShuffledJoins)
+      case _ => plan.children.flatMap(collectShuffledJoins)
+    }
+    val joins = collectShuffledJoins(plan)
+    logDebug(s"$logPrefix: ShuffledJoins: ${joins.map(_.nodeName).mkString("[", ", ", "]")}")
+    if (joins.isEmpty || joins.exists(_.isSkewJoin)) return plan
+    val topJoin = joins.head
 
-    val leftSkewThreshold = getSkewThreshold(leftMedSize)
-    val rightSkewThreshold = getSkewThreshold(rightMedSize)
-    val leftTargetSize = targetSize(leftSizes, leftSkewThreshold)
-    val rightTargetSize = targetSize(rightSizes, rightSkewThreshold)
+    // Step 1: Validate physical operators
+    // There are more and more physical operators, this whitelist is for data correctness
+    // TODO: support more operators like AggregateInPandasExec/FlatMapCoGroupsInPandasExec/etc
+    val invalidOperators = topJoin.collect {
+      case _: ShuffleQueryStageExec => None
+      case _: BroadcastQueryStageExec => None
 
-    val leftSidePartitions = mutable.ArrayBuffer.empty[ShufflePartitionSpec]
-    val rightSidePartitions = mutable.ArrayBuffer.empty[ShufflePartitionSpec]
-    var numSkewedLeft = 0
-    var numSkewedRight = 0
-    for (partitionIndex <- 0 until numPartitions) {
-      val leftSize = leftSizes(partitionIndex)
-      val isLeftSkew = canSplitLeft && leftSize > leftSkewThreshold
-      val rightSize = rightSizes(partitionIndex)
-      val isRightSkew = canSplitRight && rightSize > rightSkewThreshold
-      val leftNoSkewPartitionSpec =
-        Seq(CoalescedPartitionSpec(partitionIndex, partitionIndex + 1, leftSize))
-      val rightNoSkewPartitionSpec =
-        Seq(CoalescedPartitionSpec(partitionIndex, partitionIndex + 1, rightSize))
+      case _: SortMergeJoinExec => None
+      case _: ShuffledHashJoinExec => None
+      case _: BroadcastHashJoinExec => None
+      case _: BroadcastNestedLoopJoinExec => None
+      case _: CartesianProductExec => None
 
-      val leftParts = if (isLeftSkew) {
-        val skewSpecs = ShufflePartitionsUtil.createSkewPartitionSpecs(
-          left.mapStats.get.shuffleId, partitionIndex, leftTargetSize)
-        if (skewSpecs.isDefined) {
-          logDebug(s"Left side partition $partitionIndex " +
-            s"(${FileUtils.byteCountToDisplaySize(leftSize)}) is skewed, " +
-            s"split it into ${skewSpecs.get.length} parts.")
-          numSkewedLeft += 1
+      case _: ObjectHashAggregateExec => None
+      case _: HashAggregateExec => None
+      case _: SortAggregateExec => None
+
+      case _: WindowExec => None
+
+      case _: SortExec => None
+      case _: FilterExec => None
+      case _: ProjectExec => None
+      case _: GenerateExec => None
+      case _: CollectMetricsExec => None
+      case _: WholeStageCodegenExec => None
+
+      case _: ColumnarToRowExec => None
+      case _: RowToColumnarExec => None
+
+      case _: DeserializeToObjectExec => None
+      case _: SerializeFromObjectExec => None
+
+      case _: MapElementsExec => None
+      case _: MapPartitionsExec => None
+      case _: MapPartitionsInRWithArrowExec => None
+      case _: MapInPandasExec => None
+      case _: ArrowEvalPythonExec => None
+      case _: BatchEvalPythonExec => None
+
+      case invalid => Some(invalid)
+    }.flatten
+    if (invalidOperators.nonEmpty) {
+      logDebug(s"$logPrefix: Do NOT support operators " +
+        s"${invalidOperators.map(_.nodeName).mkString("[", ", ", "]")}")
+      return plan
+    }
+
+    // Step 2: Collect all ShuffleQueryStages
+    // TODO: support Bucket Join with other types of leaves.
+    val leaves = topJoin.collectLeaves()
+    if (leaves.exists(!_.isInstanceOf[QueryStageExec])) return plan
+    val stages = leaves.filter(_.isInstanceOf[ShuffleQueryStageExec])
+    // for a N-Join stage, there should be N+1 ShuffleQueryStages.
+    if (stages.size != joins.size + 1) return plan
+    // stageId -> MapOutputStatistics
+    val stageStats = stages.flatMap {
+      case ShuffleStage(stage: ShuffleQueryStageExec) =>
+        stage.mapStats.filter(_.bytesByPartitionId.nonEmpty).map(stats => stage.id -> stats)
+      case _ => None
+    }.toMap
+    if (stageStats.size != joins.size + 1) return plan
+    val stageIds = stageStats.keysIterator.toArray
+    logDebug(s"$logPrefix: ShuffleQueryStages: ${stageIds.mkString("[", ", ", "]")}")
+    val numPartitions = stageStats.head._2.bytesByPartitionId.length
+    if (stageStats.exists(_._2.bytesByPartitionId.length != numPartitions)) return plan
+
+    // Step 3: Collect all splittable ShuffleQueryStageExecs
+    // How to determine splittable ShuffleQueryStageExecs:
+    //  0, start at the top Join node;
+    //  1, at Join node, select the splittable paths according to its JoinType;
+    //  2, at Agg/Window node, skip all its descendants;
+    //  3, all the reached leave are splittable;
+    def collectSplittableStageIds(plan: SparkPlan): Seq[Int] = plan match {
+      case stage: ShuffleQueryStageExec => Seq(stage.id)
+
+      case join: ShuffledJoin =>
+        var splittableChildren = Seq.empty[SparkPlan]
+        if (canSplitLeftSide(join.joinType)) splittableChildren :+= join.left
+        if (canSplitRightSide(join.joinType)) splittableChildren :+= join.right
+        splittableChildren.flatMap(collectSplittableStageIds)
+
+      case _: BaseAggregateExec => Seq.empty
+
+      case _: WindowExecBase => Seq.empty
+
+      case _ => plan.children.flatMap(collectSplittableStageIds)
+    }
+    val splittableStageIds = collectSplittableStageIds(topJoin)
+    logDebug(s"$logPrefix: Splittable ShuffleQueryStages: " +
+      s"${splittableStageIds.mkString("[", ", ", "]")}")
+    if (splittableStageIds.isEmpty || !splittableStageIds.forall(stageStats.contains)) return plan
+
+    // Step 4: Precompute skewThreshold and targetSize for each splittable ShuffleQueryStageExec
+    val splittableStageInfos = splittableStageIds.map { stageId =>
+      val sizes = stageStats(stageId).bytesByPartitionId
+      val medSize = Utils.median(sizes)
+      val threshold = getSkewThreshold(medSize)
+      val target = targetSize(sizes, threshold)
+      logDebug(s"$logPrefix: Optimizing ShuffleQueryStage #$stageId in " +
+        s"skew join, size info: ${getSizeInfo(medSize, sizes)}")
+      stageId -> (threshold, target)
+    }.toMap
+
+    // Step 5: Split skew partitions
+    // within each partition, find and split the splittable skew ShuffleQueryStageExecs
+    // (partitionIndex, stageId) -> skew splits
+    val skewSpecs = mutable.OpenHashMap.empty[(Int, Int), Seq[PartialReducerPartitionSpec]]
+    val partSpecs = mutable.OpenHashMap.empty[Int, Seq[PartialReducerPartitionSpec]]
+    val maxCombinations = conf.getConf(SQLConf.SKEW_JOIN_MAX_SPLITS_PER_PARTITION)
+
+    Range(0, numPartitions).foreach { partitionIndex =>
+      partSpecs.clear()
+      splittableStageInfos.foreach { case (stageId, (threshold, target)) =>
+        val stats = stageStats(stageId)
+        val size = stats.bytesByPartitionId(partitionIndex)
+        if (size > threshold) {
+          ShufflePartitionsUtil
+            .createSkewPartitionSpecs(stats.shuffleId, partitionIndex, target)
+            .foreach { splits =>
+              logDebug(s"$logPrefix: Splitting ShuffleQueryStage #$stageId: " +
+                s"partition $partitionIndex(${FileUtils.byteCountToDisplaySize(size)}) -> " +
+                s"${splits.size} splits")
+              partSpecs(stageId) = splits
+            }
         }
-        skewSpecs.getOrElse(leftNoSkewPartitionSpec)
-      } else {
-        leftNoSkewPartitionSpec
       }
 
-      val rightParts = if (isRightSkew) {
-        val skewSpecs = ShufflePartitionsUtil.createSkewPartitionSpecs(
-          right.mapStats.get.shuffleId, partitionIndex, rightTargetSize)
-        if (skewSpecs.isDefined) {
-          logDebug(s"Right side partition $partitionIndex " +
-            s"(${FileUtils.byteCountToDisplaySize(rightSize)}) is skewed, " +
-            s"split it into ${skewSpecs.get.length} parts.")
-          numSkewedRight += 1
-        }
-        skewSpecs.getOrElse(rightNoSkewPartitionSpec)
-      } else {
-        rightNoSkewPartitionSpec
+      // Handle Combinatorial Explosion.
+      val numCombinations = safeProduct(partSpecs.valuesIterator.map(_.size))
+      if (numCombinations > maxCombinations) {
+        val (splitStageIds, numSplits) = partSpecs.mapValues(_.size).toArray.unzip
+        val combinedNumSplits = combine(maxCombinations, numSplits)
+        logDebug(s"$logPrefix: partition $partitionIndex: Combinatorial Explosion! " +
+          s"Try to combine $numCombinations(${numSplits.mkString("[", ", ", "]")}) " +
+          s"to ${safeProduct(combinedNumSplits)}(${combinedNumSplits.mkString("[", ", ", "]")})")
+
+        partSpecs.clear()
+        splitStageIds.zip(combinedNumSplits)
+          .filter(_._2 > 1)
+          .foreach { case (stageId, newNumSplits) =>
+            val stats = stageStats(stageId)
+            val size = stats.bytesByPartitionId(partitionIndex)
+            // TODO: ShufflePartitionsUtil supports target number of specs
+            // simply adjust the target size to control the number of splits for now
+            val newTarget = (1.1 * size.toDouble / newNumSplits).toLong + 1L
+            ShufflePartitionsUtil
+              .createSkewPartitionSpecs(stats.shuffleId, partitionIndex, newTarget)
+              .foreach { splits =>
+                logDebug(s"$logPrefix: Re-splitting ShuffleQueryStage #$stageId: " +
+                  s"partition $partitionIndex(${FileUtils.byteCountToDisplaySize(size)}) -> " +
+                  s"${splits.size} splits")
+                partSpecs(stageId) = splits
+              }
+          }
       }
 
-      for {
-        leftSidePartition <- leftParts
-        rightSidePartition <- rightParts
-      } {
-        leftSidePartitions += leftSidePartition
-        rightSidePartitions += rightSidePartition
+      partSpecs.foreach { case (stageId, splits) => skewSpecs((partitionIndex, stageId)) = splits }
+    }
+    partSpecs.clear()
+    logDebug(s"$logPrefix: Totally ${skewSpecs.size} skew partitions found")
+    if (skewSpecs.isEmpty) return plan
+
+    // Step 6: Generate final specs
+    // within a partition, split the skew ShuffleQueryStageExecs, and duplicate others
+    def createNonSkewSpec(partitionIndex: Int, stageId: Int) = {
+      val size = stageStats(stageId).bytesByPartitionId(partitionIndex)
+      Seq(CoalescedPartitionSpec(partitionIndex, partitionIndex + 1, size))
+    }
+
+    def traverseCombinations(seqs: Seq[Seq[ShufflePartitionSpec]]) = {
+      require(seqs.nonEmpty)
+      val iter = seqs.head.iterator.map(item => Seq(item))
+      seqs.tail.foldLeft(iter)((iter, seq) => iter.flatMap(comb => seq.map(item => comb :+ item)))
+    }
+
+    val buffers = stageIds.map(_ => mutable.ArrayBuffer.empty[ShufflePartitionSpec])
+    Range(0, numPartitions).foreach { partitionIndex =>
+      val specs = stageIds.map { stageId =>
+        skewSpecs.getOrElse((partitionIndex, stageId), createNonSkewSpec(partitionIndex, stageId))
+      }
+      traverseCombinations(specs).foreach { combination =>
+        combination.indices.foreach(i => buffers(i) += combination(i))
       }
     }
-    logDebug(s"number of skewed partitions: left $numSkewedLeft, right $numSkewedRight")
-    if (numSkewedLeft > 0 || numSkewedRight > 0) {
-      Some((
-        SkewJoinChildWrapper(AQEShuffleReadExec(left, leftSidePartitions.toSeq)),
-        SkewJoinChildWrapper(AQEShuffleReadExec(right, rightSidePartitions.toSeq))
-      ))
-    } else {
-      None
+    val newSpecs = stageIds.zip(buffers.map(_.toSeq)).toMap
+
+    // Step 7: Generate final plan
+    //  0, start at the top Join node;
+    //  1, mark all Join/Agg/Window nodes skew;
+    //  2, attach new specs to ShuffleQueryStageExecs;
+    val topJoinId = topJoin.id
+    plan transform {
+      case join: ShuffledJoin if join.id == topJoinId =>
+        join transform {
+          case smj: SortMergeJoinExec => smj.copy(isSkewJoin = true)
+          case shj: ShuffledHashJoinExec => shj.copy(isSkewJoin = true)
+
+          case obj: ObjectHashAggregateExec => obj.copy(isSkew = true)
+          case hash: HashAggregateExec => hash.copy(isSkew = true)
+          case sort: SortAggregateExec => sort.copy(isSkew = true)
+
+          case win: WindowExec => win.copy(isSkew = true)
+
+          case stage: ShuffleQueryStageExec =>
+            SkewJoinChildWrapper(AQEShuffleReadExec(stage, newSpecs(stage.id)))
+        }
     }
-  }
-
-  def optimizeSkewJoin(plan: SparkPlan): SparkPlan = plan.transformUp {
-    case smj @ SortMergeJoinExec(_, _, joinType, _,
-        s1 @ SortExec(_, _, ShuffleStage(left: ShuffleQueryStageExec), _),
-        s2 @ SortExec(_, _, ShuffleStage(right: ShuffleQueryStageExec), _), false) =>
-      tryOptimizeJoinChildren(left, right, joinType).map {
-        case (newLeft, newRight) =>
-          smj.copy(
-            left = s1.copy(child = newLeft), right = s2.copy(child = newRight), isSkewJoin = true)
-      }.getOrElse(smj)
-
-    case shj @ ShuffledHashJoinExec(_, _, joinType, _, _,
-        ShuffleStage(left: ShuffleQueryStageExec),
-        ShuffleStage(right: ShuffleQueryStageExec), false) =>
-      tryOptimizeJoinChildren(left, right, joinType).map {
-        case (newLeft, newRight) =>
-          shj.copy(left = newLeft, right = newRight, isSkewJoin = true)
-      }.getOrElse(shj)
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {
@@ -222,17 +382,36 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
       return plan
     }
 
-    // We try to optimize every skewed sort-merge/shuffle-hash joins in the query plan. If this
-    // introduces extra shuffles, we give up the optimization and return the original query plan, or
-    // accept the extra shuffles if the force-apply config is true.
-    // TODO: It's possible that only one skewed join in the query plan leads to extra shuffles and
-    //       we only need to skip optimizing that join. We should make the strategy smarter here.
-    val optimized = optimizeSkewJoin(plan)
+    val shuffledJoins = plan.collect { case s: ShuffledJoin => s }
+    if (shuffledJoins.isEmpty || shuffledJoins.exists(_.isSkewJoin)) return plan
+    if (shuffledJoins.size > conf.getConf(SQLConf.SKEW_JOIN_MAX_JOINS)) {
+      logDebug(s"${shuffledJoins.size} ShuffledJoins in ${plan.nodeName} " +
+        s"exceeds threshold ${conf.getConf(SQLConf.SKEW_JOIN_MAX_JOINS)}")
+      return plan
+    }
+
+    val unions = plan.collect { case u: UnionExec => u }
+    // there should be at most one UnionExec in one stage, skip here for safety
+    if (unions.size > 1) return plan
+
+    val optimized = if (unions.size == 1) {
+      plan transform {
+        // TODO: if extra shuffle is NOT allowed, only accept children without shuffle.
+        case u @ UnionExec(children) => u.withNewChildren(children.map(optimize))
+      }
+    } else {
+      optimize(plan)
+    }
+    if (optimized.collect { case s: ShuffledJoin if s.isSkewJoin => s }.isEmpty) return plan
+
     val requirementSatisfied = if (ensureRequirements.requiredDistribution.isDefined) {
       ValidateRequirements.validate(optimized, ensureRequirements.requiredDistribution.get)
     } else {
       ValidateRequirements.validate(optimized)
     }
+    // Two cases we will apply the skewed join optimization:
+    //   1. optimize the skew join without extra shuffle
+    //   2. optimize the skew join with extra shuffle but the force-apply config is true.
     if (requirementSatisfied) {
       optimized.transform {
         case SkewJoinChildWrapper(child) => child
@@ -252,6 +431,82 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
         s.shuffle.shuffleOrigin == ENSURE_REQUIREMENTS =>
         Some(s)
       case _ => None
+    }
+  }
+}
+
+
+private[adaptive] object OptimizeSkewedJoin {
+
+  /**
+   * same as values.product, but make sure NO overflow:
+   *    Iterator(10, 20, 30, 4, 10, 2, 1, 999, 88).product -> -751,912,960
+   */
+  def safeProduct(values: TraversableOnce[Int]): BigInt = values.foldLeft(BigInt(1))(_ * _)
+
+  /**
+   * Combine splits to make sure the total number of combinations no greater than given threshold.
+   * This algorithm iteratively estimates an appropriate shrinkage factor for remaining combinable
+   * stages (with more than 1 splits), and then perform split merge. Note that it tries to keep the
+   * proportional relationship among input numbers of splits.
+   */
+  def combine(maxCombinations: Int, numSplits: Array[Int]): Array[Int] = {
+    require(maxCombinations > 0)
+    require(numSplits.nonEmpty && numSplits.forall(_ > 0))
+
+    var numCombinations = safeProduct(numSplits)
+    if (numCombinations <= maxCombinations) return numSplits
+
+    val intNumSplits = numSplits.clone()
+    val floatNumSplits = intNumSplits.map(_.toDouble)
+    var numCombinables = intNumSplits.count(_ > 1)
+
+    val maxShrinkage = 0.999
+    val minShrinkage = 0.1
+    val maxIterations = 1000 // 20 iterations should be enough in most cases, set 1000 for safety
+    var iteration = 0
+    while (numCombinations > maxCombinations && numCombinables > 0 && iteration < maxIterations) {
+      var shrinkage = math.pow(
+        (BigDecimal(maxCombinations) / BigDecimal(numCombinations)).doubleValue,
+        1.0 / numCombinables
+      )
+      if (shrinkage.isNaN) {
+        shrinkage = maxShrinkage
+      } else {
+        // clip shrinkage for numeric stability
+        shrinkage = math.min(shrinkage, maxShrinkage)
+        shrinkage = math.max(shrinkage, minShrinkage)
+      }
+
+      floatNumSplits.indices.foreach { i =>
+        floatNumSplits(i) = math.max(1.0, floatNumSplits(i) * shrinkage)
+      }
+
+      Iterator.tabulate(floatNumSplits.length) { i =>
+        val prevIntNumSplits = intNumSplits(i)
+        val currIntNumSplits = floatNumSplits(i).round.toInt
+        (i, prevIntNumSplits, currIntNumSplits)
+      }.filter { case (_, prevIntNumSplits, currIntNumSplits) =>
+        currIntNumSplits < prevIntNumSplits
+      }.toArray.sortBy { case (i, prevIntNumSplits, currIntNumSplits) =>
+        // first try small updates to numCombinations
+        (1.0 - currIntNumSplits.toDouble / prevIntNumSplits, i)
+      }.foreach { case (i, prevIntNumSplits, currIntNumSplits) =>
+        if (numCombinations > maxCombinations) {
+          intNumSplits(i) = currIntNumSplits
+          numCombinations /= prevIntNumSplits
+          numCombinations *= currIntNumSplits
+        }
+      }
+
+      numCombinables = intNumSplits.count(_ > 1)
+      iteration += 1
+    }
+
+    if (numCombinations <= maxCombinations) {
+      intNumSplits
+    } else {
+      Array.fill(numSplits.length)(1)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -53,10 +53,13 @@ case class HashAggregateExec(
     aggregateAttributes: Seq[Attribute],
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
-    child: SparkPlan)
+    child: SparkPlan,
+    override val isSkew: Boolean = false)
   extends AggregateCodegenSupport {
 
   require(Aggregate.supportsHashAggregate(aggregateBufferAttributes))
+
+  override def stringArgs: Iterator[Any] = super.stringArgs.toSeq.dropRight(1).iterator
 
   override lazy val allAttributes: AttributeSeq =
     child.output ++ aggregateBufferAttributes ++ aggregateAttributes ++

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -66,8 +66,11 @@ case class ObjectHashAggregateExec(
     aggregateAttributes: Seq[Attribute],
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
-    child: SparkPlan)
+    child: SparkPlan,
+    override val isSkew: Boolean = false)
   extends BaseAggregateExec {
+
+  override def stringArgs: Iterator[Any] = super.stringArgs.toSeq.dropRight(1).iterator
 
   override lazy val allAttributes: AttributeSeq =
     child.output ++ aggregateBufferAttributes ++ aggregateAttributes ++

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -39,9 +39,12 @@ case class SortAggregateExec(
     aggregateAttributes: Seq[Attribute],
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
-    child: SparkPlan)
+    child: SparkPlan,
+    override val isSkew: Boolean = false)
   extends AggregateCodegenSupport
   with AliasAwareOutputOrdering {
+
+  override def stringArgs: Iterator[Any] = super.stringArgs.toSeq.dropRight(1).iterator
 
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -744,7 +744,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     assert(
       executedPlan.exists {
         case WholeStageCodegenExec(
-          HashAggregateExec(_, _, _, _, _, _, _, _, _: LocalTableScanExec)) => true
+          HashAggregateExec(_, _, _, _, _, _, _, _, _: LocalTableScanExec, _)) => true
         case _ => false
       },
       "LocalTableScanExec should be within a WholeStageCodegen domain.")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2747,11 +2747,10 @@ class AdaptiveQueryExecSuite
             "UNION ALL SELECT key2 FROM skewData2 GROUP BY key2", 1, 1)
 
         // skewJoin1 union (skewJoin2 join aggregate)
-        // skewJoin2 will lead to extra shuffles, but skew1 cannot be optimized
          checkSkewJoin(
           "SELECT key1 FROM skewData1 JOIN skewData2 ON key1 = key2 UNION ALL " +
             "SELECT key1 from (SELECT key1 FROM skewData1 JOIN skewData2 ON key1 = key2) tmp1 " +
-            "JOIN (SELECT key2 FROM skewData2 GROUP BY key2) tmp2 ON key1 = key2", 3, 0)
+            "JOIN (SELECT key2 FROM skewData2 GROUP BY key2) tmp2 ON key1 = key2", 3, 3)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -849,7 +849,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("SPARK-36638: General Skew Join: 3-table join") {
+  test("SPARK-36638: Generalize OptimizeSkewedJoin - 3-table join with Window and Aggregate") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.SKEW_JOIN_ENABLED.key -> "true",
@@ -889,7 +889,7 @@ class AdaptiveQueryExecSuite
              | LEFT JOIN (SELECT key3, max(value3) AS value3 FROM skewData3 GROUP BY key3)
              | ON key1 = key3
              |""".stripMargin
-        val query = s"SELECT value1, max(row) FROM ($join) GROUP BY value1"
+        val query = s"SELECT value1, min(value3), max(row) FROM ($join) GROUP BY value1"
 
         val (_, adaptivePlan) = runAdaptiveAndVerifyResult(query)
         val joins = findTopLevelShuffledJoin(adaptivePlan)
@@ -899,7 +899,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("SPARK-36638: General Skew Join: 3-table join UNION 2-table join") {
+  test("SPARK-36638: Generalize OptimizeSkewedJoin - 3-table join UNION 2-table join") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.SKEW_JOIN_ENABLED.key -> "true",
@@ -950,7 +950,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("SPARK-36638: General Skew Join: 5-table join") {
+  test("SPARK-36638: Generalize OptimizeSkewedJoin - 5-table join") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.SKEW_JOIN_ENABLED.key -> "true",
@@ -1020,7 +1020,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("SPARK-36638: General Skew Join: combine splits to handle Combinatorial Explosion") {
+  test("SPARK-36638: Generalize OptimizeSkewedJoin - handle Combinatorial Explosion") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.SKEW_JOIN_ENABLED.key -> "true",
@@ -1073,7 +1073,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("SPARK-36638: General Skew Join: combine splits to handle Combinatorial Explosion II") {
+  test("SPARK-36638: Generalize OptimizeSkewedJoin - handle Combinatorial Explosion II") {
     import OptimizeSkewedJoin.combine
 
     val array0 = Array(511, 622) // 317,842 splits


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to generalize `OptimizeSkewedJoin` to support all patterns that can be handled by current _split-duplicate_ strategy:

1, find the _splittable_ shuffle query stages by the semantics of internal nodes;

2, for each _splittable_ shuffle query stage, check whether skew partitions exists, if true, split them into specs;

3, handle _Combinatorial Explosion_: for each skew partition, check whether the combination number is too large, if so, re-split the stages to keep a reasonable number of combinations. For example, for partition 0, stage A/B/C are split into 100/100/100 specs, respectively. Then there are 1M combinations, which is too large, and will cause performance regression.

4, attach new specs to shuffle query stages;


### Why are the changes needed?
to Generalize OptimizeSkewedJoin 


### Does this PR introduce _any_ user-facing change?
one additional config added


### How was this patch tested?
existing testsuites, added testsuites, some cases on our productive system
