### PR TITLE
[SPARK-36643][SQL] Add more information in ERROR log while SparkConf is modified when spark.sql.legacy.setCommandRejectsSparkCoreConfs is set

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2335,10 +2335,8 @@ object QueryCompilationErrors {
   def cannotModifyValueOfSparkConfigError(key: String): Throwable = {
     new AnalysisException(
       s"""
-         |Cannot modify the value of a Spark config: $key,
-         |please refer to the Spark migration documentation
-         |'https://spark.apache.org/docs/latest/sql-migration-guide.html#ddl-statements'
-         |for further details to modify the value of a Spark config.
+         |Cannot modify the value of a Spark config: $key.
+         |See also 'https://spark.apache.org/docs/latest/sql-migration-guide.html#ddl-statements'
        """.stripMargin.replaceAll("\n", " "))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2333,7 +2333,12 @@ object QueryCompilationErrors {
   }
 
   def cannotModifyValueOfSparkConfigError(key: String): Throwable = {
-    new AnalysisException(s"Cannot modify the value of a Spark config: $key")
+    new AnalysisException(
+      s"""
+      |Cannot modify the value of a Spark config: $key,
+      |please set spark.sql.legacy.setCommandRejectsSparkCoreConfs as 'false' in
+      |order to make change value of Spark config: $key .
+      """.stripMargin.replaceAll("\n", " "))
   }
 
   def commandExecutionInRunnerUnsupportedError(runner: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2336,8 +2336,9 @@ object QueryCompilationErrors {
     new AnalysisException(
       s"""
       |Cannot modify the value of a Spark config: $key,
-      |please set spark.sql.legacy.setCommandRejectsSparkCoreConfs as 'false' in
-      |order to make change value of Spark config: $key
+      |please refer to the Spark migration documentation
+      |'https://spark.apache.org/docs/latest/sql-migration-guide.html#ddl-statements'
+      |for further details to modify the value of a Spark config.
       """.stripMargin.replaceAll("\n", " "))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2335,11 +2335,11 @@ object QueryCompilationErrors {
   def cannotModifyValueOfSparkConfigError(key: String): Throwable = {
     new AnalysisException(
       s"""
-      |Cannot modify the value of a Spark config: $key,
-      |please refer to the Spark migration documentation
-      |'https://spark.apache.org/docs/latest/sql-migration-guide.html#ddl-statements'
-      |for further details to modify the value of a Spark config.
-      """.stripMargin.replaceAll("\n", " "))
+         |Cannot modify the value of a Spark config: $key,
+         |please refer to the Spark migration documentation
+         |'https://spark.apache.org/docs/latest/sql-migration-guide.html#ddl-statements'
+         |for further details to modify the value of a Spark config.
+       """.stripMargin.replaceAll("\n", " "))
   }
 
   def commandExecutionInRunnerUnsupportedError(runner: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2337,7 +2337,7 @@ object QueryCompilationErrors {
       s"""
       |Cannot modify the value of a Spark config: $key,
       |please set spark.sql.legacy.setCommandRejectsSparkCoreConfs as 'false' in
-      |order to make change value of Spark config: $key .
+      |order to make change value of Spark config: $key
       """.stripMargin.replaceAll("\n", " "))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -319,10 +319,10 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     assert(e2.message.contains("Cannot modify the value of a static config"))
   }
 
-  test("Cannot modify the value of a Spark config") {
+  /* test("Cannot modify the value of a Spark config") {
     val e1 = intercept[AnalysisException](spark.conf.set("spark.driver.host", "myhost"))
     assert(e1.message.contains("Cannot modify the value of a Spark config"))
-  }
+  } */
 
   test("SPARK-21588 SQLContext.getConf(key, null) should return null") {
     withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -205,7 +205,8 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     assert(spark.conf.get("spark.app.id") === appId, "Should not change spark core ones")
     // spark core conf w/ entry registered
     val e1 = intercept[AnalysisException](sql("RESET spark.executor.cores"))
-    assert(e1.getMessage === "Cannot modify the value of a Spark config: spark.executor.cores")
+    val str_match = "Cannot modify the value of a Spark config: spark.executor.cores"
+    assert(e1.getMessage.contains("${str_match}"))
 
     // user defined settings
     sql("SET spark.abc=xyz")

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -206,7 +206,7 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     // spark core conf w/ entry registered
     val e1 = intercept[AnalysisException](sql("RESET spark.executor.cores"))
     val str_match = "Cannot modify the value of a Spark config: spark.executor.cores"
-    assert(e1.getMessage.contains(s"${str_match}"))
+    assert(e1.getMessage.contains(str_match))
 
     // user defined settings
     sql("SET spark.abc=xyz")
@@ -320,7 +320,7 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     assert(e2.message.contains("Cannot modify the value of a static config"))
   }
 
-  test("SPARK-36643: Cannot modify the value of a Spark config") {
+  test("SPARK-36643: Show migration guide when attempting SparkConf") {
     val e1 = intercept[AnalysisException](spark.conf.set("spark.driver.host", "myhost"))
     assert(e1.message.contains("Cannot modify the value of a Spark config"))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -206,7 +206,7 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     // spark core conf w/ entry registered
     val e1 = intercept[AnalysisException](sql("RESET spark.executor.cores"))
     val str_match = "Cannot modify the value of a Spark config: spark.executor.cores"
-    assert(e1.getMessage.contains("${str_match}"))
+    assert(e1.getMessage.contains(s"${str_match}"))
 
     // user defined settings
     sql("SET spark.abc=xyz")

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -319,10 +319,10 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     assert(e2.message.contains("Cannot modify the value of a static config"))
   }
 
-  /* test("Cannot modify the value of a Spark config") {
+  test("Cannot modify the value of a Spark config") {
     val e1 = intercept[AnalysisException](spark.conf.set("spark.driver.host", "myhost"))
     assert(e1.message.contains("Cannot modify the value of a Spark config"))
-  } */
+  }
 
   test("SPARK-21588 SQLContext.getConf(key, null) should return null") {
     withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -320,7 +320,7 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     assert(e2.message.contains("Cannot modify the value of a static config"))
   }
 
-  test("Cannot modify the value of a Spark config") {
+  test("SPARK-36643: Cannot modify the value of a Spark config") {
     val e1 = intercept[AnalysisException](spark.conf.set("spark.driver.host", "myhost"))
     assert(e1.message.contains("Cannot modify the value of a Spark config"))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -322,7 +322,7 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-36643: Show migration guide when attempting SparkConf") {
     val e1 = intercept[AnalysisException](spark.conf.set("spark.driver.host", "myhost"))
-    assert(e1.message.contains("Cannot modify the value of a Spark config"))
+    assert(e1.message.contains("https://spark.apache.org/docs/latest/sql-migration-guide.html"))
   }
 
   test("SPARK-21588 SQLContext.getConf(key, null) should return null") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -319,6 +319,11 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     assert(e2.message.contains("Cannot modify the value of a static config"))
   }
 
+  test("Cannot modify the value of a Spark config") {
+    val e1 = intercept[AnalysisException](spark.conf.set("spark.driver.host", "myhost"))
+    assert(e1.message.contains("Cannot modify the value of a Spark config"))
+  }
+
   test("SPARK-21588 SQLContext.getConf(key, null) should return null") {
     withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
       assert("1" == spark.conf.get(SQLConf.SHUFFLE_PARTITIONS.key, null))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds additional information to ERROR log while SparkConf is modified when spark.sql.legacy.setCommandRejectsSparkCoreConfs is set

### Why are the changes needed?

Right now, by default sql.legacy.setCommandRejectsSparkCoreConfs is set as true in Spark 3.* versions int order to avoid changing Spark Confs. But from the error message we get confused if we can not modify/change Spark conf in Spark 3.* or not.

### Does this PR introduce any user-facing change?

Yes. Trivial change in the error messages is included

### How was this patch tested?

New Test added - SPARK-36643: Show migration guide when attempting SparkConf
