### PR TITLE
[SPARK-36644][SQL] Push down boolean column filter

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -552,6 +552,9 @@ object DataSourceStrategy
     case expressions.Literal(false, BooleanType) =>
       Some(sources.AlwaysFalse)
 
+    case e @ pushableColumn(name) if e.dataType.isInstanceOf[BooleanType] =>
+      Some(sources.EqualTo(name, true))
+
     case _ => None
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution.datasources
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.PlanTest
-import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -17,14 +17,15 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import org.apache.spark.sql.{sources, QueryTest, Row}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.sources
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class DataSourceStrategySuite extends QueryTest with SharedSparkSession {
+class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
   val attrInts = Seq(
     'cint.int,
     Symbol("c.int").int,
@@ -313,18 +314,6 @@ class DataSourceStrategySuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-36644: Push down boolean column filter") {
     testTranslateFilter('col.boolean, Some(sources.EqualTo("col", true)))
-
-    val t = "test_table"
-    withTable(t) {
-      import testImplicits._
-      Seq(Some(true), Some(false), None).toDF().write.saveAsTable(t)
-      val df = spark.table(t).where("value")
-      df.queryExecution.executedPlan.collectFirst {
-        case f: FileSourceScanExec =>
-          assert(f.metadata("PushedFilters") == "[IsNotNull(value), EqualTo(value,true)]")
-      }
-      checkAnswer(df, Row(true))
-    }
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve `DataSourceStrategy` to be able to push down boolean column filters. Currently boolean column filters do not get pushed down and may cause unnecessary IO.


### Why are the changes needed?
The following query does not push down the filter in the current implementation
```
SELECT * FROM t WHERE boolean_field
```
although the following query pushes down the filter as expected.
```
SELECT * FROM t WHERE boolean_field = true
```
This is because the Physical Planner (`DataSourceStrategy`) currently only pushes down limited expression patterns like`EqualTo`.
It is fair for Spark SQL users to expect `boolean_field` performs the same as `boolean_field = true`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added unit tests
```
build/sbt "core/testOnly *DataSourceStrategySuite   -- -z SPARK-36644"
```
