### PR TITLE
[SPARK-36655][PYTHON] Add `versionadded` for API added in Spark 3.3.0

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -7905,6 +7905,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         with non-null values from other DataFrame. The row and column indexes
         of the resulting DataFrame will be the union of the two.
 
+        .. versionadded:: 3.3.0
+
         Parameters
         ----------
         other : DataFrame


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `versionadded` for API added in Spark 3.3.0: DataFrame.combine_first.

### Why are the changes needed?
That documents the version of Spark which added the described API.

### Does this PR introduce _any_ user-facing change?
No user-facing behavior change. Only the document of the affected API shows when it's introduced.


### How was this patch tested?
Manual test.
