### PR TITLE
[SPARK-36656][SQL][TEST] CollapseProject should not collapse correlated scalar subqueries

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1929,16 +1929,16 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       checkAnswer(
         sql(
           """
-            |select c1, s, s * 10 from (
-            |  select c1, (select first(c2) from t2 where t1.c1 = t2.c1) s from t1)
+            |SELECT c1, s, s * 10 FROM (
+            |  SELECT c1, (SELECT FIRST(c2) FROM t2 WHERE t1.c1 = t2.c1) s FROM t1)
             |""".stripMargin),
         correctAnswer)
       checkAnswer(
         sql(
           """
-            |select c1, s, s * 10 from (
-            |  select c1, sum((select first(c2) from t2 where t1.c1 = t2.c1)) s
-            |  from t1 group by c1
+            |SELECT c1, s, s * 10 FROM (
+            |  SELECT c1, SUM((SELECT FIRST(c2) FROM t2 WHERE t1.c1 = t2.c1)) s
+            |  FROM t1 GROUP BY c1
             |)
             |""".stripMargin),
         correctAnswer)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1920,4 +1920,28 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         Row(0, 1) :: Row(1, 2) :: Nil)
     }
   }
+
+  test("SPARK-36656: Do not collapse projects with correlate scalar subqueries") {
+    withTempView("t1", "t2") {
+      Seq((0, 1), (1, 2)).toDF("c1", "c2").createOrReplaceTempView("t1")
+      Seq((0, 2), (0, 3)).toDF("c1", "c2").createOrReplaceTempView("t2")
+      val correctAnswer = Row(0, 2, 20) :: Row(1, null, null) :: Nil
+      checkAnswer(
+        sql(
+          """
+            |select c1, s, s * 10 from (
+            |  select c1, (select first(c2) from t2 where t1.c1 = t2.c1) s from t1)
+            |""".stripMargin),
+        correctAnswer)
+      checkAnswer(
+        sql(
+          """
+            |select c1, s, s * 10 from (
+            |  select c1, sum((select first(c2) from t2 where t1.c1 = t2.c1)) s
+            |  from t1 group by c1
+            |)
+            |""".stripMargin),
+        correctAnswer)
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The optimizer rule `CollapseProject` used to inline expressions with correlated scalar subqueries, which can lead to inefficient and invalid plans. This issue was fixed in #33958. This PR adds an additional test to verify the behavior.

### Why are the changes needed?
To make sure CollapseProject works with correlated scalar subqueries.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test. 