### PR TITLE
[SPARK-36610][PYTHON] Add `thousands` argument to `ps.read_csv`.

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -273,9 +273,6 @@ def read_csv(
         Indicates the line should not be parsed.
     thousands: str, optional
         Thousands separator.
-
-        .. note:
-
     options : dict
         All other options passed directly into Spark's data source.
 

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -411,10 +411,12 @@ def read_csv(
         index_names = []
 
     data_spark_columns = [scol_for(sdf, col) for col in column_labels.values()]
-    if thousands:
+    if thousands is not None:
+        if not isinstance(thousands, str) or len(thousands) != 1:
+            raise ValueError("Only length-1 comment characters supported")
         new_data_spark_columns = list()
         for scol in data_spark_columns:
-            scol_replaced = F.regexp_replace(scol, ",", "")
+            scol_replaced = F.regexp_replace(scol, thousands, "")
             cond = F.when(scol_replaced.isNull(), np.nan).otherwise(scol_replaced.cast("float"))
             if len(sdf.select(cond).filter(cond.isNull()).head(1)) == 0:
                 new_data_spark_columns.append(cond)

--- a/python/pyspark/pandas/tests/test_csv.py
+++ b/python/pyspark/pandas/tests/test_csv.py
@@ -118,6 +118,17 @@ class CsvTest(PandasOnSparkTestCase, TestUtils):
             """
         )
 
+    @property
+    def csv_text_with_thousands_separator(self):
+        return normalize_text(
+            """
+            name;age;job;money
+            Jorge;30;Developer;1,000,000
+            Bob;32;Developer;-20,000,000
+            Bob;29;Developer;
+            """
+        )
+
     @contextmanager
     def csv_file(self, csv):
         with self.temp_file() as tmp:
@@ -293,6 +304,14 @@ class CsvTest(PandasOnSparkTestCase, TestUtils):
             self.assert_eq(
                 ps.read_csv(fn, escapechar="ABC", escape="E"),
                 pd.read_csv(fn, escapechar="E"),
+                almost=True,
+            )
+
+    def test_read_csv_with_thousands(self):
+        with self.csv_file(self.csv_text_with_thousands_separator) as fn:
+            self.assert_eq(
+                ps.read_csv(fn, sep=";", thousands=","),
+                pd.read_csv(fn, sep=";", thousands=","),
                 almost=True,
             )
 

--- a/python/pyspark/pandas/tests/test_csv.py
+++ b/python/pyspark/pandas/tests/test_csv.py
@@ -315,6 +315,12 @@ class CsvTest(PandasOnSparkTestCase, TestUtils):
                 almost=True,
             )
 
+            self.assertRaisesRegex(
+                ValueError,
+                "Only length-1 comment characters supported",
+                lambda: ps.read_csv(fn, thousands=",,"),
+            )
+
     def test_to_csv(self):
         pdf = pd.DataFrame({"aa": [1, 2, 3], "bb": [4, 5, 6]}, index=[0, 1, 3])
         psdf = ps.DataFrame(pdf)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes adding `thousands` argument to `ps.read_csv`.

csv_file:
```csv
name;age;job;money
Jorge;30;Developer;10,000,000
Bob;32;Developer;-2,000,000
John;29;Developer;
```

before:
```python
>>> ps.read_csv(path, sep=";").money
0    10,000,000
1    -2,000,000
2          None
Name: money, dtype: object
```

after:
```python
>>> ps.read_csv(path, sep=";", thousands=",").money
0    10000000.0
1    -2000000.0
2           NaN
Name: money, dtype: float64
```

### Why are the changes needed?

We should support the API same as pandas, as much as possible.

### Does this PR introduce _any_ user-facing change?

Yes, now the `thousands` argument is supported for `ps.read_csv`.

### How was this patch tested?

Unittest