### PR TITLE
[SPARK-36662][SQL] Special timestamps support for path filters -  modifiedBefore/modifiedAfter

### DIFF
--- a/docs/sql-data-sources-generic-options.md
+++ b/docs/sql-data-sources-generic-options.md
@@ -128,11 +128,18 @@ granularity over which files may load during a Spark batch query.
 (Note that Structured Streaming file sources don't support these options.)
 
 * `modifiedBefore`: an optional timestamp to only include files with
-modification times occurring before the specified time. The provided timestamp
-must be in the following format: YYYY-MM-DDTHH:mm:ss (e.g. 2020-06-01T13:00:00)
+modification times occurring before the specified time.
 * `modifiedAfter`: an optional timestamp to only include files with
-modification times occurring after the specified time. The provided timestamp
-must be in the following format: YYYY-MM-DDTHH:mm:ss (e.g. 2020-06-01T13:00:00)
+modification times occurring after the specified time.
+
+The provided timestamp must be in the following format: YYYY-MM-DD'T'HH:mm:ss (e.g. 2020-06-01T13:00:00),
+or special values that are converted to ordinary timestamp values when read.
+The following string values are supported for special timestamp values:
+* `epoch` - 1970-01-01 00:00:00+00 (Unix system time zero)
+* `today` - midnight today
+* `yesterday` - midnight yesterday
+* `tomorrow` - midnight tomorrow
+* `now` - current query start time
 
 When a timezone option is not provided, the timestamps will be interpreted according
 to the Spark session timezone (`spark.sql.session.timeZone`).

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2146,7 +2146,8 @@ object QueryCompilationErrors {
       strategy: String, timeString: String): Throwable = {
     new AnalysisException(
       s"The timestamp provided for the '$strategy' option is invalid. The expected format " +
-        s"is 'YYYY-MM-DDTHH:mm:ss', but the provided timestamp: $timeString")
+        "is 'YYYY-MM-DD'T'HH:mm:ss' or special values like 'today', 'tomorrow', but the provided " +
+        s"timestamp: $timeString")
   }
 
   def hostOptionNotSetError(): Throwable = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/pathFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/pathFilters.scala
@@ -89,10 +89,13 @@ object ModifiedDateFilter {
 
   def toThreshold(timeString: String, timeZoneId: String, strategy: String): Long = {
     val timeZone: TimeZone = DateTimeUtils.getTimeZone(timeZoneId)
+    val zoneId = timeZone.toZoneId
     val ts = UTF8String.fromString(timeString)
-    DateTimeUtils.stringToTimestamp(ts, timeZone.toZoneId).getOrElse {
-      throw QueryCompilationErrors.invalidTimestampProvidedForStrategyError(strategy, timeString)
-    }
+    DateTimeUtils.convertSpecialTimestamp(timeString, zoneId)
+      .orElse(DateTimeUtils.stringToTimestamp(ts, zoneId))
+      .getOrElse {
+        throw QueryCompilationErrors.invalidTimestampProvidedForStrategyError(strategy, timeString)
+      }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PathFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PathFilterSuite.scala
@@ -226,12 +226,10 @@ class PathFilterSuite extends QueryTest with SharedSparkSession {
     withTempPath { path =>
       val dataDir = path.getCanonicalPath
       Seq("foo").toDS().write.text(dataDir)
-      val df = spark.read.option("modifiedbefore", "yesterday").text(dataDir)
-      assert(df.isEmpty)
-
-      // Both glob pattern in option and path should be effective to filter files.
-      val df2 = spark.read.option("modifiedbefore", "tomorrow").text(dataDir)
-      checkAnswer(df2, Row("foo"))
+      assert(spark.read.option("modifiedbefore", "yesterday").text(dataDir).isEmpty)
+      assert(spark.read.option("modifiedAfter", "tomorrow").text(dataDir).isEmpty)
+      checkAnswer(spark.read.option("modifiedbefore", "tomorrow").text(dataDir), Row("foo"))
+      checkAnswer(spark.read.option("modifiedAfter", "yesterday").text(dataDir), Row("foo"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PathFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PathFilterSuite.scala
@@ -222,6 +222,19 @@ class PathFilterSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("SPARK-36662: special timestamps support for path filters -  modifiedBefore/modifiedAfter") {
+    withTempPath { path =>
+      val dataDir = path.getCanonicalPath
+      Seq("foo").toDS().write.text(dataDir)
+      val df = spark.read.option("modifiedbefore", "yesterday").text(dataDir)
+      assert(df.isEmpty)
+
+      // Both glob pattern in option and path should be effective to filter files.
+      val df2 = spark.read.option("modifiedbefore", "tomorrow").text(dataDir)
+      checkAnswer(df2, Row("foo"))
+    }
+  }
+
   private def executeTest(
       dir: File,
       fileDates: Seq[LocalDateTime],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Special timestamps support for path filters -  modifiedBefore/modifiedAfter

- epoch
- now
- today
- tomorrow
- yesterday
#### examples

```scala
    val beforeTodayDF = spark.read.format("parquet")
      // Files modified after the midnight of today are allowed
      .option("modifiedBefore", "today")
      .load("examples/src/main/resources/dir1");
    beforeTodayDF.show();
    // +-------------+
    // |         file|
    // +-------------+
    // |file1.parquet|
    // +-------------+
    val afterYesterdayDF = spark.read.format("parquet")
      // Files modified after the midnight of yesterday are allowed
      .option("modifiedAfter", "yesterday")
      .load("examples/src/main/resources/dir1");
    afterYesterdayDF.show();
    // +-------------+
    // |         file|
    // +-------------+
    // +-------------+
    // $example off:load_with_modified_time_filter$
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

theses special values can be useful to be supported in path filters -  modifiedBefore/modifiedAfter. e.g. for daily scheduled jobs

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, special timestamps are supported by modifiedBefore/modifiedAfter

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

newly added tests