### PR TITLE
[SPARK-36622][CORE] Making spark.history.kerberos.principal _HOST compliant

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -32,7 +32,7 @@ import com.google.common.primitives.Longs
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.hadoop.mapred.JobConf
-import org.apache.hadoop.security.{SecurityUtil}
+import org.apache.hadoop.security.SecurityUtil
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 import org.apache.hadoop.security.token.{Token, TokenIdentifier}
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -149,7 +149,6 @@ private[spark] class SparkHadoopUtil extends Logging {
   }
 
   /**
-   *
    * @param principalName : History server principal name with _HOST
    * @return : _HOST pattern replace with Server cannonical name
    */

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -32,6 +32,7 @@ import com.google.common.primitives.Longs
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.hadoop.mapred.JobConf
+import org.apache.hadoop.security.{SecurityUtil}
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 import org.apache.hadoop.security.token.{Token, TokenIdentifier}
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier
@@ -145,6 +146,15 @@ private[spark] class SparkHadoopUtil extends Logging {
         s"using principal: ${principalName} and keytab: ${keytabFilename}")
       UserGroupInformation.loginUserFromKeytab(principalName, keytabFilename)
     }
+  }
+
+  /**
+   *
+   * @param principalName : History server principal name with _HOST
+   * @return : _HOST pattern replace with Server cannonical name
+   */
+  def getServerPrincipal(principalName: String): String = {
+    SecurityUtil.getServerPrincipal(principalName, "")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -345,8 +345,9 @@ object HistoryServer extends Logging {
     // occur from the keytab.
     if (conf.get(History.KERBEROS_ENABLED)) {
       // if you have enabled kerberos the following 2 params must be set
-      val principalName = conf.get(History.KERBEROS_PRINCIPAL)
-        .getOrElse(throw new NoSuchElementException(History.KERBEROS_PRINCIPAL.key))
+      val principalName = SparkHadoopUtil.get.getServerPrincipal(conf
+        .get(History.KERBEROS_PRINCIPAL)
+        .getOrElse(throw new NoSuchElementException(History.KERBEROS_PRINCIPAL.key)))
       val keytabFilename = conf.get(History.KERBEROS_KEYTAB)
         .getOrElse(throw new NoSuchElementException(History.KERBEROS_KEYTAB.key))
       SparkHadoopUtil.get.loginUserFromKeytab(principalName, keytabFilename)

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -85,13 +85,12 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
   /**
    * test for _HOST pattern replacement with Server cannonical address
    */
-  test("server principal with _HOST pattern") {
+  test("SPARK-36622: server principal with _HOST pattern") {
     assert(SparkHadoopUtil.get.getServerPrincipal("spark/_HOST@realm.com")
-      === "spark/%s@realm.com".format(InetAddress.getLocalHost.getCanonicalHostName())
-      , s"Mismatch in expected value")
+      === "spark/%s@realm.com".format(InetAddress.getLocalHost.getCanonicalHostName()),
+      "Mismatch in expected value")
     assert(SparkHadoopUtil.get.getServerPrincipal("spark/0.0.0.0@realm.com")
-      === "spark/0.0.0.0@realm.com".format(InetAddress.getLocalHost.getCanonicalHostName())
-      , s"Mismatch in expected value")
+      === "spark/0.0.0.0@realm.com", "Mismatch in expected value")
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.deploy
 
+import java.net.InetAddress
+
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -78,6 +80,18 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
     new SparkHadoopUtil().appendSparkHadoopConfigs(sc, hadoopConf)
     // the endpoint value will not have been set
     assertConfigValue(hadoopConf, "fs.s3a.endpoint", null)
+  }
+
+  /**
+   * test for _HOST pattern replacement with Server cannonical address
+   */
+  test("server principal with _HOST pattern") {
+    assert(SparkHadoopUtil.get.getServerPrincipal("spark/_HOST@realm.com")
+      === "spark/%s@realm.com".format(InetAddress.getLocalHost.getCanonicalHostName())
+      , s"Mismatch in expected value")
+    assert(SparkHadoopUtil.get.getServerPrincipal("spark/0.0.0.0@realm.com")
+      === "spark/0.0.0.0@realm.com".format(InetAddress.getLocalHost.getCanonicalHostName())
+      , s"Mismatch in expected value")
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
spark.history.kerberos.principal can have _HOST , which will be replaced by host canonical address

### Why are the changes needed?
This change is required for user to provide prinicipal _HOST complaint . User don't need to hardcode the History server URL . This is in line with Hiveserver2, livy server and other hadoop components.  

### Does this PR introduce _any_ user-facing change?

Yes, users can now add _HOST in the spark.history.kerberos.principal

### How was this patch tested?

unit tests/local testing

