### PR TITLE
[SPARK-34952][SQL][FOLLOWUP] Change column type to be NamedReference

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/Aggregation.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/Aggregation.java
@@ -20,7 +20,7 @@ package org.apache.spark.sql.connector.expressions.aggregate;
 import java.io.Serializable;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
  * Aggregation in SQL statement.
@@ -30,14 +30,14 @@ import org.apache.spark.sql.connector.expressions.FieldReference;
 @Evolving
 public final class Aggregation implements Serializable {
   private final AggregateFunc[] aggregateExpressions;
-  private final FieldReference[] groupByColumns;
+  private final NamedReference[] groupByColumns;
 
-  public Aggregation(AggregateFunc[] aggregateExpressions, FieldReference[] groupByColumns) {
+  public Aggregation(AggregateFunc[] aggregateExpressions, NamedReference[] groupByColumns) {
     this.aggregateExpressions = aggregateExpressions;
     this.groupByColumns = groupByColumns;
   }
 
   public AggregateFunc[] aggregateExpressions() { return aggregateExpressions; }
 
-  public FieldReference[] groupByColumns() { return groupByColumns; }
+  public NamedReference[] groupByColumns() { return groupByColumns; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/Count.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/Count.java
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector.expressions.aggregate;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
  * An aggregate function that returns the number of the specific row in a group.
@@ -27,15 +27,15 @@ import org.apache.spark.sql.connector.expressions.FieldReference;
  */
 @Evolving
 public final class Count implements AggregateFunc {
-  private final FieldReference column;
+  private final NamedReference column;
   private final boolean isDistinct;
 
-  public Count(FieldReference column, boolean isDistinct) {
+  public Count(NamedReference column, boolean isDistinct) {
     this.column = column;
     this.isDistinct = isDistinct;
   }
 
-  public FieldReference column() { return column; }
+  public NamedReference column() { return column; }
   public boolean isDistinct() { return isDistinct; }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/Max.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/Max.java
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector.expressions.aggregate;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
  * An aggregate function that returns the maximum value in a group.
@@ -27,11 +27,11 @@ import org.apache.spark.sql.connector.expressions.FieldReference;
  */
 @Evolving
 public final class Max implements AggregateFunc {
-  private final FieldReference column;
+  private final NamedReference column;
 
-  public Max(FieldReference column) { this.column = column; }
+  public Max(NamedReference column) { this.column = column; }
 
-  public FieldReference column() { return column; }
+  public NamedReference column() { return column; }
 
   @Override
   public String toString() { return "MAX(" + column.describe() + ")"; }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/Min.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/Min.java
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector.expressions.aggregate;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
  * An aggregate function that returns the minimum value in a group.
@@ -27,11 +27,11 @@ import org.apache.spark.sql.connector.expressions.FieldReference;
  */
 @Evolving
 public final class Min implements AggregateFunc {
-  private final FieldReference column;
+  private final NamedReference column;
 
-  public Min(FieldReference column) { this.column = column; }
+  public Min(NamedReference column) { this.column = column; }
 
-  public FieldReference column() { return column; }
+  public NamedReference column() { return column; }
 
   @Override
   public String toString() { return "MIN(" + column.describe() + ")"; }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/Sum.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/Sum.java
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector.expressions.aggregate;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
  * An aggregate function that returns the summation of all the values in a group.
@@ -27,15 +27,15 @@ import org.apache.spark.sql.connector.expressions.FieldReference;
  */
 @Evolving
 public final class Sum implements AggregateFunc {
-  private final FieldReference column;
+  private final NamedReference column;
   private final boolean isDistinct;
 
-  public Sum(FieldReference column, boolean isDistinct) {
+  public Sum(NamedReference column, boolean isDistinct) {
     this.column = column;
     this.isDistinct = isDistinct;
   }
 
-  public FieldReference column() { return column; }
+  public NamedReference column() { return column; }
   public boolean isDistinct() { return isDistinct; }
 
   @Override

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -705,20 +705,19 @@ object DataSourceStrategy
     if (aggregates.filter.isEmpty) {
       aggregates.aggregateFunction match {
         case aggregate.Min(PushableColumnWithoutNestedColumn(name)) =>
-          Some(new Min(FieldReference(name).asInstanceOf[FieldReference]))
+          Some(new Min(FieldReference(name)))
         case aggregate.Max(PushableColumnWithoutNestedColumn(name)) =>
-          Some(new Max(FieldReference(name).asInstanceOf[FieldReference]))
+          Some(new Max(FieldReference(name)))
         case count: aggregate.Count if count.children.length == 1 =>
           count.children.head match {
             // SELECT COUNT(*) FROM table is translated to SELECT 1 FROM table
             case Literal(_, _) => Some(new CountStar())
             case PushableColumnWithoutNestedColumn(name) =>
-              Some(new Count(FieldReference(name).asInstanceOf[FieldReference],
-                aggregates.isDistinct))
+              Some(new Count(FieldReference(name), aggregates.isDistinct))
             case _ => None
           }
         case sum @ aggregate.Sum(PushableColumnWithoutNestedColumn(name), _) =>
-          Some(new Sum(FieldReference(name).asInstanceOf[FieldReference], aggregates.isDistinct))
+          Some(new Sum(FieldReference(name), aggregates.isDistinct))
         case _ => None
       }
     } else {


### PR DESCRIPTION

### What changes were proposed in this pull request?
Currently, we have `FieldReference` for aggregate column type, should be `NamedReference` instead


### Why are the changes needed?
`FieldReference` is a private class, should use `NamedReference` instead


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing tests
