### PR TITLE
[SPARK-36618][PYTHON] Support dropping rows of a single-indexed DataFrame

### DIFF
--- a/python/docs/source/migration_guide/pyspark_3.2_to_3.3.rst
+++ b/python/docs/source/migration_guide/pyspark_3.2_to_3.3.rst
@@ -1,0 +1,23 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+=================================
+Upgrading from PySpark 3.2 to 3.3
+=================================
+
+* In Spark 3.3, the ``drop`` method of pandas API on Spark DataFrame supports dropping rows by ``index``, and sets dropping by index instead of column by default.

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6737,7 +6737,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     if internal.index_level == 1:
                         internal = internal.resolved_copy
 
-                        if len(index) <= 80:
+                        if len(index) <= ps.get_option("compute.isin_limit"):
                             self_index_type = self.index.to_series().spark.data_type
                             cond = ~internal.index_spark_columns[0].isin(
                                 [SF.lit(label).cast(self_index_type) for label in index]

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6631,23 +6631,25 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def drop(
         self,
         labels: Optional[Union[Name, List[Name]]] = None,
-        axis: Axis = 1,
+        axis: Optional[Axis] = 0,
+        index: Union[Name, List[Name]] = None,
         columns: Union[Name, List[Name]] = None,
     ) -> "DataFrame":
         """
         Drop specified labels from columns.
 
-        Remove columns by specifying label names and axis=1 or columns.
-        When specifying both labels and columns, only labels will be dropped.
-        Removing rows is yet to be implemented.
+        Remove rows or columns by specifying label names and corresponding axis,
+        or by specifying directly index or column names.
+        Drop rows of a MultiIndex DataFrame is not supported yet.
 
         Parameters
         ----------
         labels : single label or list-like
             Column labels to drop.
-        axis : {1 or 'columns'}, default 1
-            .. dropna currently only works for axis=1 'columns'
-               axis=0 is yet to be implemented.
+        axis : {0 or 'index', 1 or 'columns'}, default 0
+        index : single label or list-like
+            Alternative to specifying axis (``labels, axis=0``
+            is quivalent to ``index=columns``).
         columns : single label or list-like
             Alternative to specifying axis (``labels, axis=1``
             is equivalent to ``columns=labels``).
@@ -6662,29 +6664,34 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Examples
         --------
-        >>> df = ps.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
-        ...                   columns=['x', 'y', 'z', 'w'])
+        >>> df = ps.DataFrame(np.arange(12).reshape(3, 4), columns=['A', 'B', 'C', 'D'])
         >>> df
-           x  y  z  w
-        0  1  3  5  7
-        1  2  4  6  8
+           A  B   C   D
+        0  0  1   2   3
+        1  4  5   6   7
+        2  8  9  10  11
 
-        >>> df.drop('x', axis=1)
-           y  z  w
-        0  3  5  7
-        1  4  6  8
+        Drop columns
 
-        >>> df.drop(['y', 'z'], axis=1)
-           x  w
-        0  1  7
-        1  2  8
+        >>> df.drop(['B', 'C'], axis=1)
+           A   D
+        0  0   3
+        1  4   7
+        2  8  11
 
-        >>> df.drop(columns=['y', 'z'])
-           x  w
-        0  1  7
-        1  2  8
+        >>> df.drop(columns=['B', 'C'])
+           A   D
+        0  0   3
+        1  4   7
+        2  8  11
 
-        Also support for MultiIndex
+        Drop a row by index
+
+        >>> df.drop([0, 1])
+           A  B   C   D
+        2  8  9  10  11
+
+        Also support dropping columns for MultiIndex
 
         >>> df = ps.DataFrame({'x': [1, 2], 'y': [3, 4], 'z': [5, 6], 'w': [7, 8]},
         ...                   columns=['x', 'y', 'z', 'w'])
@@ -6695,7 +6702,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
            x  y  z  w
         0  1  3  5  7
         1  2  4  6  8
-        >>> df.drop('a')  # doctest: +NORMALIZE_WHITESPACE
+        >>> df.drop(labels='a', axis=1)  # doctest: +NORMALIZE_WHITESPACE
            b
            z  w
         0  5  7
@@ -6703,14 +6710,29 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Notes
         -----
-        Currently only axis = 1 is supported in this function,
-        axis = 0 is yet to be implemented.
+        Currently, dropping rows of a MultiIndex DataFrame is not supported yet.
         """
         if labels is not None:
             axis = validate_axis(axis)
             if axis == 1:
                 return self.drop(columns=labels)
-            raise NotImplementedError("Drop currently only works for axis=1")
+            else:
+                return self.drop(index=labels)
+        elif index is not None:
+            if is_name_like_tuple(index) or is_name_like_value(index):
+                index = [index]
+
+            index_scols = self._internal.index_spark_columns
+            if len(index_scols) == 1:
+                col = None
+                for label in index:
+                    if col is None:
+                        col = index_scols[0] != SF.lit(label)
+                    else:
+                        col = col & (index_scols[0] != SF.lit(label))
+                return DataFrame(self._internal.with_filter(col))
+            else:
+                raise NotImplementedError("Drop rows of MultiIndex DataFrame is not supported yet")
         elif columns is not None:
             if is_name_like_tuple(columns):
                 columns = [columns]
@@ -6741,7 +6763,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             internal = self._internal.with_new_columns([self._psser_for(label) for label in labels])
             return DataFrame(internal)
         else:
-            raise ValueError("Need to specify at least one of 'labels' or 'columns'")
+            raise ValueError("Need to specify at least one of 'labels' or 'columns' or 'index'")
 
     def _sort(
         self, by: List[Column], ascending: Union[bool, List[bool]], na_position: str

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6647,9 +6647,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         labels : single label or list-like
             Column labels to drop.
         axis : {0 or 'index', 1 or 'columns'}, default 0
+
+            .. versionchanged:: 3.3
+               Set dropping by index by default.
         index : single label or list-like
             Alternative to specifying axis (``labels, axis=0``
             is quivalent to ``index=columns``).
+
+            .. versionchanged:: 3.3
+               Added dropping rows by 'index'.
         columns : single label or list-like
             Alternative to specifying axis (``labels, axis=1``
             is equivalent to ``columns=labels``).

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6744,7 +6744,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         internal = internal.resolved_copy
 
                         if len(index) <= ps.get_option("compute.isin_limit"):
-                            self_index_type = self.index.to_series().spark.data_type
+                            self_index_type = self.index.spark.data_type
                             cond = ~internal.index_spark_columns[0].isin(
                                 [SF.lit(label).cast(self_index_type) for label in index]
                             )

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6750,8 +6750,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                             )
                             joined_sdf = internal.spark_frame.join(
                                 other=F.broadcast(index_sdf),
-                                on=internal.index_spark_columns[0]
-                                == scol_for(index_sdf, index_sdf_col),
+                                on=(
+                                    internal.index_spark_columns[0]
+                                    == scol_for(index_sdf, index_sdf_col)
+                                ),
                                 how="anti",
                             )
                             internal = internal.with_new_sdf(joined_sdf)

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -2862,7 +2862,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3       NaN
         """
         result = self[item]
-        self._update_internal_frame(self.drop(item)._internal)
+        self._update_internal_frame(self.drop(columns=item)._internal)
         return result
 
     # TODO: add axis parameter can work when '1' or 'columns'

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -594,7 +594,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                     psdf[temp_key_col] = key
                 if isinstance(value, Series):
                     psdf[temp_value_col] = value
-                psdf = psdf.sort_values(temp_natural_order).drop(temp_natural_order)
+                psdf = psdf.sort_values(temp_natural_order).drop(columns=temp_natural_order)
 
                 psser = psdf._psser_for(column_label)
                 if isinstance(key, Series):
@@ -686,7 +686,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                     psdf[temp_key_col] = rows_sel
                 if isinstance(value, Series):
                     psdf[temp_value_col] = value
-                psdf = psdf.sort_values(temp_natural_order).drop(temp_natural_order)
+                psdf = psdf.sort_values(temp_natural_order).drop(columns=temp_natural_order)
 
                 if isinstance(rows_sel, Series):
                     rows_sel = F.col(

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1316,11 +1316,19 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             psdf.drop(labels=["A", "B", "C"], axis=0), pdf.drop(labels=["A", "B", "C"], axis=0)
         )
 
+        with ps.option_context("compute.isin_limit", 2):
+            self.assert_eq(
+                psdf.drop(labels=["A", "B", "C"], axis=0), pdf.drop(labels=["A", "B", "C"], axis=0)
+            )
+
         # Given index
         self.assert_eq(psdf.drop(index="A"), pdf.drop(index="A"))
         self.assert_eq(psdf.drop(index=["A", "C"]), pdf.drop(index=["A", "C"]))
         self.assert_eq(psdf.drop(index=["A", "B", "C"]), pdf.drop(index=["A", "B", "C"]))
         self.assert_eq(psdf.drop(index=[]), pdf.drop(index=[]))
+
+        with ps.option_context("compute.isin_limit", 2):
+            self.assert_eq(psdf.drop(index=["A", "B", "C"]), pdf.drop(index=["A", "B", "C"]))
 
         # Non-string names
         pdf.index = [10, 20, 30]
@@ -1330,6 +1338,11 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(
             psdf.drop(labels=[10, 20, 30], axis=0), pdf.drop(labels=[10, 20, 30], axis=0)
         )
+
+        with ps.option_context("compute.isin_limit", 2):
+            self.assert_eq(
+                psdf.drop(labels=[10, 20, 30], axis=0), pdf.drop(labels=[10, 20, 30], axis=0)
+            )
 
         # MultiIndex
         pdf.index = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
@@ -1350,6 +1363,11 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             psdf.drop(index=["A", "B", "C"], columns=["X", "Z"]),
             pdf.drop(index=["A", "B", "C"], columns=["X", "Z"]),
         )
+        with ps.option_context("compute.isin_limit", 2):
+            self.assert_eq(
+                psdf.drop(index=["A", "B", "C"], columns=["X", "Z"]),
+                pdf.drop(index=["A", "B", "C"], columns=["X", "Z"]),
+            )
         self.assert_eq(
             psdf.drop(index=[], columns=["X", "Z"]),
             pdf.drop(index=[], columns=["X", "Z"]),

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1269,6 +1269,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psdf.drop(columns="x"), pdf.drop(columns="x"))
         self.assert_eq(psdf.drop(columns=["y", "z"]), pdf.drop(columns=["y", "z"]))
         self.assert_eq(psdf.drop(columns=["x", "y", "z"]), pdf.drop(columns=["x", "y", "z"]))
+        self.assert_eq(psdf.drop(columns=[]), pdf.drop(columns=[]))
 
         columns = pd.MultiIndex.from_tuples([(1, "x"), (1, "y"), (2, "z")])
         pdf.columns = columns
@@ -1319,6 +1320,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psdf.drop(index="A"), pdf.drop(index="A"))
         self.assert_eq(psdf.drop(index=["A", "C"]), pdf.drop(index=["A", "C"]))
         self.assert_eq(psdf.drop(index=["A", "B", "C"]), pdf.drop(index=["A", "B", "C"]))
+        self.assert_eq(psdf.drop(index=[]), pdf.drop(index=[]))
 
         # Non-string names
         pdf.index = [10, 20, 30]
@@ -1347,6 +1349,18 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(
             psdf.drop(index=["A", "B", "C"], columns=["X", "Z"]),
             pdf.drop(index=["A", "B", "C"], columns=["X", "Z"]),
+        )
+        self.assert_eq(
+            psdf.drop(index=[], columns=["X", "Z"]),
+            pdf.drop(index=[], columns=["X", "Z"]),
+        )
+        self.assert_eq(
+            psdf.drop(index=["A", "B", "C"], columns=[]),
+            pdf.drop(index=["A", "B", "C"], columns=[]),
+        )
+        self.assert_eq(
+            psdf.drop(index=[], columns=[]),
+            pdf.drop(index=[], columns=[]),
         )
         self.assertRaises(
             ValueError,

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1328,6 +1328,25 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf = ps.from_pandas(pdf)
         self.assertRaises(NotImplementedError, lambda: psdf.drop(labels=[("a", "x")]))
 
+        #
+        # Drop rows and columns
+        #
+        pdf = pd.DataFrame({"X": [1, 2, 3], "Y": [4, 5, 6], "Z": [7, 8, 9]}, index=["A", "B", "C"])
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(psdf.drop(index="A", columns="X"), pdf.drop(index="A", columns="X"))
+        self.assert_eq(
+            psdf.drop(index=["A", "C"], columns=["X", "Z"]),
+            pdf.drop(index=["A", "C"], columns=["X", "Z"]),
+        )
+        self.assert_eq(
+            psdf.drop(index=["A", "B", "C"], columns=["X", "Z"]),
+            pdf.drop(index=["A", "B", "C"], columns=["X", "Z"]),
+        )
+        self.assertRaises(
+            ValueError,
+            lambda: psdf.drop(labels="A", axis=0, columns="X"),
+        )
+
     def _test_dropna(self, pdf, axis):
         psdf = ps.from_pandas(pdf)
 

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1255,8 +1255,13 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         with self.assertRaisesRegex(ValueError, expected_error_message):
             psdf.drop()
 
+        #
+        # Drop columns
+        #
+
         # Assert using a str for 'labels' works
         self.assert_eq(psdf.drop("x", axis=1), pdf.drop("x", axis=1))
+        self.assert_eq((psdf + 1).drop("x", axis=1), (pdf + 1).drop("x", axis=1))
         # Assert using a list for 'labels' works
         self.assert_eq(psdf.drop(["y", "z"], axis=1), pdf.drop(["y", "z"], axis=1))
         self.assert_eq(psdf.drop(["x", "y", "z"], axis=1), pdf.drop(["x", "y", "z"], axis=1))
@@ -1295,7 +1300,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psdf.drop([20, 30], axis=1), pdf.drop([20, 30], axis=1))
 
         #
-        # Drop rows by index
+        # Drop rows
         #
 
         pdf = pd.DataFrame({"X": [1, 2, 3], "Y": [4, 5, 6], "Z": [7, 8, 9]}, index=["A", "B", "C"])
@@ -1304,6 +1309,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         # Given labels (and axis = 0)
         self.assert_eq(psdf.drop(labels="A", axis=0), pdf.drop(labels="A", axis=0))
         self.assert_eq(psdf.drop(labels="A"), pdf.drop(labels="A"))
+        self.assert_eq((psdf + 1).drop(labels="A"), (pdf + 1).drop(labels="A"))
         self.assert_eq(psdf.drop(labels=["A", "C"], axis=0), pdf.drop(labels=["A", "C"], axis=0))
         self.assert_eq(
             psdf.drop(labels=["A", "B", "C"], axis=0), pdf.drop(labels=["A", "B", "C"], axis=0)

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -743,7 +743,7 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
             # 1. Check that non-percentile columns are equal.
             agg_cols = [col.name for col in psdf.groupby("a")._agg_columns]
             self.assert_eq(
-                describe_psdf.drop(list(product(agg_cols, formatted_percentiles))),
+                describe_psdf.drop(columns=list(product(agg_cols, formatted_percentiles))),
                 describe_pdf.drop(columns=formatted_percentiles, level=1),
                 check_exact=False,
             )
@@ -753,7 +753,7 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
             quantile_pdf = pdf.groupby("a").quantile(percentiles, interpolation="nearest")
             quantile_pdf = quantile_pdf.unstack(level=1).astype(float)
             self.assert_eq(
-                describe_psdf.drop(list(product(agg_cols, non_percentile_stats))),
+                describe_psdf.drop(columns=list(product(agg_cols, non_percentile_stats))),
                 quantile_pdf.rename(columns="{:.0%}".format, level=1),
             )
 
@@ -780,7 +780,7 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
         agg_column_labels = [col._column_label for col in psdf.groupby(("x", "a"))._agg_columns]
         self.assert_eq(
             describe_psdf.drop(
-                [
+                columns=[
                     tuple(list(label) + [s])
                     for label, s in product(agg_column_labels, formatted_percentiles)
                 ]
@@ -796,7 +796,7 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
 
         self.assert_eq(
             describe_psdf.drop(
-                [
+                columns=[
                     tuple(list(label) + [s])
                     for label, s in product(agg_column_labels, non_percentile_stats)
                 ]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support dropping rows of a single-indexed DataFrame.

Dropping rows and columns at the same time is supported in this PR  as well.


### Why are the changes needed?
To increase pandas API coverage.


### Does this PR introduce _any_ user-facing change?
Yes, dropping rows of a single-indexed DataFrame is supported now.

```py
>>> df = ps.DataFrame(np.arange(12).reshape(3, 4), columns=['A', 'B', 'C', 'D'])
>>> df
   A  B   C   D
0  0  1   2   3
1  4  5   6   7
2  8  9  10  11
```
#### From
```py
>>> df.drop([0, 1])
Traceback (most recent call last):
...
KeyError: [(0,), (1,)]

>>> df.drop([0, 1], axis=0)
Traceback (most recent call last):
...
NotImplementedError: Drop currently only works for axis=1

>>> df.drop(1)
Traceback (most recent call last):
...
KeyError: [(1,)]

>>> df.drop(index=1)
Traceback (most recent call last):
...
TypeError: drop() got an unexpected keyword argument 'index'

>>> df.drop(index=[0, 1], columns='A')
Traceback (most recent call last):
...
TypeError: drop() got an unexpected keyword argument 'index'
```
#### To
```py
>>> df.drop([0, 1])
   A  B   C   D
2  8  9  10  11

>>> df.drop([0, 1], axis=0)
   A  B   C   D
2  8  9  10  11

>>> df.drop(1)
   A  B   C   D
0  0  1   2   3
2  8  9  10  11

>>> df.drop(index=1)
   A  B   C   D
0  0  1   2   3
2  8  9  10  11

>>> df.drop(index=[0, 1], columns='A')
   B   C   D
2  9  10  11
```

### How was this patch tested?
Unit tests.
