### PR TITLE
[SPARK-36689][PYTHON] Cleanup the deprecated APIs and raise proper warning message.

### DIFF
--- a/python/pyspark/pandas/missing/frame.py
+++ b/python/pyspark/pandas/missing/frame.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
-
-import pandas as pd
-
 from pyspark.pandas.missing import unsupported_function, unsupported_property, common
 
 
@@ -47,12 +43,10 @@ class _MissingPandasLikeDataFrame(object):
     ewm = _unsupported_function("ewm")
     infer_objects = _unsupported_function("infer_objects")
     interpolate = _unsupported_function("interpolate")
-    lookup = _unsupported_function("lookup")
     mode = _unsupported_function("mode")
     reorder_levels = _unsupported_function("reorder_levels")
     resample = _unsupported_function("resample")
     set_axis = _unsupported_function("set_axis")
-    slice_shift = _unsupported_function("slice_shift")
     to_feather = _unsupported_function("to_feather")
     to_gbq = _unsupported_function("to_gbq")
     to_hdf = _unsupported_function("to_hdf")
@@ -60,38 +54,19 @@ class _MissingPandasLikeDataFrame(object):
     to_sql = _unsupported_function("to_sql")
     to_stata = _unsupported_function("to_stata")
     to_timestamp = _unsupported_function("to_timestamp")
-    tshift = _unsupported_function("tshift")
     tz_convert = _unsupported_function("tz_convert")
     tz_localize = _unsupported_function("tz_localize")
 
     # Deprecated functions
-    convert_objects = _unsupported_function("convert_objects", deprecated=True)
-    select = _unsupported_function("select", deprecated=True)
-    to_panel = _unsupported_function("to_panel", deprecated=True)
-    get_values = _unsupported_function("get_values", deprecated=True)
-    compound = _unsupported_function("compound", deprecated=True)
-    reindex_axis = _unsupported_function("reindex_axis", deprecated=True)
+    tshift = _unsupported_function("tshift", deprecated=True, reason="Please use shift instead.")
+    slice_shift = _unsupported_function(
+        "slice_shift", deprecated=True, reason="You can use DataFrame/Series.shift instead."
+    )
+    lookup = _unsupported_function(
+        "lookup", deprecated=True, reason="Use DataFrame.melt and DataFrame.loc instead."
+    )
 
     # Functions we won't support.
     to_pickle = common.to_pickle(_unsupported_function)
     memory_usage = common.memory_usage(_unsupported_function)
     to_xarray = common.to_xarray(_unsupported_function)
-
-    if LooseVersion(pd.__version__) < LooseVersion("1.0"):
-        # Deprecated properties
-        blocks = _unsupported_property("blocks", deprecated=True)
-        ftypes = _unsupported_property("ftypes", deprecated=True)
-        is_copy = _unsupported_property("is_copy", deprecated=True)
-        ix = _unsupported_property("ix", deprecated=True)
-
-        # Deprecated functions
-        as_blocks = _unsupported_function("as_blocks", deprecated=True)
-        as_matrix = _unsupported_function("as_matrix", deprecated=True)
-        clip_lower = _unsupported_function("clip_lower", deprecated=True)
-        clip_upper = _unsupported_function("clip_upper", deprecated=True)
-        get_ftype_counts = _unsupported_function("get_ftype_counts", deprecated=True)
-        get_value = _unsupported_function("get_value", deprecated=True)
-        set_value = _unsupported_function("set_value", deprecated=True)
-        to_dense = _unsupported_function("to_dense", deprecated=True)
-        to_sparse = _unsupported_function("to_sparse", deprecated=True)
-        to_msgpack = _unsupported_function("to_msgpack", deprecated=True)

--- a/python/pyspark/pandas/missing/indexes.py
+++ b/python/pyspark/pandas/missing/indexes.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
-
-import pandas as pd
-
 from pyspark.pandas.missing import unsupported_function, unsupported_property, common
 
 
@@ -56,7 +52,6 @@ class MissingPandasLikeIndex(object):
     get_value = _unsupported_function("get_value")
     groupby = _unsupported_function("groupby")
     is_ = _unsupported_function("is_")
-    is_lexsorted_for_tuple = _unsupported_function("is_lexsorted_for_tuple")
     join = _unsupported_function("join")
     putmask = _unsupported_function("putmask")
     ravel = _unsupported_function("ravel")
@@ -66,13 +61,12 @@ class MissingPandasLikeIndex(object):
     slice_locs = _unsupported_function("slice_locs")
     sortlevel = _unsupported_function("sortlevel")
     to_flat_index = _unsupported_function("to_flat_index")
-    to_native_types = _unsupported_function("to_native_types")
     where = _unsupported_function("where")
+    is_mixed = _unsupported_function("is_mixed")
 
     # Deprecated functions
-    is_mixed = _unsupported_function("is_mixed")
-    get_values = _unsupported_function("get_values", deprecated=True)
-    set_value = _unsupported_function("set_value")
+    set_value = _unsupported_function("set_value", deprecated=True)
+    to_native_types = _unsupported_function("to_native_types", deprecated=True)
 
     # Properties we won't support.
     array = common.array(_unsupported_property)
@@ -81,19 +75,6 @@ class MissingPandasLikeIndex(object):
     # Functions we won't support.
     memory_usage = common.memory_usage(_unsupported_function)
     __iter__ = common.__iter__(_unsupported_function)
-
-    if LooseVersion(pd.__version__) < LooseVersion("1.0"):
-        # Deprecated properties
-        strides = _unsupported_property("strides", deprecated=True)
-        data = _unsupported_property("data", deprecated=True)
-        itemsize = _unsupported_property("itemsize", deprecated=True)
-        base = _unsupported_property("base", deprecated=True)
-        flags = _unsupported_property("flags", deprecated=True)
-
-        # Deprecated functions
-        get_duplicates = _unsupported_function("get_duplicates", deprecated=True)
-        summary = _unsupported_function("summary", deprecated=True)
-        contains = _unsupported_function("contains", deprecated=True)
 
 
 class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
@@ -121,11 +102,6 @@ class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
 
 class MissingPandasLikeMultiIndex(object):
 
-    # Deprecated properties
-    strides = _unsupported_property("strides", deprecated=True)
-    data = _unsupported_property("data", deprecated=True)
-    itemsize = _unsupported_property("itemsize", deprecated=True)
-
     # Functions
     argsort = _unsupported_function("argsort")
     asof_locs = _unsupported_function("asof_locs")
@@ -143,7 +119,6 @@ class MissingPandasLikeMultiIndex(object):
     groupby = _unsupported_function("groupby")
     is_ = _unsupported_function("is_")
     is_lexsorted = _unsupported_function("is_lexsorted")
-    is_lexsorted_for_tuple = _unsupported_function("is_lexsorted_for_tuple")
     join = _unsupported_function("join")
     map = _unsupported_function("map")
     putmask = _unsupported_function("putmask")
@@ -158,15 +133,15 @@ class MissingPandasLikeMultiIndex(object):
     slice_locs = _unsupported_function("slice_locs")
     sortlevel = _unsupported_function("sortlevel")
     to_flat_index = _unsupported_function("to_flat_index")
-    to_native_types = _unsupported_function("to_native_types")
     truncate = _unsupported_function("truncate")
     where = _unsupported_function("where")
 
     # Deprecated functions
-    is_mixed = _unsupported_function("is_mixed")
-    get_duplicates = _unsupported_function("get_duplicates", deprecated=True)
-    get_values = _unsupported_function("get_values", deprecated=True)
+    is_mixed = _unsupported_function(
+        "is_mixed", deprecated=True, reason="Check index.inferred_type directly instead."
+    )
     set_value = _unsupported_function("set_value", deprecated=True)
+    to_native_types = _unsupported_function("to_native_types", deprecated=True)
 
     # Functions we won't support.
     array = common.array(_unsupported_property)
@@ -187,15 +162,3 @@ class MissingPandasLikeMultiIndex(object):
 
     # Properties we won't support.
     memory_usage = common.memory_usage(_unsupported_function)
-
-    if LooseVersion(pd.__version__) < LooseVersion("1.0"):
-        # Deprecated properties
-        base = _unsupported_property("base", deprecated=True)
-        labels = _unsupported_property("labels", deprecated=True)
-        flags = _unsupported_property("flags", deprecated=True)
-
-        # Deprecated functions
-        set_labels = _unsupported_function("set_labels")
-        summary = _unsupported_function("summary", deprecated=True)
-        to_hierarchical = _unsupported_function("to_hierarchical", deprecated=True)
-        contains = _unsupported_function("contains", deprecated=True)

--- a/python/pyspark/pandas/missing/series.py
+++ b/python/pyspark/pandas/missing/series.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
-
-import pandas as pd
-
 from pyspark.pandas.missing import unsupported_function, unsupported_property, common
 
 
@@ -47,22 +43,19 @@ class MissingPandasLikeSeries(object):
     resample = _unsupported_function("resample")
     searchsorted = _unsupported_function("searchsorted")
     set_axis = _unsupported_function("set_axis")
-    slice_shift = _unsupported_function("slice_shift")
     to_hdf = _unsupported_function("to_hdf")
     to_period = _unsupported_function("to_period")
     to_sql = _unsupported_function("to_sql")
     to_timestamp = _unsupported_function("to_timestamp")
-    tshift = _unsupported_function("tshift")
     tz_convert = _unsupported_function("tz_convert")
     tz_localize = _unsupported_function("tz_localize")
     view = _unsupported_function("view")
 
     # Deprecated functions
-    convert_objects = _unsupported_function("convert_objects", deprecated=True)
-    nonzero = _unsupported_function("nonzero", deprecated=True)
-    reindex_axis = _unsupported_function("reindex_axis", deprecated=True)
-    select = _unsupported_function("select", deprecated=True)
-    get_values = _unsupported_function("get_values", deprecated=True)
+    slice_shift = _unsupported_function(
+        "slice_shift", deprecated=True, reason="Use DataFrame/Series.shift instead."
+    )
+    tshift = _unsupported_function("slice_shift", deprecated=True, reason="Use `shift` instead.")
 
     # Properties we won't support.
     array = common.array(_unsupported_property)
@@ -84,41 +77,3 @@ class MissingPandasLikeSeries(object):
         reason="If you want to collect your flattened underlying data as an NumPy array, "
         "use 'to_numpy().ravel()' instead.",
     )
-
-    if LooseVersion(pd.__version__) < LooseVersion("1.0"):
-        # Deprecated properties
-        blocks = _unsupported_property("blocks", deprecated=True)
-        ftypes = _unsupported_property("ftypes", deprecated=True)
-        ftype = _unsupported_property("ftype", deprecated=True)
-        is_copy = _unsupported_property("is_copy", deprecated=True)
-        ix = _unsupported_property("ix", deprecated=True)
-        asobject = _unsupported_property("asobject", deprecated=True)
-        strides = _unsupported_property("strides", deprecated=True)
-        imag = _unsupported_property("imag", deprecated=True)
-        itemsize = _unsupported_property("itemsize", deprecated=True)
-        data = _unsupported_property("data", deprecated=True)
-        base = _unsupported_property("base", deprecated=True)
-        flags = _unsupported_property("flags", deprecated=True)
-
-        # Deprecated functions
-        as_blocks = _unsupported_function("as_blocks", deprecated=True)
-        as_matrix = _unsupported_function("as_matrix", deprecated=True)
-        clip_lower = _unsupported_function("clip_lower", deprecated=True)
-        clip_upper = _unsupported_function("clip_upper", deprecated=True)
-        compress = _unsupported_function("compress", deprecated=True)
-        get_ftype_counts = _unsupported_function("get_ftype_counts", deprecated=True)
-        get_value = _unsupported_function("get_value", deprecated=True)
-        set_value = _unsupported_function("set_value", deprecated=True)
-        valid = _unsupported_function("valid", deprecated=True)
-        to_dense = _unsupported_function("to_dense", deprecated=True)
-        to_sparse = _unsupported_function("to_sparse", deprecated=True)
-        to_msgpack = _unsupported_function("to_msgpack", deprecated=True)
-        compound = _unsupported_function("compound", deprecated=True)
-        put = _unsupported_function("put", deprecated=True)
-        ptp = _unsupported_function("ptp", deprecated=True)
-
-        # Functions we won't support.
-        real = _unsupported_property(
-            "real",
-            reason="If you want to collect your data as an NumPy array, use 'to_numpy()' instead.",
-        )

--- a/python/pyspark/pandas/missing/series.py
+++ b/python/pyspark/pandas/missing/series.py
@@ -55,7 +55,7 @@ class MissingPandasLikeSeries(object):
     slice_shift = _unsupported_function(
         "slice_shift", deprecated=True, reason="Use DataFrame/Series.shift instead."
     )
-    tshift = _unsupported_function("slice_shift", deprecated=True, reason="Use `shift` instead.")
+    tshift = _unsupported_function("tshift", deprecated=True, reason="Use `shift` instead.")
 
     # Properties we won't support.
     array = common.array(_unsupported_property)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes cleanup the deprecated APIs in `missing/*.py`, and raise proper warning message for the deprecated APIs such as pandas does.

Also remove the checking for pandas < 1.0, since now we only focus on following the behavior of latest pandas.

### Why are the changes needed?

We should follow the deprecation of APIs of latest pandas.

### Does this PR introduce _any_ user-facing change?

Now the some APIs raise proper alternative message for deprecated functions such as pandas does.

### How was this patch tested?

Ran `dev/lint-python` and manually check the pandas API documents one by one.