### PR TITLE
[SPARK-33781][SHUFFLE] Improve caching of MergeStatus on the executor side to save memory

### DIFF
--- a/core/benchmarks/MapStatusesSerDeserBenchmark-jdk11-results.txt
+++ b/core/benchmarks/MapStatusesSerDeserBenchmark-jdk11-results.txt
@@ -1,64 +1,64 @@
-OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 200000 MapOutputs, 10 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Serialization                                        148            164           8          1.4         739.6       1.0X
-Deserialization                                      202            303          72          1.0        1009.9       0.7X
+Serialization                                        199            211          12          1.0         995.6       1.0X
+Deserialization                                      316            412          73          0.6        1578.2       0.6X
 
 Compressed Serialized MapStatus sizes: 412 bytes
 Compressed Serialized Broadcast MapStatus sizes: 2 MB
 
 
-OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 200000 MapOutputs, 10 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         125            132           9          1.6         623.4       1.0X
-Deserialization                                       197            277          76          1.0         984.4       0.6X
+Serialization                                         167            177           7          1.2         833.0       1.0X
+Deserialization                                       315            408          73          0.6        1573.8       0.5X
 
 Compressed Serialized MapStatus sizes: 2 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
 
 
-OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 200000 MapOutputs, 100 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         260            286          17          0.8        1302.0       1.0X
-Deserialization                                       224            344         128          0.9        1121.0       1.2X
+Serialization                                         425            440          12          0.5        2127.1       1.0X
+Deserialization                                       365            478          87          0.5        1822.8       1.2X
 
 Compressed Serialized MapStatus sizes: 427 bytes
 Compressed Serialized Broadcast MapStatus sizes: 13 MB
 
 
-OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 200000 MapOutputs, 100 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                          253            272          14          0.8        1262.9       1.0X
-Deserialization                                        240            409         150          0.8        1201.0       1.1X
+Serialization                                          319            340          17          0.6        1593.7       1.0X
+Deserialization                                        316            408          94          0.6        1582.4       1.0X
 
 Compressed Serialized MapStatus sizes: 13 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
 
 
-OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 200000 MapOutputs, 1000 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                         1361           1378          24          0.1        6805.0       1.0X
-Deserialization                                        830           1022         272          0.2        4150.1       1.6X
+Serialization                                         1714           1730          23          0.1        8567.6       1.0X
+Deserialization                                        969           1012          39          0.2        4843.3       1.8X
 
 Compressed Serialized MapStatus sizes: 562 bytes
 Compressed Serialized Broadcast MapStatus sizes: 121 MB
 
 
-OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1039-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.12+7-LTS on Linux 5.8.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 200000 MapOutputs, 1000 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Serialization                                          1216           1251          51          0.2        6078.3       1.0X
-Deserialization                                         821            968         138          0.2        4105.8       1.5X
+Serialization                                          1542           1552          14          0.1        7709.0       1.0X
+Deserialization                                         922            958          55          0.2        4608.8       1.7X
 
 Compressed Serialized MapStatus sizes: 121 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes

--- a/core/benchmarks/MapStatusesSerDeserBenchmark-results.txt
+++ b/core/benchmarks/MapStatusesSerDeserBenchmark-results.txt
@@ -1,64 +1,64 @@
-OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1040-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 10 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Serialization                                        143            164          55          1.4         716.5       1.0X
-Deserialization                                      252            300          43          0.8        1262.4       0.6X
+Serialization                                        133            157          63          1.5         666.6       1.0X
+Deserialization                                      225            246          23          0.9        1127.2       0.6X
 
 Compressed Serialized MapStatus sizes: 412 bytes
 Compressed Serialized Broadcast MapStatus sizes: 2 MB
 
 
-OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1040-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 10 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         137            139           1          1.5         684.2       1.0X
-Deserialization                                       252            259          13          0.8        1259.5       0.5X
+Serialization                                         131            134           2          1.5         656.9       1.0X
+Deserialization                                       219            228          14          0.9        1095.1       0.6X
 
 Compressed Serialized MapStatus sizes: 2 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
 
 
-OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1040-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 100 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Serialization                                         279            322         116          0.7        1394.6       1.0X
-Deserialization                                       275            287          28          0.7        1372.7       1.0X
+Serialization                                         264            296          79          0.8        1320.4       1.0X
+Deserialization                                       257            306          49          0.8        1285.7       1.0X
 
 Compressed Serialized MapStatus sizes: 427 bytes
 Compressed Serialized Broadcast MapStatus sizes: 13 MB
 
 
-OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1040-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 100 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                          262            263           1          0.8        1310.3       1.0X
-Deserialization                                        274            288          22          0.7        1370.5       1.0X
+Serialization                                          247            250           4          0.8        1234.6       1.0X
+Deserialization                                        253            262           9          0.8        1267.4       1.0X
 
 Compressed Serialized MapStatus sizes: 13 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes
 
 
-OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1040-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 1000 blocks w/ broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Serialization                                         1208           1208           1          0.2        6038.4       1.0X
-Deserialization                                        555            783         394          0.4        2774.2       2.2X
+Serialization                                         1112           1493         539          0.2        5558.2       1.0X
+Deserialization                                        541            610          78          0.4        2706.2       2.1X
 
-Compressed Serialized MapStatus sizes: 562 bytes
+Compressed Serialized MapStatus sizes: 560 bytes
 Compressed Serialized Broadcast MapStatus sizes: 121 MB
 
 
-OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1039-azure
+OpenJDK 64-Bit Server VM 1.8.0_302-b08 on Linux 5.8.0-1040-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 200000 MapOutputs, 1000 blocks w/o broadcast:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Serialization                                          1097           1097           1          0.2        5484.2       1.0X
-Deserialization                                         554            596          48          0.4        2771.3       2.0X
+Serialization                                           993           1006          15          0.2        4964.4       1.0X
+Deserialization                                         502            548          52          0.4        2509.1       2.0X
 
 Compressed Serialized MapStatus sizes: 121 MB
 Compressed Serialized Broadcast MapStatus sizes: 0 bytes

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -1156,8 +1156,8 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
   // Make sure that MergeStatus reduced cache is only enabled for MergeStatus arrays that
   // use broadcast to transmit.
   if (minSizeForBroadcast > minSizeForMergeStatusReducedCache) {
-    val msg = s"spark.shuffle.mapOutput.minSizeForBroadcast ($minSizeForBroadcast bytes) must " +
-      s"be <= spark.shuffle.push.based.mergeResult.minSizeForReducedCache (" +
+    val msg = s"${SHUFFLE_MAPOUTPUT_MIN_SIZE_FOR_BROADCAST.key} ($minSizeForBroadcast bytes) " +
+      s"must be <= ${PUSH_BASED_SHUFFLE_MERGE_RESULT_MIN_SIZE_FOR_REDUCED_CACHE.key} (" +
       s"$minSizeForMergeStatusReducedCache bytes) so only broadcast MergeStatus arrays are " +
       s"using reduced cache."
     logError(msg)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2193,6 +2193,56 @@ package object config {
       // with small MB sized chunk of data.
       .createWithDefaultString("3m")
 
+<<<<<<< HEAD
+=======
+  private[spark] val PUSH_BASED_SHUFFLE_MERGE_FINALIZE_THREADS =
+    ConfigBuilder("spark.shuffle.push.merge.finalizeThreads")
+      .doc("Specify the number of threads used by DAGScheduler to finalize shuffle merge. " +
+        "Since it could potentially take seconds for a large shuffle to finalize, having " +
+        "multiple threads helps DAGScheduler to handle multiple concurrent shuffle merge " +
+        "finalize requests when push-based shuffle is enabled.")
+      .intConf
+      .createWithDefault(3)
+
+  private[spark] val PUSH_BASED_SHUFFLE_SIZE_MIN_SHUFFLE_SIZE_TO_WAIT =
+    ConfigBuilder("spark.shuffle.push.minShuffleSizeToWait")
+      .doc("The min size of total shuffle size for DAGScheduler to actually wait for merge " +
+        "finalization when push based shuffle is enabled.")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("500m")
+
+  private[spark] val PUSH_BASED_SHUFFLE_MIN_PUSH_RATIO =
+    ConfigBuilder("spark.shuffle.push.minPushRatio")
+      .doc("The min percentage of map tasks that have completed pushing their shuffle output " +
+        "for DAGScheduler to start merge finalization.")
+      .doubleConf
+      .createWithDefault(1.0)
+
+  private[spark] val PUSH_BASED_SHUFFLE_REUSE_MERGER_LOCATIONS =
+    ConfigBuilder("spark.shuffle.push.reuse.merger.locations")
+      .doc("For sibling shuffle map stages, i.e. ones that share common child stages, reusing " +
+        "merger locations between them can help to further increase shuffle locality ratio " +
+        "when push based shuffle is enabled. Examples include joins where the reduce stage " +
+        "needs to fetch shuffle data from multiple parent shuffle map stages. Set to 'true' " +
+        "to enable this feature.")
+      .booleanConf
+      .createWithDefault(true)
+
+  private[spark] val SHUFFLE_MAP_OUTPUT_MIN_SIZE_FOR_BROADCAST =
+    ConfigBuilder("spark.shuffle.mapOutput.minSizeForBroadcast")
+      .doc("The size at which we use Broadcast to send the map output statuses to the executors.")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("512k")
+
+  private[spark] val PUSH_BASED_SHUFFLE_MERGE_RESULT_MIN_SIZE_FOR_REDUCED_CACHE =
+    ConfigBuilder("spark.shuffle.push.based.mergeResult.minSizeForReducedCache")
+      .doc("If the size of the serialized MergeStatus array for a given shuffle gets larger " +
+        "than this threshold, we cache individual MergeStatus as needed instead of the entire " +
+        "MergeStatus array for this shuffle on the executor side in order to save memory.")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("5m")
+
+>>>>>>> 7fb51d7d58... LIHADOOP-56788 Improve caching of MergeStatus on the executor side
   private[spark] val JAR_IVY_REPO_PATH =
     ConfigBuilder("spark.jars.ivy")
       .doc("Path to specify the Ivy user directory, used for the local Ivy cache and " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2193,56 +2193,14 @@ package object config {
       // with small MB sized chunk of data.
       .createWithDefaultString("3m")
 
-<<<<<<< HEAD
-=======
-  private[spark] val PUSH_BASED_SHUFFLE_MERGE_FINALIZE_THREADS =
-    ConfigBuilder("spark.shuffle.push.merge.finalizeThreads")
-      .doc("Specify the number of threads used by DAGScheduler to finalize shuffle merge. " +
-        "Since it could potentially take seconds for a large shuffle to finalize, having " +
-        "multiple threads helps DAGScheduler to handle multiple concurrent shuffle merge " +
-        "finalize requests when push-based shuffle is enabled.")
-      .intConf
-      .createWithDefault(3)
-
-  private[spark] val PUSH_BASED_SHUFFLE_SIZE_MIN_SHUFFLE_SIZE_TO_WAIT =
-    ConfigBuilder("spark.shuffle.push.minShuffleSizeToWait")
-      .doc("The min size of total shuffle size for DAGScheduler to actually wait for merge " +
-        "finalization when push based shuffle is enabled.")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("500m")
-
-  private[spark] val PUSH_BASED_SHUFFLE_MIN_PUSH_RATIO =
-    ConfigBuilder("spark.shuffle.push.minPushRatio")
-      .doc("The min percentage of map tasks that have completed pushing their shuffle output " +
-        "for DAGScheduler to start merge finalization.")
-      .doubleConf
-      .createWithDefault(1.0)
-
-  private[spark] val PUSH_BASED_SHUFFLE_REUSE_MERGER_LOCATIONS =
-    ConfigBuilder("spark.shuffle.push.reuse.merger.locations")
-      .doc("For sibling shuffle map stages, i.e. ones that share common child stages, reusing " +
-        "merger locations between them can help to further increase shuffle locality ratio " +
-        "when push based shuffle is enabled. Examples include joins where the reduce stage " +
-        "needs to fetch shuffle data from multiple parent shuffle map stages. Set to 'true' " +
-        "to enable this feature.")
-      .booleanConf
-      .createWithDefault(true)
-
-  private[spark] val SHUFFLE_MAP_OUTPUT_MIN_SIZE_FOR_BROADCAST =
-    ConfigBuilder("spark.shuffle.mapOutput.minSizeForBroadcast")
-      .doc("The size at which we use Broadcast to send the map output statuses to the executors.")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("512k")
-
   private[spark] val PUSH_BASED_SHUFFLE_MERGE_RESULT_MIN_SIZE_FOR_REDUCED_CACHE =
-    ConfigBuilder("spark.shuffle.push.based.mergeResult.minSizeForReducedCache")
+    ConfigBuilder("spark.shuffle.push.mergeResult.minSizeForReducedCache")
       .doc("If the size of the serialized MergeStatus array for a given shuffle gets larger " +
         "than this threshold, we cache individual MergeStatus as needed instead of the entire " +
         "MergeStatus array for this shuffle on the executor side in order to save memory.")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("5m")
 
->>>>>>> 7fb51d7d58... LIHADOOP-56788 Improve caching of MergeStatus on the executor side
   private[spark] val JAR_IVY_REPO_PATH =
     ConfigBuilder("spark.jars.ivy")
       .doc("Path to specify the Ivy user directory, used for the local Ivy cache and " +

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -736,14 +736,14 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
-  test("cache serialized merge statuses for large result") {
+  test("SPARK-33781: cache serialized merge statuses for large result") {
     val newConf = new SparkConf
-    newConf.set("spark.shuffle.push.based.enabled", "true")
-    newConf.set("spark.shuffle.service.enabled", "true")
-    newConf.set("spark.rpc.message.maxSize", "1")
-    newConf.set("spark.rpc.askTimeout", "1") // Fail fast
-    newConf.set("spark.shuffle.mapOutput.minSizeForBroadcast", "10240") // 10 KB << 1MB framesize
-    newConf.set("spark.shuffle.push.based.mergeResult.minSizeForReducedCache", "2m")
+    newConf.set(PUSH_BASED_SHUFFLE_ENABLED, true)
+    newConf.set(IS_TESTING, true)
+    newConf.set(RPC_MESSAGE_MAX_SIZE, 1)
+    newConf.set(RPC_ASK_TIMEOUT, "1") // Fail fast
+    newConf.set(SHUFFLE_MAPOUTPUT_MIN_SIZE_FOR_BROADCAST, 10240L) // 10 KB << 1MB framesize
+    newConf.set(PUSH_BASED_SHUFFLE_MERGE_RESULT_MIN_SIZE_FOR_REDUCED_CACHE, 2097152L) // 2MB
 
     // needs TorrentBroadcast so need a SparkContext
     withSpark(new SparkContext("local", "MapOutputTrackerSuite", newConf)) { sc =>

--- a/core/src/test/scala/org/apache/spark/MapStatusesSerDeserBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/MapStatusesSerDeserBenchmark.scala
@@ -81,7 +81,7 @@ object MapStatusesSerDeserBenchmark extends BenchmarkBase {
 
     benchmark.addCase("Deserialization") { _ =>
       val result = MapOutputTracker.deserializeOutputStatuses(serializedMapStatus, sc.getConf)
-      assert(result.length == numMaps)
+      assert(result._1.length == numMaps)
     }
 
     benchmark.run()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is one of the patches for SPARK-33235: Push-based Shuffle Improvement Tasks.
At high level, in `MapOutputTrackerWorker`, if serialized `MergeStatuse` array size is larger than threshold(`spark.shuffle.push.mergeResult.minSizeForReducedCache`), cache the much more compact serialized bytes instead and only cache the deserialized `MergeStatus` objects that are needed (within `startPartitionId` until `endPartitionId`). Then deserialize the `MergeStatus` array from the cached serialized bytes again.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For large shuffles with 10s or 100s of thousands of shuffle partitions, caching the entire deserialized and decompressed MergeStatus array on the executor side, while perhaps only 0.1% of them are going to be used by the tasks running in this executor is a huge waste of memory.
This change helps save memory as well as helps with reducing GC pressure on executor side.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. This PR introduces a client-side config for push-based shuffle(`spark.shuffle.push.mergeResult.minSizeForReducedCache`). If push-based shuffle is turned-off then the users will not see any change.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit test.
Verified effectiveness with jobs that would fail due to GC issue otherwise.

Ran the benchmark using GitHub Actions and did not observe any performance penalties. The results are attached in this PR:
```
core/benchmarks/MapStatusesSerDeserBenchmark-jdk11-results.txt
core/benchmarks/MapStatusesSerDeserBenchmark-results.txt
```

Lead-authored-by: Min Shen mshen@linkedin.com
Co-authored-by: Chandni Singh chsingh@linkedin.com
Co-authored-by: Minchu Yang minyang@linkedin.com