### PR TITLE
[SPARK-36690][SS] Clean up deprecated api usage after upgrade commons-pool2 to 2.11.1

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/InternalKafkaConsumerPool.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/InternalKafkaConsumerPool.scala
@@ -18,10 +18,11 @@
 package org.apache.spark.sql.kafka010.consumer
 
 import java.{util => ju}
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 
 import org.apache.commons.pool2.{BaseKeyedPooledObjectFactory, PooledObject, SwallowedExceptionListener}
-import org.apache.commons.pool2.impl.{DefaultEvictionPolicy, DefaultPooledObject, GenericKeyedObjectPool, GenericKeyedObjectPoolConfig}
+import org.apache.commons.pool2.impl.{BaseObjectPoolConfig, DefaultEvictionPolicy, DefaultPooledObject, GenericKeyedObjectPool, GenericKeyedObjectPoolConfig}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
@@ -182,11 +183,11 @@ private[consumer] object InternalKafkaConsumerPool {
       setMaxTotal(-1)
 
       // Set minimum evictable idle time which will be referred from evictor thread
-      setMinEvictableIdleTimeMillis(minEvictableIdleTimeMillis)
-      setSoftMinEvictableIdleTimeMillis(-1)
+      setMinEvictableIdleTime(Duration.ofMillis(minEvictableIdleTimeMillis))
+      setSoftMinEvictableIdleTime(BaseObjectPoolConfig.DEFAULT_SOFT_MIN_EVICTABLE_IDLE_DURATION)
 
       // evictor thread will run test with ten idle objects
-      setTimeBetweenEvictionRunsMillis(evictorThreadRunIntervalMillis)
+      setTimeBetweenEvictionRuns(Duration.ofMillis(evictorThreadRunIntervalMillis))
       setNumTestsPerEvictionRun(10)
       setEvictionPolicy(new DefaultEvictionPolicy[InternalKafkaConsumer]())
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-36583 upgrade `Apache commons-pool2` from 2.6.2 to 2.11.1 and there are some deprecated API usage related to it that need to be cleaned up.

The list of changes is as follows:

- `BaseObjectPoolConfig.setMinEvictableIdleTimeMillis` -> `BaseObjectPoolConfig.setMinEvictableIdleTime`
- `BaseObjectPoolConfig.setSoftMinEvictableIdleTimeMillis` -> `BaseObjectPoolConfig.setSoftMinEvictableIdleTime`
- `BaseObjectPoolConfig.setTimeBetweenEvictionRunsMillis` -> `BaseObjectPoolConfig.setTimeBetweenEvictionRuns`


### Why are the changes needed?
Clean up deprecated API  usage.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA or Jenkins Tests.
