### PR TITLE
[SPARK-36692][CORE] Improve Error statement when requesting thread dump while executor already stopped

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -694,8 +694,14 @@ class SparkContext(config: SparkConf) extends Logging {
       if (executorId == SparkContext.DRIVER_IDENTIFIER) {
         Some(Utils.getThreadDump())
       } else {
-        val endpointRef = env.blockManager.master.getExecutorEndpointRef(executorId).get
-        Some(endpointRef.askSync[Array[ThreadStackTrace]](TriggerThreadDump))
+        env.blockManager.master.getExecutorEndpointRef(executorId) match {
+          case Some(endpointRef) =>
+            Some(endpointRef.askSync[Array[ThreadStackTrace]](TriggerThreadDump))
+          case None =>
+            logWarning(s"Executor $executorId might already have stopped and" +
+              s" can not request thread dump from it.")
+            None
+        }
       }
     } catch {
       case e: Exception =>

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -699,7 +699,7 @@ class SparkContext(config: SparkConf) extends Logging {
             Some(endpointRef.askSync[Array[ThreadStackTrace]](TriggerThreadDump))
           case None =>
             logWarning(s"Executor $executorId might already have stopped and" +
-              s" can not request thread dump from it.")
+              " can not request thread dump from it.")
             None
         }
       }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -698,8 +698,8 @@ class SparkContext(config: SparkConf) extends Logging {
           case Some(endpointRef) =>
             Some(endpointRef.askSync[Array[ThreadStackTrace]](TriggerThreadDump))
           case None =>
-            logWarning(s"Executor $executorId might already have stopped and" +
-              " can not request thread dump from it.")
+            logWarning(s"Executor $executorId might already have stopped and " +
+              "can not request thread dump from it.")
             None
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
For now, when user check thread dump for a executor while this executor is stopped, the error log shows following might disturb users.

![image](https://user-images.githubusercontent.com/46485123/132471501-db96894d-abe9-4d62-9943-06c578382ef2.png)



### Why are the changes needed?
Improve error message

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?


