### PR TITLE
[SPARK-36693][REPL] Implement spark-shell idle timeouts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2991,10 +2991,10 @@ External users can query the static sql config values via `SparkSession.conf` or
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr>
 <tr>
   <td><code>spark.repl.inactivityTimeout</code></td>
-  <td>0s</td>
+  <td>0ms</td>
   <td>
     Idle timeout for user input in spark-shell. The shell and the SparkContext will be closed if no new lines are
-    entered for the specified amount of time. The default value (0s) disables the feature.
+    entered for the specified amount of time. The default value (0 milliseconds) disables the feature.
   </td>
   <td>3.3.0</td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2985,6 +2985,21 @@ External users can query the static sql config values via `SparkSession.conf` or
 </tr>
 </table>
 
+### REPL
+
+<table class="table">
+<tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr>
+<tr>
+  <td><code>spark.repl.inactivityTimeout</code></td>
+  <td>0s</td>
+  <td>
+    Idle timeout for user input in spark-shell. The shell and the SparkContext will be closed if no new lines are
+    entered for the specified amount of time. The default value (0s) disables the feature.
+  </td>
+  <td>3.3.0</td>
+</tr>
+</table>
+
 ### Deploy
 
 <table class="table">

--- a/repl/src/main/scala-2.12/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala-2.12/org/apache/spark/repl/SparkILoop.scala
@@ -34,6 +34,8 @@ import scala.tools.nsc.interpreter.StdReplTags.tagOfIMain
 import scala.tools.nsc.util.stringFromStream
 import scala.util.Properties.{javaVersion, javaVmName, versionString}
 
+import org.apache.spark.repl.InactivityTimeout.{startInactivityTimer, stopInactivityTimer}
+
 /**
  *  A Spark-specific interactive shell.
  */
@@ -103,6 +105,13 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
     echo(welcomeMsg)
     echo("Type in expressions to have them evaluated.")
     echo("Type :help for more information.")
+    startInactivityTimer()
+  }
+
+  override def command(line: String): Result = {
+    stopInactivityTimer()
+    super.command(line)
+    startInactivityTimer()
   }
 
   /** Available commands */

--- a/repl/src/main/scala-2.12/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala-2.12/org/apache/spark/repl/SparkILoop.scala
@@ -110,9 +110,11 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
 
   override def processLine(line: String): Boolean = {
     inactivityTimeout.stopInactivityTimer()
-    val result = super.processLine(line)
-    inactivityTimeout.startInactivityTimer()
-    result
+    try {
+      super.processLine(line)
+    } finally {
+      inactivityTimeout.startInactivityTimer()
+    }
   }
 
   /** Available commands */

--- a/repl/src/main/scala-2.12/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala-2.12/org/apache/spark/repl/SparkILoop.scala
@@ -34,8 +34,6 @@ import scala.tools.nsc.interpreter.StdReplTags.tagOfIMain
 import scala.tools.nsc.util.stringFromStream
 import scala.util.Properties.{javaVersion, javaVmName, versionString}
 
-import org.apache.spark.repl.InactivityTimeout.{startInactivityTimer, stopInactivityTimer}
-
 /**
  *  A Spark-specific interactive shell.
  */
@@ -75,8 +73,11 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
     "import org.apache.spark.SparkContext._",
     "import spark.implicits._",
     "import spark.sql",
-    "import org.apache.spark.sql.functions._"
+    "import org.apache.spark.sql.functions._",
+    "val _timerstart = org.apache.spark.repl.Main.interp.inactivityTimeout.startInactivityTimer()"
   )
+  val inactivityTimeout = new InactivityTimeout(
+    Main.conf.getTimeAsMs(InactivityTimeout.REPL_INACTIVITY_TIMEOUT, "0ms"))
 
   def initializeSpark(): Unit = {
     if (!intp.reporter.hasErrors) {
@@ -105,13 +106,13 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
     echo(welcomeMsg)
     echo("Type in expressions to have them evaluated.")
     echo("Type :help for more information.")
-    startInactivityTimer()
   }
 
-  override def command(line: String): Result = {
-    stopInactivityTimer()
-    super.command(line)
-    startInactivityTimer()
+  override def processLine(line: String): Boolean = {
+    inactivityTimeout.stopInactivityTimer()
+    val result = super.processLine(line)
+    inactivityTimeout.startInactivityTimer()
+    result
   }
 
   /** Available commands */

--- a/repl/src/main/scala-2.13/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala-2.13/org/apache/spark/repl/SparkILoop.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.repl
 
-import org.apache.spark.repl.InactivityTimeout.{startInactivityTimer, stopInactivityTimer}
-
 import java.io.{BufferedReader, PrintWriter}
 
 // scalastyle:off println
@@ -29,6 +27,8 @@ import scala.tools.nsc.interpreter.shell.{ILoop, ShellConfig}
 import scala.tools.nsc.util.stringFromStream
 import scala.util.Properties.{javaVersion, javaVmName, versionString}
 // scalastyle:on println
+
+import org.apache.spark.repl.InactivityTimeout.{startInactivityTimer, stopInactivityTimer}
 
 /**
  *  A Spark-specific interactive shell.

--- a/repl/src/main/scala-2.13/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala-2.13/org/apache/spark/repl/SparkILoop.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.repl
 
+import org.apache.spark.repl.InactivityTimeout.{startInactivityTimer, stopInactivityTimer}
+
 import java.io.{BufferedReader, PrintWriter}
 
 // scalastyle:off println
@@ -104,6 +106,13 @@ class SparkILoop(in0: BufferedReader, out: PrintWriter)
     echo(welcomeMsg)
     echo("Type in expressions to have them evaluated.")
     echo("Type :help for more information.")
+    startInactivityTimer()
+  }
+
+  override def command(line: String): Result = {
+    stopInactivityTimer()
+    super.command(line)
+    startInactivityTimer()
   }
 
   /** Available commands */

--- a/repl/src/main/scala-2.13/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala-2.13/org/apache/spark/repl/SparkILoop.scala
@@ -111,9 +111,11 @@ class SparkILoop(in0: BufferedReader, out: PrintWriter)
 
   override def processLine(line: String): Boolean = {
     inactivityTimeout.stopInactivityTimer()
-    val result = super.processLine(line)
-    inactivityTimeout.startInactivityTimer()
-    result
+    try {
+      super.processLine(line)
+    } finally {
+      inactivityTimeout.startInactivityTimer()
+    }
   }
 
   /** Available commands */

--- a/repl/src/main/scala/org/apache/spark/repl/InactivityTimeout.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/InactivityTimeout.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.repl
+
+import java.util.{Timer, TimerTask}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.repl.Main.{conf, sparkContext}
+
+object InactivityTimeout extends Logging {
+  private[repl] var inactivityTimeoutMs = conf.getTimeAsMs("spark.repl.inactivityTimeout", "0s")
+  private[repl] var isTest: Boolean = false
+
+  private var inactivityTimer: Option[Timer] = None
+
+  private class InactivityTimerTask extends TimerTask {
+
+    override def run(): Unit = {
+      logError(s"Inactivity timeout of $inactivityTimeoutMs ms reached - closing shell")
+      if (!isTest) {
+        Option(sparkContext).foreach(_.stop)
+        System.exit(1)
+      }
+    }
+
+  }
+
+  def stopInactivityTimer(): Unit = {
+    inactivityTimer.foreach(_.cancel())
+  }
+
+  def startInactivityTimer(): Unit = {
+    if (inactivityTimeoutMs > 0) {
+      inactivityTimer.foreach(_.cancel())
+      inactivityTimer = Option(new Timer(true))
+      inactivityTimer.foreach(_.schedule(new InactivityTimerTask, inactivityTimeoutMs))
+    }
+  }
+
+}

--- a/repl/src/main/scala/org/apache/spark/repl/InactivityTimeout.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/InactivityTimeout.scala
@@ -17,10 +17,12 @@
 
 package org.apache.spark.repl
 
-import java.util.{Timer, TimerTask}
+import java.util.Timer
+import java.util.TimerTask
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.repl.Main.{conf, sparkContext}
+import org.apache.spark.repl.Main.conf
+import org.apache.spark.repl.Main.sparkContext
 
 object InactivityTimeout extends Logging {
   private[repl] var inactivityTimeoutMs = conf.getTimeAsMs("spark.repl.inactivityTimeout", "0s")
@@ -47,7 +49,7 @@ object InactivityTimeout extends Logging {
   def startInactivityTimer(): Unit = {
     if (inactivityTimeoutMs > 0) {
       inactivityTimer.foreach(_.cancel())
-      inactivityTimer = Option(new Timer(true))
+      inactivityTimer = Some(new Timer("SparkShellInactivityTimer", true))
       inactivityTimer.foreach(_.schedule(new InactivityTimerTask, inactivityTimeoutMs))
     }
   }

--- a/repl/src/main/scala/org/apache/spark/repl/InactivityTimeout.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/InactivityTimeout.scala
@@ -32,8 +32,11 @@ class InactivityTimeout(inactivityTimeoutMs: Long) extends Logging {
     override def run(): Unit = {
       logError(s"Inactivity timeout of $inactivityTimeoutMs ms reached - closing shell")
       if (!Utils.isTesting) {
-        Option(sparkContext).foreach(_.stop)
-        System.exit(1)
+        try {
+          Option(sparkContext).foreach(_.stop)
+        } finally {
+          System.exit(1)
+        }
       }
     }
   }

--- a/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -57,7 +57,9 @@ class ReplSuite extends SparkFunSuite with BeforeAndAfterAll {
 
     class SlowBufferedReader(in: Reader, readLineDelay: Long) extends BufferedReader(in) {
       override def readLine(): String = {
-        if (readLineDelay > 0) Thread.sleep(readLineDelay)
+        if (readLineDelay > 0) {
+          Thread.sleep(readLineDelay)
+        }
         super.readLine()
       }
     }

--- a/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -411,21 +411,27 @@ class ReplSuite extends SparkFunSuite with BeforeAndAfterAll {
   }
 
   test("inactivity timeout is triggered") {
-    InactivityTimeout.inactivityTimeoutMs = 500
-    InactivityTimeout.isTest = true
-    val logs = runInterpreterAndGetErrors("val a = 5 * 5", 2000)
-    assert(logs.exists(_.contains("Inactivity timeout")))
+    try {
+      Main.conf.set(InactivityTimeout.REPL_INACTIVITY_TIMEOUT, "500ms")
+      val logs = runInterpreterAndGetErrors("val a = 5 * 5", 2000)
+      assert(logs.exists(_.contains("Inactivity timeout")))
+    } finally {
+      Main.conf.remove(InactivityTimeout.REPL_INACTIVITY_TIMEOUT)
+    }
   }
 
   test("inactivity timeout does not interrupt long running command") {
-    InactivityTimeout.inactivityTimeoutMs = 500
-    InactivityTimeout.isTest = true
-    val logs = runInterpreterAndGetErrors(
-      s"""
-         |Thread.sleep(2000)
-         |val a = 5 * 5
-         |""".stripMargin,
-      10)
-    assert(!logs.exists(_.contains("Inactivity timeout")))
+    try {
+      Main.conf.set(InactivityTimeout.REPL_INACTIVITY_TIMEOUT, "500ms")
+      val logs = runInterpreterAndGetErrors(
+        s"""
+           |Thread.sleep(2000)
+           |val a = 5 * 5
+           |""".stripMargin,
+        10)
+      assert(!logs.exists(_.contains("Inactivity timeout")))
+    } finally {
+      Main.conf.remove(InactivityTimeout.REPL_INACTIVITY_TIMEOUT)
+    }
   }
 }

--- a/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -422,7 +422,7 @@ class ReplSuite extends SparkFunSuite with BeforeAndAfterAll {
 
   test("inactivity timeout does not interrupt long running command") {
     try {
-      Main.conf.set(InactivityTimeout.REPL_INACTIVITY_TIMEOUT, "500ms")
+      Main.conf.set(InactivityTimeout.REPL_INACTIVITY_TIMEOUT, "1s")
       val logs = runInterpreterAndGetErrors(
         s"""
            |Thread.sleep(2000)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a shell timeout feature via a configuration value that closes spark-shell and the context unless new lines are entered for a set amount of time.

### Why are the changes needed?

Customers have been asking for this feature because they feel like implementing session timeouts with dynamic allocation is not satisfactory and they would like to close any idle spark-shells automatically.

### Does this PR introduce _any_ user-facing change?

It adds a new config value `spark.repl.inactivityTimeout` that enables a timer for user input. Once this expires, an error is logged and the shell is closed.

### How was this patch tested?

The change was tested manually and two new unit tests have also been added.