### PR TITLE
[SPARK-36334][K8S][FOLLOWUP] Allow equal resource version to update snapshot

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsPollingSnapshotSource.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsPollingSnapshotSource.scala
@@ -67,9 +67,9 @@ private[spark] class ExecutorPodsPollingSnapshotSource(
       if (conf.get(KUBERNETES_EXECUTOR_API_POLLING_WITH_RESOURCE_VERSION)) {
         val list = pods.list(new ListOptionsBuilder().withResourceVersion("0").build())
         val newResourceVersion = UnsignedLong.valueOf(list.getMetadata.getResourceVersion())
-        // Replace only when we receive a monotonically increased resourceVersion
+        // Replace only when we receive a monotonically increased or equal resourceVersion
         // because some K8s API servers may return old(smaller) cached versions in case of HA setup.
-        if (resourceVersion == null || newResourceVersion.compareTo(resourceVersion) > 0) {
+        if (resourceVersion == null || newResourceVersion.compareTo(resourceVersion) >= 0) {
           resourceVersion = newResourceVersion
           snapshotsStore.replaceSnapshot(list.getItems.asScala.toSeq)
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to allow snapshot updates when the resource version is equal to the previous version.

### Why are the changes needed?

This will prevent the chance of timing issue when the driver may not register executors yet when the last pod update events.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A