### PR TITLE
[SPARK-36698][SQL] Allow expand 'quotedRegexColumnNames' in all expressions when it’s expanded to one named expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1714,6 +1714,11 @@ class Analyzer(override val catalogManager: CatalogManager)
             case s: Star => expand(s, child)
             case o => o :: Nil
           })
+        case s: Star =>
+          expand(s, child) match {
+            case Seq(exp) => exp
+            case _ => s
+          }
         // count(*) has been replaced by count(1)
         case o if containsStar(o.children) =>
           throw QueryCompilationErrors.invalidStarUsageError(s"expression '${o.prettyName}'",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1714,7 +1714,7 @@ class Analyzer(override val catalogManager: CatalogManager)
             case s: Star => expand(s, child)
             case o => o :: Nil
           })
-        case s: Star =>
+        case s: UnresolvedRegex =>
           expand(s, child) match {
             case Seq(exp) => exp
             case _ => s

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -854,22 +854,22 @@ class AnalysisErrorSuite extends AnalysisTest {
 
   test("SPARK-36488: Regular expression expansion should fail with a meaningful message") {
     withSQLConf(SQLConf.SUPPORT_QUOTED_REGEX_COLUMN_NAME.key -> "true") {
-      assertAnalysisError(testRelation.select(Divide(UnresolvedRegex(".?", None, false), "a")),
+      assertAnalysisError(testRelation2.select(Divide(UnresolvedRegex(".?", None, false), "a")),
         s"Invalid usage of regular expression '.?' in" :: Nil)
-      assertAnalysisError(testRelation.select(
+      assertAnalysisError(testRelation2.select(
         Divide(UnresolvedRegex(".?", None, false), UnresolvedRegex(".*", None, false))),
         s"Invalid usage of regular expressions '.?', '.*' in" :: Nil)
-      assertAnalysisError(testRelation.select(
+      assertAnalysisError(testRelation2.select(
         Divide(UnresolvedRegex(".?", None, false), UnresolvedRegex(".?", None, false))),
         s"Invalid usage of regular expression '.?' in" :: Nil)
-      assertAnalysisError(testRelation.select(Divide(UnresolvedStar(None), "a")),
+      assertAnalysisError(testRelation2.select(Divide(UnresolvedStar(None), "a")),
         "Invalid usage of '*' in" :: Nil)
-      assertAnalysisError(testRelation.select(Divide(UnresolvedStar(None), UnresolvedStar(None))),
+      assertAnalysisError(testRelation2.select(Divide(UnresolvedStar(None), UnresolvedStar(None))),
         "Invalid usage of '*' in" :: Nil)
-      assertAnalysisError(testRelation.select(Divide(UnresolvedStar(None),
+      assertAnalysisError(testRelation2.select(Divide(UnresolvedStar(None),
         UnresolvedRegex(".?", None, false))),
         "Invalid usage of '*' and regular expression '.?' in" :: Nil)
-      assertAnalysisError(testRelation.select(Least(Seq(UnresolvedStar(None),
+      assertAnalysisError(testRelation2.select(Least(Seq(UnresolvedStar(None),
         UnresolvedRegex(".*", None, false), UnresolvedRegex(".?", None, false)))),
         "Invalid usage of '*' and regular expressions '.*', '.?' in" :: Nil)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -3032,6 +3032,14 @@ class DataFrameSuite extends QueryTest
       }
     }
   }
+
+  test("SPARK-36698: Regular expressions resolve to a single named expression") {
+    withSQLConf(SQLConf.SUPPORT_QUOTED_REGEX_COLUMN_NAME.key -> "true") {
+      checkAnswer(sql("SELECT `col_.*`/exp FROM (SELECT 3 AS col_a, 1 as exp)"), Row(3) :: Nil)
+      checkAnswer(sql("SELECT `col_a`/exp FROM (SELECT 3 AS col_a, 1 as exp)"), Row(3) :: Nil)
+      checkAnswer(sql("select `col_a` as `col` from  (SELECT 3 AS col_a, 1 as exp)"), Row(3) :: Nil)
+    }
+  }
 }
 
 case class GroupByKey(a: Int, b: Int)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
With `spark.sql.parser.quotedRegexColumnNames=true` regular expressions are not allowed in expressions like  
``` SELECT `col_.*`/exp FROM (SELECT 3 AS col_a, 1 as exp) ``` 

This PR propose to improve this behavior and allow this regular expression when it expands to only one named expression. It’s the same behavior in Hive.

Example 1:
```
SELECT `col_.*`/exp FROM (SELECT 3 AS col_a, 1 as exp) 
```
col_.* expands to col_a:  OK

Example 2:
```
SELECT `col_.*`/col_b FROM (SELECT 3 AS col_a, 1 as col_b) 
```
col_.* expands to (col_a, col_b) : Fail like now

Example 3:
```
SELECT `col_a`/exp FROM (SELECT 3 AS col_a, 1 as exp) 
```
col_a expands to col_a:  OK

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve this feature and approaching hive behavior

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit testing