### PR TITLE
[SPARK-36717][CORE] Incorrect order of variable initialization may lead incorrect behavior 

### DIFF
--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -73,6 +73,10 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
   /** Size of each block. Default value is 4MB.  This value is only read by the broadcaster. */
   @transient private var blockSize: Int = _
 
+
+  /** Whether to generate checksum for blocks or not. */
+  private var checksumEnabled: Boolean = false
+
   private def setConf(conf: SparkConf): Unit = {
     compressionCodec = if (conf.get(config.BROADCAST_COMPRESS)) {
       Some(CompressionCodec.createCodec(conf))
@@ -90,8 +94,6 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
   /** Total number of blocks this broadcast variable contains. */
   private val numBlocks: Int = writeBlocks(obj)
 
-  /** Whether to generate checksum for blocks or not. */
-  private var checksumEnabled: Boolean = false
   /** The checksum for all the blocks. */
   private var checksums: Array[Int] = _
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Incorrect order of variable initialization may lead to incorrect behavior, related code: TorrentBroadcast.scala , TorrentBroadCast will get wrong checksumEnabled value after initialization, this may not be what we need, we can move L94 front of setConf(SparkEnv.get.conf) to avoid this.

Supplement:
Snippet 1
```scala
class Broadcast {
  def setConf(): Unit = {
    checksumEnabled = true
  }
  setConf()
  var checksumEnabled = false
}
println(new Broadcast().checksumEnabled)
```
output:
```scala
false
```
 Snippet 2
```scala
class Broadcast {
  var checksumEnabled = false
  def setConf(): Unit = {
    checksumEnabled = true
  }
  setConf()
}
println(new Broadcast().checksumEnabled)
```
output: 
```scala
true
```


### Why are the changes needed?
we can move L94 front of setConf(SparkEnv.get.conf) to avoid this.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No
