### PR TITLE
[SPARK-36746][PYTHON] Refactor `_select_rows_by_iterable` in `iLocIndexer` to use `Column.isin`

### DIFF
--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -1657,14 +1657,13 @@ class iLocIndexer(LocIndexerLike):
                 "however, normalised index was [%s]" % new_rows_sel
             )
 
-        sequence_scol = sdf[self._sequence_col]
-        cond = []
-        for key in new_rows_sel:
-            cond.append(sequence_scol == SF.lit(int(key)).cast(LongType()))
-
-        if len(cond) == 0:
-            cond = [SF.lit(False)]
-        return reduce(lambda x, y: x | y, cond), None, None
+        if len(new_rows_sel) == 0:
+            cond = SF.lit(False)
+        else:
+            cond = sdf[self._sequence_col].isin(
+                [SF.lit(int(key)).cast(LongType()) for key in new_rows_sel]
+            )
+        return cond, None, None
 
     def _select_rows_else(
         self, rows_sel: Any

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -1660,16 +1660,17 @@ class iLocIndexer(LocIndexerLike):
         if len(new_rows_sel) == 0:
             cond = SF.lit(False)
         else:
+
             if len(new_rows_sel) <= ps.get_option("compute.isin_limit"):
                 cond = sdf[self._sequence_col].isin(
                     [SF.lit(int(key)).cast(LongType()) for key in new_rows_sel]
                 )
             else:
-                cond = []
+                cond_list = []
                 sequence_scol = sdf[self._sequence_col]
                 for key in new_rows_sel:
-                    cond.append(sequence_scol == SF.lit(int(key)).cast(LongType()))
-                cond = reduce(lambda x, y: x | y, cond)
+                    cond_list.append(sequence_scol == SF.lit(int(key)).cast(LongType()))
+                cond = reduce(lambda x, y: x | y, cond_list)
         return cond, None, None
 
     def _select_rows_else(

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -1660,17 +1660,9 @@ class iLocIndexer(LocIndexerLike):
         if len(new_rows_sel) == 0:
             cond = SF.lit(False)
         else:
-
-            if len(new_rows_sel) <= ps.get_option("compute.isin_limit"):
-                cond = sdf[self._sequence_col].isin(
-                    [SF.lit(int(key)).cast(LongType()) for key in new_rows_sel]
-                )
-            else:
-                cond_list = []
-                sequence_scol = sdf[self._sequence_col]
-                for key in new_rows_sel:
-                    cond_list.append(sequence_scol == SF.lit(int(key)).cast(LongType()))
-                cond = reduce(lambda x, y: x | y, cond_list)
+            cond = sdf[self._sequence_col].isin(
+                [SF.lit(int(key)).cast(LongType()) for key in new_rows_sel]
+            )
         return cond, None, None
 
     def _select_rows_else(

--- a/python/pyspark/pandas/tests/test_indexing.py
+++ b/python/pyspark/pandas/tests/test_indexing.py
@@ -994,26 +994,6 @@ class IndexingTest(PandasOnSparkTestCase):
                     psdf.iloc[rows_sel, :1].sort_index(), pdf.iloc[rows_sel, :1].sort_index()
                 )
 
-            with self.subTest(rows_sel=rows_sel), ps.option_context("compute.isin_limit", 0):
-                self.assert_eq(psdf.iloc[rows_sel].sort_index(), pdf.iloc[rows_sel].sort_index())
-                self.assert_eq(
-                    psdf.A.iloc[rows_sel].sort_index(), pdf.A.iloc[rows_sel].sort_index()
-                )
-                self.assert_eq(
-                    (psdf.A + 1).iloc[rows_sel].sort_index(),
-                    (pdf.A + 1).iloc[rows_sel].sort_index(),
-                )
-
-            with self.subTest(rows_sel=rows_sel), ps.option_context("compute.isin_limit", 0):
-                self.assert_eq(
-                    psdf.iloc[rows_sel, :].sort_index(), pdf.iloc[rows_sel, :].sort_index()
-                )
-
-            with self.subTest(rows_sel=rows_sel), ps.option_context("compute.isin_limit", 0):
-                self.assert_eq(
-                    psdf.iloc[rows_sel, :1].sort_index(), pdf.iloc[rows_sel, :1].sort_index()
-                )
-
     def test_frame_loc_setitem(self):
         pdf = pd.DataFrame(
             [[1, 2], [4, 5], [7, 8]],

--- a/python/pyspark/pandas/tests/test_indexing.py
+++ b/python/pyspark/pandas/tests/test_indexing.py
@@ -994,7 +994,7 @@ class IndexingTest(PandasOnSparkTestCase):
                     psdf.iloc[rows_sel, :1].sort_index(), pdf.iloc[rows_sel, :1].sort_index()
                 )
 
-            with self.subTest(rows_sel=rows_sel) and ps.option_context("compute.isin_limit", 0):
+            with self.subTest(rows_sel=rows_sel), ps.option_context("compute.isin_limit", 0):
                 self.assert_eq(psdf.iloc[rows_sel].sort_index(), pdf.iloc[rows_sel].sort_index())
                 self.assert_eq(
                     psdf.A.iloc[rows_sel].sort_index(), pdf.A.iloc[rows_sel].sort_index()
@@ -1004,12 +1004,12 @@ class IndexingTest(PandasOnSparkTestCase):
                     (pdf.A + 1).iloc[rows_sel].sort_index(),
                 )
 
-            with self.subTest(rows_sel=rows_sel) and ps.option_context("compute.isin_limit", 0):
+            with self.subTest(rows_sel=rows_sel), ps.option_context("compute.isin_limit", 0):
                 self.assert_eq(
                     psdf.iloc[rows_sel, :].sort_index(), pdf.iloc[rows_sel, :].sort_index()
                 )
 
-            with self.subTest(rows_sel=rows_sel) and ps.option_context("compute.isin_limit", 0):
+            with self.subTest(rows_sel=rows_sel), ps.option_context("compute.isin_limit", 0):
                 self.assert_eq(
                     psdf.iloc[rows_sel, :1].sort_index(), pdf.iloc[rows_sel, :1].sort_index()
                 )

--- a/python/pyspark/pandas/tests/test_indexing.py
+++ b/python/pyspark/pandas/tests/test_indexing.py
@@ -994,6 +994,26 @@ class IndexingTest(PandasOnSparkTestCase):
                     psdf.iloc[rows_sel, :1].sort_index(), pdf.iloc[rows_sel, :1].sort_index()
                 )
 
+            with self.subTest(rows_sel=rows_sel) and ps.option_context("compute.isin_limit", 0):
+                self.assert_eq(psdf.iloc[rows_sel].sort_index(), pdf.iloc[rows_sel].sort_index())
+                self.assert_eq(
+                    psdf.A.iloc[rows_sel].sort_index(), pdf.A.iloc[rows_sel].sort_index()
+                )
+                self.assert_eq(
+                    (psdf.A + 1).iloc[rows_sel].sort_index(),
+                    (pdf.A + 1).iloc[rows_sel].sort_index(),
+                )
+
+            with self.subTest(rows_sel=rows_sel) and ps.option_context("compute.isin_limit", 0):
+                self.assert_eq(
+                    psdf.iloc[rows_sel, :].sort_index(), pdf.iloc[rows_sel, :].sort_index()
+                )
+
+            with self.subTest(rows_sel=rows_sel) and ps.option_context("compute.isin_limit", 0):
+                self.assert_eq(
+                    psdf.iloc[rows_sel, :1].sort_index(), pdf.iloc[rows_sel, :1].sort_index()
+                )
+
     def test_frame_loc_setitem(self):
         pdf = pd.DataFrame(
             [[1, 2], [4, 5], [7, 8]],


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor `_select_rows_by_iterable` in `iLocIndexer` to use `Column.isin`.

### Why are the changes needed?
For better performance.

After a rough benchmark, a long projection performs worse than `Column.isin`, even when the length of the filtering conditions exceeding `compute.isin_limit`.

So we use `Column.isin` instead.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.