### PR TITLE
[SPARK-36730][SQL] Use V2 Filter in V2 file source

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroScan.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroScan.scala
@@ -23,10 +23,10 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.avro.AvroOptions
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.v2.FileScan
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.SerializableConfiguration
@@ -38,7 +38,7 @@ case class AvroScan(
     readDataSchema: StructType,
     readPartitionSchema: StructType,
     options: CaseInsensitiveStringMap,
-    pushedFilters: Array[Filter],
+    pushedFilters: Array[V2Filter],
     partitionFilters: Seq[Expression] = Seq.empty,
     dataFilters: Seq[Expression] = Seq.empty) extends FileScan {
   override def isSplitable(path: Path): Boolean = true

--- a/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroScanBuilder.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroScanBuilder.scala
@@ -18,10 +18,10 @@ package org.apache.spark.sql.v2.avro
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.StructFilters
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -46,11 +46,11 @@ class AvroScanBuilder (
       dataFilters)
   }
 
-  override def pushDataFilters(dataFilters: Array[Filter]): Array[Filter] = {
+  override def pushDataFilters(dataFilters: Array[V2Filter]): Array[V2Filter] = {
     if (sparkSession.sessionState.conf.avroFilterPushDown) {
-      StructFilters.pushedFilters(dataFilters, dataSchema)
+      StructFilters.pushedFiltersV2(dataFilters, dataSchema)
     } else {
-      Array.empty[Filter]
+      Array.empty[V2Filter]
     }
   }
 }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroScanSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroScanSuite.scala
@@ -23,8 +23,8 @@ import org.apache.spark.sql.v2.avro.AvroScan
 class AvroScanSuite extends FileScanSuiteBase {
   val scanBuilders = Seq[(String, ScanBuilder, Seq[String])](
     ("AvroScan",
-      (s, fi, ds, rds, rps, f, o, pf, df) => AvroScan(s, fi, ds, rds, rps, o, f, pf, df),
-      Seq.empty))
+      (s, fi, ds, rds, rps, f, o, pf, df) => AvroScan(s, fi, ds, rds, rps, o,
+      f.map(_.toV2), pf, df), Seq.empty))
 
   run(scanBuilders)
 }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -2329,7 +2329,7 @@ class AvroV2Suite extends AvroSuite with ExplainSuiteHelper {
            |Format: avro
            |Location: InMemoryFileIndex\\([0-9]+ paths\\)\\[.*\\]
            |PartitionFilters: \\[isnotnull\\(id#x\\), \\(id#x > 1\\)\\]
-           |PushedFilters: \\[IsNotNull\\(value\\), GreaterThan\\(value,2\\)\\]
+           |PushedFilters: \\[value IS NOT NULL, value > 2\\]
            |ReadSchema: struct\\<value:bigint\\>
            |""".stripMargin.trim
       spark.range(10)

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/AlwaysFalse.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/AlwaysFalse.java
@@ -47,4 +47,9 @@ public final class AlwaysFalse extends Filter {
 
   @Override
   public NamedReference[] references() { return EMPTY_REFERENCE; }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.AlwaysFalse();
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/AlwaysTrue.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/AlwaysTrue.java
@@ -47,4 +47,9 @@ public final class AlwaysTrue extends Filter {
 
   @Override
   public NamedReference[] references() { return EMPTY_REFERENCE; }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.AlwaysTrue();
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/And.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/And.java
@@ -36,4 +36,9 @@ public final class And extends BinaryFilter {
   public String toString() {
     return String.format("(%s) AND (%s)", left.describe(), right.describe());
   }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.And(left.toV1(), right.toV1());
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/EqualNullSafe.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/EqualNullSafe.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.catalyst.CatalystTypeConverters;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
@@ -37,4 +38,10 @@ public final class EqualNullSafe extends BinaryComparison {
 
   @Override
   public String toString() { return this.column.describe() + " <=> " + value.describe(); }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.EqualNullSafe(
+      column.describe(), CatalystTypeConverters.convertToScala(value.value(), value.dataType()));
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/EqualTo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/EqualTo.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.catalyst.CatalystTypeConverters;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
@@ -36,4 +37,10 @@ public final class EqualTo extends BinaryComparison {
 
   @Override
   public String toString() { return column.describe() + " = " + value.describe(); }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.EqualTo(
+      (column).describe(), CatalystTypeConverters.convertToScala(value.value(), value.dataType()));
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/Filter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/Filter.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.connector.expressions.filter;
 
+import java.io.Serializable;
+
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.NamedReference;
@@ -27,7 +29,7 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
  * @since 3.3.0
  */
 @Evolving
-public abstract class Filter implements Expression {
+public abstract class Filter implements Expression, Serializable {
 
   protected static final NamedReference[] EMPTY_REFERENCE = new NamedReference[0];
 
@@ -38,4 +40,9 @@ public abstract class Filter implements Expression {
 
   @Override
   public String describe() { return this.toString(); }
+
+  /**
+   * Returns a V1 Filter.
+   */
+  public abstract org.apache.spark.sql.sources.Filter toV1();
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/GreaterThan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/GreaterThan.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.catalyst.CatalystTypeConverters;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
@@ -36,4 +37,11 @@ public final class GreaterThan extends BinaryComparison {
 
   @Override
   public String toString() { return column.describe() + " > " + value.describe(); }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.GreaterThan(
+      column.describe(), CatalystTypeConverters.convertToScala(value.value(), value.dataType()));
+  }
+
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/GreaterThanOrEqual.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/GreaterThanOrEqual.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.catalyst.CatalystTypeConverters;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
@@ -36,4 +37,10 @@ public final class GreaterThanOrEqual extends BinaryComparison {
 
   @Override
   public String toString() { return column.describe() + " >= " + value.describe(); }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.GreaterThanOrEqual(
+      column.describe(), CatalystTypeConverters.convertToScala(value.value(), value.dataType()));
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/In.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/In.java
@@ -22,8 +22,11 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.catalyst.CatalystTypeConverters;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
+
+import static org.apache.spark.sql.types.DataTypes.StringType;
 
 /**
  * A filter that evaluates to {@code true} iff the {@code column} evaluates to one of the
@@ -73,4 +76,19 @@ public final class In extends Filter {
 
   @Override
   public NamedReference[] references() { return new NamedReference[] { column }; }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    Object[] array = new Object[values.length];
+    int index = 0;
+    for (Literal value: values) {
+      if (value.dataType().sameType(StringType)) {
+        array[index] = value.value().toString();
+      } else {
+        array[index] = CatalystTypeConverters.convertToScala(value.value(), value.dataType());
+      }
+      index++;
+    }
+    return new org.apache.spark.sql.sources.In(column.describe(), array);
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/In.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/In.java
@@ -26,8 +26,6 @@ import org.apache.spark.sql.catalyst.CatalystTypeConverters;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
-import static org.apache.spark.sql.types.DataTypes.StringType;
-
 /**
  * A filter that evaluates to {@code true} iff the {@code column} evaluates to one of the
  * {@code values} in the array.
@@ -82,11 +80,7 @@ public final class In extends Filter {
     Object[] array = new Object[values.length];
     int index = 0;
     for (Literal value: values) {
-      if (value.dataType().sameType(StringType)) {
-        array[index] = value.value().toString();
-      } else {
-        array[index] = CatalystTypeConverters.convertToScala(value.value(), value.dataType());
-      }
+      array[index] = CatalystTypeConverters.convertToScala(value.value(), value.dataType());
       index++;
     }
     return new org.apache.spark.sql.sources.In(column.describe(), array);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/IsNotNull.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/IsNotNull.java
@@ -55,4 +55,9 @@ public final class IsNotNull extends Filter {
 
   @Override
   public NamedReference[] references() { return new NamedReference[] { column }; }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.IsNotNull(column.describe());
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/IsNull.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/IsNull.java
@@ -55,4 +55,9 @@ public final class IsNull extends Filter {
 
   @Override
   public NamedReference[] references() { return new NamedReference[] { column }; }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.IsNull(column.describe());
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/LessThan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/LessThan.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.catalyst.CatalystTypeConverters;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
@@ -36,4 +37,10 @@ public final class LessThan extends BinaryComparison {
 
   @Override
   public String toString() { return column.describe() + " < " + value.describe(); }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.LessThan(
+      column.describe(), CatalystTypeConverters.convertToScala(value.value(), value.dataType()));
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/LessThanOrEqual.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/LessThanOrEqual.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.catalyst.CatalystTypeConverters;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
@@ -36,4 +37,10 @@ public final class LessThanOrEqual extends BinaryComparison {
 
   @Override
   public String toString() { return column.describe() + " <= " + value.describe(); }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.LessThanOrEqual(
+      column.describe(), CatalystTypeConverters.convertToScala(value.value(), value.dataType()));
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/Not.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/Not.java
@@ -53,4 +53,9 @@ public final class Not extends Filter {
 
   @Override
   public NamedReference[] references() { return child.references(); }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.Not(child.toV1());
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/Or.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/Or.java
@@ -36,4 +36,9 @@ public final class Or extends BinaryFilter {
   public String toString() {
     return String.format("(%s) OR (%s)", left.describe(), right.describe());
   }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.Or(left.toV1(), right.toV1());
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringContains.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringContains.java
@@ -36,4 +36,9 @@ public final class StringContains extends StringPredicate {
 
   @Override
   public String toString() { return "STRING_CONTAINS(" + column.describe() + ", " + value + ")"; }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.StringContains(column.describe(), value.toString());
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringEndsWith.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringEndsWith.java
@@ -36,4 +36,9 @@ public final class StringEndsWith extends StringPredicate {
 
   @Override
   public String toString() { return "STRING_ENDS_WITH(" + column.describe() + ", " + value + ")"; }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.StringEndsWith(column.describe(), value.toString());
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringStartsWith.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringStartsWith.java
@@ -38,4 +38,9 @@ public final class StringStartsWith extends StringPredicate {
   public String toString() {
     return "STRING_STARTS_WITH(" + column.describe() + ", " + value + ")";
   }
+
+  @Override
+  public org.apache.spark.sql.sources.Filter toV1() {
+    return new org.apache.spark.sql.sources.StringStartsWith(column.describe(), value.toString());
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.catalog.functions.{BoundFunction, UnboundFunction}
 import org.apache.spark.sql.connector.expressions.{NamedReference, Transform}
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.{LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED, LEGACY_CTE_PRECEDENCE_POLICY}
 import org.apache.spark.sql.sources.Filter
@@ -1132,6 +1133,11 @@ object QueryCompilationErrors {
   }
 
   def failedToRebuildExpressionError(filter: Filter): Throwable = {
+    new AnalysisException(
+      s"Fail to rebuild expression: missing key $filter in `translatedFilterToExpr`")
+  }
+
+  def failedToRebuildExpressionError(filter: V2Filter): Throwable = {
     new AnalysisException(
       s"Fail to rebuild expression: missing key $filter in `translatedFilterToExpr`")
   }
@@ -2391,5 +2397,9 @@ object QueryCompilationErrors {
     new AnalysisException(
       errorClass = "INVALID_JSON_SCHEMA_MAPTYPE",
       messageParameters = Array(schema.toString))
+  }
+
+  def invalidDataTypeForFilterValue(value: Any): Throwable = {
+    new AnalysisException(s"Filter value $value has invalid data type")
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/SupportsPushDownCatalystFilters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/SupportsPushDownCatalystFilters.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.internal.connector
 
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 
 /**
  * A mix-in interface for {@link FileScanBuilder}. File sources can implement this interface to
@@ -37,5 +37,5 @@ trait SupportsPushDownCatalystFilters {
    * Returns the data filters that are pushed to the data source via
    * {@link #pushFilters(Expression[])}.
    */
-  def pushedFilters: Array[Filter]
+  def pushedFilters: Array[V2Filter]
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/sources/filters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/sources/filters.scala
@@ -17,15 +17,17 @@
 
 package org.apache.spark.sql.sources
 
+import java.math.{BigDecimal => JavaBigDecimal, BigInteger => JavaBigInteger}
 import java.sql.{Date, Timestamp}
-import java.time.Instant
+import java.time.{Instant, LocalDate}
 
 import org.apache.spark.annotation.{Evolving, Stable}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath
 import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue}
 import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse => V2AlwaysFalse, AlwaysTrue => V2AlwaysTrue, And => V2And, EqualNullSafe => V2EqualNullSafe, EqualTo => V2EqualTo, Filter => V2Filter, GreaterThan => V2GreaterThan, GreaterThanOrEqual => V2GreaterThanOrEqual, In => V2In, IsNotNull => V2IsNotNull, IsNull => V2IsNull, LessThan => V2LessThan, LessThanOrEqual => V2LessThanOrEqual, Not => V2Not, Or => V2Or, StringContains => V2StringContains, StringEndsWith => V2StringEndsWith, StringStartsWith => V2StringStartsWith}
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampType}
+import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DateType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -54,20 +56,33 @@ sealed abstract class Filter {
   private[sql] def toV2: V2Filter
 
   private[sql] def getLiteralValue(value: Any): LiteralValue[_] = value match {
-    case _: java.math.BigDecimal => LiteralValue(value, DecimalType.SYSTEM_DEFAULT)
+    case _: JavaBigDecimal =>
+      LiteralValue(Decimal(value.asInstanceOf[JavaBigDecimal]), DecimalType.SYSTEM_DEFAULT)
+    case _: JavaBigInteger =>
+      LiteralValue(Decimal(value.asInstanceOf[JavaBigInteger]), DecimalType.SYSTEM_DEFAULT)
+    case _: BigDecimal =>
+      LiteralValue(Decimal(value.asInstanceOf[BigDecimal]), DecimalType.SYSTEM_DEFAULT)
     case _: Boolean => LiteralValue(value, BooleanType)
     case _: Byte => LiteralValue(value, ByteType)
     case _: Array[Byte] => LiteralValue(value, BinaryType)
-    case _: Date => LiteralValue(value, DateType)
-    case _: java.time.LocalDate => LiteralValue(value, DateType)
+    case _: Date =>
+      val date = DateTimeUtils.fromJavaDate(value.asInstanceOf[Date])
+      LiteralValue(date, DateType)
+    case _: LocalDate =>
+      val date = DateTimeUtils.localDateToDays(value.asInstanceOf[LocalDate])
+      LiteralValue(date, DateType)
     case _: Double => LiteralValue(value, DoubleType)
     case _: Float => LiteralValue(value, FloatType)
     case _: Integer => LiteralValue(value, IntegerType)
     case _: Long => LiteralValue(value, LongType)
     case _: Short => LiteralValue(value, ShortType)
     case _: String => LiteralValue(UTF8String.fromString(value.toString), StringType)
-    case _: Timestamp => LiteralValue(value, TimestampType)
-    case _: Instant => LiteralValue(value, TimestampType)
+    case _: Timestamp =>
+      val ts = DateTimeUtils.fromJavaTimestamp(value.asInstanceOf[Timestamp])
+      LiteralValue(ts, TimestampType)
+    case _: Instant =>
+      val ts = DateTimeUtils.instantToMicros(value.asInstanceOf[Instant])
+      LiteralValue(ts, TimestampType)
     case _ =>
       throw QueryCompilationErrors.invalidDataTypeForFilterValue(value)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFiltersBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFiltersBase.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.orc
 import java.util.Locale
 
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.sources.{And, Filter}
+import org.apache.spark.sql.connector.expressions.filter.{And => V2And, Filter => V2Filter}
 import org.apache.spark.sql.types.{AtomicType, BinaryType, DataType, StructField, StructType}
 
 /**
@@ -28,14 +28,14 @@ import org.apache.spark.sql.types.{AtomicType, BinaryType, DataType, StructField
  */
 trait OrcFiltersBase {
 
-  private[sql] def buildTree(filters: Seq[Filter]): Option[Filter] = {
+  private[sql] def buildTree(filters: Seq[V2Filter]): Option[V2Filter] = {
     filters match {
       case Seq() => None
       case Seq(filter) => Some(filter)
-      case Seq(filter1, filter2) => Some(And(filter1, filter2))
+      case Seq(filter1, filter2) => Some(new V2And(filter1, filter2))
       case _ => // length > 2
         val (left, right) = filters.splitAt(filters.length / 2)
-        Some(And(buildTree(left).get, buildTree(right).get))
+        Some(new V2And(buildTree(left).get, buildTree(right).get))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -18,24 +18,30 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.analysis.{ResolvedDBObjectName, ResolvedNamespace, ResolvedPartitionSpec, ResolvedTable}
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, DynamicPruning, Expression, NamedExpression, PredicateHelper, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, DynamicPruning, EmptyRow, Expression, Literal, NamedExpression, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.toPrettySQL
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, StagingTableCatalog, SupportsNamespaces, SupportsPartitionManagement, SupportsWrite, Table, TableCapability, TableCatalog}
+import org.apache.spark.sql.connector.expressions.{FieldReference, Literal => V2Literal, LiteralValue}
+import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse => V2AlwaysFalse, AlwaysTrue => V2AlwaysTrue, And => V2And, EqualNullSafe => V2EqualNullSafe, EqualTo => V2EqualTo, Filter => V2Filter, GreaterThan => V2GreaterThan, GreaterThanOrEqual => V2GreaterThanOrEqual, In => V2In, IsNotNull => V2IsNotNull, IsNull => V2IsNull, LessThan => V2LessThan, LessThanOrEqual => V2LessThanOrEqual, Not => V2Not, Or => V2Or, StringContains => V2StringContains, StringEndsWith => V2StringEndsWith, StringStartsWith => V2StringStartsWith}
 import org.apache.spark.sql.connector.read.LocalScan
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
 import org.apache.spark.sql.connector.write.V1Write
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.{FilterExec, LeafExecNode, LocalTableScanExec, ProjectExec, RowDataSourceScanExec, SparkPlan}
-import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, PushableColumn, PushableColumnBase}
 import org.apache.spark.sql.execution.streaming.continuous.{WriteToContinuousDataSource, WriteToContinuousDataSourceExec}
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
+import org.apache.spark.sql.types.{BooleanType, StringType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.unsafe.types.UTF8String
 
 class DataSourceV2Strategy(session: SparkSession) extends Strategy with PredicateHelper {
 
@@ -425,5 +431,159 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       AlterTableExec(table.catalog, table.identifier, a.changes) :: Nil
 
     case _ => Nil
+  }
+}
+
+private[sql] object DataSourceV2Strategy {
+
+  private def translateLeafNodeFilterV2(
+      predicate: Expression,
+      pushableColumn: PushableColumnBase): Option[V2Filter] = predicate match {
+    case expressions.EqualTo(pushableColumn(name), Literal(v, t)) =>
+      Some(new V2EqualTo(FieldReference(name), LiteralValue(v, t)))
+    case expressions.EqualTo(Literal(v, t), pushableColumn(name)) =>
+      Some(new V2EqualTo(FieldReference(name), LiteralValue(v, t)))
+
+    case expressions.EqualNullSafe(pushableColumn(name), Literal(v, t)) =>
+      Some(new V2EqualNullSafe(FieldReference(name), LiteralValue(v, t)))
+    case expressions.EqualNullSafe(Literal(v, t), pushableColumn(name)) =>
+      Some(new V2EqualNullSafe(FieldReference(name), LiteralValue(v, t)))
+
+    case expressions.GreaterThan(pushableColumn(name), Literal(v, t)) =>
+      Some(new V2GreaterThan(FieldReference(name), LiteralValue(v, t)))
+    case expressions.GreaterThan(Literal(v, t), pushableColumn(name)) =>
+      Some(new V2LessThan(FieldReference(name), LiteralValue(v, t)))
+
+    case expressions.LessThan(pushableColumn(name), Literal(v, t)) =>
+      Some(new V2LessThan(FieldReference(name), LiteralValue(v, t)))
+    case expressions.LessThan(Literal(v, t), pushableColumn(name)) =>
+      Some(new V2GreaterThan(FieldReference(name), LiteralValue(v, t)))
+
+    case expressions.GreaterThanOrEqual(pushableColumn(name), Literal(v, t)) =>
+      Some(new V2GreaterThanOrEqual(FieldReference(name), LiteralValue(v, t)))
+    case expressions.GreaterThanOrEqual(Literal(v, t), pushableColumn(name)) =>
+      Some(new V2LessThanOrEqual(FieldReference(name), LiteralValue(v, t)))
+
+    case expressions.LessThanOrEqual(pushableColumn(name), Literal(v, t)) =>
+      Some(new V2LessThanOrEqual(FieldReference(name), LiteralValue(v, t)))
+    case expressions.LessThanOrEqual(Literal(v, t), pushableColumn(name)) =>
+      Some(new V2GreaterThanOrEqual(FieldReference(name), LiteralValue(v, t)))
+
+    case in @ expressions.InSet(pushableColumn(name), set) =>
+      val values: Array[V2Literal[_]] =
+        set.toSeq.map(elem => LiteralValue(elem, in.dataType)).toArray
+      Some(new V2In(FieldReference(name), values))
+
+    // Because we only convert In to InSet in Optimizer when there are more than certain
+    // items. So it is possible we still get an In expression here that needs to be pushed
+    // down.
+    case in @ expressions.In(pushableColumn(name), list) if list.forall(_.isInstanceOf[Literal]) =>
+      val hSet = list.map(_.eval(EmptyRow))
+      Some(new V2In(FieldReference(name),
+        hSet.toArray.map(LiteralValue(_, in.value.dataType))))
+
+    case expressions.IsNull(pushableColumn(name)) =>
+      Some(new V2IsNull(FieldReference(name)))
+    case expressions.IsNotNull(pushableColumn(name)) =>
+      Some(new V2IsNotNull(FieldReference(name)))
+    case expressions.StartsWith(pushableColumn(name), Literal(v: UTF8String, StringType)) =>
+      Some(new V2StringStartsWith(FieldReference(name), v))
+
+    case expressions.EndsWith(pushableColumn(name), Literal(v: UTF8String, StringType)) =>
+      Some(new V2StringEndsWith(FieldReference(name), v))
+
+    case expressions.Contains(pushableColumn(name), Literal(v: UTF8String, StringType)) =>
+      Some(new V2StringContains(FieldReference(name), v))
+
+    case expressions.Literal(true, BooleanType) =>
+      Some(new V2AlwaysTrue)
+
+    case expressions.Literal(false, BooleanType) =>
+      Some(new V2AlwaysFalse)
+
+    case _ => None
+  }
+
+    /**
+     * Tries to translate a Catalyst [[Expression]] into data source [[Filter]].
+     *
+     * @return a `Some[Filter]` if the input [[Expression]] is convertible, otherwise a `None`.
+     */
+    protected[sql] def translateFilterV2(
+        predicate: Expression,
+        supportNestedPredicatePushdown: Boolean): Option[V2Filter] = {
+      translateFilterV2WithMapping(predicate, None, supportNestedPredicatePushdown)
+    }
+
+  /**
+   * Tries to translate a Catalyst [[Expression]] into data source [[Filter]].
+   *
+   * @param predicate The input [[Expression]] to be translated as [[Filter]]
+   * @param translatedFilterToExpr An optional map from leaf node filter expressions to its
+   *                               translated [[Filter]]. The map is used for rebuilding
+   *                               [[Expression]] from [[Filter]].
+   * @return a `Some[Filter]` if the input [[Expression]] is convertible, otherwise a `None`.
+   */
+  protected[sql] def translateFilterV2WithMapping(
+      predicate: Expression,
+      translatedFilterToExpr: Option[mutable.HashMap[V2Filter, Expression]],
+      nestedPredicatePushdownEnabled: Boolean)
+  : Option[V2Filter] = {
+    predicate match {
+      case expressions.And(left, right) =>
+        // See SPARK-12218 for detailed discussion
+        // It is not safe to just convert one side if we do not understand the
+        // other side. Here is an example used to explain the reason.
+        // Let's say we have (a = 2 AND trim(b) = 'blah') OR (c > 0)
+        // and we do not understand how to convert trim(b) = 'blah'.
+        // If we only convert a = 2, we will end up with
+        // (a = 2) OR (c > 0), which will generate wrong results.
+        // Pushing one leg of AND down is only safe to do at the top level.
+        // You can see ParquetFilters' createFilter for more details.
+        for {
+          leftFilter <- translateFilterV2WithMapping(
+            left, translatedFilterToExpr, nestedPredicatePushdownEnabled)
+          rightFilter <- translateFilterV2WithMapping(
+            right, translatedFilterToExpr, nestedPredicatePushdownEnabled)
+        } yield new V2And(leftFilter, rightFilter)
+
+      case expressions.Or(left, right) =>
+        for {
+          leftFilter <- translateFilterV2WithMapping(
+            left, translatedFilterToExpr, nestedPredicatePushdownEnabled)
+          rightFilter <- translateFilterV2WithMapping(
+            right, translatedFilterToExpr, nestedPredicatePushdownEnabled)
+        } yield new V2Or(leftFilter, rightFilter)
+
+      case expressions.Not(child) =>
+        translateFilterV2WithMapping(child, translatedFilterToExpr, nestedPredicatePushdownEnabled)
+          .map(new V2Not(_))
+
+      case other =>
+        val filter = translateLeafNodeFilterV2(
+          other, PushableColumn(nestedPredicatePushdownEnabled))
+        if (filter.isDefined && translatedFilterToExpr.isDefined) {
+          translatedFilterToExpr.get(filter.get) = predicate
+        }
+        filter
+    }
+  }
+
+  protected[sql] def rebuildExpressionFromFilter(
+      filter: V2Filter,
+      translatedFilterToExpr: mutable.HashMap[V2Filter, Expression]): Expression = {
+    filter match {
+      case and: V2And =>
+        expressions.And(rebuildExpressionFromFilter(and.left, translatedFilterToExpr),
+          rebuildExpressionFromFilter(and.right, translatedFilterToExpr))
+      case or: V2Or =>
+        expressions.Or(rebuildExpressionFromFilter(or.left, translatedFilterToExpr),
+          rebuildExpressionFromFilter(or.right, translatedFilterToExpr))
+      case not: V2Not =>
+        expressions.Not(rebuildExpressionFromFilter(not.child, translatedFilterToExpr))
+      case other =>
+        translatedFilterToExpr.getOrElse(other,
+          throw QueryCompilationErrors.failedToRebuildExpressionError(filter))
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -27,12 +27,12 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{AttributeSet, Expression, ExpressionSet}
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, Scan, Statistics, SupportsReportStatistics}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.PartitionedFileUtil
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.internal.connector.SupportsMetadata
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
@@ -200,7 +200,7 @@ trait FileScan extends Scan
     StructType(readDataSchema.fields ++ readPartitionSchema.fields)
 
   // Returns whether the two given arrays of [[Filter]]s are equivalent.
-  protected def equivalentFilters(a: Array[Filter], b: Array[Filter]): Boolean = {
+  protected def equivalentFilters(a: Array[V2Filter], b: Array[V2Filter]): Boolean = {
     a.sortBy(_.hashCode()).sameElements(b.sortBy(_.hashCode()))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -71,7 +71,7 @@ object PushDownUtils extends PredicateHelper {
 
       case f: FileScanBuilder =>
         val postScanFilters = f.pushFilters(filters)
-        (f.pushedFilters, postScanFilters)
+        (f.pushedFilters.map(_.toV1).toSeq, postScanFilters)
       case _ => (Nil, filters)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVPartitionReaderFactory.scala
@@ -19,12 +19,12 @@ package org.apache.spark.sql.execution.datasources.v2.csv
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.csv.{CSVHeaderChecker, CSVOptions, UnivocityParser}
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.csv.CSVDataSource
 import org.apache.spark.sql.execution.datasources.v2._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -45,7 +45,7 @@ case class CSVPartitionReaderFactory(
     readDataSchema: StructType,
     partitionSchema: StructType,
     parsedOptions: CSVOptions,
-    filters: Seq[Filter]) extends FilePartitionReaderFactory {
+    filters: Seq[V2Filter]) extends FilePartitionReaderFactory {
   private val columnPruning = sqlConf.csvColumnPruning
 
   override def buildReader(file: PartitionedFile): PartitionReader[InternalRow] = {
@@ -58,7 +58,7 @@ case class CSVPartitionReaderFactory(
       actualDataSchema,
       actualReadDataSchema,
       parsedOptions,
-      filters)
+      filters.map(_.toV1))
     val schema = if (columnPruning) actualReadDataSchema else actualDataSchema
     val isStartOfFile = file.start == 0
     val headerChecker = new CSVHeaderChecker(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScan.scala
@@ -23,12 +23,12 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.csv.CSVOptions
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExprUtils}
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.csv.CSVDataSource
 import org.apache.spark.sql.execution.datasources.v2.TextBasedFileScan
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.SerializableConfiguration
@@ -40,7 +40,7 @@ case class CSVScan(
     readDataSchema: StructType,
     readPartitionSchema: StructType,
     options: CaseInsensitiveStringMap,
-    pushedFilters: Array[Filter],
+    pushedFilters: Array[V2Filter],
     partitionFilters: Seq[Expression] = Seq.empty,
     dataFilters: Seq[Expression] = Seq.empty)
   extends TextBasedFileScan(sparkSession, options) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVScanBuilder.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.execution.datasources.v2.csv
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.StructFilters
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -47,11 +47,11 @@ case class CSVScanBuilder(
       dataFilters)
   }
 
-  override def pushDataFilters(dataFilters: Array[Filter]): Array[Filter] = {
+  override def pushDataFilters(dataFilters: Array[V2Filter]): Array[V2Filter] = {
     if (sparkSession.sessionState.conf.csvFilterPushDown) {
-      StructFilters.pushedFilters(dataFilters, dataSchema)
+      StructFilters.pushedFiltersV2(dataFilters, dataSchema)
     } else {
-      Array.empty[Filter]
+      Array.empty[V2Filter]
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonPartitionReaderFactory.scala
@@ -19,12 +19,12 @@ package org.apache.spark.sql.execution.datasources.v2.json
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.json.{JacksonParser, JSONOptionsInRead}
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.json.JsonDataSource
 import org.apache.spark.sql.execution.datasources.v2._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -46,7 +46,7 @@ case class JsonPartitionReaderFactory(
     readDataSchema: StructType,
     partitionSchema: StructType,
     parsedOptions: JSONOptionsInRead,
-    filters: Seq[Filter]) extends FilePartitionReaderFactory {
+    filters: Seq[V2Filter]) extends FilePartitionReaderFactory {
 
   override def buildReader(partitionedFile: PartitionedFile): PartitionReader[InternalRow] = {
     val actualSchema =
@@ -55,7 +55,7 @@ case class JsonPartitionReaderFactory(
       actualSchema,
       parsedOptions,
       allowArrayAsStructs = true,
-      filters)
+      filters.map((_.toV1)))
     val iter = JsonDataSource(parsedOptions).readFile(
       broadcastedConf.value.value,
       partitionedFile,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScan.scala
@@ -24,12 +24,12 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExprUtils}
 import org.apache.spark.sql.catalyst.json.JSONOptionsInRead
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.json.JsonDataSource
 import org.apache.spark.sql.execution.datasources.v2.TextBasedFileScan
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.SerializableConfiguration
@@ -41,7 +41,7 @@ case class JsonScan(
     readDataSchema: StructType,
     readPartitionSchema: StructType,
     options: CaseInsensitiveStringMap,
-    pushedFilters: Array[Filter],
+    pushedFilters: Array[V2Filter],
     partitionFilters: Seq[Expression] = Seq.empty,
     dataFilters: Seq[Expression] = Seq.empty)
   extends TextBasedFileScan(sparkSession, options) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScanBuilder.scala
@@ -18,10 +18,10 @@ package org.apache.spark.sql.execution.datasources.v2.json
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.StructFilters
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -45,11 +45,11 @@ class JsonScanBuilder (
       dataFilters)
   }
 
-  override def pushDataFilters(dataFilters: Array[Filter]): Array[Filter] = {
+  override def pushDataFilters(dataFilters: Array[V2Filter]): Array[V2Filter] = {
     if (sparkSession.sessionState.conf.jsonFilterPushDown) {
-      StructFilters.pushedFilters(dataFilters, dataSchema)
+      StructFilters.pushedFiltersV2(dataFilters, dataSchema)
     } else {
-      Array.empty[Filter]
+      Array.empty[V2Filter]
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -29,13 +29,13 @@ import org.apache.orc.mapreduce.OrcInputFormat
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader}
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.orc.{OrcColumnarBatchReader, OrcDeserializer, OrcFilters, OrcUtils}
 import org.apache.spark.sql.execution.datasources.v2._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{SerializableConfiguration, Utils}
@@ -55,7 +55,7 @@ case class OrcPartitionReaderFactory(
     dataSchema: StructType,
     readDataSchema: StructType,
     partitionSchema: StructType,
-    filters: Array[Filter]) extends FilePartitionReaderFactory {
+    filters: Array[V2Filter]) extends FilePartitionReaderFactory {
   private val resultSchema = StructType(readDataSchema.fields ++ partitionSchema.fields)
   private val isCaseSensitive = sqlConf.caseSensitiveAnalysis
   private val capacity = sqlConf.orcVectorizedReaderBatchSize

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScan.scala
@@ -21,10 +21,10 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.v2.FileScan
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.SerializableConfiguration
@@ -37,7 +37,7 @@ case class OrcScan(
     readDataSchema: StructType,
     readPartitionSchema: StructType,
     options: CaseInsensitiveStringMap,
-    pushedFilters: Array[Filter],
+    pushedFilters: Array[V2Filter],
     partitionFilters: Seq[Expression] = Seq.empty,
     dataFilters: Seq[Expression] = Seq.empty) extends FileScan {
   override def isSplitable(path: Path): Boolean = true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -20,12 +20,12 @@ package org.apache.spark.sql.execution.datasources.v2.orc
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.orc.OrcFilters
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -49,13 +49,13 @@ case class OrcScanBuilder(
       readPartitionSchema(), options, pushedDataFilters, partitionFilters, dataFilters)
   }
 
-  override def pushDataFilters(dataFilters: Array[Filter]): Array[Filter] = {
+  override def pushDataFilters(dataFilters: Array[V2Filter]): Array[V2Filter] = {
     if (sparkSession.sessionState.conf.orcFilterPushDown) {
       val dataTypeMap = OrcFilters.getSearchableTypeMap(
         readDataSchema(), SQLConf.get.caseSensitiveAnalysis)
       OrcFilters.convertibleFilters(dataTypeMap, dataFilters).toArray
     } else {
-      Array.empty[Filter]
+      Array.empty[V2Filter]
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScan.scala
@@ -24,12 +24,12 @@ import org.apache.parquet.hadoop.ParquetInputFormat
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetOptions, ParquetReadSupport, ParquetWriteSupport}
 import org.apache.spark.sql.execution.datasources.v2.FileScan
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.SerializableConfiguration
@@ -41,7 +41,7 @@ case class ParquetScan(
     dataSchema: StructType,
     readDataSchema: StructType,
     readPartitionSchema: StructType,
-    pushedFilters: Array[Filter],
+    pushedFilters: Array[V2Filter],
     options: CaseInsensitiveStringMap,
     partitionFilters: Seq[Expression] = Seq.empty,
     dataFilters: Seq[Expression] = Seq.empty) extends FileScan {
@@ -85,7 +85,7 @@ case class ParquetScan(
       dataSchema,
       readDataSchema,
       readPartitionSchema,
-      pushedFilters,
+      pushedFilters.map(_.toV1),
       new ParquetOptions(options.asCaseSensitiveMap.asScala.toMap, sqlConf))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
@@ -20,12 +20,12 @@ package org.apache.spark.sql.execution.datasources.v2.parquet
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter}
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFilters, SparkToParquetSchemaConverter}
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
-import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -63,17 +63,17 @@ case class ParquetScanBuilder(
       // The rebase mode doesn't matter here because the filters are used to determine
       // whether they is convertible.
       LegacyBehaviorPolicy.CORRECTED)
-    parquetFilters.convertibleFilters(pushedDataFilters).toArray
+    pushedDataFilters
   }
 
   override protected val supportsNestedSchemaPruning: Boolean = true
 
-  override def pushDataFilters(dataFilters: Array[Filter]): Array[Filter] = dataFilters
+  override def pushDataFilters(dataFilters: Array[V2Filter]): Array[V2Filter] = dataFilters
 
   // Note: for Parquet, the actual filter push down happens in [[ParquetPartitionReaderFactory]].
   // It requires the Parquet physical schema to determine whether a filter is convertible.
   // All filters that can be converted to Parquet are pushed down.
-  override def pushedFilters(): Array[Filter] = pushedParquetFilters
+  override def pushedFilters(): Array[V2Filter] = pushedParquetFilters.toArray
 
   override def build(): Scan = {
     ParquetScan(sparkSession, hadoopConf, fileIndex, dataSchema, readDataSchema(),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
@@ -63,7 +63,7 @@ case class ParquetScanBuilder(
       // The rebase mode doesn't matter here because the filters are used to determine
       // whether they is convertible.
       LegacyBehaviorPolicy.CORRECTED)
-    pushedDataFilters
+    parquetFilters.convertibleFilters(pushedDataFilters.map(_.toV1)).toArray
   }
 
   override protected val supportsNestedSchemaPruning: Boolean = true
@@ -73,10 +73,11 @@ case class ParquetScanBuilder(
   // Note: for Parquet, the actual filter push down happens in [[ParquetPartitionReaderFactory]].
   // It requires the Parquet physical schema to determine whether a filter is convertible.
   // All filters that can be converted to Parquet are pushed down.
-  override def pushedFilters(): Array[V2Filter] = pushedParquetFilters.toArray
+  override def pushedFilters(): Array[V2Filter] = pushedParquetFilters.map(_.toV2)
 
   override def build(): Scan = {
     ParquetScan(sparkSession, hadoopConf, fileIndex, dataSchema, readDataSchema(),
-      readPartitionSchema(), pushedParquetFilters, options, partitionFilters, dataFilters)
+      readPartitionSchema(), pushedParquetFilters.map(_.toV2), options, partitionFilters,
+      dataFilters)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -458,11 +458,11 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
         val basePath = dir.getCanonicalPath + "/" + fmt
         val pushFilterMaps = Map (
           "parquet" ->
-            "|PushedFilters: \\[IsNotNull\\(value\\), GreaterThan\\(value,2\\)\\]",
+            "|PushedFilters: \\[value IS NOT NULL, value > 2\\]",
           "orc" ->
-            "|PushedFilters: \\[IsNotNull\\(value\\), GreaterThan\\(value,2\\)\\]",
+            "|PushedFilters: \\[value IS NOT NULL, value > 2\\]",
           "csv" ->
-            "|PushedFilters: \\[IsNotNull\\(value\\), GreaterThan\\(value,2\\)\\]",
+            "|PushedFilters: \\[value IS NOT NULL, value > 2\\]",
           "json" ->
             "|remove_marker"
         )

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -887,10 +887,10 @@ class FileBasedDataSourceSuite extends QueryTest
       format match {
         case "orc" =>
           assert(scan.isInstanceOf[OrcScan])
-          assert(scan.asInstanceOf[OrcScan].pushedFilters === filters)
+          assert(scan.asInstanceOf[OrcScan].pushedFilters.map(_.toV1) === filters)
         case "parquet" =>
           assert(scan.isInstanceOf[ParquetScan])
-          assert(scan.asInstanceOf[ParquetScan].pushedFilters === filters)
+          assert(scan.asInstanceOf[ParquetScan].pushedFilters.map(_.toV1) === filters)
         case _ =>
           fail(s"unknown format $format")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileScanSuite.scala
@@ -354,18 +354,18 @@ class FileScanSuite extends FileScanSuiteBase {
   val scanBuilders = Seq[(String, ScanBuilder, Seq[String])](
     ("ParquetScan",
       (s, fi, ds, rds, rps, f, o, pf, df) =>
-        ParquetScan(s, s.sessionState.newHadoopConf(), fi, ds, rds, rps, f, o, pf, df),
+        ParquetScan(s, s.sessionState.newHadoopConf(), fi, ds, rds, rps, f.map(_.toV2), o, pf, df),
       Seq.empty),
     ("OrcScan",
       (s, fi, ds, rds, rps, f, o, pf, df) =>
-        OrcScan(s, s.sessionState.newHadoopConf(), fi, ds, rds, rps, o, f, pf, df),
+        OrcScan(s, s.sessionState.newHadoopConf(), fi, ds, rds, rps, o, f.map(_.toV2), pf, df),
       Seq.empty),
     ("CSVScan",
-      (s, fi, ds, rds, rps, f, o, pf, df) => CSVScan(s, fi, ds, rds, rps, o, f, pf, df),
+      (s, fi, ds, rds, rps, f, o, pf, df) => CSVScan(s, fi, ds, rds, rps, o, f.map(_.toV2), pf, df),
       Seq.empty),
     ("JsonScan",
-      (s, fi, ds, rds, rps, f, o, pf, df) => JsonScan(s, fi, ds, rds, rps, o, f, pf, df),
-      Seq.empty),
+      (s, fi, ds, rds, rps, f, o, pf, df) =>
+        JsonScan(s, fi, ds, rds, rps, o, f.map(_.toV2), pf, df), Seq.empty),
     ("TextScan",
       (s, fi, ds, rds, rps, _, o, pf, df) => TextScan(s, fi, ds, rds, rps, o, pf, df),
       Seq("dataSchema", "pushedFilters")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3032,10 +3032,10 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       format match {
         case "orc" =>
           assert(scan.isInstanceOf[OrcScan])
-          assert(scan.asInstanceOf[OrcScan].pushedFilters === filters)
+          assert(scan.asInstanceOf[OrcScan].pushedFilters.map(_.toV1) === filters)
         case "parquet" =>
           assert(scan.isInstanceOf[ParquetScan])
-          assert(scan.asInstanceOf[ParquetScan].pushedFilters === filters)
+          assert(scan.asInstanceOf[ParquetScan].pushedFilters.map(_.toV1) === filters)
         case _ =>
           fail(s"unknown format $format")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -34,6 +34,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{functions => F, _}
 import org.apache.spark.sql.catalyst.json._
 import org.apache.spark.sql.catalyst.util.{DateTimeTestUtils, DateTimeUtils}
+import org.apache.spark.sql.connector.expressions.FieldReference
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter, IsNotNull}
 import org.apache.spark.sql.execution.ExternalRDD
 import org.apache.spark.sql.execution.datasources.{CommonFileDataSourceSuite, DataSource, InMemoryFileIndex, NoopCache}
 import org.apache.spark.sql.execution.datasources.v2.json.JsonScanBuilder
@@ -3019,7 +3021,7 @@ class JsonV2Suite extends JsonSuite {
       val options = CaseInsensitiveStringMap.empty()
       new JsonScanBuilder(spark, fileIndex, schema, schema, options)
     }
-    val filters: Array[sources.Filter] = Array(sources.IsNotNull(attr))
+    val filters: Array[V2Filter] = Array(new IsNotNull(new FieldReference(Array(attr))))
     withSQLConf(SQLConf.JSON_FILTER_PUSHDOWN_ENABLED.key -> "true") {
       withTempPath { file =>
         val scanBuilder = getBuilder(file.getCanonicalPath)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -125,7 +125,7 @@ abstract class OrcTest extends QueryTest with FileBasedDataSourceTest with Befor
           assert(o.pushedFilters.isEmpty, "Unsupported filters should not show in pushed filters")
         } else {
           assert(o.pushedFilters.nonEmpty, "No filter is pushed down")
-          val maybeFilter = OrcFilters.createFilter(query.schema, o.pushedFilters)
+          val maybeFilter = OrcFilters.createFilter(query.schema, o.pushedFilters.map(_.toV1))
           assert(maybeFilter.isEmpty, s"Couldn't generate filter predicate for ${o.pushedFilters}")
         }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcV1FilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcV1FilterSuite.scala
@@ -55,7 +55,7 @@ class OrcV1FilterSuite extends OrcFilterSuite {
       DataSourceStrategy.selectFilters(maybeRelation.get, maybeAnalyzedPredicate.toSeq)
     assert(selectedFilters.nonEmpty, "No filter is pushed down")
 
-    val maybeFilter = OrcFilters.createFilter(query.schema, selectedFilters)
+    val maybeFilter = OrcFilters.createFilter(query.schema, selectedFilters.map(_.toV2))
     assert(maybeFilter.isDefined, s"Couldn't generate filter predicate for $selectedFilters")
     checker(maybeFilter.get)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -1930,9 +1930,10 @@ class ParquetV2FilterSuite extends ParquetFilterSuite {
           val schema = new SparkToParquetSchemaConverter(conf).convert(df.schema)
           val parquetFilters = createParquetFilters(schema)
           // In this test suite, all the simple predicates are convertible here.
-          assert(parquetFilters.convertibleFilters(sourceFilters) === pushedFilters)
+          assert(parquetFilters.convertibleFilters(sourceFilters).toArray
+            === pushedFilters.map(_.toV1))
           val pushedParquetFilters = pushedFilters.map { pred =>
-            val maybeFilter = parquetFilters.createFilter(pred)
+            val maybeFilter = parquetFilters.createFilter(pred.toV1)
             assert(maybeFilter.isDefined, s"Couldn't generate filter predicate for $pred")
             maybeFilter.get
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
@@ -161,7 +161,7 @@ class ExtractPythonUDFsSuite extends SparkPlanTest with SharedSparkSession {
           // 'a is not null and 'a > 1
           val filters = scanNodes.head.scan.asInstanceOf[ParquetScan].pushedFilters
           assert(filters.length == 2)
-          assert(filters.flatMap(_.references).distinct === Array("a"))
+          assert(filters.flatMap(_.references.map(_.describe())).distinct === Array("a"))
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/FiltersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/FiltersSuite.scala
@@ -18,6 +18,11 @@
 package org.apache.spark.sql.sources
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue, NamedReference}
+import org.apache.spark.sql.connector.expressions.filter.{And => V2And, EqualNullSafe => V2EqualNullSafe, EqualTo => V2EqualTo, GreaterThan => V2GreaterThan, GreaterThanOrEqual => V2GreaterThanOrEqual, In => V2In, IsNotNull => V2IsNotNull, IsNull => V2IsNull, LessThan => V2LessThan, LessThanOrEqual => V2LessThanOrEqual, Or => V2Or, StringContains => V2StringContains, StringEndsWith => V2StringEndsWith, StringStartsWith => V2StringStartsWith}
+import org.apache.spark.sql.sources.FiltersSuite.ref
+import org.apache.spark.sql.types.{StringType}
+import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Unit test suites for data source filters.
@@ -47,6 +52,15 @@ class FiltersSuite extends SparkFunSuite {
       == Seq(Seq("b"), fieldNames.toSeq))
   }}
 
+  test("EqualTo V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = EqualTo(name, "1")
+    val v2Filter = new V2EqualTo(ref(name), LiteralValue(UTF8String.fromString("1"), StringType))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
+  }}
+
   test("EqualNullSafe references") { withFieldNames { (name, fieldNames) =>
     assert(EqualNullSafe(name, "1").references.toSeq == Seq(name))
     assert(EqualNullSafe(name, "1").v2references.toSeq.map(_.toSeq) == Seq(fieldNames.toSeq))
@@ -58,6 +72,16 @@ class FiltersSuite extends SparkFunSuite {
       == Seq(fieldNames.toSeq, Seq("b")))
     assert(EqualNullSafe("b", EqualTo(name, "2")).v2references.toSeq.map(_.toSeq)
       == Seq(Seq("b"), fieldNames.toSeq))
+  }}
+
+  test("EqualNullSafe V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = EqualNullSafe(name, "1")
+    val v2Filter = new V2EqualNullSafe(ref(name),
+      LiteralValue(UTF8String.fromString("1"), StringType))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
   }}
 
   test("GreaterThan references") { withFieldNames { (name, fieldNames) =>
@@ -73,6 +97,16 @@ class FiltersSuite extends SparkFunSuite {
       == Seq(Seq("b"), fieldNames.toSeq))
   }}
 
+  test("GreaterThan V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = GreaterThan(name, "1")
+    val v2Filter = new V2GreaterThan(ref(name),
+      LiteralValue(UTF8String.fromString("1"), StringType))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
+  }}
+
   test("GreaterThanOrEqual references") { withFieldNames { (name, fieldNames) =>
     assert(GreaterThanOrEqual(name, "1").references.toSeq == Seq(name))
     assert(GreaterThanOrEqual(name, "1").v2references.toSeq.map(_.toSeq) == Seq(fieldNames.toSeq))
@@ -86,11 +120,30 @@ class FiltersSuite extends SparkFunSuite {
       == Seq(Seq("b"), fieldNames.toSeq))
   }}
 
+  test("GreaterThanOrEqual V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = GreaterThanOrEqual(name, "1")
+    val v2Filter = new V2GreaterThanOrEqual(ref(name),
+      LiteralValue(UTF8String.fromString("1"), StringType))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
+  }}
+
   test("LessThan references") { withFieldNames { (name, fieldNames) =>
     assert(LessThan(name, "1").references.toSeq == Seq(name))
     assert(LessThan(name, "1").v2references.toSeq.map(_.toSeq) == Seq(fieldNames.toSeq))
 
     assert(LessThan("a", EqualTo("b", "2")).references.toSeq == Seq("a", "b"))
+  }}
+
+  test("LessThan V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = LessThan(name, "1")
+    val v2Filter = new V2LessThan(ref(name), LiteralValue(UTF8String.fromString("1"), StringType))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
   }}
 
   test("LessThanOrEqual references") { withFieldNames { (name, fieldNames) =>
@@ -106,6 +159,16 @@ class FiltersSuite extends SparkFunSuite {
       == Seq(Seq("b"), fieldNames.toSeq))
   }}
 
+  test("LessThanOrEqual V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = LessThanOrEqual(name, "1")
+    val v2Filter = new V2LessThanOrEqual(ref(name),
+      LiteralValue(UTF8String.fromString("1"), StringType))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
+  }}
+
   test("In references") { withFieldNames { (name, fieldNames) =>
     assert(In(name, Array("1")).references.toSeq == Seq(name))
     assert(In(name, Array("1")).v2references.toSeq.map(_.toSeq) == Seq(fieldNames.toSeq))
@@ -119,14 +182,44 @@ class FiltersSuite extends SparkFunSuite {
       == Seq(Seq("b"), fieldNames.toSeq))
   }}
 
+  test("In V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = In(name, Array("1", "2", "3", "4"))
+    val v2Filter = new V2In(ref(name), Array(LiteralValue(UTF8String.fromString("1"), StringType),
+      LiteralValue(UTF8String.fromString("2"), StringType),
+      LiteralValue(UTF8String.fromString("3"), StringType),
+      LiteralValue(UTF8String.fromString("4"), StringType)))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
+  }}
+
   test("IsNull references") { withFieldNames { (name, fieldNames) =>
     assert(IsNull(name).references.toSeq == Seq(name))
     assert(IsNull(name).v2references.toSeq.map(_.toSeq) == Seq(fieldNames.toSeq))
   }}
 
+  test("IsNull V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = IsNull(name)
+    val v2Filter = new V2IsNull(ref(name))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
+  }}
+
   test("IsNotNull references") { withFieldNames { (name, fieldNames) =>
     assert(IsNotNull(name).references.toSeq == Seq(name))
     assert(IsNull(name).v2references.toSeq.map(_.toSeq) == Seq(fieldNames.toSeq))
+  }}
+
+  test("IsNotNull V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = IsNotNull(name)
+    val v2Filter = new V2IsNotNull(ref(name))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
   }}
 
   test("And references") { withFieldNames { (name, fieldNames) =>
@@ -139,6 +232,17 @@ class FiltersSuite extends SparkFunSuite {
       Seq(Seq("b"), fieldNames.toSeq))
   }}
 
+  test("And V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = And(EqualTo(name, "1"), EqualTo("b", "1"))
+    val v2Filter = new V2And(new V2EqualTo(ref(name),
+      LiteralValue(UTF8String.fromString("1"), StringType)),
+      new V2EqualTo(ref("b"), LiteralValue(UTF8String.fromString("1"), StringType)))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
+  }}
+
   test("Or references") { withFieldNames { (name, fieldNames) =>
     assert(Or(EqualTo(name, "1"), EqualTo("b", "1")).references.toSeq == Seq(name, "b"))
     assert(Or(EqualTo("b", "1"), EqualTo(name, "1")).references.toSeq == Seq("b", name))
@@ -149,9 +253,29 @@ class FiltersSuite extends SparkFunSuite {
       Seq(Seq("b"), fieldNames.toSeq))
   }}
 
+  test("Or V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = Or(EqualTo(name, "1"), EqualTo("b", "1"))
+    val v2Filter = new V2Or(new V2EqualTo(ref(name),
+      LiteralValue(UTF8String.fromString("1"), StringType)),
+      new V2EqualTo(ref("b"), LiteralValue(UTF8String.fromString("1"), StringType)))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
+  }}
+
   test("StringStartsWith references") { withFieldNames { (name, fieldNames) =>
     assert(StringStartsWith(name, "str").references.toSeq == Seq(name))
     assert(StringStartsWith(name, "str").v2references.toSeq.map(_.toSeq) == Seq(fieldNames.toSeq))
+  }}
+
+  test("StringStartsWith V1 V2 conversion") { withFieldNames { (name, fieldNames) =>
+    val v1Filter = StringStartsWith(name, "str")
+    val v2Filter = new V2StringStartsWith(ref(name), UTF8String.fromString("str"))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
   }}
 
   test("StringEndsWith references") { withFieldNames { (name, fieldNames) =>
@@ -159,8 +283,32 @@ class FiltersSuite extends SparkFunSuite {
     assert(StringEndsWith(name, "str").v2references.toSeq.map(_.toSeq) == Seq(fieldNames.toSeq))
   }}
 
+  test("StringEndsWith V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = StringEndsWith(name, "str")
+    val v2Filter = new V2StringEndsWith(ref(name), UTF8String.fromString("str"))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
+  }}
+
   test("StringContains references") { withFieldNames { (name, fieldNames) =>
     assert(StringContains(name, "str").references.toSeq == Seq(name))
     assert(StringContains(name, "str").v2references.toSeq.map(_.toSeq) == Seq(fieldNames.toSeq))
   }}
+
+  test("StringContains V1 V2 conversion") { withFieldNames { (name, _) =>
+    val v1Filter = StringContains(name, "str")
+    val v2Filter = new V2StringContains(ref(name), UTF8String.fromString("str"))
+    assert(v1Filter.toV2 == v2Filter)
+    assert(v2Filter.toV1 == v1Filter)
+    assert(v1Filter.toV2.toV1 == v1Filter)
+    assert(v2Filter.toV1.toV2 == v2Filter)
+  }}
+}
+
+object FiltersSuite {
+  def ref(parts: String): NamedReference = {
+    FieldReference(parts)
+  }
 }


### PR DESCRIPTION
Co-Authored-By: DB Tsai d_tsai@apple.com
Co-Authored-By: Huaxin Gao huaxin_gao@apple.com

### What changes were proposed in this pull request?
This is the 2nd PR for V2 Filter support. In this PR, we have updated the V2 file source to use V2 Filters. ParquetFilter hasn't been updated to use the V2 Filters yet and will be changed in the next PR.

### Why are the changes needed?
To eliminate the unnecessary conversion between Catalyst types and Scala types when using Filters.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New and existing test suites
