### PR TITLE
[SPARK-32285][PYTHON] Add PySpark support for nested timestamps with arrow

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -191,8 +191,8 @@ class PandasConversionMixin(object):
             # to integer type e.g., np.int16, we will hit exception. So we use the inferred
             # float type, not the corrected type from the schema in this case.
             if pandas_type is not None and \
-                    not (isinstance(field.dataType, IntegralType) and field.nullable and
-                         pandas_col.isnull().any()):
+                not (isinstance(field.dataType, IntegralType) and field.nullable and
+                     pandas_col.isnull().any()):
                 dtype[fieldIdx] = pandas_type
             # Ensure we fall back to nullable numpy types, even when whole column is null:
             if isinstance(field.dataType, IntegralType) and pandas_col.isnull().any():
@@ -412,13 +412,12 @@ class SparkConversionMixin(object):
         assert isinstance(self, SparkSession)
 
         if timezone is not None:
-            from pyspark.sql.pandas.types import _check_series_convert_timestamps_tz_local
+            from pyspark.sql.pandas.types import _check_series_convert_timestamps_tz_local\
+                , _is_series_contain_timestamp
             from pandas.core.dtypes.common import is_datetime64tz_dtype
-            from pyspark.sql.pandas.types import _is_series_contain_timestamp
             copied = False
             if isinstance(schema, StructType):
                 for field in schema:
-                    # TODO: handle nested timestamps, such as ArrayType(TimestampType())?
                     if isinstance(field.dataType, TimestampType):
                         s = _check_series_convert_timestamps_tz_local(pdf[field.name], timezone)
                         if s is not pdf[field.name]:

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -178,8 +178,9 @@ def _get_local_timezone() -> str:
     return os.environ.get('TZ', 'dateutil/:')
 
 
-def _check_series_localize_timestamps(s: "PandasSeriesLike", timezone: str, datatype=None
-                                      ) -> "PandasSeriesLike":
+def _check_series_localize_timestamps(
+    s: "PandasSeriesLike", timezone: str, datatype: Optional[str] = None
+) -> "PandasSeriesLike":
     """
     Convert timezone aware timestamps to timezone-naive in the specified timezone or local timezone.
 
@@ -199,6 +200,7 @@ def _check_series_localize_timestamps(s: "PandasSeriesLike", timezone: str, data
     """
     from pyspark.sql.pandas.utils import require_minimum_pandas_version
     require_minimum_pandas_version()
+
     from pandas.api.types import is_datetime64tz_dtype
     tz = timezone or _get_local_timezone()
     # Check if its ArrayType<TimeStamp>
@@ -210,8 +212,9 @@ def _check_series_localize_timestamps(s: "PandasSeriesLike", timezone: str, data
         return s
 
 
-def _check_series_convert_timestamps_internal(s: "PandasSeriesLike", timezone: str,
-                                              datatype: Optional[str] = None) -> "PandasSeriesLike":
+def _check_series_convert_timestamps_internal(
+    s: "PandasSeriesLike", timezone: str, datatype: Optional[str] = None
+) -> "PandasSeriesLike":
     """
     Convert a tz-naive timestamp in the specified timezone or local timezone to UTC normalized for
     Spark internal storage
@@ -274,8 +277,9 @@ def _check_series_convert_timestamps_internal(s: "PandasSeriesLike", timezone: s
 
 
 def _check_series_convert_timestamps_localize(
-        s: "PandasSeriesLike", from_timezone: Optional[str], to_timezone: Optional[str],
-        datatype: Optional[str] = None) -> "PandasSeriesLike":
+    s: "PandasSeriesLike", from_timezone: Optional[str], to_timezone: Optional[str],
+    datatype: Optional[str] = None
+) -> "PandasSeriesLike":
     """
     Convert timestamp to timezone-naive in the specified timezone or local timezone
 
@@ -333,8 +337,9 @@ def modify_timestamp_array(data, to_tz: Optional[str], from_tz: Optional[str] = 
         return list(iterator)
 
 
-def _check_series_convert_timestamps_local_tz(s: "PandasSeriesLike", timezone: str, datatype=None
-                                              ) -> "PandasSeriesLike":
+def _check_series_convert_timestamps_local_tz(
+    s: "PandasSeriesLike", timezone: str, datatype: Optional[str] = None
+) -> "PandasSeriesLike":
     """
     Convert timestamp to timezone-naive in the specified timezone or local timezone
 
@@ -354,7 +359,7 @@ def _check_series_convert_timestamps_local_tz(s: "PandasSeriesLike", timezone: s
 
 
 def _check_series_convert_timestamps_tz_local(
-    s: "PandasSeriesLike", timezone: str, datatype=None
+    s: "PandasSeriesLike", timezone: str, datatype: Optional[str] = None
 ) -> "PandasSeriesLike":
     """
     Convert timestamp to timezone-naive in the specified timezone or local timezone

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -28,7 +28,7 @@ from pyspark.sql import Row, SparkSession
 from pyspark.sql.functions import rand, udf
 from pyspark.sql.types import StructType, StringType, IntegerType, LongType, \
     FloatType, DoubleType, DecimalType, DateType, TimestampType, TimestampNTZType, \
-    BinaryType, StructField, ArrayType, NullType, MapType
+    BinaryType, StructField, ArrayType, NullType
 from pyspark.testing.sqlutils import ReusedSQLTestCase, have_pandas, have_pyarrow, \
     pandas_requirement_message, pyarrow_requirement_message
 from pyspark.testing.utils import QuietTest
@@ -138,8 +138,8 @@ class ArrowTests(ReusedSQLTestCase):
 
     def test_toPandas_fallback_disabled(self):
         ts = datetime.datetime(2015, 11, 1, 0, 30)
-        schema = StructType([StructField("a", MapType(TimestampType(), TimestampType()), True)])
-        df = self.spark.createDataFrame([({ts: ts},)], schema=schema)
+        schema = StructType([StructField("a", ArrayType(ArrayType(TimestampType())), True)])
+        df = self.spark.createDataFrame([([[ts]],)], schema=schema)
         with QuietTest(self.sc):
             with self.warnings_lock:
                 with self.assertRaisesRegex(Exception, 'Unsupported type'):

--- a/python/pyspark/sql/tests/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/test_pandas_cogrouped_map.py
@@ -176,9 +176,9 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                     NotImplementedError,
-                    'Invalid return type.*ArrayType.*TimestampType'):
+                    'Invalid return type.*ArrayType.*ArrayType*.TimestampType'):
                 left.groupby('id').cogroup(right.groupby('id')).applyInPandas(
-                    lambda l, r: l, 'id long, v array<timestamp>')
+                    lambda l, r: l, 'id long, v array<array<timestamp>>')
 
     def test_wrong_args(self):
         left = self.data1

--- a/python/pyspark/sql/tests/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/test_pandas_grouped_map.py
@@ -250,10 +250,11 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                     NotImplementedError,
-                    'Invalid return type.*grouped map Pandas UDF.*ArrayType.*TimestampType'):
+                    'Invalid return type.*grouped map Pandas '
+                    'UDF.*ArrayType.*ArrayType*.TimestampType'):
                 pandas_udf(
                     lambda pdf: pdf,
-                    'id long, v array<timestamp>',
+                    'id long, v array<array<timestamp>>',
                     PandasUDFType.GROUPED_MAP)
 
     def test_wrong_args(self):
@@ -280,7 +281,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
     def test_unsupported_types(self):
         common_err_msg = 'Invalid return type.*grouped map Pandas UDF.*'
         unsupported_types = [
-            StructField('arr_ts', ArrayType(TimestampType())),
+            StructField('arr_ts', ArrayType(ArrayType(TimestampType()))),
             StructField('struct', StructType([StructField('l', LongType())])),
         ]
 

--- a/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
@@ -159,7 +159,7 @@ class GroupedAggPandasUDFTests(ReusedSQLTestCase):
 
         with QuietTest(self.sc):
             with self.assertRaisesRegex(NotImplementedError, 'not supported'):
-                @pandas_udf(ArrayType(TimestampType()), PandasUDFType.GROUPED_AGG)
+                @pandas_udf(ArrayType(ArrayType(TimestampType())), PandasUDFType.GROUPED_AGG)
                 def mean_and_std_udf(v):
                     return {v.mean(): v.std()}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added nested timestamp support for Pyspark with Arrow
Following code will run through this PR


```
from pyspark.sql.types import StructType, TimestampType, StructField, ArrayType, LongType
spark.conf.set("spark.sql.execution.arrow.pyspark.fallback.enabled", "False")
spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", "True")

import datetime
import pandas as pd
origin = pd.DataFrame({"a": [[datetime.datetime(2012, 2, 2, 2, 2, 2)]]})
df = spark.createDataFrame(origin, schema=StructType([StructField("a", ArrayType(TimestampType()), True)]))
ts = datetime.datetime(2015, 11, 1, 0, 30)

schema = StructType([StructField("a", ArrayType(TimestampType()), True)])

df = spark.createDataFrame([([ts, ts],)], schema=schema)

df.toPandas()
```


### Why are the changes needed?
This change is required to convert ArrayType(TimeStamp) to pandas via arrow. 


### Does this PR introduce any user-facing change?
Yes user will be able to convert DF which contain Arraytype(Timestamp) to pandas

### How was this patch tested?
unit tests