### PR TITLE
[SPARK-36748][PYTHON] Introduce the 'compute.isin_limit' option

### DIFF
--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -280,6 +280,10 @@ compute.ordered_head            False          'compute.ordered_head' sets wheth
                                                'compute.ordered_head' is set to True, pandas-on-
                                                Spark performs natural ordering beforehand, but it
                                                will cause a performance overhead.
+compute.isin_limit              80             'compute.isin_limit' sets the limit for filtering by
+                                               'Column.isin(list)'. If the length of the ‘list’ is
+                                               above the limit, broadcast join is used instead for
+                                               better performance.
 plotting.max_rows               1000           'plotting.max_rows' sets the visual limit on top-n-
                                                based plots such as `plot.bar` and `plot.pie`. If it
                                                is set to 1000, the first 1000 data points will be

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -195,6 +195,20 @@ _options = [
         types=bool,
     ),
     Option(
+        key="compute.isin_limit",
+        doc=(
+            "'compute.isin_limit' sets the limit for filtering by 'Column.isin(list)'. "
+            "If the length of the ‘list’ is above the limit, broadcast join is used instead "
+            "for better performance."
+        ),
+        default=80,
+        types=int,
+        check_func=(
+            lambda v: v >= 0,
+            "'compute.isin_limit' should be greater than or equal to 0.",
+        ),
+    ),
+    Option(
         key="plotting.max_rows",
         doc=(
             "'plotting.max_rows' sets the visual limit on top-n-based plots such as `plot.bar` "


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce the 'compute.isin_limit' option, with the default value of 80.

### Why are the changes needed?
`Column.isin(list)` doesn't perform well when the given `list` is large, as https://issues.apache.org/jira/browse/SPARK-33383.
Thus, 'compute.isin_limit' is introduced to constrain the usage of `Column.isin(list)` in the code base.
If the length of the ‘list’ is above the `'compute.isin_limit'`, broadcast join is used instead for better performance.

#### Why is the default value 80?
After reproducing the benchmark mentioned in https://issues.apache.org/jira/browse/SPARK-33383, 

| length of filtering list | isin time /ms| broadcast DF time / ms|
| :---:   | :-: | :-: |
| 200 | 69411 | 39296 |
| 100 | 43074 | 40087 |
| 80 | 35592 | 40350 |
| 50 | 28134 | 37847 |

We may notice when the length of the filtering list <= 80, the `isin` approach performs better than `broadcast DF`.

### Does this PR introduce _any_ user-facing change?
Users may read/write the value of `'compute.isin_limit'` as follows
```py
>>> ps.get_option('compute.isin_limit')
80

>>> ps.set_option('compute.isin_limit', 10)
>>> ps.get_option('compute.isin_limit')
10

>>> ps.set_option('compute.isin_limit', -1)
...
ValueError: 'compute.isin_limit' should be greater than or equal to 0.

>>> ps.reset_option('compute.isin_limit')
>>> ps.get_option('compute.isin_limit')
80
```

### How was this patch tested?
Manual test.