### PR TITLE
[SPARK-36727][SQL]Support sql overwrite a path that is also being read from when partit…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -68,10 +68,7 @@ case class InsertIntoHadoopFsRelationCommand(
       // scalastyle:on caselocale
       .getOrElse(conf.partitionOverwriteMode)
     val enableDynamicOverwrite = partitionOverwriteMode == PartitionOverwriteMode.DYNAMIC
-    // This config only makes sense when we are overwriting a partitioned dataset with dynamic
-    // partition columns.
-    enableDynamicOverwrite && mode == SaveMode.Overwrite &&
-      staticPartitions.size < partitionColumns.length
+    enableDynamicOverwrite && mode == SaveMode.Overwrite
   }
 
   override def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
```
// non-partitioned table overwrite
CREATE TABLE tbl (col1 INT, col2 STRING) USING PARQUET;
INSERT OVERWRITE TABLE tbl SELECT 0,1;
INSERT OVERWRITE TABLE tbl SELECT * FROM tbl;

// partitioned table static overwrite
CREATE TABLE tbl (col1 INT, col2 STRING) USING PARQUET PARTITIONED BY (pt1 INT);
INSERT OVERWRITE TABLE tbl PARTITION(p1=2021) SELECT 0 AS col1,1 AS col2;
INSERT OVERWRITE TABLE tbl PARTITION(p1=2021) SELECT col1, col2 FROM WHERE p1=2021;
```
When we run the above query, an error will be throwed "Cannot overwrite a path that is also being read from"
We need to support this operation when the spark.sql.sources.partitionOverwriteMode is dynamic

### How was this patch tested?
Unit tests -> InsertSuite.scala
