### PR TITLE
[SPARK-36705][SHUFFLE][FOLLOWUP] Avoid unnecessary logging for checking push-based shuffle

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2604,23 +2604,27 @@ private[spark] object Utils extends Logging {
    *   - serializer(such as KryoSerializer) supports relocation of serialized objects
    */
   def isPushBasedShuffleEnabled(conf: SparkConf): Boolean = {
-    val serializer = Utils.classForName(conf.get(SERIALIZER)).getConstructor(classOf[SparkConf])
-      .newInstance(conf).asInstanceOf[Serializer]
-    val canDoPushBasedShuffle =
-      conf.get(PUSH_BASED_SHUFFLE_ENABLED) &&
-        (conf.get(IS_TESTING).getOrElse(false) ||
-          (conf.get(SHUFFLE_SERVICE_ENABLED) &&
-            conf.get(SparkLauncher.SPARK_MASTER, null) == "yarn" &&
-            // TODO: [SPARK-36744] needs to support IO encryption for push-based shuffle
-            !conf.get(IO_ENCRYPTION_ENABLED) &&
-            serializer.supportsRelocationOfSerializedObjects))
-
-    if (!canDoPushBasedShuffle) {
-      logWarning("Push-based shuffle can only be enabled when the application is submitted" +
-        "to run in YARN mode, with external shuffle service enabled, IO encryption disabled, and" +
-        "relocation of serialized objects supported.")
+    if (conf.get(PUSH_BASED_SHUFFLE_ENABLED)) {
+      if (conf.get(IS_TESTING).getOrElse(false)) {
+        true
+      } else {
+        val serializer = Utils.classForName(conf.get(SERIALIZER)).getConstructor(classOf[SparkConf])
+          .newInstance(conf).asInstanceOf[Serializer]
+        val canDoPushBasedShuffle = conf.get(SHUFFLE_SERVICE_ENABLED) &&
+          conf.get(SparkLauncher.SPARK_MASTER, null) == "yarn" &&
+          // TODO: [SPARK-36744] needs to support IO encryption for push-based shuffle
+          !conf.get(IO_ENCRYPTION_ENABLED) &&
+          serializer.supportsRelocationOfSerializedObjects
+        if (!canDoPushBasedShuffle) {
+          logWarning("Push-based shuffle can only be enabled when the application is submitted " +
+            "to run in YARN mode, with external shuffle service enabled, IO encryption disabled," +
+            " and relocation of serialized objects supported.")
+        }
+        canDoPushBasedShuffle
+      }
+    } else {
+      false
     }
-    canDoPushBasedShuffle
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When running unit test for other change after rebasing master, I found the log becomes very noisy with printing a lot of lines of

```
WARN org.apache.spark.util.Utils: Push-based shuffle can only be enabled when the application is submittedto run in YARN mode, with external shuffle service enabled, IO encryption disabled, andrelocation of serialized objects supported.
```

Example screenshot for one unit test log:

<img width="1677" alt="Screen Shot 2021-09-13 at 7 40 14 PM" src="https://user-images.githubusercontent.com/4629931/133187285-21fddc6f-8c79-4fd8-89c8-1e7f80e7d88f.png">

Then I found https://github.com/apache/spark/pull/33976 where we printed the warning even when the push-based shuffle is disabled, which is unnecessary. This would generate a lot of noise for driver log which would make debugging harder.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Reduce noise in driver log.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing unit tests.