### PR TITLE
[SPARK-36750][CORE][SQL][MLLIB][YARN] Replace the Guava API with `java.util.Objects` API with the same semantics

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
@@ -31,7 +32,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 import org.apache.spark.annotation.Private;
@@ -70,7 +70,7 @@ public class InMemoryStore implements KVStore {
     Object comparable = asKey(indexedValue);
     KVTypeInfo.Accessor accessor = list.getIndexAccessor(index);
     for (Object o : view(type)) {
-      if (Objects.equal(comparable, asKey(accessor.get(o)))) {
+      if (Objects.equals(comparable, asKey(accessor.get(o)))) {
         count++;
       }
     }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreView.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreView.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.util.kvstore;
 
+import java.util.Objects;
+
 import com.google.common.base.Preconditions;
 
 import org.apache.spark.annotation.Private;
@@ -58,7 +60,7 @@ public abstract class KVStoreView<T> implements Iterable<T> {
    * Iterates according to the given index.
    */
   public KVStoreView<T> index(String name) {
-    this.index = Preconditions.checkNotNull(name);
+    this.index = Objects.requireNonNull(name);
     return this;
   }
 

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBTypeInfo.java
@@ -21,6 +21,8 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Preconditions;
@@ -305,8 +307,8 @@ class LevelDBTypeInfo {
     /** The full key in the index that identifies the given entity. */
     byte[] entityKey(byte[] prefix, Object entity) throws Exception {
       Object indexValue = getValue(entity);
-      Preconditions.checkNotNull(indexValue, "Null index value for %s in type %s.",
-        name, type.getName());
+      Objects.requireNonNull(indexValue, () -> String.format("Null index value for %s in type %s.",
+        new String(name), type.getName()));
       byte[] entityKey = start(prefix, indexValue);
       if (!isNatural) {
         entityKey = buildKey(false, entityKey, toKey(naturalIndex().getValue(entity)));
@@ -331,8 +333,8 @@ class LevelDBTypeInfo {
         byte[] naturalKey,
         byte[] prefix) throws Exception {
       Object indexValue = getValue(entity);
-      Preconditions.checkNotNull(indexValue, "Null index value for %s in type %s.",
-        name, type.getName());
+      Objects.requireNonNull(indexValue, () -> String.format("Null index value for %s in type %s.",
+        new String(name), type.getName()));
 
       byte[] entityKey = start(prefix, indexValue);
       if (!isNatural) {

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -79,8 +80,8 @@ public class TransportClient implements Closeable {
   private volatile boolean timedOut;
 
   public TransportClient(Channel channel, TransportResponseHandler handler) {
-    this.channel = Preconditions.checkNotNull(channel);
-    this.handler = Preconditions.checkNotNull(handler);
+    this.channel = Objects.requireNonNull(channel);
+    this.handler = Objects.requireNonNull(handler);
     this.timedOut = false;
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -22,13 +22,13 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.codahale.metrics.MetricSet;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import io.netty.bootstrap.Bootstrap;
@@ -94,9 +94,9 @@ public class TransportClientFactory implements Closeable {
   public TransportClientFactory(
       TransportContext context,
       List<TransportClientBootstrap> clientBootstraps) {
-    this.context = Preconditions.checkNotNull(context);
+    this.context = Objects.requireNonNull(context);
     this.conf = context.getConf();
-    this.clientBootstraps = Lists.newArrayList(Preconditions.checkNotNull(clientBootstraps));
+    this.clientBootstraps = Lists.newArrayList(Objects.requireNonNull(clientBootstraps));
     this.connectionPool = new ConcurrentHashMap<>();
     this.numConnectionsPerPeer = conf.numConnectionsPerPeer();
     this.rand = new Random();

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthEngine.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthEngine.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.Properties;
+import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -56,8 +57,8 @@ class AuthEngine implements Closeable {
   private TransportCipher sessionCipher;
 
   AuthEngine(String appId, String preSharedSecret, TransportConf conf) {
-    Preconditions.checkNotNull(appId);
-    Preconditions.checkNotNull(preSharedSecret);
+    Objects.requireNonNull(appId);
+    Objects.requireNonNull(preSharedSecret);
     this.appId = appId;
     this.preSharedSecret = preSharedSecret.getBytes(UTF_8);
     this.conf = conf;

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/AbstractMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/AbstractMessage.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.network.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 
@@ -48,7 +48,7 @@ public abstract class AbstractMessage implements Message {
   }
 
   protected boolean equals(AbstractMessage other) {
-    return isBodyInFrame == other.isBodyInFrame && Objects.equal(body, other.body);
+    return isBodyInFrame == other.isBodyInFrame && Objects.equals(body, other.body);
   }
 
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/MergedBlockMetaRequest.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/MergedBlockMetaRequest.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.network.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -79,7 +80,7 @@ public class MergedBlockMetaRequest extends AbstractMessage implements RequestMe
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(requestId, appId, shuffleId, shuffleMergeId, reduceId);
+    return Objects.hash(requestId, appId, shuffleId, shuffleMergeId, reduceId);
   }
 
   @Override
@@ -88,7 +89,7 @@ public class MergedBlockMetaRequest extends AbstractMessage implements RequestMe
       MergedBlockMetaRequest o = (MergedBlockMetaRequest) other;
       return requestId == o.requestId && shuffleId == o.shuffleId &&
         shuffleMergeId == o.shuffleMergeId && reduceId == o.reduceId &&
-        Objects.equal(appId, o.appId);
+        Objects.equals(appId, o.appId);
     }
     return false;
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/MergedBlockMetaSuccess.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/MergedBlockMetaSuccess.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.network.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -51,7 +52,7 @@ public class MergedBlockMetaSuccess extends AbstractResponseMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(requestId, numChunks);
+    return Objects.hash(requestId, numChunks);
   }
 
   @Override

--- a/common/network-common/src/main/java/org/apache/spark/network/sasl/SparkSaslServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/sasl/SparkSaslServer.java
@@ -29,8 +29,8 @@ import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
@@ -186,13 +186,13 @@ public class SparkSaslServer implements SaslEncryptionBackend {
 
   /* Encode a byte[] identifier as a Base64-encoded string. */
   public static String encodeIdentifier(String identifier) {
-    Preconditions.checkNotNull(identifier, "User cannot be null if SASL is enabled");
+    Objects.requireNonNull(identifier, "User cannot be null if SASL is enabled");
     return getBase64EncodedString(identifier);
   }
 
   /** Encode a password as a base64-encoded char[] array. */
   public static char[] encodePassword(String password) {
-    Preconditions.checkNotNull(password, "Password cannot be null if SASL is enabled");
+    Objects.requireNonNull(password, "Password cannot be null if SASL is enabled");
     return getBase64EncodedString(password).toCharArray();
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/server/BlockPushNonFatalFailure.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/BlockPushNonFatalFailure.java
@@ -18,6 +18,7 @@
 package org.apache.spark.network.server;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import com.google.common.base.Preconditions;
 
@@ -101,13 +102,13 @@ public class BlockPushNonFatalFailure extends RuntimeException {
 
   public ByteBuffer getResponse() {
     // Ensure we do not invoke this method if response is not set
-    Preconditions.checkNotNull(response);
+    Objects.requireNonNull(response);
     return response;
   }
 
   public ReturnCode getReturnCode() {
     // Ensure we do not invoke this method if returnCode is not set
-    Preconditions.checkNotNull(returnCode);
+    Objects.requireNonNull(returnCode);
     return returnCode;
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java
@@ -19,6 +19,7 @@ package org.apache.spark.network.server;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -61,7 +62,7 @@ public class OneForOneStreamManager extends StreamManager {
 
     StreamState(String appId, Iterator<ManagedBuffer> buffers, Channel channel) {
       this.appId = appId;
-      this.buffers = Preconditions.checkNotNull(buffers);
+      this.buffers = Objects.requireNonNull(buffers);
       this.associatedChannel = channel;
     }
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -20,11 +20,11 @@ package org.apache.spark.network.server;
 import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricSet;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -77,7 +77,7 @@ public class TransportServer implements Closeable {
       this.pooledAllocator = NettyUtils.createPooledByteBufAllocator(
           conf.preferDirectBufs(), true /* allowCache */, conf.serverThreads());
     }
-    this.bootstraps = Lists.newArrayList(Preconditions.checkNotNull(bootstraps));
+    this.bootstraps = Lists.newArrayList(Objects.requireNonNull(bootstraps));
 
     boolean shouldClose = true;
     try {

--- a/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -22,11 +22,11 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.Unpooled;
 import org.apache.commons.lang3.SystemUtils;
@@ -185,7 +185,7 @@ public class JavaUtils {
   }
 
   private static boolean isSymlink(File file) throws IOException {
-    Preconditions.checkNotNull(file);
+    Objects.requireNonNull(file);
     File fileInCanonicalDir = null;
     if (file.getParent() == null) {
       fileInCanonicalDir = file;

--- a/common/network-common/src/main/java/org/apache/spark/network/util/LimitedInputStream.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/LimitedInputStream.java
@@ -38,6 +38,7 @@ package org.apache.spark.network.util;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 import com.google.common.base.Preconditions;
 
@@ -69,7 +70,7 @@ public final class LimitedInputStream extends FilterInputStream {
   public LimitedInputStream(InputStream in, long limit, boolean closeWrappedStream) {
     super(in);
     this.closeWrappedStream = closeWrappedStream;
-    Preconditions.checkNotNull(in);
+    Objects.requireNonNull(in);
     Preconditions.checkArgument(limit >= 0, "limit must be non-negative");
     left = limit;
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -35,7 +36,6 @@ import com.codahale.metrics.RatioGauge;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.Counter;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -581,7 +581,7 @@ public class ExternalBlockHandler extends RpcHandler
 
     @Override
     public ManagedBuffer next() {
-      ManagedBuffer block = Preconditions.checkNotNull(mergeManager.getMergedBlockData(
+      ManagedBuffer block = Objects.requireNonNull(mergeManager.getMergedBlockData(
         appId, shuffleId, shuffleMergeId, reduceIds[reduceIdx], chunkIds[reduceIdx][chunkIdx]));
       if (chunkIdx < chunkIds[reduceIdx].length - 1) {
         chunkIdx += 1;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedBlockMeta.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedBlockMeta.java
@@ -20,8 +20,8 @@ package org.apache.spark.network.shuffle;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.roaringbitmap.RoaringBitmap;
@@ -43,7 +43,7 @@ public class MergedBlockMeta {
 
   public MergedBlockMeta(int numChunks, ManagedBuffer chunksBitmapBuffer) {
     this.numChunks = numChunks;
-    this.chunksBitmapBuffer = Preconditions.checkNotNull(chunksBitmapBuffer);
+    this.chunksBitmapBuffer = Objects.requireNonNull(chunksBitmapBuffer);
   }
 
   public int getNumChunks() {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/AbstractFetchShuffleBlocks.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/AbstractFetchShuffleBlocks.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.network.shuffle.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -61,7 +62,7 @@ public abstract class AbstractFetchShuffleBlocks extends BlockTransferMessage {
     if (o == null || getClass() != o.getClass()) return false;
     AbstractFetchShuffleBlocks that = (AbstractFetchShuffleBlocks) o;
     return shuffleId == that.shuffleId
-      && Objects.equal(appId, that.appId) && Objects.equal(execId, that.execId);
+      && Objects.equals(appId, that.appId) && Objects.equals(execId, that.execId);
   }
 
   @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockPushReturnCode.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockPushReturnCode.java
@@ -19,7 +19,6 @@ package org.apache.spark.network.shuffle.protocol;
 
 import java.util.Objects;
 
-import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -43,7 +42,7 @@ public class BlockPushReturnCode extends BlockTransferMessage {
   public final String failureBlockId;
 
   public BlockPushReturnCode(byte returnCode, String failureBlockId) {
-    Preconditions.checkNotNull(BlockPushNonFatalFailure.getReturnCode(returnCode));
+    Objects.requireNonNull(BlockPushNonFatalFailure.getReturnCode(returnCode));
     this.returnCode = returnCode;
     this.failureBlockId = failureBlockId;
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/FinalizeShuffleMerge.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/FinalizeShuffleMerge.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.network.shuffle.protocol;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -54,7 +55,7 @@ public class FinalizeShuffleMerge extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, appAttemptId, shuffleId, shuffleMergeId);
+    return Objects.hash(appId, appAttemptId, shuffleId, shuffleMergeId);
   }
 
   @Override
@@ -71,7 +72,7 @@ public class FinalizeShuffleMerge extends BlockTransferMessage {
   public boolean equals(Object other) {
     if (other != null && other instanceof FinalizeShuffleMerge) {
       FinalizeShuffleMerge o = (FinalizeShuffleMerge) other;
-      return Objects.equal(appId, o.appId)
+      return Objects.equals(appId, o.appId)
         && appAttemptId == o.appAttemptId
         && shuffleId == o.shuffleId
         && shuffleMergeId == o.shuffleMergeId;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/MergeStatuses.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/MergeStatuses.java
@@ -18,8 +18,8 @@
 package org.apache.spark.network.shuffle.protocol;
 
 import java.util.Arrays;
+import java.util.Objects;
 
-import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -78,8 +78,8 @@ public class MergeStatuses extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    int objectHashCode = Objects.hashCode(shuffleId) * 41 +
-        Objects.hashCode(shuffleMergeId);
+    int objectHashCode = Objects.hash(shuffleId) * 41 +
+        Objects.hash(shuffleMergeId);
     return (objectHashCode * 41 + Arrays.hashCode(reduceIds) * 41
       + Arrays.hashCode(bitmaps) * 41 + Arrays.hashCode(sizes));
   }
@@ -97,8 +97,8 @@ public class MergeStatuses extends BlockTransferMessage {
   public boolean equals(Object other) {
     if (other != null && other instanceof MergeStatuses) {
       MergeStatuses o = (MergeStatuses) other;
-      return Objects.equal(shuffleId, o.shuffleId)
-        && Objects.equal(shuffleMergeId, o.shuffleMergeId)
+      return Objects.equals(shuffleId, o.shuffleId)
+        && Objects.equals(shuffleMergeId, o.shuffleMergeId)
         && Arrays.equals(bitmaps, o.bitmaps)
         && Arrays.equals(reduceIds, o.reduceIds)
         && Arrays.equals(sizes, o.sizes);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/PushBlockStream.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/PushBlockStream.java
@@ -17,9 +17,9 @@
 
 package org.apache.spark.network.shuffle.protocol;
 
-import com.google.common.base.Objects;
-import io.netty.buffer.ByteBuf;
+import java.util.Objects;
 
+import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -68,7 +68,7 @@ public class PushBlockStream extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, appAttemptId, shuffleId, shuffleMergeId, mapIndex , reduceId,
+    return Objects.hash(appId, appAttemptId, shuffleId, shuffleMergeId, mapIndex , reduceId,
       index);
   }
 
@@ -89,7 +89,7 @@ public class PushBlockStream extends BlockTransferMessage {
   public boolean equals(Object other) {
     if (other != null && other instanceof PushBlockStream) {
       PushBlockStream o = (PushBlockStream) other;
-      return Objects.equal(appId, o.appId)
+      return Objects.equals(appId, o.appId)
         && appAttemptId == o.appAttemptId
         && shuffleId == o.shuffleId
         && shuffleMergeId == o.shuffleMergeId

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/mesos/RegisterDriver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/mesos/RegisterDriver.java
@@ -17,7 +17,6 @@
 
 package org.apache.spark.network.shuffle.protocol.mesos;
 
-import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.spark.network.protocol.Encoders;
@@ -25,6 +24,8 @@ import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
 
 // Needed by ScalaDoc. See SPARK-7726
 import static org.apache.spark.network.shuffle.protocol.BlockTransferMessage.Type;
+
+import java.util.Objects;
 
 /**
  * A message sent from the driver to register with the MesosExternalShuffleService.
@@ -58,7 +59,7 @@ public class RegisterDriver extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, heartbeatTimeoutMs);
+    return Objects.hash(appId, heartbeatTimeoutMs);
   }
 
   @Override
@@ -66,7 +67,7 @@ public class RegisterDriver extends BlockTransferMessage {
     if (!(o instanceof RegisterDriver)) {
       return false;
     }
-    return Objects.equal(appId, ((RegisterDriver) o).appId);
+    return Objects.equals(appId, ((RegisterDriver) o).appId);
   }
 
   public static RegisterDriver decode(ByteBuf buf) {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/mesos/RegisterDriver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/mesos/RegisterDriver.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.network.shuffle.protocol.mesos;
 
+import java.util.Objects;
+
 import io.netty.buffer.ByteBuf;
 
 import org.apache.spark.network.protocol.Encoders;
@@ -24,8 +26,6 @@ import org.apache.spark.network.shuffle.protocol.BlockTransferMessage;
 
 // Needed by ScalaDoc. See SPARK-7726
 import static org.apache.spark.network.shuffle.protocol.BlockTransferMessage.Type;
-
-import java.util.Objects;
 
 /**
  * A message sent from the driver to register with the MesosExternalShuffleService.

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -434,7 +433,7 @@ public class YarnShuffleService extends AuxiliaryService {
    * and DB exists in the local dir of NM by old version of shuffle service.
    */
   protected File initRecoveryDb(String dbName) {
-    Preconditions.checkNotNull(_recoveryPath,
+    Objects.requireNonNull(_recoveryPath,
       "recovery path should not be null if NM recovery is enabled");
 
     File recoveryFile = new File(_recoveryPath.toUri().getPath(), dbName);

--- a/core/src/main/java/org/apache/spark/api/java/Optional.java
+++ b/core/src/main/java/org/apache/spark/api/java/Optional.java
@@ -20,8 +20,6 @@ package org.apache.spark.api.java;
 import java.io.Serializable;
 import java.util.Objects;
 
-import com.google.common.base.Preconditions;
-
 /**
  * <p>Like {@code java.util.Optional} in Java 8, {@code scala.Option} in Scala, and
  * {@code com.google.common.base.Optional} in Google Guava, this class represents a
@@ -71,8 +69,7 @@ public final class Optional<T> implements Serializable {
   }
 
   private Optional(T value) {
-    Preconditions.checkNotNull(value);
-    this.value = value;
+    this.value = Objects.requireNonNull(value);
   }
 
   // java.util.Optional API (subset)
@@ -112,8 +109,7 @@ public final class Optional<T> implements Serializable {
    * @throws NullPointerException if this is empty (contains no value)
    */
   public T get() {
-    Preconditions.checkNotNull(value);
-    return value;
+    return Objects.requireNonNull(value);
   }
 
   /**

--- a/core/src/main/java/org/apache/spark/api/java/Optional.java
+++ b/core/src/main/java/org/apache/spark/api/java/Optional.java
@@ -69,7 +69,8 @@ public final class Optional<T> implements Serializable {
   }
 
   private Optional(T value) {
-    this.value = Objects.requireNonNull(value);
+    Objects.requireNonNull(value);
+    this.value = value;
   }
 
   // java.util.Optional API (subset)
@@ -109,7 +110,8 @@ public final class Optional<T> implements Serializable {
    * @throws NullPointerException if this is empty (contains no value)
    */
   public T get() {
-    return Objects.requireNonNull(value);
+    Objects.requireNonNull(value);
+    return value;
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -17,13 +17,13 @@
 
 package org.apache.spark.rdd
 
+import java.util.Objects
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonPropertyOrder}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.google.common.base.Objects
 
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
@@ -69,7 +69,7 @@ private[spark] class RDDOperationScope(
     }
   }
 
-  override def hashCode(): Int = Objects.hashCode(id, name, parent)
+  override def hashCode(): Int = Objects.hash(id, name, parent)
 
   override def toString: String = toJson
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.mllib.linalg
 
-import java.util.{Arrays, Random}
+import java.util.{Arrays, Objects, Random}
 
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder => MArrayBuilder, HashSet => MHashSet}
 import scala.language.implicitConversions
@@ -313,7 +313,7 @@ class DenseMatrix @Since("1.3.0") (
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(numRows: Integer, numCols: Integer, toArray)
+    Objects.hash(numRows: Integer, numCols: Integer, toArray)
   }
 
   private[mllib] def asBreeze: BM[Double] = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrix.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.linalg.distributed
 
+import java.util.Objects
+
 import breeze.linalg.{DenseMatrix => BDM, DenseVector => BDV, Matrix => BM}
 import scala.collection.mutable.ArrayBuffer
 
@@ -90,7 +92,7 @@ private[mllib] class GridPartitioner(
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(
+    Objects.hash(
       rows: java.lang.Integer,
       cols: java.lang.Integer,
       rowsPerPart: java.lang.Integer,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.tree.model
 
+import java.util.Objects
+
 import org.apache.spark.annotation.Since
 import org.apache.spark.mllib.tree.impurity.ImpurityCalculator
 
@@ -56,7 +58,7 @@ class InformationGainStats(
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(
+    Objects.hash(
       gain: java.lang.Double,
       impurity: java.lang.Double,
       leftImpurity: java.lang.Double,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Predict.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Predict.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.tree.model
 
+import java.util.Objects
+
 import org.apache.spark.annotation.Since
 
 /**
@@ -39,6 +41,6 @@ class Predict @Since("1.2.0") (
   }
 
   override def hashCode: Int = {
-    com.google.common.base.Objects.hashCode(predict: java.lang.Double, prob: java.lang.Double)
+    Objects.hash(predict: java.lang.Double, prob: java.lang.Double)
   }
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -22,7 +22,7 @@ import java.net.{InetAddress, UnknownHostException, URI, URL}
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
-import java.util.{Locale, Properties, UUID}
+import java.util.{Locale, Objects, Properties, UUID}
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.collection.JavaConverters._
@@ -30,7 +30,6 @@ import scala.collection.immutable.{Map => IMap}
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, ListBuffer, Map}
 import scala.util.control.NonFatal
 
-import com.google.common.base.Objects
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.hadoop.fs.permission.FsPermission
@@ -1599,7 +1598,7 @@ private[spark] object Client extends Logging {
       }
     }
 
-    Objects.equal(srcHost, dstHost) && srcUri.getPort() == dstUri.getPort()
+    Objects.equals(srcHost, dstHost) && srcUri.getPort() == dstUri.getPort()
 
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/IdentifierImpl.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/IdentifierImpl.java
@@ -22,8 +22,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.base.Preconditions;
-
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.catalyst.util.package$;
 
@@ -37,8 +35,8 @@ class IdentifierImpl implements Identifier {
   private String name;
 
   IdentifierImpl(String[] namespace, String name) {
-    Preconditions.checkNotNull(namespace, "Identifier namespace cannot be null");
-    Preconditions.checkNotNull(name, "Identifier name cannot be null");
+    Objects.requireNonNull(namespace, "Identifier namespace cannot be null");
+    Objects.requireNonNull(name, "Identifier name cannot be null");
     this.namespace = namespace;
     this.name = name;
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
-import com.google.common.base.Objects
+import java.util.Objects
 
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
@@ -47,7 +47,7 @@ case class BatchScanExec(
       false
   }
 
-  override def hashCode(): Int = Objects.hashCode(batch, runtimeFilters)
+  override def hashCode(): Int = Objects.hash(batch, runtimeFilters)
 
   @transient override lazy val partitions: Seq[InputPartition] = batch.planInputPartitions()
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -33,7 +33,6 @@ import scala.Tuple3;
 import scala.Tuple4;
 import scala.Tuple5;
 
-import com.google.common.base.Objects;
 import org.apache.spark.sql.streaming.TestGroupState;
 import org.junit.*;
 
@@ -1009,12 +1008,12 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       SmallBean smallBean = (SmallBean) o;
-      return b == smallBean.b && com.google.common.base.Objects.equal(a, smallBean.a);
+      return b == smallBean.b && Objects.equals(a, smallBean.a);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(a, b);
+      return Objects.hash(a, b);
     }
   }
 
@@ -1034,7 +1033,7 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       NestedSmallBean that = (NestedSmallBean) o;
-      return Objects.equal(f, that.f);
+      return Objects.equals(f, that.f);
     }
 
     @Override
@@ -1076,13 +1075,13 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       NestedSmallBeanWithNonNullField that = (NestedSmallBeanWithNonNullField) o;
-      return Objects.equal(nullable_f, that.nullable_f) &&
-        Objects.equal(nonNull_f, that.nonNull_f) && Objects.equal(childMap, that.childMap);
+      return Objects.equals(nullable_f, that.nullable_f) &&
+        Objects.equals(nonNull_f, that.nonNull_f) && Objects.equals(childMap, that.childMap);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(nullable_f, nonNull_f, childMap);
+      return Objects.hash(nullable_f, nonNull_f, childMap);
     }
   }
 
@@ -1103,7 +1102,7 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       NestedSmallBean2 that = (NestedSmallBean2) o;
-      return Objects.equal(f, that.f);
+      return Objects.equals(f, that.f);
     }
 
     @Override
@@ -1645,7 +1644,7 @@ public class JavaDatasetSuite implements Serializable {
     }
 
     public int hashCode() {
-      return Objects.hashCode(enumField, regularField);
+      return Objects.hash(enumField, regularField);
     }
 
     public boolean equals(Object other) {
@@ -1882,14 +1881,14 @@ public class JavaDatasetSuite implements Serializable {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       SpecificListsBean that = (SpecificListsBean) o;
-      return Objects.equal(arrayList, that.arrayList) &&
-        Objects.equal(linkedList, that.linkedList) &&
-        Objects.equal(list, that.list);
+      return Objects.equals(arrayList, that.arrayList) &&
+        Objects.equals(linkedList, that.linkedList) &&
+        Objects.equals(list, that.list);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(arrayList, linkedList, list);
+      return Objects.hash(arrayList, linkedList, list);
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -18,11 +18,11 @@
 package org.apache.spark.sql.hive
 
 import java.rmi.server.UID
+import java.util.Objects
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 
-import com.google.common.base.Objects
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -128,7 +128,7 @@ private[hive] object HiveShim {
 
     override def hashCode(): Int = {
       if (functionClassName == HIVE_GENERIC_UDF_MACRO_CLS) {
-        Objects.hashCode(functionClassName, instance.asInstanceOf[GenericUDFMacro].getBody())
+        Objects.hash(functionClassName, instance.asInstanceOf[GenericUDFMacro].getBody())
       } else {
         functionClassName.hashCode()
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Java 8 provides the` java.util.Objects`, this pr it to replace some Guava API usages with the same semantics, the replacement rules are as follows:

1. Preconditions.checkNotNull -> Objects.requireNonNull

**Guava**
```java
public static <T> T checkNotNull(T reference,
      @Nullable String errorMessageTemplate,
      @Nullable Object... errorMessageArgs) {
    if (reference == null) {
      // If either of these parameters is null, the right thing happens anyway
      throw new NullPointerException(
          format(errorMessageTemplate, errorMessageArgs));
    }
    return reference;
  }
```

**java.util.Objects**

```java
    public static <T> T requireNonNull(T obj, Supplier<String> messageSupplier) {
        if (obj == null)
            throw new NullPointerException(messageSupplier.get());
        return obj;
    }
```


2. Objects.hashCode -> j.u.Objects.hash

**Guava**
```java
  public static int hashCode(@Nullable Object... objects) {
    return java.util.Arrays.hashCode(objects);
  }
```

**java.util.Objects**

```java
    public static int hash(Object... values) {
        return java.util.Arrays.hashCode(values);
    }
```
3. Objects.equal -> j.u.Objects.equals

**Guava**
```java
  public static boolean equal(@Nullable Object a, @Nullable Object b) {
    return a == b || (a != null && a.equals(b));
  }
```

**java.util.Objects**

```java
    public static boolean equals(Object a, Object b) {
        return (a == b) || (a != null && a.equals(b));
    }
```

### Why are the changes needed?
Reduce dependence on Guava API because Spark still use Guava 14.0.1.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass the Jenkins or GitHub Action
