### PR TITLE
[SPARK-36706][SQL][3.1] OverwriteByExpression conversion in DataSourceV2Strategy use wrong param in translateFilter

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -213,7 +213,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
     case OverwriteByExpression(r: DataSourceV2Relation, deleteExpr, query, writeOptions, _) =>
       // fail if any filter cannot be converted. correctness depends on removing all matching data.
       val filters = splitConjunctivePredicates(deleteExpr).map {
-        filter => DataSourceStrategy.translateFilter(deleteExpr,
+        filter => DataSourceStrategy.translateFilter(filter,
           supportNestedPredicatePushdown = true).getOrElse(
             throw new AnalysisException(s"Cannot translate expression to source filter: $filter"))
       }.toArray

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -244,7 +244,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
 
     checkAnswer(
       spark.table("testcat.table_name"),
-      Seq(Row(1L, 1L, "a"), Row(2L, 2L, "b"), Row(3L, 3L, "c"), Row(5L, 5L, "e"), Row(6L, 6L, "f")))
+      Seq(Row(1L, 1L, "a"), Row(2L, 2L, "b"), Row(4L, 4L, "d"), Row(5L, 5L, "e"), Row(6L, 6L, "f")))
   }
 
   test("Overwrite: write to a temp view of v2 relation") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -220,7 +220,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
       Seq(Row(1L, "a"), Row(2L, "b"), Row(4L, "d"), Row(5L, "e"), Row(6L, "f")))
   }
 
-  test("Overwrite: overwrite by expression: more than one filters") {
+  test("SPARK-36706 Overwrite: overwrite by expression: more than one filters") {
     val df = spark.createDataFrame(Seq((1L, 1L, "a"), (2L, 2L, "b"), (3L, 3L, "c")))
       .toDF("id1", "id2", "data")
     df.createOrReplaceTempView("source_t")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -220,33 +220,6 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
       Seq(Row(1L, "a"), Row(2L, "b"), Row(4L, "d"), Row(5L, "e"), Row(6L, "f")))
   }
 
-  test("SPARK-36706 Overwrite: overwrite by expression: more than one filters") {
-    val df = spark.createDataFrame(Seq((1L, 1L, "a"), (2L, 2L, "b"), (3L, 3L, "c")))
-      .toDF("id1", "id2", "data")
-    df.createOrReplaceTempView("source_t")
-    val df2 = spark.createDataFrame(Seq((4L, 4L, "d"), (5L, 5L, "e"), (6L, 6L, "f")))
-      .toDF("id1", "id2", "data")
-    df2.createOrReplaceTempView("source2_t")
-
-    spark.sql(
-      "CREATE TABLE testcat.table_name (id1 bigint, id2 bigint, data string)" +
-        " USING foo PARTITIONED BY (id1, id2)")
-
-    checkAnswer(spark.table("testcat.table_name"), Seq.empty)
-
-    spark.table("source_t").writeTo("testcat.table_name").append()
-
-    checkAnswer(
-      spark.table("testcat.table_name"),
-      Seq(Row(1L, 1L, "a"), Row(2L, 2L, "b"), Row(3L, 3L, "c")))
-
-    spark.table("source2_t").writeTo("testcat.table_name").overwrite($"id1" === 3 && $"id2" === 3)
-
-    checkAnswer(
-      spark.table("testcat.table_name"),
-      Seq(Row(1L, 1L, "a"), Row(2L, 2L, "b"), Row(4L, 4L, "d"), Row(5L, 5L, "e"), Row(6L, 6L, "f")))
-  }
-
   test("Overwrite: write to a temp view of v2 relation") {
     spark.sql("CREATE TABLE testcat.table_name (id bigint, data string) USING foo")
     spark.table("source").writeTo("testcat.table_name").append()


### PR DESCRIPTION
### What changes were proposed in this pull request?
The wrong parameter is used in `translateFilter` in the following code
```
      val filters = splitConjunctivePredicates(deleteExpr).map {
        filter => DataSourceStrategy.translateFilter(deleteExpr,
          supportNestedPredicatePushdown = true).getOrElse(
            throw new AnalysisException(s"Cannot translate expression to source filter: $filter"))
      }.toArray
```

Using this as an example
```
spark.table("source2_t").writeTo("testcat.table_name").overwrite($"id1" === 3 && $"id2" === 3)
```

The above code will generate these filters: 
```
And(EqualTo(id1, 3),EqualTo(id2, 3))  
And(EqualTo(id1, 3),EqualTo(id2, 3))
```

 we want to fix the code so it will generate the filters like these: 
```
EqualTo(id1, 3)  
EqualTo(id2, 3)
```

This problem only exists in 3.1. In 3.2 and 3.3, we have

```
      val filters = splitConjunctivePredicates(deleteExpr).flatMap { pred =>
        val filter = DataSourceStrategy.translateFilter(pred, supportNestedPredicatePushdown = true)
        if (filter.isEmpty) {
          throw QueryCompilationErrors.cannotTranslateExpressionToSourceFilterError(pred)
        }
        filter
      }.toArray
```

### Why are the changes needed?
fix a bug in the code

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing tests
