### PR TITLE
[SPARK-36769][PYTHON] Improve `filter` of single-indexed DataFrame

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -9974,7 +9974,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 raise ValueError("items should be a list-like object.")
             if axis == 0:
                 if len(index_scols) == 1:
-                    if len(items) <= ps.option("compute.isin_limit"):
+                    if len(items) <= ps.get_option("compute.isin_limit"):
                         col = index_scols[0].isin([SF.lit(item) for item in items])
                         return DataFrame(self._internal.with_filter(col))
                     else:
@@ -9988,7 +9988,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         )
                         return DataFrame(self._internal.with_new_sdf(joined_sdf))
 
-                elif len(index_scols) > 1:
+                else:
                     # for multi-index
                     col = None
                     for item in items:

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -9987,7 +9987,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         joined_sdf = self._internal.spark_frame.join(
                             other=F.broadcast(item_sdf),
                             on=(index_scols[0] == scol_for(item_sdf, item_sdf_col)),
-                        ).drop(item_sdf_col)
+                            how="semi",
+                        )
 
                         return DataFrame(self._internal.with_new_sdf(joined_sdf))
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -9978,14 +9978,17 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         col = index_scols[0].isin([SF.lit(item) for item in items])
                         return DataFrame(self._internal.with_filter(col))
                     else:
-                        item_sdf_col = "__item"
+                        item_sdf_col = verify_temp_column_name(
+                            self._internal.spark_frame, "__item__"
+                        )
                         item_sdf = default_session().createDataFrame(
                             pd.DataFrame({item_sdf_col: items})
                         )
                         joined_sdf = self._internal.spark_frame.join(
                             other=F.broadcast(item_sdf),
                             on=(index_scols[0] == scol_for(item_sdf, item_sdf_col)),
-                        )
+                        ).drop(item_sdf_col)
+
                         return DataFrame(self._internal.with_new_sdf(joined_sdf))
 
                 else:

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -9974,12 +9974,20 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 raise ValueError("items should be a list-like object.")
             if axis == 0:
                 if len(index_scols) == 1:
-                    col = None
-                    for item in items:
-                        if col is None:
-                            col = index_scols[0] == SF.lit(item)
-                        else:
-                            col = col | (index_scols[0] == SF.lit(item))
+                    if len(items) <= ps.option("compute.isin_limit"):
+                        col = index_scols[0].isin([SF.lit(item) for item in items])
+                        return DataFrame(self._internal.with_filter(col))
+                    else:
+                        item_sdf_col = "__item"
+                        item_sdf = default_session().createDataFrame(
+                            pd.DataFrame({item_sdf_col: items})
+                        )
+                        joined_sdf = self._internal.spark_frame.join(
+                            other=F.broadcast(item_sdf),
+                            on=(index_scols[0] == scol_for(item_sdf, item_sdf_col)),
+                        )
+                        return DataFrame(self._internal.with_new_sdf(joined_sdf))
+
                 elif len(index_scols) > 1:
                     # for multi-index
                     col = None
@@ -9998,7 +10006,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                             col = midx_col
                         else:
                             col = col | midx_col
-                return DataFrame(self._internal.with_filter(col))
+                    return DataFrame(self._internal.with_filter(col))
             else:
                 return self[items]
         elif like is not None:

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -4196,6 +4196,13 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             psdf.filter(items=["ab", "aa"], axis=0).sort_index(),
             pdf.filter(items=["ab", "aa"], axis=0).sort_index(),
         )
+
+        with option_context("compute.isin_limit", 0):
+            self.assert_eq(
+                psdf.filter(items=["ab", "aa"], axis=0).sort_index(),
+                pdf.filter(items=["ab", "aa"], axis=0).sort_index(),
+            )
+
         self.assert_eq(
             psdf.filter(items=["ba", "db"], axis=1).sort_index(),
             pdf.filter(items=["ba", "db"], axis=1).sort_index(),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve `filter` of single-indexed DataFrame by replacing a long Project with Filter or Join.

### Why are the changes needed?
When the given `items` have too many elements, a long Project is introduced.
We may replace that with `Column.isin` or joining depending on the length of `items` for better performance.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit tests.
