### PR TITLE
[SPARK-36764][SS][TEST] Fix race-condition on "ensure continuous stream is being used" in KafkaContinuousTest

### DIFF
--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousTest.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousTest.scala
@@ -91,6 +91,7 @@ trait KafkaContinuousTest extends KafkaSourceTest {
       .load()
 
     testStream(query)(
+      makeSureGetOffsetCalled,
       Execute(q => assert(q.isInstanceOf[ContinuousExecution]))
     )
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The test “ensure continuous stream is being used“ in KafkaContinuousTest quickly checks the actual type of the execution, and stops the query. Stopping the streaming query in continuous mode is done by interrupting query execution thread and join with indefinite timeout.

In parallel, started streaming query is going to generate execution plan, including running optimizer. Some parts of SessionState can be built at that time, as they are defined as lazy. The problem is, some of them seem to “swallow” the InterruptedException and let the thread run continuously.

That said, the query can’t indicate whether there is a request on stopping query, so the query won’t stop.

This PR fixes such scenario via ensuring that streaming query has started before the test stops the query.

### Why are the changes needed?

Race-condition could end up with test hang till test framework marks it as timed-out.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.