### PR TITLE
[SPARK-34378][SQL][AVRO] Loosen AvroSerializer validation to allow extra nullable user-provided fields

### DIFF
--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -263,7 +263,8 @@ private[spark] object TestUtils {
       contains = contain(e, msg)
     }
     assert(contains,
-      s"Exception tree doesn't contain the expected exception ${typeMsg}with message: $msg")
+      s"Exception tree doesn't contain the expected exception ${typeMsg}with message: $msg\n" +
+        Utils.exceptionString(e))
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -263,8 +263,7 @@ private[spark] object TestUtils {
       contains = contain(e, msg)
     }
     assert(contains,
-      s"Exception tree doesn't contain the expected exception ${typeMsg}with message: $msg\n" +
-        Utils.exceptionString(e))
+      s"Exception tree doesn't contain the expected exception ${typeMsg}with message: $msg")
   }
 
   /**

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -262,7 +262,7 @@ private[sql] class AvroSerializer(
       avroStruct, catalystStruct, avroPath, catalystPath, positionalFieldMatch)
 
     avroSchemaHelper.validateNoExtraCatalystFields(ignoreNullable = false)
-    avroSchemaHelper.validateNoExtraAvroFields()
+    avroSchemaHelper.validateNoExtraRequiredAvroFields()
 
     val (avroIndices, fieldConverters) = avroSchemaHelper.matchedFields.map {
       case AvroMatchedField(catalystField, _, avroField) =>

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
@@ -104,7 +104,7 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
       AvroMatchedField(catalystSchema("shared2"), 3, avroSchema.getField("shared2"))
     ))
     assertThrows[IncompatibleSchemaException] {
-      helper.validateNoExtraAvroFields()
+      helper.validateNoExtraRequiredAvroFields()
     }
     helper.validateNoExtraCatalystFields(ignoreNullable = true)
     assertThrows[IncompatibleSchemaException] {
@@ -132,5 +132,28 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
     assertThrows[IncompatibleSchemaException] {
       helperNullable.validateNoExtraCatalystFields(ignoreNullable = false)
     }
+  }
+
+  test("validateNoExtraRequiredAvroFields detects required fields and ignores nullable fields") {
+    val avroSchema = SchemaBuilder.record("record").fields()
+      .requiredInt("foo")
+      .nullableInt("bar", 1)
+      .optionalInt("baz")
+      .endRecord()
+
+    val catalystFull =
+      new StructType().add("foo", IntegerType).add("bar", IntegerType).add("baz", IntegerType)
+
+    def testValidation(catalystFieldToRemove: String): Unit = {
+      val filteredSchema = StructType(catalystFull.filterNot(_.name == catalystFieldToRemove))
+      new AvroUtils.AvroSchemaHelper(avroSchema, filteredSchema, Seq(""), Seq(""), false)
+        .validateNoExtraRequiredAvroFields()
+    }
+
+    assertThrows[IncompatibleSchemaException] {
+      testValidation("foo")
+    }
+    testValidation("bar")
+    testValidation("baz")
   }
 }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
@@ -134,7 +134,7 @@ class AvroSchemaHelperSuite extends SQLTestUtils with SharedSparkSession {
     }
   }
 
-  test("validateNoExtraRequiredAvroFields detects required fields and ignores nullable fields") {
+  test("SPARK-34378: validateNoExtraRequiredAvroFields detects required and ignores nullable") {
     val avroSchema = SchemaBuilder.record("record").fields()
       .requiredInt("foo")
       .nullableInt("bar", 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Loosen the schema validation logic in `AvroSerializer` to accommodate the situation where a user has provided an explicit schema (via `avroSchema`) and this schema has extra fields which are not present in the Catalyst schema (the DF being written). Specifically, extra _nullable_ fields will be allowed and populated as null. _Required_ fields (non-null) will still be checked for existence.

### Why are the changes needed?
It's common for Avro schemas to evolve in a _compatible_ way (as discussed in Confluent's documentation on [Schema Evolution and Compatibility](https://docs.confluent.io/platform/current/schema-registry/avro.html); here I refer to `FULL` compatibility). Under such a scenario, new _optional_ fields are added to a schema. Producers are free to include the new field if they so choose, and consumers are free to read the new field if they so choose. It is optional on both sides.

Consider the following code:
```
val outputSchema = getOutputSchema()
df.write.format("avro").option("avroSchema", outputSchema).save(...)
```
If you have a situation where schemas are managed in some centralized repository (e.g. a [schema registry](https://docs.confluent.io/platform/current/schema-registry/index.html)), `outputSchema` may update at some point to add a new optional field, without you necessarily initiating any action on your side as a data producer. With the current code, this would cause the producer job to break, because validation would complain that the newly added field is not present in the DataFrame. Really, the producer should be able to continue producing data as normal even without adding the new field to the DataFrame it is writing out, because the field is optional.

### Does this PR introduce _any_ user-facing change?
Yes, when using the `avroSchema` option on the Avro data source during writes, validation is less strict, and allows for (compatible) schema evolution to be handled more gracefully.

### How was this patch tested?
New unit tests added. We've also been employing this logic internally for a few years, though the implementation was quite different due to recent changes in this area of the code.