### PR TITLE
[SPARK-36770][SQL] Replace Unbounded Following window functions with Unbounded Preceding window function (First, Last)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -89,6 +89,12 @@ case class SortOrder(
       direction == required.direction && nullOrdering == required.nullOrdering
   }
 
+  def reverse: SortOrder = {
+    val reversedDirection = if (isAscending) Descending else Ascending
+    val reversedNullOrdering = if (nullOrdering == NullsFirst) NullsLast else NullsFirst
+    this.copy(direction = reversedDirection, nullOrdering = reversedNullOrdering)
+  }
+
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): SortOrder =
     copy(child = newChildren.head, sameOrderExpressions = newChildren.tail)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/WindowFunctionOptimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/WindowFunctionOptimizer.scala
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, CurrentRow, NamedExpression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{SpecifiedWindowFrame, UnboundedFollowing}
+import org.apache.spark.sql.catalyst.expressions.{UnboundedPreceding, WindowExpression}
+import org.apache.spark.sql.catalyst.expressions.{WindowFrame, WindowSpecDefinition}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, First, Last}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.catalyst.rules.Rule
+
+// Replace UnboundedFollowing with UnboundedPreceding for window function first and last.
+
+object ReplaceUnboundedFollowingWithUnboundedPreceding extends Rule[LogicalPlan] {
+
+  private def replacedFrameSpec(frameSpec: WindowFrame): WindowFrame = {
+    frameSpec match {
+      case SpecifiedWindowFrame(frame, CurrentRow, UnboundedFollowing) =>
+        SpecifiedWindowFrame(frame, UnboundedPreceding, CurrentRow)
+      case x => x
+    }
+  }
+
+  private def reverseOrderSpec(orderSpec: Seq[SortOrder]): Seq[SortOrder] = {
+    orderSpec.map(_.reverse)
+  }
+
+  private def reverseAggFunc(aggFunc: AggregateFunction): AggregateFunction = {
+    aggFunc match {
+      case First(fChild, ignoreNulls) => Last(fChild, ignoreNulls)
+      case Last(lChild, ignoreNulls) => First(lChild, ignoreNulls)
+      case others => others
+    }
+  }
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+
+    def isApplicable(aggFunc: AggregateFunction, frameSpec: WindowFrame): Boolean = {
+      val isAggFuncApplicable = aggFunc match {
+        case _: First => true
+        case _: Last => true
+        case _ => false
+      }
+
+      val isFrameSpecApplicable = frameSpec match {
+        case SpecifiedWindowFrame(_, CurrentRow, UnboundedFollowing) => true
+        case _ => false
+      }
+
+      isAggFuncApplicable && isFrameSpecApplicable
+    }
+
+    plan.transform {
+      case win: logical.Window =>
+
+        val winExprs = win.windowExpressions
+        val (candidates, others) = winExprs.partition {
+          case Alias(w@ WindowExpression(aggExpr: AggregateExpression,
+            wsd: WindowSpecDefinition), _) =>
+            isApplicable(aggExpr.aggregateFunction, wsd.frameSpecification)
+          case _ => false
+        }
+
+        val nWinExprs: Seq[NamedExpression] = candidates.map {
+          case a@ Alias(w@ WindowExpression(aggExpr: AggregateExpression,
+            wsd: WindowSpecDefinition), _) =>
+
+            val nAggExpr = aggExpr.copy(
+              aggregateFunction = reverseAggFunc(aggExpr.aggregateFunction))
+            val reversedWsd = wsd.copy(
+              orderSpec = reverseOrderSpec(wsd.orderSpec),
+              frameSpecification = replacedFrameSpec(wsd.frameSpecification))
+            val nWinExpr = w.copy(windowFunction = nAggExpr, windowSpec = reversedWsd)
+            val nAlias = a.copy(child = nWinExpr)(exprId = a.exprId,
+              qualifier = a.qualifier, explicitMetadata = a.explicitMetadata,
+              nonInheritableMetadataKeys = a.nonInheritableMetadataKeys)
+
+            nAlias
+        }
+
+        if (nWinExprs.nonEmpty) {
+          if (others.isEmpty) {
+            win.copy(windowExpressions = nWinExprs, orderSpec = reverseOrderSpec(win.orderSpec))
+          } else {
+            val nWindow = win.copy(windowExpressions = others,
+              child = win.copy(windowExpressions = nWinExprs,
+                orderSpec = reverseOrderSpec(win.orderSpec), child = win.child))
+
+            // Restore the original output column order
+            val nOutput = win.output.flatMap { att =>
+              val nAttr = nWindow.output.find(x => att.name == x.name)
+              if (nAttr.nonEmpty) nAttr
+              else Some(att)
+            }
+            Project(nOutput, child = nWindow)
+          }
+        } else {
+          win
+        }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/WindowFunctionOptimizerTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/WindowFunctionOptimizerTestSuite.scala
@@ -1,0 +1,387 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.optimizer.ReplaceUnboundedFollowingWithUnboundedPreceding
+import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.internal.SQLConf
+
+class WindowFunctionOptimizerTestSuite extends QueryTest with PlanTest{
+
+  object TestOptimizer extends RuleExecutor[LogicalPlan] {
+    override val batches =
+      Batch("Replace UnboundedFollowing", FixedPoint(100),
+        ReplaceUnboundedFollowingWithUnboundedPreceding) :: Nil
+  }
+
+  protected var spark: SparkSession = null
+
+  /**
+   * Create a new [[SparkSession]] running in local-cluster mode with unsafe and codegen enabled.
+   */
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark = SparkSession.builder()
+      .master("local-cluster[2,1,1024]")
+      .appName("WindowFunctionOptimizerTestSuite")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      spark.stop()
+      spark = null
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  val unboundedFollowing = SpecifiedWindowFrame(RowFrame, CurrentRow, UnboundedFollowing)
+  val unboundedPreceding = SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow)
+
+  private def buildQueries(windowExpr: WindowExpression,
+                           otherWindowExpr: Seq[WindowExpression] = Seq(),
+                           buildExpectQuery: Boolean = false): Seq[LogicalPlan] = {
+
+    val testRelationA = {
+      val attributeA = 'a.int
+      val attributeB = 'b.int
+      val attributeC = 'c.int
+
+      LocalRelation.fromExternalRows(
+        Seq(attributeA, attributeB, attributeC),
+        Seq(Row(1, 2, 3),
+          Row(2, 2, 4),
+          Row(3, 2, 5),
+          Row(4, 3, 6),
+          Row(5, 3, 7),
+          Row(6, 4, 8)))
+    }
+
+    val testRelationB = {
+      val attributeD = 'a.int
+      val attributeE = 'b.int
+      val attributeF = 'c.int
+
+      LocalRelation.fromExternalRows(
+        Seq(attributeD, attributeE, attributeF),
+        Seq(Row(0, 16, 23),
+          Row(2, 16, 24),
+          Row(3, 16, 25),
+          Row(4, 16, 26),
+          Row(7, 17, 27),
+          Row(8, 18, 28)))
+    }
+
+    val isSameWinSpec: Boolean = {
+      if (otherWindowExpr.nonEmpty) {
+        !otherWindowExpr.exists(oExpr => oExpr.windowSpec != windowExpr.windowSpec)
+      } else {
+        false
+      }
+    }
+
+    val otherNamedExpr = otherWindowExpr.zipWithIndex.map {
+      case (winExpr, index) => winExpr.as(s"otherWinExpr$index")
+    }
+
+    val simpleQuery = if (otherWindowExpr.isEmpty || isSameWinSpec) {
+      testRelationA
+        .where('a > 1)
+        .select('a, 'b, 'c).logicalPlan
+        .window(Seq(windowExpr.as('window)) ++ otherNamedExpr,
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .select('a, 'b, 'window).logicalPlan
+    } else {
+      testRelationA
+        .where('a > 1)
+        .select('a, 'b, 'c).logicalPlan
+        .window(Seq(windowExpr.as('window)),
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .window(otherNamedExpr,
+          otherWindowExpr.head.windowSpec.partitionSpec,
+          otherWindowExpr.head.windowSpec.orderSpec)
+        .select('a, 'b, 'window).logicalPlan
+    }
+
+    val expectedSimpleQuery = if (otherWindowExpr.isEmpty || isSameWinSpec) {
+      simpleQuery
+    } else {
+      testRelationA
+        .where('a > 1)
+        .select('a, 'b, 'c).logicalPlan
+        .window(Seq(windowExpr.as('window)),
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .window(otherNamedExpr,
+          otherWindowExpr.head.windowSpec.partitionSpec,
+          otherWindowExpr.head.windowSpec.orderSpec)
+        // Added an extra Projection to restore the output order
+        .select({Seq(Column("a"), Column("b"), Column("c"), Column("window")).map(_.expr) ++
+          otherNamedExpr.map(x => Column(x.name).expr)}: _*).logicalPlan
+        .select('a, 'b, 'window).logicalPlan
+    }
+
+    val multipleWindowFunctions = if (otherWindowExpr.isEmpty || isSameWinSpec) {
+      testRelationA
+        .where('a > 1)
+        .select('a, 'b, 'c).logicalPlan
+        .window(Seq(windowExpr.as('window1)) ++ otherNamedExpr,
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .window(Seq(windowExpr.as('window2)) ++ otherNamedExpr,
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .select('a, 'b, 'window1, 'window2).logicalPlan
+    } else {
+      testRelationA
+        .where('a > 1)
+        .select('a, 'b, 'c).logicalPlan
+        .window(Seq(windowExpr.as('window1)),
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .window(Seq(windowExpr.as('window2)),
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .window(otherNamedExpr,
+          otherWindowExpr.head.windowSpec.partitionSpec,
+          otherWindowExpr.head.windowSpec.orderSpec)
+        .select('a, 'b, 'window1, 'window2).logicalPlan
+    }
+
+    val expectedMultipleWindowFunctions: LogicalPlan =
+      if (otherWindowExpr.isEmpty || isSameWinSpec) {
+        multipleWindowFunctions
+      } else {
+        testRelationA
+          .where('a > 1)
+          .select('a, 'b, 'c).logicalPlan
+          .window(Seq(windowExpr.as('window1)),
+            windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+          .window(otherNamedExpr,
+            otherWindowExpr.head.windowSpec.partitionSpec,
+            otherWindowExpr.head.windowSpec.orderSpec)
+          // Added an extra Projection to restore the output order
+          .select({
+            Seq(Column("a"), Column("b"), Column("c"), Column("window1")).map(_.expr) ++
+              otherNamedExpr.map(x => Column(x.name).expr)
+          }: _*).logicalPlan
+          .window(Seq(windowExpr.as('window2)),
+            windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+          .window(otherNamedExpr,
+            otherWindowExpr.head.windowSpec.partitionSpec,
+            otherWindowExpr.head.windowSpec.orderSpec)
+          // Added an extra Projection to restore the output order
+          .select(Seq(Column("a"), Column("b"), Column("c"), Column("window1")).map(_.expr) ++
+            otherNamedExpr.map(x => Column(x.name).expr) ++ Seq(Column("window2").expr) ++
+            otherNamedExpr.map(x => Column(x.name).expr): _*).logicalPlan
+          .select('a, 'b, 'window1, 'window2).logicalPlan
+      }
+
+    val leftSide = if (otherWindowExpr.isEmpty || isSameWinSpec) {
+      testRelationA
+        .where('a > 1)
+        .select('a, 'b, 'c).logicalPlan
+        .window(Seq(windowExpr.as('window)) ++ otherNamedExpr,
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .select('a, 'b, 'window).logicalPlan
+    } else {
+      testRelationA
+        .where('a > 1)
+        .select('a, 'b, 'c).logicalPlan
+        .window(Seq(windowExpr.as('window)),
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .window(otherNamedExpr,
+          otherWindowExpr.head.windowSpec.partitionSpec,
+          otherWindowExpr.head.windowSpec.orderSpec)
+        .select('a, 'b, 'window).logicalPlan
+    }
+
+    val rightSide = if (otherWindowExpr.isEmpty || isSameWinSpec) {
+      testRelationB
+        .where('a > 2)
+        .window(Seq(windowExpr.as('window)) ++ otherNamedExpr,
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .select('a, 'b, 'window).logicalPlan
+    } else {
+      testRelationB
+        .where('a > 2)
+        .window(Seq(windowExpr.as('window)),
+          windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+        .window(otherNamedExpr,
+          otherWindowExpr.head.windowSpec.partitionSpec,
+          otherWindowExpr.head.windowSpec.orderSpec)
+        .select('a, 'b, 'window).logicalPlan
+    }
+
+    val complexPlan =
+      leftSide.as("tA").join(rightSide.as("tB"), Inner)
+      .select(Symbol("tA.a"), Symbol("tA.b"), Symbol("tB.b"), Symbol("tA.window"),
+        Symbol("tB.window")).logicalPlan
+      .groupBy(Symbol("tA.window"))(sum("tB.window")).logicalPlan
+
+    val expectedComplexPlan = {
+      val expectedLeftSide = if (otherWindowExpr.isEmpty || isSameWinSpec) {
+        leftSide
+      } else {
+        testRelationA
+          .where('a > 1)
+          .select('a, 'b, 'c).logicalPlan
+          .window(Seq(windowExpr.as('window)),
+            windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+          .window(otherNamedExpr,
+            otherWindowExpr.head.windowSpec.partitionSpec,
+            otherWindowExpr.head.windowSpec.orderSpec)
+          // Added an extra Projection to restore the output order
+          .select({Seq(Column("a"), Column("b"), Column("c"), Column("window")).map(_.expr) ++
+            otherNamedExpr.map(x => Column(x.name).expr)}: _*).logicalPlan
+          .select('a, 'b, 'window).logicalPlan
+      }
+
+      val expectedRightSide = if (otherWindowExpr.isEmpty || isSameWinSpec) {
+        rightSide
+      } else {
+        testRelationB
+          .where('a > 2)
+          .window(Seq(windowExpr.as('window)),
+            windowExpr.windowSpec.partitionSpec, windowExpr.windowSpec.orderSpec)
+          .window(otherNamedExpr,
+            otherWindowExpr.head.windowSpec.partitionSpec,
+            otherWindowExpr.head.windowSpec.orderSpec)
+          // Added an extra Projection to restore the output order
+          .select({Seq(Column("a"), Column("b"), Column("c"), Column("window")).map(_.expr) ++
+            otherNamedExpr.map(x => Column(x.name).expr)}: _*).logicalPlan
+          .select('a, 'b, 'window).logicalPlan
+      }
+
+      expectedLeftSide.as("tA").join(expectedRightSide.as("tB"), Inner)
+        .select(Column("tA.a").expr, Column("tA.b").expr, Column("tB.b").expr,
+          Column("tA.window").expr, Column("tB.window").expr)
+        .groupBy(Column("tA.window").expr)(sum("tB.window").expr).logicalPlan
+    }
+
+    if (buildExpectQuery) {
+      Seq(expectedSimpleQuery, expectedMultipleWindowFunctions, expectedComplexPlan)
+    } else {
+      Seq(simpleQuery, multipleWindowFunctions, complexPlan)
+    }
+  }
+
+  private def verifyDataFrame(query: LogicalPlan): Unit = {
+    val actualDataFrame = Dataset.ofRows(spark, TestOptimizer.execute(query.analyze))
+    val originalDataFrame = {
+      var df: DataFrame = null
+      withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ReplaceUnboundedFollowingWithUnboundedPreceding") {
+        df = Dataset.ofRows(spark, query.analyze)
+      }
+      df
+    }
+
+    checkAnswer(actualDataFrame, originalDataFrame)
+  }
+
+  test("Replace UnboundedFollowing with UnboundedPreceding for First") {
+
+    val originalWinExpr = windowExpr(first('c),
+      windowSpec('b :: Nil, 'a.desc :: Nil, unboundedFollowing))
+    val expectedWinExpr = windowExpr(last('c),
+      windowSpec('b :: Nil, 'a.asc :: Nil, unboundedPreceding))
+
+    val originalQueries = buildQueries(originalWinExpr)
+    val expectedQueries = buildQueries(expectedWinExpr).map(_.analyze)
+
+    originalQueries.zip(expectedQueries).foreach {
+      case (original, expected) =>
+        comparePlans(TestOptimizer.execute(original.analyze), expected)
+        verifyDataFrame(original)
+    }
+  }
+
+  test("Replace UnboundedFollowing with UnboundedPreceding for first and other func") {
+
+    val originalWinExpr = windowExpr(first('c),
+      windowSpec('b :: Nil, 'a.desc :: Nil, unboundedFollowing))
+    val avgExpr = windowExpr(avg('c),
+      windowSpec('b :: Nil, 'a.desc :: Nil, unboundedFollowing))
+    val maxExpr = windowExpr(max('c),
+      windowSpec('b :: Nil, 'a.desc :: Nil, unboundedFollowing))
+
+    val expectedWinExpr = windowExpr(last('c),
+      windowSpec('b :: Nil, 'a.asc :: Nil, unboundedPreceding))
+
+    val originalQueries = buildQueries(originalWinExpr, Seq(avgExpr, maxExpr))
+    val expectedQueries = buildQueries(expectedWinExpr, Seq(avgExpr, maxExpr),
+      buildExpectQuery = true).map(_.analyze)
+
+    originalQueries.zip(expectedQueries).foreach {
+      case (original, expected) =>
+        comparePlans(TestOptimizer.execute(original.analyze), expected)
+        verifyDataFrame(original)
+    }
+  }
+
+  test("Keep unchanged with UnboundedPreceding for First") {
+
+    val originalWinExpr = windowExpr(first('c),
+      windowSpec('b :: Nil, 'a.asc :: Nil, unboundedPreceding))
+    val expectedWinExpr = originalWinExpr
+
+    val originalQueries = buildQueries(originalWinExpr)
+    val expectedQueries = buildQueries(expectedWinExpr).map(_.analyze)
+
+    originalQueries.zip(expectedQueries).foreach {
+      case (original, expected) =>
+        comparePlans(TestOptimizer.execute(original.analyze), expected)
+        verifyDataFrame(original)
+    }
+  }
+
+  test("Replace UnboundedFollowing with UnboundedPreceding for Last") {
+
+    val originalWinExpr = windowExpr(last('c),
+      windowSpec('b :: Nil, 'a.asc :: Nil, unboundedFollowing))
+    val expectedWinExpr = windowExpr(first('c),
+      windowSpec('b :: Nil, 'a.desc :: Nil, unboundedPreceding))
+
+    val originalQueries = buildQueries(originalWinExpr)
+    val expectedQueries = buildQueries(expectedWinExpr).map(_.analyze)
+
+    originalQueries.zip(expectedQueries).foreach {
+      case (original, expected) =>
+        comparePlans(TestOptimizer.execute(original.analyze), expected)
+        verifyDataFrame(original)
+    }
+  }
+
+  test("Keep unchanged with UnboundedPreceding for Last") {
+
+    val originalWinExpr = windowExpr(last('b),
+      windowSpec('b :: Nil, 'a.asc :: Nil, unboundedPreceding))
+    val expectedWinExpr = originalWinExpr
+
+    val originalQueries = buildQueries(originalWinExpr)
+    val expectedQueries = buildQueries(expectedWinExpr).map(_.analyze)
+
+    originalQueries.zip(expectedQueries).foreach {
+      case (original, expected) =>
+        comparePlans(TestOptimizer.execute(original.analyze), expected)
+        verifyDataFrame(original)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
**Context**

The **UnboundedFollowingWindowFunctionFrame** has the time complexity of O(N^2), N is the number of rows in the current partition, more specific the complexity is O(N* (N - 1)/2).

**What happens internally in UnboundedFollowingWindowFunctionFrame?**
In the window frame, while processing each incoming row, it will go through current row till the end of partition to do re-calculation. This process will be repeated on each incoming row, which causes the high run-time complexity.

But UnboundedPrecedingWindowFunctionFrame has much better time complexity O(N), N is the number of rows in the current partition.

 
**What is the idea of the improvement?**

Give the big time complexity difference between UnboundedFollowingWindowFunctionFrame and UnboundedPrecedingWindowFunctionFrame, we can do following conversions to improve the time complexity of first() and last() from O(N^2) to O(N)

```
case 1:
first() OVER(PARTITION BY colA ORDER BY colB ASC ROWS CURRENT ROW AND UNBOUNDED FOLLOWING) 
converts to 
last()  OVER(PARTITION BY colA ORDER BY colB DEAC ROWS UNBOUNDED PRECEDING AND CURRENT ROW)

case 2:
last()  OVER(PARTITION BY colA ORDER BY colB ASC ROWS CURRENT ROW AND UNBOUNDED FOLLOWING) 
converts to 
first() OVER(PARTITION BY colA ORDER BY colB DESC ROWS UNBOUNDED PRECEDING AND CURRENT ROW)
```

**Summary**

Replace "UNBOUNDED FOLLOWING" with "UNBOUNDED PRECEDING", and flip the ORDER BY for the window functions first() and last() for ROWS.


### Why are the changes needed?
Improve the run-time performance for window function fist() and last() against ROWS UNBOUNDED FOLLOWING.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
Added unit test: sql/core/src/test/scala/org/apache/spark/sql/WindowFunctionOptimizerTestSuite.scala

