### PR TITLE
[SPARK-36780][BUILD] Make `dev/mima` runs on Java 17

### DIFF
--- a/dev/mima
+++ b/dev/mima
@@ -43,7 +43,7 @@ fi
 
 $JAVA_CMD \
   -Xmx2g \
-  -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.util.jar=ALL-UNNAME \
+  -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.util.jar=ALL-UNNAMED \
   -cp "$TOOLS_CLASSPATH:$OLD_DEPS_CLASSPATH" \
   org.apache.spark.tools.GenerateMIMAIgnore
 

--- a/dev/mima
+++ b/dev/mima
@@ -41,14 +41,15 @@ else
   JAVA_CMD=java
 fi
 
-# Workaround to make mima runs on Java 17+
+# Workaround to make mima runs on Java 11+
 JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
-if [[ JAVA_VER -ge 17 ]]; then
+if [[ JAVA_VER -ge 11 ]]; then
   EXTRA_JAVA_OPTIONS="--add-opens=java.base/java.util.jar=ALL-UNNAMED"
 fi
 
 $JAVA_CMD \
   -Xmx2g \
+  $EXTRA_JAVA_OPTIONS \
   -cp "$TOOLS_CLASSPATH:$OLD_DEPS_CLASSPATH" \
   org.apache.spark.tools.GenerateMIMAIgnore
 

--- a/dev/mima
+++ b/dev/mima
@@ -41,16 +41,9 @@ else
   JAVA_CMD=java
 fi
 
-
-# Workaround to make mima runs on Java 11+
-JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
-if [[ JAVA_VER -ge 11 ]]; then
-  EXTRA_JAVA_OPTIONS="--add-opens=java.base/java.util.jar=ALL-UNNAMED"
-fi
-
 $JAVA_CMD \
   -Xmx2g \
-  $EXTRA_JAVA_OPTIONS \
+  -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.util.jar=ALL-UNNAME \
   -cp "$TOOLS_CLASSPATH:$OLD_DEPS_CLASSPATH" \
   org.apache.spark.tools.GenerateMIMAIgnore
 

--- a/dev/mima
+++ b/dev/mima
@@ -41,6 +41,7 @@ else
   JAVA_CMD=java
 fi
 
+
 # Workaround to make mima runs on Java 11+
 JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
 if [[ JAVA_VER -ge 11 ]]; then

--- a/dev/mima
+++ b/dev/mima
@@ -41,6 +41,12 @@ else
   JAVA_CMD=java
 fi
 
+# Workaround to make mima runs on Java 17+
+JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
+if [[ JAVA_VER -ge 17 ]]; then
+  EXTRA_JAVA_OPTIONS="--add-opens=java.base/java.util.jar=ALL-UNNAMED"
+fi
+
 $JAVA_CMD \
   -Xmx2g \
   -cp "$TOOLS_CLASSPATH:$OLD_DEPS_CLASSPATH" \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Java 17 has been officially released. This PR makes `dev/mima` runs on Java 17.

### Why are the changes needed?

To make tests pass on Java 17.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.