### PR TITLE
[SPARK-36784][SHUFFLE][WIP] Handle DNS issues on executor to prevent shuffle nodes from getting added to exclude list

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -104,4 +104,9 @@ private[spark] object Network {
       .version("1.4.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("3s")
+
+  private[spark] val DNS_HEALTH_CHECK_HOST = ConfigBuilder("spark.network.dnsHealthCheck.host")
+    .version("3.3.0")
+    .stringConf
+    .createOptional
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2056,6 +2056,16 @@ Apart from these, the following properties are also available, and may be useful
   <td>1.4.0</td>
 </tr>
 <tr>
+  <td><code>spark.network.dnsHealthCheck.host</code></td>
+  <td>(not set)</td>
+  <td>
+    Host used to check if there are DNS issues being currently faced.
+    This can be used, for example, to handle shuffle fetch failures and to prevent nodes from getting
+    added to the exclude list
+  </td>
+  <td>3.3.0</td>
+</tr>
+<tr>
   <td><code>spark.rpc.askTimeout</code></td>
   <td><code>spark.network.timeout</code></td>
   <td>


### PR DESCRIPTION
 ### What changes were proposed in this pull request?

 When a DNS issue happens on the executor node, shuffle nodes would get added to the exclude list due to FetchFailed exception. The change here is to have a configuration host value to test DNS resolution against before marking it as a FetchFailed Exception.

 ### Why are the changes needed?

 This would prevent shuffle nodes from getting added to the exclude list due to DNS issues

 ### Does this PR introduce _any_ user-facing change?

 No

 ### How was this patch tested?

 Added Unit Tests
