### PR TITLE
[SPARK-36790][SQL] Update user-facing catalog to adapt CatalogPlugin

### DIFF
--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -3977,8 +3977,8 @@ test_that("catalog APIs, currentDatabase, setCurrentDatabase, listDatabases", {
   expect_equal(currentDatabase(), "default")
   expect_error(setCurrentDatabase("default"), NA)
   expect_error(setCurrentDatabase("zxwtyswklpf"),
-               paste0("Error in setCurrentDatabase : analysis error - Database ",
-               "'zxwtyswklpf' does not exist"))
+               paste0("Error in setCurrentDatabase : no such database - Database ",
+               "'zxwtyswklpf' not found"))
   dbs <- collect(listDatabases())
   expect_equal(names(dbs), c("name", "description", "locationUri"))
   expect_equal(which(dbs[, 1] == "default"), 1)
@@ -4015,8 +4015,8 @@ test_that("catalog APIs, listTables, listColumns, listFunctions", {
   expect_equal(take(orderBy(f, "className"), 1)$className,
                "org.apache.spark.sql.catalyst.expressions.Abs")
   expect_error(listFunctions("zxwtyswklpf_db"),
-               paste("Error in listFunctions : analysis error - Database",
-                     "'zxwtyswklpf_db' does not exist"))
+               paste("Error in listFunctions : no such database - Database",
+                     "'zxwtyswklpf_db' not found"))
 
   # recoverPartitions does not work with temporary view
   expect_error(recoverPartitions("cars"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2392,4 +2392,7 @@ object QueryCompilationErrors {
       errorClass = "INVALID_JSON_SCHEMA_MAPTYPE",
       messageParameters = Array(schema.toString))
   }
+  def unsupportedActionForCurrentCatalogError(catalog: String, action: String): Throwable = {
+    new AnalysisException(s"The catalog '$catalog' does not support action '$action'.")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2916,6 +2916,50 @@ class DataSourceV2SQLSuite
     }
   }
 
+  test("SPARK-36790: Unsupport api in SparkSession.catalog for user define catalog") {
+    spark.sql("use testcat")
+    val current = spark.sessionState.catalogManager.currentCatalog.name
+    assert(current == "testcat")
+    var e = intercept[AnalysisException] {
+      spark.catalog.currentDatabase
+    }
+    assert(e.message.contains(
+      s"The catalog 'testcat' does not support action 'Get currentDatabase'."))
+    e = intercept[AnalysisException] {
+      spark.catalog.setCurrentDatabase("")
+    }
+    assert(e.message.contains(
+      s"The catalog 'testcat' does not support action 'setCurrentDatabase'."))
+    e = intercept[AnalysisException] {
+      spark.catalog.listDatabases()
+    }
+    assert(e.message.contains(s"The catalog 'testcat' does not support action 'listDatabases'."))
+    e = intercept[AnalysisException] {
+      spark.catalog.listTables("")
+    }
+    assert(e.message.contains(s"The catalog 'testcat' does not support action 'listTables'."))
+    e = intercept[AnalysisException] {
+      spark.catalog.listFunctions("")
+    }
+    assert(e.message.contains(
+      s"The catalog 'testcat' does not support action 'listFunctions'."))
+    e = intercept[AnalysisException] {
+      spark.catalog.databaseExists("")
+    }
+    assert(e.message.contains(
+      s"The catalog 'testcat' does not support action 'databaseExists'."))
+    e = intercept[AnalysisException] {
+      spark.catalog.tableExists("", "")
+    }
+    assert(e.message.contains(
+      s"The catalog 'testcat' does not support action 'tableExists'."))
+    e = intercept[AnalysisException] {
+      spark.catalog.functionExists("", "")
+    }
+    assert(e.message.contains(
+      s"The catalog 'testcat' does not support action 'functionExists'."))
+  }
+
   private def testNotSupportedV2Command(sqlCommand: String, sqlParams: String): Unit = {
     val e = intercept[AnalysisException] {
       sql(s"$sqlCommand $sqlParams")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change the CatalogImpl for user-facing catalog API.
before:
`private def sessionCatalog: SessionCatalog = sparkSession.sessionState.catalog`
So all the operations we did were based on SessionCatalog any time.

after:
`private def currentCatalog: CatalogPlugin = sparkSession.sessionState.catalogManager.currentCatalog`
When current catalog is `spark-catalog`, we do the all operations based on SessionCatalog.
Others CatalogPlugin did not support operations  at now. it will throw exception temporarily.
eg: `databaseExists` ,`currentDatabase` and so on.

### Why are the changes needed?
[#SPARK-36790](https://issues.apache.org/jira/browse/SPARK-36790)
User-facting catalog should be access the current catalog.
eg:
`
spark.sql("use testcat")
`
so: current catalog != spark.catalog

`
spark.sql("use testcat.ns1")
`
so: current database != spark.catalog.currentDatabase

`spark.sql("show tables")
`
so: result != spark.catalog.listTables

I think the SparkSession.catalog api should be keep exist instead of SparkSession.sessionState.catalogManager. So update user-facing catalog to adapt CatalogPlugin. At now just throw exception for unsupport the CatalogPlugin temporary.

### Does this PR introduce _any_ user-facing change? 
No


### How was this patch tested?
add ut test