### PR TITLE
[SPARK-36794][SQL] Ignore duplicated join keys when building relation for SEMI/ANTI hash join

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -113,7 +113,7 @@ case class BroadcastExchangeExec(
 
   @transient
   private lazy val maxBroadcastRows = mode match {
-    case HashedRelationBroadcastMode(key, _)
+    case HashedRelationBroadcastMode(key, _, _)
       // NOTE: LongHashedRelation is used for single key with LongType. This should be kept
       // consistent with HashedRelation.apply.
       if !(key.length == 1 && key.head.dataType == LongType) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -60,7 +60,8 @@ case class BroadcastHashJoinExec(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
 
   override def requiredChildDistribution: Seq[Distribution] = {
-    val mode = HashedRelationBroadcastMode(buildBoundKeys, isNullAwareAntiJoin)
+    val mode = HashedRelationBroadcastMode(
+      buildBoundKeys, isNullAwareAntiJoin, ignoreDuplicatedKey)
     buildSide match {
       case BuildLeft =>
         BroadcastDistribution(mode) :: UnspecifiedDistribution :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -158,6 +158,11 @@ trait HashJoin extends JoinCodegenSupport {
         output, (streamedPlan.output ++ buildPlan.output).map(_.withNullability(true)))
   }
 
+  @transient protected lazy val ignoreDuplicatedKey = joinType match {
+    case LeftExistence(_) if condition.isEmpty => true
+    case _ => false
+  }
+
   private def innerJoin(
       streamIter: Iterator[InternalRow],
       hashedRelation: HashedRelation): Iterator[InternalRow] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -162,7 +162,7 @@ trait HashJoin extends JoinCodegenSupport {
   @transient lazy val ignoreDuplicatedKey = joinType match {
     case LeftExistence(_) =>
       // For building hash relation, ignore duplicated rows with same join keys if:
-      // 1. Join condition is empty.
+      // 1. Join condition is empty, or
       // 2. Join condition only references streamed attributes and build join keys.
       val streamedOutputAndBuildKeys = AttributeSet(streamedOutput ++ buildKeys)
       condition.forall(_.references.subsetOf(streamedOutputAndBuildKeys))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -128,6 +128,8 @@ private[execution] object HashedRelation {
    *
    * @param allowsNullKey Allow NULL keys in HashedRelation.
    *                      This is used for full outer join in `ShuffledHashJoinExec` only.
+   * @param ignoresDuplicatedKey Ignore rows with duplicated keys in HashedRelation.
+   *                             This is only used for semi and anti join without join condition.
    */
   def apply(
       input: Iterator[InternalRow],
@@ -135,7 +137,8 @@ private[execution] object HashedRelation {
       sizeEstimate: Int = 64,
       taskMemoryManager: TaskMemoryManager = null,
       isNullAware: Boolean = false,
-      allowsNullKey: Boolean = false): HashedRelation = {
+      allowsNullKey: Boolean = false,
+      ignoresDuplicatedKey: Boolean = false): HashedRelation = {
     val mm = Option(taskMemoryManager).getOrElse {
       new TaskMemoryManager(
         new UnifiedMemoryManager(
@@ -152,7 +155,8 @@ private[execution] object HashedRelation {
       // NOTE: LongHashedRelation does not support NULL keys.
       LongHashedRelation(input, key, sizeEstimate, mm, isNullAware)
     } else {
-      UnsafeHashedRelation(input, key, sizeEstimate, mm, isNullAware, allowsNullKey)
+      UnsafeHashedRelation(input, key, sizeEstimate, mm, isNullAware, allowsNullKey,
+        ignoresDuplicatedKey)
     }
   }
 }
@@ -450,7 +454,8 @@ private[joins] object UnsafeHashedRelation {
       sizeEstimate: Int,
       taskMemoryManager: TaskMemoryManager,
       isNullAware: Boolean = false,
-      allowsNullKey: Boolean = false): HashedRelation = {
+      allowsNullKey: Boolean = false,
+      ignoresDuplicatedKey: Boolean = false): HashedRelation = {
     require(!(isNullAware && allowsNullKey),
       "isNullAware and allowsNullKey cannot be enabled at same time")
 
@@ -471,12 +476,14 @@ private[joins] object UnsafeHashedRelation {
       val key = keyGenerator(row)
       if (!key.anyNull || allowsNullKey) {
         val loc = binaryMap.lookup(key.getBaseObject, key.getBaseOffset, key.getSizeInBytes)
-        val success = loc.append(
-          key.getBaseObject, key.getBaseOffset, key.getSizeInBytes,
-          row.getBaseObject, row.getBaseOffset, row.getSizeInBytes)
-        if (!success) {
-          binaryMap.free()
-          throw QueryExecutionErrors.cannotAcquireMemoryToBuildUnsafeHashedRelationError()
+        if (!(ignoresDuplicatedKey && loc.isDefined)) {
+          val success = loc.append(
+            key.getBaseObject, key.getBaseOffset, key.getSizeInBytes,
+            row.getBaseObject, row.getBaseOffset, row.getSizeInBytes)
+          if (!success) {
+            binaryMap.free()
+            throw QueryExecutionErrors.cannotAcquireMemoryToBuildUnsafeHashedRelationError()
+          }
         }
       } else if (isNullAware) {
         binaryMap.free()
@@ -1124,7 +1131,10 @@ case object HashedRelationWithAllNullKeys extends HashedRelation {
 }
 
 /** The HashedRelationBroadcastMode requires that rows are broadcasted as a HashedRelation. */
-case class HashedRelationBroadcastMode(key: Seq[Expression], isNullAware: Boolean = false)
+case class HashedRelationBroadcastMode(
+    key: Seq[Expression],
+    isNullAware: Boolean = false,
+    ignoresDuplicatedKey: Boolean = false)
   extends BroadcastMode {
 
   override def transform(rows: Array[InternalRow]): HashedRelation = {
@@ -1136,9 +1146,11 @@ case class HashedRelationBroadcastMode(key: Seq[Expression], isNullAware: Boolea
       sizeHint: Option[Long]): HashedRelation = {
     sizeHint match {
       case Some(numRows) =>
-        HashedRelation(rows, key, numRows.toInt, isNullAware = isNullAware)
+        HashedRelation(rows, key, numRows.toInt, isNullAware = isNullAware,
+          ignoresDuplicatedKey = ignoresDuplicatedKey)
       case None =>
-        HashedRelation(rows, key, isNullAware = isNullAware)
+        HashedRelation(rows, key, isNullAware = isNullAware,
+          ignoresDuplicatedKey = ignoresDuplicatedKey)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -72,7 +72,8 @@ case class ShuffledHashJoinExec(
       buildBoundKeys,
       taskMemoryManager = context.taskMemoryManager(),
       // Full outer join needs support for NULL key in HashedRelation.
-      allowsNullKey = joinType == FullOuter)
+      allowsNullKey = joinType == FullOuter,
+      ignoresDuplicatedKey = ignoreDuplicatedKey)
     buildTime += NANOSECONDS.toMillis(System.nanoTime() - start)
     buildDataSize += relation.estimatedSize
     // This relation is usually used until the end of task.

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -306,7 +306,7 @@ Condition : isnotnull(key#x)
 
 (5) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#x]
 
 (6) BroadcastHashJoin
 Left keys [1]: [key#x]
@@ -355,7 +355,7 @@ Condition : isnotnull(key#x)
 
 (4) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#x]
 
 (5) BroadcastHashJoin
 Left keys [1]: [key#x]
@@ -777,7 +777,7 @@ Condition : (isnotnull(key#x) AND (key#x > 10))
 
 (5) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#x]
 
 (6) BroadcastHashJoin
 Left keys [1]: [key#x]
@@ -877,7 +877,7 @@ Results [2]: [key#x, max(val#x)#x AS max(val)#x]
 
 (11) BroadcastExchange
 Input [2]: [key#x, max(val)#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#x]
 
 (12) BroadcastHashJoin
 Left keys [1]: [key#x]

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -314,7 +314,7 @@ Condition : isnotnull(key#x)
 
 (7) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#x]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
@@ -366,7 +366,7 @@ Condition : isnotnull(key#x)
 
 (6) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#x]
 
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
@@ -749,7 +749,7 @@ Condition : (isnotnull(key#x) AND (key#x > 10))
 
 (7) BroadcastExchange
 Input [2]: [key#x, val#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#x]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
@@ -826,7 +826,7 @@ Results [2]: [key#x, max(val#x)#x AS max(val)#x]
 
 (9) BroadcastExchange
 Input [2]: [key#x, max(val)#x]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#x]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#x]
 
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [key#x]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
@@ -204,7 +204,7 @@ Input [2]: [ca_address_sk#20, ca_county#21]
 
 (36) BroadcastExchange
 Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_addr_sk#3]
@@ -217,7 +217,7 @@ Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#20]
 
 (39) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#23]
 
 (40) Scan parquet default.customer_demographics
 Output [9]: [cd_demo_sk#24, cd_gender#25, cd_marital_status#26, cd_education_status#27, cd_purchase_estimate#28, cd_credit_rating#29, cd_dep_count#30, cd_dep_employed_count#31, cd_dep_college_count#32]
@@ -294,7 +294,7 @@ Input [3]: [d_date_sk#8, d_year#43, d_moy#44]
 
 (53) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#45]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#45]
 
 Subquery:2 Hosting operator id = 12 Hosting Expression = cs_sold_date_sk#11 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10/explain.txt
@@ -117,7 +117,7 @@ Input [3]: [cs_ship_customer_sk#9, cs_sold_date_sk#10, d_date_sk#11]
 
 (17) BroadcastExchange
 Input [1]: [customer_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#13]
 
 (18) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
@@ -153,7 +153,7 @@ Input [3]: [ss_customer_sk#14, ss_sold_date_sk#15, d_date_sk#16]
 
 (25) BroadcastExchange
 Input [1]: [customer_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#18]
 
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
@@ -184,7 +184,7 @@ Input [2]: [ca_address_sk#19, ca_county#20]
 
 (32) BroadcastExchange
 Input [1]: [ca_address_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#21]
 
 (33) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#3]
@@ -211,7 +211,7 @@ Condition : isnotnull(cd_demo_sk#22)
 
 (38) BroadcastExchange
 Input [9]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#31]
 
 (39) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#2]
@@ -274,7 +274,7 @@ Input [3]: [d_date_sk#7, d_year#42, d_moy#43]
 
 (49) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#44]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = cs_sold_date_sk#10 IN dynamicpruning#6
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
@@ -60,7 +60,7 @@ Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
 (5) BroadcastExchange
 Input [1]: [d_date_sk#1]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#4]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#4]
 
 (6) Scan parquet default.store_sales
 Output [5]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, ss_sold_date_sk#9]
@@ -88,7 +88,7 @@ Input [6]: [d_date_sk#1, ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_s
 
 (11) BroadcastExchange
 Input [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false,false), [id=#11]
 
 (12) Scan parquet default.customer
 Output [2]: [c_customer_sk#12, c_current_addr_sk#13]
@@ -129,7 +129,7 @@ Condition : (isnotnull(s_zip#15) AND isnotnull(s_store_sk#14))
 
 (20) BroadcastExchange
 Input [2]: [s_store_sk#14, s_zip#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#16]
 
 (21) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#7]
@@ -142,7 +142,7 @@ Input [6]: [ss_item_sk#5, ss_store_sk#7, ss_ext_sales_price#8, c_current_addr_sk
 
 (23) BroadcastExchange
 Input [4]: [ss_item_sk#5, ss_ext_sales_price#8, c_current_addr_sk#13, s_zip#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#17]
 
 (24) Scan parquet default.customer_address
 Output [2]: [ca_address_sk#18, ca_zip#19]
@@ -187,7 +187,7 @@ Input [6]: [i_item_sk#20, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufac
 
 (33) BroadcastExchange
 Input [5]: [i_item_sk#20, i_brand_id#21, i_brand#22, i_manufact_id#23, i_manufact#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 (34) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19/explain.txt
@@ -75,7 +75,7 @@ Condition : ((isnotnull(ss_item_sk#4) AND isnotnull(ss_customer_sk#5)) AND isnot
 
 (8) BroadcastExchange
 Input [5]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, ss_sold_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[4, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[4, int, true] as bigint)),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [d_date_sk#1]
@@ -106,7 +106,7 @@ Input [6]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufac
 
 (15) BroadcastExchange
 Input [5]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#16]
 
 (16) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#4]
@@ -133,7 +133,7 @@ Condition : (isnotnull(c_customer_sk#17) AND isnotnull(c_current_addr_sk#18))
 
 (21) BroadcastExchange
 Input [2]: [c_customer_sk#17, c_current_addr_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#5]
@@ -160,7 +160,7 @@ Condition : (isnotnull(ca_address_sk#20) AND isnotnull(ca_zip#21))
 
 (27) BroadcastExchange
 Input [2]: [ca_address_sk#20, ca_zip#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#22]
 
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_current_addr_sk#18]
@@ -187,7 +187,7 @@ Condition : (isnotnull(s_zip#24) AND isnotnull(s_store_sk#23))
 
 (33) BroadcastExchange
 Input [2]: [s_store_sk#23, s_zip#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (34) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_store_sk#6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/explain.txt
@@ -121,7 +121,7 @@ Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_stat
 
 (11) BroadcastExchange
 Input [1]: [cd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
@@ -148,7 +148,7 @@ Condition : (s_state#17 IN (TN,AL,SD) AND isnotnull(s_store_sk#16))
 
 (17) BroadcastExchange
 Input [2]: [s_store_sk#16, s_state#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
@@ -175,7 +175,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#19, i_item_id#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -251,7 +251,7 @@ Input [2]: [s_store_sk#16, s_state#17]
 
 (39) BroadcastExchange
 Input [1]: [s_store_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#52]
 
 (40) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#3]
@@ -371,7 +371,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (66) BroadcastExchange
 Input [1]: [i_item_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#80]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#80]
 
 (67) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_item_sk#1]
@@ -436,7 +436,7 @@ Input [2]: [d_date_sk#10, d_year#109]
 
 (78) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#110]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#110]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27/explain.txt
@@ -109,7 +109,7 @@ Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_stat
 
 (8) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
@@ -148,7 +148,7 @@ Condition : (s_state#17 IN (TN,AL,SD) AND isnotnull(s_store_sk#16))
 
 (17) BroadcastExchange
 Input [2]: [s_store_sk#16, s_state#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
@@ -175,7 +175,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#19, i_item_id#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -263,7 +263,7 @@ Input [2]: [s_store_sk#16, s_state#17]
 
 (42) BroadcastExchange
 Input [1]: [s_store_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#52]
 
 (43) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#3]
@@ -371,7 +371,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (66) BroadcastExchange
 Input [1]: [i_item_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#80]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#80]
 
 (67) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_item_sk#1]
@@ -436,7 +436,7 @@ Input [2]: [d_date_sk#15, d_year#109]
 
 (78) BroadcastExchange
 Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#110]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#110]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q3.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q3.sf100/explain.txt
@@ -53,7 +53,7 @@ Input [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manufact_id#8]
 
 (8) BroadcastExchange
 Input [3]: [i_item_sk#5, i_brand_id#6, i_brand#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
@@ -128,6 +128,6 @@ Input [3]: [d_date_sk#10, d_year#11, d_moy#19]
 
 (22) BroadcastExchange
 Input [2]: [d_date_sk#10, d_year#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#20]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q3/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q3/explain.txt
@@ -57,7 +57,7 @@ Condition : isnotnull(ss_item_sk#4)
 
 (8) BroadcastExchange
 Input [3]: [ss_item_sk#4, ss_net_profit#5, ss_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manufact_id#11]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#8, i_brand_id#9, i_brand#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/explain.txt
@@ -83,7 +83,7 @@ Input [2]: [s_store_sk#8, s_county#9]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -114,7 +114,7 @@ Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_coun
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -224,6 +224,6 @@ Input [3]: [d_date_sk#7, d_year#29, d_dom#30]
 
 (40) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#31]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34/explain.txt
@@ -80,7 +80,7 @@ Input [2]: [s_store_sk#8, s_county#9]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -111,7 +111,7 @@ Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_coun
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -160,7 +160,7 @@ Condition : isnotnull(c_customer_sk#21)
 
 (28) BroadcastExchange
 Input [5]: [c_customer_sk#21, c_salutation#22, c_first_name#23, c_last_name#24, c_preferred_cust_flag#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
@@ -209,6 +209,6 @@ Input [3]: [d_date_sk#7, d_year#28, d_dom#29]
 
 (37) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#30]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q42.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q42.sf100/explain.txt
@@ -42,7 +42,7 @@ Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
 (5) BroadcastExchange
 Input [2]: [d_date_sk#1, d_year#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#4]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#4]
 
 (6) Scan parquet default.store_sales
 Output [3]: [ss_item_sk#5, ss_ext_sales_price#6, ss_sold_date_sk#7]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#9, i_category_id#10, i_category#11, i_manager_id#12]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#9, i_category_id#10, i_category#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q42/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q42/explain.txt
@@ -57,7 +57,7 @@ Condition : isnotnull(ss_item_sk#4)
 
 (8) BroadcastExchange
 Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#8, i_category_id#9, i_category#10, i_manager_id#11]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#8, i_category_id#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q43.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q43.sf100/explain.txt
@@ -42,7 +42,7 @@ Input [3]: [d_date_sk#1, d_year#2, d_day_name#3]
 
 (5) BroadcastExchange
 Input [2]: [d_date_sk#1, d_day_name#3]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#4]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#4]
 
 (6) Scan parquet default.store_sales
 Output [3]: [ss_store_sk#5, ss_sales_price#6, ss_sold_date_sk#7]
@@ -88,7 +88,7 @@ Input [4]: [s_store_sk#9, s_store_id#10, s_store_name#11, s_gmt_offset#12]
 
 (15) BroadcastExchange
 Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q43/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q43/explain.txt
@@ -57,7 +57,7 @@ Condition : isnotnull(ss_store_sk#4)
 
 (8) BroadcastExchange
 Input [3]: [ss_store_sk#4, ss_sales_price#5, ss_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
@@ -88,7 +88,7 @@ Input [4]: [s_store_sk#8, s_store_id#9, s_store_name#10, s_gmt_offset#11]
 
 (15) BroadcastExchange
 Input [3]: [s_store_sk#8, s_store_id#9, s_store_name#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46.sf100/explain.txt
@@ -95,7 +95,7 @@ Input [2]: [s_store_sk#11, s_city#12]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
@@ -126,7 +126,7 @@ Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -287,6 +287,6 @@ Input [3]: [d_date_sk#10, d_year#40, d_dow#41]
 
 (52) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#42]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46/explain.txt
@@ -87,7 +87,7 @@ Input [2]: [s_store_sk#11, s_city#12]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#4]
@@ -118,7 +118,7 @@ Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -145,7 +145,7 @@ Condition : (isnotnull(ca_address_sk#18) AND isnotnull(ca_city#19))
 
 (24) BroadcastExchange
 Input [2]: [ca_address_sk#18, ca_city#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#20]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#3]
@@ -190,7 +190,7 @@ Condition : (isnotnull(c_customer_sk#31) AND isnotnull(c_current_addr_sk#32))
 
 (33) BroadcastExchange
 Input [4]: [c_customer_sk#31, c_current_addr_sk#32, c_first_name#33, c_last_name#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#35]
 
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#1]
@@ -247,6 +247,6 @@ Input [3]: [d_date_sk#10, d_year#38, d_dow#39]
 
 (44) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#40]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q52.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q52.sf100/explain.txt
@@ -42,7 +42,7 @@ Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
 (5) BroadcastExchange
 Input [2]: [d_date_sk#1, d_year#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#4]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#4]
 
 (6) Scan parquet default.store_sales
 Output [3]: [ss_item_sk#5, ss_ext_sales_price#6, ss_sold_date_sk#7]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manager_id#12]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#9, i_brand_id#10, i_brand#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q52/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q52/explain.txt
@@ -57,7 +57,7 @@ Condition : isnotnull(ss_item_sk#4)
 
 (8) BroadcastExchange
 Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#8, i_brand_id#9, i_brand#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53.sf100/explain.txt
@@ -49,7 +49,7 @@ Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manufact_id#5]
 
 (5) BroadcastExchange
 Input [2]: [i_item_sk#1, i_manufact_id#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (6) Scan parquet default.store_sales
 Output [4]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13, ss_sold_date_sk#14]
@@ -91,7 +91,7 @@ Condition : isnotnull(s_store_sk#16)
 
 (14) BroadcastExchange
 Input [1]: [s_store_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#17]
 
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#12]
@@ -186,6 +186,6 @@ Input [3]: [d_date_sk#18, d_month_seq#28, d_qoy#19]
 
 (33) BroadcastExchange
 Input [2]: [d_date_sk#18, d_qoy#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53/explain.txt
@@ -64,7 +64,7 @@ Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
 
 (8) BroadcastExchange
 Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -103,7 +103,7 @@ Condition : isnotnull(s_store_sk#18)
 
 (17) BroadcastExchange
 Input [1]: [s_store_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
@@ -186,6 +186,6 @@ Input [3]: [d_date_sk#16, d_month_seq#28, d_qoy#17]
 
 (33) BroadcastExchange
 Input [2]: [d_date_sk#16, d_qoy#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q55.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q55.sf100/explain.txt
@@ -42,7 +42,7 @@ Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
 (5) BroadcastExchange
 Input [1]: [d_date_sk#1]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#4]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#4]
 
 (6) Scan parquet default.store_sales
 Output [3]: [ss_item_sk#5, ss_ext_sales_price#6, ss_sold_date_sk#7]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manager_id#12]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#9, i_brand_id#10, i_brand#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q55/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q55/explain.txt
@@ -57,7 +57,7 @@ Condition : isnotnull(ss_item_sk#4)
 
 (8) BroadcastExchange
 Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#8, i_brand_id#9, i_brand#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
@@ -83,7 +83,7 @@ Condition : (isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5))
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
@@ -128,7 +128,7 @@ Condition : (isnotnull(s_store_sk#37) AND isnotnull(s_store_id#38))
 
 (16) BroadcastExchange
 Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#40]
 
 (17) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#1]
@@ -159,7 +159,7 @@ Input [2]: [d_month_seq#41, d_week_seq#42]
 
 (23) BroadcastExchange
 Input [1]: [d_week_seq#42]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#43]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#43]
 
 (24) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
@@ -231,7 +231,7 @@ Condition : (isnotnull(s_store_sk#67) AND isnotnull(s_store_id#68))
 
 (38) BroadcastExchange
 Input [2]: [s_store_sk#67, s_store_id#68]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#69]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#69]
 
 (39) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#1]
@@ -262,7 +262,7 @@ Input [2]: [d_month_seq#70, d_week_seq#71]
 
 (45) BroadcastExchange
 Input [1]: [d_week_seq#71]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#72]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#72]
 
 (46) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [d_week_seq#5]
@@ -275,7 +275,7 @@ Input [9]: [d_week_seq#5, sun_sales#30, mon_sales#31, wed_sales#33, thu_sales#34
 
 (48) BroadcastExchange
 Input [8]: [d_week_seq2#73, s_store_id2#74, sun_sales2#75, mon_sales2#76, wed_sales2#77, thu_sales2#78, fri_sales2#79, sat_sales2#80]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [id=#81]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false,false), [id=#81]
 
 (49) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [s_store_id1#46, d_week_seq1#45]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59/explain.txt
@@ -83,7 +83,7 @@ Condition : (isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5))
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
@@ -128,7 +128,7 @@ Condition : (isnotnull(s_store_sk#37) AND isnotnull(s_store_id#38))
 
 (16) BroadcastExchange
 Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#40]
 
 (17) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#1]
@@ -159,7 +159,7 @@ Input [2]: [d_month_seq#41, d_week_seq#42]
 
 (23) BroadcastExchange
 Input [1]: [d_week_seq#42]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#43]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#43]
 
 (24) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
@@ -231,7 +231,7 @@ Condition : (isnotnull(s_store_sk#67) AND isnotnull(s_store_id#68))
 
 (38) BroadcastExchange
 Input [2]: [s_store_sk#67, s_store_id#68]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#69]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#69]
 
 (39) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#1]
@@ -262,7 +262,7 @@ Input [2]: [d_month_seq#70, d_week_seq#71]
 
 (45) BroadcastExchange
 Input [1]: [d_week_seq#71]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#72]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#72]
 
 (46) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [d_week_seq#5]
@@ -275,7 +275,7 @@ Input [9]: [d_week_seq#5, sun_sales#30, mon_sales#31, wed_sales#33, thu_sales#34
 
 (48) BroadcastExchange
 Input [8]: [d_week_seq2#73, s_store_id2#74, sun_sales2#75, mon_sales2#76, wed_sales2#77, thu_sales2#78, fri_sales2#79, sat_sales2#80]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [id=#81]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false,false), [id=#81]
 
 (49) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [s_store_id1#46, d_week_seq1#45]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63.sf100/explain.txt
@@ -49,7 +49,7 @@ Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manager_id#5]
 
 (5) BroadcastExchange
 Input [2]: [i_item_sk#1, i_manager_id#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (6) Scan parquet default.store_sales
 Output [4]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13, ss_sold_date_sk#14]
@@ -91,7 +91,7 @@ Condition : isnotnull(s_store_sk#16)
 
 (14) BroadcastExchange
 Input [1]: [s_store_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#17]
 
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#12]
@@ -186,6 +186,6 @@ Input [3]: [d_date_sk#18, d_month_seq#28, d_moy#19]
 
 (33) BroadcastExchange
 Input [2]: [d_date_sk#18, d_moy#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63/explain.txt
@@ -64,7 +64,7 @@ Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
 
 (8) BroadcastExchange
 Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -103,7 +103,7 @@ Condition : isnotnull(s_store_sk#18)
 
 (17) BroadcastExchange
 Input [1]: [s_store_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
@@ -186,6 +186,6 @@ Input [3]: [d_date_sk#16, d_month_seq#28, d_moy#17]
 
 (33) BroadcastExchange
 Input [2]: [d_date_sk#16, d_moy#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65.sf100/explain.txt
@@ -153,7 +153,7 @@ Results [2]: [ss_store_sk#13, avg(revenue#21)#27 AS ave#28]
 
 (23) BroadcastExchange
 Input [2]: [ss_store_sk#13, ave#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 (24) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_store_sk#2]
@@ -166,7 +166,7 @@ Input [5]: [ss_store_sk#2, ss_item_sk#1, revenue#11, ss_store_sk#13, ave#28]
 
 (26) BroadcastExchange
 Input [3]: [ss_store_sk#2, ss_item_sk#1, revenue#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#30]
 
 (27) Scan parquet default.store
 Output [2]: [s_store_sk#31, s_store_name#32]
@@ -193,7 +193,7 @@ Input [5]: [ss_store_sk#2, ss_item_sk#1, revenue#11, s_store_sk#31, s_store_name
 
 (32) BroadcastExchange
 Input [3]: [ss_item_sk#1, revenue#11, s_store_name#32]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#33]
 
 (33) Scan parquet default.item
 Output [5]: [i_item_sk#34, i_item_desc#35, i_current_price#36, i_wholesale_cost#37, i_brand#38]
@@ -252,7 +252,7 @@ Input [2]: [d_date_sk#6, d_month_seq#39]
 
 (43) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#40]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = ss_sold_date_sk#15 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65/explain.txt
@@ -104,7 +104,7 @@ Condition : isnotnull(revenue#13)
 
 (14) BroadcastExchange
 Input [3]: [ss_store_sk#4, ss_item_sk#3, revenue#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (15) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [s_store_sk#1]
@@ -131,7 +131,7 @@ Condition : isnotnull(i_item_sk#15)
 
 (20) BroadcastExchange
 Input [5]: [i_item_sk#15, i_item_desc#16, i_current_price#17, i_wholesale_cost#18, i_brand#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#20]
 
 (21) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#3]
@@ -207,7 +207,7 @@ Results [2]: [ss_store_sk#22, avg(revenue#30)#36 AS ave#37]
 
 (35) BroadcastExchange
 Input [2]: [ss_store_sk#22, ave#37]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#38]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#38]
 
 (36) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#4]
@@ -252,7 +252,7 @@ Input [2]: [d_date_sk#8, d_month_seq#39]
 
 (43) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#40]
 
 Subquery:2 Hosting operator id = 23 Hosting Expression = ss_sold_date_sk#24 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/explain.txt
@@ -93,7 +93,7 @@ Input [2]: [s_store_sk#12, s_city#13]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
@@ -124,7 +124,7 @@ Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -137,7 +137,7 @@ Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, s
 
 (21) BroadcastExchange
 Input [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false,false), [id=#19]
 
 (22) Scan parquet default.customer_address
 Output [2]: [ca_address_sk#20, ca_city#21]
@@ -182,7 +182,7 @@ Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ca_city#21 AS bought_city#32
 
 (30) BroadcastExchange
 Input [6]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#32, extended_price#33, list_price#34, extended_tax#35]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false,false), [id=#36]
 
 (31) Scan parquet default.customer
 Output [4]: [c_customer_sk#37, c_current_addr_sk#38, c_first_name#39, c_last_name#40]
@@ -280,6 +280,6 @@ Input [3]: [d_date_sk#11, d_year#45, d_dom#46]
 
 (50) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#47]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#47]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68/explain.txt
@@ -87,7 +87,7 @@ Input [2]: [s_store_sk#12, s_city#13]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#4]
@@ -118,7 +118,7 @@ Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -145,7 +145,7 @@ Condition : (isnotnull(ca_address_sk#19) AND isnotnull(ca_city#20))
 
 (24) BroadcastExchange
 Input [2]: [ca_address_sk#19, ca_city#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#3]
@@ -190,7 +190,7 @@ Condition : (isnotnull(c_customer_sk#36) AND isnotnull(c_current_addr_sk#37))
 
 (33) BroadcastExchange
 Input [4]: [c_customer_sk#36, c_current_addr_sk#37, c_first_name#38, c_last_name#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#40]
 
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#1]
@@ -247,6 +247,6 @@ Input [3]: [d_date_sk#11, d_year#43, d_dom#44]
 
 (44) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#45]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#45]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7.sf100/explain.txt
@@ -78,7 +78,7 @@ Input [3]: [p_promo_sk#11, p_channel_email#12, p_channel_event#13]
 
 (11) BroadcastExchange
 Input [1]: [p_promo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_promo_sk#3]
@@ -109,7 +109,7 @@ Input [4]: [cd_demo_sk#15, cd_gender#16, cd_marital_status#17, cd_education_stat
 
 (18) BroadcastExchange
 Input [1]: [cd_demo_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#19]
 
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
@@ -136,7 +136,7 @@ Condition : isnotnull(i_item_sk#20)
 
 (24) BroadcastExchange
 Input [2]: [i_item_sk#20, i_item_id#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#22]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -199,6 +199,6 @@ Input [2]: [d_date_sk#10, d_year#48]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7/explain.txt
@@ -66,7 +66,7 @@ Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_stat
 
 (8) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
@@ -105,7 +105,7 @@ Condition : isnotnull(i_item_sk#16)
 
 (17) BroadcastExchange
 Input [2]: [i_item_sk#16, i_item_id#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -136,7 +136,7 @@ Input [3]: [p_promo_sk#19, p_channel_email#20, p_channel_event#21]
 
 (24) BroadcastExchange
 Input [1]: [p_promo_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_promo_sk#3]
@@ -199,6 +199,6 @@ Input [2]: [d_date_sk#15, d_year#48]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/explain.txt
@@ -80,7 +80,7 @@ Input [2]: [s_store_sk#8, s_county#9]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -111,7 +111,7 @@ Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_coun
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -146,7 +146,7 @@ Condition : ((cnt#20 >= 1) AND (cnt#20 <= 5))
 
 (25) BroadcastExchange
 Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false,false), [id=#21]
 
 (26) Scan parquet default.customer
 Output [5]: [c_customer_sk#22, c_salutation#23, c_first_name#24, c_last_name#25, c_preferred_cust_flag#26]
@@ -209,6 +209,6 @@ Input [3]: [d_date_sk#7, d_year#28, d_dom#29]
 
 (37) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#30]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73/explain.txt
@@ -80,7 +80,7 @@ Input [2]: [s_store_sk#8, s_county#9]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -111,7 +111,7 @@ Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_coun
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -160,7 +160,7 @@ Condition : isnotnull(c_customer_sk#21)
 
 (28) BroadcastExchange
 Input [5]: [c_customer_sk#21, c_salutation#22, c_first_name#23, c_last_name#24, c_preferred_cust_flag#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
@@ -209,6 +209,6 @@ Input [3]: [d_date_sk#7, d_year#28, d_dom#29]
 
 (37) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#30]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/explain.txt
@@ -81,7 +81,7 @@ Input [3]: [hd_demo_sk#11, hd_dep_count#12, hd_vehicle_count#13]
 
 (11) BroadcastExchange
 Input [1]: [hd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -112,7 +112,7 @@ Input [3]: [s_store_sk#15, s_number_employees#16, s_city#17]
 
 (18) BroadcastExchange
 Input [2]: [s_store_sk#15, s_city#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
@@ -214,6 +214,6 @@ Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
 
 (38) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#36]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79/explain.txt
@@ -78,7 +78,7 @@ Input [3]: [s_store_sk#11, s_number_employees#12, s_city#13]
 
 (11) BroadcastExchange
 Input [2]: [s_store_sk#11, s_city#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
@@ -109,7 +109,7 @@ Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -154,7 +154,7 @@ Condition : isnotnull(c_customer_sk#28)
 
 (27) BroadcastExchange
 Input [3]: [c_customer_sk#28, c_first_name#29, c_last_name#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#31]
 
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
@@ -199,6 +199,6 @@ Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#35]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/explain.txt
@@ -71,7 +71,7 @@ Condition : isnotnull(s_store_sk#8)
 
 (10) BroadcastExchange
 Input [3]: [s_store_sk#8, s_store_name#9, s_company_name#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
@@ -98,7 +98,7 @@ Condition : (((i_category#15 IN (Home                                           
 
 (16) BroadcastExchange
 Input [4]: [i_item_sk#12, i_brand#13, i_class#14, i_category#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#16]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
@@ -181,6 +181,6 @@ Input [3]: [d_date_sk#6, d_year#25, d_moy#7]
 
 (32) BroadcastExchange
 Input [2]: [d_date_sk#6, d_moy#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89/explain.txt
@@ -59,7 +59,7 @@ Condition : (isnotnull(ss_item_sk#5) AND isnotnull(ss_store_sk#6))
 
 (7) BroadcastExchange
 Input [4]: [ss_item_sk#5, ss_store_sk#6, ss_sales_price#7, ss_sold_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#10]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -98,7 +98,7 @@ Condition : isnotnull(s_store_sk#13)
 
 (16) BroadcastExchange
 Input [3]: [s_store_sk#13, s_store_name#14, s_company_name#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#16]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#6]
@@ -181,6 +181,6 @@ Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
 
 (32) BroadcastExchange
 Input [2]: [d_date_sk#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q98.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q98.sf100/explain.txt
@@ -168,6 +168,6 @@ Input [2]: [d_date_sk#5, d_date#25]
 
 (30) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q98/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q98/explain.txt
@@ -54,7 +54,7 @@ Condition : (i_category#10 IN (Jewelry                                          
 
 (7) BroadcastExchange
 Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
@@ -153,6 +153,6 @@ Input [2]: [d_date_sk#12, d_date#24]
 
 (27) BroadcastExchange
 Input [1]: [d_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q1.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q1.sf100/explain.txt
@@ -162,7 +162,7 @@ Condition : isnotnull((avg(ctr_total_return) * 1.2)#23)
 
 (24) BroadcastExchange
 Input [2]: [(avg(ctr_total_return) * 1.2)#23, ctr_store_sk#12#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false,false), [id=#25]
 
 (25) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ctr_store_sk#12]
@@ -193,7 +193,7 @@ Input [2]: [s_store_sk#26, s_state#27]
 
 (31) BroadcastExchange
 Input [1]: [s_store_sk#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#28]
 
 (32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ctr_store_sk#12]
@@ -277,7 +277,7 @@ Input [2]: [d_date_sk#6, d_year#33]
 
 (48) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#34]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#34]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = sr_returned_date_sk#4 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q1/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q1/explain.txt
@@ -159,7 +159,7 @@ Condition : isnotnull((avg(ctr_total_return) * 1.2)#23)
 
 (24) BroadcastExchange
 Input [2]: [(avg(ctr_total_return) * 1.2)#23, ctr_store_sk#12#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false,false), [id=#25]
 
 (25) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ctr_store_sk#12]
@@ -190,7 +190,7 @@ Input [2]: [s_store_sk#26, s_state#27]
 
 (31) BroadcastExchange
 Input [1]: [s_store_sk#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#28]
 
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ctr_store_sk#12]
@@ -217,7 +217,7 @@ Condition : isnotnull(c_customer_sk#29)
 
 (37) BroadcastExchange
 Input [2]: [c_customer_sk#29, c_customer_id#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#31]
 
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ctr_customer_sk#11]
@@ -262,7 +262,7 @@ Input [2]: [d_date_sk#6, d_year#32]
 
 (45) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#33]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = sr_returned_date_sk#4 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/explain.txt
@@ -207,7 +207,7 @@ Input [2]: [ca_address_sk#20, ca_county#21]
 
 (36) BroadcastExchange
 Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (37) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_current_addr_sk#5]
@@ -309,7 +309,7 @@ Input [3]: [d_date_sk#10, d_year#44, d_moy#45]
 
 (56) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#46]
 
 Subquery:2 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#13 IN dynamicpruning#9
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10/explain.txt
@@ -82,7 +82,7 @@ Input [3]: [ss_customer_sk#6, ss_sold_date_sk#7, d_date_sk#9]
 
 (9) BroadcastExchange
 Input [1]: [ss_customer_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#10]
 
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
@@ -113,7 +113,7 @@ Input [3]: [ws_bill_customer_sk#11, ws_sold_date_sk#12, d_date_sk#13]
 
 (16) BroadcastExchange
 Input [1]: [ws_bill_customer_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#14]
 
 (17) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
@@ -144,7 +144,7 @@ Input [3]: [cs_ship_customer_sk#15, cs_sold_date_sk#16, d_date_sk#17]
 
 (23) BroadcastExchange
 Input [1]: [cs_ship_customer_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#18]
 
 (24) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
@@ -179,7 +179,7 @@ Input [2]: [ca_address_sk#19, ca_county#20]
 
 (31) BroadcastExchange
 Input [1]: [ca_address_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#21]
 
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#5]
@@ -206,7 +206,7 @@ Condition : isnotnull(cd_demo_sk#22)
 
 (37) BroadcastExchange
 Input [9]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#31]
 
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#4]
@@ -269,7 +269,7 @@ Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
 
 (48) BroadcastExchange
 Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#44]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = ws_sold_date_sk#12 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11.sf100/explain.txt
@@ -468,7 +468,7 @@ Condition : ((isnotnull(d_year#7) AND (d_year#7 = 2001)) AND isnotnull(d_date_sk
 
 (84) BroadcastExchange
 Input [2]: [d_date_sk#6, d_year#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#91]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#91]
 
 Subquery:2 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#28 IN dynamicpruning#29
 BroadcastExchange (88)
@@ -493,7 +493,7 @@ Condition : ((isnotnull(d_year#31) AND (d_year#31 = 2002)) AND isnotnull(d_date_
 
 (88) BroadcastExchange
 Input [2]: [d_date_sk#30, d_year#31]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#92]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#92]
 
 Subquery:3 Hosting operator id = 41 Hosting Expression = ws_sold_date_sk#51 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11/explain.txt
@@ -104,7 +104,7 @@ Condition : isnotnull(ss_customer_sk#9)
 
 (7) BroadcastExchange
 Input [4]: [ss_customer_sk#9, ss_ext_discount_amt#10, ss_ext_list_price#11, ss_sold_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [c_customer_sk#1]
@@ -180,7 +180,7 @@ Condition : isnotnull(ss_customer_sk#31)
 
 (23) BroadcastExchange
 Input [4]: [ss_customer_sk#31, ss_ext_discount_amt#32, ss_ext_list_price#33, ss_sold_date_sk#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#36]
 
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#23]
@@ -223,7 +223,7 @@ Results [3]: [c_customer_id#24 AS customer_id#42, c_preferred_cust_flag#27 AS cu
 
 (32) BroadcastExchange
 Input [3]: [customer_id#42, customer_preferred_cust_flag#43, year_total#44]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#45]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#45]
 
 (33) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#21]
@@ -265,7 +265,7 @@ Condition : isnotnull(ws_bill_customer_sk#54)
 
 (41) BroadcastExchange
 Input [4]: [ws_bill_customer_sk#54, ws_ext_discount_amt#55, ws_ext_list_price#56, ws_sold_date_sk#57]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#58]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#58]
 
 (42) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#46]
@@ -312,7 +312,7 @@ Condition : (isnotnull(year_total#66) AND (year_total#66 > 0.00))
 
 (51) BroadcastExchange
 Input [2]: [customer_id#65, year_total#66]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#67]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#67]
 
 (52) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#21]
@@ -354,7 +354,7 @@ Condition : isnotnull(ws_bill_customer_sk#76)
 
 (60) BroadcastExchange
 Input [4]: [ws_bill_customer_sk#76, ws_ext_discount_amt#77, ws_ext_list_price#78, ws_sold_date_sk#79]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#80]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#80]
 
 (61) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#68]
@@ -397,7 +397,7 @@ Results [2]: [c_customer_id#69 AS customer_id#86, MakeDecimal(sum(UnscaledValue(
 
 (69) BroadcastExchange
 Input [2]: [customer_id#86, year_total#87]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#88]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#88]
 
 (70) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#21]
@@ -437,7 +437,7 @@ Condition : ((isnotnull(d_year#16) AND (d_year#16 = 2001)) AND isnotnull(d_date_
 
 (76) BroadcastExchange
 Input [2]: [d_date_sk#15, d_year#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#89]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#89]
 
 Subquery:2 Hosting operator id = 20 Hosting Expression = ss_sold_date_sk#34 IN dynamicpruning#35
 BroadcastExchange (80)
@@ -462,7 +462,7 @@ Condition : ((isnotnull(d_year#38) AND (d_year#38 = 2002)) AND isnotnull(d_date_
 
 (80) BroadcastExchange
 Input [2]: [d_date_sk#37, d_year#38]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#90]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#90]
 
 Subquery:3 Hosting operator id = 38 Hosting Expression = ws_sold_date_sk#57 IN dynamicpruning#13
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/explain.txt
@@ -158,6 +158,6 @@ Input [2]: [d_date_sk#13, d_date#24]
 
 (28) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12/explain.txt
@@ -52,7 +52,7 @@ Condition : (i_category#10 IN (Sports                                           
 
 (7) BroadcastExchange
 Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
@@ -143,6 +143,6 @@ Input [2]: [d_date_sk#12, d_date#23]
 
 (25) BroadcastExchange
 Input [1]: [d_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#24]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13.sf100/explain.txt
@@ -66,7 +66,7 @@ Condition : (isnotnull(cd_demo_sk#12) AND ((((cd_marital_status#13 = M) AND (cd_
 
 (7) BroadcastExchange
 Input [3]: [cd_demo_sk#12, cd_marital_status#13, cd_education_status#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (8) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_cdemo_sk#1]
@@ -93,7 +93,7 @@ Condition : (isnotnull(hd_demo_sk#16) AND (((hd_dep_count#17 = 3) OR (hd_dep_cou
 
 (13) BroadcastExchange
 Input [2]: [hd_demo_sk#16, hd_dep_count#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -132,7 +132,7 @@ Condition : isnotnull(s_store_sk#20)
 
 (22) BroadcastExchange
 Input [1]: [s_store_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_store_sk#4]
@@ -163,7 +163,7 @@ Input [3]: [ca_address_sk#22, ca_state#23, ca_country#24]
 
 (29) BroadcastExchange
 Input [2]: [ca_address_sk#22, ca_state#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (30) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_addr_sk#3]
@@ -222,6 +222,6 @@ Input [2]: [d_date_sk#19, d_year#49]
 
 (39) BroadcastExchange
 Input [1]: [d_date_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#50]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13/explain.txt
@@ -66,7 +66,7 @@ Condition : isnotnull(s_store_sk#12)
 
 (7) BroadcastExchange
 Input [1]: [s_store_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#13]
 
 (8) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_store_sk#4]
@@ -97,7 +97,7 @@ Input [3]: [ca_address_sk#14, ca_state#15, ca_country#16]
 
 (14) BroadcastExchange
 Input [2]: [ca_address_sk#14, ca_state#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (15) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_addr_sk#3]
@@ -136,7 +136,7 @@ Condition : (isnotnull(cd_demo_sk#19) AND ((((cd_marital_status#20 = M) AND (cd_
 
 (23) BroadcastExchange
 Input [3]: [cd_demo_sk#19, cd_marital_status#20, cd_education_status#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#22]
 
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_cdemo_sk#1]
@@ -163,7 +163,7 @@ Condition : (isnotnull(hd_demo_sk#23) AND (((hd_dep_count#24 = 3) OR (hd_dep_cou
 
 (29) BroadcastExchange
 Input [2]: [hd_demo_sk#23, hd_dep_count#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (30) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -222,6 +222,6 @@ Input [2]: [d_date_sk#18, d_year#49]
 
 (39) BroadcastExchange
 Input [1]: [d_date_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#50]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
@@ -256,7 +256,7 @@ Condition : isnotnull(i_item_sk#23)
 
 (29) BroadcastExchange
 Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#27]
 
 (30) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#20]
@@ -282,7 +282,7 @@ Join condition: None
 
 (35) BroadcastExchange
 Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#29]
 
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#11]
@@ -391,7 +391,7 @@ Results [3]: [brand_id#30, class_id#31, category_id#32]
 
 (58) BroadcastExchange
 Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false,false), [id=#44]
 
 (59) BroadcastHashJoin [codegen id : 20]
 Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
@@ -463,7 +463,7 @@ Join condition: None
 
 (75) BroadcastExchange
 Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#53]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#53]
 
 (76) BroadcastHashJoin [codegen id : 45]
 Left keys [1]: [ss_item_sk#1]
@@ -842,7 +842,7 @@ Input [3]: [d_date_sk#47, d_year#153, d_moy#154]
 
 (150) BroadcastExchange
 Input [1]: [d_date_sk#47]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#155]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#155]
 
 Subquery:6 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
 BroadcastExchange (155)
@@ -872,7 +872,7 @@ Input [2]: [d_date_sk#14, d_year#156]
 
 (155) BroadcastExchange
 Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#157]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#157]
 
 Subquery:7 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
@@ -197,7 +197,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (19) BroadcastExchange
 Input [4]: [i_item_sk#19, i_brand_id#20, i_class_id#21, i_category_id#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (20) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#17]
@@ -222,7 +222,7 @@ Input [5]: [cs_sold_date_sk#18, i_brand_id#20, i_class_id#21, i_category_id#22, 
 
 (25) BroadcastExchange
 Input [3]: [i_brand_id#20, i_class_id#21, i_category_id#22]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false,true), [id=#25]
 
 (26) BroadcastHashJoin [codegen id : 4]
 Left keys [6]: [coalesce(i_brand_id#14, 0), isnull(i_brand_id#14), coalesce(i_class_id#15, 0), isnull(i_class_id#15), coalesce(i_category_id#16, 0), isnull(i_category_id#16)]
@@ -231,7 +231,7 @@ Join condition: None
 
 (27) BroadcastExchange
 Input [4]: [i_item_sk#13, i_brand_id#14, i_class_id#15, i_category_id#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#10]
@@ -313,7 +313,7 @@ Input [5]: [ws_sold_date_sk#33, i_brand_id#35, i_class_id#36, i_category_id#37, 
 
 (45) BroadcastExchange
 Input [3]: [i_brand_id#35, i_class_id#36, i_category_id#37]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#39]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false,true), [id=#39]
 
 (46) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#28, 0), isnull(brand_id#28), coalesce(class_id#29, 0), isnull(class_id#29), coalesce(category_id#30, 0), isnull(category_id#30)]
@@ -336,7 +336,7 @@ Results [3]: [brand_id#28, class_id#29, category_id#30]
 
 (49) BroadcastExchange
 Input [3]: [brand_id#28, class_id#29, category_id#30]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false,false), [id=#40]
 
 (50) BroadcastHashJoin [codegen id : 11]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
@@ -349,7 +349,7 @@ Input [7]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, brand_id#2
 
 (52) BroadcastExchange
 Input [1]: [ss_item_sk#41]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#42]
 
 (53) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
@@ -380,7 +380,7 @@ Join condition: None
 
 (59) BroadcastExchange
 Input [4]: [i_item_sk#43, i_brand_id#44, i_class_id#45, i_category_id#46]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#47]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#47]
 
 (60) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
@@ -747,7 +747,7 @@ Input [3]: [d_date_sk#48, d_year#146, d_moy#147]
 
 (131) BroadcastExchange
 Input [1]: [d_date_sk#48]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#148]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#148]
 
 Subquery:6 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (136)
@@ -777,7 +777,7 @@ Input [2]: [d_date_sk#27, d_year#149]
 
 (136) BroadcastExchange
 Input [1]: [d_date_sk#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#150]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#150]
 
 Subquery:7 Hosting operator id = 13 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
@@ -232,7 +232,7 @@ Condition : isnotnull(i_item_sk#23)
 
 (29) BroadcastExchange
 Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#27]
 
 (30) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#20]
@@ -258,7 +258,7 @@ Join condition: None
 
 (35) BroadcastExchange
 Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#29]
 
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#11]
@@ -367,7 +367,7 @@ Results [3]: [brand_id#30, class_id#31, category_id#32]
 
 (58) BroadcastExchange
 Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false,false), [id=#44]
 
 (59) BroadcastHashJoin [codegen id : 20]
 Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
@@ -439,7 +439,7 @@ Join condition: None
 
 (75) BroadcastExchange
 Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#53]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#53]
 
 (76) BroadcastHashJoin [codegen id : 45]
 Left keys [1]: [ss_item_sk#1]
@@ -555,7 +555,7 @@ Condition : (isnotnull(sales#89) AND (cast(sales#89 as decimal(32,6)) > cast(Reu
 
 (100) BroadcastExchange
 Input [6]: [channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sales#89, number_sales#90]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#91]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false,false), [id=#91]
 
 (101) BroadcastHashJoin [codegen id : 92]
 Left keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
@@ -710,7 +710,7 @@ Input [2]: [d_date_sk#47, d_week_seq#117]
 
 (126) BroadcastExchange
 Input [1]: [d_date_sk#47]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#120]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#120]
 
 Subquery:6 Hosting operator id = 124 Hosting Expression = Subquery scalar-subquery#118, [id=#119]
 * Project (130)
@@ -765,7 +765,7 @@ Input [2]: [d_date_sk#14, d_year#125]
 
 (135) BroadcastExchange
 Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#126]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#126]
 
 Subquery:8 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
 
@@ -801,7 +801,7 @@ Input [2]: [d_date_sk#74, d_week_seq#127]
 
 (140) BroadcastExchange
 Input [1]: [d_date_sk#74]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#130]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#130]
 
 Subquery:12 Hosting operator id = 138 Hosting Expression = Subquery scalar-subquery#128, [id=#129]
 * Project (144)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/explain.txt
@@ -176,7 +176,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (19) BroadcastExchange
 Input [4]: [i_item_sk#19, i_brand_id#20, i_class_id#21, i_category_id#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (20) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#17]
@@ -201,7 +201,7 @@ Input [5]: [cs_sold_date_sk#18, i_brand_id#20, i_class_id#21, i_category_id#22, 
 
 (25) BroadcastExchange
 Input [3]: [i_brand_id#20, i_class_id#21, i_category_id#22]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false,true), [id=#25]
 
 (26) BroadcastHashJoin [codegen id : 4]
 Left keys [6]: [coalesce(i_brand_id#14, 0), isnull(i_brand_id#14), coalesce(i_class_id#15, 0), isnull(i_class_id#15), coalesce(i_category_id#16, 0), isnull(i_category_id#16)]
@@ -210,7 +210,7 @@ Join condition: None
 
 (27) BroadcastExchange
 Input [4]: [i_item_sk#13, i_brand_id#14, i_class_id#15, i_category_id#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#10]
@@ -292,7 +292,7 @@ Input [5]: [ws_sold_date_sk#33, i_brand_id#35, i_class_id#36, i_category_id#37, 
 
 (45) BroadcastExchange
 Input [3]: [i_brand_id#35, i_class_id#36, i_category_id#37]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#39]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false,true), [id=#39]
 
 (46) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#28, 0), isnull(brand_id#28), coalesce(class_id#29, 0), isnull(class_id#29), coalesce(category_id#30, 0), isnull(category_id#30)]
@@ -315,7 +315,7 @@ Results [3]: [brand_id#28, class_id#29, category_id#30]
 
 (49) BroadcastExchange
 Input [3]: [brand_id#28, class_id#29, category_id#30]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false,false), [id=#40]
 
 (50) BroadcastHashJoin [codegen id : 11]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
@@ -328,7 +328,7 @@ Input [7]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, brand_id#2
 
 (52) BroadcastExchange
 Input [1]: [ss_item_sk#41]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#42]
 
 (53) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
@@ -359,7 +359,7 @@ Join condition: None
 
 (59) BroadcastExchange
 Input [4]: [i_item_sk#43, i_brand_id#44, i_class_id#45, i_category_id#46]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#47]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#47]
 
 (60) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
@@ -475,7 +475,7 @@ Condition : (isnotnull(sales#83) AND (cast(sales#83 as decimal(32,6)) > cast(Reu
 
 (84) BroadcastExchange
 Input [6]: [channel#82, i_brand_id#69, i_class_id#70, i_category_id#71, sales#83, number_sales#84]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#85]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false,false), [id=#85]
 
 (85) BroadcastHashJoin [codegen id : 52]
 Left keys [3]: [i_brand_id#44, i_class_id#45, i_category_id#46]
@@ -630,7 +630,7 @@ Input [2]: [d_date_sk#48, d_week_seq#111]
 
 (110) BroadcastExchange
 Input [1]: [d_date_sk#48]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#114]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#114]
 
 Subquery:6 Hosting operator id = 108 Hosting Expression = Subquery scalar-subquery#112, [id=#113]
 * Project (114)
@@ -685,7 +685,7 @@ Input [2]: [d_date_sk#27, d_year#119]
 
 (119) BroadcastExchange
 Input [1]: [d_date_sk#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#120]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#120]
 
 Subquery:8 Hosting operator id = 13 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 
@@ -721,7 +721,7 @@ Input [2]: [d_date_sk#72, d_week_seq#121]
 
 (124) BroadcastExchange
 Input [1]: [d_date_sk#72]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#124]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#124]
 
 Subquery:12 Hosting operator id = 122 Hosting Expression = Subquery scalar-subquery#122, [id=#123]
 * Project (128)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15.sf100/explain.txt
@@ -186,6 +186,6 @@ Input [3]: [d_date_sk#5, d_year#20, d_qoy#21]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15/explain.txt
@@ -54,7 +54,7 @@ Condition : (isnotnull(c_customer_sk#5) AND isnotnull(c_current_addr_sk#6))
 
 (7) BroadcastExchange
 Input [2]: [c_customer_sk#5, c_current_addr_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_customer_sk#1]
@@ -81,7 +81,7 @@ Condition : isnotnull(ca_address_sk#8)
 
 (13) BroadcastExchange
 Input [3]: [ca_address_sk#8, ca_state#9, ca_zip#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_current_addr_sk#6]
@@ -156,6 +156,6 @@ Input [3]: [d_date_sk#12, d_year#18, d_qoy#19]
 
 (27) BroadcastExchange
 Input [1]: [d_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#20]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
@@ -148,7 +148,7 @@ Input [2]: [ca_address_sk#17, ca_state#18]
 
 (24) BroadcastExchange
 Input [1]: [ca_address_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#19]
 
 (25) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_addr_sk#2]
@@ -179,7 +179,7 @@ Input [2]: [cc_call_center_sk#20, cc_county#21]
 
 (31) BroadcastExchange
 Input [1]: [cc_call_center_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_call_center_sk#3]
@@ -210,7 +210,7 @@ Input [2]: [d_date_sk#23, d_date#24]
 
 (38) BroadcastExchange
 Input [1]: [d_date_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_date_sk#1]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16/explain.txt
@@ -148,7 +148,7 @@ Input [2]: [d_date_sk#17, d_date#18]
 
 (24) BroadcastExchange
 Input [1]: [d_date_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#19]
 
 (25) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_date_sk#1]
@@ -179,7 +179,7 @@ Input [2]: [ca_address_sk#20, ca_state#21]
 
 (31) BroadcastExchange
 Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_addr_sk#2]
@@ -210,7 +210,7 @@ Input [2]: [cc_call_center_sk#23, cc_county#24]
 
 (38) BroadcastExchange
 Input [1]: [cc_call_center_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_call_center_sk#3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/explain.txt
@@ -93,7 +93,7 @@ Condition : isnotnull(s_store_sk#9)
 
 (10) BroadcastExchange
 Input [2]: [s_store_sk#9, s_state#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#3]
@@ -299,7 +299,7 @@ Input [2]: [d_date_sk#8, d_quarter_name#91]
 
 (54) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#92]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#92]
 
 Subquery:2 Hosting operator id = 24 Hosting Expression = sr_returned_date_sk#22 IN dynamicpruning#23
 BroadcastExchange (59)
@@ -329,7 +329,7 @@ Input [2]: [d_date_sk#24, d_quarter_name#93]
 
 (59) BroadcastExchange
 Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#94]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#94]
 
 Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#30 IN dynamicpruning#23
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17/explain.txt
@@ -73,7 +73,7 @@ Condition : ((isnotnull(sr_customer_sk#9) AND isnotnull(sr_item_sk#8)) AND isnot
 
 (7) BroadcastExchange
 Input [5]: [sr_item_sk#8, sr_customer_sk#9, sr_ticket_number#10, sr_return_quantity#11, sr_returned_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[0, int, false], input[2, int, false]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[0, int, false], input[2, int, false]),false,false), [id=#14]
 
 (8) BroadcastHashJoin [codegen id : 8]
 Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
@@ -101,7 +101,7 @@ Condition : (isnotnull(cs_bill_customer_sk#15) AND isnotnull(cs_item_sk#16))
 
 (13) BroadcastExchange
 Input [4]: [cs_bill_customer_sk#15, cs_item_sk#16, cs_quantity#17, cs_sold_date_sk#18]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[1, int, false] as bigint) & 4294967295))),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[1, int, false] as bigint) & 4294967295))),false,false), [id=#19]
 
 (14) BroadcastHashJoin [codegen id : 8]
 Left keys [2]: [sr_customer_sk#9, sr_item_sk#8]
@@ -164,7 +164,7 @@ Condition : isnotnull(s_store_sk#23)
 
 (28) BroadcastExchange
 Input [2]: [s_store_sk#23, s_state#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#3]
@@ -191,7 +191,7 @@ Condition : isnotnull(i_item_sk#26)
 
 (34) BroadcastExchange
 Input [3]: [i_item_sk#26, i_item_id#27, i_item_desc#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#29]
 
 (35) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#1]
@@ -254,7 +254,7 @@ Input [2]: [d_date_sk#20, d_quarter_name#88]
 
 (45) BroadcastExchange
 Input [1]: [d_date_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#89]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#89]
 
 Subquery:2 Hosting operator id = 4 Hosting Expression = sr_returned_date_sk#12 IN dynamicpruning#13
 BroadcastExchange (50)
@@ -284,7 +284,7 @@ Input [2]: [d_date_sk#21, d_quarter_name#90]
 
 (50) BroadcastExchange
 Input [1]: [d_date_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#91]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#91]
 
 Subquery:3 Hosting operator id = 10 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#13
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/explain.txt
@@ -85,7 +85,7 @@ Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14
 
 (8) BroadcastExchange
 Input [2]: [cd_demo_sk#11, cd_dep_count#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
@@ -124,7 +124,7 @@ Condition : isnotnull(i_item_sk#17)
 
 (17) BroadcastExchange
 Input [2]: [i_item_sk#17, i_item_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_item_sk#3]
@@ -177,7 +177,7 @@ Condition : (ca_state#28 IN (MS,IN,ND,OK,NM,VA) AND isnotnull(ca_address_sk#26))
 
 (29) BroadcastExchange
 Input [4]: [ca_address_sk#26, ca_county#27, ca_state#28, ca_country#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#30]
 
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#23]
@@ -300,6 +300,6 @@ Input [2]: [d_date_sk#16, d_year#83]
 
 (54) BroadcastExchange
 Input [1]: [d_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#84]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#84]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18/explain.txt
@@ -79,7 +79,7 @@ Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14
 
 (8) BroadcastExchange
 Input [2]: [cd_demo_sk#11, cd_dep_count#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (9) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_bill_cdemo_sk#2]
@@ -110,7 +110,7 @@ Input [5]: [c_customer_sk#16, c_current_cdemo_sk#17, c_current_addr_sk#18, c_bir
 
 (15) BroadcastExchange
 Input [4]: [c_customer_sk#16, c_current_cdemo_sk#17, c_current_addr_sk#18, c_birth_year#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#21]
 
 (16) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_bill_customer_sk#1]
@@ -137,7 +137,7 @@ Condition : isnotnull(cd_demo_sk#22)
 
 (21) BroadcastExchange
 Input [1]: [cd_demo_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (22) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_cdemo_sk#17]
@@ -164,7 +164,7 @@ Condition : (ca_state#26 IN (MS,IN,ND,OK,NM,VA) AND isnotnull(ca_address_sk#24))
 
 (27) BroadcastExchange
 Input [4]: [ca_address_sk#24, ca_county#25, ca_state#26, ca_country#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#28]
 
 (28) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#18]
@@ -203,7 +203,7 @@ Condition : isnotnull(i_item_sk#30)
 
 (36) BroadcastExchange
 Input [2]: [i_item_sk#30, i_item_id#31]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#32]
 
 (37) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_item_sk#3]
@@ -270,6 +270,6 @@ Input [2]: [d_date_sk#29, d_year#81]
 
 (48) BroadcastExchange
 Input [1]: [d_date_sk#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#82]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#82]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/explain.txt
@@ -77,7 +77,7 @@ Input [6]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#1
 
 (8) BroadcastExchange
 Input [5]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
@@ -116,7 +116,7 @@ Condition : (isnotnull(s_zip#16) AND isnotnull(s_store_sk#15))
 
 (17) BroadcastExchange
 Input [2]: [s_store_sk#15, s_zip#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#17]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -257,6 +257,6 @@ Input [3]: [d_date_sk#14, d_year#33, d_moy#34]
 
 (46) BroadcastExchange
 Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#35]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19/explain.txt
@@ -75,7 +75,7 @@ Condition : ((isnotnull(ss_item_sk#4) AND isnotnull(ss_customer_sk#5)) AND isnot
 
 (8) BroadcastExchange
 Input [5]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, ss_sold_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[4, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[4, int, true] as bigint)),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [d_date_sk#1]
@@ -106,7 +106,7 @@ Input [6]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufac
 
 (15) BroadcastExchange
 Input [5]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#16]
 
 (16) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#4]
@@ -133,7 +133,7 @@ Condition : (isnotnull(c_customer_sk#17) AND isnotnull(c_current_addr_sk#18))
 
 (21) BroadcastExchange
 Input [2]: [c_customer_sk#17, c_current_addr_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#5]
@@ -160,7 +160,7 @@ Condition : (isnotnull(ca_address_sk#20) AND isnotnull(ca_zip#21))
 
 (27) BroadcastExchange
 Input [2]: [ca_address_sk#20, ca_zip#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#22]
 
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_current_addr_sk#18]
@@ -187,7 +187,7 @@ Condition : (isnotnull(s_zip#24) AND isnotnull(s_store_sk#23))
 
 (33) BroadcastExchange
 Input [2]: [s_store_sk#23, s_zip#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (34) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_store_sk#6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
@@ -84,7 +84,7 @@ Condition : (isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10))
 
 (11) BroadcastExchange
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [sold_date_sk#3]
@@ -133,7 +133,7 @@ Input [2]: [d_week_seq#42, d_year#43]
 
 (21) BroadcastExchange
 Input [1]: [d_week_seq#42]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#44]
 
 (22) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [d_week_seq#10]
@@ -174,7 +174,7 @@ Input [2]: [d_week_seq#60, d_year#61]
 
 (30) BroadcastExchange
 Input [1]: [d_week_seq#60]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#62]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#62]
 
 (31) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [d_week_seq#10]
@@ -187,7 +187,7 @@ Input [9]: [d_week_seq#10, sun_sales#35, mon_sales#36, tue_sales#37, wed_sales#3
 
 (33) BroadcastExchange
 Input [8]: [d_week_seq2#63, sun_sales2#64, mon_sales2#65, tue_sales2#66, wed_sales2#67, thu_sales2#68, fri_sales2#69, sat_sales2#70]
-Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as bigint)),false), [id=#71]
+Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as bigint)),false,false), [id=#71]
 
 (34) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [d_week_seq1#45]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2/explain.txt
@@ -84,7 +84,7 @@ Condition : (isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10))
 
 (11) BroadcastExchange
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [sold_date_sk#3]
@@ -133,7 +133,7 @@ Input [2]: [d_week_seq#42, d_year#43]
 
 (21) BroadcastExchange
 Input [1]: [d_week_seq#42]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#44]
 
 (22) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [d_week_seq#10]
@@ -174,7 +174,7 @@ Input [2]: [d_week_seq#60, d_year#61]
 
 (30) BroadcastExchange
 Input [1]: [d_week_seq#60]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#62]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#62]
 
 (31) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [d_week_seq#10]
@@ -187,7 +187,7 @@ Input [9]: [d_week_seq#10, sun_sales#35, mon_sales#36, tue_sales#37, wed_sales#3
 
 (33) BroadcastExchange
 Input [8]: [d_week_seq2#63, sun_sales2#64, mon_sales2#65, tue_sales2#66, wed_sales2#67, thu_sales2#68, fri_sales2#69, sat_sales2#70]
-Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as bigint)),false), [id=#71]
+Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as bigint)),false,false), [id=#71]
 
 (34) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [d_week_seq1#45]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/explain.txt
@@ -158,6 +158,6 @@ Input [2]: [d_date_sk#13, d_date#24]
 
 (28) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20/explain.txt
@@ -52,7 +52,7 @@ Condition : (i_category#10 IN (Sports                                           
 
 (7) BroadcastExchange
 Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#1]
@@ -143,6 +143,6 @@ Input [2]: [d_date_sk#12, d_date#23]
 
 (25) BroadcastExchange
 Input [1]: [d_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#24]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21.sf100/explain.txt
@@ -60,7 +60,7 @@ Input [3]: [i_item_sk#6, i_item_id#7, i_current_price#8]
 
 (8) BroadcastExchange
 Input [2]: [i_item_sk#6, i_item_id#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
@@ -99,7 +99,7 @@ Condition : isnotnull(w_warehouse_sk#12)
 
 (17) BroadcastExchange
 Input [2]: [w_warehouse_sk#12, w_warehouse_name#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
@@ -161,6 +161,6 @@ Condition : (((isnotnull(d_date#11) AND (d_date#11 >= 2000-02-10)) AND (d_date#1
 
 (28) BroadcastExchange
 Input [2]: [d_date_sk#10, d_date#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#24]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21/explain.txt
@@ -56,7 +56,7 @@ Condition : isnotnull(w_warehouse_sk#6)
 
 (7) BroadcastExchange
 Input [2]: [w_warehouse_sk#6, w_warehouse_name#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
@@ -87,7 +87,7 @@ Input [3]: [i_item_sk#9, i_item_id#10, i_current_price#11]
 
 (14) BroadcastExchange
 Input [2]: [i_item_sk#9, i_item_id#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
@@ -161,6 +161,6 @@ Condition : (((isnotnull(d_date#14) AND (d_date#14 >= 2000-02-10)) AND (d_date#1
 
 (28) BroadcastExchange
 Input [2]: [d_date_sk#13, d_date#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#24]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q22.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q22.sf100/explain.txt
@@ -58,7 +58,7 @@ Condition : isnotnull(w_warehouse_sk#6)
 
 (7) BroadcastExchange
 Input [1]: [w_warehouse_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [inv_warehouse_sk#2]
@@ -176,6 +176,6 @@ Input [2]: [d_date_sk#8, d_month_seq#28]
 
 (31) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q22/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q22/explain.txt
@@ -67,7 +67,7 @@ Condition : isnotnull(i_item_sk#7)
 
 (10) BroadcastExchange
 Input [5]: [i_item_sk#7, i_brand#8, i_class#9, i_category#10, i_product_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
@@ -94,7 +94,7 @@ Condition : isnotnull(w_warehouse_sk#13)
 
 (16) BroadcastExchange
 Input [1]: [w_warehouse_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
@@ -161,6 +161,6 @@ Input [2]: [d_date_sk#6, d_month_seq#27]
 
 (28) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#28]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.sf100/explain.txt
@@ -526,7 +526,7 @@ Input [3]: [d_date_sk#39, d_year#58, d_moy#59]
 
 (95) BroadcastExchange
 Input [1]: [d_date_sk#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#60]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#60]
 
 Subquery:2 Hosting operator id = 5 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
 BroadcastExchange (100)
@@ -556,7 +556,7 @@ Input [3]: [d_date_sk#11, d_date#12, d_year#61]
 
 (100) BroadcastExchange
 Input [2]: [d_date_sk#11, d_date#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#62]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#62]
 
 Subquery:3 Hosting operator id = 44 Hosting Expression = Subquery scalar-subquery#37, [id=#38]
 * HashAggregate (117)
@@ -689,7 +689,7 @@ Input [2]: [d_date_sk#68, d_year#82]
 
 (122) BroadcastExchange
 Input [1]: [d_date_sk#68]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#83]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#83]
 
 Subquery:5 Hosting operator id = 52 Hosting Expression = ws_sold_date_sk#45 IN dynamicpruning#6
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a/explain.txt
@@ -120,7 +120,7 @@ Condition : isnotnull(i_item_sk#12)
 
 (12) BroadcastExchange
 Input [2]: [i_item_sk#12, i_item_desc#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#7]
@@ -159,7 +159,7 @@ Input [2]: [item_sk#20, cnt#21]
 
 (20) BroadcastExchange
 Input [1]: [item_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#22]
 
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_item_sk#2]
@@ -212,7 +212,7 @@ Condition : isnotnull(c_customer_sk#28)
 
 (32) BroadcastExchange
 Input [1]: [c_customer_sk#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#29]
 
 (33) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#24]
@@ -397,7 +397,7 @@ Input [3]: [d_date_sk#39, d_year#56, d_moy#57]
 
 (71) BroadcastExchange
 Input [1]: [d_date_sk#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#58]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#58]
 
 Subquery:2 Hosting operator id = 3 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 BroadcastExchange (76)
@@ -427,7 +427,7 @@ Input [3]: [d_date_sk#10, d_date#11, d_year#59]
 
 (76) BroadcastExchange
 Input [2]: [d_date_sk#10, d_date#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#60]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#60]
 
 Subquery:3 Hosting operator id = 38 Hosting Expression = Subquery scalar-subquery#37, [id=#38]
 * HashAggregate (91)
@@ -550,7 +550,7 @@ Input [2]: [d_date_sk#67, d_year#80]
 
 (96) BroadcastExchange
 Input [1]: [d_date_sk#67]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#81]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#81]
 
 Subquery:5 Hosting operator id = 46 Hosting Expression = ws_sold_date_sk#45 IN dynamicpruning#6
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.sf100/explain.txt
@@ -744,7 +744,7 @@ Input [3]: [d_date_sk#39, d_year#70, d_moy#71]
 
 (134) BroadcastExchange
 Input [1]: [d_date_sk#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#72]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#72]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
 BroadcastExchange (139)
@@ -774,7 +774,7 @@ Input [3]: [d_date_sk#11, d_date#12, d_year#73]
 
 (139) BroadcastExchange
 Input [2]: [d_date_sk#11, d_date#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#74]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#74]
 
 Subquery:3 Hosting operator id = 45 Hosting Expression = Subquery scalar-subquery#37, [id=#38]
 * HashAggregate (156)
@@ -907,7 +907,7 @@ Input [2]: [d_date_sk#80, d_year#94]
 
 (161) BroadcastExchange
 Input [1]: [d_date_sk#80]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#95]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#95]
 
 Subquery:5 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#37, [id=#38]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b/explain.txt
@@ -146,7 +146,7 @@ Condition : isnotnull(i_item_sk#12)
 
 (13) BroadcastExchange
 Input [2]: [i_item_sk#12, i_item_desc#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (14) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#7]
@@ -185,7 +185,7 @@ Input [2]: [item_sk#20, cnt#21]
 
 (21) BroadcastExchange
 Input [1]: [item_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#22]
 
 (22) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_item_sk#2]
@@ -238,7 +238,7 @@ Condition : isnotnull(c_customer_sk#28)
 
 (33) BroadcastExchange
 Input [1]: [c_customer_sk#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#29]
 
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#24]
@@ -335,7 +335,7 @@ Join condition: None
 
 (54) BroadcastExchange
 Input [3]: [c_customer_sk#39, c_first_name#40, c_last_name#41]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#43]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#43]
 
 (55) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_bill_customer_sk#1]
@@ -516,7 +516,7 @@ Input [3]: [d_date_sk#44, d_year#69, d_moy#70]
 
 (92) BroadcastExchange
 Input [1]: [d_date_sk#44]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#71]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#71]
 
 Subquery:2 Hosting operator id = 4 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 BroadcastExchange (97)
@@ -546,7 +546,7 @@ Input [3]: [d_date_sk#10, d_date#11, d_year#72]
 
 (97) BroadcastExchange
 Input [2]: [d_date_sk#10, d_date#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#73]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#73]
 
 Subquery:3 Hosting operator id = 39 Hosting Expression = Subquery scalar-subquery#37, [id=#38]
 * HashAggregate (112)
@@ -669,7 +669,7 @@ Input [2]: [d_date_sk#80, d_year#93]
 
 (117) BroadcastExchange
 Input [1]: [d_date_sk#80]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#94]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#94]
 
 Subquery:5 Hosting operator id = 50 Hosting Expression = ReusedSubquery Subquery scalar-subquery#37, [id=#38]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
@@ -84,7 +84,7 @@ Condition : ((isnotnull(i_color#10) AND (i_color#10 = pale                )) AND
 
 (8) BroadcastExchange
 Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#13]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
@@ -197,7 +197,7 @@ Input [5]: [s_store_sk#25, s_store_name#26, s_market_id#27, s_state#28, s_zip#29
 
 (34) BroadcastExchange
 Input [4]: [s_store_sk#25, s_store_name#26, s_state#28, s_zip#29]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false,false), [id=#30]
 
 (35) Scan parquet default.customer_address
 Output [3]: [ca_state#31, ca_zip#32, ca_country#33]
@@ -224,7 +224,7 @@ Input [7]: [s_store_sk#25, s_store_name#26, s_state#28, s_zip#29, ca_state#31, c
 
 (40) BroadcastExchange
 Input [5]: [s_store_sk#25, s_store_name#26, s_state#28, ca_state#31, ca_country#33]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [id=#34]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false,false), [id=#34]
 
 (41) BroadcastHashJoin [codegen id : 12]
 Left keys [2]: [ss_store_sk#3, c_birth_country#18]
@@ -365,7 +365,7 @@ Input [5]: [s_store_sk#25, s_store_name#26, s_market_id#27, s_state#28, s_zip#29
 
 (58) BroadcastExchange
 Input [4]: [s_store_sk#25, s_store_name#26, s_state#28, s_zip#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 (59) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_store_sk#3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a/explain.txt
@@ -128,7 +128,7 @@ Input [5]: [s_store_sk#12, s_store_name#13, s_market_id#14, s_state#15, s_zip#16
 
 (19) BroadcastExchange
 Input [4]: [s_store_sk#12, s_store_name#13, s_state#15, s_zip#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (20) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#3]
@@ -155,7 +155,7 @@ Condition : ((isnotnull(i_color#21) AND (i_color#21 = pale                )) AND
 
 (25) BroadcastExchange
 Input [6]: [i_item_sk#18, i_current_price#19, i_size#20, i_color#21, i_units#22, i_manager_id#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#24]
 
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
@@ -182,7 +182,7 @@ Condition : (isnotnull(c_customer_sk#25) AND isnotnull(c_birth_country#28))
 
 (31) BroadcastExchange
 Input [4]: [c_customer_sk#25, c_first_name#26, c_last_name#27, c_birth_country#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#29]
 
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#2]
@@ -209,7 +209,7 @@ Condition : (isnotnull(ca_country#32) AND isnotnull(ca_zip#31))
 
 (37) BroadcastExchange
 Input [3]: [ca_state#30, ca_zip#31, ca_country#32]
-Arguments: HashedRelationBroadcastMode(List(upper(input[2, string, false]), input[1, string, false]),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(upper(input[2, string, false]), input[1, string, false]),false,false), [id=#33]
 
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [2]: [c_birth_country#28, s_zip#16]
@@ -343,7 +343,7 @@ Condition : isnotnull(i_item_sk#18)
 
 (59) BroadcastExchange
 Input [6]: [i_item_sk#18, i_current_price#19, i_size#20, i_color#21, i_units#22, i_manager_id#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#48]
 
 (60) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
@@ -84,7 +84,7 @@ Condition : ((isnotnull(i_color#10) AND (i_color#10 = chiffon             )) AND
 
 (8) BroadcastExchange
 Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#13]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
@@ -197,7 +197,7 @@ Input [5]: [s_store_sk#25, s_store_name#26, s_market_id#27, s_state#28, s_zip#29
 
 (34) BroadcastExchange
 Input [4]: [s_store_sk#25, s_store_name#26, s_state#28, s_zip#29]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false,false), [id=#30]
 
 (35) Scan parquet default.customer_address
 Output [3]: [ca_state#31, ca_zip#32, ca_country#33]
@@ -224,7 +224,7 @@ Input [7]: [s_store_sk#25, s_store_name#26, s_state#28, s_zip#29, ca_state#31, c
 
 (40) BroadcastExchange
 Input [5]: [s_store_sk#25, s_store_name#26, s_state#28, ca_state#31, ca_country#33]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [id=#34]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false,false), [id=#34]
 
 (41) BroadcastHashJoin [codegen id : 12]
 Left keys [2]: [ss_store_sk#3, c_birth_country#18]
@@ -365,7 +365,7 @@ Input [5]: [s_store_sk#25, s_store_name#26, s_market_id#27, s_state#28, s_zip#29
 
 (58) BroadcastExchange
 Input [4]: [s_store_sk#25, s_store_name#26, s_state#28, s_zip#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 (59) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_store_sk#3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b/explain.txt
@@ -128,7 +128,7 @@ Input [5]: [s_store_sk#12, s_store_name#13, s_market_id#14, s_state#15, s_zip#16
 
 (19) BroadcastExchange
 Input [4]: [s_store_sk#12, s_store_name#13, s_state#15, s_zip#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (20) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#3]
@@ -155,7 +155,7 @@ Condition : ((isnotnull(i_color#21) AND (i_color#21 = chiffon             )) AND
 
 (25) BroadcastExchange
 Input [6]: [i_item_sk#18, i_current_price#19, i_size#20, i_color#21, i_units#22, i_manager_id#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#24]
 
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
@@ -182,7 +182,7 @@ Condition : (isnotnull(c_customer_sk#25) AND isnotnull(c_birth_country#28))
 
 (31) BroadcastExchange
 Input [4]: [c_customer_sk#25, c_first_name#26, c_last_name#27, c_birth_country#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#29]
 
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#2]
@@ -209,7 +209,7 @@ Condition : (isnotnull(ca_country#32) AND isnotnull(ca_zip#31))
 
 (37) BroadcastExchange
 Input [3]: [ca_state#30, ca_zip#31, ca_country#32]
-Arguments: HashedRelationBroadcastMode(List(upper(input[2, string, false]), input[1, string, false]),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(upper(input[2, string, false]), input[1, string, false]),false,false), [id=#33]
 
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [2]: [c_birth_country#28, s_zip#16]
@@ -343,7 +343,7 @@ Condition : isnotnull(i_item_sk#18)
 
 (59) BroadcastExchange
 Input [6]: [i_item_sk#18, i_current_price#19, i_size#20, i_color#21, i_units#22, i_manager_id#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#48]
 
 (60) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/explain.txt
@@ -93,7 +93,7 @@ Condition : isnotnull(s_store_sk#9)
 
 (10) BroadcastExchange
 Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#3]
@@ -299,7 +299,7 @@ Input [3]: [d_date_sk#8, d_year#47, d_moy#48]
 
 (54) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 Subquery:2 Hosting operator id = 24 Hosting Expression = sr_returned_date_sk#23 IN dynamicpruning#24
 BroadcastExchange (59)
@@ -329,7 +329,7 @@ Input [3]: [d_date_sk#25, d_year#50, d_moy#51]
 
 (59) BroadcastExchange
 Input [1]: [d_date_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#52]
 
 Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#31 IN dynamicpruning#24
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25/explain.txt
@@ -73,7 +73,7 @@ Condition : ((isnotnull(sr_customer_sk#9) AND isnotnull(sr_item_sk#8)) AND isnot
 
 (7) BroadcastExchange
 Input [5]: [sr_item_sk#8, sr_customer_sk#9, sr_ticket_number#10, sr_net_loss#11, sr_returned_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[0, int, false], input[2, int, false]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[0, int, false], input[2, int, false]),false,false), [id=#14]
 
 (8) BroadcastHashJoin [codegen id : 8]
 Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
@@ -101,7 +101,7 @@ Condition : (isnotnull(cs_bill_customer_sk#15) AND isnotnull(cs_item_sk#16))
 
 (13) BroadcastExchange
 Input [4]: [cs_bill_customer_sk#15, cs_item_sk#16, cs_net_profit#17, cs_sold_date_sk#18]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[1, int, false] as bigint) & 4294967295))),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[1, int, false] as bigint) & 4294967295))),false,false), [id=#19]
 
 (14) BroadcastHashJoin [codegen id : 8]
 Left keys [2]: [sr_customer_sk#9, sr_item_sk#8]
@@ -164,7 +164,7 @@ Condition : isnotnull(s_store_sk#23)
 
 (28) BroadcastExchange
 Input [3]: [s_store_sk#23, s_store_id#24, s_store_name#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#3]
@@ -191,7 +191,7 @@ Condition : isnotnull(i_item_sk#27)
 
 (34) BroadcastExchange
 Input [3]: [i_item_sk#27, i_item_id#28, i_item_desc#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#30]
 
 (35) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#1]
@@ -254,7 +254,7 @@ Input [3]: [d_date_sk#20, d_year#44, d_moy#45]
 
 (45) BroadcastExchange
 Input [1]: [d_date_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#46]
 
 Subquery:2 Hosting operator id = 4 Hosting Expression = sr_returned_date_sk#12 IN dynamicpruning#13
 BroadcastExchange (50)
@@ -284,7 +284,7 @@ Input [3]: [d_date_sk#21, d_year#47, d_moy#48]
 
 (50) BroadcastExchange
 Input [1]: [d_date_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 Subquery:3 Hosting operator id = 10 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#13
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26.sf100/explain.txt
@@ -66,7 +66,7 @@ Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_stat
 
 (8) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_bill_cdemo_sk#1]
@@ -97,7 +97,7 @@ Input [3]: [p_promo_sk#15, p_channel_email#16, p_channel_event#17]
 
 (15) BroadcastExchange
 Input [1]: [p_promo_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (16) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_promo_sk#3]
@@ -136,7 +136,7 @@ Condition : isnotnull(i_item_sk#20)
 
 (24) BroadcastExchange
 Input [2]: [i_item_sk#20, i_item_id#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#22]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_item_sk#2]
@@ -199,6 +199,6 @@ Input [2]: [d_date_sk#19, d_year#48]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26/explain.txt
@@ -66,7 +66,7 @@ Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_stat
 
 (8) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_bill_cdemo_sk#1]
@@ -105,7 +105,7 @@ Condition : isnotnull(i_item_sk#16)
 
 (17) BroadcastExchange
 Input [2]: [i_item_sk#16, i_item_id#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_item_sk#2]
@@ -136,7 +136,7 @@ Input [3]: [p_promo_sk#19, p_channel_email#20, p_channel_event#21]
 
 (24) BroadcastExchange
 Input [1]: [p_promo_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_promo_sk#3]
@@ -199,6 +199,6 @@ Input [2]: [d_date_sk#15, d_year#48]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27.sf100/explain.txt
@@ -66,7 +66,7 @@ Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_stat
 
 (8) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
@@ -105,7 +105,7 @@ Condition : ((isnotnull(s_state#17) AND (s_state#17 = TN)) AND isnotnull(s_store
 
 (17) BroadcastExchange
 Input [2]: [s_store_sk#16, s_state#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
@@ -132,7 +132,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#19, i_item_id#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -199,6 +199,6 @@ Input [2]: [d_date_sk#15, d_year#51]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#52]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27/explain.txt
@@ -66,7 +66,7 @@ Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_stat
 
 (8) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
@@ -105,7 +105,7 @@ Condition : ((isnotnull(s_state#17) AND (s_state#17 = TN)) AND isnotnull(s_store
 
 (17) BroadcastExchange
 Input [2]: [s_store_sk#16, s_state#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
@@ -132,7 +132,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#19, i_item_id#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -199,6 +199,6 @@ Input [2]: [d_date_sk#15, d_year#51]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#52]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/explain.txt
@@ -93,7 +93,7 @@ Condition : isnotnull(s_store_sk#9)
 
 (10) BroadcastExchange
 Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#3]
@@ -299,7 +299,7 @@ Input [3]: [d_date_sk#8, d_year#48, d_moy#49]
 
 (54) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#50]
 
 Subquery:2 Hosting operator id = 24 Hosting Expression = sr_returned_date_sk#23 IN dynamicpruning#24
 BroadcastExchange (59)
@@ -329,7 +329,7 @@ Input [3]: [d_date_sk#25, d_year#51, d_moy#52]
 
 (59) BroadcastExchange
 Input [1]: [d_date_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#53]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#53]
 
 Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#31 IN dynamicpruning#32
 BroadcastExchange (64)
@@ -359,6 +359,6 @@ Input [2]: [d_date_sk#33, d_year#54]
 
 (64) BroadcastExchange
 Input [1]: [d_date_sk#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#55]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#55]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29/explain.txt
@@ -73,7 +73,7 @@ Condition : ((isnotnull(sr_customer_sk#9) AND isnotnull(sr_item_sk#8)) AND isnot
 
 (7) BroadcastExchange
 Input [5]: [sr_item_sk#8, sr_customer_sk#9, sr_ticket_number#10, sr_return_quantity#11, sr_returned_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[0, int, false], input[2, int, false]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[0, int, false], input[2, int, false]),false,false), [id=#14]
 
 (8) BroadcastHashJoin [codegen id : 8]
 Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
@@ -101,7 +101,7 @@ Condition : (isnotnull(cs_bill_customer_sk#15) AND isnotnull(cs_item_sk#16))
 
 (13) BroadcastExchange
 Input [4]: [cs_bill_customer_sk#15, cs_item_sk#16, cs_quantity#17, cs_sold_date_sk#18]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[1, int, false] as bigint) & 4294967295))),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[1, int, false] as bigint) & 4294967295))),false,false), [id=#20]
 
 (14) BroadcastHashJoin [codegen id : 8]
 Left keys [2]: [sr_customer_sk#9, sr_item_sk#8]
@@ -164,7 +164,7 @@ Condition : isnotnull(s_store_sk#24)
 
 (28) BroadcastExchange
 Input [3]: [s_store_sk#24, s_store_id#25, s_store_name#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#27]
 
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#3]
@@ -191,7 +191,7 @@ Condition : isnotnull(i_item_sk#28)
 
 (34) BroadcastExchange
 Input [3]: [i_item_sk#28, i_item_id#29, i_item_desc#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#31]
 
 (35) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#1]
@@ -254,7 +254,7 @@ Input [3]: [d_date_sk#21, d_year#45, d_moy#46]
 
 (45) BroadcastExchange
 Input [1]: [d_date_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#47]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#47]
 
 Subquery:2 Hosting operator id = 4 Hosting Expression = sr_returned_date_sk#12 IN dynamicpruning#13
 BroadcastExchange (50)
@@ -284,7 +284,7 @@ Input [3]: [d_date_sk#22, d_year#48, d_moy#49]
 
 (50) BroadcastExchange
 Input [1]: [d_date_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#50]
 
 Subquery:3 Hosting operator id = 10 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#19
 BroadcastExchange (55)
@@ -314,6 +314,6 @@ Input [2]: [d_date_sk#23, d_year#51]
 
 (55) BroadcastExchange
 Input [1]: [d_date_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#52]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q3.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q3.sf100/explain.txt
@@ -53,7 +53,7 @@ Input [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manufact_id#8]
 
 (8) BroadcastExchange
 Input [3]: [i_item_sk#5, i_brand_id#6, i_brand#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
@@ -128,6 +128,6 @@ Input [3]: [d_date_sk#10, d_year#11, d_moy#19]
 
 (22) BroadcastExchange
 Input [2]: [d_date_sk#10, d_year#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#20]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q3/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q3/explain.txt
@@ -57,7 +57,7 @@ Condition : isnotnull(ss_item_sk#4)
 
 (8) BroadcastExchange
 Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manufact_id#11]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#8, i_brand_id#9, i_brand#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30.sf100/explain.txt
@@ -90,7 +90,7 @@ Input [2]: [ca_address_sk#15, ca_state#16]
 
 (8) BroadcastExchange
 Input [1]: [ca_address_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [c_current_addr_sk#3]
@@ -103,7 +103,7 @@ Input [15]: [c_customer_sk#1, c_customer_id#2, c_current_addr_sk#3, c_salutation
 
 (11) BroadcastExchange
 Input [13]: [c_customer_sk#1, c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (12) Scan parquet default.web_returns
 Output [4]: [wr_returning_customer_sk#19, wr_returning_addr_sk#20, wr_return_amt#21, wr_returned_date_sk#22]
@@ -295,7 +295,7 @@ Condition : isnotnull((avg(ctr_total_return) * 1.2)#46)
 
 (52) BroadcastExchange
 Input [2]: [(avg(ctr_total_return) * 1.2)#46, ctr_state#34#47]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false,false), [id=#48]
 
 (53) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ctr_state#34]
@@ -340,7 +340,7 @@ Input [2]: [d_date_sk#24, d_year#49]
 
 (60) BroadcastExchange
 Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#50]
 
 Subquery:2 Hosting operator id = 33 Hosting Expression = wr_returned_date_sk#22 IN dynamicpruning#23
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30/explain.txt
@@ -93,7 +93,7 @@ Condition : (isnotnull(ca_address_sk#7) AND isnotnull(ca_state#8))
 
 (10) BroadcastExchange
 Input [2]: [ca_address_sk#7, ca_state#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [wr_returning_addr_sk#2]
@@ -207,7 +207,7 @@ Condition : isnotnull((avg(ctr_total_return) * 1.2)#26)
 
 (33) BroadcastExchange
 Input [2]: [(avg(ctr_total_return) * 1.2)#26, ctr_state#15#27]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false,false), [id=#28]
 
 (34) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ctr_state#15]
@@ -234,7 +234,7 @@ Condition : (isnotnull(c_customer_sk#29) AND isnotnull(c_current_addr_sk#31))
 
 (39) BroadcastExchange
 Input [14]: [c_customer_sk#29, c_customer_id#30, c_current_addr_sk#31, c_salutation#32, c_first_name#33, c_last_name#34, c_preferred_cust_flag#35, c_birth_day#36, c_birth_month#37, c_birth_year#38, c_birth_country#39, c_login#40, c_email_address#41, c_last_review_date#42]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#43]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#43]
 
 (40) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ctr_customer_sk#14]
@@ -265,7 +265,7 @@ Input [2]: [ca_address_sk#44, ca_state#45]
 
 (46) BroadcastExchange
 Input [1]: [ca_address_sk#44]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#46]
 
 (47) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [c_current_addr_sk#31]
@@ -310,7 +310,7 @@ Input [2]: [d_date_sk#6, d_year#47]
 
 (54) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#48]
 
 Subquery:2 Hosting operator id = 17 Hosting Expression = wr_returned_date_sk#4 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31.sf100/explain.txt
@@ -266,7 +266,7 @@ Results [2]: [ca_county#26, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#18)
 
 (34) BroadcastExchange
 Input [2]: [ca_county#26, store_sales#30]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#31]
 
 (35) BroadcastHashJoin [codegen id : 42]
 Left keys [1]: [ca_county#10]
@@ -348,7 +348,7 @@ Results [3]: [ca_county#41, d_year#37, MakeDecimal(sum(UnscaledValue(ss_ext_sale
 
 (52) BroadcastExchange
 Input [3]: [ca_county#41, d_year#37, store_sales#45]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#46]
 
 (53) BroadcastHashJoin [codegen id : 42]
 Left keys [1]: [ca_county#10]
@@ -499,7 +499,7 @@ Results [2]: [ca_county#69, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#62)
 
 (85) BroadcastExchange
 Input [2]: [ca_county#69, web_sales#73]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#74]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#74]
 
 (86) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [ca_county#55]
@@ -581,7 +581,7 @@ Results [2]: [ca_county#83, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#76)
 
 (103) BroadcastExchange
 Input [2]: [ca_county#83, web_sales#87]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#88]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#88]
 
 (104) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [ca_county#55]
@@ -594,7 +594,7 @@ Input [5]: [ca_county#55, web_sales#60, web_sales#73, ca_county#83, web_sales#87
 
 (106) BroadcastExchange
 Input [4]: [ca_county#55, web_sales#60, web_sales#73, web_sales#87]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#89]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#89]
 
 (107) BroadcastHashJoin [codegen id : 42]
 Left keys [1]: [ca_county#41]
@@ -638,7 +638,7 @@ Condition : ((((isnotnull(d_qoy#7) AND isnotnull(d_year#6)) AND (d_qoy#7 = 2)) A
 
 (114) BroadcastExchange
 Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#95]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#95]
 
 Subquery:2 Hosting operator id = 19 Hosting Expression = ss_sold_date_sk#19 IN dynamicpruning#20
 BroadcastExchange (118)
@@ -663,7 +663,7 @@ Condition : ((((isnotnull(d_qoy#23) AND isnotnull(d_year#22)) AND (d_qoy#23 = 3)
 
 (118) BroadcastExchange
 Input [3]: [d_date_sk#21, d_year#22, d_qoy#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#96]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#96]
 
 Subquery:3 Hosting operator id = 37 Hosting Expression = ss_sold_date_sk#34 IN dynamicpruning#35
 BroadcastExchange (122)
@@ -688,7 +688,7 @@ Condition : ((((isnotnull(d_qoy#38) AND isnotnull(d_year#37)) AND (d_qoy#38 = 1)
 
 (122) BroadcastExchange
 Input [3]: [d_date_sk#36, d_year#37, d_qoy#38]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#97]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#97]
 
 Subquery:4 Hosting operator id = 55 Hosting Expression = ws_sold_date_sk#49 IN dynamicpruning#35
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31/explain.txt
@@ -134,7 +134,7 @@ Condition : (isnotnull(ca_address_sk#8) AND isnotnull(ca_county#9))
 
 (10) BroadcastExchange
 Input [2]: [ca_address_sk#8, ca_county#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#10]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_addr_sk#1]
@@ -222,7 +222,7 @@ Results [2]: [ca_county#24, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#17)
 
 (28) BroadcastExchange
 Input [2]: [ca_county#24, store_sales#28]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#29]
 
 (29) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [ca_county#9]
@@ -288,7 +288,7 @@ Results [2]: [ca_county#38, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#31)
 
 (42) BroadcastExchange
 Input [2]: [ca_county#38, store_sales#42]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#43]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#43]
 
 (43) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [ca_county#24]
@@ -358,7 +358,7 @@ Results [2]: [ca_county#51, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#45)
 
 (57) BroadcastExchange
 Input [2]: [ca_county#51, web_sales#56]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#57]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#57]
 
 (58) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [ca_county#9]
@@ -424,7 +424,7 @@ Results [2]: [ca_county#65, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#59)
 
 (71) BroadcastExchange
 Input [2]: [ca_county#65, web_sales#69]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#70]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#70]
 
 (72) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [ca_county#51]
@@ -494,7 +494,7 @@ Results [2]: [ca_county#78, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#72)
 
 (86) BroadcastExchange
 Input [2]: [ca_county#78, web_sales#82]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#83]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#83]
 
 (87) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [ca_county#51]
@@ -538,7 +538,7 @@ Condition : ((((isnotnull(d_qoy#7) AND isnotnull(d_year#6)) AND (d_qoy#7 = 1)) A
 
 (94) BroadcastExchange
 Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#89]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#89]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = ss_sold_date_sk#18 IN dynamicpruning#19
 BroadcastExchange (98)
@@ -563,7 +563,7 @@ Condition : ((((isnotnull(d_qoy#22) AND isnotnull(d_year#21)) AND (d_qoy#22 = 2)
 
 (98) BroadcastExchange
 Input [3]: [d_date_sk#20, d_year#21, d_qoy#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#90]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#90]
 
 Subquery:3 Hosting operator id = 30 Hosting Expression = ss_sold_date_sk#32 IN dynamicpruning#33
 BroadcastExchange (102)
@@ -588,7 +588,7 @@ Condition : ((((isnotnull(d_qoy#36) AND isnotnull(d_year#35)) AND (d_qoy#36 = 3)
 
 (102) BroadcastExchange
 Input [3]: [d_date_sk#34, d_year#35, d_qoy#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#91]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#91]
 
 Subquery:4 Hosting operator id = 45 Hosting Expression = ws_sold_date_sk#46 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/explain.txt
@@ -48,7 +48,7 @@ Input [2]: [i_item_sk#1, i_manufact_id#2]
 
 (5) BroadcastExchange
 Input [1]: [i_item_sk#1]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#3]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#3]
 
 (6) Scan parquet default.catalog_sales
 Output [3]: [cs_item_sk#4, cs_ext_discount_amt#5, cs_sold_date_sk#6]
@@ -110,7 +110,7 @@ Input [3]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#15, cs_item_sk#4]
 
 (18) BroadcastExchange
 Input [2]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#16]
 
 (19) Scan parquet default.catalog_sales
 Output [3]: [cs_item_sk#17, cs_ext_discount_amt#18, cs_sold_date_sk#19]
@@ -182,7 +182,7 @@ Input [2]: [d_date_sk#8, d_date#22]
 
 (32) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#23]
 
 Subquery:2 Hosting operator id = 19 Hosting Expression = cs_sold_date_sk#19 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32/explain.txt
@@ -63,7 +63,7 @@ Input [2]: [i_item_sk#5, i_manufact_id#6]
 
 (8) BroadcastExchange
 Input [1]: [i_item_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_item_sk#1]
@@ -125,7 +125,7 @@ Condition : isnotnull((1.3 * avg(cs_ext_discount_amt))#18)
 
 (21) BroadcastExchange
 Input [2]: [(1.3 * avg(cs_ext_discount_amt))#18, cs_item_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false,false), [id=#19]
 
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_sk#5]
@@ -182,7 +182,7 @@ Input [2]: [d_date_sk#20, d_date#22]
 
 (32) BroadcastExchange
 Input [1]: [d_date_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#23]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = cs_sold_date_sk#10 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33.sf100/explain.txt
@@ -125,7 +125,7 @@ Input [2]: [i_category#9, i_manufact_id#10]
 
 (14) BroadcastExchange
 Input [1]: [i_manufact_id#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#11]
 
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_manufact_id#8]
@@ -134,7 +134,7 @@ Join condition: None
 
 (16) BroadcastExchange
 Input [2]: [i_item_sk#7, i_manufact_id#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (17) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -165,7 +165,7 @@ Input [2]: [ca_address_sk#13, ca_gmt_offset#14]
 
 (23) BroadcastExchange
 Input [1]: [ca_address_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
@@ -386,7 +386,7 @@ Input [3]: [d_date_sk#6, d_year#54, d_moy#55]
 
 (68) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#56]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = cs_sold_date_sk#24 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33/explain.txt
@@ -111,7 +111,7 @@ Input [2]: [ca_address_sk#7, ca_gmt_offset#8]
 
 (11) BroadcastExchange
 Input [1]: [ca_address_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
@@ -156,7 +156,7 @@ Input [2]: [i_category#12, i_manufact_id#13]
 
 (21) BroadcastExchange
 Input [1]: [i_manufact_id#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#14]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_manufact_id#11]
@@ -165,7 +165,7 @@ Join condition: None
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#10, i_manufact_id#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -386,7 +386,7 @@ Input [3]: [d_date_sk#6, d_year#54, d_moy#55]
 
 (68) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#56]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = cs_sold_date_sk#24 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35.sf100/explain.txt
@@ -319,7 +319,7 @@ Input [3]: [d_date_sk#10, d_year#81, d_qoy#82]
 
 (58) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#83]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#83]
 
 Subquery:2 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#13 IN dynamicpruning#9
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35/explain.txt
@@ -81,7 +81,7 @@ Input [3]: [ss_customer_sk#6, ss_sold_date_sk#7, d_date_sk#9]
 
 (9) BroadcastExchange
 Input [1]: [ss_customer_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#10]
 
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
@@ -112,7 +112,7 @@ Input [3]: [ws_bill_customer_sk#11, ws_sold_date_sk#12, d_date_sk#13]
 
 (16) BroadcastExchange
 Input [1]: [ws_bill_customer_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#14]
 
 (17) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
@@ -143,7 +143,7 @@ Input [3]: [cs_ship_customer_sk#15, cs_sold_date_sk#16, d_date_sk#17]
 
 (23) BroadcastExchange
 Input [1]: [cs_ship_customer_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#18]
 
 (24) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
@@ -174,7 +174,7 @@ Condition : isnotnull(ca_address_sk#19)
 
 (30) BroadcastExchange
 Input [2]: [ca_address_sk#19, ca_state#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (31) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#5]
@@ -201,7 +201,7 @@ Condition : isnotnull(cd_demo_sk#22)
 
 (36) BroadcastExchange
 Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#28]
 
 (37) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#4]
@@ -264,7 +264,7 @@ Input [3]: [d_date_sk#9, d_year#78, d_qoy#79]
 
 (47) BroadcastExchange
 Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#80]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#80]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = ws_sold_date_sk#12 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/explain.txt
@@ -76,7 +76,7 @@ Input [2]: [s_store_sk#8, s_state#9]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
@@ -103,7 +103,7 @@ Condition : isnotnull(i_item_sk#11)
 
 (17) BroadcastExchange
 Input [3]: [i_item_sk#11, i_class#12, i_category#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
@@ -186,6 +186,6 @@ Input [2]: [d_date_sk#7, d_year#32]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#33]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36/explain.txt
@@ -72,7 +72,7 @@ Condition : isnotnull(i_item_sk#8)
 
 (10) BroadcastExchange
 Input [3]: [i_item_sk#8, i_class#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
@@ -103,7 +103,7 @@ Input [2]: [s_store_sk#12, s_state#13]
 
 (17) BroadcastExchange
 Input [1]: [s_store_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
@@ -186,6 +186,6 @@ Input [2]: [d_date_sk#7, d_year#32]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#33]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
@@ -49,7 +49,7 @@ Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, i_manufa
 
 (5) BroadcastExchange
 Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#6]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#6]
 
 (6) Scan parquet default.inventory
 Output [3]: [inv_item_sk#7, inv_quantity_on_hand#8, inv_date_sk#9]
@@ -186,6 +186,6 @@ Input [2]: [d_date_sk#11, d_date#17]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37/explain.txt
@@ -65,7 +65,7 @@ Input [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
 
 (9) BroadcastExchange
 Input [2]: [inv_item_sk#6, inv_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_item_sk#1]
@@ -90,7 +90,7 @@ Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date
 
 (15) BroadcastExchange
 Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) Scan parquet default.catalog_sales
 Output [2]: [cs_item_sk#13, cs_sold_date_sk#14]
@@ -171,6 +171,6 @@ Input [2]: [d_date_sk#11, d_date#16]
 
 (30) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/explain.txt
@@ -416,7 +416,7 @@ Input [3]: [d_date_sk#4, d_date#5, d_month_seq#41]
 
 (72) BroadcastExchange
 Input [2]: [d_date_sk#4, d_date#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#42]
 
 Subquery:2 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#3
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38/explain.txt
@@ -94,7 +94,7 @@ Condition : isnotnull(c_customer_sk#6)
 
 (10) BroadcastExchange
 Input [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_customer_sk#1]
@@ -182,7 +182,7 @@ Results [3]: [c_last_name#17, c_first_name#16, d_date#14]
 
 (28) BroadcastExchange
 Input [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 1970-01-01), isnull(input[2, date, true])),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 1970-01-01), isnull(input[2, date, true])),false,true), [id=#19]
 
 (29) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
@@ -262,7 +262,7 @@ Results [3]: [c_last_name#26, c_first_name#25, d_date#23]
 
 (44) BroadcastExchange
 Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 1970-01-01), isnull(input[2, date, true])),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 1970-01-01), isnull(input[2, date, true])),false,true), [id=#28]
 
 (45) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
@@ -331,7 +331,7 @@ Input [3]: [d_date_sk#4, d_date#5, d_month_seq#34]
 
 (55) BroadcastExchange
 Input [2]: [d_date_sk#4, d_date#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#35]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = cs_sold_date_sk#12 IN dynamicpruning#3
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39a.sf100/explain.txt
@@ -91,7 +91,7 @@ Condition : isnotnull(i_item_sk#8)
 
 (10) BroadcastExchange
 Input [1]: [i_item_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
@@ -118,7 +118,7 @@ Condition : isnotnull(w_warehouse_sk#10)
 
 (16) BroadcastExchange
 Input [2]: [w_warehouse_sk#10, w_warehouse_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
@@ -291,7 +291,7 @@ Input [3]: [d_date_sk#6, d_year#55, d_moy#7]
 
 (52) BroadcastExchange
 Input [2]: [d_date_sk#6, d_moy#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#56]
 
 Subquery:2 Hosting operator id = 26 Hosting Expression = inv_date_sk#33 IN dynamicpruning#34
 BroadcastExchange (57)
@@ -321,6 +321,6 @@ Input [3]: [d_date_sk#35, d_year#57, d_moy#36]
 
 (57) BroadcastExchange
 Input [2]: [d_date_sk#35, d_moy#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#58]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#58]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39a/explain.txt
@@ -76,7 +76,7 @@ Condition : isnotnull(i_item_sk#6)
 
 (7) BroadcastExchange
 Input [1]: [i_item_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
@@ -103,7 +103,7 @@ Condition : isnotnull(w_warehouse_sk#8)
 
 (13) BroadcastExchange
 Input [2]: [w_warehouse_sk#8, w_warehouse_name#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#10]
 
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
@@ -231,7 +231,7 @@ Input [5]: [w_warehouse_sk#35, i_item_sk#34, d_moy#38, stdev#26, mean#27]
 
 (41) BroadcastExchange
 Input [5]: [w_warehouse_sk#35, i_item_sk#34, d_moy#38, mean#50, cov#51]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false,false), [id=#52]
 
 (42) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [i_item_sk#6, w_warehouse_sk#8]
@@ -276,7 +276,7 @@ Input [3]: [d_date_sk#11, d_year#54, d_moy#12]
 
 (49) BroadcastExchange
 Input [2]: [d_date_sk#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#55]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#55]
 
 Subquery:2 Hosting operator id = 24 Hosting Expression = inv_date_sk#32 IN dynamicpruning#33
 BroadcastExchange (54)
@@ -306,6 +306,6 @@ Input [3]: [d_date_sk#37, d_year#56, d_moy#38]
 
 (54) BroadcastExchange
 Input [2]: [d_date_sk#37, d_moy#38]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#57]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#57]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39b.sf100/explain.txt
@@ -91,7 +91,7 @@ Condition : isnotnull(i_item_sk#8)
 
 (10) BroadcastExchange
 Input [1]: [i_item_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
@@ -118,7 +118,7 @@ Condition : isnotnull(w_warehouse_sk#10)
 
 (16) BroadcastExchange
 Input [2]: [w_warehouse_sk#10, w_warehouse_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
@@ -291,7 +291,7 @@ Input [3]: [d_date_sk#6, d_year#55, d_moy#7]
 
 (52) BroadcastExchange
 Input [2]: [d_date_sk#6, d_moy#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#56]
 
 Subquery:2 Hosting operator id = 26 Hosting Expression = inv_date_sk#33 IN dynamicpruning#34
 BroadcastExchange (57)
@@ -321,6 +321,6 @@ Input [3]: [d_date_sk#35, d_year#57, d_moy#36]
 
 (57) BroadcastExchange
 Input [2]: [d_date_sk#35, d_moy#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#58]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#58]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39b/explain.txt
@@ -76,7 +76,7 @@ Condition : isnotnull(i_item_sk#6)
 
 (7) BroadcastExchange
 Input [1]: [i_item_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
@@ -103,7 +103,7 @@ Condition : isnotnull(w_warehouse_sk#8)
 
 (13) BroadcastExchange
 Input [2]: [w_warehouse_sk#8, w_warehouse_name#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#10]
 
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
@@ -231,7 +231,7 @@ Input [5]: [w_warehouse_sk#35, i_item_sk#34, d_moy#38, stdev#26, mean#27]
 
 (41) BroadcastExchange
 Input [5]: [w_warehouse_sk#35, i_item_sk#34, d_moy#38, mean#50, cov#51]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false,false), [id=#52]
 
 (42) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [i_item_sk#6, w_warehouse_sk#8]
@@ -276,7 +276,7 @@ Input [3]: [d_date_sk#11, d_year#54, d_moy#12]
 
 (49) BroadcastExchange
 Input [2]: [d_date_sk#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#55]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#55]
 
 Subquery:2 Hosting operator id = 24 Hosting Expression = inv_date_sk#32 IN dynamicpruning#33
 BroadcastExchange (54)
@@ -306,6 +306,6 @@ Input [3]: [d_date_sk#37, d_year#56, d_moy#38]
 
 (54) BroadcastExchange
 Input [2]: [d_date_sk#37, d_moy#38]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#57]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#57]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4.sf100/explain.txt
@@ -678,7 +678,7 @@ Condition : ((isnotnull(d_year#9) AND (d_year#9 = 2001)) AND isnotnull(d_date_sk
 
 (122) BroadcastExchange
 Input [2]: [d_date_sk#8, d_year#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#163]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#163]
 
 Subquery:2 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#34 IN dynamicpruning#35
 BroadcastExchange (126)
@@ -703,7 +703,7 @@ Condition : ((isnotnull(d_year#37) AND (d_year#37 = 2002)) AND isnotnull(d_date_
 
 (126) BroadcastExchange
 Input [2]: [d_date_sk#36, d_year#37]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#164]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#164]
 
 Subquery:3 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#66 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4/explain.txt
@@ -140,7 +140,7 @@ Condition : isnotnull(ss_customer_sk#9)
 
 (7) BroadcastExchange
 Input [6]: [ss_customer_sk#9, ss_ext_discount_amt#10, ss_ext_sales_price#11, ss_ext_wholesale_cost#12, ss_ext_list_price#13, ss_sold_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#16]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [c_customer_sk#1]
@@ -216,7 +216,7 @@ Condition : isnotnull(ss_customer_sk#35)
 
 (23) BroadcastExchange
 Input [6]: [ss_customer_sk#35, ss_ext_discount_amt#36, ss_ext_sales_price#37, ss_ext_wholesale_cost#38, ss_ext_list_price#39, ss_sold_date_sk#40]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#42]
 
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#27]
@@ -259,7 +259,7 @@ Results [8]: [c_customer_id#28 AS customer_id#50, c_first_name#29 AS customer_fi
 
 (32) BroadcastExchange
 Input [8]: [customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56, year_total#57]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#58]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#58]
 
 (33) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [customer_id#25]
@@ -297,7 +297,7 @@ Condition : isnotnull(cs_bill_customer_sk#67)
 
 (40) BroadcastExchange
 Input [6]: [cs_bill_customer_sk#67, cs_ext_discount_amt#68, cs_ext_sales_price#69, cs_ext_wholesale_cost#70, cs_ext_list_price#71, cs_sold_date_sk#72]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#73]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#73]
 
 (41) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#59]
@@ -344,7 +344,7 @@ Condition : (isnotnull(year_total#83) AND (year_total#83 > 0.000000))
 
 (50) BroadcastExchange
 Input [2]: [customer_id#82, year_total#83]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#84]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#84]
 
 (51) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [customer_id#25]
@@ -386,7 +386,7 @@ Condition : isnotnull(cs_bill_customer_sk#93)
 
 (59) BroadcastExchange
 Input [6]: [cs_bill_customer_sk#93, cs_ext_discount_amt#94, cs_ext_sales_price#95, cs_ext_wholesale_cost#96, cs_ext_list_price#97, cs_sold_date_sk#98]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#99]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#99]
 
 (60) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#85]
@@ -429,7 +429,7 @@ Results [2]: [c_customer_id#86 AS customer_id#107, sum(CheckOverflow((promote_pr
 
 (68) BroadcastExchange
 Input [2]: [customer_id#107, year_total#108]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#109]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#109]
 
 (69) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [customer_id#25]
@@ -471,7 +471,7 @@ Condition : isnotnull(ws_bill_customer_sk#118)
 
 (77) BroadcastExchange
 Input [6]: [ws_bill_customer_sk#118, ws_ext_discount_amt#119, ws_ext_sales_price#120, ws_ext_wholesale_cost#121, ws_ext_list_price#122, ws_sold_date_sk#123]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#124]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#124]
 
 (78) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [c_customer_sk#110]
@@ -518,7 +518,7 @@ Condition : (isnotnull(year_total#134) AND (year_total#134 > 0.000000))
 
 (87) BroadcastExchange
 Input [2]: [customer_id#133, year_total#134]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#135]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#135]
 
 (88) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [customer_id#25]
@@ -560,7 +560,7 @@ Condition : isnotnull(ws_bill_customer_sk#144)
 
 (96) BroadcastExchange
 Input [6]: [ws_bill_customer_sk#144, ws_ext_discount_amt#145, ws_ext_sales_price#146, ws_ext_wholesale_cost#147, ws_ext_list_price#148, ws_sold_date_sk#149]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#150]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#150]
 
 (97) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [c_customer_sk#136]
@@ -603,7 +603,7 @@ Results [2]: [c_customer_id#137 AS customer_id#158, sum(CheckOverflow((promote_p
 
 (105) BroadcastExchange
 Input [2]: [customer_id#158, year_total#159]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#160]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#160]
 
 (106) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [customer_id#25]
@@ -643,7 +643,7 @@ Condition : ((isnotnull(d_year#18) AND (d_year#18 = 2001)) AND isnotnull(d_date_
 
 (112) BroadcastExchange
 Input [2]: [d_date_sk#17, d_year#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#161]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#161]
 
 Subquery:2 Hosting operator id = 20 Hosting Expression = ss_sold_date_sk#40 IN dynamicpruning#41
 BroadcastExchange (116)
@@ -668,7 +668,7 @@ Condition : ((isnotnull(d_year#44) AND (d_year#44 = 2002)) AND isnotnull(d_date_
 
 (116) BroadcastExchange
 Input [2]: [d_date_sk#43, d_year#44]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#162]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#162]
 
 Subquery:3 Hosting operator id = 37 Hosting Expression = cs_sold_date_sk#72 IN dynamicpruning#15
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
@@ -112,7 +112,7 @@ Input [3]: [i_item_sk#13, i_item_id#14, i_current_price#15]
 
 (18) BroadcastExchange
 Input [2]: [i_item_sk#13, i_item_id#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#16]
 
 (19) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#2]
@@ -151,7 +151,7 @@ Condition : isnotnull(w_warehouse_sk#19)
 
 (27) BroadcastExchange
 Input [2]: [w_warehouse_sk#19, w_state#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (28) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_warehouse_sk#1]
@@ -209,6 +209,6 @@ Condition : (((isnotnull(d_date#18) AND (d_date#18 >= 2000-02-10)) AND (d_date#1
 
 (37) BroadcastExchange
 Input [2]: [d_date_sk#17, d_date#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#35]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40/explain.txt
@@ -108,7 +108,7 @@ Condition : isnotnull(w_warehouse_sk#13)
 
 (17) BroadcastExchange
 Input [2]: [w_warehouse_sk#13, w_state#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (18) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_warehouse_sk#1]
@@ -139,7 +139,7 @@ Input [3]: [i_item_sk#16, i_item_id#17, i_current_price#18]
 
 (24) BroadcastExchange
 Input [2]: [i_item_sk#16, i_item_id#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#19]
 
 (25) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#2]
@@ -209,6 +209,6 @@ Condition : (((isnotnull(d_date#21) AND (d_date#21 >= 2000-02-10)) AND (d_date#2
 
 (37) BroadcastExchange
 Input [2]: [d_date_sk#20, d_date#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#35]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41.sf100/explain.txt
@@ -85,7 +85,7 @@ Input [2]: [item_cnt#13, i_manufact#5]
 
 (14) BroadcastExchange
 Input [1]: [i_manufact#5]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#14]
 
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_manufact#2]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41/explain.txt
@@ -85,7 +85,7 @@ Input [2]: [item_cnt#13, i_manufact#5]
 
 (14) BroadcastExchange
 Input [1]: [i_manufact#5]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#14]
 
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_manufact#2]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42.sf100/explain.txt
@@ -53,7 +53,7 @@ Input [4]: [i_item_sk#5, i_category_id#6, i_category#7, i_manager_id#8]
 
 (8) BroadcastExchange
 Input [3]: [i_item_sk#5, i_category_id#6, i_category#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
@@ -128,6 +128,6 @@ Input [3]: [d_date_sk#10, d_year#11, d_moy#17]
 
 (22) BroadcastExchange
 Input [2]: [d_date_sk#10, d_year#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42/explain.txt
@@ -57,7 +57,7 @@ Condition : isnotnull(ss_item_sk#4)
 
 (8) BroadcastExchange
 Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#8, i_category_id#9, i_category#10, i_manager_id#11]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#8, i_category_id#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q43.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q43.sf100/explain.txt
@@ -42,7 +42,7 @@ Input [3]: [d_date_sk#1, d_year#2, d_day_name#3]
 
 (5) BroadcastExchange
 Input [2]: [d_date_sk#1, d_day_name#3]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#4]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#4]
 
 (6) Scan parquet default.store_sales
 Output [3]: [ss_store_sk#5, ss_sales_price#6, ss_sold_date_sk#7]
@@ -88,7 +88,7 @@ Input [4]: [s_store_sk#9, s_store_id#10, s_store_name#11, s_gmt_offset#12]
 
 (15) BroadcastExchange
 Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q43/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q43/explain.txt
@@ -57,7 +57,7 @@ Condition : isnotnull(ss_store_sk#4)
 
 (8) BroadcastExchange
 Input [3]: [ss_store_sk#4, ss_sales_price#5, ss_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
@@ -88,7 +88,7 @@ Input [4]: [s_store_sk#8, s_store_id#9, s_store_name#10, s_gmt_offset#11]
 
 (15) BroadcastExchange
 Input [3]: [s_store_sk#8, s_store_id#9, s_store_name#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [3]: [item_sk#17, rank_col#18, rnk#19]
 
 (19) BroadcastExchange
 Input [2]: [item_sk#17, rnk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false,false), [id=#20]
 
 (20) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [rnk#16]
@@ -140,7 +140,7 @@ Condition : isnotnull(i_item_sk#21)
 
 (25) BroadcastExchange
 Input [2]: [i_item_sk#21, i_product_name#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [item_sk#11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/explain.txt
@@ -145,7 +145,7 @@ Condition : isnotnull(i_item_sk#20)
 
 (26) BroadcastExchange
 Input [2]: [i_item_sk#20, i_product_name#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#22]
 
 (27) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [item_sk#11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45.sf100/explain.txt
@@ -86,7 +86,7 @@ Condition : isnotnull(i_item_sk#8)
 
 (10) BroadcastExchange
 Input [2]: [i_item_sk#8, i_item_id#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#10]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#2]
@@ -195,7 +195,7 @@ Input [2]: [i_item_sk#20, i_item_id#21]
 
 (35) BroadcastExchange
 Input [1]: [i_item_id#21]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,true), [id=#22]
 
 (36) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [i_item_id#9]
@@ -262,6 +262,6 @@ Input [3]: [d_date_sk#7, d_year#28, d_qoy#29]
 
 (47) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#30]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45/explain.txt
@@ -68,7 +68,7 @@ Condition : (isnotnull(c_customer_sk#7) AND isnotnull(c_current_addr_sk#8))
 
 (7) BroadcastExchange
 Input [2]: [c_customer_sk#7, c_current_addr_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (8) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_bill_customer_sk#3]
@@ -95,7 +95,7 @@ Condition : isnotnull(ca_address_sk#10)
 
 (13) BroadcastExchange
 Input [3]: [ca_address_sk#10, ca_city#11, ca_zip#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#13]
 
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_current_addr_sk#8]
@@ -134,7 +134,7 @@ Condition : isnotnull(i_item_sk#15)
 
 (22) BroadcastExchange
 Input [2]: [i_item_sk#15, i_item_id#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#17]
 
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#2]
@@ -165,7 +165,7 @@ Input [2]: [i_item_sk#18, i_item_id#19]
 
 (29) BroadcastExchange
 Input [1]: [i_item_id#19]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,true), [id=#20]
 
 (30) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_id#16]
@@ -232,6 +232,6 @@ Input [3]: [d_date_sk#14, d_year#26, d_qoy#27]
 
 (41) BroadcastExchange
 Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#28]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/explain.txt
@@ -156,7 +156,7 @@ Input [2]: [s_store_sk#20, s_city#21]
 
 (25) BroadcastExchange
 Input [1]: [s_store_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#13]
@@ -187,7 +187,7 @@ Input [3]: [hd_demo_sk#23, hd_dep_count#24, hd_vehicle_count#25]
 
 (32) BroadcastExchange
 Input [1]: [hd_demo_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 (33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_hdemo_sk#11]
@@ -287,6 +287,6 @@ Input [3]: [d_date_sk#19, d_year#40, d_dow#41]
 
 (52) BroadcastExchange
 Input [1]: [d_date_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#42]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46/explain.txt
@@ -87,7 +87,7 @@ Input [2]: [s_store_sk#11, s_city#12]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#4]
@@ -118,7 +118,7 @@ Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -145,7 +145,7 @@ Condition : (isnotnull(ca_address_sk#18) AND isnotnull(ca_city#19))
 
 (24) BroadcastExchange
 Input [2]: [ca_address_sk#18, ca_city#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#20]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#3]
@@ -190,7 +190,7 @@ Condition : (isnotnull(c_customer_sk#31) AND isnotnull(c_current_addr_sk#32))
 
 (33) BroadcastExchange
 Input [4]: [c_customer_sk#31, c_current_addr_sk#32, c_first_name#33, c_last_name#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#35]
 
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#1]
@@ -247,6 +247,6 @@ Input [3]: [d_date_sk#10, d_year#38, d_dow#39]
 
 (44) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#40]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/explain.txt
@@ -96,7 +96,7 @@ Condition : ((isnotnull(s_store_sk#9) AND isnotnull(s_store_name#10)) AND isnotn
 
 (10) BroadcastExchange
 Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
@@ -304,6 +304,6 @@ Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR (
 
 (56) BroadcastExchange
 Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#51]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47/explain.txt
@@ -77,7 +77,7 @@ Condition : (isnotnull(ss_item_sk#4) AND isnotnull(ss_store_sk#5))
 
 (7) BroadcastExchange
 Input [4]: [ss_item_sk#4, ss_store_sk#5, ss_sales_price#6, ss_sold_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -116,7 +116,7 @@ Condition : ((isnotnull(s_store_sk#13) AND isnotnull(s_store_name#14)) AND isnot
 
 (16) BroadcastExchange
 Input [3]: [s_store_sk#13, s_store_name#14, s_company_name#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#16]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#5]
@@ -201,7 +201,7 @@ Input [8]: [i_category#26, i_brand#27, s_store_name#28, s_company_name#29, d_yea
 
 (35) BroadcastExchange
 Input [6]: [i_category#26, i_brand#27, s_store_name#28, s_company_name#29, sum_sales#36, rn#35]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], input[3, string, true], (input[5, int, false] + 1)),false), [id=#37]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], input[3, string, true], (input[5, int, false] + 1)),false,false), [id=#37]
 
 (36) BroadcastHashJoin [codegen id : 22]
 Left keys [5]: [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, rn#24]
@@ -229,7 +229,7 @@ Input [8]: [i_category#38, i_brand#39, s_store_name#40, s_company_name#41, d_yea
 
 (42) BroadcastExchange
 Input [6]: [i_category#38, i_brand#39, s_store_name#40, s_company_name#41, sum_sales#45, rn#44]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], input[3, string, true], (input[5, int, false] - 1)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], input[3, string, true], (input[5, int, false] - 1)),false,false), [id=#46]
 
 (43) BroadcastHashJoin [codegen id : 22]
 Left keys [5]: [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, rn#24]
@@ -269,6 +269,6 @@ Condition : ((((d_year#11 = 1999) OR ((d_year#11 = 1998) AND (d_moy#12 = 12))) O
 
 (49) BroadcastExchange
 Input [3]: [d_date_sk#10, d_year#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q48.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q48.sf100/explain.txt
@@ -60,7 +60,7 @@ Condition : isnotnull(s_store_sk#9)
 
 (7) BroadcastExchange
 Input [1]: [s_store_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#10]
 
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
@@ -87,7 +87,7 @@ Condition : (isnotnull(cd_demo_sk#11) AND ((((cd_marital_status#12 = M) AND (cd_
 
 (13) BroadcastExchange
 Input [3]: [cd_demo_sk#11, cd_marital_status#12, cd_education_status#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#1]
@@ -118,7 +118,7 @@ Input [3]: [ca_address_sk#15, ca_state#16, ca_country#17]
 
 (20) BroadcastExchange
 Input [2]: [ca_address_sk#15, ca_state#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
@@ -189,6 +189,6 @@ Input [2]: [d_date_sk#19, d_year#25]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q48/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q48/explain.txt
@@ -60,7 +60,7 @@ Condition : isnotnull(s_store_sk#9)
 
 (7) BroadcastExchange
 Input [1]: [s_store_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#10]
 
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
@@ -87,7 +87,7 @@ Condition : (isnotnull(cd_demo_sk#11) AND ((((cd_marital_status#12 = M) AND (cd_
 
 (13) BroadcastExchange
 Input [3]: [cd_demo_sk#11, cd_marital_status#12, cd_education_status#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#1]
@@ -118,7 +118,7 @@ Input [3]: [ca_address_sk#15, ca_state#16, ca_country#17]
 
 (20) BroadcastExchange
 Input [2]: [ca_address_sk#15, ca_state#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
@@ -189,6 +189,6 @@ Input [2]: [d_date_sk#19, d_year#25]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49.sf100/explain.txt
@@ -501,7 +501,7 @@ Input [3]: [d_date_sk#8, d_year#117, d_moy#118]
 
 (91) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#119]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#119]
 
 Subquery:2 Hosting operator id = 28 Hosting Expression = cs_sold_date_sk#45 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49/explain.txt
@@ -99,7 +99,7 @@ Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_ne
 
 (5) BroadcastExchange
 Input [5]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false,false), [id=#8]
 
 (6) Scan parquet default.web_returns
 Output [5]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12, wr_returned_date_sk#13]
@@ -207,7 +207,7 @@ Input [6]: [cs_item_sk#39, cs_order_number#40, cs_quantity#41, cs_net_paid#42, c
 
 (29) BroadcastExchange
 Input [5]: [cs_item_sk#39, cs_order_number#40, cs_quantity#41, cs_net_paid#42, cs_sold_date_sk#44]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false), [id=#45]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false,false), [id=#45]
 
 (30) Scan parquet default.catalog_returns
 Output [5]: [cr_item_sk#46, cr_order_number#47, cr_return_quantity#48, cr_return_amount#49, cr_returned_date_sk#50]
@@ -315,7 +315,7 @@ Input [6]: [ss_item_sk#76, ss_ticket_number#77, ss_quantity#78, ss_net_paid#79, 
 
 (53) BroadcastExchange
 Input [5]: [ss_item_sk#76, ss_ticket_number#77, ss_quantity#78, ss_net_paid#79, ss_sold_date_sk#81]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false), [id=#82]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false,false), [id=#82]
 
 (54) Scan parquet default.store_returns
 Output [5]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86, sr_returned_date_sk#87]
@@ -456,7 +456,7 @@ Input [3]: [d_date_sk#14, d_year#114, d_moy#115]
 
 (82) BroadcastExchange
 Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#116]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#116]
 
 Subquery:2 Hosting operator id = 25 Hosting Expression = cs_sold_date_sk#44 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/explain.txt
@@ -134,7 +134,7 @@ Condition : isnotnull(s_store_sk#22)
 
 (13) BroadcastExchange
 Input [2]: [s_store_sk#22, s_store_id#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#24]
 
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [store_sk#6]
@@ -231,7 +231,7 @@ Condition : isnotnull(cp_catalog_page_sk#64)
 
 (34) BroadcastExchange
 Input [2]: [cp_catalog_page_sk#64, cp_catalog_page_id#65]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#66]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#66]
 
 (35) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [page_sk#48]
@@ -362,7 +362,7 @@ Condition : isnotnull(web_site_sk#113)
 
 (63) BroadcastExchange
 Input [2]: [web_site_sk#113, web_site_id#114]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#115]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#115]
 
 (64) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [wsr_web_site_sk#90]
@@ -461,7 +461,7 @@ Input [2]: [d_date_sk#25, d_date#157]
 
 (82) BroadcastExchange
 Input [1]: [d_date_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#158]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#158]
 
 Subquery:2 Hosting operator id = 5 Hosting Expression = sr_returned_date_sk#15 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5/explain.txt
@@ -143,7 +143,7 @@ Condition : isnotnull(s_store_sk#23)
 
 (16) BroadcastExchange
 Input [2]: [s_store_sk#23, s_store_id#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (17) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [store_sk#6]
@@ -240,7 +240,7 @@ Condition : isnotnull(cp_catalog_page_sk#65)
 
 (37) BroadcastExchange
 Input [2]: [cp_catalog_page_sk#65, cp_catalog_page_id#66]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#67]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#67]
 
 (38) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [page_sk#48]
@@ -300,7 +300,7 @@ Input [5]: [wr_item_sk#96, wr_order_number#97, wr_return_amt#98, wr_net_loss#99,
 
 (49) BroadcastExchange
 Input [5]: [wr_item_sk#96, wr_order_number#97, wr_return_amt#98, wr_net_loss#99, wr_returned_date_sk#100]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, true] as bigint), 32) | (cast(input[1, int, true] as bigint) & 4294967295))),false), [id=#101]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, true] as bigint), 32) | (cast(input[1, int, true] as bigint) & 4294967295))),false,false), [id=#101]
 
 (50) Scan parquet default.web_sales
 Output [4]: [ws_item_sk#102, ws_web_site_sk#103, ws_order_number#104, ws_sold_date_sk#105]
@@ -359,7 +359,7 @@ Condition : isnotnull(web_site_sk#113)
 
 (63) BroadcastExchange
 Input [2]: [web_site_sk#113, web_site_id#114]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#115]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#115]
 
 (64) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [wsr_web_site_sk#90]
@@ -446,7 +446,7 @@ Input [2]: [d_date_sk#22, d_date#156]
 
 (79) BroadcastExchange
 Input [1]: [d_date_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#157]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#157]
 
 Subquery:2 Hosting operator id = 5 Hosting Expression = sr_returned_date_sk#15 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/explain.txt
@@ -115,7 +115,7 @@ Condition : isnotnull(d_date_sk#14)
 
 (19) BroadcastExchange
 Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (20) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#12]
@@ -142,7 +142,7 @@ Condition : isnotnull(s_store_sk#16)
 
 (25) BroadcastExchange
 Input [11]: [s_store_sk#16, s_store_name#17, s_company_id#18, s_street_number#19, s_street_name#20, s_street_type#21, s_suite_number#22, s_city#23, s_county#24, s_state#25, s_zip#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#27]
 
 (26) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#10]
@@ -205,6 +205,6 @@ Input [3]: [d_date_sk#6, d_year#49, d_moy#50]
 
 (36) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#51]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50/explain.txt
@@ -61,7 +61,7 @@ Condition : ((isnotnull(sr_ticket_number#8) AND isnotnull(sr_item_sk#6)) AND isn
 
 (7) BroadcastExchange
 Input [4]: [sr_item_sk#6, sr_customer_sk#7, sr_ticket_number#8, sr_returned_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(input[2, int, false], input[0, int, false], input[1, int, false]),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(input[2, int, false], input[0, int, false], input[1, int, false]),false,false), [id=#11]
 
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [3]: [ss_ticket_number#4, ss_item_sk#1, ss_customer_sk#2]
@@ -88,7 +88,7 @@ Condition : isnotnull(s_store_sk#12)
 
 (13) BroadcastExchange
 Input [11]: [s_store_sk#12, s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
@@ -115,7 +115,7 @@ Condition : isnotnull(d_date_sk#24)
 
 (19) BroadcastExchange
 Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (20) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#5]
@@ -190,6 +190,6 @@ Input [3]: [d_date_sk#26, d_year#48, d_moy#49]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#50]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q51.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q51.sf100/explain.txt
@@ -235,7 +235,7 @@ Input [3]: [d_date_sk#5, d_date#6, d_month_seq#37]
 
 (42) BroadcastExchange
 Input [2]: [d_date_sk#5, d_date#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#38]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#38]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = ss_sold_date_sk#18 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q51/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q51/explain.txt
@@ -235,7 +235,7 @@ Input [3]: [d_date_sk#5, d_date#6, d_month_seq#37]
 
 (42) BroadcastExchange
 Input [2]: [d_date_sk#5, d_date#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#38]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#38]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = ss_sold_date_sk#18 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52.sf100/explain.txt
@@ -53,7 +53,7 @@ Input [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manager_id#8]
 
 (8) BroadcastExchange
 Input [3]: [i_item_sk#5, i_brand_id#6, i_brand#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
@@ -128,6 +128,6 @@ Input [3]: [d_date_sk#10, d_year#11, d_moy#19]
 
 (22) BroadcastExchange
 Input [2]: [d_date_sk#10, d_year#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#20]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52/explain.txt
@@ -57,7 +57,7 @@ Condition : isnotnull(ss_item_sk#4)
 
 (8) BroadcastExchange
 Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#8, i_brand_id#9, i_brand#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53.sf100/explain.txt
@@ -49,7 +49,7 @@ Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manufact_id#5]
 
 (5) BroadcastExchange
 Input [2]: [i_item_sk#1, i_manufact_id#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (6) Scan parquet default.store_sales
 Output [4]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13, ss_sold_date_sk#14]
@@ -91,7 +91,7 @@ Condition : isnotnull(s_store_sk#16)
 
 (14) BroadcastExchange
 Input [1]: [s_store_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#17]
 
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#12]
@@ -186,6 +186,6 @@ Input [3]: [d_date_sk#18, d_month_seq#28, d_qoy#19]
 
 (33) BroadcastExchange
 Input [2]: [d_date_sk#18, d_qoy#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53/explain.txt
@@ -64,7 +64,7 @@ Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
 
 (8) BroadcastExchange
 Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -103,7 +103,7 @@ Condition : isnotnull(s_store_sk#18)
 
 (17) BroadcastExchange
 Input [1]: [s_store_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
@@ -186,6 +186,6 @@ Input [3]: [d_date_sk#16, d_month_seq#28, d_qoy#17]
 
 (33) BroadcastExchange
 Input [2]: [d_date_sk#16, d_qoy#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
@@ -90,7 +90,7 @@ Condition : (isnotnull(s_county#4) AND isnotnull(s_state#5))
 
 (7) BroadcastExchange
 Input [2]: [s_county#4, s_state#5]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, false], input[1, string, false]),false), [id=#6]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, false], input[1, string, false]),false,false), [id=#6]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [2]: [ca_county#2, ca_state#3]
@@ -103,7 +103,7 @@ Input [5]: [ca_address_sk#1, ca_county#2, ca_state#3, s_county#4, s_state#5]
 
 (10) BroadcastExchange
 Input [1]: [ca_address_sk#1]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#7]
 
 (11) Scan parquet default.catalog_sales
 Output [3]: [cs_bill_customer_sk#8, cs_item_sk#9, cs_sold_date_sk#10]
@@ -177,7 +177,7 @@ Input [3]: [i_item_sk#22, i_class#23, i_category#24]
 
 (27) BroadcastExchange
 Input [1]: [i_item_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (28) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [item_sk#14]
@@ -364,7 +364,7 @@ Input [3]: [d_date_sk#21, d_year#46, d_moy#47]
 
 (64) BroadcastExchange
 Input [1]: [d_date_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#48]
 
 Subquery:2 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#17 IN dynamicpruning#11
 
@@ -396,7 +396,7 @@ Input [2]: [d_date_sk#34, d_month_seq#49]
 
 (69) BroadcastExchange
 Input [1]: [d_date_sk#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#54]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#54]
 
 Subquery:4 Hosting operator id = 67 Hosting Expression = Subquery scalar-subquery#50, [id=#51]
 * HashAggregate (76)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/explain.txt
@@ -117,7 +117,7 @@ Input [3]: [i_item_sk#14, i_class#15, i_category#16]
 
 (14) BroadcastExchange
 Input [1]: [i_item_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (15) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [item_sk#7]
@@ -156,7 +156,7 @@ Condition : (isnotnull(c_customer_sk#19) AND isnotnull(c_current_addr_sk#20))
 
 (23) BroadcastExchange
 Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [customer_sk#6]
@@ -202,7 +202,7 @@ Condition : isnotnull(ss_customer_sk#23)
 
 (32) BroadcastExchange
 Input [3]: [ss_customer_sk#23, ss_ext_sales_price#24, ss_sold_date_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#27]
 
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [c_customer_sk#19]
@@ -229,7 +229,7 @@ Condition : ((isnotnull(ca_address_sk#28) AND isnotnull(ca_county#29)) AND isnot
 
 (38) BroadcastExchange
 Input [3]: [ca_address_sk#28, ca_county#29, ca_state#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#31]
 
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [c_current_addr_sk#20]
@@ -256,7 +256,7 @@ Condition : (isnotnull(s_county#32) AND isnotnull(s_state#33))
 
 (44) BroadcastExchange
 Input [2]: [s_county#32, s_state#33]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, false], input[1, string, false]),false), [id=#34]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, false], input[1, string, false]),false,false), [id=#34]
 
 (45) BroadcastHashJoin [codegen id : 11]
 Left keys [2]: [ca_county#29, ca_state#30]
@@ -349,7 +349,7 @@ Input [3]: [d_date_sk#18, d_year#47, d_moy#48]
 
 (61) BroadcastExchange
 Input [1]: [d_date_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 Subquery:2 Hosting operator id = 5 Hosting Expression = ws_sold_date_sk#10 IN dynamicpruning#4
 
@@ -381,7 +381,7 @@ Input [2]: [d_date_sk#35, d_month_seq#50]
 
 (66) BroadcastExchange
 Input [1]: [d_date_sk#35]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#55]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#55]
 
 Subquery:4 Hosting operator id = 64 Hosting Expression = Subquery scalar-subquery#51, [id=#52]
 * HashAggregate (73)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55.sf100/explain.txt
@@ -53,7 +53,7 @@ Input [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manager_id#8]
 
 (8) BroadcastExchange
 Input [3]: [i_item_sk#5, i_brand_id#6, i_brand#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
@@ -128,6 +128,6 @@ Input [3]: [d_date_sk#10, d_year#18, d_moy#19]
 
 (22) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#20]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55/explain.txt
@@ -57,7 +57,7 @@ Condition : isnotnull(ss_item_sk#4)
 
 (8) BroadcastExchange
 Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
@@ -88,7 +88,7 @@ Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
 
 (15) BroadcastExchange
 Input [3]: [i_item_sk#8, i_brand_id#9, i_brand#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q56.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q56.sf100/explain.txt
@@ -111,7 +111,7 @@ Input [2]: [ca_address_sk#7, ca_gmt_offset#8]
 
 (11) BroadcastExchange
 Input [1]: [ca_address_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
@@ -156,7 +156,7 @@ Input [2]: [i_item_id#12, i_color#13]
 
 (21) BroadcastExchange
 Input [1]: [i_item_id#12]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,true), [id=#14]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_id#11]
@@ -165,7 +165,7 @@ Join condition: None
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#10, i_item_id#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -386,7 +386,7 @@ Input [3]: [d_date_sk#6, d_year#54, d_moy#55]
 
 (68) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#56]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = cs_sold_date_sk#24 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q56/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q56/explain.txt
@@ -111,7 +111,7 @@ Input [2]: [ca_address_sk#7, ca_gmt_offset#8]
 
 (11) BroadcastExchange
 Input [1]: [ca_address_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
@@ -156,7 +156,7 @@ Input [2]: [i_item_id#12, i_color#13]
 
 (21) BroadcastExchange
 Input [1]: [i_item_id#12]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,true), [id=#14]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_id#11]
@@ -165,7 +165,7 @@ Join condition: None
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#10, i_item_id#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -386,7 +386,7 @@ Input [3]: [d_date_sk#6, d_year#54, d_moy#55]
 
 (68) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#56]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = cs_sold_date_sk#24 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/explain.txt
@@ -96,7 +96,7 @@ Condition : (isnotnull(cc_call_center_sk#9) AND isnotnull(cc_name#10))
 
 (10) BroadcastExchange
 Input [2]: [cc_call_center_sk#9, cc_name#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_call_center_sk#1]
@@ -304,6 +304,6 @@ Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR (
 
 (56) BroadcastExchange
 Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#48]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57/explain.txt
@@ -77,7 +77,7 @@ Condition : (isnotnull(cs_item_sk#5) AND isnotnull(cs_call_center_sk#4))
 
 (7) BroadcastExchange
 Input [4]: [cs_call_center_sk#4, cs_item_sk#5, cs_sales_price#6, cs_sold_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false,false), [id=#9]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -116,7 +116,7 @@ Condition : (isnotnull(cc_call_center_sk#13) AND isnotnull(cc_name#14))
 
 (16) BroadcastExchange
 Input [2]: [cc_call_center_sk#13, cc_name#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_call_center_sk#4]
@@ -201,7 +201,7 @@ Input [7]: [i_category#25, i_brand#26, cc_name#27, d_year#28, d_moy#29, sum_sale
 
 (35) BroadcastExchange
 Input [5]: [i_category#25, i_brand#26, cc_name#27, sum_sales#34, rn#33]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], (input[4, int, false] + 1)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], (input[4, int, false] + 1)),false,false), [id=#35]
 
 (36) BroadcastHashJoin [codegen id : 22]
 Left keys [4]: [i_category#3, i_brand#2, cc_name#14, rn#23]
@@ -229,7 +229,7 @@ Input [7]: [i_category#36, i_brand#37, cc_name#38, d_year#39, d_moy#40, sum_sale
 
 (42) BroadcastExchange
 Input [5]: [i_category#36, i_brand#37, cc_name#38, sum_sales#42, rn#41]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], (input[4, int, false] - 1)),false), [id=#43]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], (input[4, int, false] - 1)),false,false), [id=#43]
 
 (43) BroadcastHashJoin [codegen id : 22]
 Left keys [4]: [i_category#3, i_brand#2, cc_name#14, rn#23]
@@ -269,6 +269,6 @@ Condition : ((((d_year#11 = 1999) OR ((d_year#11 = 1998) AND (d_moy#12 = 12))) O
 
 (49) BroadcastExchange
 Input [3]: [d_date_sk#10, d_year#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#46]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58.sf100/explain.txt
@@ -93,7 +93,7 @@ Condition : (isnotnull(i_item_sk#6) AND isnotnull(i_item_id#7))
 
 (10) BroadcastExchange
 Input [2]: [i_item_sk#6, i_item_id#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
@@ -189,7 +189,7 @@ Condition : isnotnull(cs_item_rev#26)
 
 (30) BroadcastExchange
 Input [2]: [item_id#25, cs_item_rev#26]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#27]
 
 (31) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [item_id#13]
@@ -263,7 +263,7 @@ Condition : isnotnull(ws_item_rev#39)
 
 (46) BroadcastExchange
 Input [2]: [item_id#38, ws_item_rev#39]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#40]
 
 (47) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [item_id#13]
@@ -328,7 +328,7 @@ Input [2]: [d_date#46, d_week_seq#47]
 
 (57) BroadcastExchange
 Input [1]: [d_date#46]
-Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false,true), [id=#50]
 
 (58) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_date#45]
@@ -341,7 +341,7 @@ Input [2]: [d_date_sk#5, d_date#45]
 
 (60) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#51]
 
 Subquery:2 Hosting operator id = 55 Hosting Expression = Subquery scalar-subquery#48, [id=#49]
 * Project (64)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58/explain.txt
@@ -81,7 +81,7 @@ Condition : (isnotnull(i_item_sk#5) AND isnotnull(i_item_id#6))
 
 (7) BroadcastExchange
 Input [2]: [i_item_sk#5, i_item_id#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
@@ -189,7 +189,7 @@ Condition : isnotnull(cs_item_rev#26)
 
 (30) BroadcastExchange
 Input [2]: [item_id#25, cs_item_rev#26]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#27]
 
 (31) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [item_id#13]
@@ -263,7 +263,7 @@ Condition : isnotnull(ws_item_rev#39)
 
 (46) BroadcastExchange
 Input [2]: [item_id#38, ws_item_rev#39]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#40]
 
 (47) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [item_id#13]
@@ -328,7 +328,7 @@ Input [2]: [d_date#46, d_week_seq#47]
 
 (57) BroadcastExchange
 Input [1]: [d_date#46]
-Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false,true), [id=#50]
 
 (58) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_date#45]
@@ -341,7 +341,7 @@ Input [2]: [d_date_sk#8, d_date#45]
 
 (60) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#51]
 
 Subquery:2 Hosting operator id = 55 Hosting Expression = Subquery scalar-subquery#48, [id=#49]
 * Project (64)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
@@ -76,7 +76,7 @@ Condition : (isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5))
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
@@ -121,7 +121,7 @@ Condition : (isnotnull(s_store_sk#37) AND isnotnull(s_store_id#38))
 
 (16) BroadcastExchange
 Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#40]
 
 (17) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#1]
@@ -152,7 +152,7 @@ Input [2]: [d_month_seq#41, d_week_seq#42]
 
 (23) BroadcastExchange
 Input [1]: [d_week_seq#42]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#43]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#43]
 
 (24) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
@@ -189,7 +189,7 @@ Condition : (isnotnull(s_store_sk#61) AND isnotnull(s_store_id#62))
 
 (31) BroadcastExchange
 Input [2]: [s_store_sk#61, s_store_id#62]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#63]
 
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#1]
@@ -220,7 +220,7 @@ Input [2]: [d_month_seq#64, d_week_seq#65]
 
 (38) BroadcastExchange
 Input [1]: [d_week_seq#65]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#66]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#66]
 
 (39) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [d_week_seq#5]
@@ -233,7 +233,7 @@ Input [10]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#3
 
 (41) BroadcastExchange
 Input [9]: [d_week_seq2#67, s_store_id2#68, sun_sales2#69, mon_sales2#70, tue_sales2#71, wed_sales2#72, thu_sales2#73, fri_sales2#74, sat_sales2#75]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [id=#76]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false,false), [id=#76]
 
 (42) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [s_store_id1#46, d_week_seq1#45]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59/explain.txt
@@ -76,7 +76,7 @@ Condition : (isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5))
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
@@ -121,7 +121,7 @@ Condition : (isnotnull(s_store_sk#37) AND isnotnull(s_store_id#38))
 
 (16) BroadcastExchange
 Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#40]
 
 (17) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#1]
@@ -152,7 +152,7 @@ Input [2]: [d_month_seq#41, d_week_seq#42]
 
 (23) BroadcastExchange
 Input [1]: [d_week_seq#42]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#43]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#43]
 
 (24) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
@@ -189,7 +189,7 @@ Condition : (isnotnull(s_store_sk#61) AND isnotnull(s_store_id#62))
 
 (31) BroadcastExchange
 Input [2]: [s_store_sk#61, s_store_id#62]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#63]
 
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#1]
@@ -220,7 +220,7 @@ Input [2]: [d_month_seq#64, d_week_seq#65]
 
 (38) BroadcastExchange
 Input [1]: [d_week_seq#65]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#66]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#66]
 
 (39) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [d_week_seq#5]
@@ -233,7 +233,7 @@ Input [10]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#3
 
 (41) BroadcastExchange
 Input [9]: [d_week_seq2#67, s_store_id2#68, sun_sales2#69, mon_sales2#70, tue_sales2#71, wed_sales2#72, thu_sales2#73, fri_sales2#74, sat_sales2#75]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [id=#76]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false,false), [id=#76]
 
 (42) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [s_store_id1#46, d_week_seq1#45]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q60.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q60.sf100/explain.txt
@@ -111,7 +111,7 @@ Input [2]: [ca_address_sk#7, ca_gmt_offset#8]
 
 (11) BroadcastExchange
 Input [1]: [ca_address_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
@@ -156,7 +156,7 @@ Input [2]: [i_item_id#12, i_category#13]
 
 (21) BroadcastExchange
 Input [1]: [i_item_id#12]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,true), [id=#14]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_id#11]
@@ -165,7 +165,7 @@ Join condition: None
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#10, i_item_id#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -386,7 +386,7 @@ Input [3]: [d_date_sk#6, d_year#54, d_moy#55]
 
 (68) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#56]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = cs_sold_date_sk#24 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q60/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q60/explain.txt
@@ -111,7 +111,7 @@ Input [2]: [ca_address_sk#7, ca_gmt_offset#8]
 
 (11) BroadcastExchange
 Input [1]: [ca_address_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
@@ -156,7 +156,7 @@ Input [2]: [i_item_id#12, i_category#13]
 
 (21) BroadcastExchange
 Input [1]: [i_item_id#12]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,true), [id=#14]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_id#11]
@@ -165,7 +165,7 @@ Join condition: None
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#10, i_item_id#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -386,7 +386,7 @@ Input [3]: [d_date_sk#6, d_year#54, d_moy#55]
 
 (68) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#56]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = cs_sold_date_sk#24 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61.sf100/explain.txt
@@ -112,7 +112,7 @@ Input [2]: [i_item_sk#9, i_category#10]
 
 (11) BroadcastExchange
 Input [1]: [i_item_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#11]
 
 (12) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
@@ -143,7 +143,7 @@ Input [4]: [p_promo_sk#12, p_channel_dmail#13, p_channel_email#14, p_channel_tv#
 
 (18) BroadcastExchange
 Input [1]: [p_promo_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#16]
 
 (19) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_promo_sk#4]
@@ -174,7 +174,7 @@ Input [2]: [s_store_sk#17, s_gmt_offset#18]
 
 (25) BroadcastExchange
 Input [1]: [s_store_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#19]
 
 (26) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_store_sk#3]
@@ -219,7 +219,7 @@ Input [2]: [ca_address_sk#22, ca_gmt_offset#23]
 
 (35) BroadcastExchange
 Input [1]: [ca_address_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#24]
 
 (36) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_current_addr_sk#21]
@@ -232,7 +232,7 @@ Input [3]: [c_customer_sk#20, c_current_addr_sk#21, ca_address_sk#22]
 
 (38) BroadcastExchange
 Input [1]: [c_customer_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (39) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_customer_sk#2]
@@ -383,7 +383,7 @@ Input [3]: [d_date_sk#8, d_year#47, d_moy#48]
 
 (69) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 Subquery:2 Hosting operator id = 44 Hosting Expression = ss_sold_date_sk#35 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61/explain.txt
@@ -103,7 +103,7 @@ Input [2]: [s_store_sk#8, s_gmt_offset#9]
 
 (8) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (9) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_store_sk#3]
@@ -134,7 +134,7 @@ Input [4]: [p_promo_sk#11, p_channel_dmail#12, p_channel_email#13, p_channel_tv#
 
 (15) BroadcastExchange
 Input [1]: [p_promo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (16) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_promo_sk#4]
@@ -173,7 +173,7 @@ Condition : (isnotnull(c_customer_sk#17) AND isnotnull(c_current_addr_sk#18))
 
 (24) BroadcastExchange
 Input [2]: [c_customer_sk#17, c_current_addr_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (25) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_customer_sk#2]
@@ -204,7 +204,7 @@ Input [2]: [ca_address_sk#20, ca_gmt_offset#21]
 
 (31) BroadcastExchange
 Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (32) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#18]
@@ -235,7 +235,7 @@ Input [2]: [i_item_sk#23, i_category#24]
 
 (38) BroadcastExchange
 Input [1]: [i_item_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (39) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
@@ -398,7 +398,7 @@ Input [3]: [d_date_sk#16, d_year#49, d_moy#50]
 
 (72) BroadcastExchange
 Input [1]: [d_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#51]
 
 Subquery:2 Hosting operator id = 44 Hosting Expression = ss_sold_date_sk#35 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q62.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q62.sf100/explain.txt
@@ -67,7 +67,7 @@ Input [2]: [d_date_sk#6, d_month_seq#7]
 
 (8) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#8]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_date_sk#1]
@@ -94,7 +94,7 @@ Condition : isnotnull(web_site_sk#9)
 
 (14) BroadcastExchange
 Input [2]: [web_site_sk#9, web_name#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (15) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_web_site_sk#2]
@@ -121,7 +121,7 @@ Condition : isnotnull(sm_ship_mode_sk#12)
 
 (20) BroadcastExchange
 Input [2]: [sm_ship_mode_sk#12, sm_type#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_mode_sk#3]
@@ -148,7 +148,7 @@ Condition : isnotnull(w_warehouse_sk#15)
 
 (26) BroadcastExchange
 Input [2]: [w_warehouse_sk#15, w_warehouse_name#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#17]
 
 (27) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_warehouse_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q62/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q62/explain.txt
@@ -63,7 +63,7 @@ Condition : isnotnull(w_warehouse_sk#6)
 
 (7) BroadcastExchange
 Input [2]: [w_warehouse_sk#6, w_warehouse_name#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_warehouse_sk#4]
@@ -90,7 +90,7 @@ Condition : isnotnull(sm_ship_mode_sk#9)
 
 (13) BroadcastExchange
 Input [2]: [sm_ship_mode_sk#9, sm_type#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_mode_sk#3]
@@ -117,7 +117,7 @@ Condition : isnotnull(web_site_sk#12)
 
 (19) BroadcastExchange
 Input [2]: [web_site_sk#12, web_name#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (20) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_web_site_sk#2]
@@ -148,7 +148,7 @@ Input [2]: [d_date_sk#15, d_month_seq#16]
 
 (26) BroadcastExchange
 Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (27) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_date_sk#1]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63.sf100/explain.txt
@@ -49,7 +49,7 @@ Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manager_id#5]
 
 (5) BroadcastExchange
 Input [2]: [i_item_sk#1, i_manager_id#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (6) Scan parquet default.store_sales
 Output [4]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13, ss_sold_date_sk#14]
@@ -91,7 +91,7 @@ Condition : isnotnull(s_store_sk#16)
 
 (14) BroadcastExchange
 Input [1]: [s_store_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#17]
 
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#12]
@@ -186,6 +186,6 @@ Input [3]: [d_date_sk#18, d_month_seq#28, d_moy#19]
 
 (33) BroadcastExchange
 Input [2]: [d_date_sk#18, d_moy#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63/explain.txt
@@ -64,7 +64,7 @@ Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
 
 (8) BroadcastExchange
 Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -103,7 +103,7 @@ Condition : isnotnull(s_store_sk#18)
 
 (17) BroadcastExchange
 Input [1]: [s_store_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
@@ -186,6 +186,6 @@ Input [3]: [d_date_sk#16, d_month_seq#28, d_moy#17]
 
 (33) BroadcastExchange
 Input [2]: [d_date_sk#16, d_moy#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/explain.txt
@@ -156,7 +156,7 @@ Results [2]: [ss_store_sk#13, avg(revenue#21)#27 AS ave#28]
 
 (23) BroadcastExchange
 Input [2]: [ss_store_sk#13, ave#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 (24) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#2]
@@ -183,7 +183,7 @@ Condition : isnotnull(s_store_sk#30)
 
 (29) BroadcastExchange
 Input [2]: [s_store_sk#30, s_store_name#31]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#32]
 
 (30) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#2]
@@ -267,7 +267,7 @@ Input [2]: [d_date_sk#6, d_month_seq#40]
 
 (46) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#41]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#41]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = ss_sold_date_sk#15 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65/explain.txt
@@ -104,7 +104,7 @@ Condition : isnotnull(revenue#13)
 
 (14) BroadcastExchange
 Input [3]: [ss_store_sk#4, ss_item_sk#3, revenue#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (15) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [s_store_sk#1]
@@ -131,7 +131,7 @@ Condition : isnotnull(i_item_sk#15)
 
 (20) BroadcastExchange
 Input [5]: [i_item_sk#15, i_item_desc#16, i_current_price#17, i_wholesale_cost#18, i_brand#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#20]
 
 (21) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#3]
@@ -207,7 +207,7 @@ Results [2]: [ss_store_sk#22, avg(revenue#30)#36 AS ave#37]
 
 (35) BroadcastExchange
 Input [2]: [ss_store_sk#22, ave#37]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#38]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#38]
 
 (36) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#4]
@@ -252,7 +252,7 @@ Input [2]: [d_date_sk#8, d_month_seq#39]
 
 (43) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#40]
 
 Subquery:2 Hosting operator id = 23 Hosting Expression = ss_sold_date_sk#24 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q66.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q66.sf100/explain.txt
@@ -88,7 +88,7 @@ Input [2]: [sm_ship_mode_sk#9, sm_carrier#10]
 
 (8) BroadcastExchange
 Input [1]: [sm_ship_mode_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#11]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_mode_sk#2]
@@ -119,7 +119,7 @@ Input [2]: [t_time_sk#12, t_time#13]
 
 (15) BroadcastExchange
 Input [1]: [t_time_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (16) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_sold_time_sk#1]
@@ -158,7 +158,7 @@ Condition : isnotnull(w_warehouse_sk#18)
 
 (24) BroadcastExchange
 Input [7]: [w_warehouse_sk#18, w_warehouse_name#19, w_warehouse_sq_ft#20, w_city#21, w_county#22, w_state#23, w_country#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_warehouse_sk#3]
@@ -317,7 +317,7 @@ Condition : ((isnotnull(d_year#16) AND (d_year#16 = 2001)) AND isnotnull(d_date_
 
 (56) BroadcastExchange
 Input [3]: [d_date_sk#15, d_year#16, d_moy#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#556]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#556]
 
 Subquery:2 Hosting operator id = 30 Hosting Expression = cs_sold_date_sk#179 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q66/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q66/explain.txt
@@ -84,7 +84,7 @@ Condition : isnotnull(w_warehouse_sk#9)
 
 (7) BroadcastExchange
 Input [7]: [w_warehouse_sk#9, w_warehouse_name#10, w_warehouse_sq_ft#11, w_city#12, w_county#13, w_state#14, w_country#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#16]
 
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_warehouse_sk#3]
@@ -127,7 +127,7 @@ Input [2]: [t_time_sk#20, t_time#21]
 
 (17) BroadcastExchange
 Input [1]: [t_time_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_sold_time_sk#1]
@@ -158,7 +158,7 @@ Input [2]: [sm_ship_mode_sk#23, sm_carrier#24]
 
 (24) BroadcastExchange
 Input [1]: [sm_ship_mode_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_mode_sk#2]
@@ -317,7 +317,7 @@ Condition : ((isnotnull(d_year#18) AND (d_year#18 = 2001)) AND isnotnull(d_date_
 
 (56) BroadcastExchange
 Input [3]: [d_date_sk#17, d_year#18, d_moy#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#556]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#556]
 
 Subquery:2 Hosting operator id = 30 Hosting Expression = cs_sold_date_sk#179 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/explain.txt
@@ -74,7 +74,7 @@ Condition : isnotnull(s_store_sk#11)
 
 (10) BroadcastExchange
 Input [2]: [s_store_sk#11, s_store_id#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#13]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
@@ -196,6 +196,6 @@ Input [5]: [d_date_sk#7, d_month_seq#39, d_year#8, d_moy#9, d_qoy#10]
 
 (35) BroadcastExchange
 Input [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#40]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67/explain.txt
@@ -71,7 +71,7 @@ Condition : isnotnull(s_store_sk#11)
 
 (10) BroadcastExchange
 Input [2]: [s_store_sk#11, s_store_id#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#13]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
@@ -98,7 +98,7 @@ Condition : isnotnull(i_item_sk#14)
 
 (16) BroadcastExchange
 Input [5]: [i_item_sk#14, i_brand#15, i_class#16, i_category#17, i_product_name#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
@@ -181,6 +181,6 @@ Input [5]: [d_date_sk#7, d_month_seq#38, d_year#8, d_moy#9, d_qoy#10]
 
 (32) BroadcastExchange
 Input [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#39]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#39]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/explain.txt
@@ -156,7 +156,7 @@ Input [2]: [s_store_sk#21, s_city#22]
 
 (25) BroadcastExchange
 Input [1]: [s_store_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#23]
 
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#13]
@@ -187,7 +187,7 @@ Input [3]: [hd_demo_sk#24, hd_dep_count#25, hd_vehicle_count#26]
 
 (32) BroadcastExchange
 Input [1]: [hd_demo_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#27]
 
 (33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_hdemo_sk#11]
@@ -287,6 +287,6 @@ Input [3]: [d_date_sk#20, d_year#45, d_dom#46]
 
 (52) BroadcastExchange
 Input [1]: [d_date_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#47]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#47]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68/explain.txt
@@ -87,7 +87,7 @@ Input [2]: [s_store_sk#12, s_city#13]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#4]
@@ -118,7 +118,7 @@ Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -145,7 +145,7 @@ Condition : (isnotnull(ca_address_sk#19) AND isnotnull(ca_city#20))
 
 (24) BroadcastExchange
 Input [2]: [ca_address_sk#19, ca_city#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#3]
@@ -190,7 +190,7 @@ Condition : (isnotnull(c_customer_sk#36) AND isnotnull(c_current_addr_sk#37))
 
 (33) BroadcastExchange
 Input [4]: [c_customer_sk#36, c_current_addr_sk#37, c_first_name#38, c_last_name#39]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#40]
 
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#1]
@@ -247,6 +247,6 @@ Input [3]: [d_date_sk#11, d_year#43, d_dom#44]
 
 (44) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#45]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#45]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
@@ -199,7 +199,7 @@ Input [2]: [ca_address_sk#18, ca_state#19]
 
 (35) BroadcastExchange
 Input [1]: [ca_address_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#20]
 
 (36) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#3]
@@ -212,7 +212,7 @@ Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#18]
 
 (38) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#21]
 
 (39) Scan parquet default.customer_demographics
 Output [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27]
@@ -289,7 +289,7 @@ Input [3]: [d_date_sk#8, d_year#35, d_moy#36]
 
 (52) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#37]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#37]
 
 Subquery:2 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69/explain.txt
@@ -81,7 +81,7 @@ Input [3]: [ss_customer_sk#4, ss_sold_date_sk#5, d_date_sk#7]
 
 (9) BroadcastExchange
 Input [1]: [ss_customer_sk#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#8]
 
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
@@ -112,7 +112,7 @@ Input [3]: [ws_bill_customer_sk#9, ws_sold_date_sk#10, d_date_sk#11]
 
 (16) BroadcastExchange
 Input [1]: [ws_bill_customer_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#12]
 
 (17) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
@@ -143,7 +143,7 @@ Input [3]: [cs_ship_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15]
 
 (23) BroadcastExchange
 Input [1]: [cs_ship_customer_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#16]
 
 (24) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
@@ -174,7 +174,7 @@ Input [2]: [ca_address_sk#17, ca_state#18]
 
 (30) BroadcastExchange
 Input [1]: [ca_address_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#19]
 
 (31) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#3]
@@ -201,7 +201,7 @@ Condition : isnotnull(cd_demo_sk#20)
 
 (36) BroadcastExchange
 Input [6]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (37) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#2]
@@ -264,7 +264,7 @@ Input [3]: [d_date_sk#7, d_year#34, d_moy#35]
 
 (47) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#36]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = ws_sold_date_sk#10 IN dynamicpruning#6
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7.sf100/explain.txt
@@ -66,7 +66,7 @@ Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_stat
 
 (8) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
@@ -97,7 +97,7 @@ Input [3]: [p_promo_sk#15, p_channel_email#16, p_channel_event#17]
 
 (15) BroadcastExchange
 Input [1]: [p_promo_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (16) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_promo_sk#3]
@@ -136,7 +136,7 @@ Condition : isnotnull(i_item_sk#20)
 
 (24) BroadcastExchange
 Input [2]: [i_item_sk#20, i_item_id#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#22]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -199,6 +199,6 @@ Input [2]: [d_date_sk#19, d_year#48]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7/explain.txt
@@ -66,7 +66,7 @@ Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_stat
 
 (8) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
@@ -105,7 +105,7 @@ Condition : isnotnull(i_item_sk#16)
 
 (17) BroadcastExchange
 Input [2]: [i_item_sk#16, i_item_id#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -136,7 +136,7 @@ Input [3]: [p_promo_sk#19, p_channel_email#20, p_channel_event#21]
 
 (24) BroadcastExchange
 Input [1]: [p_promo_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_promo_sk#3]
@@ -199,6 +199,6 @@ Input [2]: [d_date_sk#15, d_year#48]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70.sf100/explain.txt
@@ -127,7 +127,7 @@ Condition : isnotnull(s_store_sk#13)
 
 (19) BroadcastExchange
 Input [2]: [s_store_sk#13, s_state#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (20) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#9]
@@ -174,7 +174,7 @@ Input [4]: [s_state#14, s_state#14, _w2#20, ranking#21]
 
 (29) BroadcastExchange
 Input [1]: [s_state#14]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,true), [id=#22]
 
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_state#8]
@@ -183,7 +183,7 @@ Join condition: None
 
 (31) BroadcastExchange
 Input [3]: [s_store_sk#6, s_county#7, s_state#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#1]
@@ -266,7 +266,7 @@ Input [2]: [d_date_sk#5, d_month_seq#38]
 
 (47) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#39]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#39]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70/explain.txt
@@ -115,7 +115,7 @@ Condition : isnotnull(s_store_sk#12)
 
 (16) BroadcastExchange
 Input [2]: [s_store_sk#12, s_state#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#9]
@@ -174,7 +174,7 @@ Input [4]: [s_state#13, s_state#13, _w2#20, ranking#21]
 
 (29) BroadcastExchange
 Input [1]: [s_state#13]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,true), [id=#22]
 
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_state#8]
@@ -183,7 +183,7 @@ Join condition: None
 
 (31) BroadcastExchange
 Input [3]: [s_store_sk#6, s_county#7, s_state#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#1]
@@ -266,7 +266,7 @@ Input [2]: [d_date_sk#5, d_month_seq#38]
 
 (47) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#39]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#39]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71.sf100/explain.txt
@@ -59,7 +59,7 @@ Input [4]: [i_item_sk#1, i_brand_id#2, i_brand#3, i_manager_id#4]
 
 (5) BroadcastExchange
 Input [3]: [i_item_sk#1, i_brand_id#2, i_brand#3]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#5]
 
 (6) Scan parquet default.web_sales
 Output [4]: [ws_sold_time_sk#6, ws_item_sk#7, ws_ext_sales_price#8, ws_sold_date_sk#9]
@@ -173,7 +173,7 @@ Input [4]: [t_time_sk#31, t_hour#32, t_minute#33, t_meal_time#34]
 
 (31) BroadcastExchange
 Input [3]: [t_time_sk#31, t_hour#32, t_minute#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#35]
 
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [time_sk#14]
@@ -240,7 +240,7 @@ Input [3]: [d_date_sk#11, d_year#44, d_moy#45]
 
 (43) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#46]
 
 Subquery:2 Hosting operator id = 12 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#10
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71/explain.txt
@@ -59,7 +59,7 @@ Input [4]: [i_item_sk#1, i_brand_id#2, i_brand#3, i_manager_id#4]
 
 (5) BroadcastExchange
 Input [3]: [i_item_sk#1, i_brand_id#2, i_brand#3]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#5]
 
 (6) Scan parquet default.web_sales
 Output [4]: [ws_sold_time_sk#6, ws_item_sk#7, ws_ext_sales_price#8, ws_sold_date_sk#9]
@@ -173,7 +173,7 @@ Input [4]: [t_time_sk#31, t_hour#32, t_minute#33, t_meal_time#34]
 
 (31) BroadcastExchange
 Input [3]: [t_time_sk#31, t_hour#32, t_minute#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#35]
 
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [time_sk#14]
@@ -240,7 +240,7 @@ Input [3]: [d_date_sk#11, d_year#44, d_moy#45]
 
 (43) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#46]
 
 Subquery:2 Hosting operator id = 12 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#10
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
@@ -106,7 +106,7 @@ Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
 
 (8) BroadcastExchange
 Input [1]: [hd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_hdemo_sk#3]
@@ -137,7 +137,7 @@ Input [2]: [cd_demo_sk#13, cd_marital_status#14]
 
 (15) BroadcastExchange
 Input [1]: [cd_demo_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
@@ -164,7 +164,7 @@ Condition : (isnotnull(d_date#17) AND isnotnull(d_date_sk#16))
 
 (21) BroadcastExchange
 Input [2]: [d_date_sk#16, d_date#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_ship_date_sk#1]
@@ -265,7 +265,7 @@ Condition : isnotnull(w_warehouse_sk#32)
 
 (44) BroadcastExchange
 Input [2]: [w_warehouse_sk#32, w_warehouse_name#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#34]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#34]
 
 (45) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [inv_warehouse_sk#29]
@@ -309,7 +309,7 @@ Condition : isnotnull(p_promo_sk#36)
 
 (54) BroadcastExchange
 Input [1]: [p_promo_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#37]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#37]
 
 (55) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [cs_promo_sk#5]
@@ -421,7 +421,7 @@ Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_year#50]
 
 (75) BroadcastExchange
 Input [3]: [d_date_sk#23, d_date#24, d_week_seq#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#51]
 
 (76) Scan parquet default.date_dim
 Output [2]: [d_date_sk#26, d_week_seq#52]
@@ -448,6 +448,6 @@ Input [5]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26, d_week_seq#52]
 
 (81) BroadcastExchange
 Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#53]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#53]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/explain.txt
@@ -103,7 +103,7 @@ Condition : ((isnotnull(inv_quantity_on_hand#12) AND isnotnull(inv_item_sk#10)) 
 
 (7) BroadcastExchange
 Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (8) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
@@ -130,7 +130,7 @@ Condition : isnotnull(w_warehouse_sk#15)
 
 (13) BroadcastExchange
 Input [2]: [w_warehouse_sk#15, w_warehouse_name#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#17]
 
 (14) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [inv_warehouse_sk#11]
@@ -157,7 +157,7 @@ Condition : isnotnull(i_item_sk#18)
 
 (19) BroadcastExchange
 Input [2]: [i_item_sk#18, i_item_desc#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#20]
 
 (20) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
@@ -188,7 +188,7 @@ Input [2]: [cd_demo_sk#21, cd_marital_status#22]
 
 (26) BroadcastExchange
 Input [1]: [cd_demo_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#23]
 
 (27) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_bill_cdemo_sk#2]
@@ -219,7 +219,7 @@ Input [2]: [hd_demo_sk#24, hd_buy_potential#25]
 
 (33) BroadcastExchange
 Input [1]: [hd_demo_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_bill_hdemo_sk#3]
@@ -258,7 +258,7 @@ Condition : (isnotnull(d_week_seq#31) AND isnotnull(d_date_sk#30))
 
 (42) BroadcastExchange
 Input [2]: [d_date_sk#30, d_week_seq#31]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, false] as bigint), 32) | (cast(input[0, int, false] as bigint) & 4294967295))),false), [id=#32]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, false] as bigint), 32) | (cast(input[0, int, false] as bigint) & 4294967295))),false,false), [id=#32]
 
 (43) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [d_week_seq#29, inv_date_sk#13]
@@ -285,7 +285,7 @@ Condition : (isnotnull(d_date#34) AND isnotnull(d_date_sk#33))
 
 (48) BroadcastExchange
 Input [2]: [d_date_sk#33, d_date#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#35]
 
 (49) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_ship_date_sk#1]
@@ -312,7 +312,7 @@ Condition : isnotnull(p_promo_sk#36)
 
 (54) BroadcastExchange
 Input [1]: [p_promo_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#37]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#37]
 
 (55) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_promo_sk#5]
@@ -418,6 +418,6 @@ Input [4]: [d_date_sk#27, d_date#28, d_week_seq#29, d_year#50]
 
 (75) BroadcastExchange
 Input [3]: [d_date_sk#27, d_date#28, d_week_seq#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#51]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/explain.txt
@@ -83,7 +83,7 @@ Input [2]: [s_store_sk#8, s_county#9]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -114,7 +114,7 @@ Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_coun
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -224,6 +224,6 @@ Input [3]: [d_date_sk#7, d_year#29, d_dom#30]
 
 (40) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#31]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73/explain.txt
@@ -80,7 +80,7 @@ Input [2]: [s_store_sk#8, s_county#9]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -111,7 +111,7 @@ Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_coun
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -160,7 +160,7 @@ Condition : isnotnull(c_customer_sk#21)
 
 (28) BroadcastExchange
 Input [5]: [c_customer_sk#21, c_salutation#22, c_first_name#23, c_last_name#24, c_preferred_cust_flag#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
@@ -209,6 +209,6 @@ Input [3]: [d_date_sk#7, d_year#28, d_dom#29]
 
 (37) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#30]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/explain.txt
@@ -76,7 +76,7 @@ Condition : isnotnull(d_date_sk#5)
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
@@ -103,7 +103,7 @@ Condition : isnotnull(i_item_sk#9)
 
 (13) BroadcastExchange
 Input [2]: [i_item_sk#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (14) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
@@ -131,7 +131,7 @@ Condition : (isnull(ws_ship_customer_sk#16) AND isnotnull(ws_item_sk#15))
 
 (19) BroadcastExchange
 Input [4]: [ws_item_sk#15, ws_ship_customer_sk#16, ws_ext_sales_price#17, ws_sold_date_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[3, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[3, int, true] as bigint)),false,false), [id=#19]
 
 (20) Scan parquet default.date_dim
 Output [3]: [d_date_sk#20, d_year#21, d_qoy#22]
@@ -158,7 +158,7 @@ Input [7]: [ws_item_sk#15, ws_ship_customer_sk#16, ws_ext_sales_price#17, ws_sol
 
 (25) BroadcastExchange
 Input [5]: [ws_item_sk#15, ws_ship_customer_sk#16, ws_ext_sales_price#17, d_year#21, d_qoy#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#23]
 
 (26) Scan parquet default.item
 Output [2]: [i_item_sk#24, i_category#25]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76/explain.txt
@@ -70,7 +70,7 @@ Condition : isnotnull(i_item_sk#5)
 
 (7) BroadcastExchange
 Input [2]: [i_item_sk#5, i_category#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
@@ -97,7 +97,7 @@ Condition : isnotnull(d_date_sk#8)
 
 (13) BroadcastExchange
 Input [3]: [d_date_sk#8, d_year#9, d_qoy#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (14) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77.sf100/explain.txt
@@ -129,7 +129,7 @@ Condition : isnotnull(s_store_sk#7)
 
 (10) BroadcastExchange
 Input [1]: [s_store_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
@@ -217,7 +217,7 @@ Results [3]: [s_store_sk#23, MakeDecimal(sum(UnscaledValue(sr_return_amt#19))#29
 
 (28) BroadcastExchange
 Input [3]: [s_store_sk#23, returns#31, profit_loss#32]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#33]
 
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [s_store_sk#7]
@@ -362,7 +362,7 @@ Condition : isnotnull(wp_web_page_sk#74)
 
 (59) BroadcastExchange
 Input [1]: [wp_web_page_sk#74]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#75]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#75]
 
 (60) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_web_page_sk#69]
@@ -450,7 +450,7 @@ Results [3]: [wp_web_page_sk#90, MakeDecimal(sum(UnscaledValue(wr_return_amt#86)
 
 (77) BroadcastExchange
 Input [3]: [wp_web_page_sk#90, returns#98, profit_loss#99]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#100]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#100]
 
 (78) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [wp_web_page_sk#74]
@@ -519,7 +519,7 @@ Input [2]: [d_date_sk#6, d_date#127]
 
 (90) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#128]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#128]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = sr_returned_date_sk#21 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77/explain.txt
@@ -129,7 +129,7 @@ Condition : isnotnull(s_store_sk#7)
 
 (10) BroadcastExchange
 Input [1]: [s_store_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
@@ -217,7 +217,7 @@ Results [3]: [s_store_sk#23, MakeDecimal(sum(UnscaledValue(sr_return_amt#19))#29
 
 (28) BroadcastExchange
 Input [3]: [s_store_sk#23, returns#31, profit_loss#32]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#33]
 
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [s_store_sk#7]
@@ -362,7 +362,7 @@ Condition : isnotnull(wp_web_page_sk#74)
 
 (59) BroadcastExchange
 Input [1]: [wp_web_page_sk#74]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#75]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#75]
 
 (60) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_web_page_sk#69]
@@ -450,7 +450,7 @@ Results [3]: [wp_web_page_sk#90, MakeDecimal(sum(UnscaledValue(wr_return_amt#86)
 
 (77) BroadcastExchange
 Input [3]: [wp_web_page_sk#90, returns#98, profit_loss#99]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#100]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#100]
 
 (78) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [wp_web_page_sk#74]
@@ -519,7 +519,7 @@ Input [2]: [d_date_sk#6, d_date#127]
 
 (90) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#128]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#128]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = sr_returned_date_sk#21 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/explain.txt
@@ -81,7 +81,7 @@ Input [3]: [hd_demo_sk#11, hd_dep_count#12, hd_vehicle_count#13]
 
 (11) BroadcastExchange
 Input [1]: [hd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -112,7 +112,7 @@ Input [3]: [s_store_sk#15, s_number_employees#16, s_city#17]
 
 (18) BroadcastExchange
 Input [2]: [s_store_sk#15, s_city#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
@@ -214,6 +214,6 @@ Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
 
 (38) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#36]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79/explain.txt
@@ -78,7 +78,7 @@ Input [3]: [s_store_sk#11, s_number_employees#12, s_city#13]
 
 (11) BroadcastExchange
 Input [2]: [s_store_sk#11, s_city#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
@@ -109,7 +109,7 @@ Input [3]: [hd_demo_sk#15, hd_dep_count#16, hd_vehicle_count#17]
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -154,7 +154,7 @@ Condition : isnotnull(c_customer_sk#28)
 
 (27) BroadcastExchange
 Input [3]: [c_customer_sk#28, c_first_name#29, c_last_name#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#31]
 
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
@@ -199,6 +199,6 @@ Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#35]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/explain.txt
@@ -93,7 +93,7 @@ Condition : (isnotnull(s_store_sk#6) AND isnotnull(s_zip#8))
 
 (10) BroadcastExchange
 Input [3]: [s_store_sk#6, s_store_name#7, s_zip#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
@@ -210,7 +210,7 @@ Input [2]: [ca_zip#22, cnt#23]
 
 (36) BroadcastExchange
 Input [1]: [ca_zip#22]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true])),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true])),false,true), [id=#24]
 
 (37) BroadcastHashJoin [codegen id : 11]
 Left keys [2]: [coalesce(substr(ca_zip#11, 1, 5), ), isnull(substr(ca_zip#11, 1, 5))]
@@ -308,6 +308,6 @@ Input [3]: [d_date_sk#5, d_year#33, d_qoy#34]
 
 (54) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#35]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8/explain.txt
@@ -87,7 +87,7 @@ Condition : (isnotnull(s_store_sk#6) AND isnotnull(s_zip#8))
 
 (10) BroadcastExchange
 Input [3]: [s_store_sk#6, s_store_name#7, s_zip#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#1]
@@ -145,7 +145,7 @@ Input [2]: [c_current_addr_sk#13, c_preferred_cust_flag#14]
 
 (23) BroadcastExchange
 Input [1]: [c_current_addr_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ca_address_sk#11]
@@ -184,7 +184,7 @@ Input [2]: [ca_zip#20, cnt#21]
 
 (31) BroadcastExchange
 Input [1]: [ca_zip#20]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true])),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true])),false,true), [id=#22]
 
 (32) BroadcastHashJoin [codegen id : 6]
 Left keys [2]: [coalesce(substr(ca_zip#10, 1, 5), ), isnull(substr(ca_zip#10, 1, 5))]
@@ -215,7 +215,7 @@ Results [1]: [ca_zip#23]
 
 (37) BroadcastExchange
 Input [1]: [ca_zip#23]
-Arguments: HashedRelationBroadcastMode(List(substr(input[0, string, true], 1, 2)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(substr(input[0, string, true], 1, 2)),false,false), [id=#25]
 
 (38) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [substr(s_zip#8, 1, 2)]
@@ -278,6 +278,6 @@ Input [3]: [d_date_sk#5, d_year#31, d_qoy#32]
 
 (48) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#33]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
@@ -186,7 +186,7 @@ Input [2]: [i_item_sk#16, i_current_price#17]
 
 (18) BroadcastExchange
 Input [1]: [i_item_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (19) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
@@ -217,7 +217,7 @@ Input [2]: [p_promo_sk#19, p_channel_tv#20]
 
 (25) BroadcastExchange
 Input [1]: [p_promo_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#21]
 
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
@@ -256,7 +256,7 @@ Condition : isnotnull(s_store_sk#23)
 
 (34) BroadcastExchange
 Input [2]: [s_store_sk#23, s_store_id#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
@@ -395,7 +395,7 @@ Condition : isnotnull(cp_catalog_page_sk#62)
 
 (65) BroadcastExchange
 Input [2]: [cp_catalog_page_sk#62, cp_catalog_page_id#63]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#64]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#64]
 
 (66) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_catalog_page_sk#45]
@@ -534,7 +534,7 @@ Condition : isnotnull(web_site_sk#101)
 
 (96) BroadcastExchange
 Input [2]: [web_site_sk#101, web_site_id#102]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#103]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#103]
 
 (97) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_web_site_sk#85]
@@ -621,7 +621,7 @@ Input [2]: [d_date_sk#22, d_date#145]
 
 (112) BroadcastExchange
 Input [1]: [d_date_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#146]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#146]
 
 Subquery:2 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#51 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80/explain.txt
@@ -194,7 +194,7 @@ Condition : isnotnull(s_store_sk#17)
 
 (20) BroadcastExchange
 Input [2]: [s_store_sk#17, s_store_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (21) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
@@ -225,7 +225,7 @@ Input [2]: [i_item_sk#20, i_current_price#21]
 
 (27) BroadcastExchange
 Input [1]: [i_item_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (28) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
@@ -256,7 +256,7 @@ Input [2]: [p_promo_sk#23, p_channel_tv#24]
 
 (34) BroadcastExchange
 Input [1]: [p_promo_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
@@ -371,7 +371,7 @@ Condition : isnotnull(cp_catalog_page_sk#60)
 
 (59) BroadcastExchange
 Input [2]: [cp_catalog_page_sk#60, cp_catalog_page_id#61]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#62]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#62]
 
 (60) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_catalog_page_sk#45]
@@ -510,7 +510,7 @@ Condition : isnotnull(web_site_sk#99)
 
 (90) BroadcastExchange
 Input [2]: [web_site_sk#99, web_site_id#100]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#101]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#101]
 
 (91) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_web_site_sk#85]
@@ -621,7 +621,7 @@ Input [2]: [d_date_sk#16, d_date#145]
 
 (112) BroadcastExchange
 Input [1]: [d_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#146]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#146]
 
 Subquery:2 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#51 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81.sf100/explain.txt
@@ -88,7 +88,7 @@ Condition : ((isnotnull(ca_state#14) AND (ca_state#14 = GA)) AND isnotnull(ca_ad
 
 (7) BroadcastExchange
 Input [12]: [ca_address_sk#7, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [c_current_addr_sk#3]
@@ -305,7 +305,7 @@ Condition : isnotnull((avg(ctr_total_return) * 1.2)#49)
 
 (54) BroadcastExchange
 Input [2]: [(avg(ctr_total_return) * 1.2)#49, ctr_state#36#50]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false,false), [id=#51]
 
 (55) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ctr_state#36]
@@ -350,7 +350,7 @@ Input [2]: [d_date_sk#26, d_year#52]
 
 (62) BroadcastExchange
 Input [1]: [d_date_sk#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#53]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#53]
 
 Subquery:2 Hosting operator id = 35 Hosting Expression = cr_returned_date_sk#24 IN dynamicpruning#25
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81/explain.txt
@@ -92,7 +92,7 @@ Condition : (isnotnull(ca_address_sk#7) AND isnotnull(ca_state#8))
 
 (10) BroadcastExchange
 Input [2]: [ca_address_sk#7, ca_state#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cr_returning_addr_sk#2]
@@ -206,7 +206,7 @@ Condition : isnotnull((avg(ctr_total_return) * 1.2)#26)
 
 (33) BroadcastExchange
 Input [2]: [(avg(ctr_total_return) * 1.2)#26, ctr_state#15#27]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false,false), [id=#28]
 
 (34) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ctr_state#15]
@@ -233,7 +233,7 @@ Condition : (isnotnull(c_customer_sk#29) AND isnotnull(c_current_addr_sk#31))
 
 (39) BroadcastExchange
 Input [6]: [c_customer_sk#29, c_customer_id#30, c_current_addr_sk#31, c_salutation#32, c_first_name#33, c_last_name#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#35]
 
 (40) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ctr_customer_sk#14]
@@ -260,7 +260,7 @@ Condition : ((isnotnull(ca_state#43) AND (ca_state#43 = GA)) AND isnotnull(ca_ad
 
 (45) BroadcastExchange
 Input [12]: [ca_address_sk#36, ca_street_number#37, ca_street_name#38, ca_street_type#39, ca_suite_number#40, ca_city#41, ca_county#42, ca_state#43, ca_zip#44, ca_country#45, ca_gmt_offset#46, ca_location_type#47]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#48]
 
 (46) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [c_current_addr_sk#31]
@@ -305,7 +305,7 @@ Input [2]: [d_date_sk#6, d_year#49]
 
 (53) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#50]
 
 Subquery:2 Hosting operator id = 17 Hosting Expression = cr_returned_date_sk#4 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
@@ -49,7 +49,7 @@ Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, i_manufa
 
 (5) BroadcastExchange
 Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#6]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#6]
 
 (6) Scan parquet default.inventory
 Output [3]: [inv_item_sk#7, inv_quantity_on_hand#8, inv_date_sk#9]
@@ -186,6 +186,6 @@ Input [2]: [d_date_sk#11, d_date#17]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82/explain.txt
@@ -65,7 +65,7 @@ Input [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
 
 (9) BroadcastExchange
 Input [2]: [inv_item_sk#6, inv_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_item_sk#1]
@@ -90,7 +90,7 @@ Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date
 
 (15) BroadcastExchange
 Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (16) Scan parquet default.store_sales
 Output [2]: [ss_item_sk#13, ss_sold_date_sk#14]
@@ -171,6 +171,6 @@ Input [2]: [d_date_sk#11, d_date#16]
 
 (30) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83.sf100/explain.txt
@@ -90,7 +90,7 @@ Condition : (isnotnull(i_item_sk#6) AND isnotnull(i_item_id#7))
 
 (10) BroadcastExchange
 Input [2]: [i_item_sk#6, i_item_id#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (11) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sr_item_sk#1]
@@ -178,7 +178,7 @@ Results [2]: [i_item_id#20 AS item_id#25, sum(cr_return_quantity#16)#24 AS cr_it
 
 (28) BroadcastExchange
 Input [2]: [item_id#25, cr_item_qty#26]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#27]
 
 (29) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [item_id#13]
@@ -248,7 +248,7 @@ Results [2]: [i_item_id#33 AS item_id#38, sum(wr_return_quantity#29)#37 AS wr_it
 
 (43) BroadcastExchange
 Input [2]: [item_id#38, wr_item_qty#39]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#40]
 
 (44) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [item_id#13]
@@ -326,7 +326,7 @@ Input [2]: [d_date#48, d_week_seq#49]
 
 (56) BroadcastExchange
 Input [1]: [d_week_seq#49]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#50]
 
 (57) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_week_seq#47]
@@ -339,7 +339,7 @@ Input [2]: [d_date#46, d_week_seq#47]
 
 (59) BroadcastExchange
 Input [1]: [d_date#46]
-Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false,true), [id=#51]
 
 (60) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date#45]
@@ -352,7 +352,7 @@ Input [2]: [d_date_sk#5, d_date#45]
 
 (62) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#52]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = cr_returned_date_sk#17 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83/explain.txt
@@ -78,7 +78,7 @@ Condition : (isnotnull(i_item_sk#5) AND isnotnull(i_item_id#6))
 
 (7) BroadcastExchange
 Input [2]: [i_item_sk#5, i_item_id#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sr_item_sk#1]
@@ -178,7 +178,7 @@ Results [2]: [i_item_id#19 AS item_id#25, sum(cr_return_quantity#16)#24 AS cr_it
 
 (28) BroadcastExchange
 Input [2]: [item_id#25, cr_item_qty#26]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#27]
 
 (29) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [item_id#13]
@@ -248,7 +248,7 @@ Results [2]: [i_item_id#32 AS item_id#38, sum(wr_return_quantity#29)#37 AS wr_it
 
 (43) BroadcastExchange
 Input [2]: [item_id#38, wr_item_qty#39]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#40]
 
 (44) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [item_id#13]
@@ -326,7 +326,7 @@ Input [2]: [d_date#48, d_week_seq#49]
 
 (56) BroadcastExchange
 Input [1]: [d_week_seq#49]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#50]
 
 (57) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_week_seq#47]
@@ -339,7 +339,7 @@ Input [2]: [d_date#46, d_week_seq#47]
 
 (59) BroadcastExchange
 Input [1]: [d_date#46]
-Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false,true), [id=#51]
 
 (60) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date#45]
@@ -352,7 +352,7 @@ Input [2]: [d_date_sk#8, d_date#45]
 
 (62) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#52]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = cr_returned_date_sk#17 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84.sf100/explain.txt
@@ -72,7 +72,7 @@ Input [2]: [ca_address_sk#7, ca_city#8]
 
 (8) BroadcastExchange
 Input [1]: [ca_address_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_current_addr_sk#4]
@@ -117,7 +117,7 @@ Input [3]: [ib_income_band_sk#12, ib_lower_bound#13, ib_upper_bound#14]
 
 (18) BroadcastExchange
 Input [1]: [ib_income_band_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (19) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [hd_income_band_sk#11]
@@ -130,7 +130,7 @@ Input [3]: [hd_demo_sk#10, hd_income_band_sk#11, ib_income_band_sk#12]
 
 (21) BroadcastExchange
 Input [1]: [hd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#16]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_current_hdemo_sk#3]
@@ -143,7 +143,7 @@ Input [6]: [c_customer_id#1, c_current_cdemo_sk#2, c_current_hdemo_sk#3, c_first
 
 (24) BroadcastExchange
 Input [4]: [c_customer_id#1, c_current_cdemo_sk#2, c_first_name#5, c_last_name#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false,false), [id=#17]
 
 (25) Scan parquet default.customer_demographics
 Output [1]: [cd_demo_sk#18]
@@ -170,7 +170,7 @@ Input [5]: [c_customer_id#1, c_current_cdemo_sk#2, c_first_name#5, c_last_name#6
 
 (30) BroadcastExchange
 Input [4]: [c_customer_id#1, c_first_name#5, c_last_name#6, cd_demo_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[3, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[3, int, true] as bigint)),false,false), [id=#19]
 
 (31) Scan parquet default.store_returns
 Output [2]: [sr_cdemo_sk#20, sr_returned_date_sk#21]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84/explain.txt
@@ -72,7 +72,7 @@ Input [2]: [ca_address_sk#7, ca_city#8]
 
 (8) BroadcastExchange
 Input [1]: [ca_address_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [c_current_addr_sk#4]
@@ -99,7 +99,7 @@ Condition : isnotnull(cd_demo_sk#10)
 
 (14) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (15) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [c_current_cdemo_sk#2]
@@ -126,7 +126,7 @@ Condition : (isnotnull(hd_demo_sk#12) AND isnotnull(hd_income_band_sk#13))
 
 (20) BroadcastExchange
 Input [2]: [hd_demo_sk#12, hd_income_band_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [c_current_hdemo_sk#3]
@@ -157,7 +157,7 @@ Input [3]: [ib_income_band_sk#15, ib_lower_bound#16, ib_upper_bound#17]
 
 (27) BroadcastExchange
 Input [1]: [ib_income_band_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (28) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [hd_income_band_sk#13]
@@ -170,7 +170,7 @@ Input [6]: [c_customer_id#1, c_first_name#5, c_last_name#6, cd_demo_sk#10, hd_in
 
 (30) BroadcastExchange
 Input [4]: [c_customer_id#1, c_first_name#5, c_last_name#6, cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[3, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[3, int, true] as bigint)),false,false), [id=#19]
 
 (31) Scan parquet default.store_returns
 Output [2]: [sr_cdemo_sk#20, sr_returned_date_sk#21]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
@@ -86,7 +86,7 @@ Condition : isnotnull(wp_web_page_sk#9)
 
 (7) BroadcastExchange
 Input [1]: [wp_web_page_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#10]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_web_page_sk#2]
@@ -156,7 +156,7 @@ Condition : (((isnotnull(cd_demo_sk#22) AND isnotnull(cd_marital_status#23)) AND
 
 (23) BroadcastExchange
 Input [3]: [cd_demo_sk#22, cd_marital_status#23, cd_education_status#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (24) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [wr_refunded_cdemo_sk#13]
@@ -226,7 +226,7 @@ Input [3]: [ca_address_sk#31, ca_state#32, ca_country#33]
 
 (39) BroadcastExchange
 Input [2]: [ca_address_sk#31, ca_state#32]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#34]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#34]
 
 (40) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [wr_refunded_addr_sk#14]
@@ -265,7 +265,7 @@ Condition : isnotnull(r_reason_sk#36)
 
 (48) BroadcastExchange
 Input [2]: [r_reason_sk#36, r_reason_desc#37]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#38]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#38]
 
 (49) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [wr_reason_sk#16]
@@ -328,6 +328,6 @@ Input [2]: [d_date_sk#35, d_year#59]
 
 (59) BroadcastExchange
 Input [1]: [d_date_sk#35]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#60]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#60]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85/explain.txt
@@ -66,7 +66,7 @@ Condition : ((((isnotnull(ws_item_sk#1) AND isnotnull(ws_order_number#3)) AND is
 
 (4) BroadcastExchange
 Input [7]: [ws_item_sk#1, ws_web_page_sk#2, ws_order_number#3, ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[2, int, false] as bigint) & 4294967295))),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[2, int, false] as bigint) & 4294967295))),false,false), [id=#9]
 
 (5) Scan parquet default.web_returns
 Output [9]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17, wr_returned_date_sk#18]
@@ -111,7 +111,7 @@ Condition : isnotnull(wp_web_page_sk#19)
 
 (14) BroadcastExchange
 Input [1]: [wp_web_page_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#20]
 
 (15) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_web_page_sk#2]
@@ -138,7 +138,7 @@ Condition : (((isnotnull(cd_demo_sk#21) AND isnotnull(cd_marital_status#22)) AND
 
 (20) BroadcastExchange
 Input [3]: [cd_demo_sk#21, cd_marital_status#22, cd_education_status#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#24]
 
 (21) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [wr_refunded_cdemo_sk#11]
@@ -165,7 +165,7 @@ Condition : ((isnotnull(cd_demo_sk#25) AND isnotnull(cd_marital_status#26)) AND 
 
 (26) BroadcastExchange
 Input [3]: [cd_demo_sk#25, cd_marital_status#26, cd_education_status#27]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, false], input[1, string, false], input[2, string, false]),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, false], input[1, string, false], input[2, string, false]),false,false), [id=#28]
 
 (27) BroadcastHashJoin [codegen id : 8]
 Left keys [3]: [wr_returning_cdemo_sk#13, cd_marital_status#22, cd_education_status#23]
@@ -196,7 +196,7 @@ Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
 
 (33) BroadcastExchange
 Input [2]: [ca_address_sk#29, ca_state#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#32]
 
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [wr_refunded_addr_sk#12]
@@ -235,7 +235,7 @@ Condition : isnotnull(r_reason_sk#34)
 
 (42) BroadcastExchange
 Input [2]: [r_reason_sk#34, r_reason_desc#35]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#36]
 
 (43) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [wr_reason_sk#14]
@@ -298,6 +298,6 @@ Input [2]: [d_date_sk#33, d_year#57]
 
 (53) BroadcastExchange
 Input [1]: [d_date_sk#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#58]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#58]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86.sf100/explain.txt
@@ -65,7 +65,7 @@ Condition : isnotnull(i_item_sk#6)
 
 (10) BroadcastExchange
 Input [3]: [i_item_sk#6, i_class#7, i_category#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
@@ -148,6 +148,6 @@ Input [2]: [d_date_sk#5, d_month_seq#24]
 
 (26) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86/explain.txt
@@ -65,7 +65,7 @@ Condition : isnotnull(i_item_sk#6)
 
 (10) BroadcastExchange
 Input [3]: [i_item_sk#6, i_class#7, i_category#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
@@ -148,6 +148,6 @@ Input [2]: [d_date_sk#5, d_month_seq#24]
 
 (26) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/explain.txt
@@ -416,7 +416,7 @@ Input [3]: [d_date_sk#4, d_date#5, d_month_seq#41]
 
 (72) BroadcastExchange
 Input [2]: [d_date_sk#4, d_date#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#42]
 
 Subquery:2 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#3
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87/explain.txt
@@ -94,7 +94,7 @@ Condition : isnotnull(c_customer_sk#6)
 
 (10) BroadcastExchange
 Input [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_customer_sk#1]
@@ -182,7 +182,7 @@ Results [3]: [c_last_name#17, c_first_name#16, d_date#14]
 
 (28) BroadcastExchange
 Input [3]: [c_last_name#17, c_first_name#16, d_date#14]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 1970-01-01), isnull(input[2, date, true])),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 1970-01-01), isnull(input[2, date, true])),false,true), [id=#19]
 
 (29) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
@@ -262,7 +262,7 @@ Results [3]: [c_last_name#26, c_first_name#25, d_date#23]
 
 (44) BroadcastExchange
 Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 1970-01-01), isnull(input[2, date, true])),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true]), coalesce(input[1, string, true], ), isnull(input[1, string, true]), coalesce(input[2, date, true], 1970-01-01), isnull(input[2, date, true])),false,true), [id=#28]
 
 (45) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
@@ -331,7 +331,7 @@ Input [3]: [d_date_sk#4, d_date#5, d_month_seq#34]
 
 (55) BroadcastExchange
 Input [2]: [d_date_sk#4, d_date#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#35]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = cs_sold_date_sk#12 IN dynamicpruning#3
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88.sf100/explain.txt
@@ -221,7 +221,7 @@ Input [3]: [t_time_sk#5, t_hour#6, t_minute#7]
 
 (9) BroadcastExchange
 Input [1]: [t_time_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#8]
 
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_time_sk#1]
@@ -252,7 +252,7 @@ Input [2]: [s_store_sk#9, s_store_name#10]
 
 (16) BroadcastExchange
 Input [1]: [s_store_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#11]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -283,7 +283,7 @@ Input [3]: [hd_demo_sk#12, hd_dep_count#13, hd_vehicle_count#14]
 
 (23) BroadcastExchange
 Input [1]: [hd_demo_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -350,7 +350,7 @@ Input [3]: [t_time_sk#25, t_hour#26, t_minute#27]
 
 (37) BroadcastExchange
 Input [1]: [t_time_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#28]
 
 (38) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_time_sk#21]
@@ -448,7 +448,7 @@ Input [3]: [t_time_sk#41, t_hour#42, t_minute#43]
 
 (59) BroadcastExchange
 Input [1]: [t_time_sk#41]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#44]
 
 (60) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_time_sk#37]
@@ -546,7 +546,7 @@ Input [3]: [t_time_sk#57, t_hour#58, t_minute#59]
 
 (81) BroadcastExchange
 Input [1]: [t_time_sk#57]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#60]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#60]
 
 (82) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ss_sold_time_sk#53]
@@ -644,7 +644,7 @@ Input [3]: [t_time_sk#73, t_hour#74, t_minute#75]
 
 (103) BroadcastExchange
 Input [1]: [t_time_sk#73]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#76]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#76]
 
 (104) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [ss_sold_time_sk#69]
@@ -742,7 +742,7 @@ Input [3]: [t_time_sk#89, t_hour#90, t_minute#91]
 
 (125) BroadcastExchange
 Input [1]: [t_time_sk#89]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#92]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#92]
 
 (126) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ss_sold_time_sk#85]
@@ -840,7 +840,7 @@ Input [3]: [t_time_sk#105, t_hour#106, t_minute#107]
 
 (147) BroadcastExchange
 Input [1]: [t_time_sk#105]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#108]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#108]
 
 (148) BroadcastHashJoin [codegen id : 33]
 Left keys [1]: [ss_sold_time_sk#101]
@@ -938,7 +938,7 @@ Input [3]: [t_time_sk#121, t_hour#122, t_minute#123]
 
 (169) BroadcastExchange
 Input [1]: [t_time_sk#121]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#124]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#124]
 
 (170) BroadcastHashJoin [codegen id : 38]
 Left keys [1]: [ss_sold_time_sk#117]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88/explain.txt
@@ -221,7 +221,7 @@ Input [3]: [hd_demo_sk#5, hd_dep_count#6, hd_vehicle_count#7]
 
 (9) BroadcastExchange
 Input [1]: [hd_demo_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#8]
 
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -252,7 +252,7 @@ Input [3]: [t_time_sk#9, t_hour#10, t_minute#11]
 
 (16) BroadcastExchange
 Input [1]: [t_time_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_time_sk#1]
@@ -283,7 +283,7 @@ Input [2]: [s_store_sk#13, s_store_name#14]
 
 (23) BroadcastExchange
 Input [1]: [s_store_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -362,7 +362,7 @@ Input [3]: [t_time_sk#26, t_hour#27, t_minute#28]
 
 (40) BroadcastExchange
 Input [1]: [t_time_sk#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#29]
 
 (41) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_time_sk#21]
@@ -460,7 +460,7 @@ Input [3]: [t_time_sk#42, t_hour#43, t_minute#44]
 
 (62) BroadcastExchange
 Input [1]: [t_time_sk#42]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#45]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#45]
 
 (63) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_time_sk#37]
@@ -558,7 +558,7 @@ Input [3]: [t_time_sk#58, t_hour#59, t_minute#60]
 
 (84) BroadcastExchange
 Input [1]: [t_time_sk#58]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#61]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#61]
 
 (85) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ss_sold_time_sk#53]
@@ -656,7 +656,7 @@ Input [3]: [t_time_sk#74, t_hour#75, t_minute#76]
 
 (106) BroadcastExchange
 Input [1]: [t_time_sk#74]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#77]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#77]
 
 (107) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [ss_sold_time_sk#69]
@@ -754,7 +754,7 @@ Input [3]: [t_time_sk#90, t_hour#91, t_minute#92]
 
 (128) BroadcastExchange
 Input [1]: [t_time_sk#90]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#93]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#93]
 
 (129) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ss_sold_time_sk#85]
@@ -852,7 +852,7 @@ Input [3]: [t_time_sk#106, t_hour#107, t_minute#108]
 
 (150) BroadcastExchange
 Input [1]: [t_time_sk#106]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#109]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#109]
 
 (151) BroadcastHashJoin [codegen id : 33]
 Left keys [1]: [ss_sold_time_sk#101]
@@ -950,7 +950,7 @@ Input [3]: [t_time_sk#122, t_hour#123, t_minute#124]
 
 (172) BroadcastExchange
 Input [1]: [t_time_sk#122]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#125]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#125]
 
 (173) BroadcastHashJoin [codegen id : 38]
 Left keys [1]: [ss_sold_time_sk#117]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/explain.txt
@@ -44,7 +44,7 @@ Condition : (((i_category#4 IN (Books                                           
 
 (4) BroadcastExchange
 Input [4]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#5]
 
 (5) Scan parquet default.store_sales
 Output [4]: [ss_item_sk#6, ss_store_sk#7, ss_sales_price#8, ss_sold_date_sk#9]
@@ -98,7 +98,7 @@ Condition : isnotnull(s_store_sk#13)
 
 (16) BroadcastExchange
 Input [3]: [s_store_sk#13, s_store_name#14, s_company_name#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#16]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#7]
@@ -181,6 +181,6 @@ Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
 
 (32) BroadcastExchange
 Input [2]: [d_date_sk#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89/explain.txt
@@ -59,7 +59,7 @@ Condition : (isnotnull(ss_item_sk#5) AND isnotnull(ss_store_sk#6))
 
 (7) BroadcastExchange
 Input [4]: [ss_item_sk#5, ss_store_sk#6, ss_sales_price#7, ss_sold_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#10]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -98,7 +98,7 @@ Condition : isnotnull(s_store_sk#13)
 
 (16) BroadcastExchange
 Input [3]: [s_store_sk#13, s_store_name#14, s_company_name#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#16]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#6]
@@ -181,6 +181,6 @@ Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
 
 (32) BroadcastExchange
 Input [2]: [d_date_sk#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q90.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q90.sf100/explain.txt
@@ -90,7 +90,7 @@ Input [2]: [wp_web_page_sk#5, wp_char_count#6]
 
 (9) BroadcastExchange
 Input [1]: [wp_web_page_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#7]
 
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_web_page_sk#3]
@@ -121,7 +121,7 @@ Input [2]: [hd_demo_sk#8, hd_dep_count#9]
 
 (16) BroadcastExchange
 Input [1]: [hd_demo_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_ship_hdemo_sk#2]
@@ -152,7 +152,7 @@ Input [2]: [t_time_sk#11, t_hour#12]
 
 (23) BroadcastExchange
 Input [1]: [t_time_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_time_sk#1]
@@ -243,7 +243,7 @@ Input [2]: [t_time_sk#25, t_hour#26]
 
 (43) BroadcastExchange
 Input [1]: [t_time_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#27]
 
 (44) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_time_sk#19]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q90/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q90/explain.txt
@@ -90,7 +90,7 @@ Input [2]: [hd_demo_sk#5, hd_dep_count#6]
 
 (9) BroadcastExchange
 Input [1]: [hd_demo_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#7]
 
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_ship_hdemo_sk#2]
@@ -121,7 +121,7 @@ Input [2]: [t_time_sk#8, t_hour#9]
 
 (16) BroadcastExchange
 Input [1]: [t_time_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_time_sk#1]
@@ -152,7 +152,7 @@ Input [2]: [wp_web_page_sk#11, wp_char_count#12]
 
 (23) BroadcastExchange
 Input [1]: [wp_web_page_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_web_page_sk#3]
@@ -231,7 +231,7 @@ Input [2]: [t_time_sk#24, t_hour#25]
 
 (40) BroadcastExchange
 Input [1]: [t_time_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 (41) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_time_sk#19]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91.sf100/explain.txt
@@ -74,7 +74,7 @@ Condition : ((((cd_marital_status#6 = M) AND (cd_education_status#7 = Unknown   
 
 (7) BroadcastExchange
 Input [3]: [cd_demo_sk#5, cd_marital_status#6, cd_education_status#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (8) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_cdemo_sk#2]
@@ -105,7 +105,7 @@ Input [2]: [hd_demo_sk#9, hd_buy_potential#10]
 
 (14) BroadcastExchange
 Input [1]: [hd_demo_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#11]
 
 (15) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_hdemo_sk#3]
@@ -136,7 +136,7 @@ Input [2]: [ca_address_sk#12, ca_gmt_offset#13]
 
 (21) BroadcastExchange
 Input [1]: [ca_address_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (22) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#4]
@@ -176,7 +176,7 @@ Input [5]: [cr_returning_customer_sk#15, cr_call_center_sk#16, cr_net_loss#17, c
 
 (30) BroadcastExchange
 Input [3]: [cr_returning_customer_sk#15, cr_call_center_sk#16, cr_net_loss#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#21]
 
 (31) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_customer_sk#1]
@@ -203,7 +203,7 @@ Condition : isnotnull(cc_call_center_sk#22)
 
 (36) BroadcastExchange
 Input [4]: [cc_call_center_sk#22, cc_call_center_id#23, cc_name#24, cc_manager#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (37) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cr_call_center_sk#16]
@@ -270,6 +270,6 @@ Input [3]: [d_date_sk#20, d_year#36, d_moy#37]
 
 (48) BroadcastExchange
 Input [1]: [d_date_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#38]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#38]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91/explain.txt
@@ -75,7 +75,7 @@ Condition : (isnotnull(cr_call_center_sk#6) AND isnotnull(cr_returning_customer_
 
 (7) BroadcastExchange
 Input [4]: [cr_returning_customer_sk#5, cr_call_center_sk#6, cr_net_loss#7, cr_returned_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false,false), [id=#10]
 
 (8) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cc_call_center_sk#1]
@@ -114,7 +114,7 @@ Condition : (((isnotnull(c_customer_sk#12) AND isnotnull(c_current_addr_sk#15)) 
 
 (16) BroadcastExchange
 Input [4]: [c_customer_sk#12, c_current_cdemo_sk#13, c_current_hdemo_sk#14, c_current_addr_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#16]
 
 (17) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cr_returning_customer_sk#5]
@@ -145,7 +145,7 @@ Input [2]: [ca_address_sk#17, ca_gmt_offset#18]
 
 (23) BroadcastExchange
 Input [1]: [ca_address_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#19]
 
 (24) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#15]
@@ -172,7 +172,7 @@ Condition : ((((cd_marital_status#21 = M) AND (cd_education_status#22 = Unknown 
 
 (29) BroadcastExchange
 Input [3]: [cd_demo_sk#20, cd_marital_status#21, cd_education_status#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_cdemo_sk#13]
@@ -203,7 +203,7 @@ Input [2]: [hd_demo_sk#24, hd_buy_potential#25]
 
 (36) BroadcastExchange
 Input [1]: [hd_demo_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 (37) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_hdemo_sk#14]
@@ -270,6 +270,6 @@ Input [3]: [d_date_sk#11, d_year#36, d_moy#37]
 
 (48) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#38]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#38]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/explain.txt
@@ -50,7 +50,7 @@ Input [2]: [i_item_sk#1, i_manufact_id#2]
 
 (5) BroadcastExchange
 Input [1]: [i_item_sk#1]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#3]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#3]
 
 (6) Scan parquet default.web_sales
 Output [3]: [ws_item_sk#4, ws_ext_discount_amt#5, ws_sold_date_sk#6]
@@ -112,7 +112,7 @@ Input [3]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#15, ws_item_sk#4]
 
 (18) BroadcastExchange
 Input [2]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#16]
 
 (19) Scan parquet default.web_sales
 Output [3]: [ws_item_sk#17, ws_ext_discount_amt#18, ws_sold_date_sk#19]
@@ -198,7 +198,7 @@ Input [2]: [d_date_sk#8, d_date#26]
 
 (34) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#27]
 
 Subquery:2 Hosting operator id = 19 Hosting Expression = ws_sold_date_sk#19 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92/explain.txt
@@ -65,7 +65,7 @@ Input [2]: [i_item_sk#5, i_manufact_id#6]
 
 (8) BroadcastExchange
 Input [1]: [i_item_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#1]
@@ -127,7 +127,7 @@ Condition : isnotnull((1.3 * avg(ws_ext_discount_amt))#18)
 
 (21) BroadcastExchange
 Input [2]: [(1.3 * avg(ws_ext_discount_amt))#18, ws_item_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false,false), [id=#19]
 
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_sk#5]
@@ -198,7 +198,7 @@ Input [2]: [d_date_sk#20, d_date#26]
 
 (34) BroadcastExchange
 Input [1]: [d_date_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#27]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = ws_sold_date_sk#10 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93.sf100/explain.txt
@@ -63,7 +63,7 @@ Input [2]: [r_reason_sk#6, r_reason_desc#7]
 
 (9) BroadcastExchange
 Input [1]: [r_reason_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#8]
 
 (10) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [sr_reason_sk#2]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93/explain.txt
@@ -101,7 +101,7 @@ Input [2]: [r_reason_sk#14, r_reason_desc#15]
 
 (18) BroadcastExchange
 Input [1]: [r_reason_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#16]
 
 (19) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sr_reason_sk#9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
@@ -148,7 +148,7 @@ Input [2]: [ca_address_sk#17, ca_state#18]
 
 (24) BroadcastExchange
 Input [1]: [ca_address_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#19]
 
 (25) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_addr_sk#2]
@@ -179,7 +179,7 @@ Input [2]: [web_site_sk#20, web_company_name#21]
 
 (31) BroadcastExchange
 Input [1]: [web_site_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_web_site_sk#3]
@@ -210,7 +210,7 @@ Input [2]: [d_date_sk#23, d_date#24]
 
 (38) BroadcastExchange
 Input [1]: [d_date_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_date_sk#1]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94/explain.txt
@@ -148,7 +148,7 @@ Input [2]: [d_date_sk#17, d_date#18]
 
 (24) BroadcastExchange
 Input [1]: [d_date_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#19]
 
 (25) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_date_sk#1]
@@ -179,7 +179,7 @@ Input [2]: [ca_address_sk#20, ca_state#21]
 
 (31) BroadcastExchange
 Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_addr_sk#2]
@@ -210,7 +210,7 @@ Input [2]: [web_site_sk#23, web_company_name#24]
 
 (38) BroadcastExchange
 Input [1]: [web_site_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_web_site_sk#3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
@@ -210,7 +210,7 @@ Input [2]: [ca_address_sk#18, ca_state#19]
 
 (36) BroadcastExchange
 Input [1]: [ca_address_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#20]
 
 (37) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_addr_sk#2]
@@ -241,7 +241,7 @@ Input [2]: [web_site_sk#21, web_company_name#22]
 
 (43) BroadcastExchange
 Input [1]: [web_site_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#23]
 
 (44) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_web_site_sk#3]
@@ -272,7 +272,7 @@ Input [2]: [d_date_sk#24, d_date#25]
 
 (50) BroadcastExchange
 Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 (51) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_date_sk#1]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95/explain.txt
@@ -215,7 +215,7 @@ Input [2]: [d_date_sk#18, d_date#19]
 
 (37) BroadcastExchange
 Input [1]: [d_date_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#20]
 
 (38) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_date_sk#1]
@@ -246,7 +246,7 @@ Input [2]: [ca_address_sk#21, ca_state#22]
 
 (44) BroadcastExchange
 Input [1]: [ca_address_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#23]
 
 (45) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_addr_sk#2]
@@ -277,7 +277,7 @@ Input [2]: [web_site_sk#24, web_company_name#25]
 
 (51) BroadcastExchange
 Input [1]: [web_site_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 (52) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_web_site_sk#3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96.sf100/explain.txt
@@ -67,7 +67,7 @@ Input [3]: [t_time_sk#5, t_hour#6, t_minute#7]
 
 (9) BroadcastExchange
 Input [1]: [t_time_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#8]
 
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_time_sk#1]
@@ -98,7 +98,7 @@ Input [2]: [s_store_sk#9, s_store_name#10]
 
 (16) BroadcastExchange
 Input [1]: [s_store_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#11]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -129,7 +129,7 @@ Input [2]: [hd_demo_sk#12, hd_dep_count#13]
 
 (23) BroadcastExchange
 Input [1]: [hd_demo_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96/explain.txt
@@ -67,7 +67,7 @@ Input [2]: [hd_demo_sk#5, hd_dep_count#6]
 
 (9) BroadcastExchange
 Input [1]: [hd_demo_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#7]
 
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -98,7 +98,7 @@ Input [3]: [t_time_sk#8, t_hour#9, t_minute#10]
 
 (16) BroadcastExchange
 Input [1]: [t_time_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#11]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_time_sk#1]
@@ -129,7 +129,7 @@ Input [2]: [s_store_sk#12, s_store_name#13]
 
 (23) BroadcastExchange
 Input [1]: [s_store_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q97.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q97.sf100/explain.txt
@@ -169,7 +169,7 @@ Input [2]: [d_date_sk#5, d_month_seq#29]
 
 (28) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#30]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = cs_sold_date_sk#11 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q97/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q97/explain.txt
@@ -169,7 +169,7 @@ Input [2]: [d_date_sk#5, d_month_seq#29]
 
 (28) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#30]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = cs_sold_date_sk#11 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/explain.txt
@@ -168,6 +168,6 @@ Input [2]: [d_date_sk#13, d_date#25]
 
 (30) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98/explain.txt
@@ -54,7 +54,7 @@ Condition : (i_category#10 IN (Sports                                           
 
 (7) BroadcastExchange
 Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
@@ -153,6 +153,6 @@ Input [2]: [d_date_sk#12, d_date#24]
 
 (27) BroadcastExchange
 Input [1]: [d_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q99.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q99.sf100/explain.txt
@@ -67,7 +67,7 @@ Input [2]: [d_date_sk#6, d_month_seq#7]
 
 (8) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#8]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_ship_date_sk#1]
@@ -94,7 +94,7 @@ Condition : isnotnull(sm_ship_mode_sk#9)
 
 (14) BroadcastExchange
 Input [2]: [sm_ship_mode_sk#9, sm_type#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (15) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_ship_mode_sk#3]
@@ -121,7 +121,7 @@ Condition : isnotnull(cc_call_center_sk#12)
 
 (20) BroadcastExchange
 Input [2]: [cc_call_center_sk#12, cc_name#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_call_center_sk#2]
@@ -148,7 +148,7 @@ Condition : isnotnull(w_warehouse_sk#15)
 
 (26) BroadcastExchange
 Input [2]: [w_warehouse_sk#15, w_warehouse_name#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#17]
 
 (27) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_warehouse_sk#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q99/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q99/explain.txt
@@ -63,7 +63,7 @@ Condition : isnotnull(w_warehouse_sk#6)
 
 (7) BroadcastExchange
 Input [2]: [w_warehouse_sk#6, w_warehouse_name#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_warehouse_sk#4]
@@ -90,7 +90,7 @@ Condition : isnotnull(sm_ship_mode_sk#9)
 
 (13) BroadcastExchange
 Input [2]: [sm_ship_mode_sk#9, sm_type#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_ship_mode_sk#3]
@@ -117,7 +117,7 @@ Condition : isnotnull(cc_call_center_sk#12)
 
 (19) BroadcastExchange
 Input [2]: [cc_call_center_sk#12, cc_name#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (20) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_call_center_sk#2]
@@ -148,7 +148,7 @@ Input [2]: [d_date_sk#15, d_month_seq#16]
 
 (26) BroadcastExchange
 Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (27) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_ship_date_sk#1]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
@@ -186,7 +186,7 @@ Input [2]: [ca_address_sk#19, ca_county#20]
 
 (33) BroadcastExchange
 Input [1]: [ca_address_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#21]
 
 (34) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_addr_sk#3]
@@ -199,7 +199,7 @@ Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#19]
 
 (36) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (37) Scan parquet default.customer_demographics
 Output [9]: [cd_demo_sk#23, cd_gender#24, cd_marital_status#25, cd_education_status#26, cd_purchase_estimate#27, cd_credit_rating#28, cd_dep_count#29, cd_dep_employed_count#30, cd_dep_college_count#31]
@@ -276,7 +276,7 @@ Input [3]: [d_date_sk#8, d_year#42, d_moy#43]
 
 (50) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#44]
 
 Subquery:2 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a/explain.txt
@@ -80,7 +80,7 @@ Input [3]: [ss_customer_sk#4, ss_sold_date_sk#5, d_date_sk#7]
 
 (9) BroadcastExchange
 Input [1]: [ss_customer_sk#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#8]
 
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
@@ -135,7 +135,7 @@ Input [3]: [cs_ship_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15]
 
 (22) BroadcastExchange
 Input [1]: [customer_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#17]
 
 (23) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
@@ -166,7 +166,7 @@ Input [2]: [ca_address_sk#18, ca_county#19]
 
 (29) BroadcastExchange
 Input [1]: [ca_address_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#20]
 
 (30) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#3]
@@ -193,7 +193,7 @@ Condition : isnotnull(cd_demo_sk#21)
 
 (35) BroadcastExchange
 Input [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#30]
 
 (36) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#2]
@@ -256,7 +256,7 @@ Input [3]: [d_date_sk#7, d_year#41, d_moy#42]
 
 (46) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#43]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#43]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = ws_sold_date_sk#10 IN dynamicpruning#6
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11.sf100/explain.txt
@@ -463,7 +463,7 @@ Condition : ((isnotnull(d_year#7) AND (d_year#7 = 2001)) AND isnotnull(d_date_sk
 
 (83) BroadcastExchange
 Input [2]: [d_date_sk#6, d_year#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#93]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#93]
 
 Subquery:2 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#28 IN dynamicpruning#29
 BroadcastExchange (87)
@@ -488,7 +488,7 @@ Condition : ((isnotnull(d_year#31) AND (d_year#31 = 2002)) AND isnotnull(d_date_
 
 (87) BroadcastExchange
 Input [2]: [d_date_sk#30, d_year#31]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#94]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#94]
 
 Subquery:3 Hosting operator id = 40 Hosting Expression = ws_sold_date_sk#53 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11/explain.txt
@@ -103,7 +103,7 @@ Condition : isnotnull(ss_customer_sk#9)
 
 (7) BroadcastExchange
 Input [4]: [ss_customer_sk#9, ss_ext_discount_amt#10, ss_ext_list_price#11, ss_sold_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [c_customer_sk#1]
@@ -179,7 +179,7 @@ Condition : isnotnull(ss_customer_sk#31)
 
 (23) BroadcastExchange
 Input [4]: [ss_customer_sk#31, ss_ext_discount_amt#32, ss_ext_list_price#33, ss_sold_date_sk#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#36]
 
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#23]
@@ -222,7 +222,7 @@ Results [5]: [c_customer_id#24 AS customer_id#42, c_first_name#25 AS customer_fi
 
 (32) BroadcastExchange
 Input [5]: [customer_id#42, customer_first_name#43, customer_last_name#44, customer_email_address#45, year_total#46]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#47]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#47]
 
 (33) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#21]
@@ -260,7 +260,7 @@ Condition : isnotnull(ws_bill_customer_sk#56)
 
 (40) BroadcastExchange
 Input [4]: [ws_bill_customer_sk#56, ws_ext_discount_amt#57, ws_ext_list_price#58, ws_sold_date_sk#59]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#60]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#60]
 
 (41) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#48]
@@ -307,7 +307,7 @@ Condition : (isnotnull(year_total#68) AND (year_total#68 > 0.00))
 
 (50) BroadcastExchange
 Input [2]: [customer_id#67, year_total#68]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#69]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#69]
 
 (51) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#21]
@@ -349,7 +349,7 @@ Condition : isnotnull(ws_bill_customer_sk#78)
 
 (59) BroadcastExchange
 Input [4]: [ws_bill_customer_sk#78, ws_ext_discount_amt#79, ws_ext_list_price#80, ws_sold_date_sk#81]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#82]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#82]
 
 (60) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#70]
@@ -392,7 +392,7 @@ Results [2]: [c_customer_id#71 AS customer_id#88, MakeDecimal(sum(UnscaledValue(
 
 (68) BroadcastExchange
 Input [2]: [customer_id#88, year_total#89]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#90]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#90]
 
 (69) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#21]
@@ -432,7 +432,7 @@ Condition : ((isnotnull(d_year#16) AND (d_year#16 = 2001)) AND isnotnull(d_date_
 
 (75) BroadcastExchange
 Input [2]: [d_date_sk#15, d_year#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#91]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#91]
 
 Subquery:2 Hosting operator id = 20 Hosting Expression = ss_sold_date_sk#34 IN dynamicpruning#35
 BroadcastExchange (79)
@@ -457,7 +457,7 @@ Condition : ((isnotnull(d_year#38) AND (d_year#38 = 2002)) AND isnotnull(d_date_
 
 (79) BroadcastExchange
 Input [2]: [d_date_sk#37, d_year#38]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#92]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#92]
 
 Subquery:3 Hosting operator id = 37 Hosting Expression = ws_sold_date_sk#59 IN dynamicpruning#13
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/explain.txt
@@ -158,6 +158,6 @@ Input [2]: [d_date_sk#13, d_date#24]
 
 (28) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12/explain.txt
@@ -52,7 +52,7 @@ Condition : (i_category#10 IN (Sports                                           
 
 (7) BroadcastExchange
 Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
@@ -143,6 +143,6 @@ Input [2]: [d_date_sk#12, d_date#23]
 
 (25) BroadcastExchange
 Input [1]: [d_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#24]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
@@ -232,7 +232,7 @@ Condition : isnotnull(i_item_sk#23)
 
 (29) BroadcastExchange
 Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#27]
 
 (30) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#20]
@@ -258,7 +258,7 @@ Join condition: None
 
 (35) BroadcastExchange
 Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#29]
 
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#11]
@@ -367,7 +367,7 @@ Results [3]: [brand_id#30, class_id#31, category_id#32]
 
 (58) BroadcastExchange
 Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false,false), [id=#44]
 
 (59) BroadcastHashJoin [codegen id : 20]
 Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
@@ -439,7 +439,7 @@ Join condition: None
 
 (75) BroadcastExchange
 Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#53]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#53]
 
 (76) BroadcastHashJoin [codegen id : 45]
 Left keys [1]: [ss_item_sk#1]
@@ -555,7 +555,7 @@ Condition : (isnotnull(sales#89) AND (cast(sales#89 as decimal(32,6)) > cast(Reu
 
 (100) BroadcastExchange
 Input [6]: [channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sales#89, number_sales#90]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#91]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false,false), [id=#91]
 
 (101) BroadcastHashJoin [codegen id : 92]
 Left keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
@@ -710,7 +710,7 @@ Input [2]: [d_date_sk#47, d_week_seq#117]
 
 (126) BroadcastExchange
 Input [1]: [d_date_sk#47]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#120]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#120]
 
 Subquery:6 Hosting operator id = 124 Hosting Expression = Subquery scalar-subquery#118, [id=#119]
 * Project (130)
@@ -765,7 +765,7 @@ Input [2]: [d_date_sk#14, d_year#125]
 
 (135) BroadcastExchange
 Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#126]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#126]
 
 Subquery:8 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
 
@@ -801,7 +801,7 @@ Input [2]: [d_date_sk#74, d_week_seq#127]
 
 (140) BroadcastExchange
 Input [1]: [d_date_sk#74]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#130]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#130]
 
 Subquery:12 Hosting operator id = 138 Hosting Expression = Subquery scalar-subquery#128, [id=#129]
 * Project (144)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/explain.txt
@@ -176,7 +176,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (19) BroadcastExchange
 Input [4]: [i_item_sk#19, i_brand_id#20, i_class_id#21, i_category_id#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (20) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#17]
@@ -201,7 +201,7 @@ Input [5]: [cs_sold_date_sk#18, i_brand_id#20, i_class_id#21, i_category_id#22, 
 
 (25) BroadcastExchange
 Input [3]: [i_brand_id#20, i_class_id#21, i_category_id#22]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false,true), [id=#25]
 
 (26) BroadcastHashJoin [codegen id : 4]
 Left keys [6]: [coalesce(i_brand_id#14, 0), isnull(i_brand_id#14), coalesce(i_class_id#15, 0), isnull(i_class_id#15), coalesce(i_category_id#16, 0), isnull(i_category_id#16)]
@@ -210,7 +210,7 @@ Join condition: None
 
 (27) BroadcastExchange
 Input [4]: [i_item_sk#13, i_brand_id#14, i_class_id#15, i_category_id#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#10]
@@ -292,7 +292,7 @@ Input [5]: [ws_sold_date_sk#33, i_brand_id#35, i_class_id#36, i_category_id#37, 
 
 (45) BroadcastExchange
 Input [3]: [i_brand_id#35, i_class_id#36, i_category_id#37]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#39]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false,true), [id=#39]
 
 (46) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#28, 0), isnull(brand_id#28), coalesce(class_id#29, 0), isnull(class_id#29), coalesce(category_id#30, 0), isnull(category_id#30)]
@@ -315,7 +315,7 @@ Results [3]: [brand_id#28, class_id#29, category_id#30]
 
 (49) BroadcastExchange
 Input [3]: [brand_id#28, class_id#29, category_id#30]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false,false), [id=#40]
 
 (50) BroadcastHashJoin [codegen id : 11]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
@@ -328,7 +328,7 @@ Input [7]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, brand_id#2
 
 (52) BroadcastExchange
 Input [1]: [ss_item_sk#41]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#42]
 
 (53) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
@@ -359,7 +359,7 @@ Join condition: None
 
 (59) BroadcastExchange
 Input [4]: [i_item_sk#43, i_brand_id#44, i_class_id#45, i_category_id#46]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#47]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#47]
 
 (60) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
@@ -475,7 +475,7 @@ Condition : (isnotnull(sales#83) AND (cast(sales#83 as decimal(32,6)) > cast(Reu
 
 (84) BroadcastExchange
 Input [6]: [channel#82, i_brand_id#69, i_class_id#70, i_category_id#71, sales#83, number_sales#84]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#85]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false,false), [id=#85]
 
 (85) BroadcastHashJoin [codegen id : 52]
 Left keys [3]: [i_brand_id#44, i_class_id#45, i_category_id#46]
@@ -630,7 +630,7 @@ Input [2]: [d_date_sk#48, d_week_seq#111]
 
 (110) BroadcastExchange
 Input [1]: [d_date_sk#48]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#114]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#114]
 
 Subquery:6 Hosting operator id = 108 Hosting Expression = Subquery scalar-subquery#112, [id=#113]
 * Project (114)
@@ -685,7 +685,7 @@ Input [2]: [d_date_sk#27, d_year#119]
 
 (119) BroadcastExchange
 Input [1]: [d_date_sk#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#120]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#120]
 
 Subquery:8 Hosting operator id = 13 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 
@@ -721,7 +721,7 @@ Input [2]: [d_date_sk#72, d_week_seq#121]
 
 (124) BroadcastExchange
 Input [1]: [d_date_sk#72]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#124]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#124]
 
 Subquery:12 Hosting operator id = 122 Hosting Expression = Subquery scalar-subquery#122, [id=#123]
 * Project (128)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
@@ -276,7 +276,7 @@ Condition : isnotnull(i_item_sk#23)
 
 (29) BroadcastExchange
 Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#27]
 
 (30) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#20]
@@ -302,7 +302,7 @@ Join condition: None
 
 (35) BroadcastExchange
 Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#29]
 
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#11]
@@ -411,7 +411,7 @@ Results [3]: [brand_id#30, class_id#31, category_id#32]
 
 (58) BroadcastExchange
 Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false,false), [id=#44]
 
 (59) BroadcastHashJoin [codegen id : 20]
 Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
@@ -483,7 +483,7 @@ Join condition: None
 
 (75) BroadcastExchange
 Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#53]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#53]
 
 (76) BroadcastHashJoin [codegen id : 45]
 Left keys [1]: [ss_item_sk#1]
@@ -974,7 +974,7 @@ Input [2]: [d_date_sk#188, d_year#204]
 
 (170) BroadcastExchange
 Input [1]: [d_date_sk#188]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#205]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#205]
 
 Subquery:4 Hosting operator id = 157 Hosting Expression = ws_sold_date_sk#193 IN dynamicpruning#187
 
@@ -1006,7 +1006,7 @@ Input [3]: [d_date_sk#47, d_year#206, d_moy#207]
 
 (175) BroadcastExchange
 Input [1]: [d_date_sk#47]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#208]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#208]
 
 Subquery:6 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
 BroadcastExchange (180)
@@ -1036,7 +1036,7 @@ Input [2]: [d_date_sk#14, d_year#209]
 
 (180) BroadcastExchange
 Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#210]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#210]
 
 Subquery:7 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
@@ -217,7 +217,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (19) BroadcastExchange
 Input [4]: [i_item_sk#19, i_brand_id#20, i_class_id#21, i_category_id#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (20) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#17]
@@ -242,7 +242,7 @@ Input [5]: [cs_sold_date_sk#18, i_brand_id#20, i_class_id#21, i_category_id#22, 
 
 (25) BroadcastExchange
 Input [3]: [i_brand_id#20, i_class_id#21, i_category_id#22]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false,true), [id=#25]
 
 (26) BroadcastHashJoin [codegen id : 4]
 Left keys [6]: [coalesce(i_brand_id#14, 0), isnull(i_brand_id#14), coalesce(i_class_id#15, 0), isnull(i_class_id#15), coalesce(i_category_id#16, 0), isnull(i_category_id#16)]
@@ -251,7 +251,7 @@ Join condition: None
 
 (27) BroadcastExchange
 Input [4]: [i_item_sk#13, i_brand_id#14, i_class_id#15, i_category_id#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#10]
@@ -333,7 +333,7 @@ Input [5]: [ws_sold_date_sk#33, i_brand_id#35, i_class_id#36, i_category_id#37, 
 
 (45) BroadcastExchange
 Input [3]: [i_brand_id#35, i_class_id#36, i_category_id#37]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false), [id=#39]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true]), coalesce(input[1, int, true], 0), isnull(input[1, int, true]), coalesce(input[2, int, true], 0), isnull(input[2, int, true])),false,true), [id=#39]
 
 (46) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#28, 0), isnull(brand_id#28), coalesce(class_id#29, 0), isnull(class_id#29), coalesce(category_id#30, 0), isnull(category_id#30)]
@@ -356,7 +356,7 @@ Results [3]: [brand_id#28, class_id#29, category_id#30]
 
 (49) BroadcastExchange
 Input [3]: [brand_id#28, class_id#29, category_id#30]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#40]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false,false), [id=#40]
 
 (50) BroadcastHashJoin [codegen id : 11]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
@@ -369,7 +369,7 @@ Input [7]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9, brand_id#2
 
 (52) BroadcastExchange
 Input [1]: [ss_item_sk#41]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#42]
 
 (53) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
@@ -400,7 +400,7 @@ Join condition: None
 
 (59) BroadcastExchange
 Input [4]: [i_item_sk#43, i_brand_id#44, i_class_id#45, i_category_id#46]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#47]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#47]
 
 (60) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
@@ -879,7 +879,7 @@ Input [2]: [d_date_sk#181, d_year#197]
 
 (151) BroadcastExchange
 Input [1]: [d_date_sk#181]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#198]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#198]
 
 Subquery:4 Hosting operator id = 138 Hosting Expression = ws_sold_date_sk#186 IN dynamicpruning#180
 
@@ -911,7 +911,7 @@ Input [3]: [d_date_sk#48, d_year#199, d_moy#200]
 
 (156) BroadcastExchange
 Input [1]: [d_date_sk#48]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#201]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#201]
 
 Subquery:6 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (161)
@@ -941,7 +941,7 @@ Input [2]: [d_date_sk#27, d_year#202]
 
 (161) BroadcastExchange
 Input [1]: [d_date_sk#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#203]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#203]
 
 Subquery:7 Hosting operator id = 13 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/explain.txt
@@ -192,7 +192,7 @@ Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14
 
 (8) BroadcastExchange
 Input [2]: [cd_demo_sk#11, cd_dep_count#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
@@ -231,7 +231,7 @@ Condition : isnotnull(i_item_sk#17)
 
 (17) BroadcastExchange
 Input [2]: [i_item_sk#17, i_item_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_item_sk#3]
@@ -284,7 +284,7 @@ Condition : (ca_state#28 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#2
 
 (29) BroadcastExchange
 Input [4]: [ca_address_sk#26, ca_county#27, ca_state#28, ca_country#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#30]
 
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#23]
@@ -410,7 +410,7 @@ Condition : (ca_state#28 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#2
 
 (57) BroadcastExchange
 Input [3]: [ca_address_sk#26, ca_state#28, ca_country#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#85]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#85]
 
 (58) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [c_current_addr_sk#23]
@@ -525,7 +525,7 @@ Input [3]: [ca_address_sk#26, ca_state#28, ca_country#29]
 
 (83) BroadcastExchange
 Input [2]: [ca_address_sk#26, ca_country#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#132]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#132]
 
 (84) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [c_current_addr_sk#23]
@@ -672,7 +672,7 @@ Input [2]: [ca_address_sk#26, ca_state#28]
 
 (116) BroadcastExchange
 Input [1]: [ca_address_sk#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#180]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#180]
 
 (117) BroadcastHashJoin [codegen id : 46]
 Left keys [1]: [c_current_addr_sk#23]
@@ -685,7 +685,7 @@ Input [5]: [c_customer_sk#21, c_current_cdemo_sk#22, c_current_addr_sk#23, c_bir
 
 (119) BroadcastExchange
 Input [3]: [c_customer_sk#21, c_current_cdemo_sk#22, c_birth_year#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [id=#181]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false,false), [id=#181]
 
 (120) Scan parquet default.customer_demographics
 Output [1]: [cd_demo_sk#32]
@@ -712,7 +712,7 @@ Input [4]: [c_customer_sk#21, c_current_cdemo_sk#22, c_birth_year#25, cd_demo_sk
 
 (125) BroadcastExchange
 Input [2]: [c_customer_sk#21, c_birth_year#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#182]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#182]
 
 (126) BroadcastHashJoin [codegen id : 49]
 Left keys [1]: [cs_bill_customer_sk#1]
@@ -808,7 +808,7 @@ Condition : isnotnull(i_item_sk#17)
 
 (146) BroadcastExchange
 Input [1]: [i_item_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#229]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#229]
 
 (147) BroadcastHashJoin [codegen id : 57]
 Left keys [1]: [cs_item_sk#3]
@@ -885,7 +885,7 @@ Input [2]: [d_date_sk#16, d_year#277]
 
 (161) BroadcastExchange
 Input [1]: [d_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#278]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#278]
 
 Subquery:2 Hosting operator id = 99 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a/explain.txt
@@ -189,7 +189,7 @@ Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14
 
 (8) BroadcastExchange
 Input [2]: [cd_demo_sk#11, cd_dep_count#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (9) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_bill_cdemo_sk#2]
@@ -220,7 +220,7 @@ Input [5]: [c_customer_sk#16, c_current_cdemo_sk#17, c_current_addr_sk#18, c_bir
 
 (15) BroadcastExchange
 Input [4]: [c_customer_sk#16, c_current_cdemo_sk#17, c_current_addr_sk#18, c_birth_year#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#21]
 
 (16) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_bill_customer_sk#1]
@@ -247,7 +247,7 @@ Condition : isnotnull(cd_demo_sk#22)
 
 (21) BroadcastExchange
 Input [1]: [cd_demo_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (22) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_cdemo_sk#17]
@@ -274,7 +274,7 @@ Condition : (ca_state#26 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#2
 
 (27) BroadcastExchange
 Input [4]: [ca_address_sk#24, ca_county#25, ca_state#26, ca_country#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#28]
 
 (28) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#18]
@@ -313,7 +313,7 @@ Condition : isnotnull(i_item_sk#30)
 
 (36) BroadcastExchange
 Input [2]: [i_item_sk#30, i_item_id#31]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#32]
 
 (37) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_item_sk#3]
@@ -409,7 +409,7 @@ Condition : (ca_state#26 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#2
 
 (57) BroadcastExchange
 Input [3]: [ca_address_sk#24, ca_state#26, ca_country#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#83]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#83]
 
 (58) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#18]
@@ -533,7 +533,7 @@ Input [3]: [ca_address_sk#24, ca_state#26, ca_country#27]
 
 (85) BroadcastExchange
 Input [2]: [ca_address_sk#24, ca_country#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#128]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#128]
 
 (86) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [c_current_addr_sk#18]
@@ -657,7 +657,7 @@ Input [2]: [ca_address_sk#24, ca_state#26]
 
 (113) BroadcastExchange
 Input [1]: [ca_address_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#174]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#174]
 
 (114) BroadcastHashJoin [codegen id : 31]
 Left keys [1]: [c_current_addr_sk#18]
@@ -801,7 +801,7 @@ Condition : isnotnull(i_item_sk#30)
 
 (146) BroadcastExchange
 Input [1]: [i_item_sk#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#221]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#221]
 
 (147) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [cs_item_sk#3]
@@ -866,7 +866,7 @@ Input [2]: [d_date_sk#29, d_year#269]
 
 (158) BroadcastExchange
 Input [1]: [d_date_sk#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#270]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#270]
 
 Subquery:2 Hosting operator id = 42 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/explain.txt
@@ -158,6 +158,6 @@ Input [2]: [d_date_sk#13, d_date#24]
 
 (28) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20/explain.txt
@@ -52,7 +52,7 @@ Condition : (i_category#10 IN (Sports                                           
 
 (7) BroadcastExchange
 Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#1]
@@ -143,6 +143,6 @@ Input [2]: [d_date_sk#12, d_date#23]
 
 (25) BroadcastExchange
 Input [1]: [d_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#24]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22.sf100/explain.txt
@@ -168,6 +168,6 @@ Input [2]: [d_date_sk#5, d_month_seq#26]
 
 (30) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#27]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22/explain.txt
@@ -66,7 +66,7 @@ Condition : isnotnull(i_item_sk#6)
 
 (10) BroadcastExchange
 Input [5]: [i_item_sk#6, i_brand#7, i_class#8, i_category#9, i_product_name#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
@@ -153,6 +153,6 @@ Input [2]: [d_date_sk#5, d_month_seq#25]
 
 (27) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a.sf100/explain.txt
@@ -80,7 +80,7 @@ Condition : isnotnull(w_warehouse_sk#6)
 
 (7) BroadcastExchange
 Input [1]: [w_warehouse_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [inv_warehouse_sk#2]
@@ -322,6 +322,6 @@ Input [2]: [d_date_sk#8, d_month_seq#67]
 
 (53) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#68]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#68]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a/explain.txt
@@ -89,7 +89,7 @@ Condition : isnotnull(i_item_sk#7)
 
 (10) BroadcastExchange
 Input [5]: [i_item_sk#7, i_brand#8, i_class#9, i_category#10, i_product_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
@@ -116,7 +116,7 @@ Condition : isnotnull(w_warehouse_sk#13)
 
 (16) BroadcastExchange
 Input [1]: [w_warehouse_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
@@ -307,6 +307,6 @@ Input [2]: [d_date_sk#6, d_month_seq#66]
 
 (50) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#67]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#67]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/explain.txt
@@ -69,7 +69,7 @@ Input [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
 
 (5) BroadcastExchange
 Input [4]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [id=#6]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false,false), [id=#6]
 
 (6) Scan parquet default.customer_address
 Output [4]: [ca_address_sk#7, ca_state#8, ca_zip#9, ca_country#10]
@@ -96,7 +96,7 @@ Input [8]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5, ca_address_sk#7, c
 
 (11) BroadcastExchange
 Input [6]: [s_store_sk#1, s_store_name#2, s_state#4, ca_address_sk#7, ca_state#8, ca_country#10]
-Arguments: HashedRelationBroadcastMode(List(input[3, int, true], upper(input[5, string, true])),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(input[3, int, true], upper(input[5, string, true])),false,false), [id=#11]
 
 (12) Scan parquet default.customer
 Output [5]: [c_customer_sk#12, c_current_addr_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
@@ -123,7 +123,7 @@ Input [11]: [s_store_sk#1, s_store_name#2, s_state#4, ca_address_sk#7, ca_state#
 
 (17) BroadcastExchange
 Input [7]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#8, c_customer_sk#12, c_first_name#14, c_last_name#15]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, true] as bigint), 32) | (cast(input[4, int, true] as bigint) & 4294967295))),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, true] as bigint), 32) | (cast(input[4, int, true] as bigint) & 4294967295))),false,false), [id=#17]
 
 (18) Scan parquet default.store_sales
 Output [6]: [ss_item_sk#18, ss_customer_sk#19, ss_store_sk#20, ss_ticket_number#21, ss_net_paid#22, ss_sold_date_sk#23]
@@ -168,7 +168,7 @@ Condition : ((isnotnull(i_color#27) AND (i_color#27 = pale                )) AND
 
 (27) BroadcastExchange
 Input [6]: [i_item_sk#24, i_current_price#25, i_size#26, i_color#27, i_units#28, i_manager_id#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#30]
 
 (28) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#18]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24/explain.txt
@@ -130,7 +130,7 @@ Input [5]: [s_store_sk#12, s_store_name#13, s_market_id#14, s_state#15, s_zip#16
 
 (19) BroadcastExchange
 Input [4]: [s_store_sk#12, s_store_name#13, s_state#15, s_zip#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#17]
 
 (20) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#3]
@@ -157,7 +157,7 @@ Condition : ((isnotnull(i_color#21) AND (i_color#21 = pale                )) AND
 
 (25) BroadcastExchange
 Input [6]: [i_item_sk#18, i_current_price#19, i_size#20, i_color#21, i_units#22, i_manager_id#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#24]
 
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
@@ -184,7 +184,7 @@ Condition : ((isnotnull(c_customer_sk#25) AND isnotnull(c_current_addr_sk#26)) A
 
 (31) BroadcastExchange
 Input [5]: [c_customer_sk#25, c_current_addr_sk#26, c_first_name#27, c_last_name#28, c_birth_country#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#30]
 
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#2]
@@ -211,7 +211,7 @@ Condition : ((isnotnull(ca_address_sk#31) AND isnotnull(ca_country#34)) AND isno
 
 (37) BroadcastExchange
 Input [4]: [ca_address_sk#31, ca_state#32, ca_zip#33, ca_country#34]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, false], upper(input[3, string, false]), input[2, string, false]),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, false], upper(input[3, string, false]), input[2, string, false]),false,false), [id=#35]
 
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [3]: [c_current_addr_sk#26, c_birth_country#29, s_zip#16]
@@ -353,7 +353,7 @@ Condition : isnotnull(i_item_sk#18)
 
 (61) BroadcastExchange
 Input [6]: [i_item_sk#18, i_current_price#19, i_size#20, i_color#21, i_units#22, i_manager_id#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#51]
 
 (62) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/explain.txt
@@ -109,7 +109,7 @@ Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_stat
 
 (8) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
@@ -148,7 +148,7 @@ Condition : ((isnotnull(s_state#17) AND (s_state#17 = TN)) AND isnotnull(s_store
 
 (17) BroadcastExchange
 Input [2]: [s_store_sk#16, s_state#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
@@ -175,7 +175,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#19, i_item_id#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -251,7 +251,7 @@ Input [2]: [s_store_sk#16, s_state#17]
 
 (39) BroadcastExchange
 Input [1]: [s_store_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#52]
 
 (40) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#3]
@@ -371,7 +371,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (66) BroadcastExchange
 Input [1]: [i_item_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#80]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#80]
 
 (67) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_item_sk#1]
@@ -436,7 +436,7 @@ Input [2]: [d_date_sk#15, d_year#109]
 
 (78) BroadcastExchange
 Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#110]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#110]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/explain.txt
@@ -109,7 +109,7 @@ Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_stat
 
 (8) BroadcastExchange
 Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
@@ -148,7 +148,7 @@ Condition : ((isnotnull(s_state#17) AND (s_state#17 = TN)) AND isnotnull(s_store
 
 (17) BroadcastExchange
 Input [2]: [s_store_sk#16, s_state#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
@@ -175,7 +175,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (23) BroadcastExchange
 Input [2]: [i_item_sk#19, i_item_id#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -263,7 +263,7 @@ Input [2]: [s_store_sk#16, s_state#17]
 
 (42) BroadcastExchange
 Input [1]: [s_store_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#52]
 
 (43) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#3]
@@ -371,7 +371,7 @@ Condition : isnotnull(i_item_sk#19)
 
 (66) BroadcastExchange
 Input [1]: [i_item_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#80]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#80]
 
 (67) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_item_sk#1]
@@ -436,7 +436,7 @@ Input [2]: [d_date_sk#15, d_year#109]
 
 (78) BroadcastExchange
 Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#110]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#110]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/explain.txt
@@ -83,7 +83,7 @@ Input [2]: [s_store_sk#8, s_county#9]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -114,7 +114,7 @@ Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_coun
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -224,6 +224,6 @@ Input [3]: [d_date_sk#7, d_year#29, d_dom#30]
 
 (40) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#31]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34/explain.txt
@@ -80,7 +80,7 @@ Input [2]: [s_store_sk#8, s_county#9]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
@@ -111,7 +111,7 @@ Input [4]: [hd_demo_sk#11, hd_buy_potential#12, hd_dep_count#13, hd_vehicle_coun
 
 (18) BroadcastExchange
 Input [1]: [hd_demo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
@@ -160,7 +160,7 @@ Condition : isnotnull(c_customer_sk#21)
 
 (28) BroadcastExchange
 Input [5]: [c_customer_sk#21, c_salutation#22, c_first_name#23, c_last_name#24, c_preferred_cust_flag#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
@@ -209,6 +209,6 @@ Input [3]: [d_date_sk#7, d_year#28, d_dom#29]
 
 (37) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#30]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35.sf100/explain.txt
@@ -319,7 +319,7 @@ Input [3]: [d_date_sk#10, d_year#81, d_qoy#82]
 
 (58) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#83]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#83]
 
 Subquery:2 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#13 IN dynamicpruning#9
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35/explain.txt
@@ -81,7 +81,7 @@ Input [3]: [ss_customer_sk#6, ss_sold_date_sk#7, d_date_sk#9]
 
 (9) BroadcastExchange
 Input [1]: [ss_customer_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#10]
 
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
@@ -112,7 +112,7 @@ Input [3]: [ws_bill_customer_sk#11, ws_sold_date_sk#12, d_date_sk#13]
 
 (16) BroadcastExchange
 Input [1]: [ws_bill_customer_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#14]
 
 (17) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
@@ -143,7 +143,7 @@ Input [3]: [cs_ship_customer_sk#15, cs_sold_date_sk#16, d_date_sk#17]
 
 (23) BroadcastExchange
 Input [1]: [cs_ship_customer_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#18]
 
 (24) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
@@ -174,7 +174,7 @@ Condition : isnotnull(ca_address_sk#19)
 
 (30) BroadcastExchange
 Input [2]: [ca_address_sk#19, ca_state#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#21]
 
 (31) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#5]
@@ -201,7 +201,7 @@ Condition : isnotnull(cd_demo_sk#22)
 
 (36) BroadcastExchange
 Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#28]
 
 (37) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#4]
@@ -264,7 +264,7 @@ Input [3]: [d_date_sk#9, d_year#78, d_qoy#79]
 
 (47) BroadcastExchange
 Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#80]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#80]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = ws_sold_date_sk#12 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/explain.txt
@@ -301,7 +301,7 @@ Input [3]: [d_date_sk#8, d_year#80, d_qoy#81]
 
 (55) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#82]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#82]
 
 Subquery:2 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a/explain.txt
@@ -79,7 +79,7 @@ Input [3]: [ss_customer_sk#4, ss_sold_date_sk#5, d_date_sk#7]
 
 (9) BroadcastExchange
 Input [1]: [ss_customer_sk#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#8]
 
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
@@ -134,7 +134,7 @@ Input [3]: [cs_ship_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15]
 
 (22) BroadcastExchange
 Input [1]: [customsk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,true), [id=#17]
 
 (23) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
@@ -161,7 +161,7 @@ Condition : isnotnull(ca_address_sk#18)
 
 (28) BroadcastExchange
 Input [2]: [ca_address_sk#18, ca_state#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#20]
 
 (29) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#3]
@@ -188,7 +188,7 @@ Condition : isnotnull(cd_demo_sk#21)
 
 (34) BroadcastExchange
 Input [6]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#27]
 
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#2]
@@ -251,7 +251,7 @@ Input [3]: [d_date_sk#7, d_year#77, d_qoy#78]
 
 (45) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#79]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#79]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = ws_sold_date_sk#10 IN dynamicpruning#6
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
@@ -89,7 +89,7 @@ Input [2]: [s_store_sk#8, s_state#9]
 
 (11) BroadcastExchange
 Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
@@ -116,7 +116,7 @@ Condition : isnotnull(i_item_sk#11)
 
 (17) BroadcastExchange
 Input [3]: [i_item_sk#11, i_class#12, i_category#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
@@ -271,6 +271,6 @@ Input [2]: [d_date_sk#7, d_year#71]
 
 (46) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#72]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#72]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/explain.txt
@@ -85,7 +85,7 @@ Condition : isnotnull(i_item_sk#8)
 
 (10) BroadcastExchange
 Input [3]: [i_item_sk#8, i_class#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
@@ -116,7 +116,7 @@ Input [2]: [s_store_sk#12, s_state#13]
 
 (17) BroadcastExchange
 Input [1]: [s_store_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#14]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
@@ -271,6 +271,6 @@ Input [2]: [d_date_sk#7, d_year#71]
 
 (46) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#72]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#72]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/explain.txt
@@ -96,7 +96,7 @@ Condition : ((isnotnull(s_store_sk#9) AND isnotnull(s_store_name#10)) AND isnotn
 
 (10) BroadcastExchange
 Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#12]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
@@ -304,6 +304,6 @@ Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR (
 
 (56) BroadcastExchange
 Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#51]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47/explain.txt
@@ -77,7 +77,7 @@ Condition : (isnotnull(ss_item_sk#4) AND isnotnull(ss_store_sk#5))
 
 (7) BroadcastExchange
 Input [4]: [ss_item_sk#4, ss_store_sk#5, ss_sales_price#6, ss_sold_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -116,7 +116,7 @@ Condition : ((isnotnull(s_store_sk#13) AND isnotnull(s_store_name#14)) AND isnot
 
 (16) BroadcastExchange
 Input [3]: [s_store_sk#13, s_store_name#14, s_company_name#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#16]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#5]
@@ -201,7 +201,7 @@ Input [8]: [i_category#26, i_brand#27, s_store_name#28, s_company_name#29, d_yea
 
 (35) BroadcastExchange
 Input [6]: [i_category#26, i_brand#27, s_store_name#28, s_company_name#29, sum_sales#36, rn#35]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], input[3, string, true], (input[5, int, false] + 1)),false), [id=#37]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], input[3, string, true], (input[5, int, false] + 1)),false,false), [id=#37]
 
 (36) BroadcastHashJoin [codegen id : 22]
 Left keys [5]: [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, rn#24]
@@ -229,7 +229,7 @@ Input [8]: [i_category#38, i_brand#39, s_store_name#40, s_company_name#41, d_yea
 
 (42) BroadcastExchange
 Input [6]: [i_category#38, i_brand#39, s_store_name#40, s_company_name#41, sum_sales#45, rn#44]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], input[3, string, true], (input[5, int, false] - 1)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], input[3, string, true], (input[5, int, false] - 1)),false,false), [id=#46]
 
 (43) BroadcastHashJoin [codegen id : 22]
 Left keys [5]: [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, rn#24]
@@ -269,6 +269,6 @@ Condition : ((((d_year#11 = 1999) OR ((d_year#11 = 1998) AND (d_moy#12 = 12))) O
 
 (49) BroadcastExchange
 Input [3]: [d_date_sk#10, d_year#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49.sf100/explain.txt
@@ -501,7 +501,7 @@ Input [3]: [d_date_sk#8, d_year#117, d_moy#118]
 
 (91) BroadcastExchange
 Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#119]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#119]
 
 Subquery:2 Hosting operator id = 28 Hosting Expression = cs_sold_date_sk#45 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49/explain.txt
@@ -99,7 +99,7 @@ Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_ne
 
 (5) BroadcastExchange
 Input [5]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_sold_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false,false), [id=#8]
 
 (6) Scan parquet default.web_returns
 Output [5]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12, wr_returned_date_sk#13]
@@ -207,7 +207,7 @@ Input [6]: [cs_item_sk#39, cs_order_number#40, cs_quantity#41, cs_net_paid#42, c
 
 (29) BroadcastExchange
 Input [5]: [cs_item_sk#39, cs_order_number#40, cs_quantity#41, cs_net_paid#42, cs_sold_date_sk#44]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false), [id=#45]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false,false), [id=#45]
 
 (30) Scan parquet default.catalog_returns
 Output [5]: [cr_item_sk#46, cr_order_number#47, cr_return_quantity#48, cr_return_amount#49, cr_returned_date_sk#50]
@@ -315,7 +315,7 @@ Input [6]: [ss_item_sk#76, ss_ticket_number#77, ss_quantity#78, ss_net_paid#79, 
 
 (53) BroadcastExchange
 Input [5]: [ss_item_sk#76, ss_ticket_number#77, ss_quantity#78, ss_net_paid#79, ss_sold_date_sk#81]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false), [id=#82]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] as bigint), 32) | (cast(input[0, int, true] as bigint) & 4294967295))),false,false), [id=#82]
 
 (54) Scan parquet default.store_returns
 Output [5]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86, sr_returned_date_sk#87]
@@ -456,7 +456,7 @@ Input [3]: [d_date_sk#14, d_year#114, d_moy#115]
 
 (82) BroadcastExchange
 Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#116]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#116]
 
 Subquery:2 Hosting operator id = 25 Hosting Expression = cs_sold_date_sk#44 IN dynamicpruning#7
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/explain.txt
@@ -418,7 +418,7 @@ Input [3]: [d_date_sk#5, d_date#6, d_month_seq#74]
 
 (75) BroadcastExchange
 Input [2]: [d_date_sk#5, d_date#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#75]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#75]
 
 Subquery:2 Hosting operator id = 28 Hosting Expression = ss_sold_date_sk#31 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a/explain.txt
@@ -146,7 +146,7 @@ Input [5]: [item_sk#11, d_date#15, sumws#12, ws_item_sk#16, rk#17]
 
 (18) BroadcastExchange
 Input [3]: [item_sk#18, sumws#19, rk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#20]
 
 (19) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [item_sk#11]
@@ -261,7 +261,7 @@ Input [5]: [item_sk#38, d_date#42, sumss#39, ss_item_sk#43, rk#44]
 
 (43) BroadcastExchange
 Input [3]: [item_sk#45, sumss#46, rk#44]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#47]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#47]
 
 (44) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [item_sk#38]
@@ -340,7 +340,7 @@ Input [5]: [item_sk#56, d_date#57, web_sales#58, store_sales#59, rk#62]
 
 (61) BroadcastExchange
 Input [4]: [item_sk#63, web_sales#64, store_sales#65, rk#62]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#66]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#66]
 
 (62) BroadcastHashJoin [codegen id : 54]
 Left keys [1]: [item_sk#56]
@@ -403,7 +403,7 @@ Input [3]: [d_date_sk#5, d_date#6, d_month_seq#75]
 
 (72) BroadcastExchange
 Input [2]: [d_date_sk#5, d_date#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#76]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#76]
 
 Subquery:2 Hosting operator id = 26 Hosting Expression = ss_sold_date_sk#31 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/explain.txt
@@ -96,7 +96,7 @@ Condition : (isnotnull(cc_call_center_sk#9) AND isnotnull(cc_name#10))
 
 (10) BroadcastExchange
 Input [2]: [cc_call_center_sk#9, cc_name#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_call_center_sk#1]
@@ -304,6 +304,6 @@ Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR (
 
 (56) BroadcastExchange
 Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#48]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57/explain.txt
@@ -77,7 +77,7 @@ Condition : (isnotnull(cs_item_sk#5) AND isnotnull(cs_call_center_sk#4))
 
 (7) BroadcastExchange
 Input [4]: [cs_call_center_sk#4, cs_item_sk#5, cs_sales_price#6, cs_sold_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false,false), [id=#9]
 
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
@@ -116,7 +116,7 @@ Condition : (isnotnull(cc_call_center_sk#13) AND isnotnull(cc_name#14))
 
 (16) BroadcastExchange
 Input [2]: [cc_call_center_sk#13, cc_name#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_call_center_sk#4]
@@ -201,7 +201,7 @@ Input [7]: [i_category#25, i_brand#26, cc_name#27, d_year#28, d_moy#29, sum_sale
 
 (35) BroadcastExchange
 Input [5]: [i_category#25, i_brand#26, cc_name#27, sum_sales#34, rn#33]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], (input[4, int, false] + 1)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], (input[4, int, false] + 1)),false,false), [id=#35]
 
 (36) BroadcastHashJoin [codegen id : 22]
 Left keys [4]: [i_category#3, i_brand#2, cc_name#14, rn#23]
@@ -229,7 +229,7 @@ Input [7]: [i_category#36, i_brand#37, cc_name#38, d_year#39, d_moy#40, sum_sale
 
 (42) BroadcastExchange
 Input [5]: [i_category#36, i_brand#37, cc_name#38, sum_sales#42, rn#41]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], (input[4, int, false] - 1)),false), [id=#43]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, string, true], input[2, string, true], (input[4, int, false] - 1)),false,false), [id=#43]
 
 (43) BroadcastHashJoin [codegen id : 22]
 Left keys [4]: [i_category#3, i_brand#2, cc_name#14, rn#23]
@@ -269,6 +269,6 @@ Condition : ((((d_year#11 = 1999) OR ((d_year#11 = 1998) AND (d_moy#12 = 12))) O
 
 (49) BroadcastExchange
 Input [3]: [d_date_sk#10, d_year#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#46]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/explain.txt
@@ -147,7 +147,7 @@ Condition : isnotnull(s_store_sk#22)
 
 (13) BroadcastExchange
 Input [2]: [s_store_sk#22, s_store_id#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#24]
 
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [store_sk#6]
@@ -244,7 +244,7 @@ Condition : isnotnull(cp_catalog_page_sk#64)
 
 (34) BroadcastExchange
 Input [2]: [cp_catalog_page_sk#64, cp_catalog_page_id#65]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#66]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#66]
 
 (35) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [page_sk#48]
@@ -375,7 +375,7 @@ Condition : isnotnull(web_site_sk#113)
 
 (63) BroadcastExchange
 Input [2]: [web_site_sk#113, web_site_id#114]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#115]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#115]
 
 (64) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [wsr_web_site_sk#90]
@@ -546,7 +546,7 @@ Input [2]: [d_date_sk#25, d_date#199]
 
 (95) BroadcastExchange
 Input [1]: [d_date_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#200]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#200]
 
 Subquery:2 Hosting operator id = 5 Hosting Expression = sr_returned_date_sk#15 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/explain.txt
@@ -156,7 +156,7 @@ Condition : isnotnull(s_store_sk#23)
 
 (16) BroadcastExchange
 Input [2]: [s_store_sk#23, s_store_id#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (17) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [store_sk#6]
@@ -253,7 +253,7 @@ Condition : isnotnull(cp_catalog_page_sk#65)
 
 (37) BroadcastExchange
 Input [2]: [cp_catalog_page_sk#65, cp_catalog_page_id#66]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#67]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#67]
 
 (38) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [page_sk#48]
@@ -313,7 +313,7 @@ Input [5]: [wr_item_sk#96, wr_order_number#97, wr_return_amt#98, wr_net_loss#99,
 
 (49) BroadcastExchange
 Input [5]: [wr_item_sk#96, wr_order_number#97, wr_return_amt#98, wr_net_loss#99, wr_returned_date_sk#100]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, true] as bigint), 32) | (cast(input[1, int, true] as bigint) & 4294967295))),false), [id=#101]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, true] as bigint), 32) | (cast(input[1, int, true] as bigint) & 4294967295))),false,false), [id=#101]
 
 (50) Scan parquet default.web_sales
 Output [4]: [ws_item_sk#102, ws_web_site_sk#103, ws_order_number#104, ws_sold_date_sk#105]
@@ -372,7 +372,7 @@ Condition : isnotnull(web_site_sk#113)
 
 (63) BroadcastExchange
 Input [2]: [web_site_sk#113, web_site_id#114]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#115]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#115]
 
 (64) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [wsr_web_site_sk#90]
@@ -531,7 +531,7 @@ Input [2]: [d_date_sk#22, d_date#198]
 
 (92) BroadcastExchange
 Input [1]: [d_date_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#199]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#199]
 
 Subquery:2 Hosting operator id = 5 Hosting Expression = sr_returned_date_sk#15 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
@@ -109,7 +109,7 @@ Results [2]: [cast((avg(UnscaledValue(i_current_price#8))#15 / 100.0) as decimal
 
 (13) BroadcastExchange
 Input [2]: [avg(i_current_price)#16, i_category#9]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false,false), [id=#17]
 
 (14) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_category#7]
@@ -126,7 +126,7 @@ Input [5]: [i_item_sk#5, i_current_price#6, i_category#7, avg(i_current_price)#1
 
 (17) BroadcastExchange
 Input [1]: [i_item_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
@@ -283,7 +283,7 @@ Input [2]: [d_date_sk#19, d_month_seq#34]
 
 (50) BroadcastExchange
 Input [1]: [d_date_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#37]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#37]
 
 Subquery:2 Hosting operator id = 48 Hosting Expression = Subquery scalar-subquery#35, [id=#36]
 * HashAggregate (57)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/explain.txt
@@ -70,7 +70,7 @@ Condition : (isnotnull(c_current_addr_sk#4) AND isnotnull(c_customer_sk#3))
 
 (7) BroadcastExchange
 Input [2]: [c_customer_sk#3, c_current_addr_sk#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [id=#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false,false), [id=#5]
 
 (8) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ca_address_sk#1]
@@ -98,7 +98,7 @@ Condition : (isnotnull(ss_customer_sk#7) AND isnotnull(ss_item_sk#6))
 
 (13) BroadcastExchange
 Input [3]: [ss_item_sk#6, ss_customer_sk#7, ss_sold_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false,false), [id=#10]
 
 (14) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_customer_sk#3]
@@ -169,7 +169,7 @@ Results [2]: [cast((avg(UnscaledValue(i_current_price#15))#22 / 100.0) as decima
 
 (28) BroadcastExchange
 Input [2]: [avg(i_current_price)#23, i_category#16]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false,false), [id=#24]
 
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_category#14]
@@ -186,7 +186,7 @@ Input [5]: [i_item_sk#12, i_current_price#13, i_category#14, avg(i_current_price
 
 (32) BroadcastExchange
 Input [1]: [i_item_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (33) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#6]
@@ -253,7 +253,7 @@ Input [2]: [d_date_sk#11, d_month_seq#32]
 
 (44) BroadcastExchange
 Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#35]
 
 Subquery:2 Hosting operator id = 42 Hosting Expression = Subquery scalar-subquery#33, [id=#34]
 * HashAggregate (51)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/explain.txt
@@ -357,7 +357,7 @@ Input [3]: [cs_item_sk#19, sale#40, refund#41]
 
 (33) BroadcastExchange
 Input [1]: [cs_item_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#42]
 
 (34) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_item_sk#1]
@@ -396,7 +396,7 @@ Condition : ((isnotnull(s_store_sk#45) AND isnotnull(s_store_name#46)) AND isnot
 
 (42) BroadcastExchange
 Input [3]: [s_store_sk#45, s_store_name#46, s_zip#47]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#48]
 
 (43) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_store_sk#6]
@@ -462,7 +462,7 @@ Condition : isnotnull(d_date_sk#57)
 
 (57) BroadcastExchange
 Input [2]: [d_date_sk#57, d_year#58]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#59]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#59]
 
 (58) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [c_first_sales_date_sk#55]
@@ -564,7 +564,7 @@ Condition : isnotnull(p_promo_sk#69)
 
 (81) BroadcastExchange
 Input [1]: [p_promo_sk#69]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#70]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#70]
 
 (82) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [ss_promo_sk#7]
@@ -591,7 +591,7 @@ Condition : (isnotnull(hd_demo_sk#71) AND isnotnull(hd_income_band_sk#72))
 
 (87) BroadcastExchange
 Input [2]: [hd_demo_sk#71, hd_income_band_sk#72]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#73]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#73]
 
 (88) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [ss_hdemo_sk#4]
@@ -693,7 +693,7 @@ Condition : isnotnull(ib_income_band_sk#89)
 
 (111) BroadcastExchange
 Input [1]: [ib_income_band_sk#89]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#90]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#90]
 
 (112) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [hd_income_band_sk#72]
@@ -736,7 +736,7 @@ Input [4]: [i_item_sk#92, i_current_price#93, i_color#94, i_product_name#95]
 
 (121) BroadcastExchange
 Input [2]: [i_item_sk#92, i_product_name#95]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#96]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#96]
 
 (122) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [ss_item_sk#1]
@@ -1132,7 +1132,7 @@ Condition : ((isnotnull(d_year#44) AND (d_year#44 = 1999)) AND isnotnull(d_date_
 
 (213) BroadcastExchange
 Input [2]: [d_date_sk#43, d_year#44]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#205]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#205]
 
 Subquery:2 Hosting operator id = 129 Hosting Expression = ss_sold_date_sk#139 IN dynamicpruning#140
 BroadcastExchange (217)
@@ -1157,6 +1157,6 @@ Condition : ((isnotnull(d_year#146) AND (d_year#146 = 2000)) AND isnotnull(d_dat
 
 (217) BroadcastExchange
 Input [2]: [d_date_sk#145, d_year#146]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#206]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#206]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64/explain.txt
@@ -201,7 +201,7 @@ Condition : (((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AN
 
 (4) BroadcastExchange
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[7, int, false] as bigint) & 4294967295))),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[7, int, false] as bigint) & 4294967295))),false,false), [id=#14]
 
 (5) Scan parquet default.store_returns
 Output [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
@@ -366,7 +366,7 @@ Condition : ((isnotnull(s_store_sk#44) AND isnotnull(s_store_name#45)) AND isnot
 
 (41) BroadcastExchange
 Input [3]: [s_store_sk#44, s_store_name#45, s_zip#46]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#47]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#47]
 
 (42) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_store_sk#6]
@@ -393,7 +393,7 @@ Condition : (((((isnotnull(c_customer_sk#48) AND isnotnull(c_first_sales_date_sk
 
 (47) BroadcastExchange
 Input [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#54]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#54]
 
 (48) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_customer_sk#2]
@@ -420,7 +420,7 @@ Condition : isnotnull(d_date_sk#55)
 
 (53) BroadcastExchange
 Input [2]: [d_date_sk#55, d_year#56]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#57]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#57]
 
 (54) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [c_first_sales_date_sk#53]
@@ -459,7 +459,7 @@ Condition : (isnotnull(cd_demo_sk#60) AND isnotnull(cd_marital_status#61))
 
 (62) BroadcastExchange
 Input [2]: [cd_demo_sk#60, cd_marital_status#61]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#62]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#62]
 
 (63) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_cdemo_sk#3]
@@ -498,7 +498,7 @@ Condition : isnotnull(p_promo_sk#65)
 
 (71) BroadcastExchange
 Input [1]: [p_promo_sk#65]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#66]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#66]
 
 (72) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_promo_sk#7]
@@ -525,7 +525,7 @@ Condition : (isnotnull(hd_demo_sk#67) AND isnotnull(hd_income_band_sk#68))
 
 (77) BroadcastExchange
 Input [2]: [hd_demo_sk#67, hd_income_band_sk#68]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#69]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#69]
 
 (78) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_hdemo_sk#4]
@@ -564,7 +564,7 @@ Condition : isnotnull(ca_address_sk#72)
 
 (86) BroadcastExchange
 Input [5]: [ca_address_sk#72, ca_street_number#73, ca_street_name#74, ca_city#75, ca_zip#76]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#77]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#77]
 
 (87) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_addr_sk#5]
@@ -603,7 +603,7 @@ Condition : isnotnull(ib_income_band_sk#83)
 
 (95) BroadcastExchange
 Input [1]: [ib_income_band_sk#83]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#84]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#84]
 
 (96) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [hd_income_band_sk#68]
@@ -646,7 +646,7 @@ Input [4]: [i_item_sk#86, i_current_price#87, i_color#88, i_product_name#89]
 
 (105) BroadcastExchange
 Input [2]: [i_item_sk#86, i_product_name#89]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#90]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#90]
 
 (106) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
@@ -696,7 +696,7 @@ Condition : (((((((isnotnull(ss_item_sk#121) AND isnotnull(ss_ticket_number#128)
 
 (115) BroadcastExchange
 Input [12]: [ss_item_sk#121, ss_customer_sk#122, ss_cdemo_sk#123, ss_hdemo_sk#124, ss_addr_sk#125, ss_store_sk#126, ss_promo_sk#127, ss_ticket_number#128, ss_wholesale_cost#129, ss_list_price#130, ss_coupon_amt#131, ss_sold_date_sk#132]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[7, int, false] as bigint) & 4294967295))),false), [id=#134]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false] as bigint), 32) | (cast(input[7, int, false] as bigint) & 4294967295))),false,false), [id=#134]
 
 (116) Scan parquet default.store_returns
 Output [3]: [sr_item_sk#135, sr_ticket_number#136, sr_returned_date_sk#137]
@@ -1008,7 +1008,7 @@ Condition : ((isnotnull(d_year#43) AND (d_year#43 = 1999)) AND isnotnull(d_date_
 
 (187) BroadcastExchange
 Input [2]: [d_date_sk#42, d_year#43]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#201]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#201]
 
 Subquery:2 Hosting operator id = 112 Hosting Expression = ss_sold_date_sk#132 IN dynamicpruning#133
 BroadcastExchange (191)
@@ -1033,6 +1033,6 @@ Condition : ((isnotnull(d_year#148) AND (d_year#148 = 2000)) AND isnotnull(d_dat
 
 (191) BroadcastExchange
 Input [2]: [d_date_sk#147, d_year#148]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#202]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#202]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/explain.txt
@@ -114,7 +114,7 @@ Condition : isnotnull(s_store_sk#11)
 
 (10) BroadcastExchange
 Input [2]: [s_store_sk#11, s_store_id#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#13]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
@@ -458,6 +458,6 @@ Input [5]: [d_date_sk#7, d_month_seq#139, d_year#8, d_moy#9, d_qoy#10]
 
 (75) BroadcastExchange
 Input [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#140]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#140]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a/explain.txt
@@ -111,7 +111,7 @@ Condition : isnotnull(s_store_sk#11)
 
 (10) BroadcastExchange
 Input [2]: [s_store_sk#11, s_store_id#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#13]
 
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
@@ -138,7 +138,7 @@ Condition : isnotnull(i_item_sk#14)
 
 (16) BroadcastExchange
 Input [5]: [i_item_sk#14, i_brand#15, i_class#16, i_category#17, i_product_name#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
@@ -443,6 +443,6 @@ Input [5]: [d_date_sk#7, d_month_seq#138, d_year#8, d_moy#9, d_qoy#10]
 
 (72) BroadcastExchange
 Input [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#139]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#139]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/explain.txt
@@ -140,7 +140,7 @@ Condition : isnotnull(s_store_sk#13)
 
 (19) BroadcastExchange
 Input [2]: [s_store_sk#13, s_state#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#15]
 
 (20) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#9]
@@ -187,7 +187,7 @@ Input [4]: [s_state#14, s_state#14, _w2#20, ranking#21]
 
 (29) BroadcastExchange
 Input [1]: [s_state#14]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,true), [id=#22]
 
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_state#8]
@@ -196,7 +196,7 @@ Join condition: None
 
 (31) BroadcastExchange
 Input [3]: [s_store_sk#6, s_county#7, s_state#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#1]
@@ -351,7 +351,7 @@ Input [2]: [d_date_sk#5, d_month_seq#62]
 
 (60) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#63]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/explain.txt
@@ -128,7 +128,7 @@ Condition : isnotnull(s_store_sk#12)
 
 (16) BroadcastExchange
 Input [2]: [s_store_sk#12, s_state#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#9]
@@ -187,7 +187,7 @@ Input [4]: [s_state#13, s_state#13, _w2#20, ranking#21]
 
 (29) BroadcastExchange
 Input [1]: [s_state#13]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,true), [id=#22]
 
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_state#8]
@@ -196,7 +196,7 @@ Join condition: None
 
 (31) BroadcastExchange
 Input [3]: [s_store_sk#6, s_county#7, s_state#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#23]
 
 (32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#1]
@@ -351,7 +351,7 @@ Input [2]: [d_date_sk#5, d_month_seq#62]
 
 (60) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#63]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
@@ -106,7 +106,7 @@ Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
 
 (8) BroadcastExchange
 Input [1]: [hd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#12]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_hdemo_sk#3]
@@ -137,7 +137,7 @@ Input [2]: [cd_demo_sk#13, cd_marital_status#14]
 
 (15) BroadcastExchange
 Input [1]: [cd_demo_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#15]
 
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
@@ -164,7 +164,7 @@ Condition : (isnotnull(d_date#17) AND isnotnull(d_date_sk#16))
 
 (21) BroadcastExchange
 Input [2]: [d_date_sk#16, d_date#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#18]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_ship_date_sk#1]
@@ -265,7 +265,7 @@ Condition : isnotnull(w_warehouse_sk#32)
 
 (44) BroadcastExchange
 Input [2]: [w_warehouse_sk#32, w_warehouse_name#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#34]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#34]
 
 (45) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [inv_warehouse_sk#29]
@@ -309,7 +309,7 @@ Condition : isnotnull(p_promo_sk#36)
 
 (54) BroadcastExchange
 Input [1]: [p_promo_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#37]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#37]
 
 (55) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [cs_promo_sk#5]
@@ -421,7 +421,7 @@ Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_year#50]
 
 (75) BroadcastExchange
 Input [3]: [d_date_sk#23, d_date#24, d_week_seq#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false,false), [id=#51]
 
 (76) Scan parquet default.date_dim
 Output [2]: [d_date_sk#26, d_week_seq#52]
@@ -448,6 +448,6 @@ Input [5]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26, d_week_seq#52]
 
 (81) BroadcastExchange
 Input [4]: [d_date_sk#23, d_date#24, d_week_seq#25, d_date_sk#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#53]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#53]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/explain.txt
@@ -103,7 +103,7 @@ Condition : ((isnotnull(inv_quantity_on_hand#12) AND isnotnull(inv_item_sk#10)) 
 
 (7) BroadcastExchange
 Input [4]: [inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12, inv_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#14]
 
 (8) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
@@ -130,7 +130,7 @@ Condition : isnotnull(w_warehouse_sk#15)
 
 (13) BroadcastExchange
 Input [2]: [w_warehouse_sk#15, w_warehouse_name#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#17]
 
 (14) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [inv_warehouse_sk#11]
@@ -157,7 +157,7 @@ Condition : isnotnull(i_item_sk#18)
 
 (19) BroadcastExchange
 Input [2]: [i_item_sk#18, i_item_desc#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#20]
 
 (20) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
@@ -188,7 +188,7 @@ Input [2]: [cd_demo_sk#21, cd_marital_status#22]
 
 (26) BroadcastExchange
 Input [1]: [cd_demo_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#23]
 
 (27) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_bill_cdemo_sk#2]
@@ -219,7 +219,7 @@ Input [2]: [hd_demo_sk#24, hd_buy_potential#25]
 
 (33) BroadcastExchange
 Input [1]: [hd_demo_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_bill_hdemo_sk#3]
@@ -258,7 +258,7 @@ Condition : (isnotnull(d_week_seq#31) AND isnotnull(d_date_sk#30))
 
 (42) BroadcastExchange
 Input [2]: [d_date_sk#30, d_week_seq#31]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, false] as bigint), 32) | (cast(input[0, int, false] as bigint) & 4294967295))),false), [id=#32]
+Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, false] as bigint), 32) | (cast(input[0, int, false] as bigint) & 4294967295))),false,false), [id=#32]
 
 (43) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [d_week_seq#29, inv_date_sk#13]
@@ -285,7 +285,7 @@ Condition : (isnotnull(d_date#34) AND isnotnull(d_date_sk#33))
 
 (48) BroadcastExchange
 Input [2]: [d_date_sk#33, d_date#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#35]
 
 (49) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_ship_date_sk#1]
@@ -312,7 +312,7 @@ Condition : isnotnull(p_promo_sk#36)
 
 (54) BroadcastExchange
 Input [1]: [p_promo_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#37]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#37]
 
 (55) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_promo_sk#5]
@@ -418,6 +418,6 @@ Input [4]: [d_date_sk#27, d_date#28, d_week_seq#29, d_year#50]
 
 (75) BroadcastExchange
 Input [3]: [d_date_sk#27, d_date#28, d_week_seq#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#51]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74.sf100/explain.txt
@@ -463,7 +463,7 @@ Condition : (((isnotnull(d_year#6) AND (d_year#6 = 2001)) AND d_year#6 IN (2001,
 
 (83) BroadcastExchange
 Input [2]: [d_date_sk#5, d_year#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#72]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#72]
 
 Subquery:2 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#22 IN dynamicpruning#23
 BroadcastExchange (87)
@@ -488,7 +488,7 @@ Condition : (((isnotnull(d_year#25) AND (d_year#25 = 2002)) AND d_year#25 IN (20
 
 (87) BroadcastExchange
 Input [2]: [d_date_sk#24, d_year#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#73]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#73]
 
 Subquery:3 Hosting operator id = 40 Hosting Expression = ws_sold_date_sk#41 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74/explain.txt
@@ -103,7 +103,7 @@ Condition : isnotnull(ss_customer_sk#5)
 
 (7) BroadcastExchange
 Input [3]: [ss_customer_sk#5, ss_net_paid#6, ss_sold_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [c_customer_sk#1]
@@ -179,7 +179,7 @@ Condition : isnotnull(ss_customer_sk#22)
 
 (23) BroadcastExchange
 Input [3]: [ss_customer_sk#22, ss_net_paid#23, ss_sold_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#26]
 
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#18]
@@ -222,7 +222,7 @@ Results [4]: [c_customer_id#19 AS customer_id#32, c_first_name#20 AS customer_fi
 
 (32) BroadcastExchange
 Input [4]: [customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#36]
 
 (33) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#16]
@@ -260,7 +260,7 @@ Condition : isnotnull(ws_bill_customer_sk#41)
 
 (40) BroadcastExchange
 Input [3]: [ws_bill_customer_sk#41, ws_net_paid#42, ws_sold_date_sk#43]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#44]
 
 (41) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#37]
@@ -307,7 +307,7 @@ Condition : (isnotnull(year_total#52) AND (year_total#52 > 0.00))
 
 (50) BroadcastExchange
 Input [2]: [customer_id#51, year_total#52]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#53]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#53]
 
 (51) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#16]
@@ -349,7 +349,7 @@ Condition : isnotnull(ws_bill_customer_sk#58)
 
 (59) BroadcastExchange
 Input [3]: [ws_bill_customer_sk#58, ws_net_paid#59, ws_sold_date_sk#60]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#61]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#61]
 
 (60) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#54]
@@ -392,7 +392,7 @@ Results [2]: [c_customer_id#55 AS customer_id#67, MakeDecimal(sum(UnscaledValue(
 
 (68) BroadcastExchange
 Input [2]: [customer_id#67, year_total#68]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#69]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false,false), [id=#69]
 
 (69) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#16]
@@ -432,7 +432,7 @@ Condition : (((isnotnull(d_year#11) AND (d_year#11 = 2001)) AND d_year#11 IN (20
 
 (75) BroadcastExchange
 Input [2]: [d_date_sk#10, d_year#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#70]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#70]
 
 Subquery:2 Hosting operator id = 20 Hosting Expression = ss_sold_date_sk#24 IN dynamicpruning#25
 BroadcastExchange (79)
@@ -457,7 +457,7 @@ Condition : (((isnotnull(d_year#28) AND (d_year#28 = 2002)) AND d_year#28 IN (20
 
 (79) BroadcastExchange
 Input [2]: [d_date_sk#27, d_year#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#71]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#71]
 
 Subquery:3 Hosting operator id = 37 Hosting Expression = ws_sold_date_sk#43 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
@@ -163,7 +163,7 @@ Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_categor
 
 (8) BroadcastExchange
 Input [5]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#1]
@@ -712,7 +712,7 @@ Condition : ((isnotnull(d_year#15) AND (d_year#15 = 2002)) AND isnotnull(d_date_
 
 (131) BroadcastExchange
 Input [2]: [d_date_sk#14, d_year#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#143]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#143]
 
 Subquery:2 Hosting operator id = 24 Hosting Expression = ss_sold_date_sk#29 IN dynamicpruning#6
 
@@ -741,7 +741,7 @@ Condition : ((isnotnull(d_year#90) AND (d_year#90 = 2001)) AND isnotnull(d_date_
 
 (135) BroadcastExchange
 Input [2]: [d_date_sk#89, d_year#90]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#144]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#144]
 
 Subquery:5 Hosting operator id = 86 Hosting Expression = ss_sold_date_sk#100 IN dynamicpruning#83
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/explain.txt
@@ -163,7 +163,7 @@ Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_categor
 
 (8) BroadcastExchange
 Input [5]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#13]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#1]
@@ -712,7 +712,7 @@ Condition : ((isnotnull(d_year#15) AND (d_year#15 = 2002)) AND isnotnull(d_date_
 
 (131) BroadcastExchange
 Input [2]: [d_date_sk#14, d_year#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#143]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#143]
 
 Subquery:2 Hosting operator id = 24 Hosting Expression = ss_sold_date_sk#29 IN dynamicpruning#6
 
@@ -741,7 +741,7 @@ Condition : ((isnotnull(d_year#90) AND (d_year#90 = 2001)) AND isnotnull(d_date_
 
 (135) BroadcastExchange
 Input [2]: [d_date_sk#89, d_year#90]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#144]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#144]
 
 Subquery:5 Hosting operator id = 86 Hosting Expression = ss_sold_date_sk#100 IN dynamicpruning#83
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/explain.txt
@@ -142,7 +142,7 @@ Condition : isnotnull(s_store_sk#7)
 
 (10) BroadcastExchange
 Input [1]: [s_store_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
@@ -230,7 +230,7 @@ Results [3]: [s_store_sk#23, MakeDecimal(sum(UnscaledValue(sr_return_amt#19))#29
 
 (28) BroadcastExchange
 Input [3]: [s_store_sk#23, returns#31, profit_loss#32]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#33]
 
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [s_store_sk#7]
@@ -375,7 +375,7 @@ Condition : isnotnull(wp_web_page_sk#74)
 
 (59) BroadcastExchange
 Input [1]: [wp_web_page_sk#74]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#75]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#75]
 
 (60) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_web_page_sk#69]
@@ -463,7 +463,7 @@ Results [3]: [wp_web_page_sk#90, MakeDecimal(sum(UnscaledValue(wr_return_amt#86)
 
 (77) BroadcastExchange
 Input [3]: [wp_web_page_sk#90, returns#98, profit_loss#99]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#100]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#100]
 
 (78) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [wp_web_page_sk#74]
@@ -604,7 +604,7 @@ Input [2]: [d_date_sk#6, d_date#169]
 
 (103) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#170]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#170]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = sr_returned_date_sk#21 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/explain.txt
@@ -142,7 +142,7 @@ Condition : isnotnull(s_store_sk#7)
 
 (10) BroadcastExchange
 Input [1]: [s_store_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#8]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
@@ -230,7 +230,7 @@ Results [3]: [s_store_sk#23, MakeDecimal(sum(UnscaledValue(sr_return_amt#19))#29
 
 (28) BroadcastExchange
 Input [3]: [s_store_sk#23, returns#31, profit_loss#32]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#33]
 
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [s_store_sk#7]
@@ -375,7 +375,7 @@ Condition : isnotnull(wp_web_page_sk#74)
 
 (59) BroadcastExchange
 Input [1]: [wp_web_page_sk#74]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#75]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#75]
 
 (60) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_web_page_sk#69]
@@ -463,7 +463,7 @@ Results [3]: [wp_web_page_sk#90, MakeDecimal(sum(UnscaledValue(wr_return_amt#86)
 
 (77) BroadcastExchange
 Input [3]: [wp_web_page_sk#90, returns#98, profit_loss#99]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#100]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#100]
 
 (78) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [wp_web_page_sk#74]
@@ -604,7 +604,7 @@ Input [2]: [d_date_sk#6, d_date#169]
 
 (103) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#170]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#170]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = sr_returned_date_sk#21 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78.sf100/explain.txt
@@ -414,7 +414,7 @@ Condition : ((isnotnull(d_year#15) AND (d_year#15 = 2000)) AND isnotnull(d_date_
 
 (74) BroadcastExchange
 Input [2]: [d_date_sk#14, d_year#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#95]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#95]
 
 Subquery:2 Hosting operator id = 22 Hosting Expression = ws_sold_date_sk#36 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/explain.txt
@@ -414,7 +414,7 @@ Condition : ((isnotnull(d_year#15) AND (d_year#15 = 2000)) AND isnotnull(d_date_
 
 (74) BroadcastExchange
 Input [2]: [d_date_sk#14, d_year#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#95]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#95]
 
 Subquery:2 Hosting operator id = 22 Hosting Expression = ws_sold_date_sk#36 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
@@ -199,7 +199,7 @@ Input [2]: [i_item_sk#16, i_current_price#17]
 
 (18) BroadcastExchange
 Input [1]: [i_item_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#18]
 
 (19) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
@@ -230,7 +230,7 @@ Input [2]: [p_promo_sk#19, p_channel_tv#20]
 
 (25) BroadcastExchange
 Input [1]: [p_promo_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#21]
 
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
@@ -269,7 +269,7 @@ Condition : isnotnull(s_store_sk#23)
 
 (34) BroadcastExchange
 Input [2]: [s_store_sk#23, s_store_id#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#25]
 
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
@@ -408,7 +408,7 @@ Condition : isnotnull(cp_catalog_page_sk#62)
 
 (65) BroadcastExchange
 Input [2]: [cp_catalog_page_sk#62, cp_catalog_page_id#63]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#64]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#64]
 
 (66) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_catalog_page_sk#45]
@@ -547,7 +547,7 @@ Condition : isnotnull(web_site_sk#101)
 
 (96) BroadcastExchange
 Input [2]: [web_site_sk#101, web_site_id#102]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#103]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#103]
 
 (97) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_web_site_sk#85]
@@ -706,7 +706,7 @@ Input [2]: [d_date_sk#22, d_date#187]
 
 (125) BroadcastExchange
 Input [1]: [d_date_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#188]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#188]
 
 Subquery:2 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#51 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a/explain.txt
@@ -207,7 +207,7 @@ Condition : isnotnull(s_store_sk#17)
 
 (20) BroadcastExchange
 Input [2]: [s_store_sk#17, s_store_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#19]
 
 (21) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
@@ -238,7 +238,7 @@ Input [2]: [i_item_sk#20, i_current_price#21]
 
 (27) BroadcastExchange
 Input [1]: [i_item_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#22]
 
 (28) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
@@ -269,7 +269,7 @@ Input [2]: [p_promo_sk#23, p_channel_tv#24]
 
 (34) BroadcastExchange
 Input [1]: [p_promo_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
@@ -384,7 +384,7 @@ Condition : isnotnull(cp_catalog_page_sk#60)
 
 (59) BroadcastExchange
 Input [2]: [cp_catalog_page_sk#60, cp_catalog_page_id#61]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#62]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#62]
 
 (60) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_catalog_page_sk#45]
@@ -523,7 +523,7 @@ Condition : isnotnull(web_site_sk#99)
 
 (90) BroadcastExchange
 Input [2]: [web_site_sk#99, web_site_id#100]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#101]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#101]
 
 (91) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_web_site_sk#85]
@@ -706,7 +706,7 @@ Input [2]: [d_date_sk#16, d_date#187]
 
 (125) BroadcastExchange
 Input [1]: [d_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#188]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#188]
 
 Subquery:2 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#51 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/explain.txt
@@ -78,7 +78,7 @@ Condition : isnotnull(i_item_sk#6)
 
 (10) BroadcastExchange
 Input [3]: [i_item_sk#6, i_class#7, i_category#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
@@ -233,6 +233,6 @@ Input [2]: [d_date_sk#5, d_month_seq#48]
 
 (39) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/explain.txt
@@ -78,7 +78,7 @@ Condition : isnotnull(i_item_sk#6)
 
 (10) BroadcastExchange
 Input [3]: [i_item_sk#6, i_class#7, i_category#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#9]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
@@ -233,6 +233,6 @@ Input [2]: [d_date_sk#5, d_month_seq#48]
 
 (39) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/explain.txt
@@ -163,6 +163,6 @@ Input [2]: [d_date_sk#13, d_date#25]
 
 (29) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98/explain.txt
@@ -53,7 +53,7 @@ Condition : (i_category#10 IN (Sports                                           
 
 (7) BroadcastExchange
 Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false,false), [id=#11]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
@@ -148,6 +148,6 @@ Input [2]: [d_date_sk#12, d_date#24]
 
 (26) BroadcastExchange
 Input [1]: [d_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false,false), [id=#25]
 
 

--- a/sql/core/src/test/resources/tpch-plan-stability/q10/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q10/explain.txt
@@ -62,7 +62,7 @@ Input [3]: [o_orderkey#8, o_custkey#9, o_orderdate#10]
 
 (8) BroadcastExchange
 Input [2]: [o_orderkey#8, o_custkey#9]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false,false), [id=#11]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_custkey#1]
@@ -93,7 +93,7 @@ Input [4]: [l_orderkey#12, l_extendedprice#13, l_discount#14, l_returnflag#15]
 
 (15) BroadcastExchange
 Input [3]: [l_orderkey#12, l_extendedprice#13, l_discount#14]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#16]
 
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [o_orderkey#8]
@@ -120,7 +120,7 @@ Condition : isnotnull(n_nationkey#17)
 
 (21) BroadcastExchange
 Input [2]: [n_nationkey#17, n_name#18]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#19]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_nationkey#4]

--- a/sql/core/src/test/resources/tpch-plan-stability/q11/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q11/explain.txt
@@ -53,7 +53,7 @@ Condition : (isnotnull(s_suppkey#5) AND isnotnull(s_nationkey#6))
 
 (7) BroadcastExchange
 Input [2]: [s_suppkey#5, s_nationkey#6]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#7]
 
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ps_suppkey#2]
@@ -84,7 +84,7 @@ Input [2]: [n_nationkey#8, n_name#9]
 
 (14) BroadcastExchange
 Input [1]: [n_nationkey#8]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#10]
 
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [s_nationkey#6]

--- a/sql/core/src/test/resources/tpch-plan-stability/q12/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q12/explain.txt
@@ -50,7 +50,7 @@ Input [5]: [l_orderkey#3, l_shipdate#4, l_commitdate#5, l_receiptdate#6, l_shipm
 
 (8) BroadcastExchange
 Input [2]: [l_orderkey#3, l_shipmode#7]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#8]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [o_orderkey#1]

--- a/sql/core/src/test/resources/tpch-plan-stability/q13/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q13/explain.txt
@@ -47,7 +47,7 @@ Input [3]: [o_orderkey#2, o_custkey#3, o_comment#4]
 
 (7) BroadcastExchange
 Input [2]: [o_orderkey#2, o_custkey#3]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false), [id=#5]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false,false), [id=#5]
 
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [c_custkey#1]

--- a/sql/core/src/test/resources/tpch-plan-stability/q14/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q14/explain.txt
@@ -48,7 +48,7 @@ Condition : isnotnull(p_partkey#5)
 
 (8) BroadcastExchange
 Input [2]: [p_partkey#5, p_type#6]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [l_partkey#1]

--- a/sql/core/src/test/resources/tpch-plan-stability/q15/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q15/explain.txt
@@ -73,7 +73,7 @@ Condition : (isnotnull(total_revenue#16) AND (total_revenue#16 = Subquery scalar
 
 (12) BroadcastExchange
 Input [2]: [supplier_no#15, total_revenue#16]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#19]
 
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [s_suppkey#1]

--- a/sql/core/src/test/resources/tpch-plan-stability/q16/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q16/explain.txt
@@ -58,7 +58,7 @@ Input [2]: [s_suppkey#3, s_comment#4]
 
 (8) BroadcastExchange
 Input [1]: [s_suppkey#3]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),true), [id=#5]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),true,true), [id=#5]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ps_suppkey#2]
@@ -81,7 +81,7 @@ Condition : (((((isnotnull(p_brand#7) AND isnotnull(p_type#8)) AND NOT (p_brand#
 
 (13) BroadcastExchange
 Input [4]: [p_partkey#6, p_brand#7, p_type#8, p_size#9]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#11]
 
 (14) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ps_partkey#1]

--- a/sql/core/src/test/resources/tpch-plan-stability/q17/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q17/explain.txt
@@ -58,7 +58,7 @@ Input [3]: [p_partkey#4, p_brand#5, p_container#6]
 
 (8) BroadcastExchange
 Input [1]: [p_partkey#4]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#8]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [l_partkey#1]
@@ -107,7 +107,7 @@ Condition : isnotnull((0.2 * avg(l_quantity))#17)
 
 (18) BroadcastExchange
 Input [2]: [(0.2 * avg(l_quantity))#17, l_partkey#9]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false,false), [id=#18]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [p_partkey#4]

--- a/sql/core/src/test/resources/tpch-plan-stability/q18/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q18/explain.txt
@@ -96,7 +96,7 @@ Input [2]: [l_orderkey#7, sum(l_quantity#15)#16]
 
 (14) BroadcastExchange
 Input [1]: [l_orderkey#7]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,true), [id=#17]
 
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [o_orderkey#3]
@@ -105,7 +105,7 @@ Join condition: None
 
 (16) BroadcastExchange
 Input [4]: [o_orderkey#3, o_custkey#4, o_totalprice#5, o_orderdate#6]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false,false), [id=#18]
 
 (17) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_custkey#1]
@@ -140,7 +140,7 @@ Join condition: None
 
 (24) BroadcastExchange
 Input [2]: [l_orderkey#19, l_quantity#15]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#20]
 
 (25) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [o_orderkey#3]

--- a/sql/core/src/test/resources/tpch-plan-stability/q19/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q19/explain.txt
@@ -48,7 +48,7 @@ Condition : (((isnotnull(p_size#9) AND (p_size#9 >= 1)) AND isnotnull(p_partkey#
 
 (8) BroadcastExchange
 Input [4]: [p_partkey#7, p_brand#8, p_size#9, p_container#10]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#14]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [l_partkey#1]

--- a/sql/core/src/test/resources/tpch-plan-stability/q2/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q2/explain.txt
@@ -90,7 +90,7 @@ Condition : ((isnotnull(ps_partkey#5) AND isnotnull(ps_supplycost#7)) AND isnotn
 
 (8) BroadcastExchange
 Input [3]: [ps_partkey#5, ps_suppkey#6, ps_supplycost#7]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#8]
 
 (9) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [p_partkey#1]
@@ -131,7 +131,7 @@ Condition : (isnotnull(s_suppkey#12) AND isnotnull(s_nationkey#13))
 
 (17) BroadcastExchange
 Input [2]: [s_suppkey#12, s_nationkey#13]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#14]
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ps_suppkey#10]
@@ -158,7 +158,7 @@ Condition : (isnotnull(n_nationkey#15) AND isnotnull(n_regionkey#16))
 
 (23) BroadcastExchange
 Input [2]: [n_nationkey#15, n_regionkey#16]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#17]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [s_nationkey#13]
@@ -189,7 +189,7 @@ Input [2]: [r_regionkey#18, r_name#19]
 
 (30) BroadcastExchange
 Input [1]: [r_regionkey#18]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#20]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#20]
 
 (31) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [n_regionkey#16]
@@ -224,7 +224,7 @@ Condition : isnotnull(min(ps_supplycost)#25)
 
 (37) BroadcastExchange
 Input [2]: [min(ps_supplycost)#25, ps_partkey#9]
-Arguments: HashedRelationBroadcastMode(List(input[0, decimal(10,0), false], input[1, bigint, true]),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(input[0, decimal(10,0), false], input[1, bigint, true]),false,false), [id=#26]
 
 (38) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [ps_supplycost#7, p_partkey#1]
@@ -251,7 +251,7 @@ Condition : (isnotnull(s_suppkey#27) AND isnotnull(s_nationkey#30))
 
 (43) BroadcastExchange
 Input [7]: [s_suppkey#27, s_name#28, s_address#29, s_nationkey#30, s_phone#31, s_acctbal#32, s_comment#33]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#34]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#34]
 
 (44) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ps_suppkey#6]
@@ -278,7 +278,7 @@ Condition : (isnotnull(n_nationkey#35) AND isnotnull(n_regionkey#37))
 
 (49) BroadcastExchange
 Input [3]: [n_nationkey#35, n_name#36, n_regionkey#37]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#38]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#38]
 
 (50) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [s_nationkey#30]

--- a/sql/core/src/test/resources/tpch-plan-stability/q20/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q20/explain.txt
@@ -86,7 +86,7 @@ Input [2]: [p_partkey#8, p_name#9]
 
 (11) BroadcastExchange
 Input [1]: [p_partkey#8]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,true), [id=#10]
 
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ps_partkey#5]
@@ -143,7 +143,7 @@ Condition : isnotnull((0.5 * sum(l_quantity))#21)
 
 (23) BroadcastExchange
 Input [3]: [(0.5 * sum(l_quantity))#21, l_partkey#11, l_suppkey#12]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true], input[2, bigint, true]),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true], input[2, bigint, true]),false,false), [id=#22]
 
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [2]: [ps_partkey#5, ps_suppkey#6]
@@ -156,7 +156,7 @@ Input [6]: [ps_partkey#5, ps_suppkey#6, ps_availqty#7, (0.5 * sum(l_quantity))#2
 
 (26) BroadcastExchange
 Input [1]: [ps_suppkey#6]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#23]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,true), [id=#23]
 
 (27) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_suppkey#1]
@@ -187,7 +187,7 @@ Input [2]: [n_nationkey#24, n_name#25]
 
 (33) BroadcastExchange
 Input [1]: [n_nationkey#24]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#26]
 
 (34) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_nationkey#4]

--- a/sql/core/src/test/resources/tpch-plan-stability/q21/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q21/explain.txt
@@ -82,7 +82,7 @@ Input [2]: [l_orderkey#8, l_suppkey#9]
 
 (10) BroadcastExchange
 Input [2]: [l_orderkey#8, l_suppkey#9]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#10]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#10]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [l_orderkey#4]
@@ -109,7 +109,7 @@ Input [4]: [l_orderkey#11, l_suppkey#12, l_commitdate#13, l_receiptdate#14]
 
 (16) BroadcastExchange
 Input [2]: [l_orderkey#11, l_suppkey#12]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#15]
 
 (17) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [l_orderkey#4]
@@ -118,7 +118,7 @@ Join condition: NOT (l_suppkey#12 = l_suppkey#5)
 
 (18) BroadcastExchange
 Input [2]: [l_orderkey#4, l_suppkey#5]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false,false), [id=#16]
 
 (19) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_suppkey#1]
@@ -149,7 +149,7 @@ Input [2]: [o_orderkey#17, o_orderstatus#18]
 
 (25) BroadcastExchange
 Input [1]: [o_orderkey#17]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#19]
 
 (26) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [l_orderkey#4]
@@ -180,7 +180,7 @@ Input [2]: [n_nationkey#20, n_name#21]
 
 (32) BroadcastExchange
 Input [1]: [n_nationkey#20]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#22]
 
 (33) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_nationkey#3]

--- a/sql/core/src/test/resources/tpch-plan-stability/q22/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q22/explain.txt
@@ -39,7 +39,7 @@ Input [1]: [o_custkey#6]
 
 (6) BroadcastExchange
 Input [1]: [o_custkey#6]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,true), [id=#7]
 
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [c_custkey#1]

--- a/sql/core/src/test/resources/tpch-plan-stability/q3/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q3/explain.txt
@@ -56,7 +56,7 @@ Condition : (((isnotnull(o_orderdate#5) AND (o_orderdate#5 < 1995-03-15)) AND is
 
 (8) BroadcastExchange
 Input [4]: [o_orderkey#3, o_custkey#4, o_orderdate#5, o_shippriority#6]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false,false), [id=#7]
 
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [c_custkey#1]
@@ -87,7 +87,7 @@ Input [4]: [l_orderkey#8, l_extendedprice#9, l_discount#10, l_shipdate#11]
 
 (15) BroadcastExchange
 Input [3]: [l_orderkey#8, l_extendedprice#9, l_discount#10]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#12]
 
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [o_orderkey#3]

--- a/sql/core/src/test/resources/tpch-plan-stability/q4/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q4/explain.txt
@@ -55,7 +55,7 @@ Input [3]: [l_orderkey#4, l_commitdate#5, l_receiptdate#6]
 
 (9) BroadcastExchange
 Input [1]: [l_orderkey#4]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,true), [id=#7]
 
 (10) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [o_orderkey#1]

--- a/sql/core/src/test/resources/tpch-plan-stability/q5/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q5/explain.txt
@@ -75,7 +75,7 @@ Input [3]: [o_orderkey#3, o_custkey#4, o_orderdate#5]
 
 (8) BroadcastExchange
 Input [2]: [o_orderkey#3, o_custkey#4]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false), [id=#6]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false,false), [id=#6]
 
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_custkey#1]
@@ -102,7 +102,7 @@ Condition : (isnotnull(l_orderkey#7) AND isnotnull(l_suppkey#8))
 
 (14) BroadcastExchange
 Input [4]: [l_orderkey#7, l_suppkey#8, l_extendedprice#9, l_discount#10]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#11]
 
 (15) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [o_orderkey#3]
@@ -129,7 +129,7 @@ Condition : (isnotnull(s_suppkey#12) AND isnotnull(s_nationkey#13))
 
 (20) BroadcastExchange
 Input [2]: [s_suppkey#12, s_nationkey#13]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false], input[1, bigint, false]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false], input[1, bigint, false]),false,false), [id=#14]
 
 (21) BroadcastHashJoin [codegen id : 6]
 Left keys [2]: [l_suppkey#8, c_nationkey#2]
@@ -156,7 +156,7 @@ Condition : (isnotnull(n_nationkey#15) AND isnotnull(n_regionkey#17))
 
 (26) BroadcastExchange
 Input [3]: [n_nationkey#15, n_name#16, n_regionkey#17]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#18]
 
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_nationkey#13]
@@ -187,7 +187,7 @@ Input [2]: [r_regionkey#19, r_name#20]
 
 (33) BroadcastExchange
 Input [1]: [r_regionkey#19]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#21]
 
 (34) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [n_regionkey#17]

--- a/sql/core/src/test/resources/tpch-plan-stability/q7/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q7/explain.txt
@@ -66,7 +66,7 @@ Condition : ((((isnotnull(l_shipdate#7) AND (l_shipdate#7 >= 1995-01-01)) AND (l
 
 (7) BroadcastExchange
 Input [5]: [l_orderkey#3, l_suppkey#4, l_extendedprice#5, l_discount#6, l_shipdate#7]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false,false), [id=#8]
 
 (8) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_suppkey#1]
@@ -93,7 +93,7 @@ Condition : (isnotnull(o_orderkey#9) AND isnotnull(o_custkey#10))
 
 (13) BroadcastExchange
 Input [2]: [o_orderkey#9, o_custkey#10]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#11]
 
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [l_orderkey#3]
@@ -120,7 +120,7 @@ Condition : (isnotnull(c_custkey#12) AND isnotnull(c_nationkey#13))
 
 (19) BroadcastExchange
 Input [2]: [c_custkey#12, c_nationkey#13]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#14]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#14]
 
 (20) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [o_custkey#10]
@@ -147,7 +147,7 @@ Condition : (isnotnull(n_nationkey#15) AND ((n_name#16 = FRANCE) OR (n_name#16 =
 
 (25) BroadcastExchange
 Input [2]: [n_nationkey#15, n_name#16]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#17]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#17]
 
 (26) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_nationkey#2]

--- a/sql/core/src/test/resources/tpch-plan-stability/q8/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q8/explain.txt
@@ -87,7 +87,7 @@ Condition : ((isnotnull(l_partkey#4) AND isnotnull(l_suppkey#5)) AND isnotnull(l
 
 (8) BroadcastExchange
 Input [5]: [l_orderkey#3, l_partkey#4, l_suppkey#5, l_extendedprice#6, l_discount#7]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false), [id=#8]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false,false), [id=#8]
 
 (9) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [p_partkey#1]
@@ -114,7 +114,7 @@ Condition : (isnotnull(s_suppkey#9) AND isnotnull(s_nationkey#10))
 
 (14) BroadcastExchange
 Input [2]: [s_suppkey#9, s_nationkey#10]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#11]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#11]
 
 (15) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [l_suppkey#5]
@@ -141,7 +141,7 @@ Condition : ((((isnotnull(o_orderdate#14) AND (o_orderdate#14 >= 1995-01-01)) AN
 
 (20) BroadcastExchange
 Input [3]: [o_orderkey#12, o_custkey#13, o_orderdate#14]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#15]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#15]
 
 (21) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [l_orderkey#3]
@@ -168,7 +168,7 @@ Condition : (isnotnull(c_custkey#16) AND isnotnull(c_nationkey#17))
 
 (26) BroadcastExchange
 Input [2]: [c_custkey#16, c_nationkey#17]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#18]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#18]
 
 (27) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [o_custkey#13]
@@ -195,7 +195,7 @@ Condition : (isnotnull(n_nationkey#19) AND isnotnull(n_regionkey#20))
 
 (32) BroadcastExchange
 Input [2]: [n_nationkey#19, n_regionkey#20]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#21]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#21]
 
 (33) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_nationkey#17]
@@ -222,7 +222,7 @@ Condition : isnotnull(n_nationkey#22)
 
 (38) BroadcastExchange
 Input [2]: [n_nationkey#22, n_name#23]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#24]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#24]
 
 (39) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [s_nationkey#10]
@@ -253,7 +253,7 @@ Input [2]: [r_regionkey#25, r_name#26]
 
 (45) BroadcastExchange
 Input [1]: [r_regionkey#25]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#27]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false,false), [id=#27]
 
 (46) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [n_regionkey#20]

--- a/sql/core/src/test/resources/tpch-plan-stability/q9/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q9/explain.txt
@@ -74,7 +74,7 @@ Condition : ((isnotnull(l_partkey#4) AND isnotnull(l_suppkey#5)) AND isnotnull(l
 
 (8) BroadcastExchange
 Input [6]: [l_orderkey#3, l_partkey#4, l_suppkey#5, l_quantity#6, l_extendedprice#7, l_discount#8]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false), [id=#9]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false,false), [id=#9]
 
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [p_partkey#1]
@@ -101,7 +101,7 @@ Condition : (isnotnull(s_suppkey#10) AND isnotnull(s_nationkey#11))
 
 (14) BroadcastExchange
 Input [2]: [s_suppkey#10, s_nationkey#11]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#12]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#12]
 
 (15) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [l_suppkey#5]
@@ -128,7 +128,7 @@ Condition : (isnotnull(ps_suppkey#14) AND isnotnull(ps_partkey#13))
 
 (20) BroadcastExchange
 Input [3]: [ps_partkey#13, ps_suppkey#14, ps_supplycost#15]
-Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false], input[0, bigint, false]),false), [id=#16]
+Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false], input[0, bigint, false]),false,false), [id=#16]
 
 (21) BroadcastHashJoin [codegen id : 6]
 Left keys [2]: [l_suppkey#5, l_partkey#4]
@@ -155,7 +155,7 @@ Condition : isnotnull(o_orderkey#17)
 
 (26) BroadcastExchange
 Input [2]: [o_orderkey#17, o_orderdate#18]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#19]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#19]
 
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [l_orderkey#3]
@@ -182,7 +182,7 @@ Condition : isnotnull(n_nationkey#20)
 
 (32) BroadcastExchange
 Input [2]: [n_nationkey#20, n_name#21]
-Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [id=#22]
+Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false), [id=#22]
 
 (33) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_nationkey#11]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/debug/DebuggingSuite.scala
@@ -111,7 +111,7 @@ class DebuggingSuite extends DebuggingSuiteBase with DisableAdaptiveExecutionSui
     }
 
     val output = captured.toString()
-    val hashedModeString = "HashedRelationBroadcastMode(List(input[0, bigint, false]),false)"
+    val hashedModeString = "HashedRelationBroadcastMode(List(input[0, bigint, false]),false,false)"
     assert(output.replaceAll("\\[id=#\\d+\\]", "[id=#x]").contains(
       s"""== BroadcastExchange $hashedModeString, [id=#x] ==
          |Tuples output: 0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
For LEFT SEMI and LEFT ANTI hash equi-join without extra join condition, we only need to keep one row per unique join key(s) inside hash table (`HashedRelation`) when building the hash table. This can help reduce the size of hash table of join.

This PR adds the optimization in `UnsafeHashedRelation` for broadcast hash join and shuffled hash join. The optimization for `LongHashedRelation` would be added later in the future, because it needs more change of underlying hash table data structure `LongToUnsafeRowMap` to check if key exists in hash table or not.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Help reduce the hash table size of join for LEFT SEMI and LEFT ANTI.
This can increase the chance of broadcast join of these queries, and reduce OOM possibility of shuffled hash join.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit test in `JoinSuite.scala`.

Just to help easier review, as a lot of files are changed due to unit test plan change. Below files have the real code change:

* BroadcastExchangeExec.scala
* BroadcastHashJoinExec.scala
* HashJoin.scala
* HashedRelation.scala
* ShuffledHashJoinExec.scala
* JoinSuite.scala
* DebuggingSuite.scala

All other files change are generated with followed commands:

```
SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/testOnly *SQLQueryTestSuite"
SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/testOnly *PlanStabilitySuite"
SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/testOnly *PlanStabilityWithStatsSuite"
```