### PR TITLE
[SPARK-36793][K8S] Support write container stdout/stderr to file

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1121,6 +1121,22 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>3.0.0</td>
 </tr>
 <tr>
+  <td><code>spark.kubernetes.logToFile.enabled</code></td>
+  <td><code>false</code></td>
+  <td>
+   Whether to write executor/driver stdout/stderr as log file
+  </td>
+  <td>3.2.0</td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.logToFile.path</code></td>
+  <td><code>/var/log/spark</code></td>
+  <td>
+   The path to write executor/driver stdout/stderr as log file
+  </td>
+  <td>3.2.0</td>
+</tr>
+<tr>
   <td><code>spark.kubernetes.memoryOverheadFactor</code></td>
   <td><code>0.1</code></td>
   <td>

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1126,7 +1126,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>
    Whether to write executor/driver stdout/stderr as log file
   </td>
-  <td>3.2.0</td>
+  <td>3.3.0</td>
 </tr>
 <tr>
   <td><code>spark.kubernetes.logToFile.path</code></td>
@@ -1134,7 +1134,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>
    The path to write executor/driver stdout/stderr as log file
   </td>
-  <td>3.2.0</td>
+  <td>3.3.0</td>
 </tr>
 <tr>
   <td><code>spark.kubernetes.memoryOverheadFactor</code></td>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -616,6 +616,20 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 0, "Maximum number of pending pods should be a positive integer")
       .createWithDefault(Int.MaxValue)
 
+  val KUBERNETES_LOG_TO_FILE =
+    ConfigBuilder("spark.kubernetes.logToFile.enabled")
+      .doc("Whether to write executor/driver stdout/stderr as log file")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val KUBERNETES_LOG_TO_FILE_PATH =
+    ConfigBuilder("spark.kubernetes.logToFile.path")
+      .doc("The path to write executor/driver stdout/stderr as log file")
+      .version("3.2.0")
+      .stringConf
+      .createWithDefault("/var/log/spark")
+
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."
   val KUBERNETES_DRIVER_ANNOTATION_PREFIX = "spark.kubernetes.driver.annotation."
   val KUBERNETES_DRIVER_SERVICE_ANNOTATION_PREFIX = "spark.kubernetes.driver.service.annotation."

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -66,6 +66,7 @@ private[spark] object Constants {
   val ENV_SPARK_CONF_DIR = "SPARK_CONF_DIR"
   val ENV_SPARK_USER = "SPARK_USER"
   val ENV_RESOURCE_PROFILE_ID = "SPARK_RESOURCE_PROFILE_ID"
+  val ENV_SPARK_LOG_PATH = "K8S_SPARK_LOG_PATH"
   // Spark app configs for containers
   val SPARK_CONF_VOLUME_DRIVER = "spark-conf-volume-driver"
   val SPARK_CONF_VOLUME_EXEC = "spark-conf-volume-exec"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -82,7 +82,14 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
           .withName(env._1)
           .withValue(env._2)
           .build()
-      }
+      } ++ {
+      if (conf.get(KUBERNETES_LOG_TO_FILE)) {
+        Seq(new EnvVarBuilder()
+          .withName(ENV_SPARK_LOG_PATH)
+          .withValue(conf.get(KUBERNETES_LOG_TO_FILE_PATH))
+          .build())
+      } else None
+    }
 
     val driverCpuQuantity = new Quantity(driverCoresRequest)
     val driverMemoryQuantity = new Quantity(s"${driverMemoryWithOverheadMiB}Mi")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -177,7 +177,14 @@ private[spark] class BasicExecutorFeatureStep(
             .withValue(opt)
             .build()
         }
-      }
+      } ++ {
+      if (kubernetesConf.get(KUBERNETES_LOG_TO_FILE)) {
+        Seq(new EnvVarBuilder()
+          .withName(ENV_SPARK_LOG_PATH)
+          .withValue(kubernetesConf.get(KUBERNETES_LOG_TO_FILE_PATH))
+          .build())
+      } else None
+    }
     executorEnv.find(_.getName == ENV_EXECUTOR_DIRS).foreach { e =>
       e.setValue(e.getValue
         .replaceAll(ENV_APPLICATION_ID, kubernetesConf.appId)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
@@ -50,6 +50,7 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     val resourceID = new ResourceID(SPARK_DRIVER_PREFIX, GPU)
     val resources =
       Map(("nvidia.com/gpu" -> TestResourceInformation(resourceID, "2", "nvidia.com")))
+    val logPath = "/spark/log"
     val sparkConf = new SparkConf()
       .set(KUBERNETES_DRIVER_POD_NAME, "spark-driver-pod")
       .set(DRIVER_CORES, 2)
@@ -58,6 +59,8 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
       .set(DRIVER_MEMORY_OVERHEAD, 200L)
       .set(CONTAINER_IMAGE, "spark-driver:latest")
       .set(IMAGE_PULL_SECRETS, TEST_IMAGE_PULL_SECRETS)
+      .set(KUBERNETES_LOG_TO_FILE, true)
+      .set(KUBERNETES_LOG_TO_FILE_PATH, logPath)
     resources.foreach { case (_, testRInfo) =>
       sparkConf.set(testRInfo.rId.amountConf, testRInfo.count)
       sparkConf.set(testRInfo.rId.vendorConf, testRInfo.vendor)
@@ -94,6 +97,7 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     }
     assert(envs(ENV_SPARK_USER) === Utils.getCurrentUserName())
     assert(envs(ENV_APPLICATION_ID) === kubernetesConf.appId)
+    assert(envs(ENV_SPARK_LOG_PATH) === logPath)
 
     assert(configuredPod.pod.getSpec().getImagePullSecrets.asScala ===
       TEST_IMAGE_PULL_SECRET_OBJECTS)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -436,6 +436,19 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     ))
   }
 
+  test("container log configs") {
+    val logPath = "/spark/log"
+    baseConf.set(KUBERNETES_LOG_TO_FILE, true)
+    baseConf.set(KUBERNETES_LOG_TO_FILE_PATH, logPath)
+    initDefaultProfile(baseConf)
+    val kconf = KubernetesTestConf.createExecutorConf(baseConf)
+    val step = new BasicExecutorFeatureStep(kconf, new SecurityManager(baseConf),
+      defaultProfile)
+    val executor = step.configurePod(SparkPod.initialPod())
+
+    checkEnv(executor, baseConf, Map(ENV_SPARK_LOG_PATH -> logPath))
+  }
+
   // There is always exactly one controller reference, and it points to the driver pod.
   private def checkOwnerReferences(executor: Pod, driverPodUid: String): Unit = {
     assert(executor.getMetadata.getOwnerReferences.size() === 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support write container stdout/stderr to file

### Why are the changes needed?
If users want to sidecar logging agent to send stdout/stderr to external log storage,  only way is to change entrypoint.sh, which might break compatibility with community version.

### Does this PR introduce _any_ user-facing change?
Yes. User can enable this feature by spark config.

### How was this patch tested?
Added UT in BasicDriverFeatureStepSuite and BasicExecutorFeatureStepSuite
