### PR TITLE
[SPARK-36798][CORE] Wait for listeners to finish before flushing metrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2076,11 +2076,6 @@ class SparkContext(config: SparkConf) extends Logging {
     Utils.tryLogNonFatalError {
       _ui.foreach(_.stop())
     }
-    if (env != null) {
-      Utils.tryLogNonFatalError {
-        env.metricsSystem.report()
-      }
-    }
     Utils.tryLogNonFatalError {
       _cleaner.foreach(_.stop())
     }
@@ -2097,6 +2092,11 @@ class SparkContext(config: SparkConf) extends Logging {
       Utils.tryLogNonFatalError {
         listenerBus.stop()
         _listenerBusStarted = false
+      }
+    }
+    if (env != null) {
+      Utils.tryLogNonFatalError {
+        env.metricsSystem.report()
       }
     }
     Utils.tryLogNonFatalError {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When `SparkContext` is shutting down, wait for listener bus to finish and then only flush `MetricsSystem`.


### Why are the changes needed?
In current implementation, when `SparkContext.stop()` is called, `metricsSystem.report()` is called before `listenerBus.stop()`. In this case, if some listener is producing some metrics, they would never reach sink.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
NA
