### PR TITLE
[SPARK-36799][SQL] Pass queryExecution name in CLI

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -67,7 +67,7 @@ private[hive] class SparkSQLDriver(val context: SQLContext = SparkSQLEnv.sqlCont
       val execution = context.sessionState.executePlan(context.sql(command).logicalPlan)
       val queryExecutionName = execution.executedPlan match {
         case _: CommandResultExec => None
-        case _ => Some("collect")
+        case _ => Some("cli")
       }
       hiveResponse = SQLExecution.withNewExecutionId(execution, queryExecutionName) {
         hiveResultString(execution.executedPlan)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -29,7 +29,7 @@ import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse
 import org.apache.spark.SparkThrowable
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.execution.{CommandResultExec, QueryExecution, SQLExecution}
+import org.apache.spark.sql.execution.{QueryExecution, SQLExecution}
 import org.apache.spark.sql.execution.HiveResult.hiveResultString
 import org.apache.spark.sql.internal.{SQLConf, VariableSubstitution}
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -65,11 +65,7 @@ private[hive] class SparkSQLDriver(val context: SQLContext = SparkSQLEnv.sqlCont
       }
       context.sparkContext.setJobDescription(substitutorCommand)
       val execution = context.sessionState.executePlan(context.sql(command).logicalPlan)
-      val queryExecutionName = execution.executedPlan match {
-        case _: CommandResultExec => None
-        case _ => Some("cli")
-      }
-      hiveResponse = SQLExecution.withNewExecutionId(execution, queryExecutionName) {
+      hiveResponse = SQLExecution.withNewExecutionId(execution, Some("cli")) {
         hiveResultString(execution.executedPlan)
       }
       tableSchema = getResultSetSchema(execution)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In CLI, call `SQLExecution.withNewExecutionId` and specify `cli` as `executionName` so that `QueryExecutionListener` can get the query.
### Why are the changes needed?
Now when in spark-sql CLI, `QueryExecutionListener` can receive command , but not select query.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
manual test.