### PR TITLE
[SPARK-36814][SQL] Make class ColumnarBatch extendable

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatch.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatch.java
@@ -31,7 +31,7 @@ import org.apache.spark.unsafe.types.UTF8String;
  * the entire data loading process.
  */
 @Evolving
-public final class ColumnarBatch implements AutoCloseable {
+public class ColumnarBatch implements AutoCloseable {
   private int numRows;
   private final ColumnVector[] columns;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change class ColumnarBatch to a non-final class

### Why are the changes needed?
To support better vectorized reading in multiple data source, ColumnarBatch need to be extendable. For example, To support row-level delete(  https://github.com/apache/iceberg/issues/3141) in Iceberg's vectorized read, we need to filter out deleted rows in a batch, which requires ColumnarBatch to be extendable.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No test needed.
