### PR TITLE
[SPARK-36721][SQL] Simplify boolean equalities if one side is literal

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -490,15 +490,15 @@ object SimplifyBinaryComparison
         case a GreaterThan b if canSimplifyComparison(a, b, notNullExpressions) => FalseLiteral
         case a LessThan b if canSimplifyComparison(a, b, notNullExpressions) => FalseLiteral
 
-        // Optimize equalities with (Predicate, Literal) pair to help pushing down the filters
-        case (a: Predicate) EqualTo TrueLiteral => a
-        case TrueLiteral EqualTo (b: Predicate) => b
-        case (a: Predicate) EqualTo FalseLiteral => Not(a)
-        case FalseLiteral EqualTo (b: Predicate) => Not(b)
-        case (a: Predicate) EqualNullSafe TrueLiteral if !a.nullable => a
-        case TrueLiteral EqualNullSafe (b: Predicate) if !b.nullable => b
-        case (a: Predicate) EqualNullSafe FalseLiteral if !a.nullable => Not(a)
-        case FalseLiteral EqualNullSafe (b: Predicate) if !b.nullable => Not(b)
+        // Optimize equalities when one side is Literal in order to help pushing down the filters
+        case a EqualTo TrueLiteral => a
+        case TrueLiteral EqualTo b => b
+        case a EqualTo FalseLiteral => Not(a)
+        case FalseLiteral EqualTo b => Not(b)
+        case a EqualNullSafe TrueLiteral if !a.nullable => a
+        case TrueLiteral EqualNullSafe b if !b.nullable => b
+        case a EqualNullSafe FalseLiteral if !a.nullable => Not(a)
+        case FalseLiteral EqualNullSafe b if !b.nullable => Not(b)
       }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -490,7 +490,7 @@ object SimplifyBinaryComparison
         case a GreaterThan b if canSimplifyComparison(a, b, notNullExpressions) => FalseLiteral
         case a LessThan b if canSimplifyComparison(a, b, notNullExpressions) => FalseLiteral
 
-        // One side is Literal
+        // Optimize equalities with (Predicate, Literal) pair to help pushing down the filters
         case (a: Predicate) EqualTo TrueLiteral => a
         case TrueLiteral EqualTo (b: Predicate) => b
         case (a: Predicate) EqualTo FalseLiteral => Not(a)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -495,10 +495,10 @@ object SimplifyBinaryComparison
         case TrueLiteral EqualTo (b: Predicate) => b
         case (a: Predicate) EqualTo FalseLiteral => Not(a)
         case FalseLiteral EqualTo (b: Predicate) => Not(b)
-        case (a: Predicate) EqualNullSafe TrueLiteral => And(a, IsNotNull(a))
-        case TrueLiteral EqualNullSafe (b: Predicate) => And(b, IsNotNull(b))
-        case (a: Predicate) EqualNullSafe FalseLiteral => And(Not(a), IsNotNull(a))
-        case FalseLiteral EqualNullSafe (b: Predicate) => And(Not(b), IsNotNull(b))
+        case (a: Predicate) EqualNullSafe TrueLiteral if !a.nullable => a
+        case TrueLiteral EqualNullSafe (b: Predicate) if !b.nullable => b
+        case (a: Predicate) EqualNullSafe FalseLiteral if !a.nullable => Not(a)
+        case FalseLiteral EqualNullSafe (b: Predicate) if !b.nullable => Not(b)
       }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -491,18 +491,14 @@ object SimplifyBinaryComparison
         case a LessThan b if canSimplifyComparison(a, b, notNullExpressions) => FalseLiteral
 
         // One side is Literal
-        case a EqualTo TrueLiteral if a.dataType.isInstanceOf[BooleanType] => a
-        case TrueLiteral EqualTo b if b.dataType.isInstanceOf[BooleanType] => b
-        case a EqualTo FalseLiteral if a.dataType.isInstanceOf[BooleanType] => Not(a)
-        case FalseLiteral EqualTo b if b.dataType.isInstanceOf[BooleanType] => Not(b)
-        case a EqualNullSafe TrueLiteral if a.dataType.isInstanceOf[BooleanType] =>
-          And(a, IsNotNull(a))
-        case TrueLiteral EqualNullSafe b if b.dataType.isInstanceOf[BooleanType] =>
-          And(b, IsNotNull(b))
-        case a EqualNullSafe FalseLiteral if a.dataType.isInstanceOf[BooleanType] =>
-          And(Not(a), IsNotNull(a))
-        case FalseLiteral EqualNullSafe b if b.dataType.isInstanceOf[BooleanType] =>
-          And(Not(b), IsNotNull(b))
+        case (a: Predicate) EqualTo TrueLiteral => a
+        case TrueLiteral EqualTo (b: Predicate) => b
+        case (a: Predicate) EqualTo FalseLiteral => Not(a)
+        case FalseLiteral EqualTo (b: Predicate) => Not(b)
+        case (a: Predicate) EqualNullSafe TrueLiteral => And(a, IsNotNull(a))
+        case TrueLiteral EqualNullSafe (b: Predicate) => And(b, IsNotNull(b))
+        case (a: Predicate) EqualNullSafe FalseLiteral => And(Not(a), IsNotNull(a))
+        case FalseLiteral EqualNullSafe (b: Predicate) => And(Not(b), IsNotNull(b))
       }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
@@ -205,13 +205,9 @@ class BinaryComparisonSimplificationSuite extends PlanTest with PredicateHelper 
     checkCondition(boolRelation, TrueLiteral === And('a, 'b), And('a, 'b))
     checkCondition(boolRelation, And('a, 'b) === FalseLiteral, Or(Not('a), Not('b)))
     checkCondition(boolRelation, FalseLiteral === And('a, 'b), Or(Not('a), Not('b)))
-    checkCondition(boolRelation, And('a, 'b) <=> TrueLiteral,
-      And(And('a, 'b), IsNotNull(And('a, 'b))))
-    checkCondition(boolRelation, TrueLiteral <=> And('a, 'b),
-      And(And('a, 'b), IsNotNull(And('a, 'b))))
-    checkCondition(boolRelation, And('a, 'b) <=> FalseLiteral,
-      And(Or(Not('a), Not('b)), IsNotNull(And('a, 'b))))
-    checkCondition(boolRelation, FalseLiteral <=> And('a, 'b),
-      And(Or(Not('a), Not('b)), IsNotNull(And('a, 'b))))
+    checkCondition(boolRelation, IsNull('a) <=> TrueLiteral, IsNull('a))
+    checkCondition(boolRelation, TrueLiteral <=> IsNull('a), IsNull('a))
+    checkCondition(boolRelation, IsNull('a) <=> FalseLiteral, IsNotNull('a))
+    checkCondition(boolRelation, FalseLiteral <=> IsNull('a), IsNotNull('a))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
@@ -209,5 +209,11 @@ class BinaryComparisonSimplificationSuite extends PlanTest with PredicateHelper 
     checkCondition(boolRelation, TrueLiteral <=> IsNull('a), IsNull('a))
     checkCondition(boolRelation, IsNull('a) <=> FalseLiteral, IsNotNull('a))
     checkCondition(boolRelation, FalseLiteral <=> IsNull('a), IsNotNull('a))
+
+    // Should not optimize for nullable <=> Literal
+    checkCondition(boolRelation, And('a, 'b) <=> TrueLiteral, And('a, 'b) <=> TrueLiteral)
+    checkCondition(boolRelation, TrueLiteral <=> And('a, 'b), TrueLiteral <=> And('a, 'b))
+    checkCondition(boolRelation, And('a, 'b) <=> FalseLiteral, And('a, 'b) <=> FalseLiteral)
+    checkCondition(boolRelation, FalseLiteral <=> And('a, 'b), FalseLiteral <=> And('a, 'b))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
@@ -44,8 +44,13 @@ class BinaryComparisonSimplificationSuite extends PlanTest with PredicateHelper 
         PruneFilters) :: Nil
   }
 
+  private def checkCondition(rel: LocalRelation, input: Expression, expected: Expression): Unit =
+    comparePlans(Optimize.execute(rel.where(input).analyze), rel.where(expected).analyze)
+
   val nullableRelation = LocalRelation('a.int.withNullability(true))
   val nonNullableRelation = LocalRelation('a.int.withNullability(false))
+  val boolRelation = LocalRelation('a.boolean, 'b.boolean)
+
 
   test("Preserve nullable exprs when constraintPropagation is false") {
     withSQLConf(SQLConf.CONSTRAINT_PROPAGATION_ENABLED.key -> "false") {
@@ -193,5 +198,16 @@ class BinaryComparisonSimplificationSuite extends PlanTest with PredicateHelper 
     comparePlans(
       Optimize.execute(testRelation.select(Coalesce(Seq('b, 'd)).as("out")).analyze),
       testRelation.select(Coalesce(Seq('b, 'd)).as("out")).analyze)
+  }
+
+  test("SPARK-36721: Simplify boolean equalities if one side is literal") {
+    checkCondition(boolRelation, And('a, 'b) === TrueLiteral, And('a, 'b))
+    checkCondition(boolRelation, TrueLiteral === And('a, 'b), And('a, 'b))
+    checkCondition(boolRelation, And('a, 'b) === FalseLiteral, Or(Not('a), Not('b)))
+    checkCondition(boolRelation, FalseLiteral === And('a, 'b), Or(Not('a), Not('b)))
+    checkCondition(boolRelation, Not('a) <=> TrueLiteral, And(Not('a), IsNotNull('a)))
+    checkCondition(boolRelation, TrueLiteral <=> Not('a), And(Not('a), IsNotNull('a)))
+    checkCondition(boolRelation, Not('a) <=> FalseLiteral, And('a, IsNotNull('a)))
+    checkCondition(boolRelation, FalseLiteral <=> Not('a), And('a, IsNotNull('a)))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
@@ -205,9 +205,13 @@ class BinaryComparisonSimplificationSuite extends PlanTest with PredicateHelper 
     checkCondition(boolRelation, TrueLiteral === And('a, 'b), And('a, 'b))
     checkCondition(boolRelation, And('a, 'b) === FalseLiteral, Or(Not('a), Not('b)))
     checkCondition(boolRelation, FalseLiteral === And('a, 'b), Or(Not('a), Not('b)))
-    checkCondition(boolRelation, Not('a) <=> TrueLiteral, And(Not('a), IsNotNull('a)))
-    checkCondition(boolRelation, TrueLiteral <=> Not('a), And(Not('a), IsNotNull('a)))
-    checkCondition(boolRelation, Not('a) <=> FalseLiteral, And('a, IsNotNull('a)))
-    checkCondition(boolRelation, FalseLiteral <=> Not('a), And('a, IsNotNull('a)))
+    checkCondition(boolRelation, And('a, 'b) <=> TrueLiteral,
+      And(And('a, 'b), IsNotNull(And('a, 'b))))
+    checkCondition(boolRelation, TrueLiteral <=> And('a, 'b),
+      And(And('a, 'b), IsNotNull(And('a, 'b))))
+    checkCondition(boolRelation, And('a, 'b) <=> FalseLiteral,
+      And(Or(Not('a), Not('b)), IsNotNull(And('a, 'b))))
+    checkCondition(boolRelation, FalseLiteral <=> And('a, 'b),
+      And(Or(Not('a), Not('b)), IsNotNull(And('a, 'b))))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve simplifications of `EqualTo/EqualNullSafe` binary comparators when one side is a boolean literal.
For example: `EqualTo(predicate, TrueLiteral) => predicate`, `EqualNullSafe(predicate, TrueLiteral) => predicate if !predicate.nullable`
This PR helps pushing down the filter and reducing unnecessary IO.

### Why are the changes needed?
The following query does not push down the filter in the current implementation
```
SELECT * FROM t WHERE (a AND b) = true
```
although the following equivalent query pushes down the filter as expected.
```
SELECT * FROM t WHERE (a AND b)
```
That is because the first query creates `EqualTo(And(a, b), TrueLiteral)` that is simply not in the form that we can push down. However, we should be able to get it simplified to `And(a, b)`
It is fair for Spark SQL users to expect `(a AND b) = true` performs the same as `(a AND b)`.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added unit tests
```
build/sbt "testOnly *BooleanSimplificationSuite  -- -z SPARK-36721"
```