### PR TITLE
[SPARK-36850][SQL] Migrate CreateTableStatement to v2 command framework

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -466,6 +466,23 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
 
             create.tableSchema.foreach(f => TypeUtils.failWithIntervalType(f.dataType))
 
+          case create: V2CreateTablePlanX =>
+            val references = create.partitioning.flatMap(_.references).toSet
+            val badReferences = references.map(_.fieldNames).flatMap { column =>
+              create.tableSchema.findNestedField(column) match {
+                case Some(_) =>
+                  None
+                case _ =>
+                  Some(s"${column.quoted} is missing or is in a map or array")
+              }
+            }
+
+            if (badReferences.nonEmpty) {
+              failAnalysis(s"Invalid partitioning: ${badReferences.mkString(", ")}")
+            }
+
+            create.tableSchema.foreach(f => TypeUtils.failWithIntervalType(f.dataType))
+
           case write: V2WriteCommand if write.resolved =>
             write.query.schema.foreach(f => TypeUtils.failWithIntervalType(f.dataType))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -466,23 +466,6 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
 
             create.tableSchema.foreach(f => TypeUtils.failWithIntervalType(f.dataType))
 
-          case create: V2CreateTablePlanX =>
-            val references = create.partitioning.flatMap(_.references).toSet
-            val badReferences = references.map(_.fieldNames).flatMap { column =>
-              create.tableSchema.findNestedField(column) match {
-                case Some(_) =>
-                  None
-                case _ =>
-                  Some(s"${column.quoted} is missing or is in a map or array")
-              }
-            }
-
-            if (badReferences.nonEmpty) {
-              failAnalysis(s"Invalid partitioning: ${badReferences.mkString(", ")}")
-            }
-
-            create.tableSchema.foreach(f => TypeUtils.failWithIntervalType(f.dataType))
-
           case write: V2WriteCommand if write.resolved =>
             write.query.schema.foreach(f => TypeUtils.failWithIntervalType(f.dataType))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -37,17 +37,6 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
     case UnresolvedDBObjectName(CatalogAndIdentifier(catalog, identifier), _) =>
       ResolvedDBObjectName(catalog, identifier.namespace :+ identifier.name())
 
-    case c @ CreateTableStatement(
-         NonSessionCatalogAndTable(catalog, tbl), _, _, _, _, _, _, _, _, _, _, _) =>
-      CreateV2Table(
-        catalog.asTableCatalog,
-        tbl.asIdentifier,
-        c.tableSchema,
-        // convert the bucket spec and add it as a transform
-        c.partitioning ++ c.bucketSpec.map(_.asTransform),
-        convertTableProperties(c),
-        ignoreIfExists = c.ifNotExists)
-
     case c @ CreateTableAsSelectStatement(
          NonSessionCatalogAndTable(catalog, tbl), _, _, _, _, _, _, _, _, _, _, _, _) =>
       CreateTableAsSelect(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3481,14 +3481,14 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
       case _ =>
         // Note: table schema includes both the table columns list and the partition columns
         // with data type.
-        val tableSpec = TableSpec(properties, provider, options, location, comment,
+        val tableSpec = TableSpec(bucketSpec, properties, provider, options, location, comment,
           serdeInfo, external)
         val schema = StructType(columns ++ partCols)
         CreateTable(
           UnresolvedDBObjectName(
             table,
             isNamespace = false),
-          schema, partitioning, bucketSpec, tableSpec, ignoreIfExists = ifNotExists)
+          schema, partitioning, tableSpec, ignoreIfExists = ifNotExists)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3414,7 +3414,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
   }
 
   /**
-   * Create a table, returning a [[CreateTableStatement]] logical plan.
+   * Create a table, returning a [[CreateTable]] or [[CreateV2Table]] logical plan.
    *
    * Expected format:
    * {{{
@@ -3482,8 +3482,12 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
         // Note: table schema includes both the table columns list and the partition columns
         // with data type.
         val schema = StructType(columns ++ partCols)
-        CreateTableStatement(table, schema, partitioning, bucketSpec, properties, provider,
-          options, location, comment, serdeInfo, external = external, ifNotExists = ifNotExists)
+        CreateV2Table(
+          UnresolvedDBObjectName(
+            table,
+            isNamespace = false),
+          schema, partitioning, bucketSpec, properties, options, serdeInfo, location, comment,
+          provider, external, ignoreIfExists = ifNotExists)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3414,7 +3414,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
   }
 
   /**
-   * Create a table, returning a [[CreateTable]] or [[CreateV2Table]] logical plan.
+   * Create a table, returning a [[CreateTable]] or [[CreateTableAsSelectStatement]] logical plan.
    *
    * Expected format:
    * {{{
@@ -3485,9 +3485,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
           serdeInfo, external)
         val schema = StructType(columns ++ partCols)
         CreateTable(
-          UnresolvedDBObjectName(
-            table,
-            isNamespace = false),
+          UnresolvedDBObjectName(table, isNamespace = false),
           schema, partitioning, tableSpec, ignoreIfExists = ifNotExists)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3481,14 +3481,14 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
       case _ =>
         // Note: table schema includes both the table columns list and the partition columns
         // with data type.
-        val tableProperties = TableProperties(properties, provider, options, location, comment,
+        val tableSpec = TableSpec(properties, provider, options, location, comment,
           serdeInfo, external)
         val schema = StructType(columns ++ partCols)
-        CreateV2Table(
+        CreateTable(
           UnresolvedDBObjectName(
             table,
             isNamespace = false),
-          schema, partitioning, bucketSpec, tableProperties, ignoreIfExists = ifNotExists)
+          schema, partitioning, bucketSpec, tableSpec, ignoreIfExists = ifNotExists)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3481,13 +3481,14 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
       case _ =>
         // Note: table schema includes both the table columns list and the partition columns
         // with data type.
+        val tableProperties = TableProperties(properties, provider, options, location, comment,
+          serdeInfo, external)
         val schema = StructType(columns ++ partCols)
         CreateV2Table(
           UnresolvedDBObjectName(
             table,
             isNamespace = false),
-          schema, partitioning, bucketSpec, properties, options, serdeInfo, location, comment,
-          provider, external, ignoreIfExists = ifNotExists)
+          schema, partitioning, bucketSpec, tableProperties, ignoreIfExists = ifNotExists)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -124,25 +124,6 @@ object SerdeInfo {
 }
 
 /**
- * A CREATE TABLE command, as parsed from SQL.
- *
- * This is a metadata-only command and is not used to write data to the created table.
- */
-case class CreateTableStatement(
-    tableName: Seq[String],
-    tableSchema: StructType,
-    partitioning: Seq[Transform],
-    bucketSpec: Option[BucketSpec],
-    properties: Map[String, String],
-    provider: Option[String],
-    options: Map[String, String],
-    location: Option[String],
-    comment: Option[String],
-    serde: Option[SerdeInfo],
-    external: Boolean,
-    ifNotExists: Boolean) extends LeafParsedStatement
-
-/**
  * A CREATE TABLE AS SELECT command, as parsed from SQL.
  */
 case class CreateTableAsSelectStatement(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -218,7 +218,10 @@ case class CreateV2Table(
     comment: Option[String],
     provider: Option[String],
     external: Boolean,
-    ignoreIfExists: Boolean) extends LeafCommand with V2CreateTablePlanX {
+    ignoreIfExists: Boolean) extends UnaryCommand with V2CreateTablePlanX {
+  override def child: LogicalPlan = name
+  override protected def withNewChildInternal(newChild: LogicalPlan): V2CreateTablePlanX =
+    copy(name = newChild)
   override def withPartitioning(rewritten: Seq[Transform]): V2CreateTablePlanX = {
     this.copy(partitioning = rewritten)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -211,13 +211,7 @@ case class CreateV2Table(
     tableSchema: StructType,
     partitioning: Seq[Transform],
     bucketSpec: Option[BucketSpec],
-    properties: Map[String, String],
-    options: Map[String, String],
-    serdeInfo: Option[SerdeInfo],
-    location: Option[String],
-    comment: Option[String],
-    provider: Option[String],
-    external: Boolean,
+    tableProperties: TableProperties,
     ignoreIfExists: Boolean) extends UnaryCommand with V2CreateTablePlanX {
   override def child: LogicalPlan = name
   override protected def withNewChildInternal(newChild: LogicalPlan): V2CreateTablePlanX =
@@ -1112,3 +1106,12 @@ case class DropIndex(
   override protected def withNewChildInternal(newChild: LogicalPlan): DropIndex =
     copy(table = newChild)
 }
+
+case class TableProperties(
+    properties: Map[String, String],
+    provider: Option[String],
+    options: Map[String, String],
+    location: Option[String],
+    comment: Option[String],
+    serde: Option[SerdeInfo],
+    external: Boolean)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -206,12 +206,12 @@ trait V2CreateTablePlanX extends LogicalPlan {
 /**
  * Create a new table with a v2 catalog.
  */
-case class CreateV2Table(
+case class CreateTable(
     name: LogicalPlan,
     tableSchema: StructType,
     partitioning: Seq[Transform],
     bucketSpec: Option[BucketSpec],
-    tableProperties: TableProperties,
+    tableSpec: TableSpec,
     ignoreIfExists: Boolean) extends UnaryCommand with V2CreateTablePlanX {
   override def child: LogicalPlan = name
   override protected def withNewChildInternal(newChild: LogicalPlan): V2CreateTablePlanX =
@@ -1107,7 +1107,7 @@ case class DropIndex(
     copy(table = newChild)
 }
 
-case class TableProperties(
+case class TableSpec(
     properties: Map[String, String],
     provider: Option[String],
     options: Map[String, String],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -822,6 +822,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
       redactMapString(map, maxFields)
     case t: TableSpec =>
       redactMapString(t.options, maxFields)
+      redactMapString(t.properties, maxFields)
     case table: CatalogTable =>
       table.storage.serde match {
         case Some(serde) => table.identifier :: serde :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.ScalaReflection._
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, CatalogTable, CatalogTableType, FunctionResource}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.JoinType
+import org.apache.spark.sql.catalyst.plans.logical.TableSpec
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.rules.RuleId
 import org.apache.spark.sql.catalyst.rules.RuleIdCollection
@@ -819,6 +820,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
       redactMapString(map.asCaseSensitiveMap().asScala, maxFields)
     case map: Map[_, _] =>
       redactMapString(map, maxFields)
+    case t: TableSpec =>
+      redactMapString(t.options, maxFields)
     case table: CatalogTable =>
       table.storage.serde match {
         case Some(serde) => table.identifier :: serde :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -821,8 +821,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
     case map: Map[_, _] =>
       redactMapString(map, maxFields)
     case t: TableSpec =>
-      redactMapString(t.options, maxFields)
-      redactMapString(t.properties, maxFields)
+      t.copy(properties = Utils.redact(t.properties).toMap,
+        options = Utils.redact(t.options).toMap) :: Nil
     case table: CatalogTable =>
       table.storage.serde match {
         case Some(serde) => table.identifier :: serde :: Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -307,11 +307,6 @@ private[sql] object CatalogV2Util {
     catalog.name().equalsIgnoreCase(CatalogManager.SESSION_CATALOG_NAME)
   }
 
-//  def convertTableProperties(c: CreateTableStatement): Map[String, String] = {
-//    convertTableProperties(
-//      c.properties, c.options, c.serde, c.location, c.comment, c.provider, c.external)
-//  }
-
   def convertTableProperties(c: CreateTableAsSelectStatement): Map[String, String] = {
     convertTableProperties(
       c.properties, c.options, c.serde, c.location, c.comment, c.provider, c.external)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -22,10 +22,8 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.catalyst.analysis.{NamedRelation, NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException}
-import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelectStatement, ReplaceTableAsSelectStatement, ReplaceTableStatement, SerdeInfo}
 import org.apache.spark.sql.catalyst.analysis.{AsOfTimestamp, AsOfVersion, NamedRelation, NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException, TimeTravelSpec}
-import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelectStatement, CreateTableStatement, ReplaceTableAsSelectStatement, ReplaceTableStatement, SerdeInfo}
+import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelectStatement, ReplaceTableAsSelectStatement, ReplaceTableStatement, SerdeInfo}
 import org.apache.spark.sql.connector.catalog.TableChange._
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.{ArrayType, MapType, StructField, StructType}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -22,6 +22,8 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.catalyst.analysis.{NamedRelation, NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException}
+import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelectStatement, ReplaceTableAsSelectStatement, ReplaceTableStatement, SerdeInfo}
 import org.apache.spark.sql.catalyst.analysis.{AsOfTimestamp, AsOfVersion, NamedRelation, NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException, TimeTravelSpec}
 import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelectStatement, CreateTableStatement, ReplaceTableAsSelectStatement, ReplaceTableStatement, SerdeInfo}
 import org.apache.spark.sql.connector.catalog.TableChange._
@@ -305,10 +307,10 @@ private[sql] object CatalogV2Util {
     catalog.name().equalsIgnoreCase(CatalogManager.SESSION_CATALOG_NAME)
   }
 
-  def convertTableProperties(c: CreateTableStatement): Map[String, String] = {
-    convertTableProperties(
-      c.properties, c.options, c.serde, c.location, c.comment, c.provider, c.external)
-  }
+//  def convertTableProperties(c: CreateTableStatement): Map[String, String] = {
+//    convertTableProperties(
+//      c.properties, c.options, c.serde, c.location, c.comment, c.provider, c.external)
+//  }
 
   def convertTableProperties(c: CreateTableAsSelectStatement): Map[String, String] = {
     convertTableProperties(
@@ -323,7 +325,7 @@ private[sql] object CatalogV2Util {
     convertTableProperties(r.properties, r.options, r.serde, r.location, r.comment, r.provider)
   }
 
-  private def convertTableProperties(
+  def convertTableProperties(
       properties: Map[String, String],
       options: Map[String, String],
       serdeInfo: Option[SerdeInfo],

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2291,13 +2291,13 @@ class DDLParserSuite extends AnalysisTest {
             Some(create.tableSchema),
             create.partitioning,
             create.bucketSpec,
-            create.properties,
-            create.provider,
-            create.options,
-            create.location,
-            create.comment,
-            create.serdeInfo,
-            create.external)
+            create.tableProperties.properties,
+            create.tableProperties.provider,
+            create.tableProperties.options,
+            create.tableProperties.location,
+            create.tableProperties.comment,
+            create.tableProperties.serde,
+            create.tableProperties.external)
         case replace: ReplaceTableStatement =>
           TableSpec(
             replace.tableName,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2290,7 +2290,7 @@ class DDLParserSuite extends AnalysisTest {
             create.name.asInstanceOf[UnresolvedDBObjectName].nameParts,
             Some(create.tableSchema),
             create.partitioning,
-            create.bucketSpec,
+            create.tableSpec.bucketSpec,
             create.tableSpec.properties,
             create.tableSpec.provider,
             create.tableSpec.options,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -717,8 +717,8 @@ class DDLParserSuite extends AnalysisTest {
     val parsedPlan = parsePlan(sqlStatement)
     val newTableToken = sqlStatement.split(" ")(0).trim.toUpperCase(Locale.ROOT)
     parsedPlan match {
-      case create: CreateTableStatement if newTableToken == "CREATE" =>
-        assert(create.ifNotExists == expectedIfNotExists)
+      case create: CreateV2Table if newTableToken == "CREATE" =>
+        assert(create.ignoreIfExists == expectedIfNotExists)
       case ctas: CreateTableAsSelectStatement if newTableToken == "CREATE" =>
         assert(ctas.ifNotExists == expectedIfNotExists)
       case replace: ReplaceTableStatement if newTableToken == "REPLACE" =>
@@ -2285,9 +2285,9 @@ class DDLParserSuite extends AnalysisTest {
   private object TableSpec {
     def apply(plan: LogicalPlan): TableSpec = {
       plan match {
-        case create: CreateTableStatement =>
+        case create: CreateV2Table =>
           TableSpec(
-            create.tableName,
+            create.name.asInstanceOf[UnresolvedDBObjectName].nameParts,
             Some(create.tableSchema),
             create.partitioning,
             create.bucketSpec,
@@ -2296,7 +2296,7 @@ class DDLParserSuite extends AnalysisTest {
             create.options,
             create.location,
             create.comment,
-            create.serde,
+            create.serdeInfo,
             create.external)
         case replace: ReplaceTableStatement =>
           TableSpec(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -717,7 +717,7 @@ class DDLParserSuite extends AnalysisTest {
     val parsedPlan = parsePlan(sqlStatement)
     val newTableToken = sqlStatement.split(" ")(0).trim.toUpperCase(Locale.ROOT)
     parsedPlan match {
-      case create: CreateV2Table if newTableToken == "CREATE" =>
+      case create: CreateTable if newTableToken == "CREATE" =>
         assert(create.ignoreIfExists == expectedIfNotExists)
       case ctas: CreateTableAsSelectStatement if newTableToken == "CREATE" =>
         assert(ctas.ifNotExists == expectedIfNotExists)
@@ -2285,19 +2285,19 @@ class DDLParserSuite extends AnalysisTest {
   private object TableSpec {
     def apply(plan: LogicalPlan): TableSpec = {
       plan match {
-        case create: CreateV2Table =>
+        case create: CreateTable =>
           TableSpec(
             create.name.asInstanceOf[UnresolvedDBObjectName].nameParts,
             Some(create.tableSchema),
             create.partitioning,
             create.bucketSpec,
-            create.tableProperties.properties,
-            create.tableProperties.provider,
-            create.tableProperties.options,
-            create.tableProperties.location,
-            create.tableProperties.comment,
-            create.tableProperties.serde,
-            create.tableProperties.external)
+            create.tableSpec.properties,
+            create.tableSpec.provider,
+            create.tableSpec.options,
+            create.tableSpec.location,
+            create.tableSpec.comment,
+            create.tableSpec.serde,
+            create.tableSpec.external)
         case replace: ReplaceTableStatement =>
           TableSpec(
             replace.tableName,

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ReplaceCharWithVarchar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ReplaceCharWithVarchar.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumn, CreateV2Table, LogicalPlan, ReplaceColumns, ReplaceTable}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumn, CreateTable, LogicalPlan, ReplaceColumns, ReplaceTable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.execution.command.{AlterTableAddColumnsCommand, AlterTableChangeColumnCommand, CreateDataSourceTableCommand, CreateTableCommand}
@@ -31,7 +31,7 @@ object ReplaceCharWithVarchar extends Rule[LogicalPlan] {
 
     plan.resolveOperators {
       // V2 commands
-      case cmd: CreateV2Table =>
+      case cmd: CreateTable =>
         cmd.copy(tableSchema = replaceCharWithVarcharInSchema(cmd.tableSchema))
       case cmd: ReplaceTable =>
         cmd.copy(tableSchema = replaceCharWithVarcharInSchema(cmd.tableSchema))

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -143,7 +143,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
     // For CREATE TABLE [AS SELECT], we should use the v1 command if the catalog is resolved to the
     // session catalog and the table provider is not v2.
-    case c@CreateV2Table(UnresolvedDBObjectName(
+    case c @ CreateV2Table(UnresolvedDBObjectName(
       SessionCatalogAndTable(catalog, name), _), _, _, _, _, _, _, _, _, _, _, _) =>
       val (storageFormat, provider) = getStorageFormatAndProvider(
         c.provider, c.options, c.location, c.serdeInfo, ctas = false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -143,11 +143,10 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
     // For CREATE TABLE [AS SELECT], we should use the v1 command if the catalog is resolved to the
     // session catalog and the table provider is not v2.
-    case c @ CreateV2Table(UnresolvedDBObjectName(
-      SessionCatalogAndTable(catalog, name), _), _, _, _, _, _, _, _, _, _, _, _) =>
+    case c @ CreateV2Table(ResolvedDBObjectName(catalog, name), _, _, _, _, _, _, _, _, _, _, _) =>
       val (storageFormat, provider) = getStorageFormatAndProvider(
         c.provider, c.options, c.location, c.serdeInfo, ctas = false)
-      if (!isV2Provider(provider)) {
+      if (isSessionCatalog(catalog) && !isV2Provider(provider)) {
         val tableDesc = buildCatalogTable(name.asTableIdentifier, c.tableSchema,
           c.partitioning, c.bucketSpec, c.properties, provider, c.location,
           c.comment, storageFormat, c.external)

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -143,20 +143,25 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
     // For CREATE TABLE [AS SELECT], we should use the v1 command if the catalog is resolved to the
     // session catalog and the table provider is not v2.
-    case c @ CreateV2Table(ResolvedDBObjectName(catalog, name), _, _, _, _, _, _, _, _, _, _, _) =>
+    case c @ CreateV2Table(ResolvedDBObjectName(catalog, name), _, _, _, _, _) =>
       val (storageFormat, provider) = getStorageFormatAndProvider(
-        c.provider, c.options, c.location, c.serdeInfo, ctas = false)
+        c.tableProperties.provider,
+        c.tableProperties.options,
+        c.tableProperties.location,
+        c.tableProperties.serde,
+        ctas = false)
       if (isSessionCatalog(catalog) && !isV2Provider(provider)) {
         val tableDesc = buildCatalogTable(name.asTableIdentifier, c.tableSchema,
-          c.partitioning, c.bucketSpec, c.properties, provider, c.location,
-          c.comment, storageFormat, c.external)
+          c.partitioning, c.bucketSpec, c.tableProperties.properties, provider,
+          c.tableProperties.location, c.tableProperties.comment, storageFormat,
+          c.tableProperties.external)
         val mode = if (c.ignoreIfExists) SaveMode.Ignore else SaveMode.ErrorIfExists
         CreateTable(tableDesc, mode, None)
       } else {
         CreateV2Table(
-          ResolvedDBObjectName(catalog, name),
-          c.tableSchema, c.partitioning ++ c.bucketSpec.map(_.asTransform), None, c.properties,
-          c.options, c.serdeInfo, c.location, c.comment, c.provider, c.external, c.ignoreIfExists)
+          ResolvedDBObjectName(catalog, name), c.tableSchema,
+          c.partitioning ++ c.bucketSpec.map(_.asTransform), None, c.tableProperties,
+          c.ignoreIfExists)
       }
 
     case c @ CreateTableAsSelectStatement(

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -156,8 +156,8 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       } else {
         CreateV2Table(
           ResolvedDBObjectName(catalog, name),
-          c.tableSchema, c.partitioning, c.bucketSpec, c.properties, c.options, c.serdeInfo,
-          c.location, c.comment, c.provider, c.external, c.ignoreIfExists)
+          c.tableSchema, c.partitioning ++ c.bucketSpec.map(_.asTransform), None, c.properties,
+          c.options, c.serdeInfo, c.location, c.comment, c.provider, c.external, c.ignoreIfExists)
       }
 
     case c @ CreateTableAsSelectStatement(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.{Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, RowOrdering}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.expressions.{FieldReference, RewritableTransform}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.DDLUtils
@@ -231,51 +230,6 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
       val schema = create.tableSchema
       val partitioning = create.partitioning
       val identifier = create.tableName
-      val isCaseSensitive = conf.caseSensitiveAnalysis
-      // Check that columns are not duplicated in the schema
-      val flattenedSchema = SchemaUtils.explodeNestedFieldNames(schema)
-      SchemaUtils.checkColumnNameDuplication(
-        flattenedSchema,
-        s"in the table definition of $identifier",
-        isCaseSensitive)
-
-      // Check that columns are not duplicated in the partitioning statement
-      SchemaUtils.checkTransformDuplication(
-        partitioning, "in the partitioning", isCaseSensitive)
-
-      if (schema.isEmpty) {
-        if (partitioning.nonEmpty) {
-          throw QueryCompilationErrors.specifyPartitionNotAllowedWhenTableSchemaNotDefinedError()
-        }
-
-        create
-      } else {
-        // Resolve and normalize partition columns as necessary
-        val resolver = conf.resolver
-        val normalizedPartitions = partitioning.map {
-          case transform: RewritableTransform =>
-            val rewritten = transform.references().map { ref =>
-              // Throws an exception if the reference cannot be resolved
-              val position = SchemaUtils.findColumnPosition(ref.fieldNames(), schema, resolver)
-              FieldReference(SchemaUtils.getColumnName(position, schema))
-            }
-            transform.withReferences(rewritten)
-          case other => other
-        }
-
-        create.withPartitioning(normalizedPartitions)
-      }
-
-    case create: V2CreateTablePlanX if create.childrenResolved =>
-      val schema = create.tableSchema
-      val partitioning = create.partitioning
-      val name = create.name.asInstanceOf[ResolvedDBObjectName].nameParts
-      val identifier = if (name.length == 2) {
-        Identifier.of(Array(name(0)), name(1))
-      } else {
-        Identifier.of(Array.empty, name(0))
-      }
-
       val isCaseSensitive = conf.caseSensitiveAnalysis
       // Check that columns are not duplicated in the schema
       val flattenedSchema = SchemaUtils.explodeNestedFieldNames(schema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.{Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, RowOrdering}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.expressions.{FieldReference, RewritableTransform}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.DDLUtils
@@ -229,6 +230,51 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
       val schema = create.tableSchema
       val partitioning = create.partitioning
       val identifier = create.tableName
+      val isCaseSensitive = conf.caseSensitiveAnalysis
+      // Check that columns are not duplicated in the schema
+      val flattenedSchema = SchemaUtils.explodeNestedFieldNames(schema)
+      SchemaUtils.checkColumnNameDuplication(
+        flattenedSchema,
+        s"in the table definition of $identifier",
+        isCaseSensitive)
+
+      // Check that columns are not duplicated in the partitioning statement
+      SchemaUtils.checkTransformDuplication(
+        partitioning, "in the partitioning", isCaseSensitive)
+
+      if (schema.isEmpty) {
+        if (partitioning.nonEmpty) {
+          throw QueryCompilationErrors.specifyPartitionNotAllowedWhenTableSchemaNotDefinedError()
+        }
+
+        create
+      } else {
+        // Resolve and normalize partition columns as necessary
+        val resolver = conf.resolver
+        val normalizedPartitions = partitioning.map {
+          case transform: RewritableTransform =>
+            val rewritten = transform.references().map { ref =>
+              // Throws an exception if the reference cannot be resolved
+              val position = SchemaUtils.findColumnPosition(ref.fieldNames(), schema, resolver)
+              FieldReference(SchemaUtils.getColumnName(position, schema))
+            }
+            transform.withReferences(rewritten)
+          case other => other
+        }
+
+        create.withPartitioning(normalizedPartitions)
+      }
+
+    case create: V2CreateTablePlanX if create.childrenResolved =>
+      val schema = create.tableSchema
+      val partitioning = create.partitioning
+      val name = create.name.asInstanceOf[ResolvedDBObjectName].nameParts
+      val identifier = if (name.length == 2) {
+        Identifier.of(Array(name(0)), name(1))
+      } else {
+        Identifier.of(Array.empty, name(0))
+      }
+
       val isCaseSensitive = conf.caseSensitiveAnalysis
       // Check that columns are not duplicated in the schema
       val flattenedSchema = SchemaUtils.explodeNestedFieldNames(schema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.expressions.{FieldReference, RewritableTransform}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.DDLUtils
-import org.apache.spark.sql.execution.datasources.{CreateTable => DataSourceCreateTable}
+import org.apache.spark.sql.execution.datasources.{CreateTable => CreateTableV1}
 import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
 import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.{AtomicType, StructType}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.expressions.{FieldReference, RewritableTransform}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.DDLUtils
+import org.apache.spark.sql.execution.datasources.{CreateTable => DataSourceCreateTable}
 import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
 import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.{AtomicType, StructType}
@@ -82,7 +83,7 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
     // bucketing information is specified, as we can't infer bucketing from data files currently.
     // Since the runtime inferred partition columns could be different from what user specified,
     // we fail the query if the partitioning information is specified.
-    case c @ CreateTable(tableDesc, _, None) if tableDesc.schema.isEmpty =>
+    case c @ DataSourceCreateTable(tableDesc, _, None) if tableDesc.schema.isEmpty =>
       if (tableDesc.bucketSpec.isDefined) {
         failAnalysis("Cannot specify bucketing information if the table schema is not specified " +
           "when creating and will be inferred at runtime")
@@ -97,7 +98,7 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
     // When we append data to an existing table, check if the given provider, partition columns,
     // bucket spec, etc. match the existing table, and adjust the columns order of the given query
     // if necessary.
-    case c @ CreateTable(tableDesc, SaveMode.Append, Some(query))
+    case c @ DataSourceCreateTable(tableDesc, SaveMode.Append, Some(query))
         if query.resolved && catalog.tableExists(tableDesc.identifier) =>
       // This is guaranteed by the parser and `DataFrameWriter`
       assert(tableDesc.provider.isDefined)
@@ -190,7 +191,7 @@ case class PreprocessTableCreation(sparkSession: SparkSession) extends Rule[Logi
     //   * partition columns' type must be AtomicType.
     //   * sort columns' type must be orderable.
     //   * reorder table schema or output of query plan, to put partition columns at the end.
-    case c @ CreateTable(tableDesc, _, query) if query.forall(_.resolved) =>
+    case c @ DataSourceCreateTable(tableDesc, _, query) if query.forall(_.resolved) =>
       if (query.isDefined) {
         assert(tableDesc.schema.isEmpty,
           "Schema may not be specified in a Create Table As Select (CTAS) statement")
@@ -479,7 +480,7 @@ object PreprocessTableInsertion extends Rule[LogicalPlan] {
 object HiveOnlyCheck extends (LogicalPlan => Unit) {
   def apply(plan: LogicalPlan): Unit = {
     plan.foreach {
-      case CreateTable(tableDesc, _, _) if DDLUtils.isHiveTable(tableDesc) =>
+      case DataSourceCreateTable(tableDesc, _, _) if DDLUtils.isHiveTable(tableDesc) =>
         throw QueryCompilationErrors.ddlWithoutHiveSupportEnabledError(
           "CREATE Hive TABLE (AS SELECT)")
       case i: InsertIntoDir if DDLUtils.isHiveTable(i.provider) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableExec.scala
@@ -37,11 +37,13 @@ case class CreateTableExec(
     ignoreIfExists: Boolean) extends LeafV2CommandExec {
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 
-  val props = CatalogV2Util.convertTableProperties(
-    tableSpec.properties, tableSpec.options, tableSpec.serde,
-    tableSpec.location, tableSpec.comment, tableSpec.provider,
-    tableSpec.external)
-  val tableProperties = CatalogV2Util.withDefaultOwnership(props)
+  val tableProperties = {
+    val props = CatalogV2Util.convertTableProperties(
+      tableSpec.properties, tableSpec.options, tableSpec.serde,
+      tableSpec.location, tableSpec.comment, tableSpec.provider,
+      tableSpec.external)
+    CatalogV2Util.withDefaultOwnership(props)
+  }
 
   override protected def run(): Seq[InternalRow] = {
     if (!catalog.tableExists(identifier)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableExec.scala
@@ -22,7 +22,8 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.catalyst.plans.logical.TableSpec
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, TableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.StructType
@@ -32,9 +33,15 @@ case class CreateTableExec(
     identifier: Identifier,
     tableSchema: StructType,
     partitioning: Seq[Transform],
-    tableProperties: Map[String, String],
+    tableSpec: TableSpec,
     ignoreIfExists: Boolean) extends LeafV2CommandExec {
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  val props = CatalogV2Util.convertTableProperties(
+    tableSpec.properties, tableSpec.options, tableSpec.serde,
+    tableSpec.location, tableSpec.comment, tableSpec.provider,
+    tableSpec.external)
+  val tableProperties = CatalogV2Util.withDefaultOwnership(props)
 
   override protected def run(): Seq[InternalRow] = {
     if (!catalog.tableExists(identifier)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -165,9 +165,13 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
       WriteToDataSourceV2Exec(writer, invalidateCacheFunc, planLater(query), customMetrics) :: Nil
 
-    case CreateV2Table(catalog, ident, schema, parts, props, ifNotExists) =>
+    case CreateV2Table(ResolvedDBObjectName(catalog, ident), schema, parts, bucketSpec,
+    properties, options, serde, location, comment, provider, external, ifNotExists) =>
+      val props = CatalogV2Util.convertTableProperties(
+        properties, options, serde, location, comment, provider, external)
       val propsWithOwner = CatalogV2Util.withDefaultOwnership(props)
-      CreateTableExec(catalog, ident, schema, parts, propsWithOwner, ifNotExists) :: Nil
+      CreateTableExec(catalog.asTableCatalog, ident.asIdentifier, schema,
+        parts, propsWithOwner, ifNotExists) :: Nil
 
     case CreateTableAsSelect(catalog, ident, parts, query, props, options, ifNotExists) =>
       val propsWithOwner = CatalogV2Util.withDefaultOwnership(props)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -165,10 +165,12 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
       WriteToDataSourceV2Exec(writer, invalidateCacheFunc, planLater(query), customMetrics) :: Nil
 
-    case CreateV2Table(ResolvedDBObjectName(catalog, ident), schema, parts, bucketSpec,
-    properties, options, serde, location, comment, provider, external, ifNotExists) =>
+    case CreateV2Table(ResolvedDBObjectName(catalog, ident), schema, parts, _,
+        tableProperties, ifNotExists) =>
       val props = CatalogV2Util.convertTableProperties(
-        properties, options, serde, location, comment, provider, external)
+        tableProperties.properties, tableProperties.options, tableProperties.serde,
+        tableProperties.location, tableProperties.comment, tableProperties.provider,
+        tableProperties.external)
       val propsWithOwner = CatalogV2Util.withDefaultOwnership(props)
       CreateTableExec(catalog.asTableCatalog, ident.asIdentifier, schema,
         parts, propsWithOwner, ifNotExists) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -165,16 +165,10 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
       WriteToDataSourceV2Exec(writer, invalidateCacheFunc, planLater(query), customMetrics) :: Nil
 
-    case CreateTable(ResolvedDBObjectName(catalog, ident), schema, partitioning, bucketSpec,
+    case CreateTable(ResolvedDBObjectName(catalog, ident), schema, partitioning,
         tableSpec, ifNotExists) =>
-      val props = CatalogV2Util.convertTableProperties(
-        tableSpec.properties, tableSpec.options, tableSpec.serde,
-        tableSpec.location, tableSpec.comment, tableSpec.provider,
-        tableSpec.external)
-      val propsWithOwner = CatalogV2Util.withDefaultOwnership(props)
-      val parts = partitioning ++ bucketSpec.map(_.asTransform)
       CreateTableExec(catalog.asTableCatalog, ident.asIdentifier, schema,
-        parts, propsWithOwner, ifNotExists) :: Nil
+        partitioning, tableSpec, ifNotExists) :: Nil
 
     case CreateTableAsSelect(catalog, ident, parts, query, props, options, ifNotExists) =>
       val propsWithOwner = CatalogV2Util.withDefaultOwnership(props)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -165,13 +165,14 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
       WriteToDataSourceV2Exec(writer, invalidateCacheFunc, planLater(query), customMetrics) :: Nil
 
-    case CreateV2Table(ResolvedDBObjectName(catalog, ident), schema, parts, _,
-        tableProperties, ifNotExists) =>
+    case CreateTable(ResolvedDBObjectName(catalog, ident), schema, partitioning, bucketSpec,
+        tableSpec, ifNotExists) =>
       val props = CatalogV2Util.convertTableProperties(
-        tableProperties.properties, tableProperties.options, tableProperties.serde,
-        tableProperties.location, tableProperties.comment, tableProperties.provider,
-        tableProperties.external)
+        tableSpec.properties, tableSpec.options, tableSpec.serde,
+        tableSpec.location, tableSpec.comment, tableSpec.provider,
+        tableSpec.external)
       val propsWithOwner = CatalogV2Util.withDefaultOwnership(props)
+      val parts = partitioning ++ bucketSpec.map(_.asTransform)
       CreateTableExec(catalog.asTableCatalog, ident.asIdentifier, schema,
         parts, propsWithOwner, ifNotExists) :: Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -27,8 +27,9 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.annotation.Evolving
 import org.apache.spark.api.java.function.VoidFunction2
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.analysis.UnresolvedDBObjectName
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
-import org.apache.spark.sql.catalyst.plans.logical.CreateTableStatement
+import org.apache.spark.sql.catalyst.plans.logical.CreateV2Table
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.catalog.{Identifier, SupportsWrite, Table, TableCatalog, TableProvider, V1Table, V2TableWithV1Fallback}
@@ -288,19 +289,21 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
        * Note, currently the new table creation by this API doesn't fully cover the V2 table.
        * TODO (SPARK-33638): Full support of v2 table creation
        */
-      val cmd = CreateTableStatement(
-        originalMultipartIdentifier,
+      val cmd = CreateV2Table(
+        UnresolvedDBObjectName(
+          originalMultipartIdentifier,
+          isNamespace = true),
         df.schema.asNullable,
         partitioningColumns.getOrElse(Nil).asTransforms.toSeq,
         None,
         Map.empty[String, String],
-        Some(source),
         Map.empty[String, String],
+        None,
         extraOptions.get("path"),
         None,
-        None,
+        Some(source),
         external = false,
-        ifNotExists = false)
+        ignoreIfExists = false)
       Dataset.ofRows(df.sparkSession, cmd)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -29,7 +29,7 @@ import org.apache.spark.api.java.function.VoidFunction2
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedDBObjectName
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
-import org.apache.spark.sql.catalyst.plans.logical.{CreateV2Table, TableProperties}
+import org.apache.spark.sql.catalyst.plans.logical.{CreateTable, TableSpec}
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.catalog.{Identifier, SupportsWrite, Table, TableCatalog, TableProvider, V1Table, V2TableWithV1Fallback}
@@ -289,7 +289,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
        * Note, currently the new table creation by this API doesn't fully cover the V2 table.
        * TODO (SPARK-33638): Full support of v2 table creation
        */
-      val tableProperties = TableProperties(
+      val tableProperties = TableSpec(
         Map.empty[String, String],
         Some(source),
         Map.empty[String, String],
@@ -297,7 +297,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
         None,
         None,
         false)
-      val cmd = CreateV2Table(
+      val cmd = CreateTable(
         UnresolvedDBObjectName(
           originalMultipartIdentifier,
           isNamespace = false),

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -290,6 +290,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
        * TODO (SPARK-33638): Full support of v2 table creation
        */
       val tableProperties = TableSpec(
+        None,
         Map.empty[String, String],
         Some(source),
         Map.empty[String, String],
@@ -303,7 +304,6 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
           isNamespace = false),
         df.schema.asNullable,
         partitioningColumns.getOrElse(Nil).asTransforms.toSeq,
-        None,
         tableProperties,
         ignoreIfExists = false)
       Dataset.ofRows(df.sparkSession, cmd)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.catalyst.plans.logical.{AlterColumn, AnalysisOnlyCommand, AppendData, Assignment, CreateTable => CatalystCreateTable, CreateTableAsSelect, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.FakeV2Provider
-import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogNotFoundException, CatalogV2Util, Identifier, Table, TableCapability, TableCatalog, V1Table}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogNotFoundException, Identifier, Table, TableCapability, TableCatalog, V1Table}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.datasources.CreateTable
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -471,15 +471,6 @@ class PlanResolutionSuite extends AnalysisTest {
          |OPTIONS (path 's3://bucket/path/to/data', other 20)
       """.stripMargin
 
-    val expectedProperties = Map(
-      "p1" -> "v1",
-      "p2" -> "v2",
-      "option.other" -> "20",
-      "provider" -> "parquet",
-      "location" -> "s3://bucket/path/to/data",
-      "comment" -> "table comment",
-      "other" -> "20")
-
     parseAndResolve(sql) match {
       case create: CatalystCreateTable =>
         assert(create.name.asInstanceOf[ResolvedDBObjectName].catalog.name == "testcat")
@@ -490,13 +481,6 @@ class PlanResolutionSuite extends AnalysisTest {
             .add("description", StringType)
             .add("point", new StructType().add("x", DoubleType).add("y", DoubleType)))
         assert(create.partitioning.isEmpty)
-
-        val properties = CatalogV2Util.convertTableProperties(
-          create.tableSpec.properties, create.tableSpec.options,
-          create.tableSpec.serde, create.tableSpec.location,
-          create.tableSpec.comment, create.tableSpec.provider,
-          create.tableSpec.external)
-        assert(properties == expectedProperties)
         assert(create.ignoreIfExists)
 
       case other =>
@@ -518,15 +502,6 @@ class PlanResolutionSuite extends AnalysisTest {
          |OPTIONS (path 's3://bucket/path/to/data', other 20)
       """.stripMargin
 
-    val expectedProperties = Map(
-      "p1" -> "v1",
-      "p2" -> "v2",
-      "option.other" -> "20",
-      "provider" -> "parquet",
-      "location" -> "s3://bucket/path/to/data",
-      "comment" -> "table comment",
-      "other" -> "20")
-
     parseAndResolve(sql, withDefault = true) match {
       case create: CatalystCreateTable =>
         assert(create.name.asInstanceOf[ResolvedDBObjectName].catalog.name == "testcat")
@@ -537,12 +512,6 @@ class PlanResolutionSuite extends AnalysisTest {
             .add("description", StringType)
             .add("point", new StructType().add("x", DoubleType).add("y", DoubleType)))
         assert(create.partitioning.isEmpty)
-        val properties = CatalogV2Util.convertTableProperties(
-          create.tableSpec.properties, create.tableSpec.options,
-          create.tableSpec.serde, create.tableSpec.location,
-          create.tableSpec.comment, create.tableSpec.provider,
-          create.tableSpec.external)
-        assert(properties == expectedProperties)
         assert(create.ignoreIfExists)
 
       case other =>
@@ -564,13 +533,6 @@ class PlanResolutionSuite extends AnalysisTest {
          |TBLPROPERTIES ('p1'='v1', 'p2'='v2')
       """.stripMargin
 
-    val expectedProperties = Map(
-      "p1" -> "v1",
-      "p2" -> "v2",
-      "provider" -> v2Format,
-      "location" -> "/user/external/page_view",
-      "comment" -> "This is the staging page view table")
-
     parseAndResolve(sql) match {
       case create: CatalystCreateTable =>
         assert(create.name.asInstanceOf[ResolvedDBObjectName].catalog.name ==
@@ -582,12 +544,6 @@ class PlanResolutionSuite extends AnalysisTest {
             .add("description", StringType)
             .add("point", new StructType().add("x", DoubleType).add("y", DoubleType)))
         assert(create.partitioning.isEmpty)
-        val properties = CatalogV2Util.convertTableProperties(
-          create.tableSpec.properties, create.tableSpec.options,
-          create.tableSpec.serde, create.tableSpec.location,
-          create.tableSpec.comment, create.tableSpec.provider,
-          create.tableSpec.external)
-        assert(properties == expectedProperties)
         assert(create.ignoreIfExists)
 
       case other =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -31,12 +31,12 @@ import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, 
 import org.apache.spark.sql.catalyst.expressions.{AnsiCast, AttributeReference, EqualTo, Expression, InSubquery, IntegerLiteral, ListQuery, Literal, StringLiteral}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
-import org.apache.spark.sql.catalyst.plans.logical.{AlterColumn, AnalysisOnlyCommand, AppendData, Assignment, CreateTable => CatalystCreateTable, CreateTableAsSelect, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
+import org.apache.spark.sql.catalyst.plans.logical.{AlterColumn, AnalysisOnlyCommand, AppendData, Assignment, CreateTable, CreateTableAsSelect, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.FakeV2Provider
 import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogNotFoundException, Identifier, Table, TableCapability, TableCatalog, V1Table}
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.execution.datasources.CreateTable
+import org.apache.spark.sql.execution.datasources.{CreateTable => CreateTableV1}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.{HiveSerDe, SQLConf}
 import org.apache.spark.sql.sources.SimpleScanSource
@@ -210,7 +210,7 @@ class PlanResolutionSuite extends AnalysisTest {
 
   private def extractTableDesc(sql: String): (CatalogTable, Boolean) = {
     parseAndResolve(sql).collect {
-      case CreateTable(tableDesc, mode, _) => (tableDesc, mode == SaveMode.Ignore)
+      case CreateTableV1(tableDesc, mode, _) => (tableDesc, mode == SaveMode.Ignore)
     }.head
   }
 
@@ -240,7 +240,7 @@ class PlanResolutionSuite extends AnalysisTest {
     )
 
     parseAndResolve(query) match {
-      case CreateTable(tableDesc, _, None) =>
+      case CreateTableV1(tableDesc, _, None) =>
         assert(tableDesc == expectedTableDesc.copy(createTime = tableDesc.createTime))
       case other =>
         fail(s"Expected to parse ${classOf[CreateTableCommand].getClass.getName} from query," +
@@ -282,7 +282,7 @@ class PlanResolutionSuite extends AnalysisTest {
     )
 
     parseAndResolve(query) match {
-      case CreateTable(tableDesc, _, None) =>
+      case CreateTableV1(tableDesc, _, None) =>
         assert(tableDesc == expectedTableDesc.copy(createTime = tableDesc.createTime))
       case other =>
         fail(s"Expected to parse ${classOf[CreateTableCommand].getClass.getName} from query," +
@@ -302,7 +302,7 @@ class PlanResolutionSuite extends AnalysisTest {
       comment = Some("abc"))
 
     parseAndResolve(sql) match {
-      case CreateTable(tableDesc, _, None) =>
+      case CreateTableV1(tableDesc, _, None) =>
         assert(tableDesc == expectedTableDesc.copy(createTime = tableDesc.createTime))
       case other =>
         fail(s"Expected to parse ${classOf[CreateTableCommand].getClass.getName} from query," +
@@ -322,7 +322,7 @@ class PlanResolutionSuite extends AnalysisTest {
       properties = Map("test" -> "test"))
 
     parseAndResolve(sql) match {
-      case CreateTable(tableDesc, _, None) =>
+      case CreateTableV1(tableDesc, _, None) =>
         assert(tableDesc == expectedTableDesc.copy(createTime = tableDesc.createTime))
       case other =>
         fail(s"Expected to parse ${classOf[CreateTableCommand].getClass.getName} from query," +
@@ -341,7 +341,7 @@ class PlanResolutionSuite extends AnalysisTest {
       provider = Some("parquet"))
 
     parseAndResolve(v1) match {
-      case CreateTable(tableDesc, _, None) =>
+      case CreateTableV1(tableDesc, _, None) =>
         assert(tableDesc == expectedTableDesc.copy(createTime = tableDesc.createTime))
       case other =>
         fail(s"Expected to parse ${classOf[CreateTableCommand].getClass.getName} from query," +
@@ -372,7 +372,7 @@ class PlanResolutionSuite extends AnalysisTest {
       provider = Some("parquet"))
 
     parseAndResolve(sql) match {
-      case CreateTable(tableDesc, _, None) =>
+      case CreateTableV1(tableDesc, _, None) =>
         assert(tableDesc == expectedTableDesc.copy(createTime = tableDesc.createTime))
       case other =>
         fail(s"Expected to parse ${classOf[CreateTableCommand].getClass.getName} from query," +
@@ -398,7 +398,7 @@ class PlanResolutionSuite extends AnalysisTest {
     )
 
     parseAndResolve(sql) match {
-      case CreateTable(tableDesc, _, None) =>
+      case CreateTableV1(tableDesc, _, None) =>
         assert(tableDesc == expectedTableDesc.copy(createTime = tableDesc.createTime))
       case other =>
         fail(s"Expected to parse ${classOf[CreateTableCommand].getClass.getName} from query," +
@@ -472,7 +472,7 @@ class PlanResolutionSuite extends AnalysisTest {
       """.stripMargin
 
     parseAndResolve(sql) match {
-      case create: CatalystCreateTable =>
+      case create: CreateTable =>
         assert(create.name.asInstanceOf[ResolvedDBObjectName].catalog.name == "testcat")
         assert(create.name.asInstanceOf[ResolvedDBObjectName].nameParts.mkString(".") ==
           "mydb.table_name")
@@ -484,7 +484,7 @@ class PlanResolutionSuite extends AnalysisTest {
         assert(create.ignoreIfExists)
 
       case other =>
-        fail(s"Expected to parse ${classOf[CatalystCreateTable].getName} from query," +
+        fail(s"Expected to parse ${classOf[CreateTable].getName} from query," +
             s"got ${other.getClass.getName}: $sql")
     }
   }
@@ -503,7 +503,7 @@ class PlanResolutionSuite extends AnalysisTest {
       """.stripMargin
 
     parseAndResolve(sql, withDefault = true) match {
-      case create: CatalystCreateTable =>
+      case create: CreateTable =>
         assert(create.name.asInstanceOf[ResolvedDBObjectName].catalog.name == "testcat")
         assert(create.name.asInstanceOf[ResolvedDBObjectName].nameParts.mkString(".") ==
           "mydb.table_name")
@@ -515,7 +515,7 @@ class PlanResolutionSuite extends AnalysisTest {
         assert(create.ignoreIfExists)
 
       case other =>
-        fail(s"Expected to parse ${classOf[CatalystCreateTable].getName} from query," +
+        fail(s"Expected to parse ${classOf[CreateTable].getName} from query," +
             s"got ${other.getClass.getName}: $sql")
     }
   }
@@ -534,7 +534,7 @@ class PlanResolutionSuite extends AnalysisTest {
       """.stripMargin
 
     parseAndResolve(sql) match {
-      case create: CatalystCreateTable =>
+      case create: CreateTable =>
         assert(create.name.asInstanceOf[ResolvedDBObjectName].catalog.name ==
           CatalogManager.SESSION_CATALOG_NAME)
         assert(create.name.asInstanceOf[ResolvedDBObjectName].nameParts.mkString(".") ==
@@ -547,7 +547,7 @@ class PlanResolutionSuite extends AnalysisTest {
         assert(create.ignoreIfExists)
 
       case other =>
-        fail(s"Expected to parse ${classOf[CatalystCreateTable].getName} from query," +
+        fail(s"Expected to parse ${classOf[CreateTable].getName} from query," +
             s"got ${other.getClass.getName}: $sql")
     }
   }
@@ -1660,9 +1660,9 @@ class PlanResolutionSuite extends AnalysisTest {
      */
     def normalizePlan(plan: LogicalPlan): LogicalPlan = {
       plan match {
-        case CreateTable(tableDesc, mode, query) =>
+        case CreateTableV1(tableDesc, mode, query) =>
           val newTableDesc = tableDesc.copy(createTime = -1L)
-          CreateTable(newTableDesc, mode, query)
+          CreateTableV1(newTableDesc, mode, query)
         case _ => plan // Don't transform
       }
     }
@@ -1683,8 +1683,8 @@ class PlanResolutionSuite extends AnalysisTest {
         partitionColumnNames: Seq[String] = Seq.empty,
         comment: Option[String] = None,
         mode: SaveMode = SaveMode.ErrorIfExists,
-        query: Option[LogicalPlan] = None): CreateTable = {
-      CreateTable(
+        query: Option[LogicalPlan] = None): CreateTableV1 = {
+      CreateTableV1(
         CatalogTable(
           identifier = TableIdentifier(table, database),
           tableType = tableType,
@@ -1766,7 +1766,7 @@ class PlanResolutionSuite extends AnalysisTest {
     allSources.foreach { s =>
       val query = s"CREATE TABLE my_tab STORED AS $s"
       parseAndResolve(query) match {
-        case ct: CreateTable =>
+        case ct: CreateTableV1 =>
           val hiveSerde = HiveSerDe.sourceToSerDe(s)
           assert(hiveSerde.isDefined)
           assert(ct.tableDesc.storage.serde ==
@@ -1785,14 +1785,14 @@ class PlanResolutionSuite extends AnalysisTest {
 
     // No conflicting serdes here, OK
     parseAndResolve(query1) match {
-      case parsed1: CreateTable =>
+      case parsed1: CreateTableV1 =>
         assert(parsed1.tableDesc.storage.serde == Some("anything"))
         assert(parsed1.tableDesc.storage.inputFormat == Some("inputfmt"))
         assert(parsed1.tableDesc.storage.outputFormat == Some("outputfmt"))
     }
 
     parseAndResolve(query2) match {
-      case parsed2: CreateTable =>
+      case parsed2: CreateTableV1 =>
         assert(parsed2.tableDesc.storage.serde ==
             Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
         assert(parsed2.tableDesc.storage.inputFormat == Some("inputfmt"))
@@ -1808,7 +1808,7 @@ class PlanResolutionSuite extends AnalysisTest {
       val query = s"CREATE TABLE my_tab ROW FORMAT SERDE 'anything' STORED AS $s"
       if (supportedSources.contains(s)) {
         parseAndResolve(query) match {
-          case ct: CreateTable =>
+          case ct: CreateTableV1 =>
             val hiveSerde = HiveSerDe.sourceToSerDe(s)
             assert(hiveSerde.isDefined)
             assert(ct.tableDesc.storage.serde == Some("anything"))
@@ -1829,7 +1829,7 @@ class PlanResolutionSuite extends AnalysisTest {
       val query = s"CREATE TABLE my_tab ROW FORMAT DELIMITED FIELDS TERMINATED BY ' ' STORED AS $s"
       if (supportedSources.contains(s)) {
         parseAndResolve(query) match {
-          case ct: CreateTable =>
+          case ct: CreateTableV1 =>
             val hiveSerde = HiveSerDe.sourceToSerDe(s)
             assert(hiveSerde.isDefined)
             assert(ct.tableDesc.storage.serde == hiveSerde.get.serde
@@ -1846,14 +1846,14 @@ class PlanResolutionSuite extends AnalysisTest {
   test("create hive external table") {
     val withoutLoc = "CREATE EXTERNAL TABLE my_tab STORED AS parquet"
     parseAndResolve(withoutLoc) match {
-      case ct: CreateTable =>
+      case ct: CreateTableV1 =>
         assert(ct.tableDesc.tableType == CatalogTableType.EXTERNAL)
         assert(ct.tableDesc.storage.locationUri.isEmpty)
     }
 
     val withLoc = "CREATE EXTERNAL TABLE my_tab STORED AS parquet LOCATION '/something/anything'"
     parseAndResolve(withLoc) match {
-      case ct: CreateTable =>
+      case ct: CreateTableV1 =>
         assert(ct.tableDesc.tableType == CatalogTableType.EXTERNAL)
         assert(ct.tableDesc.storage.locationUri == Some(new URI("/something/anything")))
     }
@@ -1873,7 +1873,7 @@ class PlanResolutionSuite extends AnalysisTest {
   test("create hive table - location implies external") {
     val query = "CREATE TABLE my_tab STORED AS parquet LOCATION '/something/anything'"
     parseAndResolve(query) match {
-      case ct: CreateTable =>
+      case ct: CreateTableV1 =>
         assert(ct.tableDesc.tableType == CatalogTableType.EXTERNAL)
         assert(ct.tableDesc.storage.locationUri == Some(new URI("/something/anything")))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, 
 import org.apache.spark.sql.catalyst.expressions.{AnsiCast, AttributeReference, EqualTo, Expression, InSubquery, IntegerLiteral, ListQuery, Literal, StringLiteral}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
-import org.apache.spark.sql.catalyst.plans.logical.{AlterColumn, AnalysisOnlyCommand, AppendData, Assignment, CreateTableAsSelect, CreateV2Table, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
+import org.apache.spark.sql.catalyst.plans.logical.{AlterColumn, AnalysisOnlyCommand, AppendData, Assignment, CreateTable => CatalystCreateTable, CreateTableAsSelect, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.FakeV2Provider
 import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogNotFoundException, CatalogV2Util, Identifier, Table, TableCapability, TableCatalog, V1Table}
@@ -481,7 +481,7 @@ class PlanResolutionSuite extends AnalysisTest {
       "other" -> "20")
 
     parseAndResolve(sql) match {
-      case create: CreateV2Table =>
+      case create: CatalystCreateTable =>
         assert(create.name.asInstanceOf[ResolvedDBObjectName].catalog.name == "testcat")
         assert(create.name.asInstanceOf[ResolvedDBObjectName].nameParts.mkString(".") ==
           "mydb.table_name")
@@ -492,15 +492,15 @@ class PlanResolutionSuite extends AnalysisTest {
         assert(create.partitioning.isEmpty)
 
         val properties = CatalogV2Util.convertTableProperties(
-          create.tableProperties.properties, create.tableProperties.options,
-          create.tableProperties.serde, create.tableProperties.location,
-          create.tableProperties.comment, create.tableProperties.provider,
-          create.tableProperties.external)
+          create.tableSpec.properties, create.tableSpec.options,
+          create.tableSpec.serde, create.tableSpec.location,
+          create.tableSpec.comment, create.tableSpec.provider,
+          create.tableSpec.external)
         assert(properties == expectedProperties)
         assert(create.ignoreIfExists)
 
       case other =>
-        fail(s"Expected to parse ${classOf[CreateV2Table].getName} from query," +
+        fail(s"Expected to parse ${classOf[CatalystCreateTable].getName} from query," +
             s"got ${other.getClass.getName}: $sql")
     }
   }
@@ -528,7 +528,7 @@ class PlanResolutionSuite extends AnalysisTest {
       "other" -> "20")
 
     parseAndResolve(sql, withDefault = true) match {
-      case create: CreateV2Table =>
+      case create: CatalystCreateTable =>
         assert(create.name.asInstanceOf[ResolvedDBObjectName].catalog.name == "testcat")
         assert(create.name.asInstanceOf[ResolvedDBObjectName].nameParts.mkString(".") ==
           "mydb.table_name")
@@ -538,15 +538,15 @@ class PlanResolutionSuite extends AnalysisTest {
             .add("point", new StructType().add("x", DoubleType).add("y", DoubleType)))
         assert(create.partitioning.isEmpty)
         val properties = CatalogV2Util.convertTableProperties(
-          create.tableProperties.properties, create.tableProperties.options,
-          create.tableProperties.serde, create.tableProperties.location,
-          create.tableProperties.comment, create.tableProperties.provider,
-          create.tableProperties.external)
+          create.tableSpec.properties, create.tableSpec.options,
+          create.tableSpec.serde, create.tableSpec.location,
+          create.tableSpec.comment, create.tableSpec.provider,
+          create.tableSpec.external)
         assert(properties == expectedProperties)
         assert(create.ignoreIfExists)
 
       case other =>
-        fail(s"Expected to parse ${classOf[CreateV2Table].getName} from query," +
+        fail(s"Expected to parse ${classOf[CatalystCreateTable].getName} from query," +
             s"got ${other.getClass.getName}: $sql")
     }
   }
@@ -572,7 +572,7 @@ class PlanResolutionSuite extends AnalysisTest {
       "comment" -> "This is the staging page view table")
 
     parseAndResolve(sql) match {
-      case create: CreateV2Table =>
+      case create: CatalystCreateTable =>
         assert(create.name.asInstanceOf[ResolvedDBObjectName].catalog.name ==
           CatalogManager.SESSION_CATALOG_NAME)
         assert(create.name.asInstanceOf[ResolvedDBObjectName].nameParts.mkString(".") ==
@@ -583,15 +583,15 @@ class PlanResolutionSuite extends AnalysisTest {
             .add("point", new StructType().add("x", DoubleType).add("y", DoubleType)))
         assert(create.partitioning.isEmpty)
         val properties = CatalogV2Util.convertTableProperties(
-          create.tableProperties.properties, create.tableProperties.options,
-          create.tableProperties.serde, create.tableProperties.location,
-          create.tableProperties.comment, create.tableProperties.provider,
-          create.tableProperties.external)
+          create.tableSpec.properties, create.tableSpec.options,
+          create.tableSpec.serde, create.tableSpec.location,
+          create.tableSpec.comment, create.tableSpec.provider,
+          create.tableSpec.external)
         assert(properties == expectedProperties)
         assert(create.ignoreIfExists)
 
       case other =>
-        fail(s"Expected to parse ${classOf[CreateV2Table].getName} from query," +
+        fail(s"Expected to parse ${classOf[CatalystCreateTable].getName} from query," +
             s"got ${other.getClass.getName}: $sql")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -34,8 +34,7 @@ import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.catalyst.plans.logical.{AlterColumn, AnalysisOnlyCommand, AppendData, Assignment, CreateTableAsSelect, CreateV2Table, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.FakeV2Provider
-import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogNotFoundException, Identifier, Table, TableCapability, TableCatalog, V1Table}
-import org.apache.spark.sql.connector.catalog.CatalogV2Util.convertTableProperties
+import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogNotFoundException, CatalogV2Util, Identifier, Table, TableCapability, TableCatalog, V1Table}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.datasources.CreateTable
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -480,7 +479,6 @@ class PlanResolutionSuite extends AnalysisTest {
       "location" -> "s3://bucket/path/to/data",
       "comment" -> "table comment",
       "other" -> "20")
-    import org.apache.spark.sql.connector.catalog.CatalogV2Util.convertTableProperties
 
     parseAndResolve(sql) match {
       case create: CreateV2Table =>
@@ -492,10 +490,13 @@ class PlanResolutionSuite extends AnalysisTest {
             .add("description", StringType)
             .add("point", new StructType().add("x", DoubleType).add("y", DoubleType)))
         assert(create.partitioning.isEmpty)
-        val props = convertTableProperties(
-          create.properties, create.options, create.serdeInfo, create.location, create.comment,
-          create.provider, create.external)
-        assert(props == expectedProperties)
+
+        val properties = CatalogV2Util.convertTableProperties(
+          create.tableProperties.properties, create.tableProperties.options,
+          create.tableProperties.serde, create.tableProperties.location,
+          create.tableProperties.comment, create.tableProperties.provider,
+          create.tableProperties.external)
+        assert(properties == expectedProperties)
         assert(create.ignoreIfExists)
 
       case other =>
@@ -536,10 +537,12 @@ class PlanResolutionSuite extends AnalysisTest {
             .add("description", StringType)
             .add("point", new StructType().add("x", DoubleType).add("y", DoubleType)))
         assert(create.partitioning.isEmpty)
-        val props = convertTableProperties(
-          create.properties, create.options, create.serdeInfo, create.location, create.comment,
-          create.provider, create.external)
-        assert(props == expectedProperties)
+        val properties = CatalogV2Util.convertTableProperties(
+          create.tableProperties.properties, create.tableProperties.options,
+          create.tableProperties.serde, create.tableProperties.location,
+          create.tableProperties.comment, create.tableProperties.provider,
+          create.tableProperties.external)
+        assert(properties == expectedProperties)
         assert(create.ignoreIfExists)
 
       case other =>
@@ -579,10 +582,12 @@ class PlanResolutionSuite extends AnalysisTest {
             .add("description", StringType)
             .add("point", new StructType().add("x", DoubleType).add("y", DoubleType)))
         assert(create.partitioning.isEmpty)
-        val props = convertTableProperties(
-          create.properties, create.options, create.serdeInfo, create.location, create.comment,
-          create.provider, create.external)
-        assert(props == expectedProperties)
+        val properties = CatalogV2Util.convertTableProperties(
+          create.tableProperties.properties, create.tableProperties.options,
+          create.tableProperties.serde, create.tableProperties.location,
+          create.tableProperties.comment, create.tableProperties.provider,
+          create.tableProperties.external)
+        assert(properties == expectedProperties)
         assert(create.ignoreIfExists)
 
       case other =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -2276,14 +2276,6 @@ class PlanResolutionSuite extends AnalysisTest {
     assert(e2.getMessage.contains("Operation not allowed"))
   }
 
-//  test("create table - properties") {
-//    val query = "CREATE TABLE my_table (id int, name string) TBLPROPERTIES ('k1'='v1', 'k2'='v2')"
-//    parsePlan(query) match {
-//      case state: CreateTableStatement =>
-//        assert(state.properties == Map("k1" -> "v1", "k2" -> "v2"))
-//    }
-//  }
-
   test("create table(hive) - everything!") {
     val query =
       """


### PR DESCRIPTION

### What changes were proposed in this pull request?
Migrate `CreateTableStatement` to v2 command framework


### Why are the changes needed?
Migrate to the standard V2 framework

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing tests
