### PR TITLE
[SPARK-36819][SQL] Don't insert redundant filters in case static partition pruning can be done

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
@@ -208,12 +208,12 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper with Join
     case Not(expr) => isLikelySelective(expr, joinKey)
     case And(l, r) => isLikelySelective(l, joinKey) || isLikelySelective(r, joinKey)
     case Or(l, r) => isLikelySelective(l, joinKey) && isLikelySelective(r, joinKey)
-    case expr: StringRegexExpression => true && !expr.references.subsetOf(joinKey.references)
-    case expr: BinaryComparison => true && !expr.references.subsetOf(joinKey.references)
-    case expr: In => true && !expr.references.subsetOf(joinKey.references)
-    case expr: InSet => true && !expr.references.subsetOf(joinKey.references)
-    case expr: StringPredicate => true && !expr.references.subsetOf(joinKey.references)
-    case expr: MultiLikeBase => true && !expr.references.subsetOf(joinKey.references)
+    case expr: StringRegexExpression => !expr.references.subsetOf(joinKey.references)
+    case expr: BinaryComparison => !expr.references.subsetOf(joinKey.references)
+    case expr: In => !expr.references.subsetOf(joinKey.references)
+    case expr: InSet => !expr.references.subsetOf(joinKey.references)
+    case expr: StringPredicate => !expr.references.subsetOf(joinKey.references)
+    case expr: MultiLikeBase => !expr.references.subsetOf(joinKey.references)
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
@@ -201,20 +201,41 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper with Join
   }
 
   /**
+   * Returns whether an expression is likely to be selective
+   */
+  private def isLikelySelective(e: Expression): Boolean = e match {
+    case Not(expr) => isLikelySelective(expr)
+    case And(l, r) => isLikelySelective(l) || isLikelySelective(r)
+    case Or(l, r) => isLikelySelective(l) && isLikelySelective(r)
+    case _: StringRegexExpression => true
+    case _: BinaryComparison => true
+    case _: In | _: InSet => true
+    case _: StringPredicate => true
+    case _: MultiLikeBase => true
+    case _ => false
+  }
+
+  /**
    * Returns whether an expression is likely to be selective in dynamic partition filtering.
    * 1. the predicate is selective.
    * 2. the filtering predicate must not be subset of join key. In case it is, key then partition
-   * filter. can be inferred statically in optimization phase, hence return false.
+   * filter can be inferred statically in optimization phase, hence return false.
    */
-  private def isLikelySelective(e: Expression, joinKey: Expression): (Boolean, Boolean) = e match {
-    case Not(expr) => isLikelySelective(expr, joinKey)
+  private def isLikelySelectiveWithInferFiltersEnabled(
+      e: Expression,
+      joinKey: Expression): (Boolean, Boolean) = e match {
+    case Not(expr) => isLikelySelectiveWithInferFiltersEnabled(expr, joinKey)
     case And(l, r) =>
-      val (isSelectiveLeft, notSubsetOfJoinKeyLeft) = isLikelySelective(l, joinKey)
-      val (isSelectiveRight, notSubsetOfJoinKeyRight) = isLikelySelective(r, joinKey)
+      val (isSelectiveLeft, notSubsetOfJoinKeyLeft) =
+        isLikelySelectiveWithInferFiltersEnabled(l, joinKey)
+      val (isSelectiveRight, notSubsetOfJoinKeyRight) =
+        isLikelySelectiveWithInferFiltersEnabled(r, joinKey)
       (isSelectiveLeft || isSelectiveRight, notSubsetOfJoinKeyLeft || notSubsetOfJoinKeyRight)
     case Or(l, r) =>
-      val (isSelectiveLeft, notSubsetOfJoinKeyLeft) = isLikelySelective(l, joinKey)
-      val (isSelectiveRight, notSubsetOfJoinKeyRight) = isLikelySelective(r, joinKey)
+      val (isSelectiveLeft, notSubsetOfJoinKeyLeft) =
+        isLikelySelectiveWithInferFiltersEnabled(l, joinKey)
+      val (isSelectiveRight, notSubsetOfJoinKeyRight) =
+        isLikelySelectiveWithInferFiltersEnabled(r, joinKey)
       (isSelectiveLeft && isSelectiveRight && (notSubsetOfJoinKeyLeft || notSubsetOfJoinKeyRight),
         notSubsetOfJoinKeyLeft || notSubsetOfJoinKeyRight)
     case expr: StringRegexExpression => (true, !isSubsetOfJoinKey(expr, joinKey))
@@ -225,22 +246,23 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper with Join
     case expr: MultiLikeBase => (true, !isSubsetOfJoinKey(expr, joinKey))
     case _ => (false, false)
   }
-   private def isSubsetOfJoinKey(e: Expression, joinKey: Expression): Boolean = {
-     if (conf.constraintPropagationEnabled) {
-       e.references.subsetOf(joinKey.references)
-     } else {
-       false
-     }
-   }
+
+  private def isSubsetOfJoinKey(e: Expression, joinKey: Expression): Boolean =
+      e.references.subsetOf(joinKey.references)
 
   /**
    * Search a filtering predicate in a given logical plan.
    */
   private def hasSelectivePredicate(plan: LogicalPlan, joinKey: Expression): Boolean = {
     plan.find {
-      case f: Filter => val (isSelectiveOnFilters, isSelectiveOnAttributes) = isLikelySelective(f
-        .condition, joinKey)
-        isSelectiveOnFilters && isSelectiveOnAttributes
+      case f: Filter =>
+        if (conf.constraintPropagationEnabled) {
+          val (isSelectiveOnFilters, isSelectiveOnAttributes) =
+            isLikelySelectiveWithInferFiltersEnabled(f.condition, joinKey)
+          isSelectiveOnFilters && isSelectiveOnAttributes
+        } else {
+          isLikelySelective(f.condition)
+        }
       case _ => false
     }.isDefined
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
@@ -218,7 +218,7 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper with Join
   /**
    * Returns whether an expression is likely to be selective in dynamic partition filtering.
    * 1. the predicate is selective.
-   * 2. the filtering predicate must not be subset of join key. In case it is, key then partition
+   * 2. the filtering predicate must not be subset of join key. In case it is, then partition
    * filter can be inferred statically in optimization phase, hence return false.
    */
   private def isLikelySelectiveWithInferFiltersEnabled(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1544,29 +1544,28 @@ abstract class DynamicPartitionPruningSuiteBase
     }
   }
 
-  test("No dynamic partition pruning filters in case of static partition filtering") {
+  test("SPARK-36819: No dynamic partition pruning filters in case of static partition filtering") {
     // join on single attribute
-      val sqlStr =
-        """
-          |SELECT f.date_id, f.pid, f.sid FROM
-          |(select date_id, product_id as pid, store_id as sid from fact_stats) as f
-          |JOIN dim_stats s
-          |ON f.sid = s.store_id WHERE s.store_id = 3
-        """.stripMargin
-
-      Seq(true, false).foreach { reuseBroadcastOnly =>
-        withSQLConf(
-          SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> s"$reuseBroadcastOnly") {
-          val df = sql(sqlStr)
-          checkPartitionPruningPredicate(df, false, false)
-          checkAnswer(df,
-            Row(1030, 2, 3) ::
-            Row(1040, 2, 3) ::
-            Row(1050, 2, 3) ::
-            Row(1060, 2, 3) :: Nil
-          )
-        }
+    val sqlStr =
+      """
+        |SELECT f.date_id, f.pid, f.sid FROM
+        |(select date_id, product_id as pid, store_id as sid from fact_stats) as f
+        |JOIN dim_stats s
+        |ON f.sid = s.store_id WHERE s.store_id = 3
+      """.stripMargin
+    Seq(true, false).foreach { reuseBroadcastOnly =>
+      withSQLConf(
+        SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> s"$reuseBroadcastOnly") {
+        val df = sql(sqlStr)
+        checkPartitionPruningPredicate(df, false, false)
+        checkAnswer(df,
+          Row(1030, 2, 3) ::
+          Row(1040, 2, 3) ::
+          Row(1050, 2, 3) ::
+          Row(1060, 2, 3) :: Nil
+        )
       }
+    }
 
     // Join on multiple attributes"
     withTable("fact", "dim") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1543,6 +1543,70 @@ abstract class DynamicPartitionPruningSuiteBase
       checkAnswer(df, Row(1150, 1) :: Row(1130, 4) :: Row(1140, 4) :: Nil)
     }
   }
+
+  test("No dynamic partition pruning filters in case of static partition filtering") {
+    // join on single attribute
+      val sqlStr =
+        """
+          |SELECT f.date_id, f.pid, f.sid FROM
+          |(select date_id, product_id as pid, store_id as sid from fact_stats) as f
+          |JOIN dim_stats s
+          |ON f.sid = s.store_id WHERE s.store_id = 3
+        """.stripMargin
+
+      Seq(true, false).foreach { reuseBroadcastOnly =>
+        withSQLConf(
+          SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> s"$reuseBroadcastOnly") {
+          val df = sql(sqlStr)
+          checkPartitionPruningPredicate(df, false, false)
+          checkAnswer(df,
+            Row(1030, 2, 3) ::
+            Row(1040, 2, 3) ::
+            Row(1050, 2, 3) ::
+            Row(1060, 2, 3) :: Nil
+          )
+        }
+      }
+
+    // Join on multiple attributes"
+    withTable("fact", "dim") {
+      spark.range(100).select(
+        $"id",
+        ($"id" + 1).as("one"),
+        ($"id" + 2).cast("string").as("two"),
+        ($"id" + 3).cast("string").as("three"),
+        (($"id" * 20) % 100).as("mod"),
+        ($"id" % 10).cast("string").as("str"))
+        .write.partitionBy("one", "two", "three")
+        .format(tableFormat).mode("overwrite").saveAsTable("fact")
+
+      spark.range(10).select(
+        $"id",
+        ($"id" + 1).as("one"),
+        ($"id" + 2).cast("string").as("two"),
+        ($"id" + 3).cast("string").as("three"),
+        ($"id" * 10).as("prod"))
+        .write.partitionBy("one", "two", "three", "prod")
+        .format(tableFormat).mode("overwrite").saveAsTable("dim")
+
+      // without the fix, there would be three DPP filters on different keys
+      val df = sql(
+        """
+          |SELECT f.id, f.one, f.two, f.str FROM fact f
+          |JOIN dim d
+          |ON (f.one = d.one and f.two = d.two and f.three = d.three)
+          |WHERE d.one > 9
+        """.stripMargin)
+
+      Seq(true, false).foreach { reuseBroadcastOnly =>
+        withSQLConf(
+          SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> s"$reuseBroadcastOnly") {
+          checkDistinctSubqueries(df, 2)
+          checkAnswer(df, Row(9, 10, "11", "9") :: Nil)
+        }
+      }
+    }
+  }
 }
 
 abstract class DynamicPartitionPruningV1Suite extends DynamicPartitionPruningSuiteBase {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1563,9 +1563,9 @@ abstract class DynamicPartitionPruningSuiteBase
             checkPartitionPruningPredicate(df, false, !inferFiltersFromConstraintsEnabled)
             checkAnswer(df,
               Row(1030, 2, 3) ::
-                Row(1040, 2, 3) ::
-                Row(1050, 2, 3) ::
-                Row(1060, 2, 3) :: Nil
+              Row(1040, 2, 3) ::
+              Row(1050, 2, 3) ::
+              Row(1060, 2, 3) :: Nil
             )
           }
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Don't insert dynamic partition pruning filters in case the filters already added statically. In case the filtering predicate on dimension table is on joinKey, no need to insert DPP filter in that case.

Sample query:
```
SELECT f.date_id, f.pid, f.sid FROM
(select date_id, product_id as pid, store_id as sid from fact_stats) as f
JOIN dim_stats s
ON f.sid = s.store_id WHERE s.store_id = 3
```

Without this PR DPP filter is inserted for above query despite of `store_id#4551 = 3` on fact_stats
```
  == Physical Plan ==
  *(2) Project [date_id#4548, pid#4631, sid#4632]
  +- *(2) BroadcastHashJoin [sid#4632], [store_id#4552], Inner, BuildRight, false
     :- *(2) Project [date_id#4548, product_id#4549 AS pid#4631, store_id#4551 AS sid#4632]
     :  +- *(2) ColumnarToRow
     :     +- FileScan parquet default.fact_stats[date_id#4548,product_id#4549,store_id#4551] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/D:/workspace/spark/sql/core/spark-warehouse/org.apache.spark.sql..., PartitionFilters: [(store_id#4551 = 3), isnotnull(store_id#4551), **dynamicpruningexpression(store_id#4551 IN dynamic...,** PushedFilters: [], ReadSchema: struct<date_id:int,product_id:int>
     :           +- SubqueryBroadcast dynamicpruning#4636, 0, [store_id#4552], [id=#2461]
     :              +- BroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#2460]
     :                 +- *(1) Filter (isnotnull(store_id#4552) AND (store_id#4552 = 3))
     :                    +- *(1) ColumnarToRow
     :                       +- FileScan parquet default.dim_stats[store_id#4552] Batched: true, DataFilters: [isnotnull(store_id#4552), (store_id#4552 = 3)], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/D:/workspace/spark/sql/core/spark-warehouse/org.apache.spark.sql..., PartitionFilters: [], PushedFilters: [IsNotNull(store_id), EqualTo(store_id,3)], ReadSchema: struct<store_id:int>
     +- ReusedExchange [store_id#4552], BroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#2460]
```



### Why are the changes needed?
Having redundant dynamic filters can have  unnecessary overheads: extra filtering overhead + in case of DPP subquery case, subquery execution overhead.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing UTs pass. added new test case.