### PR TITLE
[SPARK-33272][SPARK-36815][3.0][SQL] prune the attributes mapping in QueryPlan.transformUpWithNewOutput

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AnalysisHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AnalysisHelper.scala
@@ -127,7 +127,7 @@ trait AnalysisHelper extends QueryPlan[LogicalPlan] { self: LogicalPlan =>
       rule: PartialFunction[LogicalPlan, (LogicalPlan, Seq[(Attribute, Attribute)])])
   : LogicalPlan = {
     if (!analyzed) {
-      transformUpWithNewOutput(rule, skipCond = _.analyzed)
+      transformUpWithNewOutput(rule, skipCond = _.analyzed, canGetOutput = _.resolved)
     } else {
       self
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a backport PR of #30173.

For complex query plans, `QueryPlan.transformUpWithNewOutput` will keep accumulating the attributes mapping to be propagated, which may hurt performance. This PR prunes the attributes mapping before propagating.

### Why are the changes needed?

A simple perf improvement.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

existing tests

