### PR TITLE
[SPARK-36823][SQL] Support broadcast nested loop join hint for equi-join

### DIFF
--- a/docs/sql-ref-syntax-qry-select-hints.md
+++ b/docs/sql-ref-syntax-qry-select-hints.md
@@ -128,7 +128,7 @@ Join hints allow users to suggest the join strategy that Spark should use. Prior
 
 * **BROADCAST_NL**
 
-    Suggests that Spark use broadcast nested loop join. The join side with the hint will be broadcast regardless of `autoBroadcastJoinThreshold`. If both sides of the join have the broadcast hints, the one with the smaller size (based on stats) will be broadcast. Note that, this hint is only useful if the join type and build side is not supported by hash join. i.e. full outer join, left outer/semi/anti join with build left, right outer join with build right.
+    Suggests that Spark use broadcast nested loop join. The join side with the hint will be broadcast regardless of `autoBroadcastJoinThreshold`. If both sides of the join have the broadcast hints, the one with the smaller size (based on stats) will be broadcast. Note that, this hint is only useful if the join type and build side is not supported by broadcast hash join. i.e. full outer join, left outer/semi/anti join with build left, right outer join with build right.
 
 #### Examples
 

--- a/docs/sql-ref-syntax-qry-select-hints.md
+++ b/docs/sql-ref-syntax-qry-select-hints.md
@@ -128,7 +128,7 @@ Join hints allow users to suggest the join strategy that Spark should use. Prior
 
 * **BROADCAST_NL**
 
-    Suggests that Spark use broadcast nested loop join. The join side with the hint will be broadcast regardless of `autoBroadcastJoinThreshold`. If both sides of the join have the broadcast hints, the one with the smaller size (based on stats) will be broadcast.
+    Suggests that Spark use broadcast nested loop join. The join side with the hint will be broadcast regardless of `autoBroadcastJoinThreshold`. If both sides of the join have the broadcast hints, the one with the smaller size (based on stats) will be broadcast. Note that, this hint is only useful if the join type and build side is not supported by hash join. i.e. full outer join, left outer/semi/anti join with build left, right outer join with build right.
 
 #### Examples
 

--- a/docs/sql-ref-syntax-qry-select-hints.md
+++ b/docs/sql-ref-syntax-qry-select-hints.md
@@ -126,6 +126,10 @@ Join hints allow users to suggest the join strategy that Spark should use. Prior
 
     Suggests that Spark use shuffle-and-replicate nested loop join.
 
+* **BROADCAST_NL**
+
+    Suggests that Spark use broadcast nested loop join. The join side with the hint will be broadcast regardless of `autoBroadcastJoinThreshold`. If both sides of the join have the broadcast hints, the one with the smaller size (based on stats) will be broadcast.
+
 #### Examples
 
 ```sql
@@ -144,6 +148,10 @@ SELECT /*+ SHUFFLE_HASH(t1) */ * FROM t1 INNER JOIN t2 ON t1.key = t2.key;
 
 -- Join Hints for shuffle-and-replicate nested loop join
 SELECT /*+ SHUFFLE_REPLICATE_NL(t1) */ * FROM t1 INNER JOIN t2 ON t1.key = t2.key;
+
+-- Join Hints for broadcast nested loop join
+SELECT /*+ BROADCAST_NL(t1) */ * FROM t1 LEFT JOIN t2 ON t1.key = t2.key;
+SELECT /*+ BROADCAST_NL(t1) */ * FROM t1 LEFT JOIN t2;
 
 -- When different join strategy hints are specified on both sides of a join, Spark
 -- prioritizes the BROADCAST hint over the MERGE hint over the SHUFFLE_HASH hint

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -263,6 +263,15 @@ trait JoinSelectionHelper {
     )
   }
 
+  def getBroadcastNLBuildSideWithHint(
+      left: LogicalPlan,
+      right: LogicalPlan,
+      hint: JoinHint): Option[BuildSide] = {
+    val canBuildLeft = hintToBroadcastNLLeft(hint)
+    val canBuildRight = hintToBroadcastNLRight(hint)
+    getBuildSide(canBuildLeft, canBuildRight, left, right)
+  }
+
   def getShuffleHashJoinBuildSide(
       left: LogicalPlan,
       right: LogicalPlan,
@@ -353,6 +362,14 @@ trait JoinSelectionHelper {
 
   def hintToBroadcastRight(hint: JoinHint): Boolean = {
     hint.rightHint.exists(_.strategy.contains(BROADCAST))
+  }
+
+  def hintToBroadcastNLLeft(hint: JoinHint): Boolean = {
+    hint.leftHint.exists(_.strategy.contains(BROADCAST_NL))
+  }
+
+  def hintToBroadcastNLRight(hint: JoinHint): Boolean = {
+    hint.rightHint.exists(_.strategy.contains(BROADCAST_NL))
   }
 
   def hintToNotBroadcastLeft(hint: JoinHint): Boolean = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
@@ -125,7 +125,8 @@ object JoinStrategyHint {
     BROADCAST,
     SHUFFLE_MERGE,
     SHUFFLE_HASH,
-    SHUFFLE_REPLICATE_NL)
+    SHUFFLE_REPLICATE_NL,
+    BROADCAST_NL)
 }
 
 /**
@@ -167,6 +168,14 @@ case object SHUFFLE_REPLICATE_NL extends JoinStrategyHint {
   override def displayName: String = "shuffle_replicate_nl"
   override def hintAliases: Set[String] = Set(
     "SHUFFLE_REPLICATE_NL")
+}
+
+/**
+ * The hint for broadcast nested loop join.
+ */
+case object BROADCAST_NL extends JoinStrategyHint {
+  override def displayName: String = "broadcast_nl"
+  override def hintAliases: Set[String] = Set("BROADCAST_NL")
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -186,7 +186,9 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       //   3. shuffle hash hint: We pick shuffle hash join if the join type is supported. If both
       //      sides have the shuffle hash hints, choose the smaller side (based on stats) as the
       //      build side.
-      //   4. shuffle replicate NL hint: pick cartesian product if join type is inner like.
+      //   4. broadcast NL hint: pick broadcast nested loop join. If both sides have the
+      //      broadcast NL hint, choose the smaller side (based on stats) to broadcast.
+      //   5. shuffle replicate NL hint: pick cartesian product if join type is inner like.
       //
       // If there is no hint or the hints are not applicable, we follow these rules one by one:
       //   1. Pick broadcast hash join if one side is small enough to broadcast, and the join type

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
@@ -709,9 +709,9 @@ class JoinHintSuite extends PlanTest with SharedSparkSession with AdaptiveSparkP
 
   test("SPARK-36823: Support broadcast nested loop join hint for equi-join") {
     def checkBroadcastNLJoin(query: String, buildSide: BuildSide): Unit = {
-      val df = sql(query)
       withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
           SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+        val df = sql(query)
         assertBroadcastNLJoin(df, buildSide)
         df.collect()
         assertBroadcastNLJoin(df, buildSide)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a new hint `BROADCAST_NL`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For the join if one side is small and other side is large, the shuffle overhead is also very big. Due to the
bhj limitation, we can only broadcast right side for left join and left side for right join. So for the other case, we can try to use `BroadcastNestedLoopJoin` as the join strategy.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, new hint

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add new test in `JoinHintSuite`