### PR TITLE
[SPARK-36168][BUILD] Add support for Scala 2.13 in dev/test-dependencies.sh

### DIFF
--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -106,7 +106,7 @@ for HADOOP_HIVE_PROFILE in "${HADOOP_HIVE_PROFILES[@]}"; do
       classifier_end_index=index(jar_name, ".jar") - 1;
       classifier=substr(jar_name, classifier_start_index, classifier_end_index - classifier_start_index + 1);
       print artifact_id"/"version"/"classifier"/"jar_name
-    }' | sort | grep -v spark > dev/pr-deps/spark-deps-$HADOOP_HIVE_PROFILE
+    }' | sort | grep -v spark > dev/pr-deps/spark-deps-$HADOOP_HIVE_PROFILE-scala-$SCALA_BINARY_VERSION
 done
 
 if [[ $@ == **replace-manifest** ]]; then
@@ -121,8 +121,8 @@ for HADOOP_HIVE_PROFILE in "${HADOOP_HIVE_PROFILES[@]}"; do
   dep_diff="$(
     git diff \
     --no-index \
-    dev/deps/spark-deps-$HADOOP_HIVE_PROFILE \
-    dev/pr-deps/spark-deps-$HADOOP_HIVE_PROFILE \
+    dev/deps/spark-deps-$HADOOP_HIVE_PROFILE-scala-$SCALA_BINARY_VERSION \
+    dev/pr-deps/spark-deps-$HADOOP_HIVE_PROFILE-scala-$SCALA_BINARY_VERSION \
   )"
   set -e
   if [ "$dep_diff" != "" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable support of Scala 2.13 in the `dev/test-dependencies.sh`

### Why are the changes needed?

At this moment only Scala 2.12 is supported

### Does this PR introduce _any_ user-facing change?

No, this changes only build related scripts

### How was this patch tested?

./dev/change-scala-version.sh 2.13 && ./dev/test-dependencies.sh