### PR TITLE
[SPARK-35672][CORE][YARN] Handle environment variable replacement in user classpath lists

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1532,9 +1532,8 @@ private[spark] object Client extends Logging {
     // {{...}} is a YARN thing and not OS-specific. Follow Unix shell naming conventions
     (osSpecificPatterns :+ "\\{\\{([A-z_][A-z_0-9]*)}}".r("varname"))
       .foldLeft(unresolvedString) { (inputStr, pattern) =>
-        pattern.replaceSomeIn(inputStr, m => {
-          val varname = m.group("varname")
-          Some(Regex.quoteReplacement(env.getOrElse(varname, "")))
+        pattern.replaceSomeIn(inputStr, { m =>
+          Some(Regex.quoteReplacement(env.getOrElse(m.group("varname"), "")))
         })
       }
   }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1486,14 +1486,15 @@ private[spark] object Client extends Logging {
     Client.getUserClasspath(conf).map { uri =>
       val inputPath = uri.getPath
       val replacedFilePath = if (Utils.isLocalUri(uri.toString) && useClusterPath) {
-        replaceEnvVars(Client.getClusterPath(conf, inputPath), sys.env)
+        Client.getClusterPath(conf, inputPath)
       } else {
         // Any other URI schemes should have been resolved by this point
         assert(uri.getScheme == null || uri.getScheme == "file" || Utils.isLocalUri(uri.toString),
           "getUserClasspath should only return 'file' or 'local' URIs but found: " + uri)
         inputPath
       }
-      Paths.get(replacedFilePath).toAbsolutePath.toUri.toURL
+      val envVarResolvedFilePath = replaceEnvVars(replacedFilePath, sys.env)
+      Paths.get(envVarResolvedFilePath).toAbsolutePath.toUri.toURL
     }
   }
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -188,6 +188,20 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
     }))
   }
 
+  test("SPARK-35672: run Spark in yarn-client mode with additional jar using URI scheme 'local' " +
+    "and gateway-replacement path containing an environment variable") {
+    // Set up the replacement path to point to the correct path, but suffixed with some
+    // nonexistent environment variable. If environment variable replacement takes place, then
+    // the var will be replaced with an empty string, and the path will be correct again
+    def urlToParentPath(url: URL): String = Paths.get(url.toURI).getParent.toString
+    testWithAddJar(clientMode = true, "local", Some(jarUrl => {
+      (jarUrl.getPath, Map(
+        GATEWAY_ROOT_PATH.key -> urlToParentPath(jarUrl),
+        REPLACEMENT_ROOT_PATH.key -> s"${urlToParentPath(jarUrl)}{{NO_SUCH_ENV_VAR___}}"
+      ))
+    }))
+  }
+
   test("SPARK-35672: run Spark in yarn-client mode with additional jar using URI scheme 'file'") {
     testWithAddJar(clientMode = true, "file")
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add environment variable resolution logic to `yarn.Client.getUserClasspathUrls`, which allows for users to specify JAR paths (e.g. from `spark.jars`) which contain references to environment variables.

This is a best-effort attempt to mimic the variable resolution logic used by a typical shell (implemented in `yarn.Client.replaceEnvVars`).

### Why are the changes needed?
In PR #32810 the way user JAR classpaths were passed around was changed to avoid passing them via the command line, which is prone to exceeding maximum argument length limitations. However, as a result, the classpaths are no longer interpreted by the shell, so environment variables are not resolved. This is explicitly called out in the docs of `spark.yarn.config.gatewayPath` as a use case, so we definitely need to continue supporting it. There are more details in the comments of SPARK-36572.

### Does this PR introduce _any_ user-facing change?
Yes, using environment variables in `spark.jars` or `spark.yarn.config.replacementPath` will work again, as it did before PR #32810.

### How was this patch tested?
New unit tests added for this specific case in `YarnClusterSuite`.