### PR TITLE
[SPARK-36836][SQL] Fix incorrect result in `sha2` expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit._
 import java.util.zip.CRC32
 
 import scala.annotation.tailrec
+import scala.math.BigInt
 
 import org.apache.commons.codec.digest.DigestUtils
 
@@ -111,8 +112,10 @@ case class Sha2(left: Expression, right: Expression)
         // DigestUtils doesn't support SHA-224 now
         try {
           val md = MessageDigest.getInstance("SHA-224")
-          md.update(input)
-          UTF8String.fromBytes(md.digest())
+          val messageDigest = md.digest(input);
+          val hashText = BigInt(1, messageDigest).toString(16);
+          val paddedHashText = "0" * (56 - hashText.length()) + hashText
+          UTF8String.fromString(paddedHashText);
         } catch {
           // SHA-224 is not supported on the system, return null
           case noa: NoSuchAlgorithmException => null
@@ -134,8 +137,10 @@ case class Sha2(left: Expression, right: Expression)
         if ($eval2 == 224) {
           try {
             java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-224");
-            md.update($eval1);
-            ${ev.value} = UTF8String.fromBytes(md.digest());
+            byte[] messageDigest = md.digest($eval1);
+            String hashText = new java.math.BigInteger(1, messageDigest).toString(16);
+            hashText = String.format("%56s", hashText).replace(' ', '0');
+            ${ev.value} = UTF8String.fromString(hashText);
           } catch (java.security.NoSuchAlgorithmException e) {
             ${ev.isNull} = true;
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -139,8 +139,8 @@ case class Sha2(left: Expression, right: Expression)
             java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-224");
             byte[] messageDigest = md.digest($eval1);
             String hashText = new java.math.BigInteger(1, messageDigest).toString(16);
-            hashText = String.format("%56s", hashText).replace(' ', '0');
-            ${ev.value} = UTF8String.fromString(hashText);
+            String paddedHashText = String.format("%56s", hashText).replace(' ', '0');
+            ${ev.value} = UTF8String.fromString(paddedHashText);
           } catch (java.security.NoSuchAlgorithmException e) {
             ${ev.isNull} = true;
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -18,14 +18,13 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.math.{BigDecimal, RoundingMode}
-import java.security.{MessageDigest, NoSuchAlgorithmException}
 import java.util.concurrent.TimeUnit._
 import java.util.zip.CRC32
 
 import scala.annotation.tailrec
-import scala.math.BigInt
 
 import org.apache.commons.codec.digest.DigestUtils
+import org.apache.commons.codec.digest.MessageDigestAlgorithms
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
@@ -109,17 +108,8 @@ case class Sha2(left: Expression, right: Expression)
     val input = input1.asInstanceOf[Array[Byte]]
     bitLength match {
       case 224 =>
-        // DigestUtils doesn't support SHA-224 now
-        try {
-          val md = MessageDigest.getInstance("SHA-224")
-          val messageDigest = md.digest(input);
-          val hashText = BigInt(1, messageDigest).toString(16);
-          val paddedHashText = String.format("%56s", hashText).replace(" ", "0")
-          UTF8String.fromString(paddedHashText);
-        } catch {
-          // SHA-224 is not supported on the system, return null
-          case noa: NoSuchAlgorithmException => null
-        }
+        UTF8String.fromString(
+          new DigestUtils(MessageDigestAlgorithms.SHA_224).digestAsHex(input))
       case 256 | 0 =>
         UTF8String.fromString(DigestUtils.sha256Hex(input))
       case 384 =>
@@ -132,18 +122,12 @@ case class Sha2(left: Expression, right: Expression)
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val digestUtils = classOf[DigestUtils].getName
+    val messageDigestAlgorithms = classOf[MessageDigestAlgorithms].getName
     nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
       s"""
         if ($eval2 == 224) {
-          try {
-            java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-224");
-            byte[] messageDigest = md.digest($eval1);
-            String hashText = new java.math.BigInteger(1, messageDigest).toString(16);
-            String paddedHashText = String.format("%56s", hashText).replace(' ', '0');
-            ${ev.value} = UTF8String.fromString(paddedHashText);
-          } catch (java.security.NoSuchAlgorithmException e) {
-            ${ev.isNull} = true;
-          }
+          ${ev.value} = UTF8String.fromString(
+                          new $digestUtils($messageDigestAlgorithms.SHA_224).digestAsHex($eval1));
         } else if ($eval2 == 256 || $eval2 == 0) {
           ${ev.value} =
             UTF8String.fromString($digestUtils.sha256Hex($eval1));

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -114,7 +114,7 @@ case class Sha2(left: Expression, right: Expression)
           val md = MessageDigest.getInstance("SHA-224")
           val messageDigest = md.digest(input);
           val hashText = BigInt(1, messageDigest).toString(16);
-          val paddedHashText = "0" * ((bitLength / 8) * 2 - hashText.length()) + hashText
+          val paddedHashText = String.format("%56s", hashText).replace(" ", "0")
           UTF8String.fromString(paddedHashText);
         } catch {
           // SHA-224 is not supported on the system, return null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -114,7 +114,7 @@ case class Sha2(left: Expression, right: Expression)
           val md = MessageDigest.getInstance("SHA-224")
           val messageDigest = md.digest(input);
           val hashText = BigInt(1, messageDigest).toString(16);
-          val paddedHashText = "0" * (56 - hashText.length()) + hashText
+          val paddedHashText = "0" * ((bitLength / 8) * 2 - hashText.length()) + hashText
           UTF8String.fromString(paddedHashText);
         } catch {
           // SHA-224 is not supported on the system, return null

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HashExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HashExpressionsSuite.scala
@@ -60,6 +60,8 @@ class HashExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("sha2") {
+    checkEvaluation(Sha2(Literal("ABC".getBytes(StandardCharsets.UTF_8)), Literal(224)),
+      "107c5072b799c4771f328304cfe1ebb375eb6ea7f35a3aa753836fad")
     checkEvaluation(Sha2(Literal("ABC".getBytes(StandardCharsets.UTF_8)), Literal(256)),
       DigestUtils.sha256Hex("ABC"))
     checkEvaluation(Sha2(Literal.create(Array[Byte](1, 2, 3, 4, 5, 6), BinaryType), Literal(384)),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

`sha2(input, bit_length)` returns incorrect results when `bit_length == 224` for all inputs.
This error can be reproduced by running `spark.sql("SELECT sha2('abc', 224)").show()`, for instance, in spark-shell.

Spark currently returns 
```
#\t}"4�"�B�w��U�*��你���l��
```
while the expected result is
```
23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7
```

This appears to happen because the `MessageDigest.digest()` function appears to return bytes intended to be interpreted as a `BigInt` rather than a string. Thus, the output of `MessageDigest.digest()` must first be interpreted as a `BigInt` and then transformed into a hex string rather than directly being interpreted as a hex string.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`sha2(input, bit_length)` with a `bit_length` input of `224` would previously return the incorrect result.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added new test to `HashExpressionsSuite.scala` which previously failed and now pass
