### PR TITLE
[SPARK-36294][SQL] Refactor fifth set of 20 query execution errors to use error classes

### DIFF
--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -840,6 +840,15 @@ captureJVMException <- function(e, method) {
     # Extract the first message of JVM exception.
     first <- strsplit(msg[2], "\r?\n\tat")[[1]][1]
     stop(rmsg, "illegal argument - ", first, call. = FALSE)
+  } else if (any(grepl("org.apache.spark.SparkIllegalArgumentException: ",
+                       stacktrace, fixed = TRUE))) {
+    msg <- strsplit(stacktrace, "org.apache.spark.SparkIllegalArgumentException: ",
+                    fixed = TRUE)[[1]]
+    # Extract "Error in ..." message.
+    rmsg <- msg[1]
+    # Extract the first message of JVM exception.
+    first <- strsplit(msg[2], "\r?\n\tat")[[1]][1]
+    stop(rmsg, "illegal argument - ", first, call. = FALSE)
   } else if (any(grepl("org.apache.spark.sql.AnalysisException: ", stacktrace, fixed = TRUE))) {
     msg <- strsplit(stacktrace, "org.apache.spark.sql.AnalysisException: ", fixed = TRUE)[[1]]
     # Extract "Error in ..." message.

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -3891,8 +3891,7 @@ test_that("Call DataFrameWriter.save() API in Java without path and check argume
   # It makes sure that we can omit path argument in write.df API and then it calls
   # DataFrameWriter.save() without path.
   expect_error(write.df(df, source = "csv"),
-              paste("Error in save : org.apache.spark.SparkIllegalArgumentException:",
-                    "Expected exactly one path to be specified"))
+              "Error in save : illegal argument - Expected exactly one path to be specified")
   expect_error(write.json(df, jsonPath),
               "Error in json : analysis error - path file:.*already exists")
   expect_error(write.text(df, jsonPath),

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -3891,7 +3891,8 @@ test_that("Call DataFrameWriter.save() API in Java without path and check argume
   # It makes sure that we can omit path argument in write.df API and then it calls
   # DataFrameWriter.save() without path.
   expect_error(write.df(df, source = "csv"),
-              "Error in save : illegal argument - Expected exactly one path to be specified")
+              paste("Error in save : org.apache.spark.SparkIllegalArgumentException:",
+                    "Expected exactly one path to be specified"))
   expect_error(write.json(df, jsonPath),
               "Error in json : analysis error - path file:.*already exists")
   expect_error(write.text(df, jsonPath),

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -11,9 +11,27 @@
     "message" : [ "%s cannot be represented as Decimal(%s, %s)." ],
     "sqlState" : "22005"
   },
+  "CANNOT_CLEAR_SOME_DIRECTORY" : {
+    "message" : [ "Unable to clear %s directory %s prior to writing to it" ]
+  },
+  "CANNOT_DROP_NONEMPTY_NAMESPACE" : {
+    "message" : [ "Cannot drop a non-empty namespace: %s. Use CASCADE option to drop a non-empty namespace." ]
+  },
+  "CANNOT_FIND_CLASS_IN_SPARK2" : {
+    "message" : [ "%s was removed in Spark 2.0. Please check if your library is compatible with Spark 2.0" ]
+  },
   "CANNOT_PARSE_DECIMAL" : {
     "message" : [ "Cannot parse decimal" ],
     "sqlState" : "42000"
+  },
+  "CANNOT_READ_CURRENT_FILE" : {
+    "message" : [ "%s \n It is possible the underlying files have been updated. You can explicitly invalidate the cache in Spark by running 'REFRESH TABLE tableName' command in SQL or by recreating the Dataset/DataFrame involved." ]
+  },
+  "CANNOT_UPGRADE_IN_READING_DATES" : {
+    "message" : [ "You may get a different result due to the upgrading of Spark %s reading dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z from %s files can be ambiguous, as the files may be written by Spark 2.x or legacy versions of Hive, which uses a legacy hybrid calendar that is different from Spark 3.0+'s Proleptic Gregorian calendar. See more details in SPARK-31404. You can set the SQL config '%s' or the datasource option '%s' to 'LEGACY' to rebase the datetime values w.r.t. the calendar difference during reading. To read the datetime values as it is, set the SQL config '%s' or the datasource option '%s' to 'CORRECTED'." ]
+  },
+  "CANNOT_UPGRADE_IN_WRITING_DATES" : {
+    "message" : [ "You may get a different result due to the upgrading of Spark %s writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z into %s files can be dangerous, as the files may be read by Spark 2.x or legacy versions of Hive later, which uses a legacy hybrid calendar that is different from Spark 3.0+'s Proleptic Gregorian calendar. See more details in SPARK-31404. You can set %s to 'LEGACY' to rebase the datetime values w.r.t. the calendar difference during writing, to get maximum interoperability. Or set %s to 'CORRECTED' to write the datetime values as it is, if you are 100%% sure that the written files will only be read by Spark 3.0+ or other systems that use Proleptic Gregorian calendar." ]
   },
   "CAST_CAUSES_OVERFLOW" : {
     "message" : [ "Casting %s to %s causes overflow" ],
@@ -30,8 +48,30 @@
     "message" : [ "Found duplicate keys '%s'" ],
     "sqlState" : "23000"
   },
+  "END_OF_STREAM" : {
+    "message" : [ "End of stream" ]
+  },
+  "FAILED_CAST_VALUE_TO_DATATYPE_FOR_PARTITION_COLUMN" : {
+    "message" : [ "Failed to cast value `%s` to `%s` for partition column `%s`" ],
+    "sqlState" : "22023"
+  },
   "FAILED_EXECUTE_UDF" : {
     "message" : [ "Failed to execute user defined function (%s: (%s) => %s)" ]
+  },
+  "FAILED_FALLBACK_V1_BECAUSE_OF_INCONSISTENT_SCHEMA" : {
+    "message" : [ "The fallback v1 relation reports inconsistent schema:\n Schema of v2 scan:     %s\nSchema of v1 relation: %s" ]
+  },
+  "FAILED_FIND_DATASOURCE" : {
+    "message" : [ "Failed to find data source: %s. Please find packages at http://spark.apache.org/third-party-projects.html" ]
+  },
+  "FAILED_FORMAT_DATETIME_IN_NEW_FORMATTER" : {
+    "message" : [ "You may get a different result due to the upgrading of Spark %s: Fail to format it to '%s' in the new formatter. You can set %s to LEGACY to restore the behavior before Spark 3.0, or set to CORRECTED and treat it as an invalid datetime string." ]
+  },
+  "FAILED_PARSE_DATETIME_IN_NEW_PARSER" : {
+    "message" : [ "You may get a different result due to the upgrading of Spark %s: Fail to parse '%s' in the new parser. You can set %s to LEGACY to restore the behavior before Spark 3.0, or set to CORRECTED and treat it as an invalid datetime string." ]
+  },
+  "FAILED_RECOGNIZE_PATTERN_AFTER_UPGRADE" : {
+    "message" : [ "You may get a different result due to the upgrading of Spark %s: Fail to recognize '%s' pattern in the DateTimeFormatter. 1) You can set %s to LEGACY to restore the behavior before Spark 3.0. 2) You can form a valid datetime pattern with the guide from https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html" ]
   },
   "FAILED_RENAME_PATH" : {
     "message" : [ "Failed to rename %s to %s as destination already exists" ],
@@ -86,6 +126,9 @@
   "INVALID_JSON_SCHEMA_MAPTYPE" : {
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
   },
+  "JOB_ABORTED" : {
+    "message" : [ "Job aborted." ]
+  },
   "MAP_KEY_DOES_NOT_EXIST" : {
     "message" : [ "Key %s does not exist." ]
   },
@@ -96,6 +139,10 @@
   "MISSING_STATIC_PARTITION_COLUMN" : {
     "message" : [ "Unknown static partition column: %s" ],
     "sqlState" : "42000"
+  },
+  "MISSING_STREAMING_SOURCE_SCHEMA" : {
+    "message" : [ "Schema must be specified when creating a streaming source DataFrame. If some files already exist in the directory, then depending on the file format you may be able to create a static DataFrame on that directory with 'spark.read.load(directory)' and infer schema from it." ],
+    "sqlState" : "3F000"
   },
   "NON_LITERAL_PIVOT_VALUES" : {
     "message" : [ "Literal expressions required for pivot values, found '%s'" ],
@@ -121,12 +168,27 @@
     "message" : [ "The second argument of '%s' function needs to be an integer." ],
     "sqlState" : "22023"
   },
+  "SPECIFIED_MULTIPLE_PATHS" : {
+    "message" : [ "Expected exactly one path to be specified, but got: %s" ],
+    "sqlState" : "22023"
+  },
+  "TASK_FAILED_WRITING_ROWS" : {
+    "message" : [ "Task failed while writing rows." ]
+  },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
+  },
+  "UNRECOGNIZED_FORMAT" : {
+    "message" : [ "unrecognized format %s" ],
+    "sqlState" : "22023"
   },
   "UNRECOGNIZED_SQL_TYPE" : {
     "message" : [ "Unrecognized SQL type %s" ],
     "sqlState" : "42000"
+  },
+  "UNSUPPORTED_BUILD_READER_FOR_FILE_FORMAT" : {
+    "message" : [ "buildReader is not supported for %s" ],
+    "sqlState" : "0A000"
   },
   "UNSUPPORTED_CHANGE_COLUMN" : {
     "message" : [ "Please add an implementation for a column change here" ],
@@ -140,8 +202,16 @@
     "message" : [ "Unsupported literal type %s %s" ],
     "sqlState" : "0A000"
   },
+  "UNSUPPORTED_SAVE_MODE" : {
+    "message" : [ "unsupported save mode %s" ],
+    "sqlState" : "0A000"
+  },
   "UNSUPPORTED_SIMPLE_STRING_WITH_NODE_ID" : {
     "message" : [ "%s does not implement simpleStringWithNodeId" ]
+  },
+  "UNSUPPORTED_STREAMED_OPERATOR_BY_DATASOURCE" : {
+    "message" : [ "Data source %s does not support streamed %s" ],
+    "sqlState" : "0A000"
   },
   "UNSUPPORTED_TRANSACTION_BY_JDBC_SERVER" : {
     "message" : [ "The target JDBC server does not support transaction and can only support ALTER TABLE with a single action." ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -11,27 +11,23 @@
     "message" : [ "%s cannot be represented as Decimal(%s, %s)." ],
     "sqlState" : "22005"
   },
-  "CANNOT_CLEAR_SOME_DIRECTORY" : {
+  "CANNOT_CLEAR_DIRECTORY" : {
     "message" : [ "Unable to clear %s directory %s prior to writing to it" ]
   },
   "CANNOT_DROP_NONEMPTY_NAMESPACE" : {
-    "message" : [ "Cannot drop a non-empty namespace: %s. Use CASCADE option to drop a non-empty namespace." ]
+    "message" : [ "Cannot drop a non-empty namespace: %s. Use CASCADE option to drop a non-empty namespace." ],
+    "sqlState" : "42000"
   },
   "CANNOT_FIND_CLASS_IN_SPARK2" : {
-    "message" : [ "%s was removed in Spark 2.0. Please check if your library is compatible with Spark 2.0" ]
+    "message" : [ "%s was removed in Spark 2.0. Please check if your library is compatible with Spark 2.0" ],
+    "sqlState" : "0A000"
   },
   "CANNOT_PARSE_DECIMAL" : {
     "message" : [ "Cannot parse decimal" ],
     "sqlState" : "42000"
   },
   "CANNOT_READ_CURRENT_FILE" : {
-    "message" : [ "%s \n It is possible the underlying files have been updated. You can explicitly invalidate the cache in Spark by running 'REFRESH TABLE tableName' command in SQL or by recreating the Dataset/DataFrame involved." ]
-  },
-  "CANNOT_UPGRADE_IN_READING_DATES" : {
-    "message" : [ "You may get a different result due to the upgrading of Spark %s reading dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z from %s files can be ambiguous, as the files may be written by Spark 2.x or legacy versions of Hive, which uses a legacy hybrid calendar that is different from Spark 3.0+'s Proleptic Gregorian calendar. See more details in SPARK-31404. You can set the SQL config '%s' or the datasource option '%s' to 'LEGACY' to rebase the datetime values w.r.t. the calendar difference during reading. To read the datetime values as it is, set the SQL config '%s' or the datasource option '%s' to 'CORRECTED'." ]
-  },
-  "CANNOT_UPGRADE_IN_WRITING_DATES" : {
-    "message" : [ "You may get a different result due to the upgrading of Spark %s writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z into %s files can be dangerous, as the files may be read by Spark 2.x or legacy versions of Hive later, which uses a legacy hybrid calendar that is different from Spark 3.0+'s Proleptic Gregorian calendar. See more details in SPARK-31404. You can set %s to 'LEGACY' to rebase the datetime values w.r.t. the calendar difference during writing, to get maximum interoperability. Or set %s to 'CORRECTED' to write the datetime values as it is, if you are 100%% sure that the written files will only be read by Spark 3.0+ or other systems that use Proleptic Gregorian calendar." ]
+    "message" : [ "%s", "It is possible the underlying files have been updated. You can explicitly invalidate the cache in Spark by running 'REFRESH TABLE tableName' command in SQL or by recreating the Dataset/DataFrame involved." ]
   },
   "CAST_CAUSES_OVERFLOW" : {
     "message" : [ "Casting %s to %s causes overflow" ],
@@ -53,25 +49,23 @@
   },
   "FAILED_CAST_VALUE_TO_DATATYPE_FOR_PARTITION_COLUMN" : {
     "message" : [ "Failed to cast value `%s` to `%s` for partition column `%s`" ],
-    "sqlState" : "22023"
+    "sqlState" : "22005"
   },
   "FAILED_EXECUTE_UDF" : {
     "message" : [ "Failed to execute user defined function (%s: (%s) => %s)" ]
   },
-  "FAILED_FALLBACK_V1_BECAUSE_OF_INCONSISTENT_SCHEMA" : {
-    "message" : [ "The fallback v1 relation reports inconsistent schema:\n Schema of v2 scan:     %s\nSchema of v1 relation: %s" ]
+  "FAILED_FIND_DATA_SOURCE" : {
+    "message" : [ "Failed to find data source: %s. Please find packages at http://spark.apache.org/third-party-projects.html" ],
+    "sqlState" : "22023"
   },
-  "FAILED_FIND_DATASOURCE" : {
-    "message" : [ "Failed to find data source: %s. Please find packages at http://spark.apache.org/third-party-projects.html" ]
+  "FAILED_FORMAT_DATE_TIME_AFTER_UPGRADE" : {
+    "message" : [ "Fail to format it to '%s' in the new formatter. You can set %s to LEGACY to restore the behavior before Spark 3.0, or set to CORRECTED and treat it as an invalid datetime string." ]
   },
-  "FAILED_FORMAT_DATETIME_IN_NEW_FORMATTER" : {
-    "message" : [ "You may get a different result due to the upgrading of Spark %s: Fail to format it to '%s' in the new formatter. You can set %s to LEGACY to restore the behavior before Spark 3.0, or set to CORRECTED and treat it as an invalid datetime string." ]
+  "FAILED_PARSE_DATE_TIME_AFTER_UPGRADE" : {
+    "message" : [ "Fail to parse '%s' in the new parser. You can set %s to LEGACY to restore the behavior before Spark 3.0, or set to CORRECTED and treat it as an invalid datetime string." ]
   },
-  "FAILED_PARSE_DATETIME_IN_NEW_PARSER" : {
-    "message" : [ "You may get a different result due to the upgrading of Spark %s: Fail to parse '%s' in the new parser. You can set %s to LEGACY to restore the behavior before Spark 3.0, or set to CORRECTED and treat it as an invalid datetime string." ]
-  },
-  "FAILED_RECOGNIZE_PATTERN_AFTER_UPGRADE" : {
-    "message" : [ "You may get a different result due to the upgrading of Spark %s: Fail to recognize '%s' pattern in the DateTimeFormatter. 1) You can set %s to LEGACY to restore the behavior before Spark 3.0. 2) You can form a valid datetime pattern with the guide from https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html" ]
+  "FAILED_RECOGNIZE_DATE_TIME_PATTERN_AFTER_UPGRADE" : {
+    "message" : [ "Fail to recognize '%s' pattern in the DateTimeFormatter. 1) You can set %s to LEGACY to restore the behavior before Spark 3.0. 2) You can form a valid datetime pattern with the guide from https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html" ]
   },
   "FAILED_RENAME_PATH" : {
     "message" : [ "Failed to rename %s to %s as destination already exists" ],
@@ -79,6 +73,9 @@
   },
   "FAILED_SET_ORIGINAL_PERMISSION_BACK" : {
     "message" : [ "Failed to set original permission %s back to the created path: %s. Exception: %s" ]
+  },
+  "FAILED_TASK_WHILE_WRITING_ROWS" : {
+    "message" : [ "Task failed while writing rows." ]
   },
   "GROUPING_COLUMN_MISMATCH" : {
     "message" : [ "Column of grouping (%s) can't be found in grouping columns %s" ],
@@ -142,7 +139,7 @@
   },
   "MISSING_STREAMING_SOURCE_SCHEMA" : {
     "message" : [ "Schema must be specified when creating a streaming source DataFrame. If some files already exist in the directory, then depending on the file format you may be able to create a static DataFrame on that directory with 'spark.read.load(directory)' and infer schema from it." ],
-    "sqlState" : "3F000"
+    "sqlState" : "22023"
   },
   "NON_LITERAL_PIVOT_VALUES" : {
     "message" : [ "Literal expressions required for pivot values, found '%s'" ],
@@ -155,6 +152,9 @@
   "PIVOT_VALUE_DATA_TYPE_MISMATCH" : {
     "message" : [ "Invalid pivot value '%s': value data type %s does not match pivot column data type %s" ],
     "sqlState" : "42000"
+  },
+  "READING_AMBIGUOUS_DATES_AFTER_UPGRADE" : {
+    "message" : [ "reading dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z from %s files can be ambiguous, as the files may be written by Spark 2.x or legacy versions of Hive, which uses a legacy hybrid calendar that is different from Spark 3.0+'s Proleptic Gregorian calendar. See more details in SPARK-31404. You can set the SQL config '%s' or the datasource option '%s' to 'LEGACY' to rebase the datetime values w.r.t. the calendar difference during reading. To read the datetime values as it is, set the SQL config '%s' or the datasource option '%s' to 'CORRECTED'." ]
   },
   "RENAME_SRC_PATH_NOT_FOUND" : {
     "message" : [ "Failed to rename as %s was not found" ],
@@ -170,10 +170,7 @@
   },
   "SPECIFIED_MULTIPLE_PATHS" : {
     "message" : [ "Expected exactly one path to be specified, but got: %s" ],
-    "sqlState" : "22023"
-  },
-  "TASK_FAILED_WRITING_ROWS" : {
-    "message" : [ "Task failed while writing rows." ]
+    "sqlState" : "42000"
   },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
@@ -203,19 +200,22 @@
     "sqlState" : "0A000"
   },
   "UNSUPPORTED_SAVE_MODE" : {
-    "message" : [ "unsupported save mode %s" ],
+    "message" : [ "unsupported save mode %s (%s)" ],
     "sqlState" : "0A000"
   },
   "UNSUPPORTED_SIMPLE_STRING_WITH_NODE_ID" : {
     "message" : [ "%s does not implement simpleStringWithNodeId" ]
   },
-  "UNSUPPORTED_STREAMED_OPERATOR_BY_DATASOURCE" : {
+  "UNSUPPORTED_STREAMED_OPERATOR_BY_DATA_SOURCE" : {
     "message" : [ "Data source %s does not support streamed %s" ],
     "sqlState" : "0A000"
   },
   "UNSUPPORTED_TRANSACTION_BY_JDBC_SERVER" : {
     "message" : [ "The target JDBC server does not support transaction and can only support ALTER TABLE with a single action." ],
     "sqlState" : "0A000"
+  },
+  "WRITING_AMBIGUOUS_DATES_AFTER_UPGRADE" : {
+    "message" : [ "writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z into %s files can be dangerous, as the files may be read by Spark 2.x or legacy versions of Hive later, which uses a legacy hybrid calendar that is different from Spark 3.0+'s Proleptic Gregorian calendar. See more details in SPARK-31404. You can set %s to 'LEGACY' to rebase the datetime values w.r.t. the calendar difference during writing, to get maximum interoperability. Or set %s to 'CORRECTED' to write the datetime values as it is, if you are 100%% sure that the written files will only be read by Spark 3.0+ or other systems that use Proleptic Gregorian calendar." ]
   },
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -71,9 +71,11 @@ private[spark] case class ExecutorDeadException(message: String)
 /**
  * Exception thrown when Spark returns different result after upgrading to a new version.
  */
-private[spark] class SparkUpgradeException(version: String, message: String, cause: Throwable)
-  extends RuntimeException("You may get a different result due to the upgrading of Spark" +
-    s" $version: $message", cause)
+private[spark] class SparkUpgradeException(
+    errorClass: String,
+    messageParameters: Array[String],
+    cause: Throwable = null)
+  extends SparkRuntimeException(errorClass, messageParameters, cause)
 
 /**
  * Arithmetic exception thrown from Spark with an error class.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -443,7 +443,7 @@ object QueryExecutionErrors {
   def streamedOperatorUnsupportedByDataSourceError(
       className: String, operator: String): Throwable = {
     new SparkUnsupportedOperationException(
-      errorClass = "UNSUPPORTED_STREAMED_OPERATOR_BY_DATASOURCE",
+      errorClass = "UNSUPPORTED_STREAMED_OPERATOR_BY_DATA_SOURCE",
       messageParameters = Array(className, operator))
   }
 
@@ -455,7 +455,7 @@ object QueryExecutionErrors {
 
   def failedToFindDataSourceError(provider: String, error: Throwable): Throwable = {
     new SparkClassNotFoundException(
-      errorClass = "FAILED_FIND_DATASOURCE",
+      errorClass = "FAILED_FIND_DATA_SOURCE",
       messageParameters = Array(provider), error)
   }
 
@@ -480,14 +480,16 @@ object QueryExecutionErrors {
   def sparkUpgradeInReadingDatesError(
       format: String, config: String, option: String): SparkUpgradeException = {
     new SparkUpgradeException(
-      errorClass = "CANNOT_UPGRADE_IN_READING_DATES",
-      messageParameters = Array("3.0", format, config, option, config, option))
+      version = "3.0",
+      errorClass = "READING_AMBIGUOUS_DATES_AFTER_UPGRADE",
+      messageParameters = Array(format, config, option, config, option), null)
   }
 
   def sparkUpgradeInWritingDatesError(format: String, config: String): SparkUpgradeException = {
     new SparkUpgradeException(
-      errorClass = "CANNOT_UPGRADE_IN_WRITING_DATES",
-      messageParameters = Array("3.0", format, config, config))
+      version = "3.0",
+      errorClass = "WRITING_AMBIGUOUS_DATES_AFTER_UPGRADE",
+      messageParameters = Array(format, config, config), null)
   }
 
   def buildReaderUnsupportedForFileFormatError(format: String): Throwable = {
@@ -504,7 +506,7 @@ object QueryExecutionErrors {
 
   def taskFailedWhileWritingRowsError(cause: Throwable): Throwable = {
     new SparkException(
-      errorClass = "TASK_FAILED_WRITING_ROWS",
+      errorClass = "FAILED_TASK_WHILE_WRITING_ROWS",
       messageParameters = Array.empty, cause)
   }
 
@@ -517,18 +519,18 @@ object QueryExecutionErrors {
   def unsupportedSaveModeError(saveMode: String, pathExists: Boolean): Throwable = {
     new SparkIllegalStateException(
       errorClass = "UNSUPPORTED_SAVE_MODE",
-      messageParameters = Array(saveMode + " (" + pathExists.toString + ")"))
+      messageParameters = Array(saveMode, pathExists.toString))
   }
 
   def cannotClearOutputDirectoryError(staticPrefixPath: Path): Throwable = {
     new SparkIOException(
-      errorClass = "CANNOT_CLEAR_SOME_DIRECTORY",
+      errorClass = "CANNOT_CLEAR_DIRECTORY",
       messageParameters = Array("output", staticPrefixPath.toString))
   }
 
   def cannotClearPartitionDirectoryError(path: Path): Throwable = {
     new SparkIOException(
-      errorClass = "CANNOT_CLEAR_SOME_DIRECTORY",
+      errorClass = "CANNOT_CLEAR_DIRECTORY",
       messageParameters = Array("partition", path.toString))
   }
 
@@ -548,7 +550,7 @@ object QueryExecutionErrors {
   def fallbackV1RelationReportsInconsistentSchemaError(
       v2Schema: StructType, v1Schema: StructType): Throwable = {
     new SparkIllegalArgumentException(
-      errorClass = "FAILED_FALLBACK_V1_BECAUSE_OF_INCONSISTENT_SCHEMA",
+      errorClass = "INTERNAL_ERROR",
       messageParameters = Array(v2Schema.sql, v1Schema.sql))
   }
 
@@ -926,21 +928,24 @@ object QueryExecutionErrors {
 
   def failToParseDateTimeInNewParserError(s: String, e: Throwable): Throwable = {
     new SparkUpgradeException(
-      errorClass = "FAILED_PARSE_DATETIME_IN_NEW_PARSER",
-      messageParameters = Array("3.0", s, SQLConf.LEGACY_TIME_PARSER_POLICY.key), e)
+      version = "3.0",
+      errorClass = "FAILED_PARSE_DATE_TIME_AFTER_UPGRADE",
+      messageParameters = Array(s, SQLConf.LEGACY_TIME_PARSER_POLICY.key), e)
   }
 
   def failToFormatDateTimeInNewFormatterError(
       resultCandidate: String, e: Throwable): Throwable = {
     new SparkUpgradeException(
-      errorClass = "FAILED_FORMAT_DATETIME_IN_NEW_FORMATTER",
-      messageParameters = Array("3.0", resultCandidate, SQLConf.LEGACY_TIME_PARSER_POLICY.key), e)
+      version = "3.0",
+      errorClass = "FAILED_FORMAT_DATE_TIME_AFTER_UPGRADE",
+      messageParameters = Array(resultCandidate, SQLConf.LEGACY_TIME_PARSER_POLICY.key), e)
   }
 
   def failToRecognizePatternAfterUpgradeError(pattern: String, e: Throwable): Throwable = {
     new SparkUpgradeException(
-      errorClass = "FAILED_RECOGNIZE_PATTERN_AFTER_UPGRADE",
-      messageParameters = Array("3.0", pattern, SQLConf.LEGACY_TIME_PARSER_POLICY.key), e)
+      version = "3.0",
+      errorClass = "FAILED_RECOGNIZE_DATE_TIME_PATTERN_AFTER_UPGRADE",
+      messageParameters = Array(pattern, SQLConf.LEGACY_TIME_PARSER_POLICY.key), e)
   }
 
   def failToRecognizePatternError(pattern: String, e: Throwable): Throwable = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor fifth set of 20 query execution errors to use error classes. as follows:
```
createStreamingSourceNotSpecifySchemaError
streamedOperatorUnsupportedByDataSourceError
multiplePathsSpecifiedError
failedToFindDataSourceError
removedClassInSpark2Error
incompatibleDataSourceRegisterError
unrecognizedFileFormatError
sparkUpgradeInReadingDatesError
sparkUpgradeInWritingDatesError
buildReaderUnsupportedForFileFormatError
jobAbortedError
taskFailedWhileWritingRowsError
readCurrentFileNotFoundError
unsupportedSaveModeError
cannotClearOutputDirectoryError
cannotClearPartitionDirectoryError
failedToCastValueToDataTypeForPartitionColumnError
endOfStreamError
fallbackV1RelationReportsInconsistentSchemaError
cannotDropNonemptyNamespaceError
```


### Why are the changes needed?
[SPARK-36294](https://issues.apache.org/jira/browse/SPARK-36294)


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existed UT Testcase
