### PR TITLE
[SPARK-35174][K8S] Avoid opening watch when waitAppCompletion is false

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -151,23 +151,26 @@ private[spark] class Client(
         kubernetesClient.pods().delete(createdDriverPod)
         throw e
     }
-    val sId = Seq(conf.namespace, driverPodName).mkString(":")
-    breakable {
-      while (true) {
-        val podWithName = kubernetesClient
-          .pods()
-          .withName(driverPodName)
-        // Reset resource to old before we start the watch, this is important for race conditions
-        watcher.reset()
-        watch = podWithName.watch(watcher)
 
-        // Send the latest pod state we know to the watcher to make sure we didn't miss anything
-        watcher.eventReceived(Action.MODIFIED, podWithName.get())
+    if (conf.get(WAIT_FOR_APP_COMPLETION)) {
+      val sId = Seq(conf.namespace, driverPodName).mkString(":")
+      breakable {
+        while (true) {
+          val podWithName = kubernetesClient
+            .pods()
+            .withName(driverPodName)
+          // Reset resource to old before we start the watch, this is important for race conditions
+          watcher.reset()
+          watch = podWithName.watch(watcher)
 
-        // Break the while loop if the pod is completed or we don't want to wait
-        if(watcher.watchOrStop(sId)) {
-          watch.close()
-          break
+          // Send the latest pod state we know to the watcher to make sure we didn't miss anything
+          watcher.eventReceived(Action.MODIFIED, podWithName.get())
+
+          // Break the while loop if the pod is completed or we don't want to wait
+          if (watcher.watchOrStop(sId)) {
+            watch.close()
+            break
+          }
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Don't open watch when not needed

### Why are the changes needed?
In spark-submit, we currently open a pod watch for any spark submission. If WAIT_FOR_APP_COMPLETION is false, we then immediately ignore the result of the watcher and break out of the watcher.

When submitting spark applications at scale, this is a source of operational pain, since opening the watch relies on opening a websocket, which tends to run into subtle networking issues around negotiating the websocket connection.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Standard tests
