### PR TITLE
[SPARK-36842][Core] TaskSchedulerImpl - stop TaskResultGetter properly

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -928,13 +928,17 @@ private[spark] class TaskSchedulerImpl(
   override def stop(): Unit = {
     speculationScheduler.shutdown()
     if (backend != null) {
-      backend.stop()
+      Utils.tryLogNonFatalError {
+        backend.stop()
+      }
     }
     if (taskResultGetter != null) {
       taskResultGetter.stop()
     }
     if (barrierCoordinator != null) {
-      barrierCoordinator.stop()
+      Utils.tryLogNonFatalError {
+        barrierCoordinator.stop()
+      }
     }
     starvationTimer.cancel()
     abortTimer.cancel()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Catch exception during TaskSchedulerImpl.stop() so that all components can be stopped properly

### Why are the changes needed?
Otherwise some threads won't be stopped during spark session restart

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
It's tested by 
1. create a new spark session in yarn-client mode
2. kill the spark application on yarn
3. check that the spark context is stopped and create a new spark session
4. do the above steps multiple times and verify that no task-result-getter threads number doesn't increase
