### PR TITLE
[SPARK-36847][PYTHON] Explicitly specify error codes when ignoring type hint errors

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -19,6 +19,7 @@
 strict_optional = True
 no_implicit_optional = True
 disallow_untyped_defs = True
+show_error_codes = True
 
 ; Allow untyped def in internal modules and tests
 

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -568,7 +568,7 @@ class PandasOnSparkFrameMethods(object):
         ) -> "UserDefinedFunctionLike":
             ff = f
 
-            @pandas_udf(returnType=return_type)  # type: ignore
+            @pandas_udf(returnType=return_type)  # type: ignore[call-overload]
             def udf(pdf: pd.DataFrame) -> pd.Series:
                 return first_series(ff(pdf))
 
@@ -632,7 +632,9 @@ class PandasOnSparkFrameMethods(object):
                 )
                 columns = self_applied._internal.spark_columns
 
-                pudf = pandas_udf(output_func, returnType=return_schema)  # type: ignore
+                pudf = pandas_udf(  # type: ignore[call-overload]
+                    output_func, returnType=return_schema
+                )
                 temp_struct_column = verify_temp_column_name(
                     self_applied._internal.spark_frame, "__temp_struct__"
                 )
@@ -697,7 +699,9 @@ class PandasOnSparkFrameMethods(object):
                 )
                 columns = self_applied._internal.spark_columns
 
-                pudf = pandas_udf(output_func, returnType=return_schema)  # type: ignore
+                pudf = pandas_udf(  # type: ignore[call-overload]
+                    output_func, returnType=return_schema
+                )
                 temp_struct_column = verify_temp_column_name(
                     self_applied._internal.spark_frame, "__temp_struct__"
                 )
@@ -907,7 +911,7 @@ class PandasOnSparkSeriesMethods(object):
             psdf, apply_func, return_schema, retain_index=False
         )
 
-        @pandas_udf(returnType=field.spark_type)  # type: ignore
+        @pandas_udf(returnType=field.spark_type)  # type: ignore[call-overload]
         def pudf(*series: pd.Series) -> pd.Series:
             return first_series(output_func(pandas_concat(*series)))
 

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -955,7 +955,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         if isinstance(self, MultiIndex):
             raise NotImplementedError("notna is not defined for MultiIndex")
-        return (~self.isnull()).rename(self.name)  # type: ignore
+        return (~self.isnull()).rename(self.name)  # type: ignore[attr-defined]
 
     notna = notnull
 

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -160,7 +160,7 @@ class DatetimeNTZOps(DatetimeOps):
     """
 
     def _cast_spark_column_timestamp_to_long(self, scol: Column) -> Column:
-        jvm = SparkContext._active_spark_context._jvm  # type: ignore
+        jvm = SparkContext._active_spark_context._jvm  # type: ignore[attr-defined]
         return Column(jvm.PythonSQLUtils.castTimestampNTZToLong(scol._jc))
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:

--- a/python/pyspark/pandas/extensions.py
+++ b/python/pyspark/pandas/extensions.py
@@ -59,7 +59,7 @@ class CachedAccessor(Generic[T]):
     ) -> Union[T, Type[T]]:
         if obj is None:
             return self._accessor
-        accessor_obj = self._accessor(obj)  # type: ignore
+        accessor_obj = self._accessor(obj)  # type: ignore[call-arg]
         object.__setattr__(obj, self._name, accessor_obj)
         return accessor_obj
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -344,12 +344,12 @@ rectangle    16.0  2.348543e+108
 
 
 if (3, 5) <= sys.version_info < (3, 7) and __name__ != "__main__":
-    from typing import GenericMeta  # type: ignore
+    from typing import GenericMeta  # type: ignore[attr-defined]
 
     # This is a workaround to support variadic generic in DataFrame in Python 3.5+.
     # See https://github.com/python/typing/issues/193
     # We wrap the input params by a tuple to mimic variadic generic.
-    old_getitem = GenericMeta.__getitem__  # type: ignore
+    old_getitem = GenericMeta.__getitem__
 
     @no_type_check
     def new_getitem(self, params):
@@ -358,7 +358,7 @@ if (3, 5) <= sys.version_info < (3, 7) and __name__ != "__main__":
         else:
             return old_getitem(self, params)
 
-    GenericMeta.__getitem__ = new_getitem  # type: ignore
+    GenericMeta.__getitem__ = new_getitem
 
 
 class DataFrame(Frame, Generic[T]):
@@ -482,7 +482,7 @@ class DataFrame(Frame, Generic[T]):
                 {label: Series(data=self, index=label) for label in self._internal.column_labels},
             )
         else:
-            psseries = self._psseries  # type: ignore
+            psseries = cast(Dict[Label, Series], self._psseries)  # type: ignore[has-type]
             assert len(self._internal.column_labels) == len(psseries), (
                 len(self._internal.column_labels),
                 len(psseries),
@@ -490,16 +490,18 @@ class DataFrame(Frame, Generic[T]):
             if any(self is not psser._psdf for psser in psseries.values()):
                 # Refresh the dict to contain only Series anchoring `self`.
                 self._psseries = {
-                    label: psseries[label]
-                    if self is psseries[label]._psdf
-                    else Series(data=self, index=label)
+                    label: (
+                        psseries[label]
+                        if self is psseries[label]._psdf
+                        else Series(data=self, index=label)
+                    )
                     for label in self._internal.column_labels
                 }
         return self._psseries
 
     @property
     def _internal(self) -> InternalFrame:
-        return self._internal_frame  # type: ignore
+        return cast(InternalFrame, self._internal_frame)  # type: ignore[has-type]
 
     def _update_internal_frame(
         self, internal: InternalFrame, requires_same_anchor: bool = True
@@ -662,7 +664,7 @@ class DataFrame(Frame, Generic[T]):
             if len(pdf) <= limit:
                 return Series(pser)
 
-            @pandas_udf(returnType=as_spark_type(pser.dtype.type))  # type: ignore
+            @pandas_udf(returnType=as_spark_type(pser.dtype.type))  # type: ignore[call-overload]
             def calculate_columns_axis(*cols: pd.Series) -> pd.Series:
                 return getattr(pd.concat(cols, axis=1), name)(
                     axis=axis, numeric_only=numeric_only, **kwargs
@@ -1513,7 +1515,7 @@ class DataFrame(Frame, Generic[T]):
         can_return_named_tuples = sys.version_info >= (3, 7) or len(self.columns) + index < 255
 
         if name is not None and can_return_named_tuples:
-            itertuple = namedtuple(name, fields, rename=True)  # type: ignore
+            itertuple = namedtuple(name, fields, rename=True)  # type: ignore[misc]
             for k, v in map(
                 extract_kv_from_spark_row,
                 self._internal.resolved_copy.spark_frame.toLocalIterator(),
@@ -3030,7 +3032,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         psdf.index.name = verify_temp_column_name(psdf, "__index_name__")
         return_types = [psdf.index.dtype] + list(psdf.dtypes)
 
-        def pandas_between_time(pdf) -> ps.DataFrame[return_types]:  # type: ignore
+        @no_type_check
+        def pandas_between_time(pdf) -> ps.DataFrame[return_types]:
             return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
 
         # apply_batch will remove the index of the pandas-on-Spark DataFrame and attach a
@@ -3109,12 +3112,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if LooseVersion(pd.__version__) < LooseVersion("0.24"):
 
-            def pandas_at_time(pdf) -> ps.DataFrame[return_types]:  # type: ignore
+            @no_type_check
+            def pandas_at_time(pdf) -> ps.DataFrame[return_types]:
                 return pdf.at_time(time, asof).reset_index()
 
         else:
 
-            def pandas_at_time(pdf) -> ps.DataFrame[return_types]:  # type: ignore
+            @no_type_check
+            def pandas_at_time(pdf) -> ps.DataFrame[return_types]:
                 return pdf.at_time(time, asof, axis).reset_index()
 
         # apply_batch will remove the index of the pandas-on-Spark DataFrame and attach
@@ -4413,7 +4418,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     ],
                     index_names=self._internal.index_names,
                     index_fields=self._internal.index_fields,
-                    column_labels=[None],  # type: ignore
+                    column_labels=[None],
                     data_spark_columns=[scol_for(sdf, SPARK_DEFAULT_SERIES_NAME)],
                 )
             )
@@ -4590,7 +4595,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...             mode='overwrite', replaceWhere='date >= "2012-01-01"')  # doctest: +SKIP
         """
         if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-            options = options.get("options")  # type: ignore
+            options = options.get("options")  # type: ignore[assignment]
 
         mode = validate_mode(mode)
         self.spark.to_spark_io(
@@ -4667,7 +4672,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...     partition_cols=['date', 'country'])
         """
         if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-            options = options.get("options")  # type: ignore
+            options = options.get("options")
 
         mode = validate_mode(mode)
         builder = self.to_spark(index_col=index_col).write.mode(mode)
@@ -4739,7 +4744,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         ...     partition_cols=['date', 'country'])
         """
         if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-            options = options.get("options")  # type: ignore
+            options = options.get("options")  # type: ignore[assignment]
 
         mode = validate_mode(mode)
         self.spark.to_spark_io(
@@ -6398,7 +6403,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         4  1   True  1.0
         5  2  False  2.0
         """
-        from pyspark.sql.types import _parse_datatype_string  # type: ignore
+        from pyspark.sql.types import _parse_datatype_string  # type: ignore[attr-defined]
 
         if not is_list_like(include):
             include_list = [include] if include is not None else []
@@ -6978,12 +6983,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 "Specifying the sorting algorithm is not supported at the moment."
             )
 
-        if level is None or (is_list_like(level) and len(level) == 0):  # type: ignore
+        if level is None or (is_list_like(level) and len(level) == 0):  # type: ignore[arg-type]
             by = self._internal.index_spark_columns
         elif is_list_like(level):
-            by = [self._internal.index_spark_columns[l] for l in level]  # type: ignore
+            by = [self._internal.index_spark_columns[l] for l in level]  # type: ignore[union-attr]
         else:
-            by = [self._internal.index_spark_columns[level]]  # type: ignore
+            by = [self._internal.index_spark_columns[level]]  # type: ignore[index]
 
         psdf = self._sort(by=by, ascending=ascending, na_position=na_position)
         if inplace:
@@ -7591,7 +7596,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             if os is None:
                 return []
             elif is_name_like_tuple(os):
-                return [os]  # type: ignore
+                return [cast(Label, os)]
             elif is_name_like_value(os):
                 return [(os,)]
             else:
@@ -7907,7 +7912,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         need_set_index = False
         if on:
             if not is_list_like(on):
-                on = [on]  # type: ignore
+                on = [on]
             if len(on) != right._internal.index_level:
                 raise ValueError(
                     'len(left_on) must equal the number of levels in the index of "right"'
@@ -10248,7 +10253,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 if level < 0 or level >= num_indices:
                     raise ValueError("level should be an integer between [0, num_indices)")
 
-            @pandas_udf(returnType=index_mapper_ret_stype)  # type: ignore
+            @pandas_udf(returnType=index_mapper_ret_stype)  # type: ignore[call-overload]
             def index_mapper_udf(s: pd.Series) -> pd.Series:
                 return s.map(index_mapper_fn)
 
@@ -10817,7 +10822,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 # hack to use pandas' info as is.
                 object.__setattr__(self, "_data", self)
                 count_func = self.count
-                self.count = lambda: count_func().to_pandas()  # type: ignore
+                self.count = (  # type: ignore[assignment]
+                    lambda: count_func().to_pandas()  # type: ignore[assignment, misc, union-attr]
+                )
                 return pd.DataFrame.info(
                     self,
                     verbose=verbose,
@@ -10828,7 +10835,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
             finally:
                 del self._data
-                self.count = count_func  # type: ignore
+                self.count = count_func  # type: ignore[assignment]
 
     # TODO: fix parameter 'axis' and 'numeric_only' to work same as pandas'
     def quantile(
@@ -11444,7 +11451,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         else:
 
-            @pandas_udf(returnType=DoubleType())  # type: ignore
+            @pandas_udf(returnType=DoubleType())  # type: ignore[call-overload]
             def calculate_columns_axis(*cols: pd.Series) -> pd.Series:
                 return pd.concat(cols, axis=1).mad(axis=1)
 
@@ -11990,7 +11997,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if hasattr(_MissingPandasLikeDataFrame, key):
             property_or_func = getattr(_MissingPandasLikeDataFrame, key)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
 

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -782,7 +782,7 @@ class Frame(object, metaclass=ABCMeta):
         ...    ...    2012-03-31 12:00:00
         """
         if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-            options = options.get("options")  # type: ignore
+            options = options.get("options")
 
         if path is None:
             # If path is none, just collect and use pandas's to_csv.
@@ -791,7 +791,7 @@ class Frame(object, metaclass=ABCMeta):
                 self, ps.Series
             ):
                 # 0.23 seems not having 'columns' parameter in Series' to_csv.
-                return psdf_or_ser.to_pandas().to_csv(  # type: ignore
+                return psdf_or_ser.to_pandas().to_csv(
                     None,
                     sep=sep,
                     na_rep=na_rep,
@@ -800,7 +800,7 @@ class Frame(object, metaclass=ABCMeta):
                     index=False,
                 )
             else:
-                return psdf_or_ser.to_pandas().to_csv(  # type: ignore
+                return psdf_or_ser.to_pandas().to_csv(
                     None,
                     sep=sep,
                     na_rep=na_rep,
@@ -812,8 +812,10 @@ class Frame(object, metaclass=ABCMeta):
                     index=False,
                 )
 
-        psdf = self
-        if isinstance(self, ps.Series):
+        if isinstance(self, ps.DataFrame):
+            psdf = self
+        else:
+            assert isinstance(self, ps.Series)
             psdf = self.to_frame()
 
         if columns is None:
@@ -839,7 +841,7 @@ class Frame(object, metaclass=ABCMeta):
         if header is True and psdf._internal.column_labels_level > 1:
             raise ValueError("to_csv only support one-level index column now")
         elif isinstance(header, list):
-            sdf = psdf.to_spark(index_col)  # type: ignore
+            sdf = psdf.to_spark(index_col)
             sdf = sdf.select(
                 [scol_for(sdf, name_like_string(label)) for label in index_cols]
                 + [
@@ -851,7 +853,7 @@ class Frame(object, metaclass=ABCMeta):
             )
             header = True
         else:
-            sdf = psdf.to_spark(index_col)  # type: ignore
+            sdf = psdf.to_spark(index_col)
             sdf = sdf.select(
                 [scol_for(sdf, name_like_string(label)) for label in index_cols]
                 + [
@@ -872,7 +874,7 @@ class Frame(object, metaclass=ABCMeta):
         builder = sdf.write.mode(mode)
         if partition_cols is not None:
             builder.partitionBy(partition_cols)
-        builder._set_opts(
+        builder._set_opts(  # type: ignore[attr-defined]
             sep=sep,
             nullValue=na_rep,
             header=header,
@@ -983,7 +985,7 @@ class Frame(object, metaclass=ABCMeta):
         1         c
         """
         if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-            options = options.get("options")  # type: ignore
+            options = options.get("options")
 
         if not lines:
             raise NotImplementedError("lines=False is not implemented yet.")
@@ -994,17 +996,19 @@ class Frame(object, metaclass=ABCMeta):
         if path is None:
             # If path is none, just collect and use pandas's to_json.
             psdf_or_ser = self
-            pdf = psdf_or_ser.to_pandas()  # type: ignore
+            pdf = psdf_or_ser.to_pandas()
             if isinstance(self, ps.Series):
                 pdf = pdf.to_frame()
             # To make the format consistent and readable by `read_json`, convert it to pandas' and
             # use 'records' orient for now.
             return pdf.to_json(orient="records")
 
-        psdf = self
-        if isinstance(self, ps.Series):
+        if isinstance(self, ps.DataFrame):
+            psdf = self
+        else:
+            assert isinstance(self, ps.Series)
             psdf = self.to_frame()
-        sdf = psdf.to_spark(index_col=index_col)  # type: ignore
+        sdf = psdf.to_spark(index_col=index_col)
 
         if num_files is not None:
             warnings.warn(
@@ -1018,7 +1022,7 @@ class Frame(object, metaclass=ABCMeta):
         builder = sdf.write.mode(mode)
         if partition_cols is not None:
             builder.partitionBy(partition_cols)
-        builder._set_opts(compression=compression)
+        builder._set_opts(compression=compression)  # type: ignore[attr-defined]
         builder.options(**options).format("json").save(path)
         return None
 
@@ -2106,7 +2110,7 @@ class Frame(object, metaclass=ABCMeta):
         if num_columns == 0:
             return 0
         else:
-            return len(self) * num_columns  # type: ignore
+            return len(self) * num_columns  # type: ignore[arg-type]
 
     def abs(self: FrameLike) -> FrameLike:
         """
@@ -3171,25 +3175,25 @@ class Frame(object, metaclass=ABCMeta):
 
     @property
     def at(self) -> AtIndexer:
-        return AtIndexer(self)  # type: ignore
+        return AtIndexer(self)
 
     at.__doc__ = AtIndexer.__doc__
 
     @property
     def iat(self) -> iAtIndexer:
-        return iAtIndexer(self)  # type: ignore
+        return iAtIndexer(self)
 
     iat.__doc__ = iAtIndexer.__doc__
 
     @property
     def iloc(self) -> iLocIndexer:
-        return iLocIndexer(self)  # type: ignore
+        return iLocIndexer(self)
 
     iloc.__doc__ = iLocIndexer.__doc__
 
     @property
     def loc(self) -> LocIndexer:
-        return LocIndexer(self)  # type: ignore
+        return LocIndexer(self)
 
     loc.__doc__ = LocIndexer.__doc__
 

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -265,7 +265,13 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
 
         relabeling = func_or_funcs is None and is_multi_agg_with_relabel(**kwargs)
         if relabeling:
-            func_or_funcs, columns, order = normalize_keyword_aggregation(kwargs)  # type: ignore
+            (
+                func_or_funcs,
+                columns,
+                order,
+            ) = normalize_keyword_aggregation(  # type: ignore[assignment]
+                kwargs
+            )
 
         if not isinstance(func_or_funcs, (str, list)):
             if not isinstance(func_or_funcs, dict) or not all(
@@ -1157,7 +1163,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         1    52
         Name: B, dtype: int64
         """
-        if not isinstance(func, Callable):  # type: ignore
+        if not callable(func):
             raise TypeError("%s object is not callable" % type(func).__name__)
 
         spec = inspect.getfullargspec(func)
@@ -1377,7 +1383,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         5    6
         Name: B, dtype: int64
         """
-        if not isinstance(func, Callable):  # type: ignore
+        if not callable(func):
             raise TypeError("%s object is not callable" % type(func).__name__)
 
         is_series_groupby = isinstance(self, SeriesGroupBy)
@@ -1425,9 +1431,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
 
         psdf = DataFrame(self._psdf[agg_columns]._internal.with_new_sdf(sdf))
         if is_series_groupby:
-            return first_series(psdf)  # type: ignore
+            return cast(FrameLike, first_series(psdf))
         else:
-            return psdf  # type: ignore
+            return cast(FrameLike, psdf)
 
     @staticmethod
     def _prepare_group_map_apply(
@@ -1468,7 +1474,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         from pyspark.sql.utils import is_timestamp_ntz_preferred
 
         arguments_for_restore_index = psdf._internal.arguments_for_restore_index
-        prefer_timestamp_ntz = is_timestamp_ntz_preferred()  # type: ignore
+        prefer_timestamp_ntz = is_timestamp_ntz_preferred()
 
         def rename_output(pdf: pd.DataFrame) -> pd.DataFrame:
             pdf = InternalFrame.restore_index(pdf.copy(), **arguments_for_restore_index)
@@ -2224,7 +2230,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         1  28  35
         2  31  35
         """
-        if not isinstance(func, Callable):  # type: ignore
+        if not callable(func):
             raise TypeError("%s object is not callable" % type(func).__name__)
 
         spec = inspect.getfullargspec(func)
@@ -2781,7 +2787,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         if hasattr(MissingPandasLikeDataFrameGroupBy, item):
             property_or_func = getattr(MissingPandasLikeDataFrameGroupBy, item)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
         return self.__getitem__(item)
@@ -2966,7 +2972,7 @@ class SeriesGroupBy(GroupBy[Series]):
         if hasattr(MissingPandasLikeSeriesGroupBy, item):
             property_or_func = getattr(MissingPandasLikeSeriesGroupBy, item)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
         raise AttributeError(item)

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -1990,7 +1990,7 @@ class Index(IndexOpsMixin):
         if isinstance(self, MultiIndex):
             if level is not None:
                 self_names = self.names
-                self_names[level] = names  # type: ignore
+                self_names[level] = names  # type: ignore[index]
                 names = self_names
         return self.rename(name=names, inplace=inplace)
 
@@ -2060,7 +2060,7 @@ class Index(IndexOpsMixin):
                 [isinstance(item, tuple) for item in other]
             )
             if is_other_list_of_tuples:
-                other = MultiIndex.from_tuples(other)  # type: ignore
+                other = MultiIndex.from_tuples(other)  # type: ignore[arg-type]
             else:
                 raise TypeError("other must be a MultiIndex or a list of tuples")
 
@@ -2576,7 +2576,7 @@ class Index(IndexOpsMixin):
         if hasattr(MissingPandasLikeIndex, item):
             property_or_func = getattr(MissingPandasLikeIndex, item)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
         raise AttributeError("'{}' object has no attribute '{}'".format(type(self).__name__, item))

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -138,7 +138,7 @@ class DatetimeIndex(Index):
         if hasattr(MissingPandasLikeDatetimeIndex, item):
             property_or_func = getattr(MissingPandasLikeDatetimeIndex, item)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
         raise AttributeError("'DatetimeIndex' object has no attribute '{}'".format(item))

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -704,7 +704,7 @@ class MultiIndex(Index):
                     ('d', 'h')],
                    )
         """
-        return super().copy(deep=deep)  # type: ignore
+        return cast(MultiIndex, super().copy(deep=deep))
 
     def symmetric_difference(  # type: ignore[override]
         self,
@@ -911,7 +911,7 @@ class MultiIndex(Index):
         if hasattr(MissingPandasLikeMultiIndex, item):
             property_or_func = getattr(MissingPandasLikeMultiIndex, item)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
         raise AttributeError("'MultiIndex' object has no attribute '{}'".format(item))
@@ -1111,7 +1111,7 @@ class MultiIndex(Index):
             keep_name = self.names == other.names
         elif isinstance(other, Index):
             # Always returns an empty MultiIndex if `other` is Index.
-            return self.to_frame().head(0).index  # type: ignore
+            return cast(MultiIndex, self.to_frame().head(0).index)
         elif not all(isinstance(item, tuple) for item in other):
             raise TypeError("other must be a MultiIndex or a list of tuples")
         else:

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -54,11 +54,12 @@ from pyspark.pandas.utils import (
 
 if TYPE_CHECKING:
     from pyspark.pandas.frame import DataFrame  # noqa: F401 (SPARK-34943)
+    from pyspark.pandas.generic import Frame  # noqa: F401 (SPARK-34943)
     from pyspark.pandas.series import Series  # noqa: F401 (SPARK-34943)
 
 
 class IndexerLike(object):
-    def __init__(self, psdf_or_psser: Union["Series", "DataFrame"]):
+    def __init__(self, psdf_or_psser: "Frame"):
         from pyspark.pandas.frame import DataFrame
         from pyspark.pandas.series import Series
 
@@ -534,7 +535,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
         except AnalysisException:
             raise KeyError(
                 "[{}] don't exist in columns".format(
-                    [col._jc.toString() for col in data_spark_columns]  # type: ignore
+                    [col._jc.toString() for col in data_spark_columns]  # type: ignore[operator]
                 )
             )
 

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -740,7 +740,7 @@ class InternalFrame(object):
             ]
 
         assert all(
-            isinstance(ops.dtype, Dtype.__args__)  # type: ignore
+            isinstance(ops.dtype, Dtype.__args__)  # type: ignore[attr-defined]
             and (
                 ops.dtype == np.dtype("object")
                 or as_spark_type(ops.dtype, raise_error=False) is not None
@@ -758,7 +758,7 @@ class InternalFrame(object):
         self._index_fields = index_fields  # type: List[InternalField]
 
         assert all(
-            isinstance(ops.dtype, Dtype.__args__)  # type: ignore
+            isinstance(ops.dtype, Dtype.__args__)  # type: ignore[attr-defined]
             and (
                 ops.dtype == np.dtype("object")
                 or as_spark_type(ops.dtype, raise_error=False) is not None
@@ -908,7 +908,7 @@ class InternalFrame(object):
         """
         if len(sdf.columns) > 0:
             return SparkDataFrame(
-                sdf._jdf.toDF().withSequenceColumn(column_name),  # type: ignore
+                sdf._jdf.toDF().withSequenceColumn(column_name),  # type: ignore[operator]
                 sdf.sql_ctx,
             )
         else:
@@ -1452,7 +1452,7 @@ class InternalFrame(object):
             name if name is None or isinstance(name, tuple) else (name,) for name in columns.names
         ]  # type: List[Optional[Label]]
 
-        prefer_timestamp_ntz = is_timestamp_ntz_preferred()  # type: ignore
+        prefer_timestamp_ntz = is_timestamp_ntz_preferred()
 
         (
             pdf,

--- a/python/pyspark/pandas/ml.py
+++ b/python/pyspark/pandas/ml.py
@@ -78,7 +78,7 @@ def to_numeric_df(psdf: "ps.DataFrame") -> Tuple[pyspark.sql.DataFrame, List[Lab
     """
     # TODO, it should be more robust.
     accepted_types = {
-        np.dtype(dt)  # type: ignore
+        np.dtype(dt)  # type: ignore[misc]
         for dt in [np.int8, np.int16, np.int32, np.int64, np.float32, np.float64, np.bool_]
     }
     numeric_column_labels = [

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -287,7 +287,7 @@ def read_csv(
     >>> ps.read_csv('data.csv')  # doctest: +SKIP
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-        options = options.get("options")  # type: ignore
+        options = options.get("options")
 
     if mangle_dupe_cols is not True:
         raise ValueError("mangle_dupe_cols can only be `True`: %s" % mangle_dupe_cols)
@@ -295,7 +295,7 @@ def read_csv(
         raise ValueError("parse_dates can only be `False`: %s" % parse_dates)
 
     if usecols is not None and not callable(usecols):
-        usecols = list(usecols)  # type: ignore
+        usecols = list(usecols)  # type: ignore[assignment]
 
     if usecols is None or callable(usecols) or len(usecols) > 0:
         reader = default_session().read
@@ -484,7 +484,7 @@ def read_json(
     1         c     d
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-        options = options.get("options")  # type: ignore
+        options = options.get("options")
 
     if not lines:
         raise NotImplementedError("lines=False is not implemented yet.")
@@ -571,7 +571,7 @@ def read_delta(
     if version is not None and timestamp is not None:
         raise ValueError("version and timestamp cannot be used together.")
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-        options = options.get("options")  # type: ignore
+        options = options.get("options")
 
     if version is not None:
         options["versionAsOf"] = version
@@ -698,7 +698,7 @@ def read_spark_io(
     4      14
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-        options = options.get("options")  # type: ignore
+        options = options.get("options")
 
     sdf = default_session().read.load(path=path, format=format, schema=schema, **options)
     index_spark_columns, index_names = _get_index_map(sdf, index_col)
@@ -760,7 +760,7 @@ def read_parquet(
     0       0
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-        options = options.get("options")  # type: ignore
+        options = options.get("options")
 
     if columns is not None:
         columns = list(columns)
@@ -1364,7 +1364,7 @@ def read_sql_table(
     >>> ps.read_sql_table('table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-        options = options.get("options")  # type: ignore
+        options = options.get("options")
 
     reader = default_session().read
     reader.option("dbtable", table_name)
@@ -1426,7 +1426,7 @@ def read_sql_query(
     >>> ps.read_sql_query('SELECT * FROM table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-        options = options.get("options")  # type: ignore
+        options = options.get("options")
 
     reader = default_session().read
     reader.option("query", sql)
@@ -1493,7 +1493,7 @@ def read_sql(
     >>> ps.read_sql('SELECT * FROM table_name', 'jdbc:postgresql:db_name')  # doctest: +SKIP
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-        options = options.get("options")  # type: ignore
+        options = options.get("options")
 
     striped = sql.strip()
     if " " not in striped:  # TODO: identify the table name or not more precisely.
@@ -2930,7 +2930,7 @@ def read_orc(
     0       0
     """
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-        options = options.get("options")  # type: ignore
+        options = options.get("options")
 
     psdf = read_spark_io(path, format="orc", index_col=index_col, **options)
 

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -31,11 +31,11 @@ unary_np_spark_mappings = OrderedDict(
         "abs": F.abs,
         "absolute": F.abs,
         "arccos": F.acos,
-        "arccosh": pandas_udf(lambda s: np.arccosh(s), DoubleType()),  # type: ignore
+        "arccosh": pandas_udf(lambda s: np.arccosh(s), DoubleType()),  # type: ignore[call-overload]
         "arcsin": F.asin,
-        "arcsinh": pandas_udf(lambda s: np.arcsinh(s), DoubleType()),  # type: ignore
+        "arcsinh": pandas_udf(lambda s: np.arcsinh(s), DoubleType()),  # type: ignore[call-overload]
         "arctan": F.atan,
-        "arctanh": pandas_udf(lambda s: np.arctanh(s), DoubleType()),  # type: ignore
+        "arctanh": pandas_udf(lambda s: np.arctanh(s), DoubleType()),  # type: ignore[call-overload]
         "bitwise_not": F.bitwiseNOT,
         "cbrt": F.cbrt,
         "ceil": F.ceil,
@@ -43,17 +43,17 @@ unary_np_spark_mappings = OrderedDict(
         "conj": lambda _: NotImplemented,
         "conjugate": lambda _: NotImplemented,  # It requires complex type
         "cos": F.cos,
-        "cosh": pandas_udf(lambda s: np.cosh(s), DoubleType()),  # type: ignore
-        "deg2rad": pandas_udf(lambda s: np.deg2rad(s), DoubleType()),  # type: ignore
+        "cosh": pandas_udf(lambda s: np.cosh(s), DoubleType()),  # type: ignore[call-overload]
+        "deg2rad": pandas_udf(lambda s: np.deg2rad(s), DoubleType()),  # type: ignore[call-overload]
         "degrees": F.degrees,
         "exp": F.exp,
-        "exp2": pandas_udf(lambda s: np.exp2(s), DoubleType()),  # type: ignore
+        "exp2": pandas_udf(lambda s: np.exp2(s), DoubleType()),  # type: ignore[call-overload]
         "expm1": F.expm1,
-        "fabs": pandas_udf(lambda s: np.fabs(s), DoubleType()),  # type: ignore
+        "fabs": pandas_udf(lambda s: np.fabs(s), DoubleType()),  # type: ignore[call-overload]
         "floor": F.floor,
         "frexp": lambda _: NotImplemented,  # 'frexp' output lengths become different
         # and it cannot be supported via pandas UDF.
-        "invert": pandas_udf(lambda s: np.invert(s), DoubleType()),  # type: ignore
+        "invert": pandas_udf(lambda s: np.invert(s), DoubleType()),  # type: ignore[call-overload]
         "isfinite": lambda c: c != float("inf"),
         "isinf": lambda c: c == float("inf"),
         "isnan": F.isnan,
@@ -61,25 +61,27 @@ unary_np_spark_mappings = OrderedDict(
         "log": F.log,
         "log10": F.log10,
         "log1p": F.log1p,
-        "log2": pandas_udf(lambda s: np.log2(s), DoubleType()),  # type: ignore
+        "log2": pandas_udf(lambda s: np.log2(s), DoubleType()),  # type: ignore[call-overload]
         "logical_not": lambda c: ~(c.cast(BooleanType())),
         "matmul": lambda _: NotImplemented,  # Can return a NumPy array in pandas.
         "negative": lambda c: c * -1,
         "positive": lambda c: c,
-        "rad2deg": pandas_udf(lambda s: np.rad2deg(s), DoubleType()),  # type: ignore
+        "rad2deg": pandas_udf(lambda s: np.rad2deg(s), DoubleType()),  # type: ignore[call-overload]
         "radians": F.radians,
-        "reciprocal": pandas_udf(lambda s: np.reciprocal(s), DoubleType()),  # type: ignore
-        "rint": pandas_udf(lambda s: np.rint(s), DoubleType()),  # type: ignore
+        "reciprocal": pandas_udf(  # type: ignore[call-overload]
+            lambda s: np.reciprocal(s), DoubleType()
+        ),
+        "rint": pandas_udf(lambda s: np.rint(s), DoubleType()),  # type: ignore[call-overload]
         "sign": lambda c: F.when(c == 0, 0).when(c < 0, -1).otherwise(1),
         "signbit": lambda c: F.when(c < 0, True).otherwise(False),
         "sin": F.sin,
-        "sinh": pandas_udf(lambda s: np.sinh(s), DoubleType()),  # type: ignore
-        "spacing": pandas_udf(lambda s: np.spacing(s), DoubleType()),  # type: ignore
+        "sinh": pandas_udf(lambda s: np.sinh(s), DoubleType()),  # type: ignore[call-overload]
+        "spacing": pandas_udf(lambda s: np.spacing(s), DoubleType()),  # type: ignore[call-overload]
         "sqrt": F.sqrt,
-        "square": pandas_udf(lambda s: np.square(s), DoubleType()),  # type: ignore
+        "square": pandas_udf(lambda s: np.square(s), DoubleType()),  # type: ignore[call-overload]
         "tan": F.tan,
-        "tanh": pandas_udf(lambda s: np.tanh(s), DoubleType()),  # type: ignore
-        "trunc": pandas_udf(lambda s: np.trunc(s), DoubleType()),  # type: ignore
+        "tanh": pandas_udf(lambda s: np.tanh(s), DoubleType()),  # type: ignore[call-overload]
+        "trunc": pandas_udf(lambda s: np.trunc(s), DoubleType()),  # type: ignore[call-overload]
     }
 )
 
@@ -89,24 +91,44 @@ binary_np_spark_mappings = OrderedDict(
         "bitwise_and": lambda c1, c2: c1.bitwiseAND(c2),
         "bitwise_or": lambda c1, c2: c1.bitwiseOR(c2),
         "bitwise_xor": lambda c1, c2: c1.bitwiseXOR(c2),
-        "copysign": pandas_udf(lambda s1, s2: np.copysign(s1, s2), DoubleType()),  # type: ignore
-        "float_power": pandas_udf(  # type: ignore
+        "copysign": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.copysign(s1, s2), DoubleType()
+        ),
+        "float_power": pandas_udf(  # type: ignore[call-overload]
             lambda s1, s2: np.float_power(s1, s2), DoubleType()
         ),
-        "floor_divide": pandas_udf(  # type: ignore
+        "floor_divide": pandas_udf(  # type: ignore[call-overload]
             lambda s1, s2: np.floor_divide(s1, s2), DoubleType()
         ),
-        "fmax": pandas_udf(lambda s1, s2: np.fmax(s1, s2), DoubleType()),  # type: ignore
-        "fmin": pandas_udf(lambda s1, s2: np.fmin(s1, s2), DoubleType()),  # type: ignore
-        "fmod": pandas_udf(lambda s1, s2: np.fmod(s1, s2), DoubleType()),  # type: ignore
-        "gcd": pandas_udf(lambda s1, s2: np.gcd(s1, s2), DoubleType()),  # type: ignore
-        "heaviside": pandas_udf(lambda s1, s2: np.heaviside(s1, s2), DoubleType()),  # type: ignore
+        "fmax": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.fmax(s1, s2), DoubleType()
+        ),
+        "fmin": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.fmin(s1, s2), DoubleType()
+        ),
+        "fmod": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.fmod(s1, s2), DoubleType()
+        ),
+        "gcd": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.gcd(s1, s2), DoubleType()
+        ),
+        "heaviside": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.heaviside(s1, s2), DoubleType()
+        ),
         "hypot": F.hypot,
-        "lcm": pandas_udf(lambda s1, s2: np.lcm(s1, s2), DoubleType()),  # type: ignore
-        "ldexp": pandas_udf(lambda s1, s2: np.ldexp(s1, s2), DoubleType()),  # type: ignore
-        "left_shift": pandas_udf(lambda s1, s2: np.left_shift(s1, s2), LongType()),  # type: ignore
-        "logaddexp": pandas_udf(lambda s1, s2: np.logaddexp(s1, s2), DoubleType()),  # type: ignore
-        "logaddexp2": pandas_udf(  # type: ignore
+        "lcm": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.lcm(s1, s2), DoubleType()
+        ),
+        "ldexp": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.ldexp(s1, s2), DoubleType()
+        ),
+        "left_shift": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.left_shift(s1, s2), LongType()
+        ),
+        "logaddexp": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.logaddexp(s1, s2), DoubleType()
+        ),
+        "logaddexp2": pandas_udf(  # type: ignore[call-overload]
             lambda s1, s2: np.logaddexp2(s1, s2), DoubleType()
         ),
         "logical_and": lambda c1, c2: c1.cast(BooleanType()) & c2.cast(BooleanType()),
@@ -118,9 +140,13 @@ binary_np_spark_mappings = OrderedDict(
         ),
         "maximum": F.greatest,
         "minimum": F.least,
-        "modf": pandas_udf(lambda s1, s2: np.modf(s1, s2), DoubleType()),  # type: ignore
-        "nextafter": pandas_udf(lambda s1, s2: np.nextafter(s1, s2), DoubleType()),  # type: ignore
-        "right_shift": pandas_udf(  # type: ignore
+        "modf": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.modf(s1, s2), DoubleType()
+        ),
+        "nextafter": pandas_udf(  # type: ignore[call-overload]
+            lambda s1, s2: np.nextafter(s1, s2), DoubleType()
+        ),
+        "right_shift": pandas_udf(  # type: ignore[call-overload]
             lambda s1, s2: np.right_shift(s1, s2), LongType()
         ),
     }
@@ -214,12 +240,10 @@ def maybe_dispatch_ufunc_to_spark_func(
 
         @no_type_check
         def convert_arguments(*args):
-            args = [  # type: ignore
-                SF.lit(inp) if not isinstance(inp, Column) else inp for inp in args
-            ]  # type: ignore
+            args = [SF.lit(inp) if not isinstance(inp, Column) else inp for inp in args]
             return np_spark_map_func(*args)
 
-        return column_op(convert_arguments)(*inputs)  # type: ignore
+        return column_op(convert_arguments)(*inputs)
     else:
         return NotImplemented
 

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -20,7 +20,7 @@ import importlib
 import pandas as pd
 import numpy as np
 from pyspark.ml.feature import Bucketizer
-from pyspark.mllib.stat import KernelDensity  # type: ignore
+from pyspark.mllib.stat import KernelDensity  # type: ignore[no-redef]
 from pyspark.sql import functions as F
 from pandas.core.base import PandasObject
 from pandas.core.dtypes.inference import is_integer
@@ -428,7 +428,7 @@ class PandasOnSparkPlotAccessor(PandasObject):
         "area": SampledPlotBase().get_sampled,
         "line": SampledPlotBase().get_sampled,
     }
-    _backends = {}  # type: ignore
+    _backends = {}  # type: ignore[var-annotated]
 
     def __init__(self, data):
         self.data = data

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -344,9 +344,9 @@ str_type = str
 
 
 if (3, 5) <= sys.version_info < (3, 7) and __name__ != "__main__":
-    from typing import GenericMeta  # type: ignore
+    from typing import GenericMeta  # type: ignore[attr-defined]
 
-    old_getitem = GenericMeta.__getitem__  # type: ignore
+    old_getitem = GenericMeta.__getitem__
 
     @no_type_check
     def new_getitem(self, params):
@@ -355,7 +355,7 @@ if (3, 5) <= sys.version_info < (3, 7) and __name__ != "__main__":
         else:
             return old_getitem(self, params)
 
-    GenericMeta.__getitem__ = new_getitem  # type: ignore
+    GenericMeta.__getitem__ = new_getitem
 
 
 class Series(Frame, IndexOpsMixin, Generic[T]):
@@ -1065,9 +1065,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                     current = current.when(self.spark.column == SF.lit(to_replace), value)
 
             if hasattr(arg, "__missing__"):
-                tmp_val = arg[np._NoValue]  # type: ignore
+                tmp_val = arg[np._NoValue]  # type: ignore[attr-defined]
                 # Remove in case it's set in defaultdict.
-                del arg[np._NoValue]  # type: ignore
+                del arg[np._NoValue]  # type: ignore[attr-defined]
                 current = current.otherwise(SF.lit(tmp_val))
             else:
                 current = current.otherwise(SF.lit(None).cast(self.spark.data_type))
@@ -2231,7 +2231,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             if level >= internal.index_level:
                 raise ValueError("'level' should be less than the number of indexes")
 
-            if is_name_like_tuple(index):  # type: ignore
+            if is_name_like_tuple(index):
                 index_list = [cast(Label, index)]
             elif is_name_like_value(index):
                 index_list = [(index,)]
@@ -6313,7 +6313,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if hasattr(MissingPandasLikeSeries, item):
             property_or_func = getattr(MissingPandasLikeSeries, item)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
         raise AttributeError("'Series' object has no attribute '{}'".format(item))

--- a/python/pyspark/pandas/spark/accessors.py
+++ b/python/pyspark/pandas/spark/accessors.py
@@ -20,7 +20,7 @@ Spark related features. Usually, the features here are missing in pandas
 but Spark has it.
 """
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Union
 
 from pyspark import StorageLevel
 from pyspark.sql import Column, DataFrame as SparkDataFrame
@@ -743,7 +743,7 @@ class SparkFrameMethods(object):
         >>> df.to_table('%s.my_table' % db, partition_cols='date')
         """
         if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-            options = options.get("options")  # type: ignore
+            options = options.get("options")  # type: ignore[assignment]
 
         self._psdf.spark.frame(index_col=index_col).write.saveAsTable(
             name=name, format=format, mode=mode, partitionBy=partition_cols, **options
@@ -816,7 +816,7 @@ class SparkFrameMethods(object):
         >>> df.to_spark_io(path='%s/to_spark_io/foo.json' % path, format='json')
         """
         if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
-            options = options.get("options")  # type: ignore
+            options = options.get("options")  # type: ignore[assignment]
 
         self._psdf.spark.frame(index_col=index_col).write.save(
             path=path, format=format, mode=mode, partitionBy=partition_cols, **options
@@ -941,8 +941,7 @@ class SparkFrameMethods(object):
                 "The output of the function [%s] should be of a "
                 "pyspark.sql.DataFrame; however, got [%s]." % (func, type(output))
             )
-        psdf = output.to_pandas_on_spark(index_col)  # type: ignore
-        return cast("ps.DataFrame", psdf)
+        return output.to_pandas_on_spark(index_col)
 
     def repartition(self, num_partitions: int) -> "ps.DataFrame":
         """

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -23,7 +23,11 @@ import numpy as np
 
 from pyspark import SparkContext
 from pyspark.sql import functions as F
-from pyspark.sql.column import Column, _to_java_column, _create_column_from_literal  # type: ignore
+from pyspark.sql.column import (  # type: ignore[attr-defined]
+    Column,
+    _to_java_column,
+    _create_column_from_literal,
+)
 from pyspark.sql.types import (
     ByteType,
     FloatType,
@@ -36,7 +40,7 @@ def repeat(col: Column, n: Union[int, Column]) -> Column:
     """
     Repeats a string column n times, and returns it as a new string column.
     """
-    sc = SparkContext._active_spark_context  # type: ignore
+    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
     n = _to_java_column(n) if isinstance(n, Column) else _create_column_from_literal(n)
     return _call_udf(sc, "repeat", _to_java_column(col), n)
 

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-import _string  # type: ignore
+import _string  # type: ignore[import]
 from typing import Any, Dict, Optional, Union, List  # noqa: F401 (SPARK-34943)
 import inspect
 import pandas as pd
@@ -214,7 +214,7 @@ def _get_ipython_scope() -> Dict[str, Any]:
     in an IPython notebook environment.
     """
     try:
-        from IPython import get_ipython  # type: ignore
+        from IPython import get_ipython  # type: ignore[import]
 
         shell = get_ipython()
         return shell.user_ns

--- a/python/pyspark/pandas/strings.py
+++ b/python/pyspark/pandas/strings.py
@@ -1183,7 +1183,9 @@ class StringMethods(object):
         dtype: object
         """
         # type hint does not support to specify array type yet.
-        @pandas_udf(returnType=ArrayType(StringType(), containsNull=True))  # type: ignore
+        @pandas_udf(  # type: ignore[call-overload]
+            returnType=ArrayType(StringType(), containsNull=True)
+        )
         def pudf(s: pd.Series) -> pd.Series:
             return s.str.findall(pat, flags)
 
@@ -2055,7 +2057,7 @@ class StringMethods(object):
         # type hint does not support to specify array type yet.
         return_type = ArrayType(StringType(), containsNull=True)
 
-        @pandas_udf(returnType=return_type)  # type: ignore
+        @pandas_udf(returnType=return_type)  # type: ignore[call-overload]
         def pudf(s: pd.Series) -> pd.Series:
             return s.str.split(pat, n)
 
@@ -2202,7 +2204,7 @@ class StringMethods(object):
         # type hint does not support to specify array type yet.
         return_type = ArrayType(StringType(), containsNull=True)
 
-        @pandas_udf(returnType=return_type)  # type: ignore
+        @pandas_udf(returnType=return_type)  # type: ignore[call-overload]
         def pudf(s: pd.Series) -> pd.Series:
             return s.str.rsplit(pat, n)
 

--- a/python/pyspark/pandas/tests/test_categorical.py
+++ b/python/pyspark/pandas/tests/test_categorical.py
@@ -16,6 +16,7 @@
 #
 
 from distutils.version import LooseVersion
+from typing import no_type_check
 
 import numpy as np
 import pandas as pd
@@ -437,7 +438,8 @@ class CategoricalTest(PandasOnSparkTestCase, TestUtils):
 
         pdf, psdf = self.df_pair
 
-        def identity(x) -> ps.Series[psdf.b.dtype]:  # type: ignore
+        @no_type_check
+        def identity(x) -> ps.Series[psdf.b.dtype]:
             return x
 
         self.assert_eq(

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -4669,7 +4669,9 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
             psdf = ps.from_pandas(pdf)
 
-            def identify4(x) -> ps.DataFrame[float, [int, ntp.NDArray[int]]]:  # type: ignore
+            def identify4(
+                x,
+            ) -> ps.DataFrame[float, [int, ntp.NDArray[int]]]:  # type: ignore[name-defined]
                 return x
 
             actual = psdf.pandas_on_spark.apply_batch(identify4)

--- a/python/pyspark/pandas/tests/test_typedef.py
+++ b/python/pyspark/pandas/tests/test_typedef.py
@@ -116,7 +116,7 @@ class TypeHintTests(unittest.TestCase):
 
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
 
-        def func() -> pd.DataFrame[pdf.dtypes]:  # type: ignore
+        def func() -> pd.DataFrame[pdf.dtypes]:  # type: ignore[name-defined]
             pass
 
         expected = StructType([StructField("c0", LongType()), StructField("c1", LongType())])
@@ -126,14 +126,14 @@ class TypeHintTests(unittest.TestCase):
 
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": pd.Categorical(["a", "b", "c"])})
 
-        def func() -> pd.Series[pdf.b.dtype]:  # type: ignore
+        def func() -> pd.Series[pdf.b.dtype]:  # type: ignore[name-defined]
             pass
 
         inferred = infer_return_type(func)
         self.assertEqual(inferred.dtype, CategoricalDtype(categories=["a", "b", "c"]))
         self.assertEqual(inferred.spark_type, LongType())
 
-        def func() -> pd.DataFrame[pdf.dtypes]:  # type: ignore
+        def func() -> pd.DataFrame[pdf.dtypes]:  # type: ignore[name-defined]
             pass
 
         expected = StructType([StructField("c0", LongType()), StructField("c1", LongType())])
@@ -237,7 +237,7 @@ class TypeHintTests(unittest.TestCase):
         pdf = pd.DataFrame({"a": ["a", 2, None]})
 
         def try_infer_return_type():
-            def f() -> pd.DataFrame[pdf.dtypes]:  # type: ignore
+            def f() -> pd.DataFrame[pdf.dtypes]:  # type: ignore[name-defined]
                 pass
 
             infer_return_type(f)
@@ -245,7 +245,7 @@ class TypeHintTests(unittest.TestCase):
         self.assertRaisesRegex(TypeError, "object.*not understood", try_infer_return_type)
 
         def try_infer_return_type():
-            def f() -> pd.Series[pdf.a.dtype]:  # type: ignore
+            def f() -> pd.Series[pdf.a.dtype]:  # type: ignore[name-defined]
                 pass
 
             infer_return_type(f)
@@ -284,7 +284,7 @@ class TypeHintTests(unittest.TestCase):
         pdf = pd.DataFrame({"a": ["a", 2, None]})
 
         def try_infer_return_type():
-            def f() -> ps.DataFrame[pdf.dtypes]:  # type: ignore
+            def f() -> ps.DataFrame[pdf.dtypes]:  # type: ignore[name-defined]
                 pass
 
             infer_return_type(f)
@@ -292,7 +292,7 @@ class TypeHintTests(unittest.TestCase):
         self.assertRaisesRegex(TypeError, "object.*not understood", try_infer_return_type)
 
         def try_infer_return_type():
-            def f() -> ps.Series[pdf.a.dtype]:  # type: ignore
+            def f() -> ps.Series[pdf.a.dtype]:  # type: ignore[name-defined]
                 pass
 
             infer_return_type(f)

--- a/python/pyspark/pandas/usage_logging/__init__.py
+++ b/python/pyspark/pandas/usage_logging/__init__.py
@@ -113,8 +113,8 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
     except ImportError:
         pass
 
-    sql_processor._CAPTURE_SCOPES = 3  # type: ignore
-    modules.append(sql_processor)  # type: ignore
+    sql_processor._CAPTURE_SCOPES = 3
+    modules.append(sql_processor)
 
     # Modules
     for target_module in modules:

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -918,7 +918,7 @@ def spark_column_equals(left: Column, right: Column) -> bool:
     >>> spark_column_equals(sdf1["x"] + 1, sdf2["x"] + 1)
     False
     """
-    return left._jc.equals(right._jc)  # type: ignore
+    return left._jc.equals(right._jc)  # type: ignore[operator]
 
 
 def compare_null_first(

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -146,7 +146,7 @@ class RollingLike(RollingAndExpanding[FrameLike]):
         def count(scol: Column) -> Column:
             return F.count(scol).over(self._window)
 
-        return self._apply_as_series_or_frame(count).astype("float64")  # type: ignore
+        return self._apply_as_series_or_frame(count).astype("float64")  # type: ignore[attr-defined]
 
 
 class Rolling(RollingLike[FrameLike]):
@@ -172,7 +172,7 @@ class Rolling(RollingLike[FrameLike]):
         if hasattr(MissingPandasLikeRolling, item):
             property_or_func = getattr(MissingPandasLikeRolling, item)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
         raise AttributeError(item)
@@ -663,7 +663,7 @@ class RollingGroupby(RollingLike[FrameLike]):
         if hasattr(MissingPandasLikeRollingGroupby, item):
             property_or_func = getattr(MissingPandasLikeRollingGroupby, item)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
         raise AttributeError(item)
@@ -709,7 +709,7 @@ class RollingGroupby(RollingLike[FrameLike]):
             # pandas doesn't keep the groupkey as a column from 1.3 for DataFrameGroupBy
             column_labels_to_exclude = groupby._column_labels_to_exclude.copy()
             if isinstance(groupby, DataFrameGroupBy):
-                for groupkey in groupby._groupkeys:  # type: ignore
+                for groupkey in groupby._groupkeys:  # type: ignore[attr-defined]
                     column_labels_to_exclude.add(groupkey._internal.column_labels[0])
             agg_columns = [
                 psdf._psser_for(label)
@@ -1071,7 +1071,7 @@ class ExpandingLike(RollingAndExpanding[FrameLike]):
                 F.count(scol).over(self._window),
             ).otherwise(F.lit(None))
 
-        return self._apply_as_series_or_frame(count).astype("float64")  # type: ignore
+        return self._apply_as_series_or_frame(count).astype("float64")  # type: ignore[attr-defined]
 
 
 class Expanding(ExpandingLike[FrameLike]):
@@ -1092,7 +1092,7 @@ class Expanding(ExpandingLike[FrameLike]):
         if hasattr(MissingPandasLikeExpanding, item):
             property_or_func = getattr(MissingPandasLikeExpanding, item)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
         raise AttributeError(item)
@@ -1438,7 +1438,7 @@ class ExpandingGroupby(ExpandingLike[FrameLike]):
         if hasattr(MissingPandasLikeExpandingGroupby, item):
             property_or_func = getattr(MissingPandasLikeExpandingGroupby, item)
             if isinstance(property_or_func, property):
-                return property_or_func.fget(self)  # type: ignore
+                return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
         raise AttributeError(item)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Explicitly specifies error codes when ignoring type hint errors.

### Why are the changes needed?

We use a lot of `type: ignore` annotation to ignore type hint errors in pandas-on-Spark.

We should explicitly specify the error codes to make it clear what kind of error is being ignored, then the type hint checker can check more cases.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.