### PR TITLE
[SPARK-36848][SQL] Migrate ShowCurrentNamespaceStatement to v2 command framework

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -88,9 +88,6 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
         val namespace = if (ns.nonEmpty) Some(ns) else None
         SetCatalogAndNamespace(catalogManager, Some(catalog.name()), namespace)
       }
-
-    case c @ ShowCurrentNamespace(_) =>
-      c.withCatalogManager(Some(catalogManager))
   }
 
   object NonSessionCatalogAndTable {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -89,8 +89,8 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
         SetCatalogAndNamespace(catalogManager, Some(catalog.name()), namespace)
       }
 
-    case ShowCurrentNamespaceStatement() =>
-      ShowCurrentNamespace(catalogManager)
+    case c @ ShowCurrentNamespace(_) =>
+      c.withCatalogManager(Some(catalogManager))
   }
 
   object NonSessionCatalogAndTable {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3566,11 +3566,11 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
   }
 
   /**
-   * Create a [[ShowCurrentNamespaceStatement]].
+   * Create a [[ShowCurrentNamespace]].
    */
   override def visitShowCurrentNamespace(
       ctx: ShowCurrentNamespaceContext) : LogicalPlan = withOrigin(ctx) {
-    ShowCurrentNamespaceStatement()
+    ShowCurrentNamespace(None)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3570,7 +3570,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
    */
   override def visitShowCurrentNamespace(
       ctx: ShowCurrentNamespaceContext) : LogicalPlan = withOrigin(ctx) {
-    ShowCurrentNamespace(None)
+    ShowCurrentNamespace()
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -279,11 +279,6 @@ case class InsertIntoStatement(
 case class UseStatement(isNamespaceSet: Boolean, nameParts: Seq[String]) extends LeafParsedStatement
 
 /**
- * A SHOW CURRENT NAMESPACE statement, as parsed from SQL
- */
-case class ShowCurrentNamespaceStatement() extends LeafParsedStatement
-
-/**
  *  CREATE FUNCTION statement, as parsed from SQL
  */
 case class CreateFunctionStatement(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -639,11 +639,7 @@ case class RefreshTable(child: LogicalPlan) extends UnaryCommand {
 /**
  * The logical plan of the SHOW CURRENT NAMESPACE command.
  */
-case class ShowCurrentNamespace(catalogManager: Option[CatalogManager]) extends LeafCommand {
-
-  def withCatalogManager(catalogManager: Option[CatalogManager]): ShowCurrentNamespace =
-    this.copy(catalogManager = catalogManager)
-
+case class ShowCurrentNamespace() extends LeafCommand {
   override val output: Seq[Attribute] = Seq(
     AttributeReference("catalog", StringType, nullable = false)(),
     AttributeReference("namespace", StringType, nullable = false)())

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -639,7 +639,11 @@ case class RefreshTable(child: LogicalPlan) extends UnaryCommand {
 /**
  * The logical plan of the SHOW CURRENT NAMESPACE command.
  */
-case class ShowCurrentNamespace(catalogManager: CatalogManager) extends LeafCommand {
+case class ShowCurrentNamespace(catalogManager: Option[CatalogManager]) extends LeafCommand {
+
+  def withCatalogManager(catalogManager: Option[CatalogManager]): ShowCurrentNamespace =
+    this.copy(catalogManager = catalogManager)
+
   override val output: Seq[Attribute] = Seq(
     AttributeReference("catalog", StringType, nullable = false)(),
     AttributeReference("namespace", StringType, nullable = false)())

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2104,7 +2104,7 @@ class DDLParserSuite extends AnalysisTest {
   test("show current namespace") {
     comparePlans(
       parsePlan("SHOW CURRENT NAMESPACE"),
-      ShowCurrentNamespace(None))
+      ShowCurrentNamespace())
   }
 
   test("alter table: SerDe properties") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2104,7 +2104,7 @@ class DDLParserSuite extends AnalysisTest {
   test("show current namespace") {
     comparePlans(
       parsePlan("SHOW CURRENT NAMESPACE"),
-      ShowCurrentNamespaceStatement())
+      ShowCurrentNamespace(None))
   }
 
   test("alter table: SerDe properties") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -330,7 +330,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       SetCatalogAndNamespaceExec(catalogManager, catalogName, ns) :: Nil
 
     case r: ShowCurrentNamespace =>
-      ShowCurrentNamespaceExec(r.output, r.catalogManager.get) :: Nil
+      ShowCurrentNamespaceExec(r.output, session.sessionState.catalogManager) :: Nil
 
     case r @ ShowTableProperties(rt: ResolvedTable, propertyKey, output) =>
       ShowTablePropertiesExec(output, rt.table, propertyKey) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -330,7 +330,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       SetCatalogAndNamespaceExec(catalogManager, catalogName, ns) :: Nil
 
     case r: ShowCurrentNamespace =>
-      ShowCurrentNamespaceExec(r.output, r.catalogManager) :: Nil
+      ShowCurrentNamespaceExec(r.output, r.catalogManager.get) :: Nil
 
     case r @ ShowTableProperties(rt: ResolvedTable, propertyKey, output) =>
       ShowTablePropertiesExec(output, rt.table, propertyKey) :: Nil


### PR DESCRIPTION

### What changes were proposed in this pull request?

Migrate `ShowCurrentNamespaceStatement` to v2 command framework

### Why are the changes needed?
Migrate to the standard V2 framework


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests
