### PR TITLE
[SPARK-36856][BUILD] Get correct JAVA_HOME for macOS

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -23,7 +23,7 @@ SELF=$(cd $(dirname $0) && pwd)
 if [ -z "${JAVA_HOME}" -a "$(command -v javac)" ]; then
   if [ "$(uname -s)" = "Darwin" ]; then
     # For some versions of macOS, "/usr/bin/javac" is a real file instead of a symbolic link,
-    # so the java home may be set to path "/usr" improperly.
+    # so the JAVA_HOME may be set to path "/usr" improperly.
     # And following command is the appropriate way of getting java home on macOS.
     export JAVA_HOME="$(/usr/libexec/java_home)"
   else

--- a/build/mvn
+++ b/build/mvn
@@ -22,6 +22,9 @@ SELF=$(cd $(dirname $0) && pwd)
 
 if [ -z "${JAVA_HOME}" -a "$(command -v javac)" ]; then
   if [ "$(uname -s)" = "Darwin" ]; then
+    # For some version of macOS, "/usr/bin/javac" is a real file instead of a symbolic link,
+    # so the java home may be set to path "/usr" improperly.
+    # And following command is the appropriate way of getting java home on macOS.
     export JAVA_HOME="$(/usr/libexec/java_home)"
   else
     export JAVA_HOME="$(dirname $(dirname $(realpath $(command -v javac))))"

--- a/build/mvn
+++ b/build/mvn
@@ -21,7 +21,12 @@ SELF=$(cd $(dirname $0) && pwd)
 . "$SELF/util.sh"
 
 if [ -z "${JAVA_HOME}" -a "$(command -v javac)" ]; then
-  export JAVA_HOME="$(dirname $(dirname $(realpath $(command -v javac))))"
+  if [ x"$(uname -a | awk '{print $1}')" = xDarwin -a \
+      $(version $(sw_vers -productVersion)) -ge $(version 10.5) ]; then
+    export JAVA_HOME="$(/usr/libexec/java_home)"
+  else
+    export JAVA_HOME="$(dirname $(dirname $(realpath $(command -v javac))))"
+  fi
 fi
 
 # Determine the current working directory
@@ -100,9 +105,6 @@ install_app() {
     rm -f "${local_checksum}"
   fi
 }
-
-# See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
-function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
 
 # Determine the Maven version from the root pom.xml file and
 # install maven under the build/ folder if needed.

--- a/build/mvn
+++ b/build/mvn
@@ -24,7 +24,7 @@ if [ -z "${JAVA_HOME}" -a "$(command -v javac)" ]; then
   if [ "$(uname -s)" = "Darwin" ]; then
     # For some versions of macOS, "/usr/bin/javac" is a real file instead of a symbolic link,
     # so the JAVA_HOME may be set to path "/usr" improperly.
-    # And following command is the appropriate way of getting java home on macOS.
+    # The following command is an appropriate way of setting JAVA_HOME on macOS.
     export JAVA_HOME="$(/usr/libexec/java_home)"
   else
     export JAVA_HOME="$(dirname $(dirname $(realpath $(command -v javac))))"

--- a/build/mvn
+++ b/build/mvn
@@ -22,7 +22,7 @@ SELF=$(cd $(dirname $0) && pwd)
 
 if [ -z "${JAVA_HOME}" -a "$(command -v javac)" ]; then
   if [ "$(uname -s)" = "Darwin" ]; then
-    # For some version of macOS, "/usr/bin/javac" is a real file instead of a symbolic link,
+    # For some versions of macOS, "/usr/bin/javac" is a real file instead of a symbolic link,
     # so the java home may be set to path "/usr" improperly.
     # And following command is the appropriate way of getting java home on macOS.
     export JAVA_HOME="$(/usr/libexec/java_home)"

--- a/build/mvn
+++ b/build/mvn
@@ -21,8 +21,7 @@ SELF=$(cd $(dirname $0) && pwd)
 . "$SELF/util.sh"
 
 if [ -z "${JAVA_HOME}" -a "$(command -v javac)" ]; then
-  if [ "$(uname -s)" = "Darwin" -a \
-      $(version $(sw_vers -productVersion)) -ge $(version 10.5) ]; then
+  if [ "$(uname -s)" = "Darwin" ]; then
     export JAVA_HOME="$(/usr/libexec/java_home)"
   else
     export JAVA_HOME="$(dirname $(dirname $(realpath $(command -v javac))))"
@@ -105,6 +104,9 @@ install_app() {
     rm -f "${local_checksum}"
   fi
 }
+
+# See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
+function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
 
 # Determine the Maven version from the root pom.xml file and
 # install maven under the build/ folder if needed.

--- a/build/mvn
+++ b/build/mvn
@@ -21,7 +21,7 @@ SELF=$(cd $(dirname $0) && pwd)
 . "$SELF/util.sh"
 
 if [ -z "${JAVA_HOME}" -a "$(command -v javac)" ]; then
-  if [ x"$(uname -a | awk '{print $1}')" = xDarwin -a \
+  if [ "$(uname -s)" = "Darwin" -a \
       $(version $(sw_vers -productVersion)) -ge $(version 10.5) ]; then
     export JAVA_HOME="$(/usr/libexec/java_home)"
   else

--- a/build/util.sh
+++ b/build/util.sh
@@ -36,3 +36,8 @@ realpath () {
   echo "$(pwd -P)/"$TARGET_FILE""
 )
 }
+
+# See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
+version() {
+  echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }';
+}

--- a/build/util.sh
+++ b/build/util.sh
@@ -36,8 +36,3 @@ realpath () {
   echo "$(pwd -P)/"$TARGET_FILE""
 )
 }
-
-# See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
-version() {
-  echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }';
-}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, JAVA_HOME may be set to path "/usr" improperly, now JAVA_HOME is fetched from command "/usr/libexec/java_home" for macOS.


### Why are the changes needed?
Command "./build/mvn xxx" will be stuck on MacOS 11.4, because JAVA_HOME is set to path "/usr" improperly.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
`build/mvn -DskipTests package` passed on `macOS 11.5.2`.
