### PR TITLE
[SPARK-36868][SQL] Migrate CreateFunctionStatement to v2 command framework

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -34,8 +34,8 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
     case UnresolvedDBObjectName(CatalogAndNamespace(catalog, name), isNamespace) if isNamespace =>
       ResolvedDBObjectName(catalog, name)
 
-    case UnresolvedDBObjectName(CatalogAndNamespaceForIdentifier(catalog, name), _) =>
-      ResolvedDBObjectName(catalog, name)
+    case UnresolvedDBObjectName(CatalogAndIdentifier(catalog, identifier), _) =>
+      ResolvedDBObjectName(catalog, identifier.namespace :+ identifier.name())
 
     case c @ CreateTableStatement(
          NonSessionCatalogAndTable(catalog, tbl), _, _, _, _, _, _, _, _, _, _, _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -34,6 +34,9 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
     case UnresolvedDBObjectName(CatalogAndNamespace(catalog, name), isNamespace) if isNamespace =>
       ResolvedDBObjectName(catalog, name)
 
+    case UnresolvedDBObjectName(CatalogAndNamespaceForIdentifier(catalog, name), _) =>
+      ResolvedDBObjectName(catalog, name)
+
     case c @ CreateTableStatement(
          NonSessionCatalogAndTable(catalog, tbl), _, _, _, _, _, _, _, _, _, _, _) =>
       CreateV2Table(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4469,15 +4469,23 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
     }
 
     val functionIdentifier = visitMultipartIdentifier(ctx.multipartIdentifier)
-    CreateFunction(
-      UnresolvedDBObjectName(
+    if (ctx.TEMPORARY != null) {
+      CreateTempFunction(
         functionIdentifier,
-        isNamespace = false),
-      string(ctx.className),
-      resources.toSeq,
-      ctx.TEMPORARY != null,
-      ctx.EXISTS != null,
-      ctx.REPLACE != null)
+        string(ctx.className),
+        resources.toSeq,
+        ctx.EXISTS != null,
+        ctx.REPLACE != null)
+    } else {
+      CreateFunction(
+        UnresolvedDBObjectName(
+          functionIdentifier,
+          isNamespace = false),
+        string(ctx.className),
+        resources.toSeq,
+        ctx.EXISTS != null,
+        ctx.REPLACE != null)
+    }
   }
 
   override def visitRefreshFunction(ctx: RefreshFunctionContext): LogicalPlan = withOrigin(ctx) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4480,7 +4480,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
       CreateFunction(
         UnresolvedDBObjectName(
           functionIdentifier,
-          isNamespace = true),
+          isNamespace = false),
         string(ctx.className),
         resources.toSeq,
         ctx.EXISTS != null,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4478,9 +4478,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
         ctx.REPLACE != null)
     } else {
       CreateFunction(
-        UnresolvedDBObjectName(
-          functionIdentifier,
-          isNamespace = false),
+        UnresolvedFunc(functionIdentifier),
         string(ctx.className),
         resources.toSeq,
         ctx.EXISTS != null,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4449,7 +4449,7 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
   }
 
   /**
-   * Create a CREATE FUNCTION statement.
+   * Create a [[CreateFunction]] command.
    *
    * For example:
    * {{{
@@ -4469,8 +4469,10 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
     }
 
     val functionIdentifier = visitMultipartIdentifier(ctx.multipartIdentifier)
-    CreateFunctionStatement(
-      functionIdentifier,
+    CreateFunction(
+      UnresolvedDBObjectName(
+        functionIdentifier,
+        isNamespace = false),
       string(ctx.className),
       resources.toSeq,
       ctx.TEMPORARY != null,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4478,7 +4478,9 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
         ctx.REPLACE != null)
     } else {
       CreateFunction(
-        UnresolvedFunc(functionIdentifier),
+        UnresolvedDBObjectName(
+          functionIdentifier,
+          isNamespace = true),
         string(ctx.className),
         resources.toSeq,
         ctx.EXISTS != null,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.analysis.{FieldName, FieldPosition, ViewType}
-import org.apache.spark.sql.catalyst.catalog.{BucketSpec, FunctionResource}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.trees.{LeafLike, UnaryLike}
 import org.apache.spark.sql.connector.expressions.Transform
@@ -277,14 +277,3 @@ case class InsertIntoStatement(
  * A USE statement, as parsed from SQL.
  */
 case class UseStatement(isNamespaceSet: Boolean, nameParts: Seq[String]) extends LeafParsedStatement
-
-/**
- *  CREATE FUNCTION statement, as parsed from SQL
- */
-case class CreateFunctionStatement(
-    functionName: Seq[String],
-    className: String,
-    resources: Seq[FunctionResource],
-    isTemp: Boolean,
-    ignoreIfExists: Boolean,
-    replace: Boolean) extends LeafParsedStatement

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -696,13 +696,23 @@ case class DescribeFunction(child: LogicalPlan, isExtended: Boolean) extends Una
 }
 
 /**
+ * The logical plan of the CREATE TEMPORARY FUNCTION command.
+ */
+case class CreateTempFunction(
+    nameParts: Seq[String],
+    className: String,
+    resources: Seq[FunctionResource],
+    ifExists: Boolean,
+    replace: Boolean) extends LeafCommand {
+}
+
+/**
  * The logical plan of the CREATE FUNCTION command.
  */
 case class CreateFunction(
     child: LogicalPlan,
     className: String,
     resources: Seq[FunctionResource],
-    isTemp: Boolean,
     ifExists: Boolean,
     replace: Boolean) extends UnaryCommand {
   override protected def withNewChildInternal(newChild: LogicalPlan): CreateFunction =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.analysis.{NamedRelation, PartitionSpec, UnresolvedException}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.catalog.FunctionResource
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, Expression, Unevaluable}
 import org.apache.spark.sql.catalyst.plans.DescribeCommandSchema
 import org.apache.spark.sql.catalyst.trees.BinaryLike
@@ -691,6 +692,20 @@ case class RefreshFunction(child: LogicalPlan) extends UnaryCommand {
  */
 case class DescribeFunction(child: LogicalPlan, isExtended: Boolean) extends UnaryCommand {
   override protected def withNewChildInternal(newChild: LogicalPlan): DescribeFunction =
+    copy(child = newChild)
+}
+
+/**
+ * The logical plan of the CREATE FUNCTION command.
+ */
+case class CreateFunction(
+    child: LogicalPlan,
+    className: String,
+    resources: Seq[FunctionResource],
+    isTemp: Boolean,
+    ifExists: Boolean,
+    replace: Boolean) extends UnaryCommand {
+  override protected def withNewChildInternal(newChild: LogicalPlan): CreateFunction =
     copy(child = newChild)
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/LookupCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/LookupCatalog.scala
@@ -92,31 +92,6 @@ private[sql] trait LookupCatalog extends Logging {
     }
   }
 
-  object CatalogAndNamespaceForIdentifier {
-    private val globalTempDB = SQLConf.get.getConf(StaticSQLConf.GLOBAL_TEMP_DATABASE)
-    def unapply(nameParts: Seq[String]): Some[(CatalogPlugin, Seq[String])] = {
-      assert(nameParts.nonEmpty)
-      if (nameParts.length == 1) {
-        Some(currentCatalog, (catalogManager.currentNamespace :+ nameParts.head).toSeq)
-      } else if (nameParts.head.equalsIgnoreCase(globalTempDB)) {
-        // Conceptually global temp views are in a special reserved catalog. However, the v2 catalog
-        // API does not support view yet, and we have to use v1 commands to deal with global temp
-        // views. To simplify the implementation, we put global temp views in a special namespace
-        // in the session catalog. The special namespace has higher priority during name resolution.
-        // For example, if the name of a custom catalog is the same with `GLOBAL_TEMP_DATABASE`,
-        // this custom catalog can't be accessed.
-        Some((catalogManager.v2SessionCatalog, nameParts))
-      } else {
-        try {
-          Some((catalogManager.catalog(nameParts.head), nameParts.tail))
-        } catch {
-          case _: CatalogNotFoundException =>
-            Some((currentCatalog, nameParts))
-        }
-      }
-    }
-  }
-
   /**
    * Extract catalog and identifier from a multi-part name with the current catalog if needed.
    * Catalog name takes precedence over identifier, but for a single-part name, identifier takes

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2390,38 +2390,34 @@ class DDLParserSuite extends AnalysisTest {
 
   test("CREATE FUNCTION") {
     parseCompare("CREATE FUNCTION a as 'fun'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a"), false), "fun", Seq(), false, false))
+      CreateFunction(UnresolvedFunc(Seq("a")), "fun", Seq(), false, false))
 
     parseCompare("CREATE FUNCTION a.b.c as 'fun'",
-      CreateFunction(UnresolvedDBObjectName(
-        Seq("a", "b", "c"), false), "fun", Seq(), false, false))
+      CreateFunction(UnresolvedFunc(Seq("a", "b", "c")), "fun", Seq(), false, false))
 
     parseCompare("CREATE OR REPLACE FUNCTION a.b.c as 'fun'",
-      CreateFunction(UnresolvedDBObjectName(
-        Seq("a", "b", "c"), false), "fun", Seq(), false, true))
+      CreateFunction(UnresolvedFunc(Seq("a", "b", "c")), "fun", Seq(), false, true))
 
     parseCompare("CREATE TEMPORARY FUNCTION a.b.c as 'fun'",
       CreateTempFunction(Seq("a", "b", "c"), "fun", Seq(), false, false))
 
     parseCompare("CREATE FUNCTION IF NOT EXISTS a.b.c as 'fun'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), false),
-        "fun", Seq(), true, false))
+      CreateFunction(UnresolvedFunc(Seq("a", "b", "c")), "fun", Seq(), true, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING JAR 'j'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a"), false),
-        "fun", Seq(FunctionResource(JarResource, "j")), false, false))
+      CreateFunction(UnresolvedFunc(Seq("a")), "fun", Seq(FunctionResource(JarResource, "j")),
+        false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING ARCHIVE 'a'",
-      CreateFunction(UnresolvedDBObjectName(
-        Seq("a"), false), "fun", Seq(FunctionResource(ArchiveResource, "a")), false, false))
+      CreateFunction(UnresolvedFunc(Seq("a")), "fun", Seq(FunctionResource(ArchiveResource, "a")),
+        false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING FILE 'f'",
-      CreateFunction(UnresolvedDBObjectName(
-        Seq("a"), false), "fun", Seq(FunctionResource(FileResource, "f")), false, false))
+      CreateFunction(UnresolvedFunc(Seq("a")), "fun", Seq(FunctionResource(FileResource, "f")),
+        false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING JAR 'j', ARCHIVE 'a', FILE 'f'",
-      CreateFunction(UnresolvedDBObjectName(
-        Seq("a"), false), "fun", Seq(FunctionResource(JarResource, "j"),
+      CreateFunction(UnresolvedFunc(Seq("a")), "fun", Seq(FunctionResource(JarResource, "j"),
         FunctionResource(ArchiveResource, "a"), FunctionResource(FileResource, "f")),
         false, false))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2390,41 +2390,40 @@ class DDLParserSuite extends AnalysisTest {
 
   test("CREATE FUNCTION") {
     parseCompare("CREATE FUNCTION a as 'fun'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a"), false), "fun", Seq(), false, false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), false), "fun", Seq(), false, false))
 
     parseCompare("CREATE FUNCTION a.b.c as 'fun'",
       CreateFunction(UnresolvedDBObjectName(
-        Seq("a", "b", "c"), false), "fun", Seq(), false, false, false))
+        Seq("a", "b", "c"), false), "fun", Seq(), false, false))
 
     parseCompare("CREATE OR REPLACE FUNCTION a.b.c as 'fun'",
       CreateFunction(UnresolvedDBObjectName(
-        Seq("a", "b", "c"), false), "fun", Seq(), false, false, true))
+        Seq("a", "b", "c"), false), "fun", Seq(), false, true))
 
     parseCompare("CREATE TEMPORARY FUNCTION a.b.c as 'fun'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), false),
-        "fun", Seq(), true, false, false))
+      CreateTempFunction(Seq("a", "b", "c"), "fun", Seq(), false, false))
 
     parseCompare("CREATE FUNCTION IF NOT EXISTS a.b.c as 'fun'",
       CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), false),
-        "fun", Seq(), false, true, false))
+        "fun", Seq(), true, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING JAR 'j'",
       CreateFunction(UnresolvedDBObjectName(Seq("a"), false),
-        "fun", Seq(FunctionResource(JarResource, "j")), false, false, false))
+        "fun", Seq(FunctionResource(JarResource, "j")), false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING ARCHIVE 'a'",
       CreateFunction(UnresolvedDBObjectName(
-        Seq("a"), false), "fun", Seq(FunctionResource(ArchiveResource, "a")), false, false, false))
+        Seq("a"), false), "fun", Seq(FunctionResource(ArchiveResource, "a")), false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING FILE 'f'",
       CreateFunction(UnresolvedDBObjectName(
-        Seq("a"), false), "fun", Seq(FunctionResource(FileResource, "f")), false, false, false))
+        Seq("a"), false), "fun", Seq(FunctionResource(FileResource, "f")), false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING JAR 'j', ARCHIVE 'a', FILE 'f'",
       CreateFunction(UnresolvedDBObjectName(
         Seq("a"), false), "fun", Seq(FunctionResource(JarResource, "j"),
         FunctionResource(ArchiveResource, "a"), FunctionResource(FileResource, "f")),
-        false, false, false))
+        false, false))
 
     intercept("CREATE FUNCTION a as 'fun' USING OTHER 'o'",
       "Operation not allowed: CREATE FUNCTION with resource type 'other'")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2390,34 +2390,34 @@ class DDLParserSuite extends AnalysisTest {
 
   test("CREATE FUNCTION") {
     parseCompare("CREATE FUNCTION a as 'fun'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a"), true), "fun", Seq(), false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), false), "fun", Seq(), false, false))
 
     parseCompare("CREATE FUNCTION a.b.c as 'fun'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), true), "fun", Seq(), false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), false), "fun", Seq(), false, false))
 
     parseCompare("CREATE OR REPLACE FUNCTION a.b.c as 'fun'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), true), "fun", Seq(), false, true))
+      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), false), "fun", Seq(), false, true))
 
     parseCompare("CREATE TEMPORARY FUNCTION a.b.c as 'fun'",
       CreateTempFunction(Seq("a", "b", "c"), "fun", Seq(), false, false))
 
     parseCompare("CREATE FUNCTION IF NOT EXISTS a.b.c as 'fun'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), true), "fun", Seq(), true, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), false), "fun", Seq(), true, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING JAR 'j'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a"), true), "fun",
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), false), "fun",
         Seq(FunctionResource(JarResource, "j")), false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING ARCHIVE 'a'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a"), true), "fun",
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), false), "fun",
         Seq(FunctionResource(ArchiveResource, "a")), false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING FILE 'f'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a"), true), "fun",
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), false), "fun",
         Seq(FunctionResource(FileResource, "f")), false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING JAR 'j', ARCHIVE 'a', FILE 'f'",
-      CreateFunction(UnresolvedDBObjectName(Seq("a"), true), "fun",
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), false), "fun",
         Seq(FunctionResource(JarResource, "j"),
         FunctionResource(ArchiveResource, "a"), FunctionResource(FileResource, "f")),
         false, false))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2390,34 +2390,39 @@ class DDLParserSuite extends AnalysisTest {
 
   test("CREATE FUNCTION") {
     parseCompare("CREATE FUNCTION a as 'fun'",
-      CreateFunctionStatement(Seq("a"), "fun", Seq(), false, false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), false), "fun", Seq(), false, false, false))
 
     parseCompare("CREATE FUNCTION a.b.c as 'fun'",
-      CreateFunctionStatement(Seq("a", "b", "c"), "fun", Seq(), false, false, false))
+      CreateFunction(UnresolvedDBObjectName(
+        Seq("a", "b", "c"), false), "fun", Seq(), false, false, false))
 
     parseCompare("CREATE OR REPLACE FUNCTION a.b.c as 'fun'",
-      CreateFunctionStatement(Seq("a", "b", "c"), "fun", Seq(), false, false, true))
+      CreateFunction(UnresolvedDBObjectName(
+        Seq("a", "b", "c"), false), "fun", Seq(), false, false, true))
 
     parseCompare("CREATE TEMPORARY FUNCTION a.b.c as 'fun'",
-      CreateFunctionStatement(Seq("a", "b", "c"), "fun", Seq(), true, false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), false),
+        "fun", Seq(), true, false, false))
 
     parseCompare("CREATE FUNCTION IF NOT EXISTS a.b.c as 'fun'",
-      CreateFunctionStatement(Seq("a", "b", "c"), "fun", Seq(), false, true, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), false),
+        "fun", Seq(), false, true, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING JAR 'j'",
-      CreateFunctionStatement(Seq("a"), "fun", Seq(FunctionResource(JarResource, "j")),
-        false, false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), false),
+        "fun", Seq(FunctionResource(JarResource, "j")), false, false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING ARCHIVE 'a'",
-      CreateFunctionStatement(Seq("a"), "fun", Seq(FunctionResource(ArchiveResource, "a")),
-        false, false, false))
+      CreateFunction(UnresolvedDBObjectName(
+        Seq("a"), false), "fun", Seq(FunctionResource(ArchiveResource, "a")), false, false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING FILE 'f'",
-      CreateFunctionStatement(Seq("a"), "fun", Seq(FunctionResource(FileResource, "f")),
-        false, false, false))
+      CreateFunction(UnresolvedDBObjectName(
+        Seq("a"), false), "fun", Seq(FunctionResource(FileResource, "f")), false, false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING JAR 'j', ARCHIVE 'a', FILE 'f'",
-      CreateFunctionStatement(Seq("a"), "fun", Seq(FunctionResource(JarResource, "j"),
+      CreateFunction(UnresolvedDBObjectName(
+        Seq("a"), false), "fun", Seq(FunctionResource(JarResource, "j"),
         FunctionResource(ArchiveResource, "a"), FunctionResource(FileResource, "f")),
         false, false, false))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2390,34 +2390,35 @@ class DDLParserSuite extends AnalysisTest {
 
   test("CREATE FUNCTION") {
     parseCompare("CREATE FUNCTION a as 'fun'",
-      CreateFunction(UnresolvedFunc(Seq("a")), "fun", Seq(), false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), true), "fun", Seq(), false, false))
 
     parseCompare("CREATE FUNCTION a.b.c as 'fun'",
-      CreateFunction(UnresolvedFunc(Seq("a", "b", "c")), "fun", Seq(), false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), true), "fun", Seq(), false, false))
 
     parseCompare("CREATE OR REPLACE FUNCTION a.b.c as 'fun'",
-      CreateFunction(UnresolvedFunc(Seq("a", "b", "c")), "fun", Seq(), false, true))
+      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), true), "fun", Seq(), false, true))
 
     parseCompare("CREATE TEMPORARY FUNCTION a.b.c as 'fun'",
       CreateTempFunction(Seq("a", "b", "c"), "fun", Seq(), false, false))
 
     parseCompare("CREATE FUNCTION IF NOT EXISTS a.b.c as 'fun'",
-      CreateFunction(UnresolvedFunc(Seq("a", "b", "c")), "fun", Seq(), true, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a", "b", "c"), true), "fun", Seq(), true, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING JAR 'j'",
-      CreateFunction(UnresolvedFunc(Seq("a")), "fun", Seq(FunctionResource(JarResource, "j")),
-        false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), true), "fun",
+        Seq(FunctionResource(JarResource, "j")), false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING ARCHIVE 'a'",
-      CreateFunction(UnresolvedFunc(Seq("a")), "fun", Seq(FunctionResource(ArchiveResource, "a")),
-        false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), true), "fun",
+        Seq(FunctionResource(ArchiveResource, "a")), false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING FILE 'f'",
-      CreateFunction(UnresolvedFunc(Seq("a")), "fun", Seq(FunctionResource(FileResource, "f")),
-        false, false))
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), true), "fun",
+        Seq(FunctionResource(FileResource, "f")), false, false))
 
     parseCompare("CREATE FUNCTION a as 'fun' USING JAR 'j', ARCHIVE 'a', FILE 'f'",
-      CreateFunction(UnresolvedFunc(Seq("a")), "fun", Seq(FunctionResource(JarResource, "j"),
+      CreateFunction(UnresolvedDBObjectName(Seq("a"), true), "fun",
+        Seq(FunctionResource(JarResource, "j"),
         FunctionResource(ArchiveResource, "a"), FunctionResource(FileResource, "f")),
         false, false))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -469,11 +469,11 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         ignoreIfExists,
         replace)
 
-    case CreateFunction(ResolvedDBObjectName(catalog, name),
-        className, resources, ignoreIfExists, replace) if isSessionCatalog(catalog) =>
+    case CreateFunction(ResolvedFunc(identifier), className, resources, ignoreIfExists, replace) =>
+      val funcIdentifier = identifier.asFunctionIdentifier
       CreateFunctionCommand(
-        Some(catalog.name),
-        name.head,
+        funcIdentifier.database,
+        funcIdentifier.funcName,
         className,
         resources,
         false,

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -451,7 +451,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       val funcIdentifier = identifier.asFunctionIdentifier
       DropFunctionCommand(funcIdentifier.database, funcIdentifier.funcName, ifExists, isTemp)
 
-    case CreateFunctionStatement(nameParts,
+    case CreateFunction(UnresolvedDBObjectName(nameParts, _),
       className, resources, isTemp, ignoreIfExists, replace) =>
       if (isTemp) {
         // temp func doesn't belong to any catalog and we shouldn't resolve catalog in the name.

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -453,12 +453,12 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
     case CreateTempFunction(nameParts, className, resources, ignoreIfExists, replace) =>
       // temp func doesn't belong to any catalog and we shouldn't resolve catalog in the name.
-      callCreateFunctionCommand(nameParts, className, resources, true, ignoreIfExists, replace)
+      convertToV1CreateFunction(nameParts, className, resources, true, ignoreIfExists, replace)
 
     case CreateFunction(ResolvedDBObjectName(catalog, nameParts),
         className, resources, ignoreIfExists, replace) =>
       if (isSessionCatalog(catalog)) {
-        callCreateFunctionCommand(nameParts, className, resources, false, ignoreIfExists, replace)
+        convertToV1CreateFunction(nameParts, className, resources, false, ignoreIfExists, replace)
       } else {
         throw QueryCompilationErrors.functionUnsupportedInV2CatalogError()
       }
@@ -469,7 +469,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       RefreshFunctionCommand(funcIdentifier.database, funcIdentifier.funcName)
   }
 
-  private def callCreateFunctionCommand(
+  private def convertToV1CreateFunction(
       nameParts: Seq[String],
       className: String,
       resources: Seq[FunctionResource],

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -456,8 +456,12 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       callCreateFunctionCommand(nameParts, className, resources, true, ignoreIfExists, replace)
 
     case CreateFunction(ResolvedDBObjectName(catalog, nameParts),
-        className, resources, ignoreIfExists, replace) if isSessionCatalog(catalog) =>
-      callCreateFunctionCommand(nameParts, className, resources, false, ignoreIfExists, replace)
+        className, resources, ignoreIfExists, replace) =>
+      if (isSessionCatalog(catalog)) {
+        callCreateFunctionCommand(nameParts, className, resources, false, ignoreIfExists, replace)
+      } else {
+        throw QueryCompilationErrors.functionUnsupportedInV2CatalogError()
+      }
 
     case RefreshFunction(ResolvedFunc(identifier)) =>
       // Fallback to v1 command


### PR DESCRIPTION
### What changes were proposed in this pull request?
Migrate `CreateFunctionStatement` to v2 command framework

### Why are the changes needed?
Migrate to the standard V2 framework


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests
