### PR TITLE
[SPARK-36870][SQL] Introduce INTERNAL_ERROR error class

### DIFF
--- a/core/src/main/java/org/apache/spark/SparkThrowable.java
+++ b/core/src/main/java/org/apache/spark/SparkThrowable.java
@@ -38,8 +38,12 @@ public interface SparkThrowable {
 
   // Portable error identifier across SQL engines
   // If null, error class or SQLSTATE is not set
-  String getSqlState();
+  default String getSqlState() {
+    return SparkThrowableHelper.getSqlState(this.getErrorClass());
+  }
 
   // True if this error is an internal error.
-  boolean isInternalError();
+  default boolean isInternalError() {
+    return SparkThrowableHelper.isInternalError(this.getErrorClass());
+  }
 }

--- a/core/src/main/java/org/apache/spark/SparkThrowable.java
+++ b/core/src/main/java/org/apache/spark/SparkThrowable.java
@@ -39,4 +39,7 @@ public interface SparkThrowable {
   // Portable error identifier across SQL engines
   // If null, error class or SQLSTATE is not set
   String getSqlState();
+
+  // True if this error is an internal error.
+  boolean isInternalError();
 }

--- a/core/src/main/java/org/apache/spark/memory/SparkOutOfMemoryError.java
+++ b/core/src/main/java/org/apache/spark/memory/SparkOutOfMemoryError.java
@@ -51,4 +51,6 @@ public final class SparkOutOfMemoryError extends OutOfMemoryError implements Spa
     public String getSqlState() {
         return SparkThrowableHelper.getSqlState(errorClass);
     }
+
+    public boolean isInternalError() { return SparkThrowableHelper.isInternalError(errorClass); }
 }

--- a/core/src/main/java/org/apache/spark/memory/SparkOutOfMemoryError.java
+++ b/core/src/main/java/org/apache/spark/memory/SparkOutOfMemoryError.java
@@ -47,10 +47,4 @@ public final class SparkOutOfMemoryError extends OutOfMemoryError implements Spa
     public String getErrorClass() {
         return errorClass;
     }
-
-    public String getSqlState() {
-        return SparkThrowableHelper.getSqlState(errorClass);
-    }
-
-    public boolean isInternalError() { return SparkThrowableHelper.isInternalError(errorClass); }
 }

--- a/core/src/main/resources/error/README.md
+++ b/core/src/main/resources/error/README.md
@@ -40,8 +40,6 @@ Throw with arbitrary error message:
         with SparkThrowable {
         
       def getErrorClass: String = errorClass
-      def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-      def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
     }
 
 Throw with error class and message parameters:

--- a/core/src/main/resources/error/README.md
+++ b/core/src/main/resources/error/README.md
@@ -5,13 +5,16 @@ and message parameters rather than an arbitrary error message.
 
 ## Usage
 
-1. Check if an appropriate error class already exists in `error-class.json`.
-   If true, skip to step 3. Otherwise, continue to step 2.
-2. Add a new class to `error-class.json`; keep in mind the invariants below.
-3. Check if the exception type already extends `SparkThrowable`.
-   If true, skip to step 5. Otherwise, continue to step 4.
-4. Mix `SparkThrowable` into the exception.
-5. Throw the exception with the error class and message parameters.
+1. Check if the error is an internal error.
+   Internal errors are bugs in the code that we do not expect users to encounter; this does not include unsupported operations.
+   If true, use the error class `INTERNAL_ERROR` and skip to step 4.
+2. Check if an appropriate error class already exists in `error-class.json`.
+   If true, use the error class and skip to step 4.
+3. Add a new class to `error-class.json`; keep in mind the invariants below.
+4. Check if the exception type already extends `SparkThrowable`.
+   If true, skip to step 6.
+5. Mix `SparkThrowable` into the exception.
+6. Throw the exception with the error class and message parameters.
 
 ### Before
 
@@ -37,8 +40,8 @@ Throw with arbitrary error message:
         with SparkThrowable {
         
       def getErrorClass: String = errorClass
-      def getMessageParameters: Array[String] = messageParameters
       def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+      def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
     }
 
 Throw with error class and message parameters:

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -11,18 +11,9 @@
     "message" : [ "%s cannot be represented as Decimal(%s, %s)." ],
     "sqlState" : "22005"
   },
-  "CANNOT_EVALUATE_EXPRESSION" : {
-    "message" : [ "Cannot evaluate expression: %s" ]
-  },
-  "CANNOT_GENERATE_CODE_FOR_EXPRESSION" : {
-    "message" : [ "Cannot generate code for expression: %s" ]
-  },
   "CANNOT_PARSE_DECIMAL" : {
     "message" : [ "Cannot parse decimal" ],
     "sqlState" : "42000"
-  },
-  "CANNOT_TERMINATE_GENERATOR" : {
-    "message" : [ "Cannot terminate expression: %s" ]
   },
   "CAST_CAUSES_OVERFLOW" : {
     "message" : [ "Casting %s to %s causes overflow" ],
@@ -74,6 +65,9 @@
     "message" : [ "Index %s must be between 0 and the length of the ArrayData." ],
     "sqlState" : "22023"
   },
+  "INTERNAL_ERROR" : {
+    "message" : [ "%s" ]
+  },
   "INVALID_ARRAY_INDEX" : {
     "message" : [ "Invalid index: %s, numElements: %s" ]
   },
@@ -92,18 +86,11 @@
   "INVALID_JSON_SCHEMA_MAPTYPE" : {
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
   },
-  "LOGICAL_HINT_OPERATOR_NOT_REMOVED_DURING_ANALYSIS" : {
-    "message" : [ "Internal error: logical hint operator should have been removed during analysis" ]
-  },
   "MAP_KEY_DOES_NOT_EXIST" : {
     "message" : [ "Key %s does not exist." ]
   },
   "MISSING_COLUMN" : {
     "message" : [ "cannot resolve '%s' given input columns: [%s]" ],
-    "sqlState" : "42000"
-  },
-  "MISSING_METHOD" : {
-    "message" : [ "A method named \"%s\" is not declared in any enclosing class nor any supertype" ],
     "sqlState" : "42000"
   },
   "MISSING_STATIC_PARTITION_COLUMN" : {

--- a/core/src/main/scala/org/apache/spark/ErrorInfo.scala
+++ b/core/src/main/scala/org/apache/spark/ErrorInfo.scala
@@ -64,4 +64,8 @@ private[spark] object SparkThrowableHelper {
   def getSqlState(errorClass: String): String = {
     Option(errorClass).flatMap(errorClassToInfoMap.get).flatMap(_.sqlState).orNull
   }
+
+  def isInternalError(errorClass: String): Boolean = {
+    errorClass == "INTERNAL_ERROR"
+  }
 }

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -45,8 +45,6 @@ class SparkException(
       messageParameters = messageParameters)
 
   override def getErrorClass: String = errorClass.orNull
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass.orNull)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass.orNull)
 }
 
 /**
@@ -85,8 +83,6 @@ private[spark] class SparkArithmeticException(errorClass: String, messageParamet
     with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -99,8 +95,6 @@ private[spark] class SparkUnsupportedOperationException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -114,8 +108,6 @@ private[spark] class SparkClassNotFoundException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters), cause) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -129,8 +121,6 @@ private[spark] class SparkConcurrentModificationException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters), cause) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -141,8 +131,6 @@ private[spark] class SparkDateTimeException(errorClass: String, messageParameter
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -155,8 +143,6 @@ private[spark] class SparkFileAlreadyExistsException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -169,8 +155,6 @@ private[spark] class SparkIllegalStateException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -183,8 +167,6 @@ private[spark] class SparkFileNotFoundException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -197,8 +179,6 @@ private[spark] class SparkNumberFormatException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -211,8 +191,6 @@ private[spark] class SparkNoSuchMethodException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -225,8 +203,6 @@ private[spark] class SparkIllegalArgumentException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -239,8 +215,6 @@ private[spark] class SparkIndexOutOfBoundsException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -253,8 +227,6 @@ private[spark] class SparkIOException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 private[spark] class SparkRuntimeException(
@@ -265,8 +237,6 @@ private[spark] class SparkRuntimeException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters), cause) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -279,8 +249,6 @@ private[spark] class SparkSecurityException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -293,8 +261,6 @@ private[spark] class SparkArrayIndexOutOfBoundsException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -307,8 +273,6 @@ private[spark] class SparkSQLException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -321,8 +285,6 @@ private[spark] class SparkNoSuchElementException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -335,6 +297,4 @@ private[spark] class SparkSQLFeatureNotSupportedException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
 
   override def getErrorClass: String = errorClass
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -46,6 +46,7 @@ class SparkException(
 
   override def getErrorClass: String = errorClass.orNull
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass.orNull)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass.orNull)
 }
 
 /**
@@ -85,6 +86,7 @@ private[spark] class SparkArithmeticException(errorClass: String, messageParamet
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -98,6 +100,7 @@ private[spark] class SparkUnsupportedOperationException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -112,6 +115,7 @@ private[spark] class SparkClassNotFoundException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -126,6 +130,7 @@ private[spark] class SparkConcurrentModificationException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -137,6 +142,7 @@ private[spark] class SparkDateTimeException(errorClass: String, messageParameter
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -150,6 +156,7 @@ private[spark] class SparkFileAlreadyExistsException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -163,6 +170,7 @@ private[spark] class SparkIllegalStateException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -176,6 +184,7 @@ private[spark] class SparkFileNotFoundException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -189,6 +198,7 @@ private[spark] class SparkNumberFormatException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -202,6 +212,7 @@ private[spark] class SparkNoSuchMethodException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -215,6 +226,7 @@ private[spark] class SparkIllegalArgumentException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -228,6 +240,7 @@ private[spark] class SparkIndexOutOfBoundsException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -241,6 +254,7 @@ private[spark] class SparkIOException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 private[spark] class SparkRuntimeException(
@@ -252,6 +266,7 @@ private[spark] class SparkRuntimeException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -265,6 +280,7 @@ private[spark] class SparkSecurityException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -278,6 +294,7 @@ private[spark] class SparkArrayIndexOutOfBoundsException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -291,6 +308,7 @@ private[spark] class SparkSQLException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -304,6 +322,7 @@ private[spark] class SparkNoSuchElementException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }
 
 /**
@@ -317,4 +336,5 @@ private[spark] class SparkSQLFeatureNotSupportedException(
 
   override def getErrorClass: String = errorClass
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass)
 }

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -160,4 +160,21 @@ class SparkThrowableSuite extends SparkFunSuite {
         assert(false)
     }
   }
+
+  test("Try catching internal SparkError") {
+    try {
+      throw new SparkException(
+        errorClass = "INTERNAL_ERROR",
+        messageParameters = Array("this is an internal error"),
+        cause = null
+      )
+    } catch {
+      case e: SparkThrowable =>
+        assert(e.isInternalError)
+        assert(e.getSqlState == null)
+      case _: Throwable =>
+        // Should not end up here
+        assert(false)
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -92,6 +92,4 @@ class AnalysisException protected[sql] (
   }
 
   override def getErrorClass: String = errorClass.orNull
-  override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass.orNull)
-  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass.orNull)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -93,4 +93,5 @@ class AnalysisException protected[sql] (
 
   override def getErrorClass: String = errorClass.orNull
   override def getSqlState: String = SparkThrowableHelper.getSqlState(errorClass.orNull)
+  override def isInternalError: Boolean = SparkThrowableHelper.isInternalError(errorClass.orNull)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -72,23 +72,24 @@ object QueryExecutionErrors {
   }
 
   def logicalHintOperatorNotRemovedDuringAnalysisError(): Throwable = {
-    new SparkIllegalStateException(errorClass = "LOGICAL_HINT_OPERATOR_NOT_REMOVED_DURING_ANALYSIS",
-      messageParameters = Array.empty)
+    new SparkIllegalStateException(errorClass = "INTERNAL_ERROR",
+      messageParameters = Array(
+        "Internal error: logical hint operator should have been removed during analysis"))
   }
 
   def cannotEvaluateExpressionError(expression: Expression): Throwable = {
-    new SparkUnsupportedOperationException(errorClass = "CANNOT_EVALUATE_EXPRESSION",
-      messageParameters = Array("", expression.toString))
+    new SparkUnsupportedOperationException(errorClass = "INTERNAL_ERROR",
+      messageParameters = Array(s"Cannot evaluate expression: $expression"))
   }
 
   def cannotGenerateCodeForExpressionError(expression: Expression): Throwable = {
-    new SparkUnsupportedOperationException(errorClass = "CANNOT_GENERATE_CODE_FOR_EXPRESSION",
-      messageParameters = Array(expression.toString))
+    new SparkUnsupportedOperationException(errorClass = "INTERNAL_ERROR",
+      messageParameters = Array(s"Cannot generate code for expression: $expression"))
   }
 
   def cannotTerminateGeneratorError(generator: UnresolvedGenerator): Throwable = {
-    new SparkUnsupportedOperationException(errorClass = "CANNOT_TERMINATE_GENERATOR",
-      messageParameters = Array(generator.toString))
+    new SparkUnsupportedOperationException(errorClass = "INTERNAL_ERROR",
+      messageParameters = Array(s"Cannot terminate expression: $generator"))
   }
 
   def castingCauseOverflowError(t: Any, targetType: String): ArithmeticException = {
@@ -130,8 +131,8 @@ object QueryExecutionErrors {
 
   def evaluateUnevaluableAggregateUnsupportedError(
       methodName: String, unEvaluable: UnevaluableAggregate): Throwable = {
-    new SparkUnsupportedOperationException(errorClass = "CANNOT_EVALUATE_EXPRESSION",
-      messageParameters = Array(methodName + ": " + unEvaluable.toString))
+    new SparkUnsupportedOperationException(errorClass = "INTERNAL_ERROR",
+      messageParameters = Array(s"Cannot evaluate expression: $methodName: $unEvaluable"))
   }
 
   def dataTypeUnsupportedError(dt: DataType): Throwable = {
@@ -279,7 +280,9 @@ object QueryExecutionErrors {
   }
 
   def methodNotDeclaredError(name: String): Throwable = {
-    new SparkNoSuchMethodException(errorClass = "MISSING_METHOD", Array(name))
+    new SparkNoSuchMethodException(errorClass = "INTERNAL_ERROR",
+      messageParameters = Array(
+        s"""A method named "$name" is not declared in any enclosing class nor any supertype"""))
   }
 
   def constructorNotFoundError(cls: String): Throwable = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds the `INTERNAL_ERROR` error class and the `isInternalError` API to `SparkThrowable`.
Removes existing error classes that are internal-only and replaces them with `INTERNAL_ERROR`.

### Why are the changes needed?

Makes it easy for end-users to diagnose whether an error is an internal error. If an end-user encounters an internal error, it should be reported immediately. This also limits the number of error classes, making it easy to audit. We do not need high-quality error messages for internal errors, as they should not be exposed to the end-user.

### Does this PR introduce _any_ user-facing change?

Yes; this changes the error class in master.

### How was this patch tested?

Unit tests
