### PR TITLE
[SPARK-36849][SQL] Migrate UseStatement to v2 command framework

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -80,8 +80,8 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
         writeOptions = c.writeOptions,
         orCreate = c.orCreate)
 
-    case UseStatement(isNamespaceSet, nameParts) =>
-      if (isNamespaceSet) {
+    case Use(UnresolvedDBObjectName(nameParts, isNamespace)) =>
+      if (isNamespace) {
         SetCatalogAndNamespace(catalogManager, None, Some(nameParts))
       } else {
         val CatalogAndNamespace(catalog, ns) = nameParts

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3565,11 +3565,13 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
   }
 
   /**
-   * Create a [[UseStatement]] logical plan.
+   * Create a [[Use]] logical plan.
    */
   override def visitUse(ctx: UseContext): LogicalPlan = withOrigin(ctx) {
     val nameParts = visitMultipartIdentifier(ctx.multipartIdentifier)
-    UseStatement(ctx.NAMESPACE != null, nameParts)
+    Use(UnresolvedDBObjectName(
+      nameParts,
+      ctx.NAMESPACE != null))
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -274,11 +274,6 @@ case class InsertIntoStatement(
 }
 
 /**
- * A USE statement, as parsed from SQL.
- */
-case class UseStatement(isNamespaceSet: Boolean, nameParts: Seq[String]) extends LeafParsedStatement
-
-/**
  *  CREATE FUNCTION statement, as parsed from SQL
  */
 case class CreateFunctionStatement(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1031,3 +1031,13 @@ case class UncacheTable(
 
   override def markAsAnalyzed(): LogicalPlan = copy(isAnalyzed = true)
 }
+
+/**
+ * The logical plan of the USE command.
+ */
+case class Use(name: LogicalPlan) extends UnaryCommand {
+  override def child: LogicalPlan = name
+  override protected def withNewChildInternal(newChild: LogicalPlan): Use = {
+    copy(name = newChild)
+  }
+}


### PR DESCRIPTION
What changes were proposed in this pull request?
Migrate UseStatement to v2 command framework

Why are the changes needed?
Migrate to the standard V2 framework

Does this PR introduce any user-facing change?
no

How was this patch tested?
existing tests