### PR TITLE
[MINOR][SS][TEST] Remove unsupportedOperationCheck setting for TextSocketStreamSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketStreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketStreamSuite.scala
@@ -34,7 +34,6 @@ import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.execution.datasources.v2.StreamingDataSourceV2Relation
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.continuous._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{StreamingQueryException, StreamTest}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
@@ -96,80 +95,76 @@ class TextSocketStreamSuite extends StreamTest with SharedSparkSession {
     serverThread = new ServerThread()
     serverThread.start()
 
-    withSQLConf(SQLConf.UNSUPPORTED_OPERATION_CHECK_ENABLED.key -> "false") {
-      val ref = spark
-      import ref.implicits._
+    val ref = spark
+    import ref.implicits._
 
-      val socket = spark
-        .readStream
-        .format("socket")
-        .options(Map("host" -> "localhost", "port" -> serverThread.port.toString))
-        .load()
-        .as[String]
+    val socket = spark
+      .readStream
+      .format("socket")
+      .options(Map("host" -> "localhost", "port" -> serverThread.port.toString))
+      .load()
+      .as[String]
 
-      assert(socket.schema === StructType(StructField("value", StringType) :: Nil))
+    assert(socket.schema === StructType(StructField("value", StringType) :: Nil))
 
-      testStream(socket)(
-        StartStream(),
-        AddSocketData("hello"),
-        CheckAnswer("hello"),
-        AddSocketData("world"),
-        CheckLastBatch("world"),
-        CheckAnswer("hello", "world"),
-        StopStream
-      )
-    }
+    testStream(socket)(
+      StartStream(),
+      AddSocketData("hello"),
+      CheckAnswer("hello"),
+      AddSocketData("world"),
+      CheckLastBatch("world"),
+      CheckAnswer("hello", "world"),
+      StopStream
+    )
   }
 
   test("timestamped usage") {
     serverThread = new ServerThread()
     serverThread.start()
 
-    withSQLConf(SQLConf.UNSUPPORTED_OPERATION_CHECK_ENABLED.key -> "false") {
-      val socket = spark
-        .readStream
-        .format("socket")
-        .options(Map(
-          "host" -> "localhost",
-          "port" -> serverThread.port.toString,
-          "includeTimestamp" -> "true"))
-        .load()
+    val socket = spark
+      .readStream
+      .format("socket")
+      .options(Map(
+        "host" -> "localhost",
+        "port" -> serverThread.port.toString,
+        "includeTimestamp" -> "true"))
+      .load()
 
-      assert(socket.schema === StructType(StructField("value", StringType) ::
-        StructField("timestamp", TimestampType) :: Nil))
+    assert(socket.schema === StructType(StructField("value", StringType) ::
+      StructField("timestamp", TimestampType) :: Nil))
 
-      var batch1Stamp: Timestamp = null
-      var batch2Stamp: Timestamp = null
+    var batch1Stamp: Timestamp = null
+    var batch2Stamp: Timestamp = null
 
-      val curr = System.currentTimeMillis()
-      testStream(socket)(
-        StartStream(),
-        AddSocketData("hello"),
-        CheckAnswerRowsByFunc(
-          rows => {
-            assert(rows.size === 1)
-            assert(rows.head.getAs[String](0) === "hello")
-            batch1Stamp = rows.head.getAs[Timestamp](1)
-            Thread.sleep(10)
-          },
-          true),
-        AddSocketData("world"),
-        CheckAnswerRowsByFunc(
-          rows => {
-            assert(rows.size === 1)
-            assert(rows.head.getAs[String](0) === "world")
-            batch2Stamp = rows.head.getAs[Timestamp](1)
-          },
-          true),
-        StopStream
-      )
+    val curr = System.currentTimeMillis()
+    testStream(socket)(
+      StartStream(),
+      AddSocketData("hello"),
+      CheckAnswerRowsByFunc(
+        rows => {
+          assert(rows.size === 1)
+          assert(rows.head.getAs[String](0) === "hello")
+          batch1Stamp = rows.head.getAs[Timestamp](1)
+          Thread.sleep(10)
+        },
+        true),
+      AddSocketData("world"),
+      CheckAnswerRowsByFunc(
+        rows => {
+          assert(rows.size === 1)
+          assert(rows.head.getAs[String](0) === "world")
+          batch2Stamp = rows.head.getAs[Timestamp](1)
+        },
+        true),
+      StopStream
+    )
 
-      // Timestamp for rate stream is round to second which leads to milliseconds lost, that will
-      // make batch1stamp smaller than current timestamp if both of them are in the same second.
-      // Comparing by second to make sure the correct behavior.
-      assert(batch1Stamp.getTime >= SECONDS.toMillis(MILLISECONDS.toSeconds(curr)))
-      assert(!batch2Stamp.before(batch1Stamp))
-    }
+    // Timestamp for rate stream is round to second which leads to milliseconds lost, that will
+    // make batch1stamp smaller than current timestamp if both of them are in the same second.
+    // Comparing by second to make sure the correct behavior.
+    assert(batch1Stamp.getTime >= SECONDS.toMillis(MILLISECONDS.toSeconds(curr)))
+    assert(!batch2Stamp.before(batch1Stamp))
   }
 
   test("params not given") {
@@ -209,51 +204,67 @@ class TextSocketStreamSuite extends StreamTest with SharedSparkSession {
     serverThread = new ServerThread()
     serverThread.start()
 
-    withSQLConf(SQLConf.UNSUPPORTED_OPERATION_CHECK_ENABLED.key -> "false") {
-      val ref = spark
-      import ref.implicits._
+    val ref = spark
+    import ref.implicits._
 
-      val socket = spark
-        .readStream
-        .format("socket")
-        .options(Map("host" -> "localhost", "port" -> serverThread.port.toString))
-        .load()
-        .as[String]
+    val socket = spark
+      .readStream
+      .format("socket")
+      .options(Map("host" -> "localhost", "port" -> serverThread.port.toString))
+      .load()
+      .as[String]
 
-      assert(socket.schema === StructType(StructField("value", StringType) :: Nil))
+    assert(socket.schema === StructType(StructField("value", StringType) :: Nil))
 
-      testStream(socket)(
-        StartStream(),
-        AddSocketData("hello"),
-        CheckAnswer("hello"),
-        AssertOnQuery { q =>
-          val numRowMetric =
-            q.lastExecution.executedPlan.collectLeaves().head.metrics.get("numOutputRows")
-          numRowMetric.nonEmpty && numRowMetric.get.value == 1
-        },
-        StopStream
-      )
-    }
+    testStream(socket)(
+      StartStream(),
+      AddSocketData("hello"),
+      CheckAnswer("hello"),
+      AssertOnQuery { q =>
+        val numRowMetric =
+          q.lastExecution.executedPlan.collectLeaves().head.metrics.get("numOutputRows")
+        numRowMetric.nonEmpty && numRowMetric.get.value == 1
+      },
+      StopStream
+    )
   }
 
   test("verify ServerThread only accepts the first connection") {
     serverThread = new ServerThread()
     serverThread.start()
 
-    withSQLConf(SQLConf.UNSUPPORTED_OPERATION_CHECK_ENABLED.key -> "false") {
-      val ref = spark
-      import ref.implicits._
+    val ref = spark
+    import ref.implicits._
 
-      val socket = spark
+    val socket = spark
+      .readStream
+      .format("socket")
+      .options(Map("host" -> "localhost", "port" -> serverThread.port.toString))
+      .load()
+      .as[String]
+
+    assert(socket.schema === StructType(StructField("value", StringType) :: Nil))
+
+    testStream(socket)(
+      StartStream(),
+      AddSocketData("hello"),
+      CheckAnswer("hello"),
+      AddSocketData("world"),
+      CheckLastBatch("world"),
+      CheckAnswer("hello", "world"),
+      StopStream
+    )
+
+    // we are trying to connect to the server once again which should fail
+    try {
+      val socket2 = spark
         .readStream
         .format("socket")
         .options(Map("host" -> "localhost", "port" -> serverThread.port.toString))
         .load()
         .as[String]
 
-      assert(socket.schema === StructType(StructField("value", StringType) :: Nil))
-
-      testStream(socket)(
+      testStream(socket2)(
         StartStream(),
         AddSocketData("hello"),
         CheckAnswer("hello"),
@@ -263,29 +274,9 @@ class TextSocketStreamSuite extends StreamTest with SharedSparkSession {
         StopStream
       )
 
-      // we are trying to connect to the server once again which should fail
-      try {
-        val socket2 = spark
-          .readStream
-          .format("socket")
-          .options(Map("host" -> "localhost", "port" -> serverThread.port.toString))
-          .load()
-          .as[String]
-
-        testStream(socket2)(
-          StartStream(),
-          AddSocketData("hello"),
-          CheckAnswer("hello"),
-          AddSocketData("world"),
-          CheckLastBatch("world"),
-          CheckAnswer("hello", "world"),
-          StopStream
-        )
-
-        fail("StreamingQueryException is expected!")
-      } catch {
-        case e: StreamingQueryException if e.cause.isInstanceOf[SocketException] => // pass
-      }
+      fail("StreamingQueryException is expected!")
+    } catch {
+      case e: StreamingQueryException if e.cause.isInstanceOf[SocketException] => // pass
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch simply removes a few `unsupportedOperationCheck` in `TextSocketStreamSuite`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`unsupportedOperationCheck` is used to disable the check of unsupported operations. If we are not to test unsupported operations, it was unnecessarily set in `TextSocketStreamSuite` and could cause unexpected error by missing check.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Existing tests.
