### PR TITLE
[SPARK-36883][INFRA] Upgrade R version to 4.1.1 in CI images

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -228,7 +228,7 @@ jobs:
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20210928
+      image: dongjoon/apache-spark-github-action-image:20210929
     strategy:
       fail-fast: false
       matrix:
@@ -326,7 +326,7 @@ jobs:
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20210928
+      image: dongjoon/apache-spark-github-action-image:20210929
     env:
       HADOOP_PROFILE: ${{ needs.configure-jobs.outputs.hadoop }}
       HIVE_PROFILE: hive2.3
@@ -392,7 +392,7 @@ jobs:
       LANG: C.UTF-8
       PYSPARK_DRIVER_PYTHON: python3.9
     container:
-      image: dongjoon/apache-spark-github-action-image:20210928
+      image: dongjoon/apache-spark-github-action-image:20210929
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -228,7 +228,7 @@ jobs:
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20210929
+      image: dongjoon/apache-spark-github-action-image:20210930
     strategy:
       fail-fast: false
       matrix:
@@ -326,7 +326,7 @@ jobs:
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20210929
+      image: dongjoon/apache-spark-github-action-image:20210930
     env:
       HADOOP_PROFILE: ${{ needs.configure-jobs.outputs.hadoop }}
       HIVE_PROFILE: hive2.3
@@ -393,7 +393,7 @@ jobs:
       PYSPARK_DRIVER_PYTHON: python3.9
       PYSPARK_PYTHON: python3.9
     container:
-      image: dongjoon/apache-spark-github-action-image:20210929
+      image: dongjoon/apache-spark-github-action-image:20210930
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -391,6 +391,7 @@ jobs:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
       PYSPARK_DRIVER_PYTHON: python3.9
+      PYSPARK_PYTHON: python3.9
     container:
       image: dongjoon/apache-spark-github-action-image:20210929
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -228,7 +228,7 @@ jobs:
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20210730
+      image: dongjoon/apache-spark-github-action-image:20210928
     strategy:
       fail-fast: false
       matrix:
@@ -326,7 +326,7 @@ jobs:
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20210602
+      image: dongjoon/apache-spark-github-action-image:20210928
     env:
       HADOOP_PROFILE: ${{ needs.configure-jobs.outputs.hadoop }}
       HIVE_PROFILE: hive2.3
@@ -392,7 +392,7 @@ jobs:
       LANG: C.UTF-8
       PYSPARK_DRIVER_PYTHON: python3.9
     container:
-      image: dongjoon/apache-spark-github-action-image:20210602
+      image: dongjoon/apache-spark-github-action-image:20210928
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade GitHub Action CI image to recover CRAN installation failure.

### Why are the changes needed?

Sometimes, GitHub Action linter job failed
- https://github.com/apache/spark/runs/3739748809

New image have R 4.1.1 and will recover the failure.
```
$ docker run -it --rm dongjoon/apache-spark-github-action-image:20210928 R --version
R version 4.1.1 (2021-08-10) -- "Kick Things"
Copyright (C) 2021 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under the terms of the
GNU General Public License versions 2 or 3.
For more information about these matters see
https://www.gnu.org/licenses/.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass `GitHub Action`.