### PR TITLE
[SPARK-36876][SQL] Support Dynamic Partition pruning for HiveTableScanExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/CleanupDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/CleanupDynamicPruningFilters.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.dynamicpruning
 
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.expressions.{DynamicPruning, PredicateHelper}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
@@ -43,6 +44,8 @@ object CleanupDynamicPruningFilters extends Rule[LogicalPlan] with PredicateHelp
       _.containsAnyPattern(DYNAMIC_PRUNING_EXPRESSION, DYNAMIC_PRUNING_SUBQUERY)) {
       // pass through anything that is pushed down into PhysicalOperation
       case p @ PhysicalOperation(_, _, LogicalRelation(_: HadoopFsRelation, _, _, _)) => p
+      // pass through anything that is pushed down into PhysicalOperation
+      case p @ PhysicalOperation(_, _, HiveTableRelation(_, _, _, _, _)) => p
       case p @ PhysicalOperation(_, _, _: DataSourceV2ScanRelation) => p
       // remove any Filters with DynamicPruning that didn't get pushed down to PhysicalOperation.
       case f @ Filter(condition, _) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.dynamicpruning
 
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans._
@@ -70,6 +71,12 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper {
               None
             }
           case _ => None
+        }
+      case (resExp, l: HiveTableRelation) =>
+        if (resExp.references.subsetOf(AttributeSet(l.partitionCols))) {
+          return Some(l)
+        } else {
+          None
         }
       case (resExp, r @ DataSourceV2ScanRelation(_, scan: SupportsRuntimeFiltering, _)) =>
         val filterAttrs = V2ExpressionUtils.resolveRefs[Attribute](scan.filterAttributes, r)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
@@ -54,8 +54,8 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper {
   /**
    * Searches for a table scan that can be filtered for a given column in a logical plan.
    *
-   * This methods tries to find either a v1 partitioned scan for a given partition column or
-   * a v2 scan that support runtime filtering on a given attribute.
+   * This methods tries to find either a v1 or Hive serde partitioned scan for a given
+   * partition column or a v2 scan that support runtime filtering on a given attribute.
    */
   def getFilterableTableScan(a: Expression, plan: LogicalPlan): Option[LogicalPlan] = {
     val srcInfo: Option[(Expression, LogicalPlan)] = findExpressionAndTrackLineageDown(a, plan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -173,15 +173,14 @@ abstract class DynamicPartitionPruningSuiteBase
     }
   }
 
-
   /**
    * Check if the query plan has a partition pruning filter inserted as
    * a subquery duplicate or as a custom broadcast exchange.
    */
   def checkPartitionPruningPredicate(
-    df: DataFrame,
-    withSubquery: Boolean,
-    withBroadcast: Boolean): Unit = {
+      df: DataFrame,
+      withSubquery: Boolean,
+      withBroadcast: Boolean): Unit = {
     df.collect()
 
     val plan = df.queryExecution.executedPlan
@@ -496,9 +495,9 @@ abstract class DynamicPartitionPruningSuiteBase
 
         checkAnswer(df,
           Row(1030, 2, 10, 3) ::
-            Row(1040, 2, 50, 3) ::
-            Row(1050, 2, 50, 3) ::
-            Row(1060, 2, 50, 3) :: Nil
+          Row(1040, 2, 50, 3) ::
+          Row(1050, 2, 50, 3) ::
+          Row(1060, 2, 50, 3) :: Nil
         )
       }
 
@@ -516,7 +515,7 @@ abstract class DynamicPartitionPruningSuiteBase
 
         checkAnswer(df,
           Row(1010, 1, 10, 2) ::
-            Row(1020, 1, 10, 2) :: Nil
+          Row(1020, 1, 10, 2) :: Nil
         )
       }
     }
@@ -1140,9 +1139,9 @@ abstract class DynamicPartitionPruningSuiteBase
 
       checkAnswer(df,
         Row(1000, 1, 1, 10) ::
-          Row(1010, 2, 1, 10) ::
-          Row(1020, 2, 1, 10) ::
-          Row(1030, 3, 2, 10) :: Nil
+        Row(1010, 2, 1, 10) ::
+        Row(1020, 2, 1, 10) ::
+        Row(1030, 3, 2, 10) :: Nil
       )
     }
 
@@ -1160,9 +1159,9 @@ abstract class DynamicPartitionPruningSuiteBase
 
       checkAnswer(df,
         Row(1000, 1, 1, 10) ::
-          Row(1010, 2, 1, 10) ::
-          Row(1020, 2, 1, 10) ::
-          Row(1030, 3, 2, 10) :: Nil
+        Row(1010, 2, 1, 10) ::
+        Row(1020, 2, 1, 10) ::
+        Row(1030, 3, 2, 10) :: Nil
       )
     }
   }
@@ -1189,9 +1188,9 @@ abstract class DynamicPartitionPruningSuiteBase
 
             checkAnswer(df,
               Row(1030, 2, 10, 3) ::
-                Row(1040, 2, 50, 3) ::
-                Row(1050, 2, 50, 3) ::
-                Row(1060, 2, 50, 3) :: Nil
+              Row(1040, 2, 50, 3) ::
+              Row(1050, 2, 50, 3) ::
+              Row(1060, 2, 50, 3) :: Nil
             )
           }
         }
@@ -1278,9 +1277,9 @@ abstract class DynamicPartitionPruningSuiteBase
 
       checkAnswer(df,
         Row(1030, 2) ::
-          Row(1040, 2) ::
-          Row(1050, 2) ::
-          Row(1060, 2) :: Nil
+        Row(1040, 2) ::
+        Row(1050, 2) ::
+        Row(1060, 2) :: Nil
       )
     }
   }
@@ -1298,15 +1297,15 @@ abstract class DynamicPartitionPruningSuiteBase
 
       checkAnswer(df,
         Row(1030, 2) ::
-          Row(1040, 2) ::
-          Row(1050, 2) ::
-          Row(1060, 2) ::
-          Row(1070, 2) ::
-          Row(1080, 3) ::
-          Row(1090, 3) ::
-          Row(1100, 3) ::
-          Row(1110, 3) ::
-          Row(1120, 4) :: Nil
+        Row(1040, 2) ::
+        Row(1050, 2) ::
+        Row(1060, 2) ::
+        Row(1070, 2) ::
+        Row(1080, 3) ::
+        Row(1090, 3) ::
+        Row(1100, 3) ::
+        Row(1110, 3) ::
+        Row(1120, 4) :: Nil
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -33,6 +33,9 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 
+/**
+ * Test suite for the filtering ratio policy used to trigger dynamic partition pruning (DPP).
+ */
 abstract class DynamicPartitionPruningSuiteBase
     extends QueryTest
     with SQLTestUtils
@@ -1369,11 +1372,7 @@ abstract class DynamicPartitionPruningSuiteBase
   }
 }
 
-
-/**
- * Test suite for the filtering ratio policy used to trigger dynamic partition pruning (DPP).
- */
-abstract class DSDynamicPartitionPruningSuiteBase
+abstract class DynamicPartitionPruningDataSourceSuiteBase
     extends DynamicPartitionPruningSuiteBase
     with SharedSparkSession {
   import testImplicits._
@@ -1522,7 +1521,7 @@ abstract class DSDynamicPartitionPruningSuiteBase
   }
 }
 
-abstract class DynamicPartitionPruningV1Suite extends DSDynamicPartitionPruningSuiteBase {
+abstract class DynamicPartitionPruningV1Suite extends DynamicPartitionPruningDataSourceSuiteBase {
 
   import testImplicits._
 
@@ -1616,7 +1615,7 @@ class DynamicPartitionPruningV1SuiteAEOff extends DynamicPartitionPruningV1Suite
 class DynamicPartitionPruningV1SuiteAEOn extends DynamicPartitionPruningV1Suite
   with EnableAdaptiveExecutionSuite
 
-abstract class DynamicPartitionPruningV2Suite extends DSDynamicPartitionPruningSuiteBase {
+abstract class DynamicPartitionPruningV2Suite extends DynamicPartitionPruningDataSourceSuiteBase {
   override protected def runAnalyzeColumnCommands: Boolean = false
 
   override protected def initState(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -471,8 +471,8 @@ abstract class DynamicPartitionPruningSuiteBase
 
       Given("no stats and selective predicate with the size of dim too large")
       withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
-        SQLConf.DYNAMIC_PARTITION_PRUNING_USE_STATS.key -> "true",
-        SQLConf.DYNAMIC_PARTITION_PRUNING_FALLBACK_FILTER_RATIO.key -> "0.02") {
+          SQLConf.DYNAMIC_PARTITION_PRUNING_USE_STATS.key -> "true",
+          SQLConf.DYNAMIC_PARTITION_PRUNING_FALLBACK_FILTER_RATIO.key -> "0.02") {
         withTable("fact_aux") {
           sql(
             """
@@ -503,7 +503,7 @@ abstract class DynamicPartitionPruningSuiteBase
 
       Given("no stats and selective predicate with the size of dim too large but cached")
       withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
-        SQLConf.DYNAMIC_PARTITION_PRUNING_USE_STATS.key -> "true") {
+          SQLConf.DYNAMIC_PARTITION_PRUNING_USE_STATS.key -> "true") {
         withTable("fact_aux") {
           withTempView("cached_dim_store") {
             sql(
@@ -551,8 +551,8 @@ abstract class DynamicPartitionPruningSuiteBase
 
         checkAnswer(df,
           Row(1010, 1, 10, 2) ::
-            Row(1020, 1, 10, 2) ::
-            Row(1000, 1, 10, 1) :: Nil
+          Row(1020, 1, 10, 2) ::
+          Row(1000, 1, 10, 1) :: Nil
         )
       }
     }
@@ -1486,6 +1486,7 @@ abstract class DynamicPartitionPruningSuiteBase
 abstract class DynamicPartitionPruningDataSourceSuiteBase
     extends DynamicPartitionPruningSuiteBase
     with SharedSparkSession {
+
   import testImplicits._
 
   test("no partition pruning when the build side is a stream") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -610,9 +610,9 @@ abstract class DynamicPartitionPruningSuiteBase
 
       checkAnswer(df,
         Row(1030, 2, 3) ::
-        Row(1040, 2, 3) ::
-        Row(1050, 2, 3) ::
-        Row(1060, 2, 3) :: Nil
+          Row(1040, 2, 3) ::
+          Row(1050, 2, 3) ::
+          Row(1060, 2, 3) :: Nil
       )
     }
 
@@ -636,9 +636,9 @@ abstract class DynamicPartitionPruningSuiteBase
 
       checkAnswer(df,
         Row(1030, 2, 3) ::
-        Row(1040, 2, 3) ::
-        Row(1050, 2, 3) ::
-        Row(1060, 2, 3) :: Nil
+          Row(1040, 2, 3) ::
+          Row(1050, 2, 3) ::
+          Row(1060, 2, 3) :: Nil
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -39,9 +39,9 @@ abstract class DynamicPartitionPruningSuiteBase
     with GivenWhenThen
     with AdaptiveSparkPlanHelper {
 
-  import testImplicits._
-
   val tableFormat: String = "parquet"
+
+  import testImplicits._
 
   protected def initState(): Unit = {}
   protected def runAnalyzeColumnCommands: Boolean = true

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -262,7 +262,7 @@ case class HiveTableScanExec(
   // Filters unused DynamicPruningExpression expressions - one which has been replaced
   // with DynamicPruningExpression(Literal.TrueLiteral) during Physical Planning
   private def filterUnusedDynamicPruningExpressions(
-    predicates: Seq[Expression]): Seq[Expression] = {
+      predicates: Seq[Expression]): Seq[Expression] = {
     predicates.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral))
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -216,7 +216,7 @@ case class HiveTableScanExec(
         BindReferences.bindReference(pred, relation.partitionCols)
       }
 
-      val ret = boundPruningPredForDynamic match {
+      boundPruningPredForDynamic match {
         case None => prunedPartitions
         case Some(shouldKeep) => prunedPartitions.filter { part =>
           val dataTypes = relation.partitionCols.map(_.dataType)
@@ -225,11 +225,10 @@ case class HiveTableScanExec(
 
           // Only partitioned values are needed here, since the predicate has already been bound to
           // partition key attribute references.
-          val row = InternalRow.fromSeq(castedValues)
+          val row: InternalRow = InternalRow.fromSeq(castedValues)
           shouldKeep.eval(row).asInstanceOf[Boolean]
         }
       }
-      ret
     } else {
       prunedPartitions
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -64,6 +64,9 @@ case class HiveTableScanExec(
 
   override def nodeName: String = s"Scan hive ${relation.tableMeta.qualifiedName}"
 
+  private def isDynamicPruningFilter(e: Expression): Boolean =
+    e.find(_.isInstanceOf[PlanExpression[_]]).isDefined
+
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
 
@@ -77,9 +80,13 @@ case class HiveTableScanExec(
     requestedAttributes.map(originalAttributes)
   }
 
+  private lazy val (partitionPruningPredNotDynamic, partitionPruningPredOfDynamic) =
+    partitionPruningPred.partition(!isDynamicPruningFilter(_))
+
   // Bind all partition key attribute references in the partition pruning predicate for later
   // evaluation.
-  private lazy val boundPruningPred = partitionPruningPred.reduceLeftOption(And).map { pred =>
+  private lazy val boundPruningPred = partitionPruningPredNotDynamic
+    .reduceLeftOption(And).map { pred =>
     require(pred.dataType == BooleanType,
       s"Data type of predicate $pred must be ${BooleanType.catalogString} rather than " +
         s"${pred.dataType.catalogString}.")
@@ -167,14 +174,14 @@ case class HiveTableScanExec(
     if (relation.prunedPartitions.nonEmpty) {
       val hivePartitions =
         relation.prunedPartitions.get.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
-      if (partitionPruningPred.forall(!ExecSubqueryExpression.hasSubquery(_))) {
+      if (partitionPruningPredNotDynamic.forall(!ExecSubqueryExpression.hasSubquery(_))) {
         hivePartitions
       } else {
         prunePartitions(hivePartitions)
       }
     } else {
       if (sparkSession.sessionState.conf.metastorePartitionPruning &&
-        partitionPruningPred.nonEmpty) {
+        partitionPruningPredNotDynamic.nonEmpty) {
         rawPartitions
       } else {
         prunePartitions(rawPartitions)
@@ -186,9 +193,9 @@ case class HiveTableScanExec(
   @transient lazy val rawPartitions: Seq[HivePartition] = {
     val prunedPartitions =
       if (sparkSession.sessionState.conf.metastorePartitionPruning &&
-        partitionPruningPred.nonEmpty) {
+        partitionPruningPredNotDynamic.nonEmpty) {
         // Retrieve the original attributes based on expression ID so that capitalization matches.
-        val normalizedFilters = partitionPruningPred.map(_.transform {
+        val normalizedFilters = partitionPruningPredNotDynamic.map(_.transform {
           case a: AttributeReference => originalAttributes(a)
         })
         sparkSession.sessionState.catalog
@@ -197,6 +204,35 @@ case class HiveTableScanExec(
         sparkSession.sessionState.catalog.listPartitions(relation.tableMeta.identifier)
       }
     prunedPartitions.map(HiveClientImpl.toHivePartition(_, hiveQlTable))
+  }
+
+  // We can only determine the actual partitions at runtime when a dynamic partition filter is
+  // present. This is because such a filter relies on information that is only available at run
+  // time (for instance the keys used in the other side of a join).
+  @transient private lazy val dynamicallyPrunedPartitions: Seq[HivePartition] = {
+    if (partitionPruningPredOfDynamic.nonEmpty) {
+      val boundPruningPredForDynamic = partitionPruningPredOfDynamic
+        .reduceLeftOption(And).map { pred =>
+        BindReferences.bindReference(pred, relation.partitionCols)
+      }
+
+      val ret = boundPruningPredForDynamic match {
+        case None => prunedPartitions
+        case Some(shouldKeep) => prunedPartitions.filter { part =>
+          val dataTypes = relation.partitionCols.map(_.dataType)
+          val castedValues = part.getValues.asScala.zip(dataTypes)
+            .map { case (value, dataType) => castFromString(value, dataType) }
+
+          // Only partitioned values are needed here, since the predicate has already been bound to
+          // partition key attribute references.
+          val row = InternalRow.fromSeq(castedValues)
+          shouldKeep.eval(row).asInstanceOf[Boolean]
+        }
+      }
+      ret
+    } else {
+      prunedPartitions
+    }
   }
 
   protected override def doExecute(): RDD[InternalRow] = {
@@ -208,7 +244,7 @@ case class HiveTableScanExec(
       }
     } else {
       Utils.withDummyCallSite(sparkContext) {
-        hadoopReader.makeRDDForPartitionedTable(prunedPartitions)
+        hadoopReader.makeRDDForPartitionedTable(dynamicallyPrunedPartitions)
       }
     }
     val numOutputRows = longMetric("numOutputRows")
@@ -224,12 +260,20 @@ case class HiveTableScanExec(
     }
   }
 
+  // Filters unused DynamicPruningExpression expressions - one which has been replaced
+  // with DynamicPruningExpression(Literal.TrueLiteral) during Physical Planning
+  private def filterUnusedDynamicPruningExpressions(
+    predicates: Seq[Expression]): Seq[Expression] = {
+    predicates.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral))
+  }
+
   override def doCanonicalize(): HiveTableScanExec = {
     val input: AttributeSeq = relation.output
     HiveTableScanExec(
       requestedAttributes.map(QueryPlan.normalizeExpressions(_, input)),
       relation.canonicalized.asInstanceOf[HiveTableRelation],
-      QueryPlan.normalizePredicates(partitionPruningPred, input))(sparkSession)
+      QueryPlan.normalizePredicates(
+        filterUnusedDynamicPruningExpressions(partitionPruningPred), input))(sparkSession)
   }
 
   override def otherCopyArgs: Seq[AnyRef] = Seq(sparkSession)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -225,7 +225,7 @@ case class HiveTableScanExec(
 
           // Only partitioned values are needed here, since the predicate has already been bound to
           // partition key attribute references.
-          val row: InternalRow = InternalRow.fromSeq(castedValues)
+          val row = InternalRow.fromSeq(castedValues.toSeq)
           shouldKeep.eval(row).asInstanceOf[Boolean]
         }
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.expressions.{DynamicPruningExpression, Expression}
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.adaptive.{AQEPropagateEmptyRelation, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.hive.execution.HiveTableScanExec
+import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SQLTestUtils
+
+abstract class DynamicPartitionPruningHiveScanSuite
+    extends DynamicPartitionPruningSuiteBase with TestHiveSingleton with SQLTestUtils {
+
+  override val tableFormat: String = "hive"
+
+  override protected def collectDynamicPruningExpressions(plan: SparkPlan): Seq[Expression] = {
+    flatMap(plan) {
+      case s: FileSourceScanExec => s.partitionFilters.collect {
+        case d: DynamicPruningExpression => d.child
+      }
+      case s: BatchScanExec => s.runtimeFilters.collect {
+        case d: DynamicPruningExpression => d.child
+      }
+      case h: HiveTableScanExec => h.partitionPruningPred.collect {
+        case d: DynamicPruningExpression => d.child
+      }
+      case _ => Nil
+    }
+  }
+
+  test("SPARK-36876: simple inner join triggers DPP with mock-up tables") {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false",
+      HiveUtils.CONVERT_METASTORE_ORC.key -> "false",
+      "hive.exec.dynamic.partition.mode" -> "nonstrict") {
+      withTable("df1", "df2") {
+        spark.range(1000)
+          .select(col("id"), col("id").as("k"))
+          .write
+          .partitionBy("k")
+          .format(tableFormat)
+          .mode("overwrite")
+          .saveAsTable("df1")
+
+        spark.range(100)
+          .select(col("id"), col("id").as("k"))
+          .write
+          .partitionBy("k")
+          .format(tableFormat)
+          .mode("overwrite")
+          .saveAsTable("df2")
+
+        val df = sql("SELECT df1.id, df2.k FROM df1 JOIN df2 ON df1.k = df2.k AND df2.id < 2")
+
+        checkPartitionPruningPredicate(df, true, false)
+
+        checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
+      }
+    }
+  }
+
+  /**
+   * The filtering policy has a fallback when the stats are unavailable
+   */
+  test("filtering ratio policy fallback") {
+    withSQLConf(
+      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false",
+      SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> AQEPropagateEmptyRelation.ruleName) {
+      Given("no stats and selective predicate")
+      withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+        SQLConf.DYNAMIC_PARTITION_PRUNING_USE_STATS.key -> "true") {
+        val df = sql(
+          """
+            |SELECT f.date_id, f.product_id, f.units_sold, f.store_id FROM fact_sk f
+            |JOIN dim_store s
+            |ON f.store_id = s.store_id WHERE s.country LIKE '%C_%'
+          """.stripMargin)
+
+        checkPartitionPruningPredicate(df, true, false)
+      }
+
+      Given("no stats and selective predicate with the size of dim too large")
+      withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+        SQLConf.DYNAMIC_PARTITION_PRUNING_USE_STATS.key -> "true") {
+        withTable("fact_aux") {
+          sql(
+            """
+              |SELECT f.date_id, f.product_id, f.units_sold, f.store_id
+              |FROM fact_sk f WHERE store_id < 5
+            """.stripMargin)
+            .write
+            .partitionBy("store_id")
+            .saveAsTable("fact_aux")
+
+          val df = sql(
+            """
+              |SELECT f.date_id, f.product_id, f.units_sold, f.store_id
+              |FROM fact_aux f JOIN dim_store s
+              |ON f.store_id = s.store_id WHERE s.country = 'US'
+            """.stripMargin)
+
+          checkPartitionPruningPredicate(df, true, false)
+
+          checkAnswer(df,
+            Row(1070, 2, 10, 4) ::
+              Row(1080, 3, 20, 4) ::
+              Row(1090, 3, 10, 4) ::
+              Row(1100, 3, 10, 4) :: Nil
+          )
+        }
+      }
+
+      Given("no stats and selective predicate with the size of dim too large but cached")
+      withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+        SQLConf.DYNAMIC_PARTITION_PRUNING_USE_STATS.key -> "true") {
+        withTable("fact_aux") {
+          withTempView("cached_dim_store") {
+            sql(
+              """
+                |SELECT f.date_id, f.product_id, f.units_sold, f.store_id
+                |FROM fact_sk f WHERE store_id < 5
+              """.stripMargin)
+              .write
+              .partitionBy("store_id")
+              .saveAsTable("fact_aux")
+
+            spark.table("dim_store").cache()
+              .createOrReplaceTempView("cached_dim_store")
+
+            val df = sql(
+              """
+                |SELECT f.date_id, f.product_id, f.units_sold, f.store_id
+                |FROM fact_aux f JOIN cached_dim_store s
+                |ON f.store_id = s.store_id WHERE s.country = 'US'
+              """.stripMargin)
+
+            checkPartitionPruningPredicate(df, true, false)
+
+            checkAnswer(df,
+              Row(1070, 2, 10, 4) ::
+                Row(1080, 3, 20, 4) ::
+                Row(1090, 3, 10, 4) ::
+                Row(1100, 3, 10, 4) :: Nil
+            )
+          }
+        }
+      }
+
+      Given("no stats and selective predicate with the size of dim small")
+      withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+        SQLConf.DYNAMIC_PARTITION_PRUNING_USE_STATS.key -> "true") {
+        val df = sql(
+          """
+            |SELECT f.date_id, f.product_id, f.units_sold, f.store_id FROM fact_sk f
+            |JOIN dim_store s
+            |ON f.store_id = s.store_id WHERE s.country = 'NL'
+          """.stripMargin)
+
+        checkPartitionPruningPredicate(df, true, false)
+
+        checkAnswer(df,
+          Row(1010, 1, 10, 2) ::
+            Row(1020, 1, 10, 2) ::
+            Row(1000, 1, 10, 1) :: Nil
+        )
+      }
+    }
+  }
+}
+
+class DynamicPartitionPruningHiveScanSuiteAEOff extends DynamicPartitionPruningHiveScanSuite
+  with DisableAdaptiveExecutionSuite
+
+class DynamicPartitionPruningHiveScanSuiteAEOn extends DynamicPartitionPruningHiveScanSuite
+  with EnableAdaptiveExecutionSuite

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -47,38 +47,6 @@ abstract class DynamicPartitionPruningHiveScanSuite
       case _ => Nil
     }
   }
-
-  test("SPARK-36876: simple inner join triggers DPP with mock-up tables") {
-    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
-      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
-      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false",
-      HiveUtils.CONVERT_METASTORE_ORC.key -> "false",
-      "hive.exec.dynamic.partition.mode" -> "nonstrict") {
-      withTable("df1", "df2") {
-        spark.range(1000)
-          .select(col("id"), col("id").as("k"))
-          .write
-          .partitionBy("k")
-          .format(tableFormat)
-          .mode("overwrite")
-          .saveAsTable("df1")
-
-        spark.range(100)
-          .select(col("id"), col("id").as("k"))
-          .write
-          .partitionBy("k")
-          .format(tableFormat)
-          .mode("overwrite")
-          .saveAsTable("df2")
-
-        val df = sql("SELECT df1.id, df2.k FROM df1 JOIN df2 ON df1.k = df2.k AND df2.id < 2")
-
-        checkPartitionPruningPredicate(df, true, false)
-
-        checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
-      }
-    }
-  }
 }
 
 class DynamicPartitionPruningHiveScanSuiteAEOff extends DynamicPartitionPruningHiveScanSuite

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -22,10 +22,8 @@ import org.apache.spark.sql.catalyst.expressions.{DynamicPruningExpression, Expr
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.{DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
-import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.hive.execution.HiveTableScanExec
 import org.apache.spark.sql.hive.test.TestHiveSingleton
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 
 abstract class DynamicPartitionPruningHiveScanSuite

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -47,39 +47,6 @@ abstract class DynamicPartitionPruningHiveScanSuite
       case _ => Nil
     }
   }
-
-  test("SPARK-36876: simple inner join triggers DPP with mock-up tables") {
-    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
-      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
-      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false",
-      HiveUtils.CONVERT_METASTORE_ORC.key -> "false",
-      "hive.exec.dynamic.partition.mode" -> "nonstrict") {
-      withTable("df1", "df2") {
-        spark.range(1000)
-          .select(col("id"), col("id").as("k"))
-          .write
-          .partitionBy("k")
-          .format(tableFormat)
-          .mode("overwrite")
-          .saveAsTable("df1")
-
-        spark.range(100)
-          .select(col("id"), col("id").as("k"))
-          .write
-          .partitionBy("k")
-          .format(tableFormat)
-          .mode("overwrite")
-          .saveAsTable("df2")
-
-        val df = sql("SELECT df1.id, df2.k FROM df1 JOIN df2 ON df1.k = df2.k AND df2.id < 2")
-
-        assert(collectDynamicPruningExpressions(df.queryExecution.executedPlan).size == 1)
-        checkPartitionPruningPredicate(df, true, false)
-
-        checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
-      }
-    }
-  }
 }
 
 class DynamicPartitionPruningHiveScanSuiteAEOff extends DynamicPartitionPruningHiveScanSuite


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current code just support dynamic partition pruning for DSV1 and DSV2, here we support HiveTableScan


### Why are the changes needed?
Optimize Hive Table Scan dynamic partition pruning 


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Added UT
