### PR TITLE
[SPARK-36889][SQL] Respect `spark.sql.parquet.filterPushdown` by v2 parquet scan builder

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.InferFiltersFromConstraints
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath
+import org.apache.spark.sql.execution.ExplainMode
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation, LogicalRelation, PushableColumnAndNestedColumn}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
@@ -2036,6 +2037,18 @@ class ParquetV2FilterSuite extends ParquetFilterSuite {
 
         case _ =>
           throw new AnalysisException("Can not match ParquetTable in the query.")
+      }
+    }
+  }
+
+  test("SPARK-XXXXX: Don't show pushed filters when filters pushdown is disabled") {
+    import testImplicits._
+    withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "false") {
+      withTempPath { path =>
+        Seq(1, 2).toDF("c0").write.parquet(path.getAbsolutePath)
+        val readback = spark.read.parquet(path.getAbsolutePath).where("c0 == 1")
+        val explain = readback.queryExecution.explainString(ExplainMode.fromString("extended"))
+        assert(explain.contains("PushedFilters: []"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2041,7 +2041,7 @@ class ParquetV2FilterSuite extends ParquetFilterSuite {
     }
   }
 
-  test("SPARK-XXXXX: Don't show pushed filters when filters pushdown is disabled") {
+  test("SPARK-36889: Respect disabling of filters pushdown for DSv2 by explain") {
     import testImplicits._
     withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "false") {
       withTempPath { path =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to take into account the SQL config `spark.sql.parquet.filterPushdown` while building the array of pushed down filters in v2 `ParquetScanBuilder`.

### Why are the changes needed?
Before the changes, `explain()` outputs some filters even filter pushdown to parquet is disabled:
```
== Physical Plan ==
*(1) Filter (isnotnull(c0#7) AND (c0#7 = 1))
+- *(1) ColumnarToRow
   +- BatchScan[c0#7] ParquetScan DataFilters: [isnotnull(c0#7), (c0#7 = 1)], ... PushedFilters: [IsNotNull(c0), EqualTo(c0,1)] RuntimeFilters: []
```

### Does this PR introduce _any_ user-facing change?
If users parse `explain()`'s output, this PR can influence to them. But in general, it shouldn't. Also, need to highlight that the PR affects DSv2 only.


### How was this patch tested?
By running new test in `ParquetV2FilterSuite`:
```
$ build/sbt "test:testOnly *ParquetV2FilterSuite"
```
