### PR TITLE
[SPARK-36890][K8S] Use default WebsocketPingInterval for Kubernetes watches

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -88,7 +88,6 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
     val config = new ConfigBuilder(autoConfigure(kubeContext.getOrElse(null)))
       .withApiVersion("v1")
       .withMasterUrl(master)
-      .withWebsocketPingInterval(0)
       .withRequestTimeout(clientType.requestTimeout(sparkConf))
       .withConnectionTimeout(clientType.connectionTimeout(sparkConf))
       .withTrustCerts(sparkConf.get(KUBERNETES_TRUST_CERTIFICATES))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request removes the configuration that disables the WebsocketPingInterval. The default value of the [fabric8io/kubernetes-client](https://github.com/fabric8io/kubernetes-client/blob/master/README.md) library is 30 seconds.

Users still can fallback to `0` if needed.
```
export KUBERNETES_WEBSOCKET_PING_INTERVAL=0
```

### Why are the changes needed?
With a periodical websocket ping, the tunnel timeout in loadbalancers should work as expected.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
It is not possible for me to write a test for this particular infrastructure. I have checked the setting locally within my infrastructure.
