### PR TITLE
[SPARK-36896][PYTHON] Return boolean for `dropTempView` and `dropGlobalTempView`

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -323,6 +323,7 @@ class Catalog(object):
         >>> spark.table("my_table").collect()
         [Row(_1=1, _2=1)]
         >>> spark.catalog.dropTempView("my_table")
+        True
         >>> spark.table("my_table") # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
             ...
@@ -343,6 +344,7 @@ class Catalog(object):
         >>> spark.table("global_temp.my_table").collect()
         [Row(_1=1, _2=1)]
         >>> spark.catalog.dropGlobalTempView("my_table")
+        True
         >>> spark.table("global_temp.my_table") # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
             ...

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -50,7 +50,7 @@ class Catalog(object):
     @since(2.0)
     def setCurrentDatabase(self, dbName):
         """Sets the current default database in this session."""
-        return self._jcatalog.setCurrentDatabase(dbName)
+        self._jcatalog.setCurrentDatabase(dbName)
 
     @since(2.0)
     def listDatabases(self):
@@ -328,7 +328,7 @@ class Catalog(object):
             ...
         AnalysisException: ...
         """
-        self._jcatalog.dropTempView(viewName)
+        return self._jcatalog.dropTempView(viewName)
 
     def dropGlobalTempView(self, viewName):
         """Drops the global temporary view with the given view name in the catalog.
@@ -348,7 +348,7 @@ class Catalog(object):
             ...
         AnalysisException: ...
         """
-        self._jcatalog.dropGlobalTempView(viewName)
+        return self._jcatalog.dropGlobalTempView(viewName)
 
     def registerFunction(self, name, f, returnType=None):
         """An alias for :func:`spark.udf.register`.

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -136,6 +136,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> sorted(df.collect()) == sorted(df2.collect())
         True
         >>> spark.catalog.dropTempView("people")
+        True
+
         """
         warnings.warn(
             "Deprecated in 2.0, use createOrReplaceTempView instead.",
@@ -164,6 +166,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         ...
         AnalysisException: u"Temporary table 'people' already exists;"
         >>> spark.catalog.dropTempView("people")
+        True
 
         """
         self._jdf.createTempView(name)
@@ -185,6 +188,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> sorted(df3.collect()) == sorted(df2.collect())
         True
         >>> spark.catalog.dropTempView("people")
+        True
 
         """
         self._jdf.createOrReplaceTempView(name)
@@ -209,6 +213,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         ...
         AnalysisException: u"Temporary table 'people' already exists;"
         >>> spark.catalog.dropGlobalTempView("people")
+        True
 
         """
         self._jdf.createGlobalTempView(name)
@@ -229,6 +234,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> sorted(df3.collect()) == sorted(df2.collect())
         True
         >>> spark.catalog.dropGlobalTempView("people")
+        True
 
         """
         self._jdf.createOrReplaceGlobalTempView(name)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently `dropTempView` and `dropGlobalTempView` don't have return value, which conflicts with their docstring:
`Returns true if this view is dropped successfully, false otherwise.`. And that's not consistent with the same API in other languages.

The PR proposes a fix for that.


### Why are the changes needed?
Be consistent with API in other languages.

### Does this PR introduce _any_ user-facing change?
Yes.
#### From
```py
# dropTempView
>>> spark.createDataFrame([(1, 1)]).createTempView("my_table")
>>> spark.table("my_table").collect()
[Row(_1=1, _2=1)]  
>>> spark.catalog.dropTempView("my_table")
>>> spark.catalog.dropTempView("my_table")

# dropGlobalTempView
>>> spark.createDataFrame([(1, 1)]).createGlobalTempView("my_table")
>>> spark.table("global_temp.my_table").collect()
[Row(_1=1, _2=1)]
>>> spark.catalog.dropGlobalTempView("my_table")
>>> spark.catalog.dropGlobalTempView("my_table")
```

#### To
```py
# dropTempView
>>> spark.createDataFrame([(1, 1)]).createTempView("my_table")
>>> spark.table("my_table").collect()
[Row(_1=1, _2=1)]  
>>> spark.catalog.dropTempView("my_table")
True
>>> spark.catalog.dropTempView("my_table")
False

# dropGlobalTempView
>>> spark.createDataFrame([(1, 1)]).createGlobalTempView("my_table")
>>> spark.table("global_temp.my_table").collect()
[Row(_1=1, _2=1)]
>>> spark.catalog.dropGlobalTempView("my_table")
True
>>> spark.catalog.dropGlobalTempView("my_table")
False
```

### How was this patch tested?
Existing tests.
