### PR TITLE
[SPARK-36902][SQL] Migrate CreateTableAsSelectStatement to v2 command

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -45,17 +45,23 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
         convertTableProperties(c),
         ignoreIfExists = c.ifNotExists)
 
-    case c @ CreateTableAsSelectStatement(
-         NonSessionCatalogAndTable(catalog, tbl), _, _, _, _, _, _, _, _, _, _, _, _) =>
+    case c @ CreateTableAsSelect(
+      UnresolvedDBObjectName(
+         NonSessionCatalogAndTable(catalog, name), _), _, _, _, _, _, _, _, _, _, _, _) =>
       CreateTableAsSelect(
-        catalog.asTableCatalog,
-        tbl.asIdentifier,
+        ResolvedDBObjectName(catalog, name),
         // convert the bucket spec and add it as a transform
         c.partitioning ++ c.bucketSpec.map(_.asTransform),
-        c.asSelect,
+        c.query,
         convertTableProperties(c),
-        writeOptions = c.writeOptions,
-        ignoreIfExists = c.ifNotExists)
+        c.bucketSpec,
+        c.provider,
+        c.options,
+        c.location,
+        c.comment,
+        c.serdeInfo,
+        c.external,
+        c.ignoreIfExists)
 
     case c @ ReplaceTableStatement(
          NonSessionCatalogAndTable(catalog, tbl), _, _, _, _, _, _, _, _, _, _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3447,9 +3447,20 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
           ctx)
 
       case Some(query) =>
-        CreateTableAsSelectStatement(
-          table, query, partitioning, bucketSpec, properties, provider, options, location, comment,
-          writeOptions = Map.empty, serdeInfo, external = external, ifNotExists = ifNotExists)
+        CreateTableAsSelect(
+          UnresolvedDBObjectName(table, isNamespace = false),
+          partitioning,
+          query,
+          properties,
+          writeOptions = Map.empty,
+          bucketSpec,
+          provider,
+          options,
+          location,
+          comment,
+          serdeInfo,
+          external = external,
+          ignoreIfExists = ifNotExists)
 
       case _ =>
         // Note: table schema includes both the table columns list and the partition columns

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -143,29 +143,6 @@ case class CreateTableStatement(
     ifNotExists: Boolean) extends LeafParsedStatement
 
 /**
- * A CREATE TABLE AS SELECT command, as parsed from SQL.
- */
-case class CreateTableAsSelectStatement(
-    tableName: Seq[String],
-    asSelect: LogicalPlan,
-    partitioning: Seq[Transform],
-    bucketSpec: Option[BucketSpec],
-    properties: Map[String, String],
-    provider: Option[String],
-    options: Map[String, String],
-    location: Option[String],
-    comment: Option[String],
-    writeOptions: Map[String, String],
-    serde: Option[SerdeInfo],
-    external: Boolean,
-    ifNotExists: Boolean) extends UnaryParsedStatement {
-
-  override def child: LogicalPlan = asSelect
-  override protected def withNewChildInternal(newChild: LogicalPlan): CreateTableAsSelectStatement =
-    copy(asSelect = newChild)
-}
-
-/**
  * A CREATE VIEW statement, as parsed from SQL.
  */
 case class CreateViewStatement(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -23,7 +23,7 @@ import java.util.Collections
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.catalyst.analysis.{NamedRelation, NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException}
-import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelectStatement, CreateTableStatement, ReplaceTableAsSelectStatement, ReplaceTableStatement, SerdeInfo}
+import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelect, CreateTableStatement, ReplaceTableAsSelectStatement, ReplaceTableStatement, SerdeInfo}
 import org.apache.spark.sql.connector.catalog.TableChange._
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.{ArrayType, MapType, StructField, StructType}
@@ -298,17 +298,16 @@ private[sql] object CatalogV2Util {
       c.properties, c.options, c.serde, c.location, c.comment, c.provider, c.external)
   }
 
-  def convertTableProperties(c: CreateTableAsSelectStatement): Map[String, String] = {
-    convertTableProperties(
-      c.properties, c.options, c.serde, c.location, c.comment, c.provider, c.external)
-  }
-
   def convertTableProperties(r: ReplaceTableStatement): Map[String, String] = {
     convertTableProperties(r.properties, r.options, r.serde, r.location, r.comment, r.provider)
   }
 
   def convertTableProperties(r: ReplaceTableAsSelectStatement): Map[String, String] = {
     convertTableProperties(r.properties, r.options, r.serde, r.location, r.comment, r.provider)
+  }
+
+  def convertTableProperties(c: CreateTableAsSelect): Map[String, String] = {
+    convertTableProperties(c.properties, c.options, c.serdeInfo, c.location, c.comment, c.provider)
   }
 
   private def convertTableProperties(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -719,8 +719,8 @@ class DDLParserSuite extends AnalysisTest {
     parsedPlan match {
       case create: CreateTableStatement if newTableToken == "CREATE" =>
         assert(create.ifNotExists == expectedIfNotExists)
-      case ctas: CreateTableAsSelectStatement if newTableToken == "CREATE" =>
-        assert(ctas.ifNotExists == expectedIfNotExists)
+      case ctas: CreateTableAsSelect if newTableToken == "CREATE" =>
+        assert(ctas.ignoreIfExists == expectedIfNotExists)
       case replace: ReplaceTableStatement if newTableToken == "REPLACE" =>
       case replace: ReplaceTableAsSelectStatement if newTableToken == "REPLACE" =>
       case other =>
@@ -2469,10 +2469,10 @@ class DDLParserSuite extends AnalysisTest {
             replace.location,
             replace.comment,
             replace.serde)
-        case ctas: CreateTableAsSelectStatement =>
+        case ctas: CreateTableAsSelect =>
           TableSpec(
-            ctas.tableName,
-            Some(ctas.asSelect).filter(_.resolved).map(_.schema),
+            ctas.name.asInstanceOf[UnresolvedDBObjectName].nameParts,
+            Some(ctas.query).filter(_.resolved).map(_.schema),
             ctas.partitioning,
             ctas.bucketSpec,
             ctas.properties,
@@ -2480,7 +2480,7 @@ class DDLParserSuite extends AnalysisTest {
             ctas.options,
             ctas.location,
             ctas.comment,
-            ctas.serde,
+            ctas.serdeInfo,
             ctas.external)
         case rtas: ReplaceTableAsSelectStatement =>
           TableSpec(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Migrate ```CreateTableAsSelectStatement``` to v2 command


### Why are the changes needed?
Migrate ```CreateTableAsSelectStatement``` to v2 command


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Exist tests
