### PR TITLE
[SPARK-36907][PYTHON] Fix DataFrameGroupBy.apply without shortcut

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -1221,10 +1221,12 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 return cast(Union[Series, DataFrame], psser_or_psdf)
 
             if len(grouped) <= 1:
-                warnings.warn(
-                    "The amount of data for return type inference might not be large enough. "
-                    "Consider increasing an option `compute.shortcut_limit`."
-                )
+                with warnings.catch_warnings():
+                    warnings.simplefilter("always")
+                    warnings.warn(
+                        "The amount of data for return type inference might not be large enough. "
+                        "Consider increasing an option `compute.shortcut_limit`."
+                    )
 
             if isinstance(psser_or_psdf, Series):
                 should_return_series = True

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -42,6 +42,7 @@ from typing import (
     cast,
     TYPE_CHECKING,
 )
+import warnings
 
 import pandas as pd
 from pandas.api.types import is_hashable, is_list_like
@@ -1207,16 +1208,23 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 pdf[groupkey_name].rename(psser.name)
                 for groupkey_name, psser in zip(groupkey_names, self._groupkeys)
             ]
+            grouped = pdf.groupby(groupkeys)
             if is_series_groupby:
-                pser_or_pdf = pdf.groupby(groupkeys)[name].apply(pandas_apply, *args, **kwargs)
+                pser_or_pdf = grouped[name].apply(pandas_apply, *args, **kwargs)
             else:
-                pser_or_pdf = pdf.groupby(groupkeys).apply(pandas_apply, *args, **kwargs)
+                pser_or_pdf = grouped.apply(pandas_apply, *args, **kwargs)
             psser_or_psdf = ps.from_pandas(pser_or_pdf)
 
             if len(pdf) <= limit:
                 if isinstance(psser_or_psdf, ps.Series) and is_series_groupby:
                     psser_or_psdf = psser_or_psdf.rename(cast(SeriesGroupBy, self)._psser.name)
                 return cast(Union[Series, DataFrame], psser_or_psdf)
+
+            if len(grouped) <= 1:
+                warnings.warn(
+                    "The amount of data for return type inference might not be large enough. "
+                    "Consider increasing an option `compute.shortcut_limit`."
+                )
 
             if isinstance(psser_or_psdf, Series):
                 should_return_series = True
@@ -1295,6 +1303,8 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 pdf_or_ser = pdf.groupby(groupkey_names)[name].apply(wrapped_func, *args, **kwargs)
             else:
                 pdf_or_ser = pdf.groupby(groupkey_names).apply(wrapped_func, *args, **kwargs)
+                if should_return_series and isinstance(pdf_or_ser, pd.DataFrame):
+                    pdf_or_ser = pdf_or_ser.stack()
 
             if not isinstance(pdf_or_ser, pd.DataFrame):
                 return pd.DataFrame(pdf_or_ser)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `DataFrameGroupBy.apply` without shortcut.

Pandas' `DataFrameGroupBy.apply` sometimes behaves weirdly when the udf returns `Series` and whether there is only one group or more. E.g.,:

```py
>>> pdf = pd.DataFrame(
...      {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},
...      columns=["a", "b", "c"],
... )

>>> pdf.groupby('b').apply(lambda x: x['a'])
b
1  0    1
   1    2
2  2    3
3  3    4
5  4    5
8  5    6
Name: a, dtype: int64
>>> pdf[pdf['b'] == 1].groupby('b').apply(lambda x: x['a'])
a  0  1
b
1  1  2
```

If there is only one group, it returns a "wide" `DataFrame` instead of `Series`.

In our non-shortcut path, there is always only one group because it will be run in `groupby-applyInPandas`, so we will get `DataFrame`, then we should convert it to `Series` ourselves.

### Why are the changes needed?

`DataFrameGroupBy.apply` without shortcut could raise an exception when it returns `Series`.

```py
>>> ps.options.compute.shortcut_limit = 3
>>> psdf = ps.DataFrame(
...     {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},
...     columns=["a", "b", "c"],
... )
>>> psdf.groupby("b").apply(lambda x: x["a"])
org.apache.spark.api.python.PythonException: Traceback (most recent call last):
...
ValueError: Length mismatch: Expected axis has 2 elements, new values have 3 elements
```

### Does this PR introduce _any_ user-facing change?

The error above will be gone:

```py
>>> psdf.groupby("b").apply(lambda x: x["a"])
b
1  0    1
   1    2
2  2    3
3  3    4
5  4    5
8  5    6
Name: a, dtype: int64
```

### How was this patch tested?

Added tests.