### PR TITLE
[SPARK-36915][INFRA] Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/cancel_duplicate_workflow_runs.yml
+++ b/.github/workflows/cancel_duplicate_workflow_runs.yml
@@ -29,7 +29,7 @@ jobs:
     name: "Cancel duplicate workflow runs"
     runs-on: ubuntu-latest
     steps:
-      - uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738 # @master
+      - uses: potiuk/cancel-workflow-runs@4723494a065d162f8e9efd071b98e0126e00f866 # @master
         name: "Cancel duplicate workflow runs"
         with:
           cancelMode: allDuplicates

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -22,6 +22,7 @@
 # currently randomly picks any associated workflow.
 # So, the name was changed to make sense in that context too.
 # See also https://github.community/t/specify-check-suite-when-creating-a-checkrun/118380/10
+
 name: "On pull requests"
 on: pull_request_target
 
@@ -30,20 +31,20 @@ jobs:
     name: Label pull requests
     runs-on: ubuntu-latest
     steps:
-      # In order to get back the negated matches like in the old config,
-      # we need the actinons/labeler concept of `all` and `any` which matches
-      # all of the given constraints / glob patterns for either `all`
-      # files or `any` file in the change set.
-      #
-      # Github issue which requests a timeline for a release with any/all support:
-      #     - https://github.com/actions/labeler/issues/111
-      # This issue also references the issue that mentioned that any/all are only
-      # supported on main branch (previously called master):
-      #    - https://github.com/actions/labeler/issues/73#issuecomment-639034278
-      #
-      # However, these are not in a published release and the current `main` branch
-      # has some issues upon testing.
-      - uses: actions/labeler@5f867a63be70efff62b767459b009290364495eb # pin@2.2.0
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: true
+    # In order to get back the negated matches like in the old config,
+    # we need the actinons/labeler concept of `all` and `any` which matches
+    # all of the given constraints / glob patterns for either `all`
+    # files or `any` file in the change set.
+    #
+    # Github issue which requests a timeline for a release with any/all support:
+    #     - https://github.com/actions/labeler/issues/111
+    # This issue also references the issue that mentioned that any/all are only
+    # supported on main branch (previously called master):
+    #    - https://github.com/actions/labeler/issues/73#issuecomment-639034278
+    #
+    # However, these are not in a published release and the current `main` branch
+    # has some issues upon testing.
+    - uses: actions/labeler@5f867a63be70efff62b767459b009290364495eb # pin@2.2.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -22,7 +22,6 @@
 # currently randomly picks any associated workflow.
 # So, the name was changed to make sense in that context too.
 # See also https://github.community/t/specify-check-suite-when-creating-a-checkrun/118380/10
-
 name: "On pull requests"
 on: pull_request_target
 
@@ -31,20 +30,20 @@ jobs:
     name: Label pull requests
     runs-on: ubuntu-latest
     steps:
-    # In order to get back the negated matches like in the old config,
-    # we need the actinons/labeler concept of `all` and `any` which matches
-    # all of the given constraints / glob patterns for either `all`
-    # files or `any` file in the change set.
-    #
-    # Github issue which requests a timeline for a release with any/all support:
-    #     - https://github.com/actions/labeler/issues/111
-    # This issue also references the issue that mentioned that any/all are only
-    # supported on main branch (previously called master):
-    #    - https://github.com/actions/labeler/issues/73#issuecomment-639034278
-    #
-    # However, these are not in a published release and the current `main` branch
-    # has some issues upon testing.
-    - uses: actions/labeler@2.2.0
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
+      # In order to get back the negated matches like in the old config,
+      # we need the actinons/labeler concept of `all` and `any` which matches
+      # all of the given constraints / glob patterns for either `all`
+      # files or `any` file in the change set.
+      #
+      # Github issue which requests a timeline for a release with any/all support:
+      #     - https://github.com/actions/labeler/issues/111
+      # This issue also references the issue that mentioned that any/all are only
+      # supported on main branch (previously called master):
+      #    - https://github.com/actions/labeler/issues/73#issuecomment-639034278
+      #
+      # However, these are not in a published release and the current `main` branch
+      # has some issues upon testing.
+      - uses: actions/labeler@5f867a63be70efff62b767459b009290364495eb # pin@2.2.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true

--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -25,7 +25,7 @@
 name: On pull request update
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   notify:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Notify test workflow"
-        uses: actions/github-script@v3
+        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3 # pin@v3
         if: ${{ github.base_ref == 'master' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -25,7 +25,7 @@
 name: On pull request update
 on:
   pull_request_target:
-    types: [ opened, reopened, synchronize ]
+    types: [opened, reopened, synchronize]
 
 jobs:
   notify:

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -21,7 +21,7 @@ name: Publish Snapshot
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+  - cron: '0 0 * * *'
 
 jobs:
   publish-snapshot:

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -35,26 +35,26 @@ jobs:
           - branch-3.2
           - branch-3.1
     steps:
-      - name: Checkout Spark repository
-        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # pin@master
-        with:
-          ref: ${{ matrix.branch }}
-      - name: Cache Maven local repository
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # pin@v2
-        with:
-          path: ~/.m2/repository
-          key: snapshot-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            snapshot-maven-
-      - name: Install Java 8
-        uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # pin@v1
-        with:
-          java-version: 8
-      - name: Publish snapshot
-        env:
-          ASF_USERNAME: ${{ secrets.NEXUS_USER }}
-          ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
-          GPG_KEY: "not_used"
-          GPG_PASSPHRASE: "not_used"
-          GIT_REF: ${{ matrix.branch }}
-        run: ./dev/create-release/release-build.sh publish-snapshot
+    - name: Checkout Spark repository
+      uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # pin@master
+      with:
+        ref: ${{ matrix.branch }}
+    - name: Cache Maven local repository
+      uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # pin@v2
+      with:
+        path: ~/.m2/repository
+        key: snapshot-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          snapshot-maven-
+    - name: Install Java 8
+      uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # pin@v1
+      with:
+        java-version: 8
+    - name: Publish snapshot
+      env:
+        ASF_USERNAME: ${{ secrets.NEXUS_USER }}
+        ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
+        GPG_KEY: "not_used"
+        GPG_PASSPHRASE: "not_used"
+        GIT_REF: ${{ matrix.branch }}
+      run: ./dev/create-release/release-build.sh publish-snapshot

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -21,7 +21,7 @@ name: Publish Snapshot
 
 on:
   schedule:
-  - cron: '0 0 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   publish-snapshot:
@@ -35,26 +35,26 @@ jobs:
           - branch-3.2
           - branch-3.1
     steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@master
-      with:
-        ref: ${{ matrix.branch }}
-    - name: Cache Maven local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: snapshot-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          snapshot-maven-
-    - name: Install Java 8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - name: Publish snapshot
-      env:
-        ASF_USERNAME: ${{ secrets.NEXUS_USER }}
-        ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
-        GPG_KEY: "not_used"
-        GPG_PASSPHRASE: "not_used"
-        GIT_REF: ${{ matrix.branch }}
-      run: ./dev/create-release/release-build.sh publish-snapshot
+      - name: Checkout Spark repository
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # pin@master
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Cache Maven local repository
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # pin@v2
+        with:
+          path: ~/.m2/repository
+          key: snapshot-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            snapshot-maven-
+      - name: Install Java 8
+        uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # pin@v1
+        with:
+          java-version: 8
+      - name: Publish snapshot
+        env:
+          ASF_USERNAME: ${{ secrets.NEXUS_USER }}
+          ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
+          GPG_KEY: "not_used"
+          GPG_PASSPHRASE: "not_used"
+          GIT_REF: ${{ matrix.branch }}
+        run: ./dev/create-release/release-build.sh publish-snapshot

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,22 +21,22 @@ name: Close stale PRs
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+  - cron: "0 0 * * *"
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@c201d45ef4b0ccbd3bb0616f93bae13e73d0a080 # pin@v1.1.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-pr-message: >
-            We're closing this PR because it hasn't been updated in a while.
-            This isn't a judgement on the merit of the PR in any way. It's just
-            a way of keeping the PR queue manageable.
+    - uses: actions/stale@c201d45ef4b0ccbd3bb0616f93bae13e73d0a080 # pin@v1.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: >
+          We're closing this PR because it hasn't been updated in a while.
+          This isn't a judgement on the merit of the PR in any way. It's just
+          a way of keeping the PR queue manageable.
 
-            If you'd like to revive this PR, please reopen it and ask a committer to remove the Stale tag!
-          days-before-stale: 100
-          # Setting this to 0 is the same as setting it to 1.
-          # See: https://github.com/actions/stale/issues/28
-          days-before-close: 0
+          If you'd like to revive this PR, please reopen it and ask a committer to remove the Stale tag!
+        days-before-stale: 100
+        # Setting this to 0 is the same as setting it to 1.
+        # See: https://github.com/actions/stale/issues/28
+        days-before-close: 0

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,23 +21,22 @@ name: Close stale PRs
 
 on:
   schedule:
-  - cron: "0 0 * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1.1.0
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: >
-          We're closing this PR because it hasn't been updated in a while.
-          This isn't a judgement on the merit of the PR in any way. It's just
-          a way of keeping the PR queue manageable.
+      - uses: actions/stale@c201d45ef4b0ccbd3bb0616f93bae13e73d0a080 # pin@v1.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: >
+            We're closing this PR because it hasn't been updated in a while.
+            This isn't a judgement on the merit of the PR in any way. It's just
+            a way of keeping the PR queue manageable.
 
-          If you'd like to revive this PR, please reopen it and ask a
-          committer to remove the Stale tag!
-        days-before-stale: 100
-        # Setting this to 0 is the same as setting it to 1.
-        # See: https://github.com/actions/stale/issues/28
-        days-before-close: 0
+            If you'd like to revive this PR, please reopen it and ask a committer to remove the Stale tag!
+          days-before-stale: 100
+          # Setting this to 0 is the same as setting it to 1.
+          # See: https://github.com/actions/stale/issues/28
+          days-before-close: 0

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -35,7 +35,8 @@ jobs:
           This isn't a judgement on the merit of the PR in any way. It's just
           a way of keeping the PR queue manageable.
 
-          If you'd like to revive this PR, please reopen it and ask a committer to remove the Stale tag!
+          If you'd like to revive this PR, please reopen it and ask a
+          committer to remove the Stale tag!
         days-before-stale: 100
         # Setting this to 0 is the same as setting it to 1.
         # See: https://github.com/actions/stale/issues/28

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -20,7 +20,7 @@
 name: Report test results
 on:
   workflow_run:
-    workflows: ["Build and test"]
+    workflows: [ "Build and test" ]
     types:
       - completed
 
@@ -28,17 +28,17 @@ jobs:
   test_report:
     runs-on: ubuntu-latest
     steps:
-    - name: Download test results to report
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        workflow: ${{ github.event.workflow_run.workflow_id }}
-        commit: ${{ github.event.workflow_run.head_commit.id }}
-        workflow_conclusion: completed
-    - name: Publish test report
-      uses: scacap/action-surefire-report@v1
-      with:
-        check_name: Report test results
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        report_paths: "**/target/test-reports/*.xml"
-        commit: ${{ github.event.workflow_run.head_commit.id }}
+      - name: Download test results to report
+        uses: dawidd6/action-download-artifact@6f8f427fb41886a66b82ea11a5a15d1454c79415 # pin@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          workflow_conclusion: completed
+      - name: Publish test report
+        uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648 # pin@v1
+        with:
+          check_name: Report test results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: "**/target/test-reports/*.xml"
+          commit: ${{ github.event.workflow_run.head_commit.id }}

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -20,7 +20,7 @@
 name: Report test results
 on:
   workflow_run:
-    workflows: [ "Build and test" ]
+    workflows: ["Build and test"]
     types:
       - completed
 
@@ -28,17 +28,17 @@ jobs:
   test_report:
     runs-on: ubuntu-latest
     steps:
-      - name: Download test results to report
-        uses: dawidd6/action-download-artifact@6f8f427fb41886a66b82ea11a5a15d1454c79415 # pin@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          commit: ${{ github.event.workflow_run.head_commit.id }}
-          workflow_conclusion: completed
-      - name: Publish test report
-        uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648 # pin@v1
-        with:
-          check_name: Report test results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: "**/target/test-reports/*.xml"
-          commit: ${{ github.event.workflow_run.head_commit.id }}
+    - name: Download test results to report
+      uses: dawidd6/action-download-artifact@6f8f427fb41886a66b82ea11a5a15d1454c79415 # pin@v2
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        commit: ${{ github.event.workflow_run.head_commit.id }}
+        workflow_conclusion: completed
+    - name: Publish test report
+      uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648 # pin@v1
+      with:
+        check_name: Report test results
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        report_paths: "**/target/test-reports/*.xml"
+        commit: ${{ github.event.workflow_run.head_commit.id }}

--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -21,7 +21,7 @@ name: Update build status workflow
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+  - cron: "*/15 * * * *"
 
 jobs:
   update:

--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -21,7 +21,7 @@ name: Update build status workflow
 
 on:
   schedule:
-  - cron: "*/15 * * * *"
+    - cron: "*/15 * * * *"
 
 jobs:
   update:
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Update build status"
-        uses: actions/github-script@v3
+        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3 # pin@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
Pinning github actions to a SHA


### Why are the changes needed?
Pinning an action to a full length commit SHA is currently the only way to use an action as
an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a
backdoor to the action's repository, as they would need to generate a SHA-1 collision for
a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies


### Does this PR introduce _any_ user-facing change?
Running github action and checking the SHA with the existing repository


### How was this patch tested?
Running the GitHub action
