### PR TITLE
[SPARK-36918][SQL] Ignore types when comparing structs for unionByName

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -429,8 +429,7 @@ object DataType {
   }
 
   /**
-   * Returns true if the two data types share the same shape by name, i.e. the names
-   * are the same, but the types don't need to be the same.
+   * Returns true if the two data types have the same field names in order recursively.
    */
   def equalsStructurallyByName(
       from: DataType,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -428,6 +428,33 @@ object DataType {
     }
   }
 
+  /**
+   * Returns true if the two data types share the same shape by name, i.e. the names
+   * are the same, but the types don't need to be the same.
+   */
+  def equalsStructurallyByName(
+      from: DataType,
+      to: DataType,
+      resolver: Resolver): Boolean = {
+    (from, to) match {
+      case (left: ArrayType, right: ArrayType) =>
+        equalsStructurallyByName(left.elementType, right.elementType, resolver)
+
+      case (left: MapType, right: MapType) =>
+        equalsStructurallyByName(left.keyType, right.keyType, resolver) &&
+          equalsStructurallyByName(left.valueType, right.valueType, resolver)
+
+      case (StructType(fromFields), StructType(toFields)) =>
+        fromFields.length == toFields.length &&
+          fromFields.zip(toFields)
+            .forall { case (l, r) =>
+              resolver(l.name, r.name) && equalsStructurallyByName(l.dataType, r.dataType, resolver)
+            }
+
+      case _ => true
+    }
+  }
+
   private val SparkGeneratedName = """col\d+""".r
   private def isSparkGeneratedName(name: String): Boolean = name match {
     case SparkGeneratedName(_*) => true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.types
 import com.fasterxml.jackson.core.JsonParseException
 
 import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.sql.catalyst.analysis.{caseInsensitiveResolution, caseSensitiveResolution}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.util.StringUtils.StringConcat
 import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, yearMonthIntervalTypes}
@@ -583,6 +584,69 @@ class DataTypeSuite extends SparkFunSuite {
       ArrayType(IntegerType, true), ArrayType(IntegerType, true), true),
     true,
     ignoreNullability = true)
+
+  def checkEqualsStructurallyByName(
+      from: DataType,
+      to: DataType,
+      expected: Boolean,
+      caseSensitive: Boolean = false): Unit = {
+    val testName = s"equalsStructurallyByName: (from: $from, to: $to, " +
+        s"caseSensitive: $caseSensitive)"
+
+    val resolver = if (caseSensitive) {
+      caseSensitiveResolution
+    } else {
+      caseInsensitiveResolution
+    }
+
+    test(testName) {
+      assert(DataType.equalsStructurallyByName(from, to, resolver) === expected)
+    }
+  }
+
+  checkEqualsStructurallyByName(
+    ArrayType(
+      ArrayType(IntegerType)),
+    ArrayType(
+      ArrayType(IntegerType)),
+    true)
+
+  // Type doesn't matter
+  checkEqualsStructurallyByName(BooleanType, BooleanType, true)
+  checkEqualsStructurallyByName(BooleanType, IntegerType, true)
+  checkEqualsStructurallyByName(IntegerType, LongType, true)
+
+  checkEqualsStructurallyByName(
+    new StructType().add("f1", IntegerType).add("f2", IntegerType),
+    new StructType().add("f1", LongType).add("f2", StringType),
+    true)
+
+  checkEqualsStructurallyByName(
+    new StructType().add("f1", IntegerType).add("f2", IntegerType),
+    new StructType().add("f2", LongType).add("f1", StringType),
+    false)
+
+  checkEqualsStructurallyByName(
+    new StructType().add("f1", IntegerType).add("f", new StructType().add("f2", StringType)),
+    new StructType().add("f1", LongType).add("f", new StructType().add("f2", BooleanType)),
+    true)
+
+  checkEqualsStructurallyByName(
+    new StructType().add("f1", IntegerType).add("f", new StructType().add("f2", StringType)),
+    new StructType().add("f", new StructType().add("f2", BooleanType)).add("f1", LongType),
+    false)
+
+  checkEqualsStructurallyByName(
+    new StructType().add("f1", IntegerType).add("f2", IntegerType),
+    new StructType().add("F1", LongType).add("F2", StringType),
+    true,
+    caseSensitive = false)
+
+  checkEqualsStructurallyByName(
+    new StructType().add("f1", IntegerType).add("f2", IntegerType),
+    new StructType().add("F1", LongType).add("F2", StringType),
+    false,
+    caseSensitive = true)
 
   test("SPARK-25031: MapType should produce current formatted string for complex types") {
     val keyType: DataType = StructType(Seq(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -590,7 +590,7 @@ class DataTypeSuite extends SparkFunSuite {
       to: DataType,
       expected: Boolean,
       caseSensitive: Boolean = false): Unit = {
-    val testName = s"equalsStructurallyByName: (from: $from, to: $to, " +
+    val testName = s"SPARK-36918: equalsStructurallyByName: (from: $from, to: $to, " +
         s"caseSensitive: $caseSensitive)"
 
     val resolver = if (caseSensitive) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Rather than using `DataType.sameType` for comparing structs when unioning by name, only compare the names and orders of the fields, since all we are doing is determining if we need to recreate the struct in a different order. After ResolveUnion is done, the normal union will handle if the types are incompatible or not.

Additionally, adds a check to the recursive struct handling as well, so we don't have to recreate a nested struct if only one of its parents or siblings are different.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Performance improvement, especially with nested nullable structs, which get wrapped in an If(IsNull()). Unioning three or more structs can explode the plan due to the multiple structs created extracting values from If(IsNull()) values when the projections are collapsed.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, just a performance improvement.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New unit test for the helper method, and existing tests still pass.
