### PR TITLE
[SPARK-36929][SQL] Remove Unused Method EliminateSubqueryAliasesSuite#assertEquivalent

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSubqueryAliasesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSubqueryAliasesSuite.scala
@@ -34,12 +34,6 @@ class EliminateSubqueryAliasesSuite extends PlanTest with PredicateHelper {
     val batches = Batch("EliminateSubqueryAliases", Once, EliminateSubqueryAliases) :: Nil
   }
 
-  private def assertEquivalent(e1: Expression, e2: Expression): Unit = {
-    val correctAnswer = Project(Alias(e2, "out")() :: Nil, OneRowRelation()).analyze
-    val actual = Optimize.execute(Project(Alias(e1, "out")() :: Nil, OneRowRelation()).analyze)
-    comparePlans(actual, correctAnswer)
-  }
-
   private def afterOptimization(plan: LogicalPlan): LogicalPlan = {
     Optimize.execute(analysis.SimpleAnalyzer.execute(plan))
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSubqueryAliasesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSubqueryAliasesSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.PlanTest


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove Unused method in EliminateSubqueryAliasesSuite


### Why are the changes needed?
Remove Unused method to simplify the codebase.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

Covered by existing tests.