### PR TITLE
[SPARK-36096][CORE] Grouping exception in core/resource

### DIFF
--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -157,6 +157,14 @@ object SparkCoreErrors {
     new SparkException("Checkpoint dir must be specified.")
   }
 
+  def resourceNotExistInProfileIdError(resource: String, id: Int): Throwable = {
+    new SparkException(s"Resource $resource doesn't exist in profile id: $id")
+  }
+
+  def noAmountSpecifiedForResourceError(str: String): Throwable = {
+    new SparkException(s"You must specify an amount for ${str}")
+  }
+
   def askStandaloneSchedulerToShutDownExecutorsError(e: Exception): Throwable = {
     new SparkException("Error asking standalone scheduler to shut down executors", e)
   }

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.annotation.{Evolving, Since}
+import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Python.PYSPARK_EXECUTOR_MEMORY
@@ -101,7 +102,7 @@ class ResourceProfile(
    */
   private[spark] def getSchedulerTaskResourceAmount(resource: String): Int = {
     val taskAmount = taskResources.getOrElse(resource,
-      throw new SparkException(s"Resource $resource doesn't exist in profile id: $id"))
+      throw SparkCoreErrors.resourceNotExistInProfileIdError(resource, id))
    if (taskAmount.amount < 1) 1 else taskAmount.amount.toInt
   }
 
@@ -110,7 +111,7 @@ class ResourceProfile(
       calculateTasksAndLimitingResource(sparkConf)
     }
     _executorResourceSlotsPerAddr.get.getOrElse(resource,
-      throw new SparkException(s"Resource $resource doesn't exist in profile id: $id"))
+      throw SparkCoreErrors.resourceNotExistInProfileIdError(resource, id))
   }
 
   // Maximum tasks you could put on an executor with this profile based on the limiting resource.

--- a/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
@@ -28,6 +28,7 @@ import org.json4s.jackson.JsonMethods._
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.api.resource.ResourceDiscoveryPlugin
+import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.{EXECUTOR_CORES, RESOURCES_DISCOVERY_PLUGIN, SPARK_TASK_PREFIX}
 import org.apache.spark.internal.config.Tests.{RESOURCES_WARNING_TESTING}
@@ -140,7 +141,7 @@ private[spark] object ResourceUtils extends Logging {
   def parseResourceRequest(sparkConf: SparkConf, resourceId: ResourceID): ResourceRequest = {
     val settings = sparkConf.getAllWithPrefix(resourceId.confPrefix).toMap
     val amount = settings.getOrElse(AMOUNT,
-      throw new SparkException(s"You must specify an amount for ${resourceId.resourceName}")
+      throw SparkCoreErrors.noAmountSpecifiedForResourceError(resourceId.resourceName)
     ).toInt
     val discoveryScript = Optional.ofNullable(settings.get(DISCOVERY_SCRIPT).orNull)
     val vendor = Optional.ofNullable(settings.get(VENDOR).orNull)
@@ -193,7 +194,7 @@ private[spark] object ResourceUtils extends Logging {
     listResourceIds(sparkConf, SPARK_TASK_PREFIX).map { resourceId =>
       val settings = sparkConf.getAllWithPrefix(resourceId.confPrefix).toMap
       val amountDouble = settings.getOrElse(AMOUNT,
-        throw new SparkException(s"You must specify an amount for ${resourceId.resourceName}")
+        throw SparkCoreErrors.noAmountSpecifiedForResourceError(resourceId.resourceName)
       ).toDouble
       treqs.resource(resourceId.resourceName, amountDouble)
     }
@@ -205,7 +206,7 @@ private[spark] object ResourceUtils extends Logging {
     val rnamesAndAmounts = resourceIds.map { resourceId =>
       val settings = sparkConf.getAllWithPrefix(resourceId.confPrefix).toMap
       val amountDouble = settings.getOrElse(AMOUNT,
-        throw new SparkException(s"You must specify an amount for ${resourceId.resourceName}")
+        throw SparkCoreErrors.noAmountSpecifiedForResourceError(resourceId.resourceName)
       ).toDouble
       (resourceId.resourceName, amountDouble)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR group exception messages in core/src/main/scala/org/apache/spark/resource

### Why are the changes needed?
It will largely help with standardization of error messages and its maintenance.

### Does this PR introduce _any_ user-facing change?
No. Error messages remain unchanged.

### How was this patch tested?
No new tests - pass all original tests to make sure it doesn't break any existing behavior.