### PR TITLE
[SPARK-36939][PYTHON][DOCS] Add orphan migration page into list in PySpark documentation

### DIFF
--- a/python/docs/source/migration_guide/index.rst
+++ b/python/docs/source/migration_guide/index.rst
@@ -25,6 +25,7 @@ This page describes the migration guide specific to PySpark.
 .. toctree::
    :maxdepth: 2
 
+   pyspark_3.2_to_3.3
    pyspark_3.1_to_3.2
    pyspark_2.4_to_3.0
    pyspark_2.3_to_2.4


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the warning below during PySpark documentation build:

```
checking consistency... /.../spark/python/docs/source/migration_guide/pyspark_3.2_to_3.3.rst: WARNING: document isn't included in any toctree
done
```

SPARK-36618 added a new migration guide page but that's mistakenly not added to `spark/python/docs/source/migration_guideindex.rst` resulting in not being shown.

### Why are the changes needed?

To show the migration guides to end users.

### Does this PR introduce _any_ user-facing change?

It's not yet released but we should better backport to branch-3.2.
It's a followup of the new page in PySpark documentation (branch-3.2).

### How was this patch tested?

Manually built the docs
