### PR TITLE
[SPARK-36751][PYTHON][DOCS][FOLLOW-UP] Fix unexpected section title for Examples in docstring

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -3329,7 +3329,7 @@ def octet_length(col: "ColumnOrName") -> Column:
         Byte length of the col
 
     Examples
-    -------
+    --------
     >>> from pyspark.sql.functions import octet_length
     >>> spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat']) \
             .select(octet_length('cat')).collect()
@@ -3355,7 +3355,7 @@ def bit_length(col: "ColumnOrName") -> Column:
         Bit length of the col
 
     Examples
-    -------
+    --------
     >>> from pyspark.sql.functions import bit_length
     >>> spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat']) \
             .select(bit_length('cat')).collect()

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -3331,8 +3331,8 @@ def octet_length(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> from pyspark.sql.functions import octet_length
-    >>> spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat']) \
-            .select(octet_length('cat')).collect()
+    >>> spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat']) \\
+    ...      .select(octet_length('cat')).collect()
         [Row(octet_length(cat)=3), Row(octet_length(cat)=4)]
     """
     return _invoke_function_over_column("octet_length", col)
@@ -3357,8 +3357,8 @@ def bit_length(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> from pyspark.sql.functions import bit_length
-    >>> spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat']) \
-            .select(bit_length('cat')).collect()
+    >>> spark.createDataFrame([('cat',), ( '\U0001F408',)], ['cat']) \\
+    ...      .select(bit_length('cat')).collect()
         [Row(bit_length(cat)=24), Row(bit_length(cat)=32)]
     """
     return _invoke_function_over_column("bit_length", col)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a minor followup of https://github.com/apache/spark/pull/33992 to fix the warnings during PySpark documentation build:

```
/.../spark/python/pyspark/sql/functions.py:docstring of pyspark.sql.functions.bit_length:19: WARNING: Unexpected section title or transition.

-------
/.../spark/python/pyspark/sql/functions.py:docstring of pyspark.sql.functions.octet_length:19: WARNING: Unexpected section title or transition.

-------
```

We should always have the same length of hyphens with the title.

### Why are the changes needed?

To remove warnings during the documentation build and show the HTML pages correctly.

### Does this PR introduce _any_ user-facing change?

This is not released yet, and only in master branch. So, no to end users.

### How was this patch tested?

Manually built the docs via `make clean html` at `python/docs` directory.