### PR TITLE
[SPARK-36935][SQL] Extend ParquetSchemaConverter to compute Parquet repetition & definition level

### DIFF
--- a/sql/core/src/main/java/org/apache/parquet/io/ColumnIOUtil.java
+++ b/sql/core/src/main/java/org/apache/parquet/io/ColumnIOUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.parquet.io;
+
+/**
+ * This is a workaround since methods below are not public in {@link ColumnIO}.
+ *
+ * TODO(SPARK-36511): we should remove this once PARQUET-2050 and PARQUET-2083 are released with
+ *   Parquet 1.13.
+ */
+public class ColumnIOUtil {
+  private ColumnIOUtil() {}
+
+  public static int getDefinitionLevel(ColumnIO column) {
+    return column.getDefinitionLevel();
+  }
+
+  public static int getRepetitionLevel(ColumnIO column) {
+    return column.getRepetitionLevel();
+  }
+
+  public static String[] getFieldPath(ColumnIO column) {
+    return column.getFieldPath();
+  }
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
@@ -200,6 +200,7 @@ public abstract class SpecificParquetRecordReaderBase<T> extends RecordReader<Vo
     Configuration config = new Configuration();
     config.setBoolean(SQLConf.PARQUET_BINARY_AS_STRING().key() , false);
     config.setBoolean(SQLConf.PARQUET_INT96_AS_TIMESTAMP().key(), false);
+    config.setBoolean(SQLConf.CASE_SENSITIVE().key(), false);
     this.sparkSchema = new ParquetToSparkSchemaConverter(config).convert(requestedSchema);
     this.totalRowCount = totalRowCount;
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
@@ -152,6 +152,7 @@ public abstract class SpecificParquetRecordReaderBase<T> extends RecordReader<Vo
     Configuration config = new Configuration();
     config.setBoolean(SQLConf.PARQUET_BINARY_AS_STRING().key() , false);
     config.setBoolean(SQLConf.PARQUET_INT96_AS_TIMESTAMP().key(), false);
+    config.setBoolean(SQLConf.CASE_SENSITIVE().key(), false);
 
     this.file = new Path(path);
     long length = this.file.getFileSystem(config).getFileStatus(this.file).getLen();

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumn.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumn.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import scala.collection.mutable
-
 import org.apache.parquet.column.ColumnDescriptor
-import org.apache.parquet.io.{ColumnIOUtil, GroupColumnIO, PrimitiveColumnIO}
+import org.apache.parquet.io.ColumnIOUtil
+import org.apache.parquet.io.GroupColumnIO
+import org.apache.parquet.io.PrimitiveColumnIO
 import org.apache.parquet.schema.Type.Repetition
 
 import org.apache.spark.sql.types.DataType
@@ -38,19 +38,6 @@ case class ParquetColumn(
     children: Seq[ParquetColumn]) {
 
   def isPrimitive: Boolean = descriptor.nonEmpty
-
-  /**
-   * Returns all the leaves (i.e., primitive columns) of this, in depth-first order.
-   */
-  def leaves: Seq[ParquetColumn] = {
-    val buffer = mutable.ArrayBuffer[ParquetColumn]()
-    leaves0(buffer)
-    buffer.toSeq
-  }
-
-  private def leaves0(buffer: mutable.ArrayBuffer[ParquetColumn]): Unit = {
-    children.foreach(_.leaves0(buffer))
-  }
 }
 
 object ParquetColumn {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -25,8 +25,9 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.parquet.column.Dictionary
+import org.apache.parquet.io.ColumnIOFactory
 import org.apache.parquet.io.api.{Binary, Converter, GroupConverter, PrimitiveConverter}
-import org.apache.parquet.schema.{GroupType, Type}
+import org.apache.parquet.schema.{GroupType, Type, Types}
 import org.apache.parquet.schema.LogicalTypeAnnotation._
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.{BINARY, FIXED_LEN_BYTE_ARRAY, INT32, INT64, INT96}
 
@@ -609,7 +610,9 @@ private[parquet] class ParquetRowConverter(
       //
       // If the element type does not match the Catalyst type and the underlying repeated type
       // does not belong to the legacy LIST type, then it is case 1; otherwise, it is case 2.
-      val guessedElementType = schemaConverter.convertField(repeatedType)
+      val messageType = Types.buildMessage().addField(repeatedType).named("foo")
+      val column = new ColumnIOFactory().getColumnIO(messageType)
+      val guessedElementType = schemaConverter.convertField(column.getChild(0)).sparkType
       val isLegacy = schemaConverter.isElementType(repeatedType, parquetSchema.getName)
 
       if (DataType.equalsIgnoreCompatibleNullability(guessedElementType, elementType) || isLegacy) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -610,6 +610,10 @@ private[parquet] class ParquetRowConverter(
       //
       // If the element type does not match the Catalyst type and the underlying repeated type
       // does not belong to the legacy LIST type, then it is case 1; otherwise, it is case 2.
+      //
+      // Since `convertField` method requires a Parquet `ColumnIO` as input, here we first create
+      // a dummy message type which wraps the given repeated type, and then convert it to the
+      // `ColumnIO` using Parquet API.
       val messageType = Types.buildMessage().addField(repeatedType).named("foo")
       val column = new ColumnIOFactory().getColumnIO(messageType)
       val guessedElementType = schemaConverter.convertField(column.getChild(0)).sparkType

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -74,7 +74,7 @@ class ParquetToSparkSchemaConverter(
    * This is necessary since conversion from Parquet to Spark could cause precision loss. For
    * instance, Spark read schema is smallint/tinyint but Parquet only support int.
    */
-  def convertTypeInfo(
+  def convertParquetType(
       parquetSchema: MessageType,
       sparkReadSchema: Option[StructType] = None,
       caseSensitive: Boolean = true): ParquetType = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -115,7 +115,7 @@ class ParquetToSparkSchemaConverter(
         }
       }
 
-      var convertedField = convertField(field, fieldReadType)
+      val convertedField = convertField(field, fieldReadType)
 
       field.getType.getRepetition match {
         case OPTIONAL | REQUIRED =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetType.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetType.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import scala.collection.mutable
+
+import org.apache.parquet.column.ColumnDescriptor
+import org.apache.parquet.io.{ColumnIOUtil, GroupColumnIO, PrimitiveColumnIO}
+import org.apache.parquet.schema.Type.Repetition
+
+import org.apache.spark.sql.types.DataType
+
+/**
+ * Rich type information for a Parquet type together with its SparkSQL type.
+ */
+case class ParquetType(
+    sparkType: DataType,
+    descriptor: Option[ColumnDescriptor], // only set when this is a primitive type
+    repetitionLevel: Int,
+    definitionLevel: Int,
+    required: Boolean,
+    path: Seq[String],
+    children: Seq[ParquetType]) {
+
+  def isPrimitive: Boolean = descriptor.nonEmpty
+
+  /**
+   * Returns all the leaves (i.e., primitive columns) of this, in depth-first order.
+   */
+  def leaves: Seq[ParquetType] = {
+    val buffer = mutable.ArrayBuffer[ParquetType]()
+    leaves0(buffer)
+    buffer.toSeq
+  }
+
+  private def leaves0(buffer: mutable.ArrayBuffer[ParquetType]): Unit = {
+    children.foreach(_.leaves0(buffer))
+  }
+}
+
+object ParquetType {
+  def apply(sparkType: DataType, io: PrimitiveColumnIO): ParquetType = {
+    this(sparkType, Some(io.getColumnDescriptor), ColumnIOUtil.getRepetitionLevel(io),
+      ColumnIOUtil.getDefinitionLevel(io), io.getType.isRepetition(Repetition.REQUIRED),
+      ColumnIOUtil.getFieldPath(io), Seq.empty)
+  }
+
+  def apply(sparkType: DataType, io: GroupColumnIO, children: Seq[ParquetType]): ParquetType = {
+    this(sparkType, None, ColumnIOUtil.getRepetitionLevel(io),
+      ColumnIOUtil.getDefinitionLevel(io), io.getType.isRepetition(Repetition.REQUIRED),
+      ColumnIOUtil.getFieldPath(io), children)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -139,8 +139,8 @@ abstract class ParquetSchemaTest extends ParquetTest with SharedSparkSession {
         s"actual = ${actual.sparkType}, expected = ${expected.sparkType}")
     assert(actual.descriptor === expected.descriptor, "column descriptor mismatch: " +
         s"actual = ${actual.descriptor}, expected = ${expected.descriptor})")
-    // Parquet ColumnDescriptor equals only compare path so we'll need to compare other fields
-    // explicitly here
+    // since Parquet ColumnDescriptor equals only compares path, we'll need to compare other
+    // fields explicitly here
     if (actual.descriptor.isDefined && expected.descriptor.isDefined) {
       val actualDesc = actual.descriptor.get
       val expectedDesc = expected.descriptor.get
@@ -156,9 +156,9 @@ abstract class ParquetSchemaTest extends ParquetTest with SharedSparkSession {
     assert(actual.required == expected.required, "required mismatch: " +
         s"actual = ${actual.required}, expected = ${expected.required}")
     assert(actual.path == expected.path, "path mismatch: " +
-        s"actual = $actual.path, expected = ${expected.path}")
+        s"actual = ${actual.path}, expected = ${expected.path}")
 
-    assert(actual.children.size == expected.children.size, "number of children mismatch: " +
+    assert(actual.children.size == expected.children.size, "size of children mismatch: " +
         s"actual = ${actual.children.size}, expected = ${expected.children.size}")
     actual.children.zip(expected.children).foreach { case (actualChild, expectedChild) =>
       compareParquetColumn(actualChild, expectedChild)
@@ -169,8 +169,8 @@ abstract class ParquetSchemaTest extends ParquetTest with SharedSparkSession {
       sparkType: DataType,
       parquetTypeName: PrimitiveTypeName,
       repetition: Repetition,
-      repLevel: Int,
-      defLevel: Int,
+      repetitionLevel: Int,
+      definitionLevel: Int,
       path: Seq[String],
       logicalTypeAnnotation: Option[LogicalTypeAnnotation] = None): ParquetColumn = {
     var typeBuilder = repetition match {
@@ -184,9 +184,9 @@ abstract class ParquetSchemaTest extends ParquetTest with SharedSparkSession {
     ParquetColumn(
       sparkType = sparkType,
       descriptor = Some(new ColumnDescriptor(path.toArray,
-        typeBuilder.named(path.last), repLevel, defLevel)),
-      repetitionLevel = repLevel,
-      definitionLevel = defLevel,
+        typeBuilder.named(path.last), repetitionLevel, definitionLevel)),
+      repetitionLevel = repetitionLevel,
+      definitionLevel = definitionLevel,
       required = repetition != Repetition.OPTIONAL,
       path = path,
       children = Seq.empty)
@@ -1896,7 +1896,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional int32 f1;
       |}
-      |""".stripMargin,
+    """.stripMargin,
     binaryAsString = true,
     int96AsTimestamp = true,
     sparkReadSchema = Some(StructType(Seq(StructField("F1", ShortType)))),
@@ -1919,7 +1919,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional int32 f1;
       |}
-      |""".stripMargin,
+    """.stripMargin,
     binaryAsString = true,
     int96AsTimestamp = true,
     caseSensitive = true,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -68,7 +68,7 @@ abstract class ParquetSchemaTest extends ParquetTest with SharedSparkSession {
       assumeInt96IsTimestamp = int96AsTimestamp)
 
     test(s"sql <= parquet: $testName") {
-      val actualParquetType = converter.convertTypeInfo(
+      val actualParquetType = converter.convertParquetType(
           MessageTypeParser.parseMessageType(parquetSchema))
       val actual = actualParquetType.sparkType
       val expected = sqlSchema

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -17,14 +17,13 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.parquet.column.ColumnDescriptor
-
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
+import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.io.ParquetDecodingException
-import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.parquet.schema._
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.parquet.schema.Type._
 
 import org.apache.spark.SparkException
@@ -228,7 +227,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
           primitiveParquetType(DoubleType, PrimitiveTypeName.DOUBLE, Repetition.REQUIRED,
             0, 0, Seq("_5")),
           primitiveParquetType(BinaryType, PrimitiveTypeName.BINARY, Repetition.OPTIONAL,
-            0, 1, Seq("_6")),
+            0, 1, Seq("_6"))
         )))
   )
 
@@ -598,11 +597,11 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
                 primitiveParquetType(StringType, PrimitiveTypeName.BINARY, Repetition.OPTIONAL,
                   1, 3, Seq("_1", "key_value", "key", "_2"),
                   logicalTypeAnnotation = Some(LogicalTypeAnnotation.stringType())))
-              ),
+            ),
             primitiveParquetType(StringType, PrimitiveTypeName.BINARY, Repetition.OPTIONAL,
               1, 3, Seq("_1", "key_value", "value"),
               logicalTypeAnnotation = Some(LogicalTypeAnnotation.stringType())))
-          )))))
+        )))))
 
   testSchemaInference[Tuple1[(Int, String)]](
     "struct",
@@ -751,9 +750,8 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
                           Seq("_1", "key_value", "value", "_2", "bag", "array", "_1")),
                         primitiveParquetType(DoubleType, PrimitiveTypeName.DOUBLE,
                           Repetition.REQUIRED, 2, 6,
-                          Seq("_1", "key_value", "value", "_2", "bag", "array", "_2")),
-                      ))),
-                ))),
+                          Seq("_1", "key_value", "value", "_2", "bag", "array", "_2"))
+                      ))))))
           ))))))
 
   testSchemaInference[Tuple1[Map[Int, (String, Seq[(Int, Double)])]]](
@@ -860,9 +858,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
                           Seq("_1", "key_value", "value", "_2", "list", "element", "_1")),
                         primitiveParquetType(DoubleType, PrimitiveTypeName.DOUBLE,
                           Repetition.REQUIRED, 2, 6,
-                          Seq("_1", "key_value", "value", "_2", "list", "element", "_2")),
-                    ))),
-              ))),
+                          Seq("_1", "key_value", "value", "_2", "list", "element", "_2"))))))))
         ))))))
 
   testSchemaInference[(Option[Int], Map[Int, Option[Double]])](
@@ -911,8 +907,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
             primitiveParquetType(IntegerType, PrimitiveTypeName.INT32, Repetition.REQUIRED,
               1, 2, Seq("_2", "key_value", "key")),
             primitiveParquetType(DoubleType, PrimitiveTypeName.DOUBLE, Repetition.OPTIONAL,
-              1, 3, Seq("_2", "key_value", "value")),
-          )))
+              1, 3, Seq("_2", "key_value", "value")))))
     )))
 }
 
@@ -1588,7 +1583,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
               1, 2, Seq("f1", "key_value", "key")),
             primitiveParquetType(StringType, PrimitiveTypeName.BINARY, Repetition.REQUIRED,
               1, 2, Seq("f1", "key_value", "value"),
-              logicalTypeAnnotation = Some(LogicalTypeAnnotation.stringType())),
+              logicalTypeAnnotation = Some(LogicalTypeAnnotation.stringType()))
           ))))))
 
   testParquetToCatalyst(
@@ -1633,7 +1628,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
               1, 2, Seq("f1", "key_value", "num")),
             primitiveParquetType(StringType, PrimitiveTypeName.BINARY, Repetition.REQUIRED,
               1, 2, Seq("f1", "key_value", "str"),
-              logicalTypeAnnotation = Some(LogicalTypeAnnotation.stringType())),
+              logicalTypeAnnotation = Some(LogicalTypeAnnotation.stringType()))
           ))))))
 
   testParquetToCatalyst(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR includes the following:
1. adds a new class `ParquetColumn`, which is a wrapper on a Spark `DataType` with additional Parquet column information, including its max repetition level & definition level, path from the root schema, column descriptor if the node is a leaf, the children nodes is it is a non-leaf, etc. This is needed to support complex type in the vectorized path, where we need to assemble a column vector of complex type using these information.
2. extends `ParquetSchemaConverter` to convert from a Parquet `MessageType` to a `ParquetColumn`, mostly by piggy-backing on the existing logic. A new method `converParquetColumn` is added for this purpose, and the existing `convert` is changed to simply by calling the former.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In order to support complex type for the vectorized Parquet reader (see SPARK-34863 for more info), we'll need to capture Parquet specific information such as max repetition/definition level for Spark's `DataType`, so that we can assemble primitive column vectors into ones with complex type (e.g., struct, map, array).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Extended the test cases in `ParquetSchemaSuite`