### PR TITLE
[SPARK-36941][SQL][TESTS] Check saving/loading of ANSI intervals to Hive Parquet table

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
@@ -382,4 +382,16 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
       }
     }
   }
+
+  test("SPARK-36941: Save/load ANSI intervals to Hive Parquet table") {
+    val tableName = "tbl_ansi_intervals"
+    withTable(tableName) {
+      val (ym, dt) = (java.time.Period.ofMonths(10), java.time.Duration.ofDays(1))
+      val df = Seq((ym, dt)).toDF("ym", "dt")
+      df.write.mode(SaveMode.Overwrite).format("parquet").saveAsTable(tableName)
+      checkAnswer(
+        sql(s"select * from $tableName"),
+        Row(ym, dt))
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
@@ -23,13 +23,14 @@ import java.io.IOException
 import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 /**
  * A suite of tests for the Parquet support through the data sources API.
  */
-class HiveParquetSourceSuite extends ParquetPartitioningTest {
+class HiveParquetSourceSuite extends ParquetPartitioningTest with ParquetTest {
   import testImplicits._
   import spark._
 
@@ -389,9 +390,9 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest {
       val (ym, dt) = (java.time.Period.ofMonths(10), java.time.Duration.ofDays(1))
       val df = Seq((ym, dt)).toDF("ym", "dt")
       df.write.mode(SaveMode.Overwrite).format("parquet").saveAsTable(tableName)
-      checkAnswer(
-        sql(s"select * from $tableName"),
-        Row(ym, dt))
+      withAllParquetReaders {
+        checkAnswer(sql(s"select * from $tableName"), Row(ym, dt))
+      }
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to add new test which checks saving/loading of ANSI intervals as columns of a dataframe to/from a table using Hive External catalog and the Parquet datasource.

Since Hive Metastore/Serde doesn't support interval types natively, Spark fallbacks to Spark specific format for schema w/ ANSI intervals. And it outputs the warning:
```
23:35:46.289 WARN org.apache.spark.sql.hive.test.TestHiveExternalCatalog: Could not persist `default`.`tbl_ansi_intervals` in a Hive compatible way. Persisting it into Hive metastore in Spark SQL specific format.
org.apache.hadoop.hive.ql.metadata.HiveException: java.lang.IllegalArgumentException: Error: type expected at the position 0 of 'interval year to month:interval day to second' but 'interval year to month' is found.
	at org.apache.hadoop.hive.ql.metadata.Hive.createTable(Hive.java:869)
``` 

### Why are the changes needed?
To improve test coverage.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running new test:
```
$ ./build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *HiveParquetSourceSuite"
```