### PR TITLE
[SPARK-36930][PYTHON][FOLLOW-UP] Fix test case for MultiIndex.dtypes with pandas version < 1.3

### DIFF
--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -6006,13 +6006,24 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         pmidx = pd.MultiIndex.from_arrays(arrays, names=("number", "color"))
         psmidx = ps.from_pandas(pmidx)
 
-        self.assert_eq(psmidx.dtypes, pmidx.dtypes)
+        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
+            self.assert_eq(psmidx.dtypes, pmidx.dtypes)
+        else:
+            expected = pd.Series([np.dtype("int64"), np.dtype("O")], index=["number", "color"])
+            self.assert_eq(psmidx.dtypes, expected)
 
         # multiple labels
         pmidx = pd.MultiIndex.from_arrays(arrays, names=[("zero", "first"), ("one", "second")])
         psmidx = ps.from_pandas(pmidx)
 
-        self.assert_eq(psmidx.dtypes, pmidx.dtypes)
+        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
+            self.assert_eq(psmidx.dtypes, pmidx.dtypes)
+        else:
+            expected = pd.Series(
+                [np.dtype("int64"), np.dtype("O")],
+                index=pd.Index([("zero", "first"), ("one", "second")]),
+            )
+            self.assert_eq(psmidx.dtypes, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a minor followup of https://github.com/apache/spark/pull/34179 to fix test case for ```MultiIndex.dtypes``` with pandas version < 1.3.

### Why are the changes needed?

Fix test case for ```MultiIndex.dtypes``` with pandas version < 1.3.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
manual test
