### PR TITLE
[SPARK-36711][PYTHON][FOLLOW-UP] Skip docs tests having MultiIndex.dtypes

### DIFF
--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -720,13 +720,13 @@ def create_tuple_for_frame_type(params: Any) -> object:
         >>> pdf = pd.DataFrame({'a': range(3)}, index=idx)
         >>> ps.DataFrame[[int, int], [int, int]]  # doctest: +ELLIPSIS
         typing.Tuple[...IndexNameType, ...IndexNameType, ...NameType, ...NameType]
-        >>> ps.DataFrame[pdf.index.dtypes, pdf.dtypes]  # doctest: +ELLIPSIS
+        >>> ps.DataFrame[pdf.index.dtypes, pdf.dtypes]  # doctest: +ELLIPSIS, +SKIP
         typing.Tuple[...IndexNameType, ...NameType]
         >>> ps.DataFrame[[("index-1", int), ("index-2", int)], [("id", int), ("A", int)]]
         ... # doctest: +ELLIPSIS
         typing.Tuple[...IndexNameType, ...IndexNameType, ...NameType, ...NameType]
         >>> ps.DataFrame[zip(pdf.index.names, pdf.index.dtypes), zip(pdf.columns, pdf.dtypes)]
-        ... # doctest: +ELLIPSIS
+        ... # doctest: +ELLIPSIS, +SKIP
         typing.Tuple[...IndexNameType, ...NameType]
     """
     return Tuple[_to_type_holders(params)]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a minor followup of #34176 to skip docs test which use ```pd.MultiIndex.dtypes``` which is only supported in pandas version 1.3+.

### Why are the changes needed?
Skip docs test which use ```pd.MultiIndex.dtypes``` which is only supported in pandas version 1.3+.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual test
