### PR TITLE
[SPARK-36304][SQL] Refactor fifteenth set of 20 query execution errors to use error classes

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -137,7 +137,7 @@
     "message" : [ "Unknown static partition column: %s" ],
     "sqlState" : "42000"
   },
-  "MULTI_FAILURES_IN_STAGE_MATERIALIZATION" : {
+  "MULTIPLE_FAILURES_IN_STAGE_MATERIALIZATION" : {
     "message" : [ "Multiple failures in stage materialization." ]
   },
   "NON_LITERAL_PIVOT_VALUES" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -3,13 +3,37 @@
     "message" : [ "Field name %s is ambiguous and has %s matching fields in the struct." ],
     "sqlState" : "42000"
   },
+  "CANNOT_ADD_MULTI_PARTITIONS_ON_NONATOMIC_PARTITION_TABLE" : {
+    "message" : [ "Nonatomic partition table %s can not add multiple partitions." ],
+    "sqlState" : "0A000"
+  },
   "CANNOT_CAST_DATATYPE" : {
     "message" : [ "Cannot cast %s to %s." ],
     "sqlState" : "22005"
   },
+  "CANNOT_CAST_NULL_LITERALS" : {
+    "message" : [ "null literals can't be casted to %s" ],
+    "sqlState" : "22018"
+  },
   "CANNOT_CHANGE_DECIMAL_PRECISION" : {
     "message" : [ "%s cannot be represented as Decimal(%s, %s)." ],
     "sqlState" : "22005"
+  },
+  "CANNOT_CREATE_PARQUET_CONVERTER_FOR_DATATYPE" : {
+    "message" : [ "Unable to create Parquet converter for data type %s whose Parquet type is %s" ],
+    "sqlState" : "0A000"
+  },
+  "CANNOT_CREATE_PARQUET_CONVERTER_FOR_DECIMAL_TYPE" : {
+    "message" : [ "Unable to create Parquet converter for decimal type %s whose Parquet type is %s. Parquet DECIMAL type can only be backed by INT32, INT64,FIXED_LEN_BYTE_ARRAY, or BINARY." ],
+    "sqlState" : "0A000"
+  },
+  "CANNOT_CREATE_PARQUET_CONVERTER_FOR_TYPE" : {
+    "message" : [ "Unable to create Parquet converter for %s whose Parquet type is %s without decimal metadata. Please read this column/field as Spark BINARY type." ],
+    "sqlState" : "0A000"
+  },
+  "CANNOT_LOAD_USER_DEFINED_TYPE" : {
+    "message" : [ "Can not load in UserDefinedType %s for user class %s." ],
+    "sqlState" : "0A000"
   },
   "CANNOT_PARSE_DECIMAL" : {
     "message" : [ "Cannot parse decimal" ],
@@ -21,6 +45,10 @@
   },
   "CONCURRENT_QUERY" : {
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
+  },
+  "DATA_SOURCE_DOES_NOT_PROVIDE_FILE_FORMAT" : {
+    "message" : [ "Only Data Sources providing FileFormat are supported: %s" ],
+    "sqlState" : "0A000"
   },
   "DIVIDE_BY_ZERO" : {
     "message" : [ "divide by zero" ],
@@ -37,8 +65,20 @@
     "message" : [ "Failed to rename %s to %s as destination already exists" ],
     "sqlState" : "22023"
   },
+  "FAILED_SET_ORIGINAL_ACL_BACK" : {
+    "message" : [ "Failed to set original ACL %s back to the created path: %s. Exception: %s" ],
+    "sqlState" : "42000"
+  },
   "FAILED_SET_ORIGINAL_PERMISSION_BACK" : {
     "message" : [ "Failed to set original permission %s back to the created path: %s. Exception: %s" ]
+  },
+  "FIELD_INDEX_ON_ROW_WITHOUT_SCHEMA" : {
+    "message" : [ "fieldIndex on a Row without schema is undefined." ],
+    "sqlState" : "07009"
+  },
+  "GET_PARENT_LOGGER_UNSUPPORTED" : {
+    "message" : [ "%s.getParentLogger is not yet implemented." ],
+    "sqlState" : "0A000"
   },
   "GROUPING_COLUMN_MISMATCH" : {
     "message" : [ "Column of grouping (%s) can't be found in grouping columns %s" ],
@@ -97,12 +137,23 @@
     "message" : [ "Unknown static partition column: %s" ],
     "sqlState" : "42000"
   },
+  "MULTI_FAILURES_IN_STAGE_MATERIALIZATION" : {
+    "message" : [ "Multiple failures in stage materialization." ]
+  },
   "NON_LITERAL_PIVOT_VALUES" : {
     "message" : [ "Literal expressions required for pivot values, found '%s'" ],
     "sqlState" : "42000"
   },
   "NON_PARTITION_COLUMN" : {
     "message" : [ "PARTITION clause cannot contain a non-partition column name: %s" ],
+    "sqlState" : "42000"
+  },
+  "NOT_PUBLIC_CLASS" : {
+    "message" : [ "%s is not a public class. Only public classes are supported." ],
+    "sqlState" : "0A000"
+  },
+  "NOT_USER_DEFINED_TYPE" : {
+    "message" : [ "%s is not an UserDefinedType. Please make sure registering an UserDefinedType for %s" ],
     "sqlState" : "42000"
   },
   "PIVOT_VALUE_DATA_TYPE_MISMATCH" : {
@@ -121,8 +172,16 @@
     "message" : [ "The second argument of '%s' function needs to be an integer." ],
     "sqlState" : "22023"
   },
+  "TIMESTAMP_TYPE_DOES_NOT_SPECIFY_TIME_ZONE_ID" : {
+    "message" : [ "%s must supply timeZoneId parameter" ],
+    "sqlState" : "23000"
+  },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
+  },
+  "UNRECOGNIZED_COMPRESSION_SCHEMA_TYPE_ID" : {
+    "message" : [ "Unrecognized compression scheme type ID: %s" ],
+    "sqlState" : "42000"
   },
   "UNRECOGNIZED_SQL_TYPE" : {
     "message" : [ "Unrecognized SQL type %s" ],
@@ -140,12 +199,24 @@
     "message" : [ "Unsupported literal type %s %s" ],
     "sqlState" : "0A000"
   },
+  "UNSUPPORTED_PRIMITIVE_TYPES" : {
+    "message" : [ "Primitive types are not supported." ],
+    "sqlState" : "0A000"
+  },
   "UNSUPPORTED_SIMPLE_STRING_WITH_NODE_ID" : {
     "message" : [ "%s does not implement simpleStringWithNodeId" ]
   },
   "UNSUPPORTED_TRANSACTION_BY_JDBC_SERVER" : {
     "message" : [ "The target JDBC server does not support transaction and can only support ALTER TABLE with a single action." ],
     "sqlState" : "0A000"
+  },
+  "UNSUPPORTED_USER_SPECIFIED_SCHEMA" : {
+    "message" : [ "%s source does not support user-specified schema." ],
+    "sqlState" : "0A000"
+  },
+  "VALUE_IS_NULL" : {
+    "message" : [ "Value at index %s is null" ],
+    "sqlState" : "22023"
   },
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -76,10 +76,6 @@
     "message" : [ "fieldIndex on a Row without schema is undefined." ],
     "sqlState" : "07009"
   },
-  "GET_PARENT_LOGGER_UNSUPPORTED" : {
-    "message" : [ "%s.getParentLogger is not yet implemented." ],
-    "sqlState" : "0A000"
-  },
   "GROUPING_COLUMN_MISMATCH" : {
     "message" : [ "Column of grouping (%s) can't be found in grouping columns %s" ],
     "sqlState" : "42000"
@@ -193,6 +189,10 @@
   },
   "UNSUPPORTED_DATATYPE" : {
     "message" : [ "Unsupported data type %s" ],
+    "sqlState" : "0A000"
+  },
+  "UNSUPPORTED_GET_PARENT_LOGGER" : {
+    "message" : [ "%s.getParentLogger is not yet implemented." ],
     "sqlState" : "0A000"
   },
   "UNSUPPORTED_LITERAL_TYPE" : {

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -98,6 +98,16 @@ private[spark] class SparkUnsupportedOperationException(
 }
 
 /**
+ * Null Pointer exception thrown from Spark with an error class.
+ */
+private[spark] class SparkNullPointerException(errorClass: String, messageParameters: Array[String])
+  extends NullPointerException(SparkThrowableHelper.getMessage(errorClass, messageParameters))
+    with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+}
+
+/**
  * Class not found exception thrown from Spark with an error class.
  */
 private[spark] class SparkClassNotFoundException(
@@ -229,6 +239,9 @@ private[spark] class SparkIOException(
   override def getErrorClass: String = errorClass
 }
 
+/**
+ * Run time exception thrown from Spark with an error class.
+ */
 private[spark] class SparkRuntimeException(
     errorClass: String,
     messageParameters: Array[String],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1623,7 +1623,7 @@ object QueryExecutionErrors {
 
   def getParentLoggerNotImplementedError(className: String): Throwable = {
     new SparkSQLFeatureNotSupportedException(
-      errorClass = "GET_PARENT_LOGGER_UNSUPPORTED",
+      errorClass = "UNSUPPORTED_GET_PARENT_LOGGER",
       messageParameters = Array(className)
     )
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1556,7 +1556,7 @@ object QueryExecutionErrors {
 
   def timeZoneIdNotSpecifiedForTimestampTypeError(): Throwable = {
     new SparkUnsupportedOperationException(
-      errorClass = "TIME_ZONE_ID_NOT_SPECIFIED_FOR_TIMESTAMP_TYPE",
+      errorClass = "TIMESTAMP_TYPE_DOES_NOT_SPECIFY_TIME_ZONE_ID",
       messageParameters = Array(TimestampType.catalogString))
   }
 
@@ -1589,7 +1589,7 @@ object QueryExecutionErrors {
 
   def onlySupportDataSourcesProvidingFileFormatError(providingClass: String): Throwable = {
     new SparkException(
-      errorClass = "ONLY_SUPPORT_DATA_SOURCES_PROVIDING_FILE_FORMAT",
+      errorClass = "DATA_SOURCE_DOES_NOT_PROVIDE_FILE_FORMAT",
       messageParameters = Array(providingClass), null)
   }
 
@@ -1610,7 +1610,7 @@ object QueryExecutionErrors {
 
   def multiFailuresInStageMaterializationError(error: Throwable): Throwable = {
     new SparkException(
-      errorClass = "MULTI_FAILURES_IN_STAGE_MATERIALIZATION",
+      errorClass = "MULTIPLE_FAILURES_IN_STAGE_MATERIALIZATION",
       messageParameters = Array.empty, error)
   }
 
@@ -1623,7 +1623,7 @@ object QueryExecutionErrors {
 
   def getParentLoggerNotImplementedError(className: String): Throwable = {
     new SparkSQLFeatureNotSupportedException(
-      errorClass = "GET_PARENT_LOGGER_NOT_IMPLEMENTED",
+      errorClass = "GET_PARENT_LOGGER_UNSUPPORTED",
       messageParameters = Array(className)
     )
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -32,7 +32,7 @@ import org.apache.hadoop.fs.permission.FsPermission
 import org.codehaus.commons.compiler.CompileException
 import org.codehaus.janino.InternalCompilerException
 
-import org.apache.spark.{Partition, SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkClassNotFoundException, SparkConcurrentModificationException, SparkDateTimeException, SparkException, SparkFileAlreadyExistsException, SparkFileNotFoundException, SparkIllegalArgumentException, SparkIllegalStateException, SparkIndexOutOfBoundsException, SparkNoSuchElementException, SparkNoSuchMethodException, SparkNumberFormatException, SparkRuntimeException, SparkSecurityException, SparkSQLException, SparkSQLFeatureNotSupportedException, SparkUnsupportedOperationException, SparkUpgradeException}
+import org.apache.spark.{Partition, SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkClassNotFoundException, SparkConcurrentModificationException, SparkDateTimeException, SparkException, SparkFileAlreadyExistsException, SparkFileNotFoundException, SparkIllegalArgumentException, SparkIllegalStateException, SparkIndexOutOfBoundsException, SparkNoSuchElementException, SparkNoSuchMethodException, SparkNullPointerException, SparkNumberFormatException, SparkRuntimeException, SparkSecurityException, SparkSQLException, SparkSQLFeatureNotSupportedException, SparkUnsupportedOperationException, SparkUpgradeException}
 import org.apache.spark.executor.CommitDeniedException
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.memory.SparkOutOfMemoryError
@@ -1529,106 +1529,136 @@ object QueryExecutionErrors {
   }
 
   def unsupportedOperationExceptionError(): Throwable = {
-    new UnsupportedOperationException
+    new SparkUnsupportedOperationException(
+      errorClass = "INTERNAL_ERROR",
+      messageParameters = Array.empty
+    )
   }
 
   def nullLiteralsCannotBeCastedError(name: String): Throwable = {
-    new UnsupportedOperationException(s"null literals can't be casted to $name")
+    new SparkUnsupportedOperationException(
+      errorClass = "CANNOT_CAST_NULL_LITERALS",
+      messageParameters = Array(name)
+    )
   }
 
   def notUserDefinedTypeError(name: String, userClass: String): Throwable = {
-    new SparkException(s"$name is not an UserDefinedType. Please make sure registering " +
-        s"an UserDefinedType for ${userClass}")
+    new SparkException(
+      errorClass = "NOT_USER_DEFINED_TYPE",
+      messageParameters = Array(name, userClass), null)
   }
 
   def cannotLoadUserDefinedTypeError(name: String, userClass: String): Throwable = {
-    new SparkException(s"Can not load in UserDefinedType ${name} for user class ${userClass}.")
+    new SparkException(
+      errorClass = "CANNOT_LOAD_USER_DEFINED_TYPE",
+      messageParameters = Array(name, userClass), null)
   }
 
   def timeZoneIdNotSpecifiedForTimestampTypeError(): Throwable = {
-    new UnsupportedOperationException(
-      s"${TimestampType.catalogString} must supply timeZoneId parameter")
+    new SparkUnsupportedOperationException(
+      errorClass = "TIME_ZONE_ID_NOT_SPECIFIED_FOR_TIMESTAMP_TYPE",
+      messageParameters = Array(TimestampType.catalogString))
   }
 
   def notPublicClassError(name: String): Throwable = {
-    new UnsupportedOperationException(
-      s"$name is not a public class. Only public classes are supported.")
+    new SparkUnsupportedOperationException(
+      errorClass = "NOT_PUBLIC_CLASS",
+      messageParameters = Array(name))
   }
 
   def primitiveTypesNotSupportedError(): Throwable = {
-    new UnsupportedOperationException("Primitive types are not supported.")
+    new SparkUnsupportedOperationException(
+      errorClass = "UNSUPPORTED_PRIMITIVE_TYPES",
+      messageParameters = Array.empty
+    )
   }
 
   def fieldIndexOnRowWithoutSchemaError(): Throwable = {
-    new UnsupportedOperationException("fieldIndex on a Row without schema is undefined.")
+    new SparkUnsupportedOperationException(
+      errorClass = "FIELD_INDEX_ON_ROW_WITHOUT_SCHEMA",
+      messageParameters = Array.empty
+    )
   }
 
   def valueIsNullError(index: Int): Throwable = {
-    new NullPointerException(s"Value at index $index is null")
+    new SparkNullPointerException(
+      errorClass = "VALUE_IS_NULL",
+      messageParameters = Array(index.toString)
+    )
   }
 
   def onlySupportDataSourcesProvidingFileFormatError(providingClass: String): Throwable = {
-    new SparkException(s"Only Data Sources providing FileFormat are supported: $providingClass")
+    new SparkException(
+      errorClass = "ONLY_SUPPORT_DATA_SOURCES_PROVIDING_FILE_FORMAT",
+      messageParameters = Array(providingClass), null)
   }
 
   def failToSetOriginalPermissionBackError(
       permission: FsPermission,
       path: Path,
       e: Throwable): Throwable = {
-    new SparkSecurityException(errorClass = "FAILED_SET_ORIGINAL_PERMISSION_BACK",
-      Array(permission.toString, path.toString, e.getMessage))
+    new SparkSecurityException(
+      errorClass = "FAILED_SET_ORIGINAL_PERMISSION_BACK",
+      messageParameters = Array(permission.toString, path.toString, e.getMessage))
   }
 
   def failToSetOriginalACLBackError(aclEntries: String, path: Path, e: Throwable): Throwable = {
-    new SecurityException(s"Failed to set original ACL $aclEntries back to " +
-      s"the created path: $path. Exception: ${e.getMessage}")
+    new SparkSecurityException(
+      errorClass = "FAILED_SET_ORIGINAL_ACL_BACK",
+      messageParameters = Array(aclEntries, path.toString, e.getMessage))
   }
 
   def multiFailuresInStageMaterializationError(error: Throwable): Throwable = {
-    new SparkException("Multiple failures in stage materialization.", error)
+    new SparkException(
+      errorClass = "MULTI_FAILURES_IN_STAGE_MATERIALIZATION",
+      messageParameters = Array.empty, error)
   }
 
   def unrecognizedCompressionSchemaTypeIDError(typeId: Int): Throwable = {
-    new UnsupportedOperationException(s"Unrecognized compression scheme type ID: $typeId")
+    new SparkUnsupportedOperationException(
+      errorClass = "UNRECOGNIZED_COMPRESSION_SCHEMA_TYPE_ID",
+      messageParameters = Array(typeId.toString)
+    )
   }
 
   def getParentLoggerNotImplementedError(className: String): Throwable = {
-    new SQLFeatureNotSupportedException(s"$className.getParentLogger is not yet implemented.")
+    new SparkSQLFeatureNotSupportedException(
+      errorClass = "GET_PARENT_LOGGER_NOT_IMPLEMENTED",
+      messageParameters = Array(className)
+    )
   }
 
   def cannotCreateParquetConverterForTypeError(t: DecimalType, parquetType: String): Throwable = {
-    new RuntimeException(
-      s"""
-         |Unable to create Parquet converter for ${t.typeName}
-         |whose Parquet type is $parquetType without decimal metadata. Please read this
-         |column/field as Spark BINARY type.
-       """.stripMargin.replaceAll("\n", " "))
+    new SparkRuntimeException(
+      errorClass = "CANNOT_CREATE_PARQUET_CONVERTER_FOR_TYPE",
+      messageParameters = Array(t.typeName, parquetType))
   }
 
   def cannotCreateParquetConverterForDecimalTypeError(
       t: DecimalType, parquetType: String): Throwable = {
-    new RuntimeException(
-      s"""
-         |Unable to create Parquet converter for decimal type ${t.json} whose Parquet type is
-         |$parquetType.  Parquet DECIMAL type can only be backed by INT32, INT64,
-         |FIXED_LEN_BYTE_ARRAY, or BINARY.
-       """.stripMargin.replaceAll("\n", " "))
+    new SparkRuntimeException(
+      errorClass = "CANNOT_CREATE_PARQUET_CONVERTER_FOR_DECIMAL_TYPE",
+      messageParameters = Array(t.json, parquetType))
   }
 
   def cannotCreateParquetConverterForDataTypeError(
       t: DataType, parquetType: String): Throwable = {
-    new RuntimeException(s"Unable to create Parquet converter for data type ${t.json} " +
-      s"whose Parquet type is $parquetType")
+    new SparkRuntimeException(
+      errorClass = "CANNOT_CREATE_PARQUET_CONVERTER_FOR_DATATYPE",
+      messageParameters = Array(t.json, parquetType))
   }
 
   def cannotAddMultiPartitionsOnNonatomicPartitionTableError(tableName: String): Throwable = {
-    new UnsupportedOperationException(
-      s"Nonatomic partition table $tableName can not add multiple partitions.")
+    new SparkUnsupportedOperationException(
+      errorClass = "CANNOT_ADD_MULTI_PARTITIONS_ON_NONATOMIC_PARTITION_TABLE",
+      messageParameters = Array(tableName)
+    )
   }
 
   def userSpecifiedSchemaUnsupportedByDataSourceError(provider: TableProvider): Throwable = {
-    new UnsupportedOperationException(
-      s"${provider.getClass.getSimpleName} source does not support user-specified schema.")
+    new SparkUnsupportedOperationException(
+      errorClass = "UNSUPPORTED_USER_SPECIFIED_SCHEMA",
+      messageParameters = Array(provider.getClass.getSimpleName))
   }
 
   def cannotDropMultiPartitionsOnNonatomicPartitionTableError(tableName: String): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
@@ -21,6 +21,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericRow, GenericRowWithSchema}
 import org.apache.spark.sql.types._
@@ -40,10 +41,10 @@ class RowTest extends AnyFunSpec with Matchers {
 
   describe("Row (without schema)") {
     it("throws an exception when accessing by fieldName") {
-      intercept[UnsupportedOperationException] {
+      intercept[SparkUnsupportedOperationException] {
         noSchemaRow.fieldIndex("col1")
       }
-      intercept[UnsupportedOperationException] {
+      intercept[SparkUnsupportedOperationException] {
         noSchemaRow.getAs("col1")
       }
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderErrorMessageSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderErrorMessageSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.encoders
 
 import scala.reflect.ClassTag
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkUnsupportedOperationException}
 import org.apache.spark.sql.Encoders
 
 class NonEncodable(i: Int)
@@ -40,15 +40,15 @@ class EncoderErrorMessageSuite extends SparkFunSuite {
   // That is done in Java because Scala cannot create truly private classes.
 
   test("primitive types in encoders using Kryo serialization") {
-    intercept[UnsupportedOperationException] { Encoders.kryo[Int] }
-    intercept[UnsupportedOperationException] { Encoders.kryo[Long] }
-    intercept[UnsupportedOperationException] { Encoders.kryo[Char] }
+    intercept[SparkUnsupportedOperationException] { Encoders.kryo[Int] }
+    intercept[SparkUnsupportedOperationException] { Encoders.kryo[Long] }
+    intercept[SparkUnsupportedOperationException] { Encoders.kryo[Char] }
   }
 
   test("primitive types in encoders using Java serialization") {
-    intercept[UnsupportedOperationException] { Encoders.javaSerialization[Int] }
-    intercept[UnsupportedOperationException] { Encoders.javaSerialization[Long] }
-    intercept[UnsupportedOperationException] { Encoders.javaSerialization[Char] }
+    intercept[SparkUnsupportedOperationException] { Encoders.javaSerialization[Int] }
+    intercept[SparkUnsupportedOperationException] { Encoders.javaSerialization[Long] }
+    intercept[SparkUnsupportedOperationException] { Encoders.javaSerialization[Char] }
   }
 
   test("nice error message for missing encoder") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
@@ -21,7 +21,7 @@ import java.time.ZoneId
 
 import org.apache.arrow.vector.types.pojo.ArrowType
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkUnsupportedOperationException}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.LA
 import org.apache.spark.sql.types._
 
@@ -50,7 +50,7 @@ class ArrowUtilsSuite extends SparkFunSuite {
     roundtrip(DateType)
     roundtrip(YearMonthIntervalType())
     roundtrip(DayTimeIntervalType())
-    val tsExMsg = intercept[UnsupportedOperationException] {
+    val tsExMsg = intercept[SparkUnsupportedOperationException] {
       roundtrip(TimestampType)
     }
     assert(tsExMsg.getMessage.contains("timeZoneId"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamProviderSuite.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.streaming.{Offset, SparkDataStream}
@@ -298,7 +299,7 @@ class RateStreamProviderSuite extends StreamTest {
   }
 
   test("user-specified schema given") {
-    val exception = intercept[UnsupportedOperationException] {
+    val exception = intercept[SparkUnsupportedOperationException] {
       spark.readStream
         .format("rate")
         .schema(spark.range(1).schema)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketStreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketStreamSuite.scala
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit._
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.connector.read.streaming.{Offset, SparkDataStream}
@@ -193,7 +194,7 @@ class TextSocketStreamSuite extends StreamTest with SharedSparkSession {
       StructField("name", StringType) ::
       StructField("area", StringType) :: Nil)
     val params = Map("host" -> "localhost", "port" -> "1234")
-    val exception = intercept[UnsupportedOperationException] {
+    val exception = intercept[SparkUnsupportedOperationException] {
       spark.readStream.schema(userSpecifiedSchema).format("socket").options(params).load()
     }
     assert(exception.getMessage.contains(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->Adds error classes to some of the exceptions in QueryExecutionErrors.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->Improves auditing for developers and adds useful fields for users (error class and SQLSTATE).


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->Fills in missing error class and SQLSTATE fields.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->Existing tests
