### PR TITLE
[SPARK-36946][PYTHON] Support time for ps.to_datetime

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -1643,6 +1643,21 @@ def to_datetime(
         "months": "month",
         "day": "day",
         "days": "day",
+        "hour": "h",
+        "hours": "h",
+        "minute": "m",
+        "minutes": "m",
+        "second": "s",
+        "seconds": "s",
+        "ms": "ms",
+        "millisecond": "ms",
+        "milliseconds": "ms",
+        "us": "us",
+        "microsecond": "us",
+        "microseconds": "us",
+        "ns": "ns",
+        "nanosecond": "ns",
+        "nanoseconds": "ns",
     }
 
     # replace passed unit with _unit_map
@@ -1657,7 +1672,7 @@ def to_datetime(
 
     def pandas_to_datetime(pser_or_pdf: Union[pd.DataFrame, pd.Series]) -> Series[np.datetime64]:
         if isinstance(pser_or_pdf, pd.DataFrame):
-            pser_or_pdf = pser_or_pdf[[unit_rev["year"], unit_rev["month"], unit_rev["day"]]]
+            pser_or_pdf = pser_or_pdf[[*list_cols]]
         return pd.to_datetime(
             pser_or_pdf,
             errors=errors,
@@ -1672,7 +1687,13 @@ def to_datetime(
     if isinstance(arg, DataFrame):
         unit = {k: f(k) for k in arg.keys()}
         unit_rev = {v: k for k, v in unit.items()}
-        psdf = arg[[unit_rev["year"], unit_rev["month"], unit_rev["day"]]]
+        list_cols = [unit_rev["year"], unit_rev["month"], unit_rev["day"]]
+        for u in ["h", "m", "s", "ms", "us", "ns"]:
+            value = unit_rev.get(u)
+            if value is not None and value in arg:
+                list_cols.append(value)
+
+        psdf = arg[[*list_cols]]
         return psdf.pandas_on_spark.transform_batch(pandas_to_datetime)
     return pd.to_datetime(
         arg,

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -1658,7 +1658,7 @@ def to_datetime(
     }
 
     def pandas_to_datetime(
-        pser_or_pdf: Union[pd.DataFrame, pd.Series], cols: List[str]
+        pser_or_pdf: Union[pd.DataFrame, pd.Series], cols: Optional[List[str]] = None
     ) -> Series[np.datetime64]:
         if isinstance(pser_or_pdf, pd.DataFrame):
             pser_or_pdf = pser_or_pdf[cols]

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -1655,9 +1655,6 @@ def to_datetime(
         "us": "us",
         "microsecond": "us",
         "microseconds": "us",
-        "ns": "ns",
-        "nanosecond": "ns",
-        "nanoseconds": "ns",
     }
 
     # replace passed unit with _unit_map
@@ -1688,7 +1685,7 @@ def to_datetime(
         unit = {k: f(k) for k in arg.keys()}
         unit_rev = {v: k for k, v in unit.items()}
         list_cols = [unit_rev["year"], unit_rev["month"], unit_rev["day"]]
-        for u in ["h", "m", "s", "ms", "us", "ns"]:
+        for u in ["h", "m", "s", "ms", "us"]:
             value = unit_rev.get(u)
             if value is not None and value in arg:
                 list_cols.append(value)

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -1672,7 +1672,7 @@ def to_datetime(
 
     def pandas_to_datetime(pser_or_pdf: Union[pd.DataFrame, pd.Series]) -> Series[np.datetime64]:
         if isinstance(pser_or_pdf, pd.DataFrame):
-            pser_or_pdf = pser_or_pdf[[*list_cols]]
+            pser_or_pdf = pser_or_pdf[list_cols]
         return pd.to_datetime(
             pser_or_pdf,
             errors=errors,
@@ -1693,7 +1693,7 @@ def to_datetime(
             if value is not None and value in arg:
                 list_cols.append(value)
 
-        psdf = arg[[*list_cols]]
+        psdf = arg[list_cols]
         return psdf.pandas_on_spark.transform_batch(pandas_to_datetime)
     return pd.to_datetime(
         arg,

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -92,6 +92,44 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
         self.assert_eq(pd.to_datetime(dict_from_pdf), ps.to_datetime(dict_from_pdf))
 
+        pdf = pd.DataFrame(
+            {
+                "year": [2015, 2016],
+                "month": [2, 3],
+                "day": [4, 5],
+                "hour": [2, 3],
+                "minute": [10, 30],
+                "second": [21, 25],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        dict_from_pdf = pdf.to_dict()
+
+        self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
+        self.assert_eq(pd.to_datetime(dict_from_pdf), ps.to_datetime(dict_from_pdf))
+
+        pdf = pd.DataFrame(
+            {
+                "year": [2015, 2016],
+                "month": [2, 3],
+                "day": [4, 5],
+                "hour": [2, 3],
+                "minute": [10, 30],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        dict_from_pdf = pdf.to_dict()
+
+        self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
+        self.assert_eq(pd.to_datetime(dict_from_pdf), ps.to_datetime(dict_from_pdf))
+
+        pdf = pd.DataFrame({"year": [2015, 2016], "month": [2, 3], "day": [4, 5], "hour": [2, 3]})
+        psdf = ps.from_pandas(pdf)
+        dict_from_pdf = pdf.to_dict()
+
+        self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
+        self.assert_eq(pd.to_datetime(dict_from_pdf), ps.to_datetime(dict_from_pdf))
+
     def test_date_range(self):
         self.assert_eq(
             ps.date_range(start="1/1/2018", end="1/08/2018"),

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -130,6 +130,41 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
         self.assert_eq(pd.to_datetime(dict_from_pdf), ps.to_datetime(dict_from_pdf))
 
+        pdf = pd.DataFrame(
+            {
+                "year": [2015, 2016],
+                "month": [2, 3],
+                "day": [4, 5],
+                "hour": [2, 3],
+                "minute": [10, 30],
+                "second": [21, 25],
+                "ms": [50, 69],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        dict_from_pdf = pdf.to_dict()
+
+        self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
+        self.assert_eq(pd.to_datetime(dict_from_pdf), ps.to_datetime(dict_from_pdf))
+
+        pdf = pd.DataFrame(
+            {
+                "year": [2015, 2016],
+                "month": [2, 3],
+                "day": [4, 5],
+                "hour": [2, 3],
+                "minute": [10, 30],
+                "second": [21, 25],
+                "ms": [50, 69],
+                "millisecond": [123, 678],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        dict_from_pdf = pdf.to_dict()
+
+        self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
+        self.assert_eq(pd.to_datetime(dict_from_pdf), ps.to_datetime(dict_from_pdf))
+
     def test_date_range(self):
         self.assert_eq(
             ps.date_range(start="1/1/2018", end="1/08/2018"),

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -166,6 +166,24 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
         self.assert_eq(pd.to_datetime(dict_from_pdf), ps.to_datetime(dict_from_pdf))
 
+        pdf = pd.DataFrame(
+            {
+                "Year": [2015, 2016],
+                "Month": [2, 3],
+                "Day": [4, 5],
+                "Hour": [2, 3],
+                "Minute": [10, 30],
+                "Second": [21, 25],
+                "ms": [50, 69],
+                "millisecond": [123, 678],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        dict_from_pdf = pdf.to_dict()
+
+        self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
+        self.assert_eq(pd.to_datetime(dict_from_pdf), ps.to_datetime(dict_from_pdf))
+
     def test_date_range(self):
         self.assert_eq(
             ps.date_range(start="1/1/2018", end="1/08/2018"),

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -92,6 +92,7 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
         self.assert_eq(pd.to_datetime(dict_from_pdf), ps.to_datetime(dict_from_pdf))
 
+        # SPARK-36946: Support time for ps.to_datetime
         pdf = pd.DataFrame(
             {
                 "year": [2015, 2016],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Support time for ps.to_datetime


### Why are the changes needed?
ps.to_datetime does not support time elements
```python
# pandas
df_pan = pd.DataFrame({'year': [2015, 2016], 'month': [2, 3], 'day': [4, 5], 'hour': [2, 3], 'minute': [10, 30], 'second': [21,25]})
df_pan['datetime'] = pd.to_datetime(df_pan[['year', 'month', 'day', 'hour', 'minute']])
df_pan

   year  month  day  hour  minute  second            datetime
0  2015      2    4     2      10      21 2015-02-04 02:10:00
1  2016      3    5     3      30      25 2016-03-05 03:30:00


# pandas on spark
df_test = ps.DataFrame({'year': [2015, 2016], 'month': [2, 3], 'day': [4, 5], 'hour': [2, 3], 'minute': [10, 30], 'second': [21,25]})
df_test['datetime'] = ps.to_datetime(df_test[['year', 'month', 'day', 'hour', 'minute']])
df_test

   year  month  day  hour  minute  second   datetime
0  2015      2    4     2      10      21 2015-02-04
1  2016      3    5     3      30      25 2016-03-05
```


### Does this PR introduce _any_ user-facing change?
Yes.
After that
```python
# pandas on spark
df_test = ps.DataFrame({'year': [2015, 2016], 'month': [2, 3], 'day': [4, 5], 'hour': [2, 3], 'minute': [10, 30], 'second': [21,25]})
df_test['datetime'] = ps.to_datetime(df_test[['year', 'month', 'day', 'hour', 'minute']])
df_test

   year  month  day  hour  minute  second            datetime
0  2015      2    4     2      10      21 2015-02-04 02:10:00
1  2016      3    5     3      30      25 2016-03-05 03:30:00

```


### How was this patch tested?
Unit test
