### PR TITLE
[SPARK-36948][SQL][TESTS] Check CREATE TABLE with ANSI intervals using Hive external catalog and Parquet

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hive
 
+import java.time.{Duration, Period}
 import java.time.temporal.ChronoUnit
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
@@ -137,8 +138,8 @@ class HiveParquetSuite extends QueryTest with ParquetTest with TestHiveSingleton
       checkAnswer(
         sql(s"SELECT * FROM $tbl"),
         Row(
-          java.time.Period.ofYears(1).plusMonths(1),
-          java.time.Duration.ofDays(1).plusHours(2).plusMinutes(3).plusSeconds(4)
+          Period.ofYears(1).plusMonths(1),
+          Duration.ofDays(1).plusHours(2).plusMinutes(3).plusSeconds(4)
             .plus(123456, ChronoUnit.MICROS)))
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.hive
 
+import java.time.temporal.ChronoUnit
+
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.hive.test.TestHiveSingleton
@@ -121,6 +123,23 @@ class HiveParquetSuite extends QueryTest with ParquetTest with TestHiveSingleton
           """.stripMargin)
       }.getMessage
       assert(msg.contains("cannot resolve 'c3' given input columns"))
+    }
+  }
+
+  test("SPARK-36948: Create a table with ANSI intervals using Hive external catalog") {
+    val tbl = "tbl_with_ansi_intervals"
+    withTable(tbl) {
+      sql(s"CREATE TABLE $tbl (ym INTERVAL YEAR TO MONTH, dt INTERVAL DAY TO SECOND) USING PARQUET")
+      sql(
+        s"""INSERT INTO $tbl VALUES (
+           |  INTERVAL '1-1' YEAR TO MONTH,
+           |  INTERVAL '1 02:03:04.123456' DAY TO SECOND)""".stripMargin)
+      checkAnswer(
+        sql(s"SELECT * FROM $tbl"),
+        Row(
+          java.time.Period.ofYears(1).plusMonths(1),
+          java.time.Duration.ofDays(1).plusHours(2).plusMinutes(3).plusSeconds(4)
+            .plus(123456, ChronoUnit.MICROS)))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose new test to check:
1. CREATE TABLE with ANSI interval columns
2. INSERT INTO the table ANSI interval values
3. SELECT the table with ANSI interval columns

Since Hive Metastore/Parquet Serde doesn't support interval types natively, Spark fallbacks to its specific format while saving the schema to Hive external catalog, and outputs the warning:
```
20:10:52.797 WARN org.apache.spark.sql.hive.test.TestHiveExternalCatalog: Could not persist `default`.`tbl_with_ansi_intervals` in a Hive compatible way. Persisting it into Hive metastore in Spark SQL specific format.
org.apache.hadoop.hive.ql.metadata.HiveException: java.lang.IllegalArgumentException: Error: type expected at the position 0 of 'interval year to month:interval day to second' but 'interval year to month' is found.
	at org.apache.hadoop.hive.ql.metadata.Hive.createTable(Hive.java:869)
``` 

### Why are the changes needed?
To improve test coverage.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running new test:
```
$ ./build/sbt -Phive-2.3 "test:testOnly *HiveParquetSuite"
```