### PR TITLE
[SPARK-36839][INFRA][FOLLOW-UP] Add Hadoop 2 daily job into schedule

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,6 +25,8 @@ on:
     - '**'
     - '!branch-*.*'
   schedule:
+    # master, Hadoop 2
+    - cron: '0 1 * * *'
     # master
     - cron: '0 4 * * *'
     # branch-3.2


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/34091 to set the Hadoop 2 daily job properly.
The previous PR mistakenly did not set the schedule so the daily jobs are not being triggered - looks like I forgot to sync the PR with the testing base in my fork.

### Why are the changes needed?

In order to run the daily job with Hadoop 2.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

It will be tested once it's merged. It won't break any build in any event.