### PR TITLE
[SPARK-36897][PYTHON] Use NamedTuple with variable type hints instead of namedtuple

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -17,8 +17,7 @@
 
 import sys
 import warnings
-from collections import namedtuple
-from typing import Any, Callable, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, NamedTuple, List, Optional, TYPE_CHECKING
 
 from pyspark import since
 from pyspark.sql.dataframe import DataFrame
@@ -30,10 +29,34 @@ if TYPE_CHECKING:
     from pyspark.sql.types import DataType
 
 
-Database = namedtuple("Database", "name description locationUri")
-Table = namedtuple("Table", "name database description tableType isTemporary")
-Column = namedtuple("Column", "name description dataType nullable isPartition isBucket")
-Function = namedtuple("Function", "name description className isTemporary")
+class Database(NamedTuple):
+    name: str
+    description: Optional[str]
+    locationUri: str
+
+
+class Table(NamedTuple):
+    name: str
+    database: Optional[str]
+    description: Optional[str]
+    tableType: str
+    isTemporary: bool
+
+
+class Column(NamedTuple):
+    name: str
+    description: Optional[str]
+    dataType: str
+    nullable: bool
+    isPartition: bool
+    isBucket: bool
+
+
+class Function(NamedTuple):
+    name: str
+    description: Optional[str]
+    className: str
+    isTemporary: bool
 
 
 class Catalog(object):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `NamedTuple` with variable type hints instead of `namedtuple`.

### Why are the changes needed?

Per discussion under https://github.com/apache/spark/pull/34133#discussion_r718833451, we wanted to replace `collections.namedtuple()` by `typing.NamedTuple`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.