### PR TITLE
[SPARK-36839][INFRA][FOLLOW-UP] Respect Hadoop version configured in scheduled GitHub Actions jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -91,7 +91,7 @@ jobs:
         java:
           - 8
         hadoop:
-          - hadoop3.2
+          - ${{ needs.configure-jobs.outputs.hadoop }}
         hive:
           - hive2.3
         # TODO(SPARK-32246): We don't test 'streaming-kinesis-asl' for now.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of #34091 and https://github.com/apache/spark/pull/34217.
We should respect the default Hadoop 2.7 (not only in Hive's tests).

### Why are the changes needed?

In order to run the daily job with Hadoop 2 for all tests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

It will be tested once it's merged. It won't break any build in any event.
