### PR TITLE
[SPARK-36964][CORE][YARN] Share cached dnsToSwitchMapping for yarn locality container requests

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/SparkRackResolver.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/SparkRackResolver.scala
@@ -53,7 +53,7 @@ private[spark] class SparkRackResolver(conf: Configuration) extends Logging {
     case Success(result) =>
       logInfo(s"Using yarn RackResolver dnsToSwitchMapping.")
       result
-    case Failure(NonFatal(_)) =>
+    case Failure(_) =>
       logInfo(s"Using spark RackResolver dnsToSwitchMapping.")
       val dnsToSwitchMappingClass =
         conf.getClass(CommonConfigurationKeysPublic.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/SparkRackResolver.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/SparkRackResolver.scala
@@ -20,7 +20,6 @@ package org.apache.spark.deploy.yarn
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Success, Try}
-import scala.util.control.NonFatal
 
 import com.google.common.base.Strings
 import org.apache.hadoop.conf.Configuration


### PR DESCRIPTION
### What changes were proposed in this pull request?

since SPARK-13704, spark re-implemented RackResolver and created a separate dnsToSwitchMapping instance. Here change to use RackResolver's internal dnsToSwitchMapping to reduce the time taken by YarnAllocator to add container requests.

### Why are the changes needed?

If submits a stage with abundant tasks, rack resolving takes a long time when YarnAllocator add requests with locality preference, which is caused by a large number of loops to execute the rack parsing script, eventually causing ExecutorAllocationManager request total Executors rpc  timeout.

### How was this patch tested?
UT +  manually testing on a 5w+ node cluster.