### PR TITLE
[SPARK-35973][SQL] Add command `SHOW CATALOGS`

### DIFF
--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -329,6 +329,7 @@ Below is a list of all the keywords in Spark SQL.
 |CASE|reserved|non-reserved|reserved|
 |CAST|reserved|non-reserved|reserved|
 |CATALOG|non-reserved|non-reserved|non-reserved|
+|CATALOGS|non-reserved|non-reserved|non-reserved|
 |CHANGE|non-reserved|non-reserved|non-reserved|
 |CHECK|reserved|non-reserved|reserved|
 |CLEAR|non-reserved|non-reserved|non-reserved|

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -214,6 +214,7 @@ statement
         (LIKE? (multipartIdentifier | pattern=STRING))?                #showFunctions
     | SHOW CREATE TABLE multipartIdentifier (AS SERDE)?                #showCreateTable
     | SHOW CURRENT NAMESPACE                                           #showCurrentNamespace
+    | SHOW CATALOGS (LIKE? pattern=STRING)?                            #showCatalogs
     | (DESC | DESCRIBE) FUNCTION EXTENDED? describeFuncName            #describeFunction
     | (DESC | DESCRIBE) namespace EXTENDED?
         multipartIdentifier                                            #describeNamespace
@@ -1066,6 +1067,7 @@ ansiNonReserved
     | CACHE
     | CASCADE
     | CATALOG
+    | CATALOGS
     | CHANGE
     | CLEAR
     | CLUSTER
@@ -1296,6 +1298,7 @@ nonReserved
     | CASE
     | CAST
     | CATALOG
+    | CATALOGS
     | CHANGE
     | CHECK
     | CLEAR
@@ -1551,6 +1554,7 @@ CASCADE: 'CASCADE';
 CASE: 'CASE';
 CAST: 'CAST';
 CATALOG: 'CATALOG';
+CATALOGS: 'CATALOGS';
 CHANGE: 'CHANGE';
 CHECK: 'CHECK';
 CLEAR: 'CLEAR';

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.connector.catalog
 
 import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.SQLConfHelper
@@ -131,7 +130,7 @@ class CatalogManager(
     }
   }
 
-  def listCatalogs(pattern: Option[String]): Seq[String] = synchronized {
+  def listCatalogs(pattern: Option[String]): Seq[String] = {
     val allCatalogs = synchronized(catalogs.keys.toSeq).sorted
     pattern.map(StringUtils.filterPattern(allCatalogs, _)).getOrElse(allCatalogs)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -132,11 +132,8 @@ class CatalogManager(
   }
 
   def listCatalogs(pattern: Option[String]): Seq[String] = synchronized {
-    val result = new ArrayBuffer[String]
-    val allCatalogs = catalogs.keys.toSeq.sorted
-    val matched = pattern.map(StringUtils.filterPattern(allCatalogs, _)).getOrElse(allCatalogs)
-    result ++= matched
-    result.toSeq
+    val allCatalogs = synchronized(catalogs.keys.toSeq).sorted
+    pattern.map(StringUtils.filterPattern(allCatalogs, _)).getOrElse(allCatalogs)
   }
 
   // Clear all the registered catalogs. Only used in tests.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -18,10 +18,12 @@
 package org.apache.spark.sql.connector.catalog
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog
+import org.apache.spark.sql.catalyst.util.StringUtils
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
 
@@ -127,6 +129,14 @@ class CatalogManager(
       // when we switch back to session catalog, the current namespace definitely is ["default"].
       v1SessionCatalog.setCurrentDatabase(SessionCatalog.DEFAULT_DATABASE)
     }
+  }
+
+  def listCatalogs(pattern: Option[String]): Seq[String] = synchronized {
+    val result = new ArrayBuffer[String]
+    val allCatalogs = catalogs.keys.toSeq.sorted
+    val matched = pattern.map(StringUtils.filterPattern(allCatalogs, _)).getOrElse(allCatalogs)
+    result ++= matched
+    result.toSeq
   }
 
   // Clear all the registered catalogs. Only used in tests.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -261,6 +261,13 @@ class SparkSqlAstBuilder extends AstBuilder {
   }
 
   /**
+   * Create a [[ShowCatalogsCommand]] logical command.
+   */
+  override def visitShowCatalogs(ctx: ShowCatalogsContext) : LogicalPlan = withOrigin(ctx) {
+    ShowCatalogsCommand(Option(ctx.pattern).map(string))
+  }
+
+  /**
    * Converts a multi-part identifier to a TableIdentifier.
    *
    * If the multi-part identifier has too many parts, this will throw a ParseException.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ShowCatalogsCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ShowCatalogsCommand.scala
@@ -34,10 +34,6 @@ case class ShowCatalogsCommand(pattern: Option[String]) extends LeafRunnableComm
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val rows = new ArrayBuffer[Row]
     val catalogManager = sparkSession.sessionState.catalogManager
-    val catalogs = catalogManager.listCatalogs(pattern)
-    catalogs.foreach { name =>
-      rows += Row(name)
-    }
-    rows.toSeq
+    catalogManager.listCatalogs(pattern).map(Row(_))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ShowCatalogsCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ShowCatalogsCommand.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.command
 
-import scala.collection.mutable.ArrayBuffer
-
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.types.StringType
@@ -32,7 +30,6 @@ case class ShowCatalogsCommand(pattern: Option[String]) extends LeafRunnableComm
     AttributeReference("catalog", StringType, nullable = false)())
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val rows = new ArrayBuffer[Row]
     val catalogManager = sparkSession.sessionState.catalogManager
     catalogManager.listCatalogs(pattern).map(Row(_))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ShowCatalogsCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ShowCatalogsCommand.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.types.StringType
+
+
+/**
+ * The command for `SHOW CATALOGS`.
+ */
+case class ShowCatalogsCommand(pattern: Option[String]) extends LeafRunnableCommand {
+  override val output: Seq[Attribute] = Seq(
+    AttributeReference("catalog", StringType, nullable = false)())
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val rows = new ArrayBuffer[Row]
+    val catalogManager = sparkSession.sessionState.catalogManager
+    val catalogs = catalogManager.listCatalogs(pattern)
+    catalogs.foreach { name =>
+      rows += Row(name)
+    }
+    rows.toSeq
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -416,4 +416,13 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
       parser.parsePlan("SET CATALOG `a b c`"),
       SetCatalogCommand("a b c"))
   }
+
+  test("SHOW CATALOGS") {
+    comparePlans(
+      parser.parsePlan("SHOW CATALOGS"),
+      ShowCatalogsCommand(None))
+    comparePlans(
+      parser.parsePlan("SHOW CATALOGS LIKE 'defau*'"),
+      ShowCatalogsCommand(Some("defau*")))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
[History](https://github.com/apache/spark/pull/33175)
Datasource V2 can support multiple catalogs. Having "SHOW CATALOGS" to list the catalogs name will be useful.

### Why are the changes needed?
[SPARK-35973](https://issues.apache.org/jira/browse/SPARK-35973)

### Does this PR introduce _any_ user-facing change?
Yes, we can use `SHOW CATALOGS` command to list catalogs info. eg:
```
+-------------+
|      catalog|
+-------------+
|spark_catalog|
|      testcat|
+-------------+
```
### How was this patch tested?
Add ut test
