### PR TITLE
[SPARK-36965][PYTHON] Extend python test runner by logging out the temp output files

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -48,6 +48,11 @@ def print_red(text):
     print('\033[31m' + text + '\033[0m')
 
 
+def get_valid_filename(s):
+    s = s.strip().replace(' ', '_').replace(os.sep, '_')
+    return re.sub(r'(?u)[^-\w.]', '', s)
+
+
 SKIPPED_TESTS = None
 LOG_FILE = os.path.join(SPARK_HOME, "python/unit-tests.log")
 FAILURE_REPORTING_LOCK = Lock()
@@ -98,10 +103,11 @@ def run_individual_python_test(target_dir, test_name, pyspark_python):
     ]
     env["PYSPARK_SUBMIT_ARGS"] = " ".join(spark_args)
 
-    LOGGER.info("Starting test(%s): %s", pyspark_python, test_name)
+    output_prefix = get_valid_filename(pyspark_python + "__" + test_name + "__").lstrip("_")
+    per_test_output = tempfile.NamedTemporaryFile(prefix=output_prefix, suffix=".log")
+    LOGGER.info("Starting test(%s): %s (temp output: %s)", pyspark_python, test_name, per_test_output.name)
     start_time = time.time()
     try:
-        per_test_output = tempfile.TemporaryFile()
         retcode = subprocess.Popen(
             [os.path.join(SPARK_HOME, "bin/pyspark")] + test_name.split(),
             stderr=per_test_output, stdout=per_test_output, env=env).wait()

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -49,6 +49,7 @@ def print_red(text):
 
 
 def get_valid_filename(s):
+    """Replace whitespaces and special characters in the given string to get a valid file name."""
     s = s.strip().replace(' ', '_').replace(os.sep, '_')
     return re.sub(r'(?u)[^-\w.]', '', s)
 

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -105,7 +105,8 @@ def run_individual_python_test(target_dir, test_name, pyspark_python):
 
     output_prefix = get_valid_filename(pyspark_python + "__" + test_name + "__").lstrip("_")
     per_test_output = tempfile.NamedTemporaryFile(prefix=output_prefix, suffix=".log")
-    LOGGER.info("Starting test(%s): %s (temp output: %s)", pyspark_python, test_name, per_test_output.name)
+    LOGGER.info(
+        "Starting test(%s): %s (temp output: %s)", pyspark_python, test_name, per_test_output.name)
     start_time = time.time()
     try:
         retcode = subprocess.Popen(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extending the python test runner by logging out the temp output files.

### Why are the changes needed?

I was running a python test which was extremely slow and I was surprised the unit-tests.log has not been even created. Looked into the code and as I got the tests can be executed in parallel and each one has its own temporary output file which is only added to the unit-tests.log when a test is finished with a failure (after acquiring a lock to avoid parallel write on unit-tests.log).

To avoid such a confusion it would make sense to log out the path of those temporary output files this way when a test got stuck we can peek into its log file.

### Does this PR introduce _any_ user-facing change?

No. 

### How was this patch tested?

I was running the python tests:
```
./python/run-tests
Running PySpark tests. Output is in /Users/attilazsoltpiros/git/attilapiros/spark/python/unit-tests.log
Will test against the following Python executables: ['/usr/local/bin/python3']
Will test the following Python modules: ['pyspark-core', 'pyspark-ml', 'pyspark-mllib', 'pyspark-pandas', 'pyspark-pandas-slow', 'pyspark-resource', 'pyspark-sql', 'pyspark-streaming']
/usr/local/bin/python3 python_implementation is CPython
/usr/local/bin/python3 version is: Python 3.9.7
Starting test(/usr/local/bin/python3): pyspark.ml.tests.test_feature (temp output: /tmp/usr_local_bin_python3__pyspark.ml.tests.test_feature__yc5_5mjk.log)
Starting test(/usr/local/bin/python3): pyspark.ml.tests.test_algorithms (temp output: /tmp/usr_local_bin_python3__pyspark.ml.tests.test_algorithms__icc6xxai.log)
Starting test(/usr/local/bin/python3): pyspark.ml.tests.test_base (temp output: /tmp/usr_local_bin_python3__pyspark.ml.tests.test_base__4m6xyiv5.log)
Starting test(/usr/local/bin/python3): pyspark.ml.tests.test_evaluation (temp output: /tmp/usr_local_bin_python3__pyspark.ml.tests.test_evaluation__fkzjlfmm.log)
Finished test(/usr/local/bin/python3): pyspark.ml.tests.test_base (16s)
Starting test(/usr/local/bin/python3): pyspark.ml.tests.test_image (temp output: /tmp/usr_local_bin_python3__pyspark.ml.tests.test_image__iuckk_c0.log)
Finished test(/usr/local/bin/python3): pyspark.ml.tests.test_evaluation (20s)
Starting test(/usr/local/bin/python3): pyspark.ml.tests.test_linalg (temp output: /tmp/usr_local_bin_python3__pyspark.ml.tests.test_linalg__3tncana4.log)
...
```
