### PR TITLE
[SPARK-36647][SQL][TESTS] Push down Aggregate (Min/Max/Count) for Parquet if filter is on partition col

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
@@ -130,10 +130,10 @@ case class ParquetScanBuilder(
       // are combined with filter or group by
       // e.g. SELECT COUNT(col1) FROM t WHERE col2 = 8
       //      SELECT COUNT(col1) FROM t GROUP BY col2
-      // Todo: 1. add support if groupby column is partition col
-      //          (https://issues.apache.org/jira/browse/SPARK-36646)
-      //       2. add support if filter col is partition col
-      //          (https://issues.apache.org/jira/browse/SPARK-36647)
+      // However, if the filter or group by is on partition column,
+      // max/min/count can still be pushed down
+      // Todo:  add support if groupby column is partition col
+      //        (https://issues.apache.org/jira/browse/SPARK-36646)
       return false
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
@@ -130,8 +130,7 @@ case class ParquetScanBuilder(
       // are combined with filter or group by
       // e.g. SELECT COUNT(col1) FROM t WHERE col2 = 8
       //      SELECT COUNT(col1) FROM t GROUP BY col2
-      // However, if the filter or group by is on partition column,
-      // max/min/count can still be pushed down
+      // However, if the filter is on partition column, max/min/count can still be pushed down
       // Todo:  add support if groupby column is partition col
       //        (https://issues.apache.org/jira/browse/SPARK-36646)
       return false

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAggregatePushDownSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAggregatePushDownSuite.scala
@@ -248,14 +248,14 @@ abstract class ParquetAggregatePushDownSuite
         Seq("false", "true").foreach { enableVectorizedReader =>
           withSQLConf(SQLConf.PARQUET_AGGREGATE_PUSHDOWN_ENABLED.key -> "true",
             vectorizedReaderEnabledKey -> enableVectorizedReader) {
-            val max = sql("SELECT max(id) FROM tmp WHERE p = 0")
+            val max = sql("SELECT max(id), min(id), count(id) FROM tmp WHERE p = 0")
             max.queryExecution.optimizedPlan.collect {
               case _: DataSourceV2ScanRelation =>
                 val expected_plan_fragment =
-                  "PushedAggregation: [MAX(id)]"
+                  "[MAX(id), MIN(id), COUNT(id)]"
                 checkKeywordsExistsInExplain(max, expected_plan_fragment)
             }
-            checkAnswer(max, Seq(Row(9)))
+            checkAnswer(max, Seq(Row(9, 0, 4)))
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAggregatePushDownSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAggregatePushDownSuite.scala
@@ -129,10 +129,9 @@ abstract class ParquetAggregatePushDownSuite
         .write.partitionBy("p").parquet(dir.getCanonicalPath)
       withTempView("tmp") {
         spark.read.parquet(dir.getCanonicalPath).createOrReplaceTempView("tmp");
-        val enableVectorizedReader = Seq("false", "true")
-        for (testVectorizedReader <- enableVectorizedReader) {
+        Seq("false", "true").foreach { enableVectorizedReader =>
           withSQLConf(SQLConf.PARQUET_AGGREGATE_PUSHDOWN_ENABLED.key -> "true",
-            vectorizedReaderEnabledKey -> testVectorizedReader) {
+            vectorizedReaderEnabledKey -> enableVectorizedReader) {
             val count = sql("SELECT COUNT(p) FROM tmp")
             count.queryExecution.optimizedPlan.collect {
               case _: DataSourceV2ScanRelation =>
@@ -246,10 +245,9 @@ abstract class ParquetAggregatePushDownSuite
         .write.partitionBy("p").parquet(dir.getCanonicalPath)
       withTempView("tmp") {
         spark.read.parquet(dir.getCanonicalPath).createOrReplaceTempView("tmp");
-        val enableVectorizedReader = Seq("false", "true")
-        for (testVectorizedReader <- enableVectorizedReader) {
+        Seq("false", "true").foreach { enableVectorizedReader =>
           withSQLConf(SQLConf.PARQUET_AGGREGATE_PUSHDOWN_ENABLED.key -> "true",
-            vectorizedReaderEnabledKey -> testVectorizedReader) {
+            vectorizedReaderEnabledKey -> enableVectorizedReader) {
             val max = sql("SELECT max(id) FROM tmp WHERE p = 0")
             max.queryExecution.optimizedPlan.collect {
               case _: DataSourceV2ScanRelation =>
@@ -380,10 +378,9 @@ abstract class ParquetAggregatePushDownSuite
       spark.createDataFrame(rdd, schema).write.parquet(file.getCanonicalPath)
       withTempView("test") {
         spark.read.parquet(file.getCanonicalPath).createOrReplaceTempView("test")
-        val enableVectorizedReader = Seq("false", "true")
-        for (testVectorizedReader <- enableVectorizedReader) {
+        Seq("false", "true").foreach { enableVectorizedReader =>
           withSQLConf(SQLConf.PARQUET_AGGREGATE_PUSHDOWN_ENABLED.key -> "true",
-            vectorizedReaderEnabledKey -> testVectorizedReader) {
+            vectorizedReaderEnabledKey -> enableVectorizedReader) {
 
             val testMinWithTS = sql("SELECT min(StringCol), min(BooleanCol), min(ByteCol), " +
               "min(BinaryCol), min(ShortCol), min(IntegerCol), min(LongCol), min(FloatCol), " +
@@ -501,10 +498,9 @@ abstract class ParquetAggregatePushDownSuite
   }
 
   test("aggregate push down - column name case sensitivity") {
-    val enableVectorizedReader = Seq("false", "true")
-    for (testVectorizedReader <- enableVectorizedReader) {
+    Seq("false", "true").foreach { enableVectorizedReader =>
       withSQLConf(SQLConf.PARQUET_AGGREGATE_PUSHDOWN_ENABLED.key -> "true",
-        vectorizedReaderEnabledKey -> testVectorizedReader) {
+        vectorizedReaderEnabledKey -> enableVectorizedReader) {
         withTempPath { dir =>
           spark.range(10).selectExpr("id", "id % 3 as p")
             .write.partitionBy("p").parquet(dir.getCanonicalPath)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAggregatePushDownSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetAggregatePushDownSuite.scala
@@ -252,7 +252,7 @@ abstract class ParquetAggregatePushDownSuite
             max.queryExecution.optimizedPlan.collect {
               case _: DataSourceV2ScanRelation =>
                 val expected_plan_fragment =
-                  "[MAX(id), MIN(id), COUNT(id)]"
+                  "PushedAggregation: [MAX(id), MIN(id), COUNT(id)]"
                 checkKeywordsExistsInExplain(max, expected_plan_fragment)
             }
             checkAnswer(max, Seq(Row(9, 0, 4)))


### PR DESCRIPTION
### What changes were proposed in this pull request?
I just realized that with the changes in https://github.com/apache/spark/pull/33650, the restriction for not pushing down Min/Max/Count for partition filter was already removed. This PR just added test to make sure Min/Max/Count in parquet are pushed down if filter is on partition col.


### Why are the changes needed?
To complete the work for Aggregate (Min/Max/Count) push down for Parquet


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
new test
