### PR TITLE
[SPARK-36905][SQL] Fix reading hive views without explicit column names

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -921,7 +921,7 @@ class SessionCatalog(
       // the schema in metadata will be `_c0` while the parsed view plan has column named `1`
       metadata.schema.zipWithIndex.map { case (field, index) =>
         val col = GetColumnByOrdinal(index, field.dataType)
-        Alias(col, field.name)(explicitMetadata = Some(field.metadata))
+        Alias(UpCast(col, field.dataType), field.name)(explicitMetadata = Some(field.metadata))
       }
     }
     View(desc = metadata, isTempView = isTempView, child = Project(projectList, parsedPlan))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -862,11 +862,6 @@ class SessionCatalog(
     }
   }
 
-  private def isSparkCreatedView(metadata: CatalogTable): Boolean = {
-    // For view created before Spark 2.2.0, only schema properties are set.
-    metadata.properties.contains("spark.sql.schema.numParts")
-  }
-
   private def fromCatalogTable(metadata: CatalogTable, isTempView: Boolean): View = {
     val viewText = metadata.viewText.getOrElse {
       throw new IllegalStateException("Invalid view without text.")
@@ -875,35 +870,28 @@ class SessionCatalog(
     val parsedPlan = SQLConf.withExistingConf(View.effectiveSQLConf(viewConfigs, isTempView)) {
       parser.parsePlan(viewText)
     }
-    val viewColumnNames = if (metadata.viewQueryColumnNames.isEmpty) {
-      // For view created before Spark 2.2.0, the view text is already fully qualified, the plan
-      // output is the same with the view output.
-      metadata.schema.fieldNames.toSeq
-    } else {
+
+    val projectList = if (metadata.viewQueryColumnNames.nonEmpty) {
       assert(metadata.viewQueryColumnNames.length == metadata.schema.length)
-      metadata.viewQueryColumnNames
-    }
-
-    // For view queries like `SELECT * FROM t`, the schema of the referenced table/view may
-    // change after the view has been created. We need to add an extra SELECT to pick the columns
-    // according to the recorded column names (to get the correct view column ordering and omit
-    // the extra columns that we don't require), with UpCast (to make sure the type change is
-    // safe) and Alias (to respect user-specified view column names) according to the view schema
-    // in the catalog.
-    // Note that, the column names may have duplication, e.g. `CREATE VIEW v(x, y) AS
-    // SELECT 1 col, 2 col`. We need to make sure that the matching attributes have the same
-    // number of duplications, and pick the corresponding attribute by ordinal.
-    val viewConf = View.effectiveSQLConf(metadata.viewSQLConfigs, isTempView)
-    val normalizeColName: String => String = if (viewConf.caseSensitiveAnalysis) {
-      identity
-    } else {
-      _.toLowerCase(Locale.ROOT)
-    }
-    val nameToCounts = viewColumnNames.groupBy(normalizeColName).mapValues(_.length)
-    val nameToCurrentOrdinal = scala.collection.mutable.HashMap.empty[String, Int]
-    val viewDDL = buildViewDDL(metadata, isTempView)
-
-    val projectList = if (isSparkCreatedView(metadata)) {
+      val viewColumnNames = metadata.viewQueryColumnNames
+      // For view queries like `SELECT * FROM t`, the schema of the referenced table/view may
+      // change after the view has been created. We need to add an extra SELECT to pick the columns
+      // according to the recorded column names (to get the correct view column ordering and omit
+      // the extra columns that we don't require), with UpCast (to make sure the type change is
+      // safe) and Alias (to respect user-specified view column names) according to the view schema
+      // in the catalog.
+      // Note that, the column names may have duplication, e.g. `CREATE VIEW v(x, y) AS
+      // SELECT 1 col, 2 col`. We need to make sure that the matching attributes have the same
+      // number of duplications, and pick the corresponding attribute by ordinal.
+      val viewConf = View.effectiveSQLConf(metadata.viewSQLConfigs, isTempView)
+      val normalizeColName: String => String = if (viewConf.caseSensitiveAnalysis) {
+        identity
+      } else {
+        _.toLowerCase(Locale.ROOT)
+      }
+      val nameToCounts = viewColumnNames.groupBy(normalizeColName).mapValues(_.length)
+      val nameToCurrentOrdinal = scala.collection.mutable.HashMap.empty[String, Int]
+      val viewDDL = buildViewDDL(metadata, isTempView)
       viewColumnNames.zip(metadata.schema).map { case (name, field) =>
         val normalizedName = normalizeColName(name)
         val count = nameToCounts(normalizedName)
@@ -914,9 +902,11 @@ class SessionCatalog(
         Alias(UpCast(col, field.dataType), field.name)(explicitMetadata = Some(field.metadata))
       }
     } else {
-      // For view created by hive, the parsed view plan may have different output columns with
+      // For view created by Hive, the parsed view plan may have different output columns with
       // the schema stored in metadata. For example: `CREATE VIEW v AS SELECT 1 FROM t`
       // the schema in metadata will be `_c0` while the parsed view plan has column named `1`
+      // For view created by Spark 2.1 or prior, the view text is already fully qualified, the plan
+      // output is the same with the view output. But it's ok to add a redundant alias.
       metadata.schema.zipWithIndex.map { case (field, index) =>
         val col = GetColumnByOrdinal(index, field.dataType)
         Alias(col, field.name)(explicitMetadata = Some(field.metadata))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -862,6 +862,13 @@ class SessionCatalog(
     }
   }
 
+  private def isHiveCreatedView(metadata: CatalogTable): Boolean = {
+    // For views created by hive without explicit column names, there will be auto-generated
+    // column names like "_c0", "_c1", "_c2"...
+    metadata.viewQueryColumnNames.isEmpty &&
+      metadata.schema.fieldNames.exists(_.matches("_c[0-9]+"))
+  }
+
   private def fromCatalogTable(metadata: CatalogTable, isTempView: Boolean): View = {
     val viewText = metadata.viewText.getOrElse {
       throw new IllegalStateException("Invalid view without text.")
@@ -870,28 +877,35 @@ class SessionCatalog(
     val parsedPlan = SQLConf.withExistingConf(View.effectiveSQLConf(viewConfigs, isTempView)) {
       parser.parsePlan(viewText)
     }
-
-    val projectList = if (metadata.viewQueryColumnNames.nonEmpty) {
+    val viewColumnNames = if (metadata.viewQueryColumnNames.isEmpty) {
+      // For view created before Spark 2.2.0, the view text is already fully qualified, the plan
+      // output is the same with the view output.
+      metadata.schema.fieldNames.toSeq
+    } else {
       assert(metadata.viewQueryColumnNames.length == metadata.schema.length)
-      val viewColumnNames = metadata.viewQueryColumnNames
-      // For view queries like `SELECT * FROM t`, the schema of the referenced table/view may
-      // change after the view has been created. We need to add an extra SELECT to pick the columns
-      // according to the recorded column names (to get the correct view column ordering and omit
-      // the extra columns that we don't require), with UpCast (to make sure the type change is
-      // safe) and Alias (to respect user-specified view column names) according to the view schema
-      // in the catalog.
-      // Note that, the column names may have duplication, e.g. `CREATE VIEW v(x, y) AS
-      // SELECT 1 col, 2 col`. We need to make sure that the matching attributes have the same
-      // number of duplications, and pick the corresponding attribute by ordinal.
-      val viewConf = View.effectiveSQLConf(metadata.viewSQLConfigs, isTempView)
-      val normalizeColName: String => String = if (viewConf.caseSensitiveAnalysis) {
-        identity
-      } else {
-        _.toLowerCase(Locale.ROOT)
-      }
-      val nameToCounts = viewColumnNames.groupBy(normalizeColName).mapValues(_.length)
-      val nameToCurrentOrdinal = scala.collection.mutable.HashMap.empty[String, Int]
-      val viewDDL = buildViewDDL(metadata, isTempView)
+      metadata.viewQueryColumnNames
+    }
+
+    // For view queries like `SELECT * FROM t`, the schema of the referenced table/view may
+    // change after the view has been created. We need to add an extra SELECT to pick the columns
+    // according to the recorded column names (to get the correct view column ordering and omit
+    // the extra columns that we don't require), with UpCast (to make sure the type change is
+    // safe) and Alias (to respect user-specified view column names) according to the view schema
+    // in the catalog.
+    // Note that, the column names may have duplication, e.g. `CREATE VIEW v(x, y) AS
+    // SELECT 1 col, 2 col`. We need to make sure that the matching attributes have the same
+    // number of duplications, and pick the corresponding attribute by ordinal.
+    val viewConf = View.effectiveSQLConf(metadata.viewSQLConfigs, isTempView)
+    val normalizeColName: String => String = if (viewConf.caseSensitiveAnalysis) {
+      identity
+    } else {
+      _.toLowerCase(Locale.ROOT)
+    }
+    val nameToCounts = viewColumnNames.groupBy(normalizeColName).mapValues(_.length)
+    val nameToCurrentOrdinal = scala.collection.mutable.HashMap.empty[String, Int]
+    val viewDDL = buildViewDDL(metadata, isTempView)
+
+    val projectList = if (!isHiveCreatedView(metadata)) {
       viewColumnNames.zip(metadata.schema).map { case (name, field) =>
         val normalizedName = normalizeColName(name)
         val count = nameToCounts(normalizedName)
@@ -902,11 +916,9 @@ class SessionCatalog(
         Alias(UpCast(col, field.dataType), field.name)(explicitMetadata = Some(field.metadata))
       }
     } else {
-      // For view created by Hive, the parsed view plan may have different output columns with
+      // For view created by hive, the parsed view plan may have different output columns with
       // the schema stored in metadata. For example: `CREATE VIEW v AS SELECT 1 FROM t`
       // the schema in metadata will be `_c0` while the parsed view plan has column named `1`
-      // For view created by Spark 2.1 or prior, the view text is already fully qualified, the plan
-      // output is the same with the view output. But it's ok to add a redundant alias.
       metadata.schema.zipWithIndex.map { case (field, index) =>
         val col = GetColumnByOrdinal(index, field.dataType)
         Alias(col, field.name)(explicitMetadata = Some(field.metadata))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2634,18 +2634,13 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
   }
 
   test("SPARK-36905: read hive views without without explicit column names") {
-    withTempDir { dir =>
-      val t1Loc = s"file:///$dir/t1"
       withTable("t1") {
         withView("test_view") {
-          hiveClient.runSqlHive(
-            s"create table t1(id int) stored as avro location '$t1Loc'")
-          hiveClient.runSqlHive("insert into t1 select 2")
+          hiveClient.runSqlHive("create table t1 stored as avro as select 2 as id")
           hiveClient.runSqlHive("create view test_view as select 1, id + 1 from t1")
           checkAnswer(sql("select * from test_view"), Seq(Row(1, 3)))
         }
       }
-    }
   }
 }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2634,13 +2634,13 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
   }
 
   test("SPARK-36905: read hive views without without explicit column names") {
-      withTable("t1") {
-        withView("test_view") {
-          hiveClient.runSqlHive("create table t1 stored as avro as select 2 as id")
-          hiveClient.runSqlHive("create view test_view as select 1, id + 1 from t1")
-          checkAnswer(sql("select * from test_view"), Seq(Row(1, 3)))
-        }
+    withTable("t1") {
+      withView("test_view") {
+        hiveClient.runSqlHive("create table t1 stored as avro as select 2 as id")
+        hiveClient.runSqlHive("create view test_view as select 1, id + 1 from t1")
+        checkAnswer(sql("select * from test_view"), Seq(Row(1, 3)))
       }
+    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
When a hive view is created without explicit column names, spark couldn't read it correctly. For example:
```
-- use hive to create the view
CREATE VIEW test_view AS SELECT 1 FROM t
-- use spark to read the view
SELECT * FROM test_view
```
We will get an exception about: `cannot resolve '_c0' given input columns: [1]`
The problematic plan is:
```
'Project [upcast('_c0, IntegerType) AS _c0#3]
 +- Project [1 AS 1#4]
    +- SubqueryAlias spark_catalog.default.some_table
       +- Relation default.some_table[id#1L] orc
```

This PR handles the views created by Hive separately to fix this issue.

### Why are the changes needed?
bugfix


### Does this PR introduce _any_ user-facing change?
No, this is a regression.


### How was this patch tested?
newly added UT
