### PR TITLE
[SPARK-36982][SQL] Migrate SHOW NAMESPACES to use V2 command by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/KeepLegacyOutputs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/KeepLegacyOutputs.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ShowTables}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ShowNamespaces, ShowTables}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.internal.SQLConf
@@ -36,6 +36,9 @@ object KeepLegacyOutputs extends Rule[LogicalPlan] {
           assert(s.output.length == 3)
           val newOutput = s.output.head.withName("database") +: s.output.tail
           s.copy(output = newOutput)
+        case s: ShowNamespaces =>
+          assert(s.output.length == 1)
+          s.copy(output = Seq(s.output.head.withName("databaseName")))
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3364,7 +3364,7 @@ object SQLConf {
     buildConf("spark.sql.legacy.keepCommandOutputSchema")
       .internal()
       .doc("When true, Spark will keep the output schema of commands such as SHOW DATABASES " +
-        "unchanged, for v1 catalog and/or table.")
+        "unchanged.")
       .version("3.0.2")
       .booleanConf
       .createWithDefault(false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -121,14 +121,6 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
     case SetNamespaceLocation(DatabaseInSessionCatalog(db), location) =>
       AlterDatabaseSetLocationCommand(db, location)
 
-    case s @ ShowNamespaces(ResolvedNamespace(cata, _), _, output) if isSessionCatalog(cata) =>
-      if (conf.getConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA)) {
-        assert(output.length == 1)
-        s.copy(output = Seq(output.head.withName("databaseName")))
-      } else {
-        s
-      }
-
     case RenameTable(ResolvedV1TableOrViewIdentifier(oldName), newName, isView) =>
       AlterTableRenameCommand(oldName.asTableIdentifier, newName.asTableIdentifier, isView)
 
@@ -270,13 +262,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       DropDatabaseCommand(db, d.ifExists, d.cascade)
 
     case ShowTables(DatabaseInSessionCatalog(db), pattern, output) if conf.useV1Command =>
-      val newOutput = if (conf.getConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA)) {
-        assert(output.length == 3)
-        output.head.withName("database") +: output.tail
-      } else {
-        output
-      }
-      ShowTablesCommand(Some(db), pattern, newOutput)
+      ShowTablesCommand(Some(db), pattern, output)
 
     case ShowTableExtended(
         DatabaseInSessionCatalog(db),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandTestUtils.scala
@@ -39,7 +39,9 @@ import org.apache.spark.sql.test.SQLTestUtils
  */
 trait DDLCommandTestUtils extends SQLTestUtils {
   // The version of the catalog under testing such as "V1", "V2", "Hive V1".
-  protected def version: String
+  protected def catalogVersion: String
+  // The version of the SQL command under testing such as "V1", "V2".
+  protected def commandVersion: String
   // Name of the command as SQL statement, for instance "SHOW PARTITIONS"
   protected def command: String
   // The catalog name which can be used in SQL statements under testing
@@ -51,7 +53,8 @@ trait DDLCommandTestUtils extends SQLTestUtils {
   // the failed test in logs belongs to.
   override def test(testName: String, testTags: Tag*)(testFun: => Any)
     (implicit pos: Position): Unit = {
-    super.test(s"$command $version: " + testName, testTags: _*)(testFun)
+    val testNamePrefix = s"$command using $catalogVersion catalog $commandVersion command"
+    super.test(s"$testNamePrefix: $testName", testTags: _*)(testFun)
   }
 
   protected def withNamespaceAndTable(ns: String, tableName: String, cat: String = catalog)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowNamespacesSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowNamespacesSuiteBase.scala
@@ -128,4 +128,10 @@ trait ShowNamespacesSuiteBase extends QueryTest with DDLCommandTestUtils {
       spark.sessionState.catalogManager.reset()
     }
   }
+
+  test("SPARK-34359: keep the legacy output schema") {
+    withSQLConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA.key -> "true") {
+      assert(sql("SHOW NAMESPACES").schema.fieldNames.toSeq == Seq("databaseName"))
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TestsV1AndV2Commands.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TestsV1AndV2Commands.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.internal.SQLConf
  * The trait that enables running a test for both v1 and v2 command.
  */
 trait TestsV1AndV2Commands extends DDLCommandTestUtils {
-  var _version: String = ""
+  private var _version: String = ""
   override def commandVersion: String = _version
 
   // Tests using V1 catalogs will run with `spark.sql.legacy.useV1Command` on and off
@@ -34,11 +34,7 @@ trait TestsV1AndV2Commands extends DDLCommandTestUtils {
   override def test(testName: String, testTags: Tag*)(testFun: => Any)
     (implicit pos: Position): Unit = {
     Seq(true, false).foreach { useV1Command =>
-      _version = if (useV1Command) {
-        "V1"
-      } else {
-        "V2"
-      }
+      _version = if (useV1Command) "V1" else "V2"
       super.test(testName, testTags: _*) {
         withSQLConf(SQLConf.LEGACY_USE_V1_COMMAND.key -> useV1Command.toString) {
           testFun

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TestsV1AndV2Commands.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TestsV1AndV2Commands.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command
+
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * The trait that enables running a test for both v1 and v2 command.
+ */
+trait TestsV1AndV2Commands extends DDLCommandTestUtils {
+  var _version: String = ""
+  override def commandVersion: String = _version
+
+  // Tests using V1 catalogs will run with `spark.sql.legacy.useV1Command` on and off
+  // to test both V1 and V2 commands.
+  override def test(testName: String, testTags: Tag*)(testFun: => Any)
+    (implicit pos: Position): Unit = {
+    Seq(true, false).foreach { useV1Command =>
+      _version = if (useV1Command) {
+        "V1"
+      } else {
+        "V2"
+      }
+      super.test(testName, testTags: _*) {
+        withSQLConf(SQLConf.LEGACY_USE_V1_COMMAND.key -> useV1Command.toString) {
+          testFun
+        }
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/CommandSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/CommandSuiteBase.scala
@@ -17,8 +17,13 @@
 
 package org.apache.spark.sql.execution.command.v1
 
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.execution.command.DDLCommandTestUtils
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 /**
@@ -46,5 +51,31 @@ trait CommandSuiteBase extends SharedSparkSession {
       .first().getString(0)
     val location = information.split("\\r?\\n").filter(_.startsWith("Location:")).head
     assert(location.endsWith(expected))
+  }
+}
+
+/**
+ * The trait that enables running a test for both v1 and v2 command.
+ */
+trait TestsV1AndV2Commands extends DDLCommandTestUtils {
+  var _version: String = ""
+  override def version: String = _version
+
+  // Tests using V1 catalogs will run with `spark.sql.legacy.useV1Command` on and off
+  // to test both V1 and V2 commands.
+  override def test(testName: String, testTags: Tag*)(testFun: => Any)
+    (implicit pos: Position): Unit = {
+    Seq(true, false).foreach { useV1Command =>
+      _version = if (useV1Command) {
+        "using V1 catalog with V1 command"
+      } else {
+        "using V1 catalog with V2 command"
+      }
+      super.test(testName, testTags: _*) {
+        withSQLConf(SQLConf.LEGACY_USE_V1_COMMAND.key -> useV1Command.toString) {
+          testFun
+        }
+      }
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowNamespacesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowNamespacesSuite.scala
@@ -38,18 +38,9 @@ trait ShowNamespacesSuiteBase extends command.ShowNamespacesSuiteBase {
     }.getMessage
     assert(errMsg.contains("Namespace 'dummy' not found"))
   }
-
-  test("SPARK-34359: keep the legacy output schema") {
-    withSQLConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA.key -> "true") {
-      assert(sql("SHOW NAMESPACES").schema.fieldNames.toSeq == Seq("databaseName"))
-    }
-  }
 }
 
-class ShowNamespacesSuite extends ShowNamespacesSuiteBase
-    with CommandSuiteBase with TestsV1AndV2Commands {
-  override def version: String = super[TestsV1AndV2Commands].version
-
+class ShowNamespacesSuite extends ShowNamespacesSuiteBase with CommandSuiteBase {
   test("case sensitivity") {
     Seq(true, false).foreach { caseSensitive =>
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowNamespacesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowNamespacesSuite.scala
@@ -46,7 +46,10 @@ trait ShowNamespacesSuiteBase extends command.ShowNamespacesSuiteBase {
   }
 }
 
-class ShowNamespacesSuite extends ShowNamespacesSuiteBase with CommandSuiteBase {
+class ShowNamespacesSuite extends ShowNamespacesSuiteBase
+    with CommandSuiteBase with TestsV1AndV2Commands {
+  override def version: String = super[TestsV1AndV2Commands].version
+
   test("case sensitivity") {
     Seq(true, false).foreach { caseSensitive =>
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowNamespacesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowNamespacesSuite.scala
@@ -41,6 +41,8 @@ trait ShowNamespacesSuiteBase extends command.ShowNamespacesSuiteBase {
 }
 
 class ShowNamespacesSuite extends ShowNamespacesSuiteBase with CommandSuiteBase {
+  override def commandVersion: String = "V2" // There is only V2 variant of SHOW NAMESPACES.
+
   test("case sensitivity") {
     Seq(true, false).foreach { caseSensitive =>
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -17,9 +17,6 @@
 
 package org.apache.spark.sql.execution.command.v1
 
-import org.scalactic.source.Position
-import org.scalatest.Tag
-
 import org.apache.spark.sql.{AnalysisException, Row, SaveMode}
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.execution.command
@@ -35,26 +32,6 @@ import org.apache.spark.sql.internal.SQLConf
  */
 trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase {
   override def defaultNamespace: Seq[String] = Seq("default")
-  var _version: String = ""
-  override def version: String = _version
-
-  // Tests using V1 catalogs will run with `spark.sql.legacy.useV1Command` on and off
-  // to test both V1 and V2 commands.
-  override def test(testName: String, testTags: Tag*)(testFun: => Any)
-    (implicit pos: Position): Unit = {
-    Seq(true, false).foreach { useV1Command =>
-      _version = if (useV1Command) {
-        "using V1 catalog with V1 command"
-      } else {
-        "using V1 catalog with V2 command"
-      }
-      super.test(testName, testTags: _*) {
-        withSQLConf(SQLConf.LEGACY_USE_V1_COMMAND.key -> useV1Command.toString) {
-          testFun
-        }
-      }
-    }
-  }
 
   private def withSourceViews(f: => Unit): Unit = {
     withTable("source", "source2") {
@@ -164,8 +141,8 @@ trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase {
 /**
  * The class contains tests for the `SHOW TABLES` command to check V1 In-Memory table catalog.
  */
-class ShowTablesSuite extends ShowTablesSuiteBase with CommandSuiteBase {
-  override def version: String = super[ShowTablesSuiteBase].version
+class ShowTablesSuite extends ShowTablesSuiteBase with CommandSuiteBase with TestsV1AndV2Commands {
+  override def version: String = super[TestsV1AndV2Commands].version
 
   test("SPARK-33670: show partitions from a datasource table") {
     import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.internal.SQLConf
  *   - V1 In-Memory catalog: `org.apache.spark.sql.execution.command.v1.ShowTablesSuite`
  *   - V1 Hive External catalog: `org.apache.spark.sql.hive.execution.command.ShowTablesSuite`
  */
-trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase {
+trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase with command.TestsV1AndV2Commands {
   override def defaultNamespace: Seq[String] = Seq("default")
 
   private def withSourceViews(f: => Unit): Unit = {
@@ -141,8 +141,8 @@ trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase {
 /**
  * The class contains tests for the `SHOW TABLES` command to check V1 In-Memory table catalog.
  */
-class ShowTablesSuite extends ShowTablesSuiteBase with CommandSuiteBase with TestsV1AndV2Commands {
-  override def version: String = super[TestsV1AndV2Commands].version
+class ShowTablesSuite extends ShowTablesSuiteBase with CommandSuiteBase {
+  override def commandVersion: String = super[ShowTablesSuiteBase].commandVersion
 
   test("SPARK-33670: show partitions from a datasource table") {
     import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CommandSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CommandSuiteBase.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.test.SharedSparkSession
  * for all unified datasource V1 and V2 test suites.
  */
 trait CommandSuiteBase extends SharedSparkSession {
-  def version: String = "V2" // The prefix is added to test names
+  def catalogVersion: String = "V2" // The catalog version is added to test names
+  def commandVersion: String = "V2" // The command version is added to test names
   def catalog: String = "test_catalog" // The default V2 catalog for testing
   def defaultUsing: String = "USING _" // The clause is used in creating v2 tables under testing
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowNamespacesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowNamespacesSuite.scala
@@ -27,6 +27,8 @@ import org.apache.spark.sql.internal.SQLConf
  * The class contains tests for the `SHOW NAMESPACES` command to check V2 table catalogs.
  */
 class ShowNamespacesSuite extends command.ShowNamespacesSuiteBase with CommandSuiteBase {
+  override def commandVersion: String = "V2" // There is only V2 variant of SHOW NAMESPACES.
+
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.testcat_no_namespace", classOf[BasicInMemoryTableCatalog].getName)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowNamespacesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowNamespacesSuite.scala
@@ -27,8 +27,6 @@ import org.apache.spark.sql.internal.SQLConf
  * The class contains tests for the `SHOW NAMESPACES` command to check V2 table catalogs.
  */
 class ShowNamespacesSuite extends command.ShowNamespacesSuiteBase with CommandSuiteBase {
-  override def commandVersion: String = "V2" // There is only V2 variant of SHOW NAMESPACES.
-
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.testcat_no_namespace", classOf[BasicInMemoryTableCatalog].getName)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/CommandSuiteBase.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/CommandSuiteBase.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.hive.test.TestHiveSingleton
  * settings for all unified datasource V1 and V2 test suites.
  */
 trait CommandSuiteBase extends TestHiveSingleton {
-  def version: String = "Hive V1" // The prefix is added to test names
+  def catalogVersion: String = "Hive V1" // The catalog version is added to test names
+  def commandVersion: String = "V1" // The command version is added to test names
   def catalog: String = CatalogManager.SESSION_CATALOG_NAME
   def defaultUsing: String = "USING HIVE" // The clause is used in creating tables under testing
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowNamespacesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowNamespacesSuite.scala
@@ -25,6 +25,8 @@ import org.apache.spark.sql.internal.SQLConf
  * V1 Hive external table catalog.
  */
 class ShowNamespacesSuite extends v1.ShowNamespacesSuiteBase with CommandSuiteBase {
+  override def commandVersion: String = "V2" // There is only V2 variant of SHOW NAMESPACES.
+
   test("case sensitivity") {
     Seq(true, false).foreach { caseSensitive =>
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowNamespacesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowNamespacesSuite.scala
@@ -24,10 +24,7 @@ import org.apache.spark.sql.internal.SQLConf
  * The class contains tests for the `SHOW NAMESPACES` and `SHOW DATABASES` commands to check
  * V1 Hive external table catalog.
  */
-class ShowNamespacesSuite extends v1.ShowNamespacesSuiteBase
-    with CommandSuiteBase with v1.TestsV1AndV2Commands {
-  override def version: String = super[TestsV1AndV2Commands].version
-
+class ShowNamespacesSuite extends v1.ShowNamespacesSuiteBase with CommandSuiteBase {
   test("case sensitivity") {
     Seq(true, false).foreach { caseSensitive =>
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowNamespacesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowNamespacesSuite.scala
@@ -24,7 +24,10 @@ import org.apache.spark.sql.internal.SQLConf
  * The class contains tests for the `SHOW NAMESPACES` and `SHOW DATABASES` commands to check
  * V1 Hive external table catalog.
  */
-class ShowNamespacesSuite extends v1.ShowNamespacesSuiteBase with CommandSuiteBase {
+class ShowNamespacesSuite extends v1.ShowNamespacesSuiteBase
+    with CommandSuiteBase with v1.TestsV1AndV2Commands {
+  override def version: String = super[TestsV1AndV2Commands].version
+
   test("case sensitivity") {
     Seq(true, false).foreach { caseSensitive =>
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
@@ -22,8 +22,9 @@ import org.apache.spark.sql.execution.command.v1
 /**
  * The class contains tests for the `SHOW TABLES` command to check V1 Hive external table catalog.
  */
-class ShowTablesSuite extends v1.ShowTablesSuiteBase with CommandSuiteBase {
-  override def version: String = super[ShowTablesSuiteBase].version
+class ShowTablesSuite extends v1.ShowTablesSuiteBase
+    with CommandSuiteBase with v1.TestsV1AndV2Commands {
+  override def version: String = super[TestsV1AndV2Commands].version
 
   test("hive client calls") {
     withNamespaceAndTable("ns", "tbl") { t =>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowTablesSuite.scala
@@ -22,9 +22,8 @@ import org.apache.spark.sql.execution.command.v1
 /**
  * The class contains tests for the `SHOW TABLES` command to check V1 Hive external table catalog.
  */
-class ShowTablesSuite extends v1.ShowTablesSuiteBase
-    with CommandSuiteBase with v1.TestsV1AndV2Commands {
-  override def version: String = super[TestsV1AndV2Commands].version
+class ShowTablesSuite extends v1.ShowTablesSuiteBase with CommandSuiteBase {
+  override def commandVersion: String = super[ShowTablesSuiteBase].commandVersion
 
   test("hive client calls") {
     withNamespaceAndTable("ns", "tbl") { t =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to use V2 commands as default as outlined in [SPARK-36588](https://issues.apache.org/jira/browse/SPARK-36588), and this PR migrates `SHOW NAMESPACES` to use v2 command by default. (Technically speaking, there is no v1 command for `SHOW NAMESPACES/DATABASES`, but this PR removes an extra check in `ResolveSessionCatalog` to handle session catalog.)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's been a while since we introduced the v2 commands,  and it seems reasonable to use v2 commands by default even for the session catalog, with a legacy config to fall back to the v1 commands.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the user can use v1 command by setting `spark.sql.legacy.useV1Command` to `true`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests.