### PR TITLE
[SPARK-36978][SQL] InferConstraints rule should create IsNotNull constraints on the accessed nested field instead of the root nested type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -89,7 +89,7 @@ object ExtractValue {
   }
 }
 
-trait ExtractValue extends Expression {
+trait ExtractValue extends Expression with NullIntolerant {
   final override val nodePatterns: Seq[TreePattern] = Seq(EXTRACT_VALUE)
 }
 
@@ -102,7 +102,7 @@ trait ExtractValue extends Expression {
  * For example, when get field `yEAr` from `<year: int, month: int>`, we should pass in `yEAr`.
  */
 case class GetStructField(child: Expression, ordinal: Int, name: Option[String] = None)
-  extends UnaryExpression with ExtractValue with NullIntolerant {
+  extends UnaryExpression with ExtractValue {
 
   lazy val childSchema = child.dataType.asInstanceOf[StructType]
 
@@ -155,7 +155,7 @@ case class GetArrayStructFields(
     field: StructField,
     ordinal: Int,
     numFields: Int,
-    containsNull: Boolean) extends UnaryExpression with ExtractValue with NullIntolerant {
+    containsNull: Boolean) extends UnaryExpression with ExtractValue {
 
   override def dataType: DataType = ArrayType(field.dataType, containsNull)
   override def toString: String = s"$child.${field.name}"
@@ -230,8 +230,7 @@ case class GetArrayItem(
     child: Expression,
     ordinal: Expression,
     failOnError: Boolean = SQLConf.get.ansiEnabled)
-  extends BinaryExpression with GetArrayItemUtil with ExpectsInputTypes with ExtractValue
-  with NullIntolerant {
+  extends BinaryExpression with GetArrayItemUtil with ExpectsInputTypes with ExtractValue {
 
   def this(child: Expression, ordinal: Expression) = this(child, ordinal, SQLConf.get.ansiEnabled)
 
@@ -437,7 +436,7 @@ case class GetMapValue(
     child: Expression,
     key: Expression,
     failOnError: Boolean = SQLConf.get.ansiEnabled)
-  extends GetMapValueUtil with ExtractValue with NullIntolerant {
+  extends GetMapValueUtil with ExtractValue {
 
   def this(child: Expression, key: Expression) = this(child, key, SQLConf.get.ansiEnabled)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -118,10 +118,11 @@ trait ConstraintHelper {
     }
 
   /**
-   * Recursively explores the expressions which are null intolerant and returns all attributes
-   * in these expressions.
+   * Recursively explores the expressions which are null intolerant and returns all
+   * attributes/ExtractValues in these expressions for scalar/nested types respectively.
    */
-  private def scanNullIntolerantAttribute(expr: Expression): Seq[Attribute] = expr match {
+  private def scanNullIntolerantAttribute(expr: Expression): Seq[Expression] = expr match {
+    case e: ExtractValue => Seq(e)
     case a: Attribute => Seq(a)
     case _: NullIntolerant => expr.children.flatMap(scanNullIntolerantAttribute)
     case _ => Seq.empty[Attribute]


### PR DESCRIPTION
### What changes were proposed in this pull request?
The PR modifies `IsNotNull` constraint generation to generate constraints on the referenced nested field instead of generating a constraint on the top level nested type. See the following section for an example.

### Why are the changes needed?
[InferFiltersFromConstraints](https://github.com/apache/spark/blob/05c0fa573881b49d8ead9a5e16071190e5841e1b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala#L1206) optimization rule generates `IsNotNull` constraints corresponding to null intolerant predicates. The `IsNotNull` constraints are generated on the attribute inside the corresponding predicate.
e.g. A predicate `a > 0` on an integer column a will result in a constraint `IsNotNull(a)`. On the other hand a predicate on a nested int column `structCol.b` where `structCol` is a struct column results in a constraint `IsNotNull(structCol)`.

This generation of constraints on the root level nested type is extremely conservative as it could lead to materialization of the the entire struct. The constraint should instead be generated on the nested field being referenced by the predicate. In the above example, the constraint should be `IsNotNull(structCol.b)` instead of `IsNotNull(structCol)`. 

The new constraints also create opportunities for nested pruning. Currently `IsNotNull(structCol)` constraint would preclude pruning of `structCol`. However the constraint `IsNotNull(structCol.b)` could create opportunities to prune `structCol`.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added test to `InferFiltersFromConstraintsSuite`.