### PR TITLE
[SPARK-36985][PYTHON] Fix future typing errors in pyspark.pandas

### DIFF
--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -178,6 +178,7 @@ class Index(IndexOpsMixin):
         from pyspark.pandas.indexes.multi import MultiIndex
         from pyspark.pandas.indexes.numeric import Float64Index, Int64Index
 
+        instance: Index
         if anchor._internal.index_level > 1:
             instance = object.__new__(MultiIndex)
         elif isinstance(anchor._internal.index_fields[0].dtype, CategoricalDtype):
@@ -198,7 +199,7 @@ class Index(IndexOpsMixin):
         else:
             instance = object.__new__(Index)
 
-        instance._anchor = anchor
+        instance._anchor = anchor  # type: ignore[attr-defined]
         return instance
 
     @property


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix future typing errors in pyspark.pandas detected with mypy master.

### Why are the changes needed?

The following problems are detected on master with mypy master.

```
pyspark/pandas/indexes/base.py:184: error: Incompatible types in assignment (expression has type "CategoricalIndex", variable has type "MultiIndex")  [assignment]
pyspark/pandas/indexes/base.py:188: error: Incompatible types in assignment (expression has type "Int64Index", variable has type "MultiIndex")  [assignment]
pyspark/pandas/indexes/base.py:192: error: Incompatible types in assignment (expression has type "Float64Index", variable has type "MultiIndex")  [assignment]
pyspark/pandas/indexes/base.py:197: error: Incompatible types in assignment (expression has type "DatetimeIndex", variable has type "MultiIndex")  [assignment]
pyspark/pandas/indexes/base.py:199: error: Incompatible types in assignment (expression has type "Index", variable has type "MultiIndex")  [assignment]
pyspark/pandas/indexes/base.py:201: error: "MultiIndex" has no attribute "_anchor"  [attr-defined]
```

The complaints are legitimate now and we should fix them.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually checked with the latest mypy master https://github.com/python/mypy/commit/066da4d92af594d90420369f9af8cda2ca3b6c00.
