### PR TITLE
[SPARK-36998][CORE] Handle concurrent eviction of same application in SHS

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
@@ -21,8 +21,9 @@ import java.io.File
 
 import org.mockito.AdditionalAnswers
 import org.mockito.ArgumentMatchers.{anyBoolean, anyLong, eq => meq}
-import org.mockito.Mockito.{doAnswer, spy}
-import org.scalatest.BeforeAndAfter
+import org.mockito.Mockito.{doAnswer, spy, when}
+import org.scalatest.{BeforeAndAfter, PrivateMethodTester}
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config.History._
@@ -30,7 +31,8 @@ import org.apache.spark.status.KVUtils
 import org.apache.spark.util.{ManualClock, Utils}
 import org.apache.spark.util.kvstore.KVStore
 
-class HistoryServerDiskManagerSuite extends SparkFunSuite with BeforeAndAfter {
+class HistoryServerDiskManagerSuite extends SparkFunSuite
+  with PrivateMethodTester with BeforeAndAfter {
 
   private def doReturn(value: Any) = org.mockito.Mockito.doReturn(value, Seq.empty: _*)
 
@@ -156,6 +158,28 @@ class HistoryServerDiskManagerSuite extends SparkFunSuite with BeforeAndAfter {
       new ManualClock())
     assert(manager.approximateSize(50L, false) < 50L)
     assert(manager.approximateSize(50L, true) > 50L)
+  }
+
+  test("SPARK-36998: Should be able to delete a store") {
+    val manager = mockManager()
+    val tempDir = Utils.createTempDir()
+    tempDir.delete()
+    Seq(true, false).foreach { exists =>
+      val file = mock[File]
+      when(file.exists()).thenReturn(true).thenReturn(true).thenReturn(exists)
+      when(file.isDirectory).thenReturn(true)
+      when(file.toPath).thenReturn(tempDir.toPath)
+      when(file.getAbsolutePath).thenReturn(tempDir.getAbsolutePath)
+      val deleteStore = PrivateMethod[Unit]('deleteStore)
+      if (exists) {
+        val m = intercept[Exception] {
+          manager invokePrivate deleteStore(file)
+        }.getMessage
+        assert(m.contains("Unknown I/O error"))
+      } else {
+        manager invokePrivate deleteStore(file)
+      }
+    }
   }
 
   test("SPARK-32024: update ApplicationStoreInfo.size during initializing") {


### PR DESCRIPTION
 ### What changes were proposed in this pull request?
 To gracefully handle the error thrown when we try to make room for parsing of different applications and they try to evict the same application by deleting the directory path.

Also, added a test for `deleteStore` in `HistoryServerDiskManagerSuite`

 ### Why are the changes needed?
 Otherwise, an NoSuchFileException is thrown when it cannot find the directory path to exist.

 ### Does this PR introduce _any_ user-facing change?
 no

 ### How was this patch tested?
Added a unit test for `deleteStore` but not specifically testing the concurrency fix.