### PR TITLE
[WIP][SPARK-36994][BUILD] Update Thrift to 0.15.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -186,7 +186,7 @@ kubernetes-model-storageclass/5.8.0//kubernetes-model-storageclass-5.8.0.jar
 lapack/2.2.0//lapack-2.2.0.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
-libthrift/0.14.2//libthrift-0.14.2.jar
+libthrift/0.13.0//libthrift-0.13.0.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
@@ -241,8 +241,6 @@ stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.5.0//threeten-extra-1.5.0.jar
 tink/1.6.0//tink-1.6.0.jar
-tomcat-annotations-api/8.5.46//tomcat-annotations-api-8.5.46.jar
-tomcat-embed-core/8.5.46//tomcat-embed-core-8.5.46.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 velocity/1.5//velocity-1.5.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -186,7 +186,7 @@ kubernetes-model-storageclass/5.8.0//kubernetes-model-storageclass-5.8.0.jar
 lapack/2.2.0//lapack-2.2.0.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
-libthrift/0.15.0//libthrift-0.15.0.jar
+libthrift/0.14.2//libthrift-0.14.2.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
@@ -241,6 +241,8 @@ stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.5.0//threeten-extra-1.5.0.jar
 tink/1.6.0//tink-1.6.0.jar
+tomcat-annotations-api/8.5.46//tomcat-annotations-api-8.5.46.jar
+tomcat-embed-core/8.5.46//tomcat-embed-core-8.5.46.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 velocity/1.5//velocity-1.5.jar

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -130,6 +130,7 @@ jakarta.ws.rs-api/2.1.6//jakarta.ws.rs-api-2.1.6.jar
 jakarta.xml.bind-api/2.3.2//jakarta.xml.bind-api-2.3.2.jar
 janino/3.0.16//janino-3.0.16.jar
 javassist/3.25.0-GA//javassist-3.25.0-GA.jar
+javax.annotation-api/1.3.2//javax.annotation-api-1.3.2.jar
 javax.inject/1//javax.inject-1.jar
 javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
 javolution/5.5.1//javolution-5.5.1.jar
@@ -185,7 +186,7 @@ kubernetes-model-storageclass/5.8.0//kubernetes-model-storageclass-5.8.0.jar
 lapack/2.2.0//lapack-2.2.0.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
-libthrift/0.12.0//libthrift-0.12.0.jar
+libthrift/0.15.0//libthrift-0.15.0.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -120,6 +120,7 @@ jakarta.ws.rs-api/2.1.6//jakarta.ws.rs-api-2.1.6.jar
 jakarta.xml.bind-api/2.3.2//jakarta.xml.bind-api-2.3.2.jar
 janino/3.0.16//janino-3.0.16.jar
 javassist/3.25.0-GA//javassist-3.25.0-GA.jar
+javax.annotation-api/1.3.2//javax.annotation-api-1.3.2.jar
 javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
@@ -172,7 +173,7 @@ kubernetes-model-storageclass/5.8.0//kubernetes-model-storageclass-5.8.0.jar
 lapack/2.2.0//lapack-2.2.0.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
-libthrift/0.12.0//libthrift-0.12.0.jar
+libthrift/0.15.0//libthrift-0.15.0.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -173,7 +173,7 @@ kubernetes-model-storageclass/5.8.0//kubernetes-model-storageclass-5.8.0.jar
 lapack/2.2.0//lapack-2.2.0.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
-libthrift/0.14.2//libthrift-0.14.2.jar
+libthrift/0.13.0//libthrift-0.13.0.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
@@ -228,8 +228,6 @@ stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.5.0//threeten-extra-1.5.0.jar
 tink/1.6.0//tink-1.6.0.jar
-tomcat-annotations-api/8.5.46//tomcat-annotations-api-8.5.46.jar
-tomcat-embed-core/8.5.46//tomcat-embed-core-8.5.46.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 velocity/1.5//velocity-1.5.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -173,7 +173,7 @@ kubernetes-model-storageclass/5.8.0//kubernetes-model-storageclass-5.8.0.jar
 lapack/2.2.0//lapack-2.2.0.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
-libthrift/0.15.0//libthrift-0.15.0.jar
+libthrift/0.14.2//libthrift-0.14.2.jar
 log4j/1.2.17//log4j-1.2.17.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
@@ -228,6 +228,8 @@ stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.5.0//threeten-extra-1.5.0.jar
 tink/1.6.0//tink-1.6.0.jar
+tomcat-annotations-api/8.5.46//tomcat-annotations-api-8.5.46.jar
+tomcat-embed-core/8.5.46//tomcat-embed-core-8.5.46.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 velocity/1.5//velocity-1.5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <joda.version>2.10.12</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
-    <libthrift.version>0.15.0</libthrift.version>
+    <libthrift.version>0.14.2</libthrift.version>
     <antlr4.version>4.8</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>3.141.59</selenium.version>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <joda.version>2.10.12</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
-    <libthrift.version>0.12.0</libthrift.version>
+    <libthrift.version>0.15.0</libthrift.version>
     <antlr4.version>4.8</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>3.141.59</selenium.version>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <joda.version>2.10.12</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
-    <libthrift.version>0.14.2</libthrift.version>
+    <libthrift.version>0.13.0</libthrift.version>
     <antlr4.version>4.8</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>3.141.59</selenium.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to upgrade Thrift to 0.15.0.

### Why are the changes needed?

To addresses CVEs:

Component Name | Component Version Name | Vulnerability | Fixed version
-- | -- | -- | --
Apache Thrift | 0.11.0-4. | [CVE-2019-0205](https://nvd.nist.gov/vuln/detail/CVE-2019-0205) | 0.13.0
Apache Thrift | 0.11.0-4. | CVE-2019-0210 | 0.13.0
Apache Thrift | 0.11.0-4. | CVE-2020-13949 | 0.14.1

### Does this PR introduce _any_ user-facing change?

I think no. CVE-2019-0205 and CVE-2019-0210 are more a bug fix.
CVE-2020-13949 might be valid.

### How was this patch tested?

Existing tests should cover.