### PR TITLE
[SPARK-37002][PYTHON] Introduce the 'compute.eager_check' option

### DIFF
--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -280,13 +280,13 @@ compute.ordered_head            False          'compute.ordered_head' sets wheth
                                                'compute.ordered_head' is set to True, pandas-on-
                                                Spark performs natural ordering beforehand, but it
                                                will cause a performance overhead.
-compute.check_identical_indices True           'compute.check_identical_indices' sets whether or not
-                                               to operate dot with identical indexes checking. If
-                                               'compute.check_identical_indices' is set to True,
-                                               pandas-on-Spark performs identical indexes checking
-                                               beforehand, but it will cause a performance overhead.
-                                               Otherwise, pandas-on-Spark just proceeds and performs
-                                               by ignoring mismatches with NaN permissively.
+compute.eager_check             True           'compute.eager_check' sets whether or not to launch
+                                               some Spark jobs just for the sake of validation. If
+                                               'compute.eager_check' is set to True, pandas-on-Spark
+                                               performs the validation beforehand, but it will cause
+                                               a performance overhead. Otherwise, pandas-on-Spark
+                                               skip the validation and will be slightly different
+                                               from pandas
 compute.isin_limit              80             'compute.isin_limit' sets the limit for filtering by
                                                'Column.isin(list)'. If the length of the ‘list’ is
                                                above the limit, broadcast join is used instead for

--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -280,6 +280,13 @@ compute.ordered_head            False          'compute.ordered_head' sets wheth
                                                'compute.ordered_head' is set to True, pandas-on-
                                                Spark performs natural ordering beforehand, but it
                                                will cause a performance overhead.
+compute.check_identical_indices True           'compute.check_identical_indices' sets whether or not
+                                               to operate dot with identical indexes checking. If
+                                               'compute.check_identical_indices' is set to True,
+                                               pandas-on-Spark performs identical indexes checking
+                                               beforehand, but it will cause a performance overhead.
+                                               Otherwise, pandas-on-Spark just proceeds and performs
+                                               by ignoring mismatches with NaN permissively.
 compute.isin_limit              80             'compute.isin_limit' sets the limit for filtering by
                                                'Column.isin(list)'. If the length of the ‘list’ is
                                                above the limit, broadcast join is used instead for

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -195,6 +195,18 @@ _options: List[Option] = [
         types=bool,
     ),
     Option(
+        key="compute.check_identical_indices",
+        doc=(
+            "'compute.check_identical_indices' sets whether or not to operate dot with identical "
+            "indexes checking. If 'compute.check_identical_indices' is set to True, "
+            "pandas-on-Spark performs identical indexes checking beforehand, but it will cause a "
+            "performance overhead. Otherwise, pandas-on-Spark just proceeds and performs by "
+            "ignoring mismatches with NaN permissively."
+        ),
+        default=True,
+        types=bool,
+    ),
+    Option(
         key="compute.isin_limit",
         doc=(
             "'compute.isin_limit' sets the limit for filtering by 'Column.isin(list)'. "

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -195,13 +195,12 @@ _options: List[Option] = [
         types=bool,
     ),
     Option(
-        key="compute.check_identical_indices",
+        key="compute.eager_check",
         doc=(
-            "'compute.check_identical_indices' sets whether or not to operate dot with identical "
-            "indexes checking. If 'compute.check_identical_indices' is set to True, "
-            "pandas-on-Spark performs identical indexes checking beforehand, but it will cause a "
-            "performance overhead. Otherwise, pandas-on-Spark just proceeds and performs by "
-            "ignoring mismatches with NaN permissively."
+            "'compute.eager_check' sets whether or not to launch some Spark jobs just for the sake "
+            "of validation. If 'compute.eager_check' is set to True, pandas-on-Spark performs the "
+            "validation beforehand, but it will cause a performance overhead. Otherwise, "
+            "pandas-on-Spark skip the validation and will be slightly different from pandas"
         ),
         default=True,
         types=bool,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce the ```compute.eager_check``` option, with the default value of ```True```.

### Why are the changes needed?
Input validation is a expensive operation, ```compute.eager_check``` is introduced to set whether or not do this operation.

### Does this PR introduce _any_ user-facing change?
```python
>>> ps.get_option('compute.eager_check')
True
>>> ps.set_option('compute.eager_check', False)
>>> ps.get_option('compute.eager_check')
False
>>> ps.set_option('compute.eager_check', 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/u02/spark/python/pyspark/pandas/config.py", line 348, in set_option
    _options_dict[key].validate(value)
  File "/u02/spark/python/pyspark/pandas/config.py", line 104, in validate
    raise TypeError(
TypeError: The value for option 'compute.eager_check' was <class 'int'>; however, expected types are [<class 'bool'>].
>>> ps.reset_option('compute.eager_check')
>>> ps.get_option('compute.eager_check')
True
```
### How was this patch tested?
Existing tests