### PR TITLE
[SPARK-36871][SQL][FOLLOWUP] Move error checking from create cmd to parser

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1849,19 +1849,6 @@ object QueryCompilationErrors {
     new AnalysisException("Cannot overwrite a path that is also being read from.")
   }
 
-  def createFuncWithBothIfNotExistsAndReplaceError(): Throwable = {
-    new AnalysisException("CREATE FUNCTION with both IF NOT EXISTS and REPLACE is not allowed.")
-  }
-
-  def defineTempFuncWithIfNotExistsError(): Throwable = {
-    new AnalysisException("It is not allowed to define a TEMPORARY function with IF NOT EXISTS.")
-  }
-
-  def specifyingDBInCreateTempFuncError(databaseName: String): Throwable = {
-    new AnalysisException(
-      s"Specifying a database in CREATE TEMPORARY FUNCTION is not allowed: '$databaseName'")
-  }
-
   def specifyingDBInDropTempFuncError(databaseName: String): Throwable = {
     new AnalysisException(
       s"Specifying a database in DROP TEMPORARY FUNCTION is not allowed: '$databaseName'")
@@ -2009,19 +1996,6 @@ object QueryCompilationErrors {
       s"Failed to execute SHOW CREATE TABLE against table/view ${table.identifier}, " +
         "which is created by Hive and uses the following unsupported feature(s)\n" +
         features.map(" - " + _).mkString("\n"))
-  }
-
-  def createViewWithBothIfNotExistsAndReplaceError(): Throwable = {
-    new AnalysisException("CREATE VIEW with both IF NOT EXISTS and REPLACE is not allowed.")
-  }
-
-  def defineTempViewWithIfNotExistsError(): Throwable = {
-    new AnalysisException("It is not allowed to define a TEMPORARY view with IF NOT EXISTS.")
-  }
-
-  def notAllowedToAddDBPrefixForTempViewError(database: String): Throwable = {
-    new AnalysisException(
-      s"It is not allowed to add database prefix `$database` for the TEMPORARY view name.")
   }
 
   def logicalPlanForViewNotAnalyzedError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -391,4 +391,38 @@ object QueryParsingErrors {
   def invalidGroupingSetError(element: String, ctx: GroupingAnalyticsContext): Throwable = {
     new ParseException(s"Empty set in $element grouping sets is not supported.", ctx)
   }
+
+  def createViewWithBothIfNotExistsAndReplaceError(ctx: CreateViewContext): Throwable = {
+    new ParseException("CREATE VIEW with both IF NOT EXISTS and REPLACE is not allowed.", ctx)
+  }
+
+  def defineTempViewWithIfNotExistsError(ctx: CreateViewContext): Throwable = {
+    new ParseException("It is not allowed to define a TEMPORARY view with IF NOT EXISTS.", ctx)
+  }
+
+  def notAllowedToAddDBPrefixForTempViewError(
+      database: String,
+      ctx: CreateViewContext): Throwable = {
+    new ParseException(
+      s"It is not allowed to add database prefix `$database` for the TEMPORARY view name.", ctx)
+  }
+
+  def createFuncWithBothIfNotExistsAndReplaceError(ctx: CreateFunctionContext): Throwable = {
+    new ParseException("CREATE FUNCTION with both IF NOT EXISTS and REPLACE is not allowed.", ctx)
+  }
+
+  def defineTempFuncWithIfNotExistsError(ctx: CreateFunctionContext): Throwable = {
+    new ParseException("It is not allowed to define a TEMPORARY function with IF NOT EXISTS.", ctx)
+  }
+
+  def unsupportedFunctionNameError(quoted: String, ctx: CreateFunctionContext): Throwable = {
+    new ParseException(s"Unsupported function name '$quoted'", ctx)
+  }
+
+  def specifyingDBInCreateTempFuncError(
+      databaseName: String,
+      ctx: CreateFunctionContext): Throwable = {
+    new ParseException(
+      s"Specifying a database in CREATE TEMPORARY FUNCTION is not allowed: '$databaseName'", ctx)
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -471,7 +471,8 @@ class SparkSqlAstBuilder extends AstBuilder {
       LocalTempView
     }
     if (viewType == PersistedView) {
-      require(Option(source(ctx.query)).isDefined,
+      val originalText = source(ctx.query)
+      require(Option(originalText).isDefined,
         "'originalText' must be provided to create permanent view")
       CreateView(
         UnresolvedDBObjectName(
@@ -480,7 +481,7 @@ class SparkSqlAstBuilder extends AstBuilder {
         userSpecifiedColumns,
         visitCommentSpecList(ctx.commentSpec()),
         properties,
-        Option(source(ctx.query)),
+        Some(originalText),
         plan(ctx.query),
         ctx.EXISTS != null,
         ctx.REPLACE != null)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -57,15 +57,6 @@ case class CreateFunctionCommand(
     replace: Boolean)
   extends LeafRunnableCommand {
 
-  if (ignoreIfExists && replace) {
-    throw QueryCompilationErrors.createFuncWithBothIfNotExistsAndReplaceError()
-  }
-
-  // Disallow to define a temporary function with `IF NOT EXISTS`
-  if (ignoreIfExists && isTemp) {
-    throw QueryCompilationErrors.defineTempFuncWithIfNotExistsError()
-  }
-
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val func = CatalogFunction(FunctionIdentifier(functionName, databaseName), className, resources)


### PR DESCRIPTION


### What changes were proposed in this pull request?
Move error checking from create cmd to parser


### Why are the changes needed?
catch error earlier and also make code consistent between parsing CreateFunction and CreateView


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests
