### PR TITLE
[SPARK-36900][CORE][TEST] Refactor `SPARK-36464: size returns correct positive number even with over 2GB data` to pass with Java 8, 11 and 17

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/io/ChunkedByteBufferOutputStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/io/ChunkedByteBufferOutputStreamSuite.scala
@@ -121,10 +121,13 @@ class ChunkedByteBufferOutputStreamSuite extends SparkFunSuite {
   }
 
   test("SPARK-36464: size returns correct positive number even with over 2GB data") {
-    val ref = new Array[Byte](1024 * 1024 * 4)
-    val o = new ChunkedByteBufferOutputStream(1024 * 1024 * 4, ByteBuffer.allocate)
-    (0 to 512).foreach(_ => o.write(ref))
+    val data4M = 1024 * 1024 * 4
+    val writeTimes = 513
+    val ref = new Array[Byte](data4M)
+    val o = new ChunkedByteBufferOutputStream(data4M, ByteBuffer.allocate)
+    (0 until writeTimes).foreach(_ => o.write(ref))
+    o.close()
     assert(o.size > 0L) // make sure it is not overflowing
-    assert(o.size == ref.length.toLong * 513)
+    assert(o.size == ref.length.toLong * writeTimes)
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/io/ChunkedByteBufferOutputStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/io/ChunkedByteBufferOutputStreamSuite.scala
@@ -121,12 +121,10 @@ class ChunkedByteBufferOutputStreamSuite extends SparkFunSuite {
   }
 
   test("SPARK-36464: size returns correct positive number even with over 2GB data") {
-    val ref = new Array[Byte](1024 * 1024 * 1024)
-    val o = new ChunkedByteBufferOutputStream(1024 * 1024, ByteBuffer.allocate)
-    o.write(ref)
-    o.write(ref)
-    o.close()
+    val ref = new Array[Byte](1024 * 1024 * 4)
+    val o = new ChunkedByteBufferOutputStream(1024 * 1024 * 4, ByteBuffer.allocate)
+    (0 to 512).foreach(_ => o.write(ref))
     assert(o.size > 0L) // make sure it is not overflowing
-    assert(o.size == ref.length.toLong * 2)
+    assert(o.size == ref.length.toLong * 513)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor `SPARK-36464: size returns correct positive number even with over 2GB data` in `ChunkedByteBufferOutputStreamSuite` to reduce the total use of memory for this test case, then this case can pass with Java 8, Java 11 and Java 17 use `-Xmx4g`.



### Why are the changes needed?
`SPARK-36464: size returns correct positive number even with over 2GB data` pass with Java 8 but OOM with Java 11 and Java 17.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

- Pass the Jenkins or GitHub Action
- Manual test 
```
mvn clean install -pl core -am -Dtest=none -DwildcardSuites=org.apache.spark.util.io.ChunkedByteBufferOutputStreamSuite
``` 
with Java 8, Java 11 and Java 17, all tests passed.
