### PR TITLE
[SPARK-36337][PYTHON][CORE] Switch pyrolite v4.30 to pickle v1.2 to fix decimal NaN issue

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -478,7 +478,7 @@ org.typelevel:spire-util_2.12
 org.typelevel:algebra_2.12:jar
 org.typelevel:cats-kernel_2.12
 org.typelevel:machinist_2.12
-net.razorvine:pyrolite
+net.razorvine:pickle
 org.slf4j:jcl-over-slf4j
 org.slf4j:jul-to-slf4j
 org.slf4j:slf4j-api

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -421,14 +421,8 @@
     </dependency>
     <dependency>
       <groupId>net.razorvine</groupId>
-      <artifactId>pyrolite</artifactId>
-      <version>4.30</version>
-      <exclusions>
-        <exclusion>
-          <groupId>net.razorvine</groupId>
-          <artifactId>serpent</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>pickle</artifactId>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>net.sf.py4j</groupId>

--- a/core/src/main/scala/org/apache/spark/api/python/WriteInputFormatTestDataGenerator.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/WriteInputFormatTestDataGenerator.scala
@@ -30,7 +30,7 @@ import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.errors.SparkCoreErrors
 
 /**
- * A class to test Pyrolite serialization on the Scala side, that will be deserialized
+ * A class to test Pickle serialization on the Scala side, that will be deserialized
  * in Python
  */
 case class TestWritable(var str: String, var int: Int, var double: Double) extends Writable {

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -214,9 +214,9 @@ parquet-encoding/1.12.1//parquet-encoding-1.12.1.jar
 parquet-format-structures/1.12.1//parquet-format-structures-1.12.1.jar
 parquet-hadoop/1.12.1//parquet-hadoop-1.12.1.jar
 parquet-jackson/1.12.1//parquet-jackson-1.12.1.jar
+pickle/1.2//pickle-1.2.jar
 protobuf-java/2.5.0//protobuf-java-2.5.0.jar
 py4j/0.10.9.2//py4j-0.10.9.2.jar
-pyrolite/4.30//pyrolite-4.30.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
 rocksdbjni/6.20.3//rocksdbjni-6.20.3.jar
 scala-collection-compat_2.12/2.1.1//scala-collection-compat_2.12-2.1.1.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -201,9 +201,9 @@ parquet-encoding/1.12.1//parquet-encoding-1.12.1.jar
 parquet-format-structures/1.12.1//parquet-format-structures-1.12.1.jar
 parquet-hadoop/1.12.1//parquet-hadoop-1.12.1.jar
 parquet-jackson/1.12.1//parquet-jackson-1.12.1.jar
+pickle/1.2//pickle-1.2.jar
 protobuf-java/2.5.0//protobuf-java-2.5.0.jar
 py4j/0.10.9.2//py4j-0.10.9.2.jar
-pyrolite/4.30//pyrolite-4.30.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
 rocksdbjni/6.20.3//rocksdbjni-6.20.3.jar
 scala-collection-compat_2.12/2.1.1//scala-collection-compat_2.12-2.1.1.jar

--- a/docs/rdd-programming-guide.md
+++ b/docs/rdd-programming-guide.md
@@ -442,7 +442,7 @@ Apart from text files, Spark's Python API also supports several other data forma
 **Writable Support**
 
 PySpark SequenceFile support loads an RDD of key-value pairs within Java, converts Writables to base Java types, and pickles the
-resulting Java objects using [Pyrolite](https://github.com/irmen/Pyrolite/). When saving an RDD of key-value pairs to SequenceFile,
+resulting Java objects using [pickle](https://github.com/irmen/pickle/). When saving an RDD of key-value pairs to SequenceFile,
 PySpark does the reverse. It unpickles Python objects into Java objects and then converts them to Writables. The following
 Writables are automatically converted:
 
@@ -500,7 +500,7 @@ the key and value classes can easily be converted according to the above table,
 then this approach should work well for such cases.
 
 If you have custom serialized binary data (such as loading data from Cassandra / HBase), then you will first need to
-transform that data on the Scala/Java side to something which can be handled by Pyrolite's pickler.
+transform that data on the Scala/Java side to something which can be handled by pickle's pickler.
 A [Converter](api/scala/org/apache/spark/api/python/Converter.html) trait is provided
 for this. Simply extend this trait and implement your transformation code in the ```convert```
 method. Remember to ensure that this class, along with any dependencies required to access your ```InputFormat```, are packaged into your Spark job jar and included on the PySpark

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -755,7 +755,7 @@ class SparkContext(object):
 
             1. A Java RDD is created from the SequenceFile or other InputFormat, and the key
                and value Writable classes
-            2. Serialization is attempted via Pyrolite pickling
+            2. Serialization is attempted via Pickle pickling
             3. If this fails, the fallback is to call 'toString' on each key and value
             4. :class:`PickleSerializer` is used to deserialize pickled objects on the Python side
 

--- a/python/pyspark/ml/common.py
+++ b/python/pyspark/ml/common.py
@@ -55,7 +55,7 @@ _picklable_classes = [
 def _to_java_object_rdd(rdd):
     """ Return an JavaRDD of Object by unpickling
 
-    It will convert each Python object into Java object by Pyrolite, whenever the
+    It will convert each Python object into Java object by Pickle, whenever the
     RDD is serialized in batch or not.
     """
     rdd = rdd._reserialize(AutoBatchedSerializer(PickleSerializer()))

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -677,7 +677,7 @@ class NaiveBayesModel(Saveable, Loader):
         """
         java_model = sc._jvm.org.apache.spark.mllib.classification.NaiveBayesModel.load(
             sc._jsc.sc(), path)
-        # Can not unpickle array.array from Pyrolite in Python3 with "bytes"
+        # Can not unpickle array.array from Pickle in Python3 with "bytes"
         py_labels = _java2py(sc, java_model.labels(), "latin1")
         py_pi = _java2py(sc, java_model.pi(), "latin1")
         py_theta = _java2py(sc, java_model.theta(), "latin1")

--- a/python/pyspark/mllib/common.py
+++ b/python/pyspark/mllib/common.py
@@ -57,7 +57,7 @@ _picklable_classes = [
 def _to_java_object_rdd(rdd):
     """ Return a JavaRDD of Object by unpickling
 
-    It will convert each Python object into Java object by Pyrolite, whenever the
+    It will convert each Python object into Java object by Pickle, whenever the
     RDD is serialized in batch or not.
     """
     rdd = rdd._reserialize(AutoBatchedSerializer(PickleSerializer()))

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1732,7 +1732,7 @@ class RDD(object):
         system, using the "org.apache.hadoop.io.Writable" types that we convert from the
         RDD's key and value types. The mechanism is as follows:
 
-            1. Pyrolite is used to convert pickled Python RDD into RDD of Java objects.
+            1. Pickle is used to convert pickled Python RDD into RDD of Java objects.
             2. Keys and values of this Java RDD are converted to Writables and written out.
 
         Parameters
@@ -2613,7 +2613,7 @@ class RDD(object):
     def _to_java_object_rdd(self):
         """ Return a JavaRDD of Object by unpickling
 
-        It will convert each Python object into Java object by Pyrolite, whenever the
+        It will convert each Python object into Java object by Pickle, whenever the
         RDD is serialized in batch or not.
         """
         rdd = self._pickled()

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+from decimal import Decimal
 import os
 import pydoc
 import shutil
@@ -949,6 +950,13 @@ class DataFrameTests(ReusedSQLTestCase):
 
         assert_frame_equal(pdf, psdf_from_sdf.to_pandas())
         assert_frame_equal(pdf_with_index, psdf_from_sdf_with_index.to_pandas())
+
+    # test for SPARK-36337
+    def test_create_nan_decimal_dataframe(self):
+        self.assertEqual(
+            self.spark.createDataFrame(data=[Decimal('NaN')], schema='decimal').collect(),
+            [Row(value=None)]
+        )
 
 
 class QueryExecutionListenerTests(unittest.TestCase, SQLTestUtils):

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvaluatePython.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvaluatePython.scala
@@ -45,7 +45,7 @@ object EvaluatePython {
   }
 
   /**
-   * Helper for converting from Catalyst type to java type suitable for Pyrolite.
+   * Helper for converting from Catalyst type to java type suitable for Pickle.
    */
   def toJava(obj: Any, dataType: DataType): Any = (obj, dataType) match {
     case (null, _) => null


### PR DESCRIPTION
### What changes were proposed in this pull request?
Switch (or upgrade) the [irmen/pyrolite.pickle](https://github.com/irmen/Pyrolite/tree/master) v4.30 to [irmen/pickle](https://github.com/irmen/pickle) v1.2 in this patch

### Why are the changes needed?
- Spark was using `Pyrolite.pickle` (v4.30) to pickle Java objects to python objects, but there was [a problem when pickling decimal(NaN)](https://github.com/irmen/pickle/issues/7) .
- irmen/Pyrolite pickle is splited as separate [irmen/pickle](https://github.com/irmen/pickle) library after Pyrolite v5, the bugfix would not be backported to v4.x, that means we have to switch pyrolite to pickle.
- The double NaN pickled issue solved in https://github.com/irmen/pickle/issues/7 in [irmen/pickle](https://github.com/irmen/pickle) v1.2

So, We switch (or upgrade) the pyrolite.pickle to pickle in this patch.


### Does this PR introduce _any_ user-facing change?

Before this patch:
```python
>>> import decimal
>>> spark.createDataFrame(data=[decimal.Decimal('NaN')], schema='decimal')
DataFrame[value: decimal(10,0)]
>>> spark.createDataFrame(data=[decimal.Decimal('NaN')], schema='decimal').collect()
21/10/14 18:06:47 ERROR Executor: Exception in task 7.0 in stage 5.0 (TID 31)
net.razorvine.pickle.PickleException: problem construction object: java.lang.reflect.InvocationTargetException
    at net.razorvine.pickle.objects.AnyClassConstructor.construct(AnyClassConstructor.java:29)
    at net.razorvine.pickle.Unpickler.load_reduce(Unpickler.java:773)
    at net.razorvine.pickle.Unpickler.dispatch(Unpickler.java:213)
    at net.razorvine.pickle.Unpickler.load(Unpickler.java:123)
    at net.razorvine.pickle.Unpickler.loads(Unpickler.java:136)
    at org.apache.spark.api.python.SerDeUtil$.$anonfun$pythonToJava$2(SerDeUtil.scala:121)
    ... ...
```
After this patch:
```python
>>> import decimal
>>> spark.createDataFrame(data=[decimal.Decimal('NaN')], schema='decimal')
DataFrame[value: decimal(10,0)]
>>> spark.createDataFrame(data=[decimal.Decimal('NaN')], schema='decimal').collect()
[Row(value=None)]
```

### How was this patch tested?
```
>>> import decimal
>>> spark.createDataFrame(data=[decimal.Decimal('NaN')], schema='decimal').collect()
```
