### PR TITLE
[SPARK-37016][SQL] Publicise UpperCaseCharStream

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -161,8 +161,7 @@ object CatalystSqlParser extends CatalystSqlParser
  * only accept capitalized tokens in case it is run from other tools like antlrworks which do not
  * have the UpperCaseCharStream implementation.
  */
-
-private[parser] class UpperCaseCharStream(wrapped: CodePointCharStream) extends CharStream {
+class UpperCaseCharStream(wrapped: CodePointCharStream) extends CharStream {
   override def consume(): Unit = wrapped.consume
   override def getSourceName(): String = wrapped.getSourceName
   override def index(): Int = wrapped.index


### PR DESCRIPTION
What changes were proposed in this pull request?
Publicise `UpperCaseCharStream`

Why are the changes needed?
Many Spark extension projects are copying `UpperCaseCharStream` because it is private beneath `parser` package, such as:
[Delta Lake](https://github.com/delta-io/delta/blob/625de3b305f109441ad04b20dba91dd6c4e1d78e/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala#L290)
[Hudi](https://github.com/apache/hudi/blob/3f8ca1a3552bb866163d3b1648f68d9c4824e21d/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/parser/HoodieCommonSqlParser.scala#L112)
[Iceberg](https://github.com/apache/iceberg/blob/c3ac4c6ca74a0013b4705d5bd5d17fade8e6f499/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala#L175)
[Submarine](https://github.com/apache/submarine/blob/2faebb8efd69833853f62d89b4f1fea1b1718148/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/parser/UpperCaseCharStream.scala#L31)
[Kyuubi](https://github.com/apache/incubator-kyuubi/blob/8a5134e3223844714fc58833a6859d4df5b68d57/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/zorder/ZorderSparkSqlExtensionsParserBase.scala#L108)
[Spark-ACID](https://github.com/qubole/spark-acid/blob/19bd6db757677c40f448e85c74d9995ba97d5942/src/main/scala/com/qubole/spark/datasources/hiveacid/sql/catalyst/parser/ParseDriver.scala#L13)
We can publicise `UpperCaseCharStream` to eliminate code duplication.

Does this PR introduce any user-facing change?
no

How was this patch tested?
existing tests