### PR TITLE
[SPARK-37017][SQL] Reduce the scope of synchronized to prevent potential deadlock

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -89,12 +89,16 @@ class CatalogManager(
 
   private var _currentNamespace: Option[Array[String]] = None
 
-  def currentNamespace: Array[String] = synchronized {
-    _currentNamespace.getOrElse {
-      if (currentCatalog.name() == SESSION_CATALOG_NAME) {
-        Array(v1SessionCatalog.getCurrentDatabase)
-      } else {
-        currentCatalog.defaultNamespace()
+  def currentNamespace: Array[String] = {
+    val defaultNamespace = if (currentCatalog.name() == SESSION_CATALOG_NAME) {
+      Array(v1SessionCatalog.getCurrentDatabase)
+    } else {
+      currentCatalog.defaultNamespace()
+    }
+
+    this.synchronized {
+      _currentNamespace.getOrElse {
+        defaultNamespace
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
There is a `synchronize` block in `CatalogManager.currentNamespace` function.
This PR pulls `SessionCatalog.getCurrentDatabase` out from this `synchronize` block to prevent potential deadlock.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In our case, we have implemented an external catalog, and there is a thread that directly calls SessionCatalog.getTempViewOrPermanentTableMetadata and holds the lock of SessionCatalog. It eventually goes into our external catalog, unfortunately, we then call some functions of SparkSession, e.g. sql. When it calls CatalogManager.currentNamespace, it tries to hold the lock of CatalogManager.

In the meantime, there are some query threads that execute sqls via DataFrame interface.

This is how deadlock occurs.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Currently spark cannot trigger this deadlock. So we wrote our own test to verify the effectiveness of this change.
In our external catalog code base, We write a UT to call SessionCatalog.getTempViewOrPermanentTableMetadata in one thread and while calling spark.sql("show databases") in other thread. Without this patch, a deadlock occurs and timeout exception was thrown. With this patch, UT works correctly.
We also tested this patch on the client's production environment, and the deadlock is fixed.


