### PR TITLE
[SPARK-36230][SPARK-36232][PYTHON] Add regression for hasnan of Decimal(NaN) 

### DIFF
--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -21,6 +21,7 @@ from distutils.version import LooseVersion
 import inspect
 from itertools import product
 from datetime import datetime, timedelta
+from decimal import Decimal
 
 import numpy as np
 import pandas as pd
@@ -2555,6 +2556,11 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(pser.hasnans, psser.hasnans)
 
         pser = pd.Series([pd.Timestamp("2020-07-30"), np.nan, pd.Timestamp("2020-07-30")])
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser.hasnans, psser.hasnans)
+
+        # DecimalType
+        pser = pd.Series([Decimal("0.1"), Decimal("NaN")])
         psser = ps.from_pandas(pser)
         self.assert_eq(pser.hasnans, psser.hasnans)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch add the regression test for:

- SPARK-36232: Add decimal(NaN) create check with arrow disable(default)
- SPARK-36230: Add decimal hasnan test


### Why are the changes needed?
These issues had been resolved after https://github.com/apache/spark/pull/34285 merged

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
test case