### PR TITLE
[SPARK-37026][ML][BUILD] Ensure the element type of `ResolvedRFormula.terms` is scala.Seq for Scala 2.13

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -449,7 +449,7 @@ object RFormulaModel extends MLReadable[RFormulaModel] {
       val dataPath = new Path(path, "data").toString
       val data = sparkSession.read.parquet(dataPath).select("label", "terms", "hasIntercept").head()
       val label = data.getString(0)
-      val terms = data.getSeq[Seq[String]](1)
+      val terms = data.getSeq[scala.collection.Seq[String]](1).map(_.toSeq)
       val hasIntercept = data.getBoolean(2)
       val resolvedRFormula = ResolvedRFormula(label, terms, hasIntercept)
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/RFormulaSuite.scala
@@ -627,4 +627,15 @@ class RFormulaSuite extends MLTest with DefaultReadWriteTest {
     assert(get_output("keep").count() == 6)
   }
 
+  test("SPARK-37026: Ensure the element type of ResolvedRFormula.terms is " +
+    "scala.Seq for Scala 2.13") {
+    withTempPath { path =>
+      val dataset = Seq((1, "foo", "zq"), (2, "bar", "zq"), (3, "bar", "zz")).toDF("id", "a", "b")
+      val rFormula = new RFormula().setFormula("id ~ a:b")
+      val model = rFormula.fit(dataset)
+      model.save(path.getCanonicalPath)
+      val newModel = RFormulaModel.load(path.getCanonicalPath)
+      newModel.resolvedFormula.toString
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes the issue that `scala.Seq[scala.collection.mutable.ArraySeq$ofRef]` will be passed to `ResolvedRFormula.terms` though it expects `scala.Seq[scala.Seq[String]]` with Scala 2.13.
As of Scala 2.13, `scala.Seq` is `scala.collection.immutable.Seq`, so this issue happens.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix.
Due to this issue, `ResolvedRFormula.toString` throws `ClassCastException`.
```
java.lang.ClassCastException: scala.collection.mutable.ArraySeq$ofRef cannot be cast to scala.collection.immutable.Seq
        at scala.collection.immutable.List.map(List.scala:246)
        at scala.collection.immutable.List.map(List.scala:79)
        at org.apache.spark.ml.feature.ResolvedRFormula.toString(RFormulaParser.scala:143)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
        at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
        at py4j.Gateway.invoke(Gateway.java:282)
        at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
        at py4j.commands.CallCommand.execute(CallCommand.java:79)
        at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:182)
        at py4j.ClientServerConnection.run(ClientServerConnection.java:106)
        at java.lang.Thread.run(Thread.java:748)
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New test is added and `build/sbt -Pscala-2.13 "testOnly org.apache.spark.ml.feature.RFormulaSuite"` passes.
CIs should ensure that this change works with Scala 2.12 too.