### PR TITLE
[SPARK-37028][UI] Add a 'kill' executor link in the Web UI.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage-template.html
@@ -127,6 +127,7 @@ limitations under the License.
                   title="Bytes and records written to disk in order to be read by a shuffle in a future stage.">
               Shuffle Write</span></th>
           <th>Logs</th>
+          <th>Kill</th>
           <th>Thread Dump</th>
           <th>Exec Loss Reason</th>
         </tr>

--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -48,6 +48,22 @@ function formatBytes(bytes, type) {
   var i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }
+
+function createConfirm(id, actionType) {
+  var confirm = "if (window.confirm('Are you sure you want to " + actionType + " " + id + " ?')) " +
+  "{ this.parentNode.submit(); return true; } else { return false; }";
+  return confirm;
+}
+
+function getKillExecutorURI(id, baseURI) {
+  var newURI  = '';
+  if (baseURI != null && baseURI != '') {
+    newURI += baseURI;
+    newURI += "?executorId=" + id;
+  }
+  return newURI;
+}
+
 /* eslint-enable no-unused-vars */
 
 function padZeroes(num) {

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -81,10 +81,11 @@ private[spark] class SparkUI private (
     val jobsTab = new JobsTab(this, store)
     attachTab(jobsTab)
     val stagesTab = new StagesTab(this, store)
+    val executorsTab = new ExecutorsTab(this)
     attachTab(stagesTab)
     attachTab(new StorageTab(this, store))
     attachTab(new EnvironmentTab(this, store))
-    attachTab(new ExecutorsTab(this))
+    attachTab(executorsTab)
     addStaticHandler(SparkUI.STATIC_RESOURCE_DIR)
     attachHandler(createRedirectHandler("/", "/jobs/", basePath = basePath))
     attachHandler(ApiRootResource.getServletHandler(this))
@@ -97,6 +98,10 @@ private[spark] class SparkUI private (
       "/jobs/job/kill", "/jobs/", jobsTab.handleKillRequest, httpMethods = Set("GET", "POST")))
     attachHandler(createRedirectHandler(
       "/stages/stage/kill", "/stages/", stagesTab.handleKillRequest,
+      httpMethods = Set("GET", "POST")))
+
+    attachHandler(createRedirectHandler(
+      "/executors/forceKill", "/executors/", executorsTab.handleKillExecutorRequest,
       httpMethods = Set("GET", "POST")))
   }
 
@@ -193,6 +198,9 @@ private[spark] class SparkUI private (
 
 private[spark] abstract class SparkUITab(parent: SparkUI, prefix: String)
   extends WebUITab(parent, prefix) {
+  val killEnabled = parent.killEnabled
+  val conf = parent.conf
+  val sc = parent.sc
 
   def appName: String = parent.appName
 

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobsTab.scala
@@ -29,10 +29,6 @@ import org.apache.spark.ui._
 private[ui] class JobsTab(parent: SparkUI, store: AppStatusStore)
   extends SparkUITab(parent, "jobs") {
 
-  val sc = parent.sc
-  val conf = parent.conf
-  val killEnabled = parent.killEnabled
-
   // Show pool information for only live UI.
   def isFairScheduler: Boolean = {
     sc.isDefined &&

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagesTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagesTab.scala
@@ -29,10 +29,6 @@ import org.apache.spark.ui.{SparkUI, SparkUITab}
 private[ui] class StagesTab(val parent: SparkUI, val store: AppStatusStore)
   extends SparkUITab(parent, "stages") {
 
-  val sc = parent.sc
-  val conf = parent.conf
-  val killEnabled = parent.killEnabled
-
   attachPage(new AllStagesPage(this))
   attachPage(new StagePage(this, store))
   attachPage(new PoolPage(this))


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Add a 'kill' executor link in the Web UI,  so it's easier for users to kill executors in the UI.

### Why are the changes needed?
The executor which is running in a bad node(eg. The system is overloaded or disks are busy) or  has big GC overheads may affect the efficiency of job execution, although there are speculative mechanisms to resolve this problem, but sometimes the speculated task may also run in a bad executor.
We should have a "kill" link for each executor, similar to what we have for each stage, so it's easier for users to kill executors in the UI.

### Does this PR introduce _any_ user-facing change?
Yes,  user can  kill executors via the Web UI.
![image](https://user-images.githubusercontent.com/39684231/137618317-752fec71-6db7-4c75-a6f3-7a5644769cec.png)


### How was this patch tested?

Add unittests.