### PR TITLE
[SPARK-37018][SQL] Spark SQL should support create function with Aggregator

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSQLViewSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSQLViewSuite.scala
@@ -196,7 +196,7 @@ class HiveSQLViewSuite extends SQLViewSuite with TestHiveSingleton {
         // create a view using a function in 'default' database
         withView("v1") {
           sql(s"CREATE VIEW v1 AS SELECT $functionName(col1) AS func FROM VALUES (1), (2), (3)")
-          checkAnswer(sql(s"SELECT * FROM v1"), Seq(Row(102.0)))
+          checkAnswer(sql("SELECT * FROM v1"), Seq(Row(102.0)))
         }
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSQLViewSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSQLViewSuite.scala
@@ -179,4 +179,32 @@ class HiveSQLViewSuite extends SQLViewSuite with TestHiveSingleton {
       }
     }
   }
+
+  test("SPARK-33692: 2") {
+    val avgFuncClass = "test.org.apache.spark.sql.MyDoubleAverage"
+    val sumFuncClass = "test.org.apache.spark.sql.MyDoubleSum"
+    val functionName = "test_udf"
+    withTempDatabase { dbName =>
+      withUserDefinedFunction(
+        s"default.$functionName" -> false,
+        s"$dbName.$functionName" -> false,
+        functionName -> true) {
+        // create a function in default database
+        sql("USE DEFAULT")
+        sql(s"CREATE FUNCTION $functionName AS '$avgFuncClass'")
+        // create a view using a function in 'default' database
+//        val viewName = createView(
+//          "v1", s"SELECT $functionName(col1) AS func FROM VALUES (1), (2), (3)")
+//        // create function in another database with the same function name
+//        sql(s"USE $dbName")
+//        sql(s"CREATE FUNCTION $functionName AS '$sumFuncClass'")
+//        // create temporary function with the same function name
+//        sql(s"CREATE TEMPORARY FUNCTION $functionName AS '$sumFuncClass'")
+//        withView(viewName) {
+//          // view v1 should still using function defined in `default` database
+//          checkViewOutput(viewName, Seq(Row(102.0)))
+//        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark SQL not supports to create function of `Aggregator` yet and deprecated `UserDefinedAggregateFunction`.
If we want remove `UserDefinedAggregateFunction`, Spark SQL should provide a new option.


### Why are the changes needed?
We need to provide a new way to create user defined aggregate function so as remove `UserDefinedAggregateFunction` in future.


### Does this PR introduce _any_ user-facing change?
Yes. Users will create user defined aggregate function by implement `Aggregator`.


### How was this patch tested?
New tests.
