### PR TITLE
[SPARK-36151][INFRA] MiMa updates after 3.2.0 release: bump previousSparkVersion and re-enable tests for Scala 2.13 artifacts

### DIFF
--- a/dev/mima
+++ b/dev/mima
@@ -25,11 +25,6 @@ FWDIR="$(cd "`dirname "$0"`"/..; pwd)"
 cd "$FWDIR"
 
 SPARK_PROFILES=${1:-"-Pmesos -Pkubernetes -Pyarn -Pspark-ganglia-lgpl -Pkinesis-asl -Phive-thriftserver -Phive"}
-# Apache Spark doesn't have Scala 2.13 maven artifacts yet.
-# TODO(SPARK-36151) Enable MiMa for Scala 2.13 artifacts after Spark 3.2.0 release
-if [[ "$SPARK_PROFILES" == *"-Pscala-2.13"* ]]; then
-  exit 0
-fi
 TOOLS_CLASSPATH="$(build/sbt -DcopyDependencies=false "export tools/fullClasspath" | grep jar | tail -n1)"
 OLD_DEPS_CLASSPATH="$(build/sbt -DcopyDependencies=false $SPARK_PROFILES "export oldDeps/fullClasspath" | grep jar | tail -n1)"
 

--- a/project/MimaBuild.scala
+++ b/project/MimaBuild.scala
@@ -86,7 +86,7 @@ object MimaBuild {
 
   def mimaSettings(sparkHome: File, projectRef: ProjectRef): Seq[Setting[_]] = {
     val organization = "org.apache.spark"
-    val previousSparkVersion = "3.1.1"
+    val previousSparkVersion = "3.2.0"
     val project = projectRef.project
     val fullId = "spark-" + project + "_2.12"
 

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -34,7 +34,7 @@ import com.typesafe.tools.mima.core.ProblemFilters._
  */
 object MimaExcludes {
 
-  // Exclude rules for 3.3.x from 3.2.0 after 3.2.0 release
+  // Exclude rules for 3.3.x from 3.2.0
   lazy val v33excludes = v32excludes ++ Seq(
   )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates MiMa checks following Spark 3.2.0's release:

- Bump `previousSparkVersion` to `3.2.0`
- Re-enable MiMa checks for Scala 2.13 artifacts (see #33355)

### Why are the changes needed?

To ensure that MiMa checks cover new APIs added in Spark 3.2.0.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

```
$ dev/mima -Pscala-2.12
$ dev/mima -Pscala-2.13
```