### PR TITLE
[SPARK-37035][SQL] Improve error message when use parquet vectorize reader

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -599,7 +599,7 @@ object QueryExecutionErrors {
       colName: String,
       path: String,
       e: Exception): UnsupportedOperationException = {
-    val message = s"Decoding to $valueType is not supported when reading col `$colName` " +
+    val message = s"Decoding to $valueType is not supported when reading column `$colName` " +
       s"by $dictionary while reading file $path"
     new UnsupportedOperationException(message, e)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -596,10 +596,11 @@ object QueryExecutionErrors {
   def unsupportedParquetDictionaryDecodingError(
       valueType: String,
       dictionary: String,
-      file: String,
+      colName: String,
+      path: String,
       e: Exception): UnsupportedOperationException = {
-    val message = s"Decoding to $valueType is not supported by $dictionary " +
-      s"while reading file $file"
+    val message = s"Decoding to $valueType is not supported when reading col `$colName` " +
+      s"by $dictionary while reading file $path"
     new UnsupportedOperationException(message, e)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -593,6 +593,16 @@ object QueryExecutionErrors {
     new QueryExecutionException(message, e)
   }
 
+  def unsupportedParquetDictionaryDecodingError(
+      valueType: String,
+      dictionary: String,
+      file: String,
+      e: Exception): UnsupportedOperationException = {
+    val message = s"Decoding to $valueType is not supported by $dictionary " +
+      s"while reading file $file"
+    new UnsupportedOperationException(message, e)
+  }
+
   def cannotCreateColumnarReaderError(): Throwable = {
     new UnsupportedOperationException("Cannot create columnar reader.")
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionary.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionary.java
@@ -92,7 +92,8 @@ public final class ParquetDictionary implements Dictionary {
       if (needTransform) {
         // For unsigned int64, it stores as dictionary encoded signed int64 in Parquet
         // whenever dictionary is available.
-        // Here we lazily decode it to the original signed long value then convert to decimal(20, 0).
+        // Here we lazily decode it to the original signed long value
+        // then convert to decimal(20, 0).
         long signed = dictionary.decodeToLong(id);
         return new BigInteger(Long.toUnsignedString(signed)).toByteArray();
       } else {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionary.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionary.java
@@ -24,15 +24,15 @@ import java.math.BigInteger;
 
 public final class ParquetDictionary implements Dictionary {
   private org.apache.parquet.column.Dictionary dictionary;
-  private String file;
+  private String path;
   private boolean needTransform = false;
 
   public ParquetDictionary(
       org.apache.parquet.column.Dictionary dictionary,
-      String file,
+      String path,
       boolean needTransform) {
     this.dictionary = dictionary;
-    this.file = file;
+    this.path = path;
     this.needTransform = needTransform;
   }
 
@@ -46,7 +46,7 @@ public final class ParquetDictionary implements Dictionary {
       }
     } catch (UnsupportedOperationException e) {
       throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
-        "Int", dictionary.getClass().getSimpleName(), file, e);
+        "Int", dictionary.getClass().getSimpleName(), path, e);
     }
   }
 
@@ -63,7 +63,7 @@ public final class ParquetDictionary implements Dictionary {
       }
     } catch (UnsupportedOperationException e) {
       throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
-        "Long", dictionary.getClass().getSimpleName(), file, e);
+        "Long", dictionary.getClass().getSimpleName(), path, e);
     }
   }
 
@@ -73,7 +73,7 @@ public final class ParquetDictionary implements Dictionary {
       return dictionary.decodeToFloat(id);
     } catch (UnsupportedOperationException e) {
       throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
-        "Float", dictionary.getClass().getSimpleName(), file, e);
+        "Float", dictionary.getClass().getSimpleName(), path, e);
     }
   }
 
@@ -83,7 +83,7 @@ public final class ParquetDictionary implements Dictionary {
       return dictionary.decodeToDouble(id);
     } catch (UnsupportedOperationException e) {
       throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
-        "Double", dictionary.getClass().getSimpleName(), file, e);
+        "Double", dictionary.getClass().getSimpleName(), path, e);
     }
   }
 
@@ -102,7 +102,7 @@ public final class ParquetDictionary implements Dictionary {
       }
     } catch (UnsupportedOperationException e) {
       throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
-        "Binary", dictionary.getClass().getSimpleName(), file, e);
+        "Binary", dictionary.getClass().getSimpleName(), path, e);
     }
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionary.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionary.java
@@ -24,14 +24,17 @@ import java.math.BigInteger;
 
 public final class ParquetDictionary implements Dictionary {
   private org.apache.parquet.column.Dictionary dictionary;
+  private String colName;
   private String path;
   private boolean needTransform = false;
 
   public ParquetDictionary(
       org.apache.parquet.column.Dictionary dictionary,
+      String colName,
       String path,
       boolean needTransform) {
     this.dictionary = dictionary;
+    this.colName = colName;
     this.path = path;
     this.needTransform = needTransform;
   }
@@ -46,7 +49,7 @@ public final class ParquetDictionary implements Dictionary {
       }
     } catch (UnsupportedOperationException e) {
       throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
-        "Int", dictionary.getClass().getSimpleName(), path, e);
+        "Int", dictionary.getClass().getSimpleName(), colName, path, e);
     }
   }
 
@@ -63,7 +66,7 @@ public final class ParquetDictionary implements Dictionary {
       }
     } catch (UnsupportedOperationException e) {
       throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
-        "Long", dictionary.getClass().getSimpleName(), path, e);
+        "Long", dictionary.getClass().getSimpleName(), colName, path, e);
     }
   }
 
@@ -73,7 +76,7 @@ public final class ParquetDictionary implements Dictionary {
       return dictionary.decodeToFloat(id);
     } catch (UnsupportedOperationException e) {
       throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
-        "Float", dictionary.getClass().getSimpleName(), path, e);
+        "Float", dictionary.getClass().getSimpleName(), colName, path, e);
     }
   }
 
@@ -83,7 +86,7 @@ public final class ParquetDictionary implements Dictionary {
       return dictionary.decodeToDouble(id);
     } catch (UnsupportedOperationException e) {
       throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
-        "Double", dictionary.getClass().getSimpleName(), path, e);
+        "Double", dictionary.getClass().getSimpleName(), colName, path, e);
     }
   }
 
@@ -102,7 +105,7 @@ public final class ParquetDictionary implements Dictionary {
       }
     } catch (UnsupportedOperationException e) {
       throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
-        "Binary", dictionary.getClass().getSimpleName(), path, e);
+        "Binary", dictionary.getClass().getSimpleName(), colName, path, e);
     }
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionary.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetDictionary.java
@@ -17,13 +17,14 @@
 
 package org.apache.spark.sql.execution.datasources.parquet;
 
+import org.apache.spark.sql.errors.QueryExecutionErrors;
 import org.apache.spark.sql.execution.vectorized.Dictionary;
 
 import java.math.BigInteger;
 
 public final class ParquetDictionary implements Dictionary {
   private org.apache.parquet.column.Dictionary dictionary;
-  private String  file;
+  private String file;
   private boolean needTransform = false;
 
   public ParquetDictionary(
@@ -44,8 +45,8 @@ public final class ParquetDictionary implements Dictionary {
         return dictionary.decodeToInt(id);
       }
     } catch (UnsupportedOperationException e) {
-      throw new UnsupportedOperationException("Decoding to Int failed when reading file " +
-        file + "using " + e.getMessage(), e.getCause());
+      throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
+        "Int", dictionary.getClass().getSimpleName(), file, e);
     }
   }
 
@@ -61,8 +62,8 @@ public final class ParquetDictionary implements Dictionary {
         return dictionary.decodeToLong(id);
       }
     } catch (UnsupportedOperationException e) {
-      throw new UnsupportedOperationException("Decoding to Long failed when reading file " +
-        file + "using " + e.getMessage(), e.getCause());
+      throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
+        "Long", dictionary.getClass().getSimpleName(), file, e);
     }
   }
 
@@ -71,8 +72,8 @@ public final class ParquetDictionary implements Dictionary {
     try {
       return dictionary.decodeToFloat(id);
     } catch (UnsupportedOperationException e) {
-      throw new UnsupportedOperationException("Decoding to Float failed when reading file " +
-        file + "using " + e.getMessage(), e.getCause());
+      throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
+        "Float", dictionary.getClass().getSimpleName(), file, e);
     }
   }
 
@@ -81,8 +82,8 @@ public final class ParquetDictionary implements Dictionary {
     try {
       return dictionary.decodeToDouble(id);
     } catch (UnsupportedOperationException e) {
-      throw new UnsupportedOperationException("Decoding to Double failed when reading file " +
-        file + "using " + e.getMessage(), e.getCause());
+      throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
+        "Double", dictionary.getClass().getSimpleName(), file, e);
     }
   }
 
@@ -100,8 +101,8 @@ public final class ParquetDictionary implements Dictionary {
         return dictionary.decodeToBinary(id).getBytes();
       }
     } catch (UnsupportedOperationException e) {
-      throw new UnsupportedOperationException("Decoding to Binary failed when reading file " +
-        file + "using " + e.getMessage(), e.getCause());
+      throw QueryExecutionErrors.unsupportedParquetDictionaryDecodingError(
+        "Binary", dictionary.getClass().getSimpleName(), file, e);
     }
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
@@ -189,10 +189,12 @@ public abstract class SpecificParquetRecordReaderBase<T> extends RecordReader<Vo
 
   @VisibleForTesting
   protected void initialize(
+      String path,
       MessageType fileSchema,
       MessageType requestedSchema,
       ParquetRowGroupReader rowGroupReader,
       int totalRowCount) throws IOException {
+    this.file = new Path(path);
     this.reader = rowGroupReader;
     this.fileSchema = fileSchema;
     this.requestedSchema = requestedSchema;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -85,6 +85,7 @@ public class VectorizedColumnReader {
   private final ColumnDescriptor descriptor;
   private final LogicalTypeAnnotation logicalTypeAnnotation;
   private final String datetimeRebaseMode;
+  private final String file;
 
   public VectorizedColumnReader(
       ColumnDescriptor descriptor,
@@ -93,7 +94,8 @@ public class VectorizedColumnReader {
       PrimitiveIterator.OfLong rowIndexes,
       ZoneId convertTz,
       String datetimeRebaseMode,
-      String int96RebaseMode) throws IOException {
+      String int96RebaseMode,
+      String file) throws IOException {
     this.descriptor = descriptor;
     this.pageReader = pageReader;
     this.readState = new ParquetReadState(descriptor.getMaxDefinitionLevel(), rowIndexes);
@@ -121,6 +123,7 @@ public class VectorizedColumnReader {
     this.datetimeRebaseMode = datetimeRebaseMode;
     assert "LEGACY".equals(int96RebaseMode) || "EXCEPTION".equals(int96RebaseMode) ||
       "CORRECTED".equals(int96RebaseMode);
+    this.file = file;
   }
 
   private boolean isLazyDecodingSupported(PrimitiveType.PrimitiveTypeName typeName) {
@@ -204,7 +207,7 @@ public class VectorizedColumnReader {
           boolean isUnsignedInt64 = updaterFactory.isUnsignedIntTypeMatched(64);
 
           boolean needTransform = castLongToInt || isUnsignedInt32 || isUnsignedInt64;
-          column.setDictionary(new ParquetDictionary(dictionary, needTransform));
+          column.setDictionary(new ParquetDictionary(dictionary, file, needTransform));
         } else {
           updater.decodeDictionaryIds(readState.offset - startOffset, startOffset, column,
             dictionaryIds, dictionary);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -207,7 +207,8 @@ public class VectorizedColumnReader {
           boolean isUnsignedInt64 = updaterFactory.isUnsignedIntTypeMatched(64);
 
           boolean needTransform = castLongToInt || isUnsignedInt32 || isUnsignedInt64;
-          column.setDictionary(new ParquetDictionary(dictionary, file, needTransform));
+          column.setDictionary(new ParquetDictionary(dictionary,
+            descriptor.getPrimitiveType().getName(), file, needTransform));
         } else {
           updater.decodeDictionaryIds(readState.offset - startOffset, startOffset, column,
             dictionaryIds, dictionary);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
@@ -350,7 +350,8 @@ public class VectorizedParquetRecordReader extends SpecificParquetRecordReaderBa
         pages.getRowIndexes().orElse(null),
         convertTz,
         datetimeRebaseMode,
-        int96RebaseMode);
+        int96RebaseMode,
+        file.toString());
     }
     totalCountLoadedSoFar += pages.getRowCount();
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
@@ -351,7 +351,7 @@ public class VectorizedParquetRecordReader extends SpecificParquetRecordReaderBa
         convertTz,
         datetimeRebaseMode,
         int96RebaseMode,
-        file.toString());
+        file == null? "null": file.toString());
     }
     totalCountLoadedSoFar += pages.getRowCount();
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
@@ -170,11 +170,12 @@ public class VectorizedParquetRecordReader extends SpecificParquetRecordReaderBa
   @VisibleForTesting
   @Override
   public void initialize(
+      String path,
       MessageType fileSchema,
       MessageType requestedSchema,
       ParquetRowGroupReader rowGroupReader,
       int totalRowCount) throws IOException {
-    super.initialize(fileSchema, requestedSchema, rowGroupReader, totalRowCount);
+    super.initialize(path, fileSchema, requestedSchema, rowGroupReader, totalRowCount);
     initializeInternal();
   }
 
@@ -351,7 +352,7 @@ public class VectorizedParquetRecordReader extends SpecificParquetRecordReaderBa
         convertTz,
         datetimeRebaseMode,
         int96RebaseMode,
-        file == null? "null": file.toString());
+        file.toString());
     }
     totalCountLoadedSoFar += pages.getRowCount();
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -1106,7 +1106,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
         val msg = intercept[UnsupportedOperationException] {
           parquetDictionary.decodeToInt(0)
         }.getMessage
-        assert(msg.contains("Decoding to Int is not supported when reading col `_1` by " +
+        assert(msg.contains("Decoding to Int is not supported when reading column `_1` by " +
           s"PlainIntegerDictionary while reading file $file"))
       } finally {
         reader.close()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -1105,7 +1105,8 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
         val msg = intercept[UnsupportedOperationException] {
           parquetDictionary.decodeToInt(0)
         }.getMessage
-        assert(msg.contains("Decoding to Int is not supported"))
+        assert(msg.contains("Decoding to Int is not supported by PlainIntegerDictionary " +
+          s"while reading file $file"))
       } finally {
         reader.close()
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorizedSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorizedSuite.scala
@@ -294,7 +294,7 @@ class ParquetVectorizedSuite extends QueryTest with ParquetTest with SharedSpark
 
     val recordReader = new VectorizedParquetRecordReader(
       DateTimeUtils.getZoneId("EST"), "CORRECTED", "CORRECTED", true, batchSize)
-    recordReader.initialize(fileSchema, fileSchema,
+    recordReader.initialize("/path/to/dummy.parquet", fileSchema, fileSchema,
       TestParquetRowGroupReader(Seq(readStore)), totalRowCount)
 
     // convert both actual and expected rows into collections


### PR DESCRIPTION
### What changes were proposed in this pull request?
When we use parquet, found vectorized read won't show error message about failed read parquet file path. This makes it difficult to find out that the file is faulty.

None-vectorized parquet reader 
```
Exception: Encounter error while reading parquet files. One possible cause: Parquet column cannot be converted in the corresponding files. Details:
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.nextIterator(FileScanRDD.scala:193)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.hasNext(FileScanRDD.scala:101)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
	at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:462)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:125)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:55)
	at org.apache.spark.scheduler.Task.run(Task.scala:123)
	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:408)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.parquet.io.ParquetDecodingException: Can not read value at 1 in block 0 in file hdfs://R2/projects/data_notificationmart/dwd_traceid_sent_civ_first_di/tz_type=local/grass_region=TW/grass_date=2021-10-13/noti_type=AR/part-00013-22bdd509-4469-47f7-a37e-50fddd4266a7-c000.zstd.parquet
	at org.apache.parquet.hadoop.InternalParquetRecordReader.nextKeyValue(InternalParquetRecordReader.java:251)
	at org.apache.parquet.hadoop.ParquetRecordReader.nextKeyValue(ParquetRecordReader.java:207)
	at org.apache.spark.sql.execution.datasources.RecordReaderIterator.hasNext(RecordReaderIterator.scala:39)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.hasNext(FileScanRDD.scala:101)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.nextIterator(FileScanRDD.scala:181)
	... 15 more
```


Vectorize parquet reader
```
21/10/15 18:01:54 WARN TaskSetManager: Lost task 1881.0 in stage 16.0 (TID 10380, ip-10-130-169-140.idata-server.shopee.io, executor 168): TaskKilled (Stage cancelled)
: An error occurred while calling o362.showString.
: org.apache.spark.SparkException: Job aborted due to stage failure: Task 963 in stage 17.0 failed 4 times, most recent failure: Lost task 963.3 in stage 17.0 (TID 10351, ip-10-130-75-201.idata-server.shopee.io, executor 99): java.lang.UnsupportedOperationException: org.apache.parquet.column.values.dictionary.PlainValuesDictionary$PlainIntegerDictionary
	at org.apache.parquet.column.Dictionary.decodeToLong(Dictionary.java:49)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetDictionary.decodeToLong(ParquetDictionary.java:36)
	at org.apache.spark.sql.execution.vectorized.OnHeapColumnVector.getLong(OnHeapColumnVector.java:364)
	at org.apache.spark.sql.execution.vectorized.MutableColumnarRow.getLong(MutableColumnarRow.java:120)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.writeFields_0_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
	at org.apache.spark.sql.execution.FileSourceScanExec$$anonfun$doExecute$2$$anonfun$apply$2.apply(DataSourceScanExec.scala:351)
	at org.apache.spark.sql.execution.FileSourceScanExec$$anonfun$doExecute$2$$anonfun$apply$2.apply(DataSourceScanExec.scala:349)
	at scala.collection.Iterator$$anon$11.next(Iterator.scala:410)
	at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:463)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:125)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:55)
	at org.apache.spark.scheduler.Task.run(Task.scala:123)
	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:408)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

This is caused in vectorized reader, it use `Dictionary` don't have file information,
```
public abstract class Dictionary {
    private final Encoding encoding;

    public Dictionary(Encoding encoding) {
        this.encoding = encoding;
    }

    public Encoding getEncoding() {
        return this.encoding;
    }

    public abstract int getMaxId();

    public Binary decodeToBinary(int id) {
        throw new UnsupportedOperationException(this.getClass().getName());
    }

    public int decodeToInt(int id) {
        throw new UnsupportedOperationException(this.getClass().getName());
    }

    public long decodeToLong(int id) {
        throw new UnsupportedOperationException(this.getClass().getName());
    }

    public float decodeToFloat(int id) {
        throw new UnsupportedOperationException(this.getClass().getName());
    }

    public double decodeToDouble(int id) {
        throw new UnsupportedOperationException(this.getClass().getName());
    }

    public boolean decodeToBoolean(int id) {
        throw new UnsupportedOperationException(this.getClass().getName());
    }
}
```
 and spark have wrapper a `ParquetDictionary` so we can do this in `ParquetDictionary`, to add file information in error message.

### Why are the changes needed?
Improve error message to help make sure which file have problem.

### Does this PR introduce _any_ user-facing change?
User can know which file failed to read when use parquet vectorized  reader


### How was this patch tested?
WIP
