### PR TITLE
[SPARK-37046][SQL]: Alter view does not preserve column case

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -567,7 +567,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     verifyTableProperties(tableDefinition)
 
     if (tableDefinition.tableType == VIEW) {
-      client.alterTable(tableDefinition)
+      val newTableProps = tableDefinition.properties ++ tableMetaToTableProps(tableDefinition).toMap
+      client.alterTable(tableDefinition.copy(properties = newTableProps))
     } else {
       val oldTableDef = getRawTable(db, tableDefinition.identifier.table)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3025,4 +3025,49 @@ class HiveDDLSuite
       assert(errMsg2.contains("Cannot use interval type in the table schema"))
     }
   }
+
+  test("Put-in-jira: Alter view should preserve column case with view definition change") {
+    withView("v") {
+      // Changing view definition should preserve column case
+      spark.sql("CREATE VIEW v AS SELECT 1 AS A, 1 AS B")
+      val df = spark.table("v")
+      assert("A".equals(df.schema.fields(0).name))
+      assert("B".equals(df.schema.fields(1).name))
+
+      spark.sql("ALTER VIEW v AS SELECT 1 AS C, 1 AS D")
+      val df1 = spark.table("v")
+      assert("C".equals(df1.schema.fields(0).name))
+      assert("D".equals(df1.schema.fields(1).name))
+    }
+  }
+
+  test("Put-in-jira: Alter view should preserve column case with view name change") {
+    withView("v") {
+      // Renaming view should preserve column case
+      spark.sql("CREATE VIEW v AS SELECT 1 AS A, 1 AS B")
+      val df = spark.table("v")
+      assert("A".equals(df.schema.fields(0).name))
+      assert("B".equals(df.schema.fields(1).name))
+
+      sql("ALTER VIEW v RENAME TO vRenamed")
+      val df1 = spark.table("vRenamed")
+      assert("A".equals(df1.schema.fields(0).name))
+      assert("B".equals(df1.schema.fields(1).name))
+    }
+  }
+
+  test("Put-in-jira: Alter view should preserve column case with tbl properties change") {
+    withView("v") {
+      // Setting table properties should preserve column case
+      spark.sql("CREATE VIEW v AS SELECT 1 AS A, 1 AS B")
+      val df = spark.table("v")
+      assert("A".equals(df.schema.fields(0).name))
+      assert("B".equals(df.schema.fields(1).name))
+
+      sql("ALTER VIEW v SET TBLPROPERTIES('testkey' = 'testval')")
+      val df1 = spark.table("v")
+      assert("A".equals(df1.schema.fields(0).name))
+      assert("B".equals(df1.schema.fields(1).name))
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3026,7 +3026,7 @@ class HiveDDLSuite
     }
   }
 
-  test("Put-in-jira: Alter view should preserve column case with view definition change") {
+  test("SPARK-37046: Alter view should preserve column case with view definition change") {
     withView("v") {
       // Changing view definition should preserve column case
       spark.sql("CREATE VIEW v AS SELECT 1 AS A, 1 AS B")
@@ -3041,7 +3041,7 @@ class HiveDDLSuite
     }
   }
 
-  test("Put-in-jira: Alter view should preserve column case with view name change") {
+  test("SPARK-37046: Alter view should preserve column case with view name change") {
     withView("v") {
       // Renaming view should preserve column case
       spark.sql("CREATE VIEW v AS SELECT 1 AS A, 1 AS B")
@@ -3056,7 +3056,7 @@ class HiveDDLSuite
     }
   }
 
-  test("Put-in-jira: Alter view should preserve column case with tbl properties change") {
+  test("SPARK-37046: Alter view should preserve column case with tbl properties change") {
     withView("v") {
       // Setting table properties should preserve column case
       spark.sql("CREATE VIEW v AS SELECT 1 AS A, 1 AS B")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3031,13 +3031,11 @@ class HiveDDLSuite
       // Changing view definition should preserve column case
       spark.sql("CREATE VIEW v AS SELECT 1 AS A, 1 AS B")
       val df = spark.table("v")
-      assert("A".equals(df.schema.fields(0).name))
-      assert("B".equals(df.schema.fields(1).name))
+      assert(df.schema.names.toSeq == Seq("A", "B"))
 
       spark.sql("ALTER VIEW v AS SELECT 1 AS C, 1 AS D")
       val df1 = spark.table("v")
-      assert("C".equals(df1.schema.fields(0).name))
-      assert("D".equals(df1.schema.fields(1).name))
+      assert(df1.schema.names.toSeq == Seq("C", "D"))
     }
   }
 
@@ -3046,13 +3044,11 @@ class HiveDDLSuite
       // Renaming view should preserve column case
       spark.sql("CREATE VIEW v AS SELECT 1 AS A, 1 AS B")
       val df = spark.table("v")
-      assert("A".equals(df.schema.fields(0).name))
-      assert("B".equals(df.schema.fields(1).name))
+      assert(df.schema.names.toSeq == Seq("A", "B"))
 
       sql("ALTER VIEW v RENAME TO vRenamed")
       val df1 = spark.table("vRenamed")
-      assert("A".equals(df1.schema.fields(0).name))
-      assert("B".equals(df1.schema.fields(1).name))
+      assert(df1.schema.names.toSeq == Seq("A", "B"))
     }
   }
 
@@ -3061,13 +3057,11 @@ class HiveDDLSuite
       // Setting table properties should preserve column case
       spark.sql("CREATE VIEW v AS SELECT 1 AS A, 1 AS B")
       val df = spark.table("v")
-      assert("A".equals(df.schema.fields(0).name))
-      assert("B".equals(df.schema.fields(1).name))
+      assert(df.schema.names.toSeq == Seq("A", "B"))
 
       sql("ALTER VIEW v SET TBLPROPERTIES('testkey' = 'testval')")
       val df1 = spark.table("v")
-      assert("A".equals(df1.schema.fields(0).name))
-      assert("B".equals(df1.schema.fields(1).name))
+      assert(df1.schema.names.toSeq == Seq("A", "B"))
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Column case was lost when we did an alter view because we would not save schema information in table properties for datasource tables when doing an alter view.
The fix proposed is to save the required properties in table props in the alter codepath


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is a bug as schema case information is lost. Repro

```
scala> sql("create view v as select 1 as A, 1 as B")
res2: org.apache.spark.sql.DataFrame = []

scala> sql("describe v").collect.foreach(println)
[A,int,null]
[B,int,null]

scala> sql("alter view v as select 1 as C, 1 as D")
res4: org.apache.spark.sql.DataFrame = []

scala> sql("describe v").collect.foreach(println)
[c,int,null]
[d,int,null]
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Now on an alter view, user will see column case preserved.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests.
