### PR TITLE
[SPARK-37052][CORE] Spark should only pass --verbose argument to main class when is sql shell

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -853,7 +853,7 @@ private[spark] class SparkSubmit extends Logging {
     }
     sparkConf.set(SUBMIT_PYTHON_FILES, formattedPyFiles.split(",").toSeq)
 
-    if (args.verbose) {
+    if (args.verbose && isSqlShell(childMainClass)) {
       childArgs ++= Seq("--verbose")
     }
     (childArgs.toSeq, childClasspath.toSeq, sparkConf, childMainClass)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In https://github.com/apache/spark/pull/32163 spark pass `--verbose` to main class o support spark-sql shell can use verbose argument too. 
But for other shell main class such as saprk-shell, it's intercepter don't support `--verbose`, so we should only pass `--verbose` for sql shell


### Why are the changes needed?
Fix bug


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

