### PR TITLE
[SPARK-37059][PYTHON][TESTS] Ensure the sort order of the output in the PySpark doctests

### DIFF
--- a/python/pyspark/ml/fpm.py
+++ b/python/pyspark/ml/fpm.py
@@ -191,27 +191,27 @@ class FPGrowth(JavaEstimator, _FPGrowthParams, JavaMLWritable, JavaMLReadable):
     >>> fpm = fp.fit(data)
     >>> fpm.setPredictionCol("newPrediction")
     FPGrowthModel...
-    >>> fpm.freqItemsets.show(5)
+    >>> fpm.freqItemsets.sort("items").show(5)
     +---------+----+
     |    items|freq|
     +---------+----+
-    |      [s]|   3|
-    |   [s, x]|   3|
-    |[s, x, z]|   2|
-    |   [s, z]|   2|
-    |      [r]|   3|
+    |      [p]|   2|
+    |   [p, r]|   2|
+    |[p, r, z]|   2|
+    |   [p, z]|   2|
+    |      [q]|   2|
     +---------+----+
     only showing top 5 rows
     ...
-    >>> fpm.associationRules.show(5)
+    >>> fpm.associationRules.sort("antecedent", "consequent").show(5)
     +----------+----------+----------+----+------------------+
     |antecedent|consequent|confidence|lift|           support|
     +----------+----------+----------+----+------------------+
-    |    [t, s]|       [y]|       1.0| 2.0|0.3333333333333333|
-    |    [t, s]|       [x]|       1.0| 1.5|0.3333333333333333|
-    |    [t, s]|       [z]|       1.0| 1.2|0.3333333333333333|
     |       [p]|       [r]|       1.0| 2.0|0.3333333333333333|
     |       [p]|       [z]|       1.0| 1.2|0.3333333333333333|
+    |    [p, r]|       [z]|       1.0| 1.2|0.3333333333333333|
+    |    [p, z]|       [r]|       1.0| 2.0|0.3333333333333333|
+    |       [q]|       [t]|       1.0| 2.0|0.3333333333333333|
     +----------+----------+----------+----+------------------+
     only showing top 5 rows
     ...

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -874,8 +874,8 @@ def collect_set(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df2 = spark.createDataFrame([(2,), (5,), (5,)], ('age',))
-    >>> df2.agg(collect_set('age')).collect()
-    [Row(collect_set(age)=[5, 2])]
+    >>> df2.agg(array_sort(collect_set('age')).alias('c')).collect()
+    [Row(c=[2, 5])]
     """
     return _invoke_function_over_column("collect_set", col)
 

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -61,7 +61,7 @@ LOGGER = logging.getLogger()
 
 # Find out where the assembly jars are located.
 # TODO: revisit for Scala 2.13
-for scala in ["2.12"]:
+for scala in ["2.12", "2.13"]:
     build_dir = os.path.join(SPARK_HOME, "assembly", "target", "scala-" + scala)
     if os.path.isdir(build_dir):
         SPARK_DIST_CLASSPATH = os.path.join(build_dir, "jars", "*")


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes an issue that  PySpark doctests for the `collect_set` builtin function and `FPGrouthModel.freqItemsets` fail with Scala 2.13.

The `collect_set` builtin function doesn't ensure the sort order of its result for each row. `FPGrouthModel.freqItemsets` also doesn't ensure the sort order of the result rows.
Nevertheless, their PySpark doctests assume a certain kind of sort order, causing that such doctests fail with Scala 2.13.

```
**********************************************************************          
File "/home/kou/work/oss/spark-scala-2.13/python/pyspark/sql/functions.py", line 876, in pyspark.sql.functions.collect_set
Failed example:
    df2.agg(collect_set('age')).collect()
Expected:
    [Row(collect_set(age)=[5, 2])]
Got:
    [Row(collect_set(age)=[2, 5])]
**********************************************************************
   1 of   2 in pyspark.sql.functions.collect_set
***Test Failed*** 1 failures.
```
```
**********************************************************************
File "/home/kou/work/oss/spark-scala-2.13/python/pyspark/ml/fpm.py", line 194, in __main__.FPGrowth
Failed example:
    fpm.freqItemsets.show(5)
Expected:
    +---------+----+
    |    items|freq|
    +---------+----+
    |      [s]|   3|
    |   [s, x]|   3|
    |[s, x, z]|   2|
    |   [s, z]|   2|
    |      [r]|   3|
    +---------+----+
    only showing top 5 rows
    ...
Got:
    +------+----+
    | items|freq|
    +------+----+
    |   [z]|   5|
    |   [x]|   4|
    |[x, z]|   3|
    |   [s]|   3|
    |[s, z]|   2|
    +------+----+
    only showing top 5 rows
    <BLANKLINE>
**********************************************************************
File "/home/kou/work/oss/spark-scala-2.13/python/pyspark/ml/fpm.py", line 206, in __main__.FPGrowth
Failed example:
    fpm.associationRules.show(5)
Expected:
    +----------+----------+----------+----+------------------+
    |antecedent|consequent|confidence|lift|           support|
    +----------+----------+----------+----+------------------+
    |    [t, s]|       [y]|       1.0| 2.0|0.3333333333333333|
    |    [t, s]|       [x]|       1.0| 1.5|0.3333333333333333|
    |    [t, s]|       [z]|       1.0| 1.2|0.3333333333333333|
    |       [p]|       [r]|       1.0| 2.0|0.3333333333333333|
    |       [p]|       [z]|       1.0| 1.2|0.3333333333333333|
    +----------+----------+----------+----+------------------+
    only showing top 5 rows
    ...
Got:
    +----------+----------+----------+----+------------------+
    |antecedent|consequent|confidence|lift|           support|
    +----------+----------+----------+----+------------------+
    |    [t, s]|       [z]|       1.0| 1.2|0.3333333333333333|
    |    [t, s]|       [x]|       1.0| 1.5|0.3333333333333333|
    |    [t, s]|       [y]|       1.0| 2.0|0.3333333333333333|
    |       [p]|       [z]|       1.0| 1.2|0.3333333333333333|
    |       [p]|       [r]|       1.0| 2.0|0.3333333333333333|
    +----------+----------+----------+----+------------------+
    only showing top 5 rows
    <BLANKLINE>
**********************************************************************
   2 of  14 in __main__.FPGrowth
***Test Failed*** 2 failures.
```

After these doctests are fixed, all the PySpark doctests should pass with Scala 2.13, so this PR also enables PySpark tests with Scala 2.13.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix in the doctests.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The following tests pass with Scala 2.13.
```
python/run-tests --testnames pyspark.sql.functions
python/run-tests --testnames pyspark.ml.fpm
```
I also confirmed that all the PySpark tests pass with Scala 2.13 on GA.
https://github.com/sarutak/spark/runs/3938866496?check_suite_focus=true#step:9:65
https://github.com/sarutak/spark/runs/3938866567?check_suite_focus=true#step:9:65
https://github.com/sarutak/spark/runs/3938866658?check_suite_focus=true#step:9:65
https://github.com/sarutak/spark/runs/3938866713?check_suite_focus=true#step:9:65

Tests for Scala 2.12 should be done by CIs.