### PR TITLE
[SPARK-36763][SQL] Pull out complex sorting expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -156,7 +156,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       InlineCTE,
       ReplaceExpressions,
       RewriteNonCorrelatedExists,
-      PullOutGroupingExpressions,
+      PullOutComplexExpressions,
       ComputeCurrentTime,
       ReplaceCurrentLike(catalogManager),
       SpecialDatetimeValues,
@@ -283,7 +283,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       RewritePredicateSubquery.ruleName ::
       NormalizeFloatingNumbers.ruleName ::
       ReplaceUpdateFieldsExpression.ruleName ::
-      PullOutGroupingExpressions.ruleName ::
+      PullOutComplexExpressions.ruleName ::
       RewriteAsOfJoin.ruleName ::
       RewriteLateralSubquery.ruleName :: Nil
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullOutSortingExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullOutSortingExpressionsSuite.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules._
+
+class PullOutSortingExpressionsSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("PullOutComplexExpressions", Once,
+      PullOutComplexExpressions,
+      CollapseProject) :: Nil
+  }
+
+  private val testRelation = LocalRelation('a.int, 'b.int, 'c.int)
+
+  test("Pull out sorting expressions") {
+    val originalQuery = testRelation.orderBy(('a - 'b).asc)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val correctAnswer =
+      testRelation
+        .select('a, 'b, 'c, ('a - 'b).as("_sortingexpression"))
+        .orderBy($"_sortingexpression".asc)
+        .select('a, 'b, 'c)
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Pull out sorting expressions: multiple sorting expressions") {
+    val originalQuery = testRelation.orderBy(('a - 'b).asc, 'a.asc, rand(1).asc)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val correctAnswer =
+      testRelation
+        .select('a, 'b, 'c, rand(1).as("_nondeterministic"))
+        .select('a, 'b, 'c, $"_nondeterministic", ('a - 'b).as("_sortingexpression"))
+        .orderBy($"_sortingexpression".asc, 'a.asc, $"_nondeterministic".asc)
+        .select('a, 'b, 'c)
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Shouldn't pull out sorting expressions if it is not global sorting") {
+    val originalQuery = testRelation.sortBy(('a - 'b).asc)
+    comparePlans(Optimize.execute(originalQuery.analyze), originalQuery.analyze)
+  }
+
+  test("Shouldn't pull out sorting expressions if there is no complex expressions") {
+    val originalQuery = testRelation.orderBy('a.asc, 'b.asc)
+    comparePlans(Optimize.execute(originalQuery.analyze), originalQuery.analyze)
+  }
+}
+

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -37,7 +37,7 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
   object Optimizer extends RuleExecutor[LogicalPlan] {
     val batches =
       Batch("Finish Analysis", Once,
-        PullOutGroupingExpressions) ::
+        PullOutComplexExpressions) ::
       Batch("collapse projections", FixedPoint(10),
         CollapseProject) ::
       Batch("Constant Folding", FixedPoint(10),
@@ -59,7 +59,7 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
   private def checkRule(originalQuery: LogicalPlan, correctAnswer: LogicalPlan) = {
     val optimized = Optimizer.execute(originalQuery.analyze)
     assert(optimized.resolved, "optimized plans must be still resolvable")
-    comparePlans(optimized, PullOutGroupingExpressions(correctAnswer.analyze))
+    comparePlans(optimized, PullOutComplexExpressions(correctAnswer.analyze))
   }
 
   test("explicit get from namedStruct") {

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/explain.txt
@@ -177,12 +177,12 @@ Right keys [1]: [c_customer_sk#29]
 Join condition: None
 
 (32) Project [codegen id : 9]
-Output [7]: [c_last_name#31, c_first_name#30, substr(s_city#17, 1, 30) AS substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27, s_city#17]
+Output [7]: [c_last_name#31, c_first_name#30, substr(s_city#17, 1, 30) AS substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27, substr(s_city#17, 1, 30) AS _sortingexpression#34]
 Input [8]: [ss_ticket_number#5, ss_customer_sk#1, s_city#17, amt#26, profit#27, c_customer_sk#29, c_first_name#30, c_last_name#31]
 
 (33) TakeOrderedAndProject
-Input [7]: [c_last_name#31, c_first_name#30, substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27, s_city#17]
-Arguments: 100, [c_last_name#31 ASC NULLS FIRST, c_first_name#30 ASC NULLS FIRST, substr(s_city#17, 1, 30) ASC NULLS FIRST, profit#27 ASC NULLS FIRST], [c_last_name#31, c_first_name#30, substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27]
+Input [7]: [c_last_name#31, c_first_name#30, substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27, _sortingexpression#34]
+Arguments: 100, [c_last_name#31 ASC NULLS FIRST, c_first_name#30 ASC NULLS FIRST, _sortingexpression#34 ASC NULLS FIRST, profit#27 ASC NULLS FIRST], [c_last_name#31, c_first_name#30, substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27]
 
 ===== Subqueries =====
 
@@ -195,25 +195,25 @@ BroadcastExchange (38)
 
 
 (34) Scan parquet default.date_dim
-Output [3]: [d_date_sk#10, d_year#34, d_dow#35]
+Output [3]: [d_date_sk#10, d_year#35, d_dow#36]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dow), EqualTo(d_dow,1), In(d_year, [1998,1999,2000]), GreaterThanOrEqual(d_date_sk,2450819), LessThanOrEqual(d_date_sk,2451904), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dow:int>
 
 (35) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
+Input [3]: [d_date_sk#10, d_year#35, d_dow#36]
 
 (36) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
-Condition : (((((isnotnull(d_dow#35) AND (d_dow#35 = 1)) AND d_year#34 IN (1998,1999,2000)) AND (d_date_sk#10 >= 2450819)) AND (d_date_sk#10 <= 2451904)) AND isnotnull(d_date_sk#10))
+Input [3]: [d_date_sk#10, d_year#35, d_dow#36]
+Condition : (((((isnotnull(d_dow#36) AND (d_dow#36 = 1)) AND d_year#35 IN (1998,1999,2000)) AND (d_date_sk#10 >= 2450819)) AND (d_date_sk#10 <= 2451904)) AND isnotnull(d_date_sk#10))
 
 (37) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
+Input [3]: [d_date_sk#10, d_year#35, d_dow#36]
 
 (38) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#37]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 30),ss_ticket_number,amt]
+TakeOrderedAndProject [c_last_name,c_first_name,_sortingexpression,profit,substr(s_city, 1, 30),ss_ticket_number,amt]
   WholeStageCodegen (9)
     Project [c_last_name,c_first_name,s_city,ss_ticket_number,amt,profit]
       SortMergeJoin [ss_customer_sk,c_customer_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79/explain.txt
@@ -162,12 +162,12 @@ Right keys [1]: [c_customer_sk#28]
 Join condition: None
 
 (29) Project [codegen id : 6]
-Output [7]: [c_last_name#30, c_first_name#29, substr(s_city#13, 1, 30) AS substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27, s_city#13]
+Output [7]: [c_last_name#30, c_first_name#29, substr(s_city#13, 1, 30) AS substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27, substr(s_city#13, 1, 30) AS _sortingexpression#33]
 Input [8]: [ss_ticket_number#5, ss_customer_sk#1, s_city#13, amt#26, profit#27, c_customer_sk#28, c_first_name#29, c_last_name#30]
 
 (30) TakeOrderedAndProject
-Input [7]: [c_last_name#30, c_first_name#29, substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27, s_city#13]
-Arguments: 100, [c_last_name#30 ASC NULLS FIRST, c_first_name#29 ASC NULLS FIRST, substr(s_city#13, 1, 30) ASC NULLS FIRST, profit#27 ASC NULLS FIRST], [c_last_name#30, c_first_name#29, substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27]
+Input [7]: [c_last_name#30, c_first_name#29, substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27, _sortingexpression#33]
+Arguments: 100, [c_last_name#30 ASC NULLS FIRST, c_first_name#29 ASC NULLS FIRST, _sortingexpression#33 ASC NULLS FIRST, profit#27 ASC NULLS FIRST], [c_last_name#30, c_first_name#29, substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27]
 
 ===== Subqueries =====
 
@@ -180,25 +180,25 @@ BroadcastExchange (35)
 
 
 (31) Scan parquet default.date_dim
-Output [3]: [d_date_sk#10, d_year#33, d_dow#34]
+Output [3]: [d_date_sk#10, d_year#34, d_dow#35]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dow), EqualTo(d_dow,1), In(d_year, [1998,1999,2000]), GreaterThanOrEqual(d_date_sk,2450819), LessThanOrEqual(d_date_sk,2451904), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dow:int>
 
 (32) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
+Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
 
 (33) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
-Condition : (((((isnotnull(d_dow#34) AND (d_dow#34 = 1)) AND d_year#33 IN (1998,1999,2000)) AND (d_date_sk#10 >= 2450819)) AND (d_date_sk#10 <= 2451904)) AND isnotnull(d_date_sk#10))
+Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
+Condition : (((((isnotnull(d_dow#35) AND (d_dow#35 = 1)) AND d_year#34 IN (1998,1999,2000)) AND (d_date_sk#10 >= 2450819)) AND (d_date_sk#10 <= 2451904)) AND isnotnull(d_date_sk#10))
 
 (34) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
+Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#36]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 30),ss_ticket_number,amt]
+TakeOrderedAndProject [c_last_name,c_first_name,_sortingexpression,profit,substr(s_city, 1, 30),ss_ticket_number,amt]
   WholeStageCodegen (6)
     Project [c_last_name,c_first_name,s_city,ss_ticket_number,amt,profit]
       BroadcastHashJoin [ss_customer_sk,c_customer_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/explain.txt
@@ -144,12 +144,12 @@ Input [9]: [i_category#15, i_class#14, i_brand#13, s_store_name#9, s_company_nam
 Condition : (isnotnull(avg_monthly_sales#24) AND (NOT (avg_monthly_sales#24 = 0.000000) AND (CheckOverflow((promote_precision(abs(CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true), false)) / promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(38,16), true) > 0.1000000000000000)))
 
 (26) Project [codegen id : 7]
-Output [8]: [i_category#15, i_class#14, i_brand#13, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#21, avg_monthly_sales#24]
+Output [9]: [i_category#15, i_class#14, i_brand#13, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#21, avg_monthly_sales#24, CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#25]
 Input [9]: [i_category#15, i_class#14, i_brand#13, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#21, _w0#22, avg_monthly_sales#24]
 
 (27) TakeOrderedAndProject
-Input [8]: [i_category#15, i_class#14, i_brand#13, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#21, avg_monthly_sales#24]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, s_store_name#9 ASC NULLS FIRST], [i_category#15, i_class#14, i_brand#13, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#21, avg_monthly_sales#24]
+Input [9]: [i_category#15, i_class#14, i_brand#13, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#21, avg_monthly_sales#24, _sortingexpression#25]
+Arguments: 100, [_sortingexpression#25 ASC NULLS FIRST, s_store_name#9 ASC NULLS FIRST], [i_category#15, i_class#14, i_brand#13, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#21, avg_monthly_sales#24]
 
 ===== Subqueries =====
 
@@ -162,25 +162,25 @@ BroadcastExchange (32)
 
 
 (28) Scan parquet default.date_dim
-Output [3]: [d_date_sk#6, d_year#25, d_moy#7]
+Output [3]: [d_date_sk#6, d_year#26, d_moy#7]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), GreaterThanOrEqual(d_date_sk,2451545), LessThanOrEqual(d_date_sk,2451910), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (29) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#25, d_moy#7]
+Input [3]: [d_date_sk#6, d_year#26, d_moy#7]
 
 (30) Filter [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#25, d_moy#7]
-Condition : ((((isnotnull(d_year#25) AND (d_year#25 = 2000)) AND (d_date_sk#6 >= 2451545)) AND (d_date_sk#6 <= 2451910)) AND isnotnull(d_date_sk#6))
+Input [3]: [d_date_sk#6, d_year#26, d_moy#7]
+Condition : ((((isnotnull(d_year#26) AND (d_year#26 = 2000)) AND (d_date_sk#6 >= 2451545)) AND (d_date_sk#6 <= 2451910)) AND isnotnull(d_date_sk#6))
 
 (31) Project [codegen id : 1]
 Output [2]: [d_date_sk#6, d_moy#7]
-Input [3]: [d_date_sk#6, d_year#25, d_moy#7]
+Input [3]: [d_date_sk#6, d_year#26, d_moy#7]
 
 (32) BroadcastExchange
 Input [2]: [d_date_sk#6, d_moy#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#27]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_class,i_brand,s_company_name,d_moy]
+TakeOrderedAndProject [_sortingexpression,s_store_name,i_category,i_class,i_brand,s_company_name,d_moy,sum_sales,avg_monthly_sales]
   WholeStageCodegen (7)
     Project [i_category,i_class,i_brand,s_store_name,s_company_name,d_moy,sum_sales,avg_monthly_sales]
       Filter [avg_monthly_sales,sum_sales]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89/explain.txt
@@ -144,12 +144,12 @@ Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#
 Condition : (isnotnull(avg_monthly_sales#24) AND (NOT (avg_monthly_sales#24 = 0.000000) AND (CheckOverflow((promote_precision(abs(CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true), false)) / promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(38,16), true) > 0.1000000000000000)))
 
 (26) Project [codegen id : 7]
-Output [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
+Output [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24, CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#25]
 Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, _w0#22, avg_monthly_sales#24]
 
 (27) TakeOrderedAndProject
-Input [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, s_store_name#14 ASC NULLS FIRST], [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
+Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24, _sortingexpression#25]
+Arguments: 100, [_sortingexpression#25 ASC NULLS FIRST, s_store_name#14 ASC NULLS FIRST], [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
 
 ===== Subqueries =====
 
@@ -162,25 +162,25 @@ BroadcastExchange (32)
 
 
 (28) Scan parquet default.date_dim
-Output [3]: [d_date_sk#11, d_year#25, d_moy#12]
+Output [3]: [d_date_sk#11, d_year#26, d_moy#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), GreaterThanOrEqual(d_date_sk,2451545), LessThanOrEqual(d_date_sk,2451910), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (29) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
+Input [3]: [d_date_sk#11, d_year#26, d_moy#12]
 
 (30) Filter [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
-Condition : ((((isnotnull(d_year#25) AND (d_year#25 = 2000)) AND (d_date_sk#11 >= 2451545)) AND (d_date_sk#11 <= 2451910)) AND isnotnull(d_date_sk#11))
+Input [3]: [d_date_sk#11, d_year#26, d_moy#12]
+Condition : ((((isnotnull(d_year#26) AND (d_year#26 = 2000)) AND (d_date_sk#11 >= 2451545)) AND (d_date_sk#11 <= 2451910)) AND isnotnull(d_date_sk#11))
 
 (31) Project [codegen id : 1]
 Output [2]: [d_date_sk#11, d_moy#12]
-Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
+Input [3]: [d_date_sk#11, d_year#26, d_moy#12]
 
 (32) BroadcastExchange
 Input [2]: [d_date_sk#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#27]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_class,i_brand,s_company_name,d_moy]
+TakeOrderedAndProject [_sortingexpression,s_store_name,i_category,i_class,i_brand,s_company_name,d_moy,sum_sales,avg_monthly_sales]
   WholeStageCodegen (7)
     Project [i_category,i_class,i_brand,s_store_name,s_company_name,d_moy,sum_sales,avg_monthly_sales]
       Filter [avg_monthly_sales,sum_sales]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/explain.txt
@@ -149,12 +149,12 @@ Input [7]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, _w1#27,
 Arguments: [rank(_w3#29) windowspecdefinition(_w1#27, _w2#28, _w3#29 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#31], [_w1#27, _w2#28], [_w3#29 ASC NULLS FIRST]
 
 (27) Project [codegen id : 7]
-Output [5]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31]
+Output [6]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31, CASE WHEN (lochierarchy#26 = 0) THEN i_category#15 END AS _sortingexpression#32]
 Input [8]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, _w1#27, _w2#28, _w3#29, rank_within_parent#31]
 
 (28) TakeOrderedAndProject
-Input [5]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31]
-Arguments: 100, [lochierarchy#26 DESC NULLS LAST, CASE WHEN (lochierarchy#26 = 0) THEN i_category#15 END ASC NULLS FIRST, rank_within_parent#31 ASC NULLS FIRST], [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31]
+Input [6]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31, _sortingexpression#32]
+Arguments: 100, [lochierarchy#26 DESC NULLS LAST, _sortingexpression#32 ASC NULLS FIRST, rank_within_parent#31 ASC NULLS FIRST], [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31]
 
 ===== Subqueries =====
 
@@ -167,25 +167,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet default.date_dim
-Output [2]: [d_date_sk#7, d_year#32]
+Output [2]: [d_date_sk#7, d_year#33]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#32]
+Input [2]: [d_date_sk#7, d_year#33]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#32]
-Condition : ((isnotnull(d_year#32) AND (d_year#32 = 2001)) AND isnotnull(d_date_sk#7))
+Input [2]: [d_date_sk#7, d_year#33]
+Condition : ((isnotnull(d_year#33) AND (d_year#33 = 2001)) AND isnotnull(d_date_sk#7))
 
 (32) Project [codegen id : 1]
 Output [1]: [d_date_sk#7]
-Input [2]: [d_date_sk#7, d_year#32]
+Input [2]: [d_date_sk#7, d_year#33]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#34]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i_class]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,gross_margin,i_category,i_class]
   WholeStageCodegen (7)
     Project [gross_margin,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36/explain.txt
@@ -149,12 +149,12 @@ Input [7]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, _w1#27,
 Arguments: [rank(_w3#29) windowspecdefinition(_w1#27, _w2#28, _w3#29 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#31], [_w1#27, _w2#28], [_w3#29 ASC NULLS FIRST]
 
 (27) Project [codegen id : 7]
-Output [5]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31]
+Output [6]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31, CASE WHEN (lochierarchy#26 = 0) THEN i_category#15 END AS _sortingexpression#32]
 Input [8]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, _w1#27, _w2#28, _w3#29, rank_within_parent#31]
 
 (28) TakeOrderedAndProject
-Input [5]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31]
-Arguments: 100, [lochierarchy#26 DESC NULLS LAST, CASE WHEN (lochierarchy#26 = 0) THEN i_category#15 END ASC NULLS FIRST, rank_within_parent#31 ASC NULLS FIRST], [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31]
+Input [6]: [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31, _sortingexpression#32]
+Arguments: 100, [lochierarchy#26 DESC NULLS LAST, _sortingexpression#32 ASC NULLS FIRST, rank_within_parent#31 ASC NULLS FIRST], [gross_margin#25, i_category#15, i_class#16, lochierarchy#26, rank_within_parent#31]
 
 ===== Subqueries =====
 
@@ -167,25 +167,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet default.date_dim
-Output [2]: [d_date_sk#7, d_year#32]
+Output [2]: [d_date_sk#7, d_year#33]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#32]
+Input [2]: [d_date_sk#7, d_year#33]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#32]
-Condition : ((isnotnull(d_year#32) AND (d_year#32 = 2001)) AND isnotnull(d_date_sk#7))
+Input [2]: [d_date_sk#7, d_year#33]
+Condition : ((isnotnull(d_year#33) AND (d_year#33 = 2001)) AND isnotnull(d_date_sk#7))
 
 (32) Project [codegen id : 1]
 Output [1]: [d_date_sk#7]
-Input [2]: [d_date_sk#7, d_year#32]
+Input [2]: [d_date_sk#7, d_year#33]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#34]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i_class]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,gross_margin,i_category,i_class]
   WholeStageCodegen (7)
     Project [gross_margin,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/explain.txt
@@ -272,12 +272,12 @@ Right keys [5]: [i_category#40, i_brand#41, s_store_name#42, s_company_name#43, 
 Join condition: None
 
 (51) Project [codegen id : 36]
-Output [10]: [i_category#16, i_brand#15, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, sum_sales#38 AS psum#49, sum_sales#47 AS nsum#50]
+Output [11]: [i_category#16, i_brand#15, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, sum_sales#38 AS psum#49, sum_sales#47 AS nsum#50, CheckOverflow((promote_precision(cast(sum_sales#22 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#26 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#51]
 Input [16]: [i_category#16, i_brand#15, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#22, avg_monthly_sales#26, rn#25, sum_sales#38, i_category#40, i_brand#41, s_store_name#42, s_company_name#43, sum_sales#47, rn#46]
 
 (52) TakeOrderedAndProject
-Input [10]: [i_category#16, i_brand#15, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, psum#49, nsum#50]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#22 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#26 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST], [i_category#16, i_brand#15, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, psum#49, nsum#50]
+Input [11]: [i_category#16, i_brand#15, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, psum#49, nsum#50, _sortingexpression#51]
+Arguments: 100, [_sortingexpression#51 ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST], [i_category#16, i_brand#15, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, psum#49, nsum#50]
 
 ===== Subqueries =====
 
@@ -304,6 +304,6 @@ Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR (
 
 (56) BroadcastExchange
 Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#52]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_brand,s_company_name,d_year,d_moy,psum,nsum]
+TakeOrderedAndProject [_sortingexpression,s_store_name,i_category,i_brand,s_company_name,d_year,d_moy,avg_monthly_sales,sum_sales,psum,nsum]
   WholeStageCodegen (36)
     Project [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,avg_monthly_sales,sum_sales,sum_sales,sum_sales]
       SortMergeJoin [i_category,i_brand,s_store_name,s_company_name,rn,i_category,i_brand,s_store_name,s_company_name,rn]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47/explain.txt
@@ -237,12 +237,12 @@ Right keys [5]: [i_category#38, i_brand#39, s_store_name#40, s_company_name#41, 
 Join condition: None
 
 (44) Project [codegen id : 22]
-Output [10]: [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, sum_sales#36 AS psum#47, sum_sales#45 AS nsum#48]
+Output [11]: [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, sum_sales#36 AS psum#47, sum_sales#45 AS nsum#48, CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#25 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#49]
 Input [16]: [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, d_year#11, d_moy#12, sum_sales#21, avg_monthly_sales#25, rn#24, sum_sales#36, i_category#38, i_brand#39, s_store_name#40, s_company_name#41, sum_sales#45, rn#44]
 
 (45) TakeOrderedAndProject
-Input [10]: [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, psum#47, nsum#48]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#25 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, s_store_name#14 ASC NULLS FIRST], [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, psum#47, nsum#48]
+Input [11]: [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, psum#47, nsum#48, _sortingexpression#49]
+Arguments: 100, [_sortingexpression#49 ASC NULLS FIRST, s_store_name#14 ASC NULLS FIRST], [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, psum#47, nsum#48]
 
 ===== Subqueries =====
 
@@ -269,6 +269,6 @@ Condition : ((((d_year#11 = 1999) OR ((d_year#11 = 1998) AND (d_moy#12 = 12))) O
 
 (49) BroadcastExchange
 Input [3]: [d_date_sk#10, d_year#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#50]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_brand,s_company_name,d_year,d_moy,psum,nsum]
+TakeOrderedAndProject [_sortingexpression,s_store_name,i_category,i_brand,s_company_name,d_year,d_moy,avg_monthly_sales,sum_sales,psum,nsum]
   WholeStageCodegen (22)
     Project [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,avg_monthly_sales,sum_sales,sum_sales,sum_sales]
       BroadcastHashJoin [i_category,i_brand,s_store_name,s_company_name,rn,i_category,i_brand,s_store_name,s_company_name,rn]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/explain.txt
@@ -272,12 +272,12 @@ Right keys [4]: [i_category#38, i_brand#39, cc_name#40, (rn#43 - 1)]
 Join condition: None
 
 (51) Project [codegen id : 36]
-Output [9]: [i_category#15, i_brand#14, cc_name#10, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, sum_sales#36 AS psum#46, sum_sales#44 AS nsum#47]
+Output [10]: [i_category#15, i_brand#14, cc_name#10, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, sum_sales#36 AS psum#46, sum_sales#44 AS nsum#47, CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#25 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#48]
 Input [14]: [i_category#15, i_brand#14, cc_name#10, d_year#7, d_moy#8, sum_sales#21, avg_monthly_sales#25, rn#24, sum_sales#36, i_category#38, i_brand#39, cc_name#40, sum_sales#44, rn#43]
 
 (52) TakeOrderedAndProject
-Input [9]: [i_category#15, i_brand#14, cc_name#10, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, psum#46, nsum#47]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#25 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, cc_name#10 ASC NULLS FIRST], [i_category#15, i_brand#14, cc_name#10, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, psum#46, nsum#47]
+Input [10]: [i_category#15, i_brand#14, cc_name#10, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, psum#46, nsum#47, _sortingexpression#48]
+Arguments: 100, [_sortingexpression#48 ASC NULLS FIRST, cc_name#10 ASC NULLS FIRST], [i_category#15, i_brand#14, cc_name#10, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, psum#46, nsum#47]
 
 ===== Subqueries =====
 
@@ -304,6 +304,6 @@ Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR (
 
 (56) BroadcastExchange
 Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,cc_name,i_category,i_brand,d_year,d_moy,psum,nsum]
+TakeOrderedAndProject [_sortingexpression,cc_name,i_category,i_brand,d_year,d_moy,avg_monthly_sales,sum_sales,psum,nsum]
   WholeStageCodegen (36)
     Project [i_category,i_brand,cc_name,d_year,d_moy,avg_monthly_sales,sum_sales,sum_sales,sum_sales]
       SortMergeJoin [i_category,i_brand,cc_name,rn,i_category,i_brand,cc_name,rn]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57/explain.txt
@@ -237,12 +237,12 @@ Right keys [4]: [i_category#36, i_brand#37, cc_name#38, (rn#41 - 1)]
 Join condition: None
 
 (44) Project [codegen id : 22]
-Output [9]: [i_category#3, i_brand#2, cc_name#14, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, sum_sales#34 AS psum#44, sum_sales#42 AS nsum#45]
+Output [10]: [i_category#3, i_brand#2, cc_name#14, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, sum_sales#34 AS psum#44, sum_sales#42 AS nsum#45, CheckOverflow((promote_precision(cast(sum_sales#20 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#46]
 Input [14]: [i_category#3, i_brand#2, cc_name#14, d_year#11, d_moy#12, sum_sales#20, avg_monthly_sales#24, rn#23, sum_sales#34, i_category#36, i_brand#37, cc_name#38, sum_sales#42, rn#41]
 
 (45) TakeOrderedAndProject
-Input [9]: [i_category#3, i_brand#2, cc_name#14, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, psum#44, nsum#45]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#20 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, cc_name#14 ASC NULLS FIRST], [i_category#3, i_brand#2, cc_name#14, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, psum#44, nsum#45]
+Input [10]: [i_category#3, i_brand#2, cc_name#14, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, psum#44, nsum#45, _sortingexpression#46]
+Arguments: 100, [_sortingexpression#46 ASC NULLS FIRST, cc_name#14 ASC NULLS FIRST], [i_category#3, i_brand#2, cc_name#14, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, psum#44, nsum#45]
 
 ===== Subqueries =====
 
@@ -269,6 +269,6 @@ Condition : ((((d_year#11 = 1999) OR ((d_year#11 = 1998) AND (d_moy#12 = 12))) O
 
 (49) BroadcastExchange
 Input [3]: [d_date_sk#10, d_year#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#47]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,cc_name,i_category,i_brand,d_year,d_moy,psum,nsum]
+TakeOrderedAndProject [_sortingexpression,cc_name,i_category,i_brand,d_year,d_moy,avg_monthly_sales,sum_sales,psum,nsum]
   WholeStageCodegen (22)
     Project [i_category,i_brand,cc_name,d_year,d_moy,avg_monthly_sales,sum_sales,sum_sales,sum_sales]
       BroadcastHashJoin [i_category,i_brand,cc_name,rn,i_category,i_brand,cc_name,rn]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70.sf100/explain.txt
@@ -229,12 +229,12 @@ Input [7]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, _w1#33, _w2#
 Arguments: [rank(_w3#35) windowspecdefinition(_w1#33, _w2#34, _w3#35 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#37], [_w1#33, _w2#34], [_w3#35 DESC NULLS LAST]
 
 (41) Project [codegen id : 11]
-Output [5]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37]
+Output [6]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37, CASE WHEN (lochierarchy#32 = 0) THEN s_state#24 END AS _sortingexpression#38]
 Input [8]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, _w1#33, _w2#34, _w3#35, rank_within_parent#37]
 
 (42) TakeOrderedAndProject
-Input [5]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37]
-Arguments: 100, [lochierarchy#32 DESC NULLS LAST, CASE WHEN (lochierarchy#32 = 0) THEN s_state#24 END ASC NULLS FIRST, rank_within_parent#37 ASC NULLS FIRST], [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37]
+Input [6]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37, _sortingexpression#38]
+Arguments: 100, [lochierarchy#32 DESC NULLS LAST, _sortingexpression#38 ASC NULLS FIRST, rank_within_parent#37 ASC NULLS FIRST], [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37]
 
 ===== Subqueries =====
 
@@ -247,26 +247,26 @@ BroadcastExchange (47)
 
 
 (43) Scan parquet default.date_dim
-Output [2]: [d_date_sk#5, d_month_seq#38]
+Output [2]: [d_date_sk#5, d_month_seq#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1200), LessThanOrEqual(d_month_seq,1211), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
 (44) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#38]
+Input [2]: [d_date_sk#5, d_month_seq#39]
 
 (45) Filter [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#38]
-Condition : (((isnotnull(d_month_seq#38) AND (d_month_seq#38 >= 1200)) AND (d_month_seq#38 <= 1211)) AND isnotnull(d_date_sk#5))
+Input [2]: [d_date_sk#5, d_month_seq#39]
+Condition : (((isnotnull(d_month_seq#39) AND (d_month_seq#39 >= 1200)) AND (d_month_seq#39 <= 1211)) AND isnotnull(d_date_sk#5))
 
 (46) Project [codegen id : 1]
 Output [1]: [d_date_sk#5]
-Input [2]: [d_date_sk#5, d_month_seq#38]
+Input [2]: [d_date_sk#5, d_month_seq#39]
 
 (47) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#39]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#40]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,s_state,rank_within_parent,total_sum,s_county]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,total_sum,s_state,s_county]
   WholeStageCodegen (11)
     Project [total_sum,s_state,s_county,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70/explain.txt
@@ -229,12 +229,12 @@ Input [7]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, _w1#33, _w2#
 Arguments: [rank(_w3#35) windowspecdefinition(_w1#33, _w2#34, _w3#35 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#37], [_w1#33, _w2#34], [_w3#35 DESC NULLS LAST]
 
 (41) Project [codegen id : 11]
-Output [5]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37]
+Output [6]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37, CASE WHEN (lochierarchy#32 = 0) THEN s_state#24 END AS _sortingexpression#38]
 Input [8]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, _w1#33, _w2#34, _w3#35, rank_within_parent#37]
 
 (42) TakeOrderedAndProject
-Input [5]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37]
-Arguments: 100, [lochierarchy#32 DESC NULLS LAST, CASE WHEN (lochierarchy#32 = 0) THEN s_state#24 END ASC NULLS FIRST, rank_within_parent#37 ASC NULLS FIRST], [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37]
+Input [6]: [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37, _sortingexpression#38]
+Arguments: 100, [lochierarchy#32 DESC NULLS LAST, _sortingexpression#38 ASC NULLS FIRST, rank_within_parent#37 ASC NULLS FIRST], [total_sum#31, s_state#24, s_county#25, lochierarchy#32, rank_within_parent#37]
 
 ===== Subqueries =====
 
@@ -247,26 +247,26 @@ BroadcastExchange (47)
 
 
 (43) Scan parquet default.date_dim
-Output [2]: [d_date_sk#5, d_month_seq#38]
+Output [2]: [d_date_sk#5, d_month_seq#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1200), LessThanOrEqual(d_month_seq,1211), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
 (44) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#38]
+Input [2]: [d_date_sk#5, d_month_seq#39]
 
 (45) Filter [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#38]
-Condition : (((isnotnull(d_month_seq#38) AND (d_month_seq#38 >= 1200)) AND (d_month_seq#38 <= 1211)) AND isnotnull(d_date_sk#5))
+Input [2]: [d_date_sk#5, d_month_seq#39]
+Condition : (((isnotnull(d_month_seq#39) AND (d_month_seq#39 >= 1200)) AND (d_month_seq#39 <= 1211)) AND isnotnull(d_date_sk#5))
 
 (46) Project [codegen id : 1]
 Output [1]: [d_date_sk#5]
-Input [2]: [d_date_sk#5, d_month_seq#38]
+Input [2]: [d_date_sk#5, d_month_seq#39]
 
 (47) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#39]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#40]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,s_state,rank_within_parent,total_sum,s_county]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,total_sum,s_state,s_county]
   WholeStageCodegen (11)
     Project [total_sum,s_state,s_county,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/explain.txt
@@ -177,12 +177,12 @@ Right keys [1]: [c_customer_sk#29]
 Join condition: None
 
 (32) Project [codegen id : 9]
-Output [7]: [c_last_name#31, c_first_name#30, substr(s_city#17, 1, 30) AS substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27, s_city#17]
+Output [7]: [c_last_name#31, c_first_name#30, substr(s_city#17, 1, 30) AS substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27, substr(s_city#17, 1, 30) AS _sortingexpression#34]
 Input [8]: [ss_ticket_number#5, ss_customer_sk#1, s_city#17, amt#26, profit#27, c_customer_sk#29, c_first_name#30, c_last_name#31]
 
 (33) TakeOrderedAndProject
-Input [7]: [c_last_name#31, c_first_name#30, substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27, s_city#17]
-Arguments: 100, [c_last_name#31 ASC NULLS FIRST, c_first_name#30 ASC NULLS FIRST, substr(s_city#17, 1, 30) ASC NULLS FIRST, profit#27 ASC NULLS FIRST], [c_last_name#31, c_first_name#30, substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27]
+Input [7]: [c_last_name#31, c_first_name#30, substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27, _sortingexpression#34]
+Arguments: 100, [c_last_name#31 ASC NULLS FIRST, c_first_name#30 ASC NULLS FIRST, _sortingexpression#34 ASC NULLS FIRST, profit#27 ASC NULLS FIRST], [c_last_name#31, c_first_name#30, substr(s_city, 1, 30)#33, ss_ticket_number#5, amt#26, profit#27]
 
 ===== Subqueries =====
 
@@ -195,25 +195,25 @@ BroadcastExchange (38)
 
 
 (34) Scan parquet default.date_dim
-Output [3]: [d_date_sk#10, d_year#34, d_dow#35]
+Output [3]: [d_date_sk#10, d_year#35, d_dow#36]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dow), EqualTo(d_dow,1), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dow:int>
 
 (35) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
+Input [3]: [d_date_sk#10, d_year#35, d_dow#36]
 
 (36) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
-Condition : (((isnotnull(d_dow#35) AND (d_dow#35 = 1)) AND d_year#34 IN (1999,2000,2001)) AND isnotnull(d_date_sk#10))
+Input [3]: [d_date_sk#10, d_year#35, d_dow#36]
+Condition : (((isnotnull(d_dow#36) AND (d_dow#36 = 1)) AND d_year#35 IN (1999,2000,2001)) AND isnotnull(d_date_sk#10))
 
 (37) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
+Input [3]: [d_date_sk#10, d_year#35, d_dow#36]
 
 (38) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#37]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 30),ss_ticket_number,amt]
+TakeOrderedAndProject [c_last_name,c_first_name,_sortingexpression,profit,substr(s_city, 1, 30),ss_ticket_number,amt]
   WholeStageCodegen (9)
     Project [c_last_name,c_first_name,s_city,ss_ticket_number,amt,profit]
       SortMergeJoin [ss_customer_sk,c_customer_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79/explain.txt
@@ -162,12 +162,12 @@ Right keys [1]: [c_customer_sk#28]
 Join condition: None
 
 (29) Project [codegen id : 6]
-Output [7]: [c_last_name#30, c_first_name#29, substr(s_city#13, 1, 30) AS substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27, s_city#13]
+Output [7]: [c_last_name#30, c_first_name#29, substr(s_city#13, 1, 30) AS substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27, substr(s_city#13, 1, 30) AS _sortingexpression#33]
 Input [8]: [ss_ticket_number#5, ss_customer_sk#1, s_city#13, amt#26, profit#27, c_customer_sk#28, c_first_name#29, c_last_name#30]
 
 (30) TakeOrderedAndProject
-Input [7]: [c_last_name#30, c_first_name#29, substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27, s_city#13]
-Arguments: 100, [c_last_name#30 ASC NULLS FIRST, c_first_name#29 ASC NULLS FIRST, substr(s_city#13, 1, 30) ASC NULLS FIRST, profit#27 ASC NULLS FIRST], [c_last_name#30, c_first_name#29, substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27]
+Input [7]: [c_last_name#30, c_first_name#29, substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27, _sortingexpression#33]
+Arguments: 100, [c_last_name#30 ASC NULLS FIRST, c_first_name#29 ASC NULLS FIRST, _sortingexpression#33 ASC NULLS FIRST, profit#27 ASC NULLS FIRST], [c_last_name#30, c_first_name#29, substr(s_city, 1, 30)#32, ss_ticket_number#5, amt#26, profit#27]
 
 ===== Subqueries =====
 
@@ -180,25 +180,25 @@ BroadcastExchange (35)
 
 
 (31) Scan parquet default.date_dim
-Output [3]: [d_date_sk#10, d_year#33, d_dow#34]
+Output [3]: [d_date_sk#10, d_year#34, d_dow#35]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dow), EqualTo(d_dow,1), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dow:int>
 
 (32) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
+Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
 
 (33) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
-Condition : (((isnotnull(d_dow#34) AND (d_dow#34 = 1)) AND d_year#33 IN (1999,2000,2001)) AND isnotnull(d_date_sk#10))
+Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
+Condition : (((isnotnull(d_dow#35) AND (d_dow#35 = 1)) AND d_year#34 IN (1999,2000,2001)) AND isnotnull(d_date_sk#10))
 
 (34) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
+Input [3]: [d_date_sk#10, d_year#34, d_dow#35]
 
 (35) BroadcastExchange
 Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#36]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 30),ss_ticket_number,amt]
+TakeOrderedAndProject [c_last_name,c_first_name,_sortingexpression,profit,substr(s_city, 1, 30),ss_ticket_number,amt]
   WholeStageCodegen (6)
     Project [c_last_name,c_first_name,s_city,ss_ticket_number,amt,profit]
       BroadcastHashJoin [ss_customer_sk,c_customer_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86.sf100/explain.txt
@@ -111,12 +111,12 @@ Input [7]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, _w1#19, _w
 Arguments: [rank(_w3#21) windowspecdefinition(_w1#19, _w2#20, _w3#21 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#23], [_w1#19, _w2#20], [_w3#21 DESC NULLS LAST]
 
 (20) Project [codegen id : 6]
-Output [5]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23]
+Output [6]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23, CASE WHEN (lochierarchy#18 = 0) THEN i_category#10 END AS _sortingexpression#24]
 Input [8]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, _w1#19, _w2#20, _w3#21, rank_within_parent#23]
 
 (21) TakeOrderedAndProject
-Input [5]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23]
-Arguments: 100, [lochierarchy#18 DESC NULLS LAST, CASE WHEN (lochierarchy#18 = 0) THEN i_category#10 END ASC NULLS FIRST, rank_within_parent#23 ASC NULLS FIRST], [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23]
+Input [6]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23, _sortingexpression#24]
+Arguments: 100, [lochierarchy#18 DESC NULLS LAST, _sortingexpression#24 ASC NULLS FIRST, rank_within_parent#23 ASC NULLS FIRST], [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23]
 
 ===== Subqueries =====
 
@@ -129,25 +129,25 @@ BroadcastExchange (26)
 
 
 (22) Scan parquet default.date_dim
-Output [2]: [d_date_sk#5, d_month_seq#24]
+Output [2]: [d_date_sk#5, d_month_seq#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1200), LessThanOrEqual(d_month_seq,1211), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
 (23) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#24]
+Input [2]: [d_date_sk#5, d_month_seq#25]
 
 (24) Filter [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#24]
-Condition : (((isnotnull(d_month_seq#24) AND (d_month_seq#24 >= 1200)) AND (d_month_seq#24 <= 1211)) AND isnotnull(d_date_sk#5))
+Input [2]: [d_date_sk#5, d_month_seq#25]
+Condition : (((isnotnull(d_month_seq#25) AND (d_month_seq#25 >= 1200)) AND (d_month_seq#25 <= 1211)) AND isnotnull(d_date_sk#5))
 
 (25) Project [codegen id : 1]
 Output [1]: [d_date_sk#5]
-Input [2]: [d_date_sk#5, d_month_seq#24]
+Input [2]: [d_date_sk#5, d_month_seq#25]
 
 (26) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,total_sum,i_class]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,total_sum,i_category,i_class]
   WholeStageCodegen (6)
     Project [total_sum,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86/explain.txt
@@ -111,12 +111,12 @@ Input [7]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, _w1#19, _w
 Arguments: [rank(_w3#21) windowspecdefinition(_w1#19, _w2#20, _w3#21 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#23], [_w1#19, _w2#20], [_w3#21 DESC NULLS LAST]
 
 (20) Project [codegen id : 6]
-Output [5]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23]
+Output [6]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23, CASE WHEN (lochierarchy#18 = 0) THEN i_category#10 END AS _sortingexpression#24]
 Input [8]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, _w1#19, _w2#20, _w3#21, rank_within_parent#23]
 
 (21) TakeOrderedAndProject
-Input [5]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23]
-Arguments: 100, [lochierarchy#18 DESC NULLS LAST, CASE WHEN (lochierarchy#18 = 0) THEN i_category#10 END ASC NULLS FIRST, rank_within_parent#23 ASC NULLS FIRST], [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23]
+Input [6]: [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23, _sortingexpression#24]
+Arguments: 100, [lochierarchy#18 DESC NULLS LAST, _sortingexpression#24 ASC NULLS FIRST, rank_within_parent#23 ASC NULLS FIRST], [total_sum#17, i_category#10, i_class#11, lochierarchy#18, rank_within_parent#23]
 
 ===== Subqueries =====
 
@@ -129,25 +129,25 @@ BroadcastExchange (26)
 
 
 (22) Scan parquet default.date_dim
-Output [2]: [d_date_sk#5, d_month_seq#24]
+Output [2]: [d_date_sk#5, d_month_seq#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1200), LessThanOrEqual(d_month_seq,1211), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
 (23) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#24]
+Input [2]: [d_date_sk#5, d_month_seq#25]
 
 (24) Filter [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#24]
-Condition : (((isnotnull(d_month_seq#24) AND (d_month_seq#24 >= 1200)) AND (d_month_seq#24 <= 1211)) AND isnotnull(d_date_sk#5))
+Input [2]: [d_date_sk#5, d_month_seq#25]
+Condition : (((isnotnull(d_month_seq#25) AND (d_month_seq#25 >= 1200)) AND (d_month_seq#25 <= 1211)) AND isnotnull(d_date_sk#5))
 
 (25) Project [codegen id : 1]
 Output [1]: [d_date_sk#5]
-Input [2]: [d_date_sk#5, d_month_seq#24]
+Input [2]: [d_date_sk#5, d_month_seq#25]
 
 (26) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,total_sum,i_class]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,total_sum,i_category,i_class]
   WholeStageCodegen (6)
     Project [total_sum,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/explain.txt
@@ -144,12 +144,12 @@ Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#
 Condition : (isnotnull(avg_monthly_sales#24) AND (NOT (avg_monthly_sales#24 = 0.000000) AND (CheckOverflow((promote_precision(abs(CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true), false)) / promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(38,16), true) > 0.1000000000000000)))
 
 (26) Project [codegen id : 7]
-Output [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
+Output [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24, CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#25]
 Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, _w0#22, avg_monthly_sales#24]
 
 (27) TakeOrderedAndProject
-Input [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, s_store_name#14 ASC NULLS FIRST], [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
+Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24, _sortingexpression#25]
+Arguments: 100, [_sortingexpression#25 ASC NULLS FIRST, s_store_name#14 ASC NULLS FIRST], [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
 
 ===== Subqueries =====
 
@@ -162,25 +162,25 @@ BroadcastExchange (32)
 
 
 (28) Scan parquet default.date_dim
-Output [3]: [d_date_sk#11, d_year#25, d_moy#12]
+Output [3]: [d_date_sk#11, d_year#26, d_moy#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (29) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
+Input [3]: [d_date_sk#11, d_year#26, d_moy#12]
 
 (30) Filter [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
-Condition : ((isnotnull(d_year#25) AND (d_year#25 = 1999)) AND isnotnull(d_date_sk#11))
+Input [3]: [d_date_sk#11, d_year#26, d_moy#12]
+Condition : ((isnotnull(d_year#26) AND (d_year#26 = 1999)) AND isnotnull(d_date_sk#11))
 
 (31) Project [codegen id : 1]
 Output [2]: [d_date_sk#11, d_moy#12]
-Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
+Input [3]: [d_date_sk#11, d_year#26, d_moy#12]
 
 (32) BroadcastExchange
 Input [2]: [d_date_sk#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#27]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_class,i_brand,s_company_name,d_moy]
+TakeOrderedAndProject [_sortingexpression,s_store_name,i_category,i_class,i_brand,s_company_name,d_moy,sum_sales,avg_monthly_sales]
   WholeStageCodegen (7)
     Project [i_category,i_class,i_brand,s_store_name,s_company_name,d_moy,sum_sales,avg_monthly_sales]
       Filter [avg_monthly_sales,sum_sales]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89/explain.txt
@@ -144,12 +144,12 @@ Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#
 Condition : (isnotnull(avg_monthly_sales#24) AND (NOT (avg_monthly_sales#24 = 0.000000) AND (CheckOverflow((promote_precision(abs(CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true), false)) / promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(38,16), true) > 0.1000000000000000)))
 
 (26) Project [codegen id : 7]
-Output [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
+Output [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24, CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#25]
 Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, _w0#22, avg_monthly_sales#24]
 
 (27) TakeOrderedAndProject
-Input [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, s_store_name#14 ASC NULLS FIRST], [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
+Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24, _sortingexpression#25]
+Arguments: 100, [_sortingexpression#25 ASC NULLS FIRST, s_store_name#14 ASC NULLS FIRST], [i_category#4, i_class#3, i_brand#2, s_store_name#14, s_company_name#15, d_moy#12, sum_sales#21, avg_monthly_sales#24]
 
 ===== Subqueries =====
 
@@ -162,25 +162,25 @@ BroadcastExchange (32)
 
 
 (28) Scan parquet default.date_dim
-Output [3]: [d_date_sk#11, d_year#25, d_moy#12]
+Output [3]: [d_date_sk#11, d_year#26, d_moy#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (29) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
+Input [3]: [d_date_sk#11, d_year#26, d_moy#12]
 
 (30) Filter [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
-Condition : ((isnotnull(d_year#25) AND (d_year#25 = 1999)) AND isnotnull(d_date_sk#11))
+Input [3]: [d_date_sk#11, d_year#26, d_moy#12]
+Condition : ((isnotnull(d_year#26) AND (d_year#26 = 1999)) AND isnotnull(d_date_sk#11))
 
 (31) Project [codegen id : 1]
 Output [2]: [d_date_sk#11, d_moy#12]
-Input [3]: [d_date_sk#11, d_year#25, d_moy#12]
+Input [3]: [d_date_sk#11, d_year#26, d_moy#12]
 
 (32) BroadcastExchange
 Input [2]: [d_date_sk#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#27]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_class,i_brand,s_company_name,d_moy]
+TakeOrderedAndProject [_sortingexpression,s_store_name,i_category,i_class,i_brand,s_company_name,d_moy,sum_sales,avg_monthly_sales]
   WholeStageCodegen (7)
     Project [i_category,i_class,i_brand,s_store_name,s_company_name,d_moy,sum_sales,avg_monthly_sales]
       Filter [avg_monthly_sales,sum_sales]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
@@ -234,12 +234,12 @@ Input [5]: [gross_margin#22, i_category#13, i_class#12, lochierarchy#25, _w0#68]
 Arguments: [rank(gross_margin#22) windowspecdefinition(lochierarchy#25, _w0#68, gross_margin#22 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#70], [lochierarchy#25, _w0#68], [gross_margin#22 ASC NULLS FIRST]
 
 (40) Project [codegen id : 21]
-Output [5]: [gross_margin#22, i_category#13, i_class#12, lochierarchy#25, rank_within_parent#70]
+Output [6]: [gross_margin#22, i_category#13, i_class#12, lochierarchy#25, rank_within_parent#70, CASE WHEN (lochierarchy#25 = 0) THEN i_category#13 END AS _sortingexpression#71]
 Input [6]: [gross_margin#22, i_category#13, i_class#12, lochierarchy#25, _w0#68, rank_within_parent#70]
 
 (41) TakeOrderedAndProject
-Input [5]: [gross_margin#22, i_category#13, i_class#12, lochierarchy#25, rank_within_parent#70]
-Arguments: 100, [lochierarchy#25 DESC NULLS LAST, CASE WHEN (lochierarchy#25 = 0) THEN i_category#13 END ASC NULLS FIRST, rank_within_parent#70 ASC NULLS FIRST], [gross_margin#22, i_category#13, i_class#12, lochierarchy#25, rank_within_parent#70]
+Input [6]: [gross_margin#22, i_category#13, i_class#12, lochierarchy#25, rank_within_parent#70, _sortingexpression#71]
+Arguments: 100, [lochierarchy#25 DESC NULLS LAST, _sortingexpression#71 ASC NULLS FIRST, rank_within_parent#70 ASC NULLS FIRST], [gross_margin#22, i_category#13, i_class#12, lochierarchy#25, rank_within_parent#70]
 
 ===== Subqueries =====
 
@@ -252,25 +252,25 @@ BroadcastExchange (46)
 
 
 (42) Scan parquet default.date_dim
-Output [2]: [d_date_sk#7, d_year#71]
+Output [2]: [d_date_sk#7, d_year#72]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (43) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#71]
+Input [2]: [d_date_sk#7, d_year#72]
 
 (44) Filter [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#71]
-Condition : ((isnotnull(d_year#71) AND (d_year#71 = 2001)) AND isnotnull(d_date_sk#7))
+Input [2]: [d_date_sk#7, d_year#72]
+Condition : ((isnotnull(d_year#72) AND (d_year#72 = 2001)) AND isnotnull(d_date_sk#7))
 
 (45) Project [codegen id : 1]
 Output [1]: [d_date_sk#7]
-Input [2]: [d_date_sk#7, d_year#71]
+Input [2]: [d_date_sk#7, d_year#72]
 
 (46) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#72]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#73]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i_class]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,gross_margin,i_category,i_class]
   WholeStageCodegen (21)
     Project [gross_margin,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/explain.txt
@@ -234,12 +234,12 @@ Input [5]: [gross_margin#22, i_category#10, i_class#9, lochierarchy#25, _w0#68]
 Arguments: [rank(gross_margin#22) windowspecdefinition(lochierarchy#25, _w0#68, gross_margin#22 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#70], [lochierarchy#25, _w0#68], [gross_margin#22 ASC NULLS FIRST]
 
 (40) Project [codegen id : 21]
-Output [5]: [gross_margin#22, i_category#10, i_class#9, lochierarchy#25, rank_within_parent#70]
+Output [6]: [gross_margin#22, i_category#10, i_class#9, lochierarchy#25, rank_within_parent#70, CASE WHEN (lochierarchy#25 = 0) THEN i_category#10 END AS _sortingexpression#71]
 Input [6]: [gross_margin#22, i_category#10, i_class#9, lochierarchy#25, _w0#68, rank_within_parent#70]
 
 (41) TakeOrderedAndProject
-Input [5]: [gross_margin#22, i_category#10, i_class#9, lochierarchy#25, rank_within_parent#70]
-Arguments: 100, [lochierarchy#25 DESC NULLS LAST, CASE WHEN (lochierarchy#25 = 0) THEN i_category#10 END ASC NULLS FIRST, rank_within_parent#70 ASC NULLS FIRST], [gross_margin#22, i_category#10, i_class#9, lochierarchy#25, rank_within_parent#70]
+Input [6]: [gross_margin#22, i_category#10, i_class#9, lochierarchy#25, rank_within_parent#70, _sortingexpression#71]
+Arguments: 100, [lochierarchy#25 DESC NULLS LAST, _sortingexpression#71 ASC NULLS FIRST, rank_within_parent#70 ASC NULLS FIRST], [gross_margin#22, i_category#10, i_class#9, lochierarchy#25, rank_within_parent#70]
 
 ===== Subqueries =====
 
@@ -252,25 +252,25 @@ BroadcastExchange (46)
 
 
 (42) Scan parquet default.date_dim
-Output [2]: [d_date_sk#7, d_year#71]
+Output [2]: [d_date_sk#7, d_year#72]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (43) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#71]
+Input [2]: [d_date_sk#7, d_year#72]
 
 (44) Filter [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#71]
-Condition : ((isnotnull(d_year#71) AND (d_year#71 = 2001)) AND isnotnull(d_date_sk#7))
+Input [2]: [d_date_sk#7, d_year#72]
+Condition : ((isnotnull(d_year#72) AND (d_year#72 = 2001)) AND isnotnull(d_date_sk#7))
 
 (45) Project [codegen id : 1]
 Output [1]: [d_date_sk#7]
-Input [2]: [d_date_sk#7, d_year#71]
+Input [2]: [d_date_sk#7, d_year#72]
 
 (46) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#72]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#73]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i_class]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,gross_margin,i_category,i_class]
   WholeStageCodegen (21)
     Project [gross_margin,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/explain.txt
@@ -272,12 +272,12 @@ Right keys [5]: [i_category#40, i_brand#41, s_store_name#42, s_company_name#43, 
 Join condition: None
 
 (51) Project [codegen id : 36]
-Output [7]: [i_category#16, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, sum_sales#38 AS psum#49, sum_sales#47 AS nsum#50]
+Output [8]: [i_category#16, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, sum_sales#38 AS psum#49, sum_sales#47 AS nsum#50, CheckOverflow((promote_precision(cast(sum_sales#22 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#26 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#51]
 Input [16]: [i_category#16, i_brand#15, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#22, avg_monthly_sales#26, rn#25, sum_sales#38, i_category#40, i_brand#41, s_store_name#42, s_company_name#43, sum_sales#47, rn#46]
 
 (52) TakeOrderedAndProject
-Input [7]: [i_category#16, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, psum#49, nsum#50]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#22 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#26 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], [i_category#16, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, psum#49, nsum#50]
+Input [8]: [i_category#16, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, psum#49, nsum#50, _sortingexpression#51]
+Arguments: 100, [_sortingexpression#51 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], [i_category#16, d_year#7, d_moy#8, avg_monthly_sales#26, sum_sales#22, psum#49, nsum#50]
 
 ===== Subqueries =====
 
@@ -304,6 +304,6 @@ Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR (
 
 (56) BroadcastExchange
 Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#51]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#52]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_moy,i_category,d_year,psum,nsum]
+TakeOrderedAndProject [_sortingexpression,d_moy,i_category,d_year,avg_monthly_sales,sum_sales,psum,nsum]
   WholeStageCodegen (36)
     Project [i_category,d_year,d_moy,avg_monthly_sales,sum_sales,sum_sales,sum_sales]
       SortMergeJoin [i_category,i_brand,s_store_name,s_company_name,rn,i_category,i_brand,s_store_name,s_company_name,rn]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47/explain.txt
@@ -237,12 +237,12 @@ Right keys [5]: [i_category#38, i_brand#39, s_store_name#40, s_company_name#41, 
 Join condition: None
 
 (44) Project [codegen id : 22]
-Output [7]: [i_category#3, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, sum_sales#36 AS psum#47, sum_sales#45 AS nsum#48]
+Output [8]: [i_category#3, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, sum_sales#36 AS psum#47, sum_sales#45 AS nsum#48, CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#25 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#49]
 Input [16]: [i_category#3, i_brand#2, s_store_name#14, s_company_name#15, d_year#11, d_moy#12, sum_sales#21, avg_monthly_sales#25, rn#24, sum_sales#36, i_category#38, i_brand#39, s_store_name#40, s_company_name#41, sum_sales#45, rn#44]
 
 (45) TakeOrderedAndProject
-Input [7]: [i_category#3, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, psum#47, nsum#48]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#25 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, d_moy#12 ASC NULLS FIRST], [i_category#3, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, psum#47, nsum#48]
+Input [8]: [i_category#3, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, psum#47, nsum#48, _sortingexpression#49]
+Arguments: 100, [_sortingexpression#49 ASC NULLS FIRST, d_moy#12 ASC NULLS FIRST], [i_category#3, d_year#11, d_moy#12, avg_monthly_sales#25, sum_sales#21, psum#47, nsum#48]
 
 ===== Subqueries =====
 
@@ -269,6 +269,6 @@ Condition : ((((d_year#11 = 1999) OR ((d_year#11 = 1998) AND (d_moy#12 = 12))) O
 
 (49) BroadcastExchange
 Input [3]: [d_date_sk#10, d_year#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#50]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_moy,i_category,d_year,psum,nsum]
+TakeOrderedAndProject [_sortingexpression,d_moy,i_category,d_year,avg_monthly_sales,sum_sales,psum,nsum]
   WholeStageCodegen (22)
     Project [i_category,d_year,d_moy,avg_monthly_sales,sum_sales,sum_sales,sum_sales]
       BroadcastHashJoin [i_category,i_brand,s_store_name,s_company_name,rn,i_category,i_brand,s_store_name,s_company_name,rn]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/explain.txt
@@ -272,12 +272,12 @@ Right keys [4]: [i_category#38, i_brand#39, cc_name#40, (rn#43 - 1)]
 Join condition: None
 
 (51) Project [codegen id : 36]
-Output [8]: [i_category#15, i_brand#14, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, sum_sales#36 AS psum#46, sum_sales#44 AS nsum#47]
+Output [9]: [i_category#15, i_brand#14, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, sum_sales#36 AS psum#46, sum_sales#44 AS nsum#47, CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#25 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#48]
 Input [14]: [i_category#15, i_brand#14, cc_name#10, d_year#7, d_moy#8, sum_sales#21, avg_monthly_sales#25, rn#24, sum_sales#36, i_category#38, i_brand#39, cc_name#40, sum_sales#44, rn#43]
 
 (52) TakeOrderedAndProject
-Input [8]: [i_category#15, i_brand#14, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, psum#46, nsum#47]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#21 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#25 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, d_year#7 ASC NULLS FIRST], [i_category#15, i_brand#14, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, psum#46, nsum#47]
+Input [9]: [i_category#15, i_brand#14, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, psum#46, nsum#47, _sortingexpression#48]
+Arguments: 100, [_sortingexpression#48 ASC NULLS FIRST, d_year#7 ASC NULLS FIRST], [i_category#15, i_brand#14, d_year#7, d_moy#8, avg_monthly_sales#25, sum_sales#21, psum#46, nsum#47]
 
 ===== Subqueries =====
 
@@ -304,6 +304,6 @@ Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR (
 
 (56) BroadcastExchange
 Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#49]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_year,i_category,i_brand,d_moy,psum,nsum]
+TakeOrderedAndProject [_sortingexpression,d_year,i_category,i_brand,d_moy,avg_monthly_sales,sum_sales,psum,nsum]
   WholeStageCodegen (36)
     Project [i_category,i_brand,d_year,d_moy,avg_monthly_sales,sum_sales,sum_sales,sum_sales]
       SortMergeJoin [i_category,i_brand,cc_name,rn,i_category,i_brand,cc_name,rn]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57/explain.txt
@@ -237,12 +237,12 @@ Right keys [4]: [i_category#36, i_brand#37, cc_name#38, (rn#41 - 1)]
 Join condition: None
 
 (44) Project [codegen id : 22]
-Output [8]: [i_category#3, i_brand#2, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, sum_sales#34 AS psum#44, sum_sales#42 AS nsum#45]
+Output [9]: [i_category#3, i_brand#2, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, sum_sales#34 AS psum#44, sum_sales#42 AS nsum#45, CheckOverflow((promote_precision(cast(sum_sales#20 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) AS _sortingexpression#46]
 Input [14]: [i_category#3, i_brand#2, cc_name#14, d_year#11, d_moy#12, sum_sales#20, avg_monthly_sales#24, rn#23, sum_sales#34, i_category#36, i_brand#37, cc_name#38, sum_sales#42, rn#41]
 
 (45) TakeOrderedAndProject
-Input [8]: [i_category#3, i_brand#2, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, psum#44, nsum#45]
-Arguments: 100, [CheckOverflow((promote_precision(cast(sum_sales#20 as decimal(22,6))) - promote_precision(cast(avg_monthly_sales#24 as decimal(22,6)))), DecimalType(22,6), true) ASC NULLS FIRST, d_year#11 ASC NULLS FIRST], [i_category#3, i_brand#2, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, psum#44, nsum#45]
+Input [9]: [i_category#3, i_brand#2, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, psum#44, nsum#45, _sortingexpression#46]
+Arguments: 100, [_sortingexpression#46 ASC NULLS FIRST, d_year#11 ASC NULLS FIRST], [i_category#3, i_brand#2, d_year#11, d_moy#12, avg_monthly_sales#24, sum_sales#20, psum#44, nsum#45]
 
 ===== Subqueries =====
 
@@ -269,6 +269,6 @@ Condition : ((((d_year#11 = 1999) OR ((d_year#11 = 1998) AND (d_moy#12 = 12))) O
 
 (49) BroadcastExchange
 Input [3]: [d_date_sk#10, d_year#11, d_moy#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#47]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_year,i_category,i_brand,d_moy,psum,nsum]
+TakeOrderedAndProject [_sortingexpression,d_year,i_category,i_brand,d_moy,avg_monthly_sales,sum_sales,psum,nsum]
   WholeStageCodegen (22)
     Project [i_category,i_brand,d_year,d_moy,avg_monthly_sales,sum_sales,sum_sales,sum_sales]
       BroadcastHashJoin [i_category,i_brand,cc_name,rn,i_category,i_brand,cc_name,rn]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/explain.txt
@@ -314,12 +314,12 @@ Input [5]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, _w0#59]
 Arguments: [rank(total_sum#28) windowspecdefinition(lochierarchy#31, _w0#59, total_sum#28 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#61], [lochierarchy#31, _w0#59], [total_sum#28 DESC NULLS LAST]
 
 (54) Project [codegen id : 33]
-Output [5]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61]
+Output [6]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61, CASE WHEN (lochierarchy#31 = 0) THEN s_state#8 END AS _sortingexpression#62]
 Input [6]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, _w0#59, rank_within_parent#61]
 
 (55) TakeOrderedAndProject
-Input [5]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61]
-Arguments: 100, [lochierarchy#31 DESC NULLS LAST, CASE WHEN (lochierarchy#31 = 0) THEN s_state#8 END ASC NULLS FIRST, rank_within_parent#61 ASC NULLS FIRST], [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61]
+Input [6]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61, _sortingexpression#62]
+Arguments: 100, [lochierarchy#31 DESC NULLS LAST, _sortingexpression#62 ASC NULLS FIRST, rank_within_parent#61 ASC NULLS FIRST], [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61]
 
 ===== Subqueries =====
 
@@ -332,26 +332,26 @@ BroadcastExchange (60)
 
 
 (56) Scan parquet default.date_dim
-Output [2]: [d_date_sk#5, d_month_seq#62]
+Output [2]: [d_date_sk#5, d_month_seq#63]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
 (57) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#62]
+Input [2]: [d_date_sk#5, d_month_seq#63]
 
 (58) Filter [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#62]
-Condition : (((isnotnull(d_month_seq#62) AND (d_month_seq#62 >= 1212)) AND (d_month_seq#62 <= 1223)) AND isnotnull(d_date_sk#5))
+Input [2]: [d_date_sk#5, d_month_seq#63]
+Condition : (((isnotnull(d_month_seq#63) AND (d_month_seq#63 >= 1212)) AND (d_month_seq#63 <= 1223)) AND isnotnull(d_date_sk#5))
 
 (59) Project [codegen id : 1]
 Output [1]: [d_date_sk#5]
-Input [2]: [d_date_sk#5, d_month_seq#62]
+Input [2]: [d_date_sk#5, d_month_seq#63]
 
 (60) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#64]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,s_state,rank_within_parent,total_sum,s_county]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,total_sum,s_state,s_county]
   WholeStageCodegen (33)
     Project [total_sum,s_state,s_county,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/explain.txt
@@ -314,12 +314,12 @@ Input [5]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, _w0#59]
 Arguments: [rank(total_sum#28) windowspecdefinition(lochierarchy#31, _w0#59, total_sum#28 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#61], [lochierarchy#31, _w0#59], [total_sum#28 DESC NULLS LAST]
 
 (54) Project [codegen id : 33]
-Output [5]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61]
+Output [6]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61, CASE WHEN (lochierarchy#31 = 0) THEN s_state#8 END AS _sortingexpression#62]
 Input [6]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, _w0#59, rank_within_parent#61]
 
 (55) TakeOrderedAndProject
-Input [5]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61]
-Arguments: 100, [lochierarchy#31 DESC NULLS LAST, CASE WHEN (lochierarchy#31 = 0) THEN s_state#8 END ASC NULLS FIRST, rank_within_parent#61 ASC NULLS FIRST], [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61]
+Input [6]: [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61, _sortingexpression#62]
+Arguments: 100, [lochierarchy#31 DESC NULLS LAST, _sortingexpression#62 ASC NULLS FIRST, rank_within_parent#61 ASC NULLS FIRST], [total_sum#28, s_state#8, s_county#7, lochierarchy#31, rank_within_parent#61]
 
 ===== Subqueries =====
 
@@ -332,26 +332,26 @@ BroadcastExchange (60)
 
 
 (56) Scan parquet default.date_dim
-Output [2]: [d_date_sk#5, d_month_seq#62]
+Output [2]: [d_date_sk#5, d_month_seq#63]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
 (57) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#62]
+Input [2]: [d_date_sk#5, d_month_seq#63]
 
 (58) Filter [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#62]
-Condition : (((isnotnull(d_month_seq#62) AND (d_month_seq#62 >= 1212)) AND (d_month_seq#62 <= 1223)) AND isnotnull(d_date_sk#5))
+Input [2]: [d_date_sk#5, d_month_seq#63]
+Condition : (((isnotnull(d_month_seq#63) AND (d_month_seq#63 >= 1212)) AND (d_month_seq#63 <= 1223)) AND isnotnull(d_date_sk#5))
 
 (59) Project [codegen id : 1]
 Output [1]: [d_date_sk#5]
-Input [2]: [d_date_sk#5, d_month_seq#62]
+Input [2]: [d_date_sk#5, d_month_seq#63]
 
 (60) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#63]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#64]
 
 Subquery:2 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#4
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,s_state,rank_within_parent,total_sum,s_county]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,total_sum,s_state,s_county]
   WholeStageCodegen (33)
     Project [total_sum,s_state,s_county,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/explain.txt
@@ -196,12 +196,12 @@ Input [5]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, _w0#45]
 Arguments: [rank(total_sum#14) windowspecdefinition(lochierarchy#17, _w0#45, total_sum#14 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#47], [lochierarchy#17, _w0#45], [total_sum#14 DESC NULLS LAST]
 
 (33) Project [codegen id : 18]
-Output [5]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47]
+Output [6]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47, CASE WHEN (lochierarchy#17 = 0) THEN i_category#8 END AS _sortingexpression#48]
 Input [6]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, _w0#45, rank_within_parent#47]
 
 (34) TakeOrderedAndProject
-Input [5]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47]
-Arguments: 100, [lochierarchy#17 DESC NULLS LAST, CASE WHEN (lochierarchy#17 = 0) THEN i_category#8 END ASC NULLS FIRST, rank_within_parent#47 ASC NULLS FIRST], [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47]
+Input [6]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47, _sortingexpression#48]
+Arguments: 100, [lochierarchy#17 DESC NULLS LAST, _sortingexpression#48 ASC NULLS FIRST, rank_within_parent#47 ASC NULLS FIRST], [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47]
 
 ===== Subqueries =====
 
@@ -214,25 +214,25 @@ BroadcastExchange (39)
 
 
 (35) Scan parquet default.date_dim
-Output [2]: [d_date_sk#5, d_month_seq#48]
+Output [2]: [d_date_sk#5, d_month_seq#49]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
 (36) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#48]
+Input [2]: [d_date_sk#5, d_month_seq#49]
 
 (37) Filter [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#48]
-Condition : (((isnotnull(d_month_seq#48) AND (d_month_seq#48 >= 1212)) AND (d_month_seq#48 <= 1223)) AND isnotnull(d_date_sk#5))
+Input [2]: [d_date_sk#5, d_month_seq#49]
+Condition : (((isnotnull(d_month_seq#49) AND (d_month_seq#49 >= 1212)) AND (d_month_seq#49 <= 1223)) AND isnotnull(d_date_sk#5))
 
 (38) Project [codegen id : 1]
 Output [1]: [d_date_sk#5]
-Input [2]: [d_date_sk#5, d_month_seq#48]
+Input [2]: [d_date_sk#5, d_month_seq#49]
 
 (39) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,total_sum,i_class]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,total_sum,i_category,i_class]
   WholeStageCodegen (18)
     Project [total_sum,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/explain.txt
@@ -196,12 +196,12 @@ Input [5]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, _w0#45]
 Arguments: [rank(total_sum#14) windowspecdefinition(lochierarchy#17, _w0#45, total_sum#14 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#47], [lochierarchy#17, _w0#45], [total_sum#14 DESC NULLS LAST]
 
 (33) Project [codegen id : 18]
-Output [5]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47]
+Output [6]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47, CASE WHEN (lochierarchy#17 = 0) THEN i_category#8 END AS _sortingexpression#48]
 Input [6]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, _w0#45, rank_within_parent#47]
 
 (34) TakeOrderedAndProject
-Input [5]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47]
-Arguments: 100, [lochierarchy#17 DESC NULLS LAST, CASE WHEN (lochierarchy#17 = 0) THEN i_category#8 END ASC NULLS FIRST, rank_within_parent#47 ASC NULLS FIRST], [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47]
+Input [6]: [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47, _sortingexpression#48]
+Arguments: 100, [lochierarchy#17 DESC NULLS LAST, _sortingexpression#48 ASC NULLS FIRST, rank_within_parent#47 ASC NULLS FIRST], [total_sum#14, i_category#8, i_class#7, lochierarchy#17, rank_within_parent#47]
 
 ===== Subqueries =====
 
@@ -214,25 +214,25 @@ BroadcastExchange (39)
 
 
 (35) Scan parquet default.date_dim
-Output [2]: [d_date_sk#5, d_month_seq#48]
+Output [2]: [d_date_sk#5, d_month_seq#49]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
 (36) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#48]
+Input [2]: [d_date_sk#5, d_month_seq#49]
 
 (37) Filter [codegen id : 1]
-Input [2]: [d_date_sk#5, d_month_seq#48]
-Condition : (((isnotnull(d_month_seq#48) AND (d_month_seq#48 >= 1212)) AND (d_month_seq#48 <= 1223)) AND isnotnull(d_date_sk#5))
+Input [2]: [d_date_sk#5, d_month_seq#49]
+Condition : (((isnotnull(d_month_seq#49) AND (d_month_seq#49 >= 1212)) AND (d_month_seq#49 <= 1223)) AND isnotnull(d_date_sk#5))
 
 (38) Project [codegen id : 1]
 Output [1]: [d_date_sk#5]
-Input [2]: [d_date_sk#5, d_month_seq#48]
+Input [2]: [d_date_sk#5, d_month_seq#49]
 
 (39) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,total_sum,i_class]
+TakeOrderedAndProject [lochierarchy,_sortingexpression,rank_within_parent,total_sum,i_category,i_class]
   WholeStageCodegen (18)
     Project [total_sum,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr pull out complex sorting expressions if it is global sorting to reduce the evaluation of complex expressions. For example:
```sql
SELECT id AS a, id AS b FROM range(10) ORDER BY a - b
```
Before this pr:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Sort [(a#0L - b#1L) ASC NULLS FIRST], true, 0
   +- Exchange rangepartitioning((a#0L - b#1L) ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [id=#12]
      +- Project [id#2L AS a#0L, id#2L AS b#1L]
         +- Range (0, 10, step=1, splits=2)
```
After this pr:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Project [a#0L, b#1L]
   +- Sort [_sortingexpression#5L ASC NULLS FIRST], true, 0
      +- Exchange rangepartitioning(_sortingexpression#5L ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [id=#16]
         +- Project [id#2L AS a#0L, id#2L AS b#1L, (id#2L - id#2L) AS _sortingexpression#5L]
            +- Range (0, 10, step=1, splits=2)
```

### Why are the changes needed?

Improve order performance if the sorting expressions contains complex expressions.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test and benchmark test:
```scala
import org.apache.spark.benchmark.Benchmark
val numRows = 1024 * 1024 * 10
spark.sql(s"CREATE TABLE t1 using parquet AS select id AS a, id AS b FROM range(${numRows}L)")
val benchmark = new Benchmark("Benchmark pull out ordering expressions", numRows, minNumIters = 5)

Seq(false, true).foreach { pullOutEnabled =>
  val name = s"Pull out ordering expressions ${if (pullOutEnabled) "(Enabled)" else "(Disabled)"}"
  benchmark.addCase(name) { _ =>
    withSQLConf("spark.sql.pullOutOrderingExpressions" -> s"$pullOutEnabled") {
      spark.sql("SELECT t1.* FROM t1 ORDER BY translate(t1.a, '123', 'abc')").write.format("noop").mode("Overwrite").save()
    }
  }
}
benchmark.run()
```
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.7
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark pull out ordering expressions:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Pull out ordering expressions (Disabled)           9232           9753         867          1.1         880.4       1.0X
Pull out ordering expressions (Enabled)            7084           7462         370          1.5         675.5       1.3X
```