### PR TITLE
[SPARK-36348][TEST] Complete test_astype for index

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -2243,12 +2243,14 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
 
         pidx = pd.Index([10, 20, 15, 30, 45, None], name="x")
         psidx = ps.Index(pidx)
+        self.assert_eq(psidx.astype(bool), pidx.astype(bool))
+        self.assert_eq(psidx.astype(str), pidx.astype(str))
 
         pidx = pd.Index(["hi", "hi ", " ", " \t", "", None], name="x")
         psidx = ps.Index(pidx)
 
         self.assert_eq(psidx.astype(bool), pidx.astype(bool))
-        self.assert_eq(psidx.astype(str).to_numpy(), ["hi", "hi ", " ", " \t", "", "None"])
+        self.assert_eq(psidx.astype(str), pidx.astype(str))
 
         pidx = pd.Index([True, False, None], name="x")
         psidx = ps.Index(pidx)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Before 3.2, there was a bug:
```
pidx = pd.Index([10, 20, 15, 30, 45, None], name="x")
psidx = ps.Index(pidx)
self.assert_eq(psidx.astype(str), pidx.astype(str))

[left pandas on spark]: Index(['10.0', '20.0', '15.0', '30.0', '45.0', 'nan'], dtype='object', name='x')
[right pandas]: Index(['10', '20', '15', '30', '45', 'None'], dtype='object', name='x')
```
So, we didn't add any test on [test_base.py int_with_nan]https://github.com/apache/spark/blob/bcc595c112a23d8e3024ace50f0dbc7eab7144b2/python/pyspark/pandas/tests/indexes/test_base.py#L2249

Now, the bug had been resolved, we complete the testcase in here.

### Why are the changes needed?
regression for SPARK-36348 and complete testcase.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test only
