### PR TITLE
[SPARK-37064][SQL] Fix outer join return the wrong max rows if other side is empty

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -386,13 +386,13 @@ case class Join(
           if left.maxRows.isDefined && right.maxRows.isDefined =>
         val leftMaxRows = BigInt(left.maxRows.get)
         val rightMaxRows = BigInt(right.maxRows.get)
-        val maxRows = joinType match {
-          case LeftOuter | RightOuter | FullOuter =>
-            (leftMaxRows * rightMaxRows).max(
-              leftMaxRows + rightMaxRows)
-          case _ =>
-            leftMaxRows * rightMaxRows
+        val minRows = joinType match {
+          case LeftOuter => leftMaxRows
+          case RightOuter => rightMaxRows
+          case FullOuter => leftMaxRows + rightMaxRows
+          case _ => BigInt(0)
         }
+        val maxRows = (leftMaxRows * rightMaxRows).max(minRows)
         if (maxRows.isValidLong) {
           Some(maxRows.toLong)
         } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -383,8 +383,16 @@ case class Join(
   override def maxRows: Option[Long] = {
     joinType match {
       case Inner | Cross | FullOuter | LeftOuter | RightOuter
-        if left.maxRows.isDefined && right.maxRows.isDefined =>
-        val maxRows = BigInt(left.maxRows.get) * BigInt(right.maxRows.get)
+          if left.maxRows.isDefined && right.maxRows.isDefined =>
+        val leftMaxRows = BigInt(left.maxRows.get)
+        val rightMaxRows = BigInt(right.maxRows.get)
+        val maxRows = joinType match {
+          case LeftOuter | RightOuter | FullOuter =>
+            (leftMaxRows * rightMaxRows).max(
+              leftMaxRows + rightMaxRows)
+          case _ =>
+            leftMaxRows * rightMaxRows
+        }
         if (maxRows.isValidLong) {
           Some(maxRows.toLong)
         } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
@@ -51,6 +51,7 @@ class CombiningLimitsSuite extends PlanTest {
   )
   val testRelation3 = RelationWithoutMaxRows(Seq("i".attr.int))
   val testRelation4 = LongMaxRelation(Seq("j".attr.int))
+  val testRelation5 = EmptyRelation(Seq("k".attr.int))
 
   test("limits: combines two limits") {
     val originalQuery =
@@ -186,6 +187,7 @@ class CombiningLimitsSuite extends PlanTest {
         testRelation.join(testRelation2, joinType),
         20
       )
+
       checkPlanAndMaxRow(
         testRelation.join(testRelation2, joinType).limit(10),
         testRelation.join(testRelation2, joinType).limit(10),
@@ -235,6 +237,44 @@ class CombiningLimitsSuite extends PlanTest {
     comparePlans(optimized, testRelation)
   }
 
+  test("SPARK-37064: Fix outer join return the wrong max rows if other side is empty") {
+    Seq(LeftOuter, FullOuter).foreach { joinType =>
+      checkPlanAndMaxRow(
+        testRelation.join(testRelation5, joinType).limit(9),
+        testRelation.join(testRelation5, joinType).limit(9),
+        9
+      )
+
+      checkPlanAndMaxRow(
+        testRelation.join(testRelation5, joinType).limit(10),
+        testRelation.join(testRelation5, joinType),
+        10
+      )
+    }
+
+    Seq(RightOuter, FullOuter).foreach { joinType =>
+      checkPlanAndMaxRow(
+        testRelation5.join(testRelation, joinType).limit(9),
+        testRelation5.join(testRelation, joinType).limit(9),
+        9
+      )
+
+      checkPlanAndMaxRow(
+        testRelation5.join(testRelation, joinType).limit(10),
+        testRelation5.join(testRelation, joinType),
+        10
+      )
+    }
+
+    Seq(Inner, Cross).foreach { joinType =>
+      checkPlanAndMaxRow(
+        testRelation.join(testRelation5, joinType).limit(9),
+        testRelation.join(testRelation5, joinType),
+        0
+      )
+    }
+  }
+
   private def checkPlanAndMaxRow(
       optimized: LogicalPlan, expected: LogicalPlan, expectedMaxRow: Long): Unit = {
     comparePlans(Optimize.execute(optimized.analyze), expected.analyze)
@@ -248,4 +288,8 @@ case class RelationWithoutMaxRows(output: Seq[Attribute]) extends LeafNode {
 
 case class LongMaxRelation(output: Seq[Attribute]) extends LeafNode {
   override def maxRows: Option[Long] = Some(Long.MaxValue)
+}
+
+case class EmptyRelation(output: Seq[Attribute]) extends LeafNode {
+  override def maxRows: Option[Long] = Some(0)
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
@@ -187,7 +187,6 @@ class CombiningLimitsSuite extends PlanTest {
         testRelation.join(testRelation2, joinType),
         20
       )
-
       checkPlanAndMaxRow(
         testRelation.join(testRelation2, joinType).limit(10),
         testRelation.join(testRelation2, joinType).limit(10),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add min rows check in `Join.maxRows` if the join type is outer join.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Outer join should return at least num rows of it's outer side, i.e left outer join with its left side, right outer join with its right side, full outer join with its both side.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, bug fix

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
add test