### PR TITLE
[SPARK-37067][SQL] Use ZoneId.of() to handle timezone string in DatetimeUtils

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -197,6 +197,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       expected = Option(date(2015, 3, 18, 12, 3, 17, zid = zoneId))
       checkStringToTimestamp("2015-03-18T12:03:17-13:53", expected)
       checkStringToTimestamp("2015-03-18T12:03:17GMT-13:53", expected)
+      checkStringToTimestamp("2015-03-18T12:03:17-1353", expected)
 
       expected = Option(date(2015, 3, 18, 12, 3, 17, zid = UTC))
       checkStringToTimestamp("2015-03-18T12:03:17Z", expected)
@@ -208,16 +209,19 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       checkStringToTimestamp("2015-03-18T12:03:17-1:0", expected)
       checkStringToTimestamp("2015-03-18T12:03:17-01:00", expected)
       checkStringToTimestamp("2015-03-18T12:03:17GMT-01:00", expected)
+      checkStringToTimestamp("2015-03-18T12:03:17-0100", expected)
 
       zoneId = getZoneId("+07:30")
       expected = Option(date(2015, 3, 18, 12, 3, 17, zid = zoneId))
       checkStringToTimestamp("2015-03-18T12:03:17+07:30", expected)
       checkStringToTimestamp("2015-03-18T12:03:17 GMT+07:30", expected)
+      checkStringToTimestamp("2015-03-18T12:03:17+0730", expected)
 
       zoneId = getZoneId("+07:03")
       expected = Option(date(2015, 3, 18, 12, 3, 17, zid = zoneId))
       checkStringToTimestamp("2015-03-18T12:03:17+07:03", expected)
       checkStringToTimestamp("2015-03-18T12:03:17GMT+07:03", expected)
+      checkStringToTimestamp("2015-03-18T12:03:17+0703", expected)
 
       // tests for the string including milliseconds.
       expected = Option(date(2015, 3, 18, 12, 3, 17, 123000, zid = zid))
@@ -236,16 +240,19 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       checkStringToTimestamp("2015-03-18T12:03:17.123-1:0", expected)
       checkStringToTimestamp("2015-03-18T12:03:17.123-01:00", expected)
       checkStringToTimestamp("2015-03-18T12:03:17.123 GMT-01:00", expected)
+      checkStringToTimestamp("2015-03-18T12:03:17.123-0100", expected)
 
       zoneId = getZoneId("+07:30")
       expected = Option(date(2015, 3, 18, 12, 3, 17, 123000, zid = zoneId))
       checkStringToTimestamp("2015-03-18T12:03:17.123+07:30", expected)
       checkStringToTimestamp("2015-03-18T12:03:17.123 GMT+07:30", expected)
+      checkStringToTimestamp("2015-03-18T12:03:17.123+0730", expected)
 
       zoneId = getZoneId("+07:30")
       expected = Option(date(2015, 3, 18, 12, 3, 17, 123000, zid = zoneId))
       checkStringToTimestamp("2015-03-18T12:03:17.123+07:30", expected)
       checkStringToTimestamp("2015-03-18T12:03:17.123GMT+07:30", expected)
+      checkStringToTimestamp("2015-03-18T12:03:17.123+0730", expected)
 
       expected = Option(date(2015, 3, 18, 12, 3, 17, 123121, zid = zoneId))
       checkStringToTimestamp("2015-03-18T12:03:17.123121+7:30", expected)
@@ -255,6 +262,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       expected = Option(date(2015, 3, 18, 12, 3, 17, 123120, zid = zoneId))
       checkStringToTimestamp("2015-03-18T12:03:17.12312+7:30", expected)
       checkStringToTimestamp("2015-03-18T12:03:17.12312 UT+07:30", expected)
+      checkStringToTimestamp("2015-03-18T12:03:17.12312+0730", expected)
 
       expected = Option(time(18, 12, 15, zid = zid))
       checkStringToTimestamp("18:12:15", expected)
@@ -263,11 +271,13 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       expected = Option(time(18, 12, 15, 123120, zid = zoneId))
       checkStringToTimestamp("T18:12:15.12312+7:30", expected)
       checkStringToTimestamp("T18:12:15.12312 UTC+07:30", expected)
+      checkStringToTimestamp("T18:12:15.12312+0730", expected)
 
       zoneId = getZoneId("+07:30")
       expected = Option(time(18, 12, 15, 123120, zid = zoneId))
       checkStringToTimestamp("18:12:15.12312+7:30", expected)
       checkStringToTimestamp("18:12:15.12312 GMT+07:30", expected)
+      checkStringToTimestamp("18:12:15.12312+0730", expected)
 
       expected = Option(date(2011, 5, 6, 7, 8, 9, 100000, zid = zid))
       checkStringToTimestamp("2011-05-06 07:08:09.1000", expected)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2347,7 +2347,7 @@ abstract class CSVSuite
   }
 
   test("exception mode for parsing date/timestamp string") {
-    val ds = Seq("2020-01-27T20:06:11.847-0800").toDS()
+    val ds = Seq("2020-01-27T20:06:11.847-08000").toDS()
     val csv = spark.read
       .option("header", false)
       .option("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSz")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2692,7 +2692,7 @@ abstract class JsonSuite
   }
 
   test("exception mode for parsing date/timestamp string") {
-    val ds = Seq("{'t': '2020-01-27T20:06:11.847-0800'}").toDS()
+    val ds = Seq("{'t': '2020-01-27T20:06:11.847-08000'}").toDS()
     val json = spark.read
       .schema("t timestamp")
       .option("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSz")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `ZoneId.of()` to handle timezone string in `DatetimeUtils.stringToTimestamp()`
instead of manually splitting it into hours and minutes.


### Why are the changes needed?
In current implementation. we will split the timezone string into hours and minutes.
But if there is no colon in the timezone, the full digits will be treated as hours, then
we couldn't get the correct value.
For example:
`2021-10-11T03:58:03.000+0700` will return null, but "+0700" is actually correct
format that accepted by `ZoneId.of()`


### Does this PR introduce _any_ user-facing change?
bugfix. this allows Spark to accept a more valid timezone format.


### How was this patch tested?
newly added UT
