### PR TITLE
[SPARK-37074][SQL] Push extra predicates through non-join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -141,6 +141,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       // join condition.
       Batch("Push extra predicate through join", fixedPoint,
         PushExtraPredicateThroughJoin,
+        PushExtraPredicateThroughNonJoin,
         PushDownPredicates) :: Nil
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushExtraPredicateThroughNonJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushExtraPredicateThroughNonJoin.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, AttributeSet, Expression, PredicateHelper}
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.{AGGREGATE, FILTER, GENERATE, WINDOW}
+
+/**
+ * Try partially pushing down disjunctive filter condition through a non-join child
+ * that produces new columns.
+ * To avoid expanding the filter condition,
+ * the filter condition will be kept in the original form even when predicate pushdown happens.
+ */
+object PushExtraPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelper {
+
+  private def findExtraConditions(
+    condition: Expression, outputSet: AttributeSet): Seq[Expression] = {
+    splitConjunctivePredicates(condition).filter { f =>
+      f.deterministic && f.references.nonEmpty && !f.references.subsetOf(outputSet)
+    }.flatMap(extractPredicatesWithinOutputSet(_, outputSet))
+  }
+
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
+    t => t.containsPattern(FILTER) && t.containsAnyPattern(WINDOW, GENERATE, AGGREGATE), ruleId) {
+    case filter @ Filter(condition, aggregate: Aggregate)
+      if aggregate.aggregateExpressions.forall(_.deterministic)
+        && aggregate.groupingExpressions.nonEmpty =>
+      val aliasMap = getAliasMap(aggregate)
+      val replaced = replaceAlias(condition, aliasMap)
+      val extraConditions = findExtraConditions(replaced, aggregate.child.outputSet)
+
+      if (extraConditions.nonEmpty) {
+        val pushDownPredicate = extraConditions.reduce(And)
+        filter.copy(child = aggregate.copy(child = Filter(pushDownPredicate, aggregate.child)))
+      } else {
+        filter
+      }
+
+    case filter @ Filter(condition, g: Generate) if g.expressions.forall(_.deterministic) =>
+      val extraConditions = findExtraConditions(condition, g.child.outputSet)
+
+      if (extraConditions.nonEmpty) {
+        val pushDownPredicate = extraConditions.reduce(And)
+        filter.copy(child = g.copy(child = Filter(pushDownPredicate, g.child)))
+      } else {
+        filter
+      }
+
+    case filter @ Filter(condition, w: Window)
+        if w.partitionSpec.forall(_.isInstanceOf[AttributeReference]) =>
+      val partitionAttrs = AttributeSet(w.partitionSpec.flatMap(_.references))
+      val extraConditions = findExtraConditions(condition, partitionAttrs)
+
+      if (extraConditions.nonEmpty) {
+        val pushDownPredicate = extraConditions.reduce(And)
+        filter.copy(child = w.copy(child = Filter(pushDownPredicate, w.child)))
+      } else {
+        filter
+      }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -127,6 +127,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.PruneFilters" ::
       "org.apache.spark.sql.catalyst.optimizer.PushDownLeftSemiAntiJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.PushExtraPredicateThroughJoin" ::
+        "org.apache.spark.sql.catalyst.optimizer.PushExtraPredicateThroughNonJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.PushFoldableIntoBranches" ::
       "org.apache.spark.sql.catalyst.optimizer.PushLeftSemiLeftAntiThroughJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.ReassignLambdaVariableID" ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -35,16 +35,16 @@ class FilterPushdownSuite extends PlanTest {
     val batches =
       Batch("Subqueries", Once,
         EliminateSubqueryAliases) ::
-        Batch("Filter Pushdown", FixedPoint(10),
-          CombineFilters,
-          PushPredicateThroughNonJoin,
-          BooleanSimplification,
-          PushPredicateThroughJoin,
-          CollapseProject) ::
-        Batch("Push down extra predicates", FixedPoint(10),
-          PushExtraPredicateThroughJoin,
-          PushExtraPredicateThroughNonJoin,
-          PushDownPredicates) :: Nil
+      Batch("Filter Pushdown", FixedPoint(10),
+        CombineFilters,
+        PushPredicateThroughNonJoin,
+        BooleanSimplification,
+        PushPredicateThroughJoin,
+        CollapseProject) ::
+      Batch("Push down extra predicates", FixedPoint(10),
+        PushExtraPredicateThroughJoin,
+        PushExtraPredicateThroughNonJoin,
+        PushDownPredicates) :: Nil
   }
 
   val attrA = 'a.int
@@ -288,8 +288,8 @@ class FilterPushdownSuite extends PlanTest {
 
     val originalQuery = {
       x.join(y)
-        .where(("x.a".attr === 1 && "y.d".attr === "x.b".attr) ||
-          ("x.a".attr === 1 && "y.d".attr === "x.c".attr))
+       .where(("x.a".attr === 1 && "y.d".attr === "x.b".attr) ||
+              ("x.a".attr === 1 && "y.d".attr === "x.c".attr))
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -489,7 +489,7 @@ class FilterPushdownSuite extends PlanTest {
     val left = testRelation.where('b === 2).subquery('l)
     val right = testRelation.where('b === 1).subquery('r)
     val correctAnswer =
-      left.join(right, LeftOuter, Some("l.a".attr === 3)).
+      left.join(right, LeftOuter, Some("l.a".attr===3)).
         where("r.b".attr === 2 && "l.c".attr === "r.c".attr).analyze
 
     comparePlans(optimized, correctAnswer)
@@ -582,7 +582,7 @@ class FilterPushdownSuite extends PlanTest {
     val correctAnswer =
       lleft.join(
         left.join(right, condition = Some("x.b".attr === "y.b".attr)),
-        condition = Some("z.a".attr === "x.b".attr))
+          condition = Some("z.a".attr === "x.b".attr))
         .analyze
 
     comparePlans(optimized, correctAnswer)
@@ -634,7 +634,7 @@ class FilterPushdownSuite extends PlanTest {
         y.where("y.b".attr > 2),
         ExistenceJoin(fillerVal),
         Some("x.a".attr > 1))
-        .analyze
+      .analyze
     comparePlans(optimized, correctAnswer)
   }
 
@@ -716,24 +716,24 @@ class FilterPushdownSuite extends PlanTest {
 
   test("aggregate: push down filter when filter on group by expression") {
     val originalQuery = testRelation
-      .groupBy('a)('a, count('b) as 'c)
-      .select('a, 'c)
-      .where('a === 2)
+                        .groupBy('a)('a, count('b) as 'c)
+                        .select('a, 'c)
+                        .where('a === 2)
 
     val optimized = Optimize.execute(originalQuery.analyze)
 
     val correctAnswer = testRelation
-      .where('a === 2)
-      .groupBy('a)('a, count('b) as 'c)
-      .analyze
+                        .where('a === 2)
+                        .groupBy('a)('a, count('b) as 'c)
+                        .analyze
     comparePlans(optimized, correctAnswer)
   }
 
   test("aggregate: don't push down filter when filter not on group by expression") {
     val originalQuery = testRelation
-      .select('a, 'b)
-      .groupBy('a)('a, count('b) as 'c)
-      .where('c === 2L)
+                        .select('a, 'b)
+                        .groupBy('a)('a, count('b) as 'c)
+                        .where('c === 2L)
 
     val optimized = Optimize.execute(originalQuery.analyze)
 
@@ -742,18 +742,18 @@ class FilterPushdownSuite extends PlanTest {
 
   test("aggregate: push down filters partially which are subset of group by expressions") {
     val originalQuery = testRelation
-      .select('a, 'b)
-      .groupBy('a)('a, count('b) as 'c)
-      .where('c === 2L && 'a === 3)
+                        .select('a, 'b)
+                        .groupBy('a)('a, count('b) as 'c)
+                        .where('c === 2L && 'a === 3)
 
     val optimized = Optimize.execute(originalQuery.analyze)
 
     val correctAnswer = testRelation
-      .where('a === 3)
-      .select('a, 'b)
-      .groupBy('a)('a, count('b) as 'c)
-      .where('c === 2L)
-      .analyze
+                        .where('a === 3)
+                        .select('a, 'b)
+                        .groupBy('a)('a, count('b) as 'c)
+                        .where('c === 2L)
+                        .analyze
 
     comparePlans(optimized, correctAnswer)
   }
@@ -1210,22 +1210,22 @@ class FilterPushdownSuite extends PlanTest {
 
   test("push down predicate through expand") {
     val query =
-      Filter('a > 1,
+        Filter('a > 1,
+          Expand(
+            Seq(
+              Seq('a, 'b, 'c, Literal.create(null, StringType), 1),
+              Seq('a, 'b, 'c, 'a, 2)),
+            Seq('a, 'b, 'c),
+            testRelation)).analyze
+    val optimized = Optimize.execute(query)
+
+    val expected =
         Expand(
           Seq(
             Seq('a, 'b, 'c, Literal.create(null, StringType), 1),
             Seq('a, 'b, 'c, 'a, 2)),
           Seq('a, 'b, 'c),
-          testRelation)).analyze
-    val optimized = Optimize.execute(query)
-
-    val expected =
-      Expand(
-        Seq(
-          Seq('a, 'b, 'c, Literal.create(null, StringType), 1),
-          Seq('a, 'b, 'c, 'a, 2)),
-        Seq('a, 'b, 'c),
-        Filter('a > 1, testRelation)).analyze
+          Filter('a > 1, testRelation)).analyze
 
     comparePlans(optimized, expected)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the `Optimizer` partially push some predicates through a non-join nodes, that produce new columns: `Aggregate`, `Generate`, `Window`.

### Why are the changes needed?
Performance improvements

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New UTs