### PR TITLE
[SPARK-37076][SQL] Implement StructType.toString explicitly for Scala 2.13

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -127,6 +127,10 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     }
   }
 
+  override def toString(): String = {
+    s"StructType${fields.map(_.toString).mkString("(", ",", ")")}"
+  }
+
   private lazy val _hashCode: Int = java.util.Arrays.hashCode(fields.asInstanceOf[Array[AnyRef]])
   override def hashCode(): Int = _hashCode
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -128,7 +128,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
   }
 
   override def toString(): String = {
-    s"StructType${fields.map(_.toString).mkString("(", ",", ")")}"
+    s"${getClass.getSimpleName}${fields.map(_.toString).mkString("(", ",", ")")}"
   }
 
   private lazy val _hashCode: Int = java.util.Arrays.hashCode(fields.asInstanceOf[Array[AnyRef]])

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -405,4 +405,9 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
       assert(st2.merge(st1) === expectedStruct)
     }
   }
+
+  test("SPARK-XXXXX: Implement toString explicitly in StructType for Scala 2.13") {
+    val struct = StructType(StructField("a", IntegerType) :: Nil)
+    assert(struct.toString() === "StructType(StructField(a,IntegerType,true)")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -406,8 +406,8 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
     }
   }
 
-  test("SPARK-XXXXX: Implement toString explicitly in StructType for Scala 2.13") {
+  test("SPARK-37076: Implement StructType.toString explicitly for Scala 2.13") {
     val struct = StructType(StructField("a", IntegerType) :: Nil)
-    assert(struct.toString() === "StructType(StructField(a,IntegerType,true)")
+    assert(struct.toString() === "StructType(StructField(a,IntegerType,true))")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes an issue that the string returned by `StructType.toString` is different between Scala 2.12 and 2.13.

* Scala 2.12
```
val st = StructType(StructField("a", IntegerType) :: Nil)
st.toString
res0: String = StructType(StructField(a,IntegerType,true)
```

* Scala 2.13
```
val st = StructType(StructField("a", IntegerType) :: Nil)
st.toString
val res0: String = Seq(StructField(a,IntegerType,true))
```

It's because the logic to make the prefix of the string was changed from Scala 2.13.

Scala 2.12: https://github.com/scala/scala/blob/v2.12.15/src/library/scala/collection/TraversableLike.scala#L804
Scala 2:13:https://github.com/scala/scala/blob/v2.13.5/src/library/scala/collection/Seq.scala#L46

One option which solves this issue would be to override `className` because it's used as the prefix of the string returned by `toString`.
https://github.com/scala/scala/blob/v2.13.5/src/library/scala/collection/Iterable.scala#L76

But it doesn't works with Scala 2.12 because `className` was introduced from Scala 2.12.
Another option would be to override `stringPrefix` and this should work with both Scala 2.12 and 2.13.
https://github.com/scala/scala/blob/v2.12.15/src/library/scala/collection/TraversableLike.scala#L796
https://github.com/scala/scala/blob/v2.13.5/src/library/scala/collection/Iterable.scala#L56

But we need to make the method `public` for Scala 2.12 though it is expected to be used only from `toString`, while the method is `private[this]` for Scala 2.13.

So, rather than exposing a new public method, this PR proposes to implement `Struct.toString` explicitly.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To fix a kind of compatibility issue.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
New test is added and confirmed it passed with the following command.
```
build/sbt  -Pscala-2.13 "testOnly org.apache.spark.sql.types.StructTypeSuite -- -z SPARK-37076"
```