### PR TITLE
[SPARK-37061][SQL] Fix CustomMetrics when using Inner Classes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
@@ -29,7 +29,7 @@ object CustomMetrics {
    * `CustomMetric`.
    */
   def buildV2CustomMetricTypeName(customMetric: CustomMetric): String = {
-    s"${V2_CUSTOM}_${customMetric.getClass.getCanonicalName}"
+    s"${V2_CUSTOM}_${customMetric.getClass.getName}"
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Previously CustomMetrics use Class.getCanonicalName when attempting to get the
class name of CustomMetric implementations. These names replace special characters
for marking inner classes like ($) with ".". While those names are appropriate for
referring to classes within source files, they will not work during reflection where
the Class.getName output should be used.

### Why are the changes needed?
InnerClasses could never be found in when they are used as Custom Metrics

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tests modified so they access both an independent metric class as well as an inner class.