### PR TITLE
[SPARK-36645][SQL][FOLLOWUP] Disable min/max push down for Parquet Binary

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.datasources.parquet.{ParquetFilters, Spark
 import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.{ArrayType, LongType, MapType, StructField, StructType, TimestampType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, DecimalType, LongType, MapType, StringType, StructField, StructType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 case class ParquetScanBuilder(
@@ -114,7 +114,11 @@ case class ParquetScanBuilder(
         // not push down complex type
         // not push down Timestamp because INT96 sort order is undefined,
         // Parquet doesn't return statistics for INT96
-        case StructType(_) | ArrayType(_, _) | MapType(_, _, _) | TimestampType =>
+        // not push down Parquet Binary because min/max could be truncated
+        // (https://issues.apache.org/jira/browse/PARQUET-1685), Parquet Binary
+        // could be Spark StringType, BinaryType or DecimalType
+        case StructType(_) | ArrayType(_, _) | MapType(_, _, _) | TimestampType
+            | StringType | BinaryType | DecimalType() =>
           false
         case _ =>
           finalSchema = finalSchema.add(structField.copy(s"$aggType(" + structField.name + ")"))


### PR DESCRIPTION


### What changes were proposed in this pull request?
Disable min/max push down for Parquet Binary


### Why are the changes needed?
Parquet Binary min/max could be truncated. We may get wrong result if we rely on parquet Binary min/max.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
modify existing tests
