### PR TITLE
[SPARK-37079][PYTHON][SQL] Fix DataFrameWriterV2.partitionedBy to send the arguments to JVM properly

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -1374,6 +1374,7 @@ class DataFrameWriterV2(object):
         """
         col = _to_java_column(col)
         cols = _to_seq(self._spark._sc, [_to_java_column(c) for c in cols])
+        self._jwriter.partitionedBy(col, cols)
         return self
 
     @since(3.1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `DataFrameWriterV2.partitionedBy` to send the arguments to JVM properly.

### Why are the changes needed?

In PySpark, `DataFrameWriterV2.partitionedBy` doesn't send the arguments to JVM properly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually checked whether the arguments are sent to JVM or not.