### PR TITLE
[SPARK-37078][CORE] Support old 3-parameter Sink constructors

### DIFF
--- a/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/MetricsSystemSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.metrics
 
+import java.util.Properties
+
 import scala.collection.mutable.ArrayBuffer
 
 import com.codahale.metrics.MetricRegistry
@@ -269,4 +271,23 @@ class MetricsSystemSuite extends SparkFunSuite with BeforeAndAfter with PrivateM
     assert(metricName === source.sourceName)
   }
 
+  test("SPARK-37078: Support old 3-parameter Sink constructors") {
+    conf.set(
+      "spark.metrics.conf.*.sink.jmx.class",
+      "org.apache.spark.metrics.ThreeParameterConstructorSink")
+    val metricsSystem = MetricsSystem.createMetricsSystem("legacy", conf)
+    metricsSystem.start()
+    val sinks = PrivateMethod[ArrayBuffer[Sink]](Symbol("sinks"))
+
+    assert(metricsSystem.invokePrivate(sinks()).length === 1)
+  }
+}
+
+class ThreeParameterConstructorSink(
+    val property: Properties,
+    val registry: MetricRegistry,
+    securityMgr: SecurityManager) extends Sink {
+  override def start(): Unit = {}
+  override def stop(): Unit = {}
+  override def report(): Unit = {}
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support 3-parameter Sink constructors which have `SecurityManager` as the 3rd parameter.

### Why are the changes needed?

Apache Spark 3.2.0 cannot load old Sink libraries because SPARK-34520 removed `SecurityManager` parameter and try to create Sink class with new two-parameter constructor only.

### Does this PR introduce _any_ user-facing change?

This will recover the breaking change.

### How was this patch tested?

Pass the CIs with newly added test coverage.