### PR TITLE
[SPARK-36554][SQL][PYTHON] Expose make_date expression in functions.scala

### DIFF
--- a/python/docs/source/reference/pyspark.sql.rst
+++ b/python/docs/source/reference/pyspark.sql.rst
@@ -466,6 +466,7 @@ Functions
     lower
     lpad
     ltrim
+    make_date
     map_concat
     map_entries
     map_filter

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2138,7 +2138,7 @@ def make_date(year: "ColumnOrName", month: "ColumnOrName", day: "ColumnOrName") 
     Examples
     --------
     >>> df = spark.createDataFrame([(2020, 6, 26)], ['Y', 'M', 'D'])
-    >>> df.select(make_date(df.Y, df.M, df.D).alias("datefield")).show()
+    >>> df.select(make_date(df.Y, df.M, df.D).alias("datefield")).collect()
     [Row(datefield=datetime.date(2020, 6, 26))]
     """
     sc = SparkContext._active_spark_context  # type: ignore[attr-defined]

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2131,7 +2131,7 @@ def weekofyear(col: "ColumnOrName") -> Column:
     return Column(sc._jvm.functions.weekofyear(_to_java_column(col)))
 
 
-def make_date(year: Column, month: Column, day: Column) -> Column:
+def make_date(year: "ColumnOrName", month: "ColumnOrName", day: "ColumnOrName") -> Column:
     """
     Returns a column with date built from the year, month and day columns.
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2133,7 +2133,15 @@ def weekofyear(col: "ColumnOrName") -> Column:
 
 def make_date(year: "ColumnOrName", month: "ColumnOrName", day: "ColumnOrName") -> Column:
     """
-    Returns a column with date built from the year, month and day columns.
+    Returns a column with a date built from the year, month and day columns.
+
+    .. versionadded:: 3.3.0
+
+    Parameters
+    ----------
+    year : :class:`ColumnOrName` with the year to build the date
+    month : :class:`ColumnOrName` with the month to build the date
+    day : :class:`ColumnOrName` with the day to build the date
 
     Examples
     --------

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2142,7 +2142,10 @@ def make_date(year: "ColumnOrName", month: "ColumnOrName", day: "ColumnOrName") 
     [Row(datefield=datetime.date(2020, 6, 26))]
     """
     sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
-    jc = sc._jvm.functions.make_date(_to_java_column(year), _to_java_column(month), _to_java_column(day))
+    year_col = _to_java_column(year)
+    month_col = _to_java_column(month)
+    day_col = _to_java_column(day)
+    jc = sc._jvm.functions.make_date(year_col, month_col, day_col)
     return Column(jc)
 
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2131,6 +2131,21 @@ def weekofyear(col: "ColumnOrName") -> Column:
     return Column(sc._jvm.functions.weekofyear(_to_java_column(col)))
 
 
+def make_date(year: Column, month: Column, day: Column) -> Column:
+    """
+    Returns a column with date built from the year, month and day columns.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([(2020, 6, 26)], ['Y', 'M', 'D'])
+    >>> df.select(make_date(df.Y, df.M, df.D).alias("datefield")).show()
+    [Row(datefield=datetime.date(2020, 6, 26))]
+    """
+    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    jc = sc._jvm.functions.make_date(_to_java_column(year), _to_java_column(month), _to_java_column(day))
+    return Column(jc)
+
+
 def date_add(start: "ColumnOrName", days: int) -> Column:
     """
     Returns the date that is `days` days after `start`

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2139,9 +2139,12 @@ def make_date(year: "ColumnOrName", month: "ColumnOrName", day: "ColumnOrName") 
 
     Parameters
     ----------
-    year : :class:`ColumnOrName` with the year to build the date
-    month : :class:`ColumnOrName` with the month to build the date
-    day : :class:`ColumnOrName` with the day to build the date
+    year : :class:`~pyspark.sql.Column` or str
+        The year to build the date
+    month : :class:`~pyspark.sql.Column` or str
+        The month to build the date
+    day : :class:`~pyspark.sql.Column` or str
+        The day to build the date
 
     Examples
     --------

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -241,6 +241,12 @@ class FunctionsTests(ReusedSQLTestCase):
         row = df.select(dayofweek(df.date)).first()
         self.assertEqual(row[0], 2)
 
+    def test_make_date(self):
+        from pyspark.sql.functions import make_date
+        df = self.spark.createDataFrame([(2020, 6, 26)], ['Y', 'M', 'D'])
+        row = df.select(make_date(df.Y, df.M, df.D)).first()
+        self.assertEqual(row[0], datetime.date(2020, 6, 26))
+
     def test_expr(self):
         from pyspark.sql import functions
         row = Row(a="length string", b=75)

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -25,7 +25,7 @@ from pyspark.sql import Row, Window, types
 from pyspark.sql.functions import udf, input_file_name, col, percentile_approx, \
     lit, assert_true, sum_distinct, sumDistinct, shiftleft, shiftLeft, shiftRight, \
     shiftright, shiftrightunsigned, shiftRightUnsigned, octet_length, bit_length, \
-    sec, csc, cot
+    sec, csc, cot, make_date
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
 
 
@@ -242,7 +242,7 @@ class FunctionsTests(ReusedSQLTestCase):
         self.assertEqual(row[0], 2)
 
     def test_make_date(self):
-        from pyspark.sql.functions import make_date
+        # SPARK-36554: expose make_date expression
         df = self.spark.createDataFrame([(2020, 6, 26)], ['Y', 'M', 'D'])
         row_from_col = df.select(make_date(df.Y, df.M, df.D)).first()
         self.assertEqual(row_from_col[0], datetime.date(2020, 6, 26))

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -244,8 +244,10 @@ class FunctionsTests(ReusedSQLTestCase):
     def test_make_date(self):
         from pyspark.sql.functions import make_date
         df = self.spark.createDataFrame([(2020, 6, 26)], ['Y', 'M', 'D'])
-        row = df.select(make_date(df.Y, df.M, df.D)).first()
-        self.assertEqual(row[0], datetime.date(2020, 6, 26))
+        row_from_col = df.select(make_date(df.Y, df.M, df.D)).first()
+        self.assertEqual(row_from_col[0], datetime.date(2020, 6, 26))
+        row_from_name = df.select(make_date("Y", "M", "D")).first()
+        self.assertEqual(row_from_name[0], datetime.date(2020, 6, 26))
 
     def test_expr(self):
         from pyspark.sql import functions

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3214,6 +3214,15 @@ object functions {
   def minute(e: Column): Column = withExpr { Minute(e.expr) }
 
   /**
+   * @return A date created from year, month and day fields.
+   * @group datetime_funcs
+   * @since 3.3.0
+   */
+  def make_date(year: Column, month: Column, day: Column): Column = withExpr {
+    MakeDate(year.expr, month.expr, day.expr)
+  }
+
+  /**
    * Returns number of months between dates `start` and `end`.
    *
    * A whole number is returned if both inputs have the same day of month or both are the last day


### PR DESCRIPTION
Hi, this is my first PR to spark, let me know if I forgot anything! 

### What changes were proposed in this pull request?

This commit solves `SPARK-36554`. It exposes the `make_date` sql expression into the scala functions file to be able to use it in expressions.


### Why are the changes needed?
### Does this PR introduce _any_ user-facing change?

It exposes the `make_date` function to use as an expression without the need to use `expr("make_date(...)")`.


### How was this patch tested?

It has an unit test in the `test_functions.py` file.