### PR TITLE
[SPARK-37086][R][ML][TESTS] Fix the R test of FPGrowthModel for Scala 2.13

### DIFF
--- a/R/pkg/tests/fulltests/test_mllib_fpm.R
+++ b/R/pkg/tests/fulltests/test_mllib_fpm.R
@@ -32,11 +32,11 @@ test_that("spark.fpGrowth", {
 
   model <- spark.fpGrowth(data, minSupport = 0.3, minConfidence = 0.8, numPartitions = 1)
 
-  itemsets <- collect(spark.freqItemsets(model))
+  itemsets <- collect(orderBy(spark.freqItemsets(model), "items"))
 
   expected_itemsets <- data.frame(
-    items = I(list(list("3"), list("3", "1"), list("2"), list("2", "1"), list("1"))),
-    freq = c(2, 2, 3, 3, 4)
+    items = I(list(list("1"), list("2"), list("2", "1"), list("3"), list("3", "1"))),
+    freq = c(4, 3, 3, 2, 2)
   )
 
   expect_equivalent(expected_itemsets, itemsets)
@@ -71,7 +71,7 @@ test_that("spark.fpGrowth", {
 
     expect_equivalent(
       itemsets,
-      collect(spark.freqItemsets(loaded_model)))
+      collect(orderBy(spark.freqItemsets(loaded_model), "items")))
 
     unlink(modelPath)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes an issue that the R test of FPGrowthModel fails with Scala 2.13.
Similar to the issue filed in SPARK-37059 (#34330), the R test of FPGrowthModel assumes that the result records returned by `FPGrowthModel.freqItemsets` are sorted by a certain kind of order but it's wrong.
As a result, the test fails with Scala 2.13.

```
 ══ Failed ══════════════════════════════════════════════════════════════════════
── 1. Failure (test_mllib_fpm.R:42:3): spark.fpGrowth ──────────────────────────
`expected_itemsets` not equivalent to `itemsets`.
Component “items”: Component 1: Component 1: 1 string mismatch
Component “items”: Component 2: Length mismatch: comparison on first 1 components
Component “items”: Component 2: Component 1: 1 string mismatch
Component “items”: Component 3: Length mismatch: comparison on first 1 components
Component “items”: Component 4: Length mismatch: comparison on first 1 components
Component “items”: Component 4: Component 1: 1 string mismatch
Component “items”: Component 5: Length mismatch: comparison on first 1 components
Component “items”: Component 5: Component 1: 1 string mismatch
Component “freq”: Mean relative difference: 0.5454545
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For test stability.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
All the R tests passed on GA with a modified GA config to run with Scala 2.13 (set `scala2.13` to the `SPARK_PROFILE` environment variable).
https://github.com/sarutak/spark/runs/3964081433?check_suite_focus=true#step:7:380

Test for Scala 2.12 should be done on the regular GA.
