### PR TITLE
[SPARK-37069][SQL] Properly fallback when Hive.getWithoutRegisterFns is not available

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -204,8 +204,8 @@ private[hive] class HiveClientImpl(
     try {
       Hive.getWithoutRegisterFns(conf)
     } catch {
-      // Not all Hive versions have the above method (e.g., Hive 2.3.9 has it but 2.3.8 don't),
-      // therefore here we fallback when encountering the exception
+      // SPARK-37069: not all Hive versions have the above method (e.g., Hive 2.3.9 has it but
+      // 2.3.8 don't), therefore here we fallback when encountering the exception.
       case _: NoSuchMethodError =>
         Hive.get(conf)
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -57,11 +57,11 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces._
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.QueryExecutionException
-import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
+import org.apache.spark.sql.hive.HiveExternalCatalog
 import org.apache.spark.sql.hive.HiveExternalCatalog.DATASOURCE_SCHEMA
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.util.{CircularBuffer, Utils, VersionUtils}
+import org.apache.spark.util.{CircularBuffer, Utils}
 
 /**
  * A class that wraps the HiveClient and converts its responses to externally visible classes.
@@ -201,12 +201,13 @@ private[hive] class HiveClientImpl(
   }
 
   private def getHive(conf: HiveConf): Hive = {
-    VersionUtils.majorMinorPatchVersion(version.fullVersion).map {
-      case (2, 3, v) if v >= 9 => Hive.getWithoutRegisterFns(conf)
-      case _ => Hive.get(conf)
-    }.getOrElse {
-      throw QueryExecutionErrors.unsupportedHiveMetastoreVersionError(
-        version.fullVersion, HiveUtils.HIVE_METASTORE_VERSION.key)
+    try {
+      Hive.getWithoutRegisterFns(conf)
+    } catch {
+      // Not all Hive versions have the above method (e.g., Hive 2.3.9 has it but 2.3.8 don't),
+      // therefore here we fallback when encountering the exception
+      case _: NoSuchMethodError =>
+        Hive.get(conf)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Properly fallback to `Hive.get` when `Hive.getWithoutRegisterFns` is unavailable to a Hive version.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

In SPARK-35321 we switched to use the new method `Hive.getWithoutRegisterFns` introduced by [HIVE-21563](https://issues.apache.org/jira/browse/HIVE-21563). The code path is supposed to only active for Hive versions that are >= 2.3.9. However, due to how `HiveVersion` is initialized in `IsolatedClientLoader`, if users set `spark.sql.hive.metastore.version` to `2.3.8`, Spark will still convert it to "2.3.9" and thus will subsequently fail with `NoSuchMethodError`.

This fixes it by always fallback on `NoSuchMethodError`. By doing this we are also able to support other Hive versions with `Hive.getWithoutRegisterFns` implemented.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

I manually tested via launching a Spark session with custom Hive version:

```
$SPARK_HOME/bin/spark-shell --conf spark.sql.hive.metastore.version=2.3.8 --conf spark.sql.hive.metastore.jars="/tmp/apache-hive-2.3.8-bin/lib/*
```

And then tried this command:
```
import org.apache.spark.sql.SparkSession
val spark = SparkSession.builder()
  .master("local[*]")
  .enableHiveSupport()
  .config("spark.sql.hive.metastore.version", "2.3.8")
  .config("spark.sql.hive.metastore.jars", "/tmp/apache-hive-2.3.8-bin/lib/*")
  .getOrCreate()
spark.sql("show tables").show
```

The command is failing before this PR, but working afterwards.
