### PR TITLE
[SPARK-37090] Upgrade libthrift to avoid security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <joda.version>2.10.12</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
-    <libthrift.version>0.12.0</libthrift.version>
+    <libthrift.version>0.15.0</libthrift.version>
     <antlr4.version>4.8</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>3.141.59</selenium.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade libthrift dependency from 0.12.0 to 0.15.0

### Why are the changes needed?

https://snyk.io/vuln/maven:org.apache.thrift%3Alibthrift lists a couple of high-impact vulnerabilities of libthrift 0.12.0, in particular
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13949
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-0205

Keep the library up to date to fix vulnerabilities.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.