### PR TITLE
[SPARK-37073][AVRO][TEST] Pass all UTs in `external/avro` with Java 17

### DIFF
--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -1071,7 +1071,8 @@ abstract class AvroSuite
           .write.format("avro").option("avroSchema", avroSchema)
           .save(s"$tempDir/${UUID.randomUUID()}")
       }.getCause.getMessage
-      assert(message.contains("Caused by: java.lang.NullPointerException: " +
+      assert(message.contains("Caused by: java.lang.NullPointerException: "))
+      assert(message.contains(
         "null of string in string in field Name of test_schema in test_schema"))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `external/avro` module test with Java 17 has 2 UT failed, the reason for the failure is that the content of the error message  fragment used for assertion has changed from 

```
Caused by: java.lang.NullPointerException: null of string in string in field Name of test_schema in test_schema
``` 
to 

```
Caused by: java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "datum" is null of string in string in field Name of test_schema in test_schema
```

This change should be caused by `JEP 358: Helpful NullPointerExceptions`.

So the change of this pr is  splits one assertion into two assertions to be compatible with different Java versions.

### Why are the changes needed?
Pass UT with JDK 17


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- Pass the Jenkins or GitHub Action

- Manual test  use Java 17

`mvn clean install -pl external/avro`

**Before**
```
Run completed in 49 seconds, 212 milliseconds.
Total number of tests run: 283
Suites: completed 14, aborted 0
Tests: succeeded 281, failed 2, canceled 0, ignored 2, pending 0
*** 2 TESTS FAILED ***
```

**After**

```
Run completed in 42 seconds, 825 milliseconds.
Total number of tests run: 283
Suites: completed 14, aborted 0
Tests: succeeded 283, failed 0, canceled 0, ignored 2, pending 0
All tests passed.
```