### PR TITLE
[SPARK-37097][YARN] yarn-cluster mode don't need to retry when AM container exit code 0 but application failed.

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1280,7 +1280,7 @@ private[spark] class Client(
         diags.foreach { err =>
           logError(s"Application diagnostics message: $err")
         }
-        var amContainerSucceed =
+        val amContainerSucceed =
           Option(yarnClient.getApplicationReport(appId).getCurrentApplicationAttemptId)
             .flatMap(attemptId => Option(yarnClient.getApplicationAttemptReport(attemptId)))
             .flatMap(attemptReport => Option(attemptReport.getAMContainerId))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Some yarn-cluster application meet such exception.
```
21/10/20 03:31:55 ERROR Client: Application diagnostics message: Application application_1632999510150_2163647 failed 1 times (global limit =8; local limit is =1) due to AM Container for appattempt_1632999510150_2163647_000001 exited with  exitCode: 0
Failing this attempt.Diagnostics: For more detailed output, check the application tracking page: http://ip-xx-xx-xx-xx.idata-server.shopee.io:8088/cluster/app/application_1632999510150_2163647 Then click on links to logs of each attempt.
. Failing the application.
Exception in thread "main" org.apache.spark.SparkException: Application application_1632999510150_2163647 finished with failed status
```

It's caused by below situation:
1. yarn-cluster mode application usr code finished, AM shutdown hook triggered
2. AM call unregister from RM but timeout, since AM shutdown hook have try catch, won't throw exception, so AM container exit with code 0(application user code running success).
3. Since RM lose connection with AM, then treat this container as failed final status.
4. Then client side got application report as final status failed but am container exit code 0. client treat it as failed, then retry.


it's a unnecessary retry. we can avoid it.


### Why are the changes needed?
Avoid unnecessary retry

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

Manual tested