### PR TITLE
[SPARK-37089][SQL] Do not register ParquetFileFormat completion listener lazily

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/RecordReaderIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/RecordReaderIterator.scala
@@ -56,6 +56,13 @@ class RecordReaderIterator[T](
     rowReader.getCurrentValue
   }
 
+  override def map[B](f: (T) => B): Iterator[B] with Closeable =
+    new Iterator[B] with Closeable {
+      override def hasNext: Boolean = RecordReaderIterator.this.hasNext
+      override def next(): B = f(RecordReaderIterator.this.next())
+      override def close(): Unit = RecordReaderIterator.this.close()
+    }
+
   override def close(): Unit = {
     if (rowReader != null) {
       try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -256,24 +256,6 @@ class ParquetFileFormat
     val datetimeRebaseModeInRead = parquetOptions.datetimeRebaseModeInRead
     val int96RebaseModeInRead = parquetOptions.int96RebaseModeInRead
 
-    var currentIterator: RecordReaderIterator[_] = null
-    def setCurrentIterator(newIterator: RecordReaderIterator[_]): Unit = {
-      if (currentIterator != null) {
-        currentIterator.close()
-      }
-      currentIterator = newIterator
-    }
-    // SPARK-23457: Register a task completion listener to close the iterator before calling
-    // `RecordReader#initialize()`. This avoids leaking the iterator's resources in case there is an
-    // exception in initialization.
-    //
-    // SPARK-37089: Register the listener up front rather than lazily in the function below. The
-    // listener invalidates the result iterator and any rows it has produced. Since task completion
-    // listeners are called in reverse order of registration, registering it up front guarantees the
-    // iterator is only invalidated after downstream operators' listeners have run.
-    val taskContext = Option(TaskContext.get())
-    taskContext.foreach(_.addTaskCompletionListener[Unit](_ => setCurrentIterator(null)))
-
     (file: PartitionedFile) => {
       assert(file.partitionValues.numFields == partitionSchema.size)
 
@@ -337,6 +319,7 @@ class ParquetFileFormat
       if (pushed.isDefined) {
         ParquetInputFormat.setFilterPredicate(hadoopAttemptContext.getConfiguration, pushed.get)
       }
+      val taskContext = Option(TaskContext.get())
       if (enableVectorizedReader) {
         val vectorizedReader = new VectorizedParquetRecordReader(
           convertTz.orNull,
@@ -345,7 +328,8 @@ class ParquetFileFormat
           enableOffHeapColumnVector && taskContext.isDefined,
           capacity)
         val iter = new RecordReaderIterator(vectorizedReader)
-        setCurrentIterator(iter)
+        // SPARK-23457 Register a task completion listener before `initialization`.
+        taskContext.foreach(_.addTaskCompletionListener[Unit](_ => iter.close()))
         vectorizedReader.initialize(split, hadoopAttemptContext)
         logDebug(s"Appending $partitionSchema ${file.partitionValues}")
         vectorizedReader.initBatch(partitionSchema, file.partitionValues)
@@ -370,7 +354,8 @@ class ParquetFileFormat
           new ParquetRecordReader[InternalRow](readSupport)
         }
         val iter = new RecordReaderIterator[InternalRow](reader)
-        setCurrentIterator(iter)
+        // SPARK-23457 Register a task completion listener before `initialization`.
+        taskContext.foreach(_.addTaskCompletionListener[Unit](_ => iter.close()))
         reader.initialize(split, hadoopAttemptContext)
 
         val fullSchema = requiredSchema.toAttributes ++ partitionSchema.toAttributes


### PR DESCRIPTION
### What changes were proposed in this pull request?

The previous PR https://github.com/apache/spark/pull/34245 assumed task completion listeners are registered bottom-up. `ParquetFileFormat#buildReaderWithPartitionValues()` violates this assumption by registering a task completion listener to close its output iterator lazily. Since task completion listeners are executed in reverse order of registration, this listener always runs before other listeners. When the downstream operator contains a Python UDF and the off-heap vectorized Parquet reader is enabled, this results in a use-after-free that causes a segfault.

The fix is to close the output iterator using FileScanRDD's task completion listener.

### Why are the changes needed?

Without this PR, the Python tests introduced in https://github.com/apache/spark/pull/34245 are flaky ([see details in thread](https://github.com/apache/spark/pull/34245#issuecomment-948713545)). They intermittently fail with a segfault.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Repeatedly ran one of the Python tests introduced in https://github.com/apache/spark/pull/34245 using the commands below. Previously, the test was flaky and failed after about 50 runs. With this PR, the test has not failed after 1000 runs.

```sh
./build/sbt -Phive clean package && ./build/sbt test:compile
seq 1000 | parallel -j 8 --halt now,fail=1 'echo {#}; python/run-tests --testnames pyspark.sql.tests.test_udf'
```