### PR TITLE
[SPARK-37105][TEST] Pass all UTs in `sql/hive` with Java 17

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
@@ -32,6 +32,7 @@ public class JavaModuleOptions {
       "--add-opens=java.base/java.nio=ALL-UNNAMED",
       "--add-opens=java.base/java.util=ALL-UNNAMED",
       "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+      "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
       "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
       "--add-opens=java.base/sun.security.action=ALL-UNNAMED",

--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,7 @@
       --add-opens=java.base/java.nio=ALL-UNNAMED
       --add-opens=java.base/java.util=ALL-UNNAMED
       --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+      --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
       --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
       --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
       --add-opens=java.base/sun.security.action=ALL-UNNAMED

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1136,6 +1136,7 @@ object TestSettings {
         "--add-opens=java.base/java.nio=ALL-UNNAMED",
         "--add-opens=java.base/java.util=ALL-UNNAMED",
         "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+        "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
         "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
         "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
         "--add-opens=java.base/sun.security.action=ALL-UNNAMED",

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -234,7 +234,7 @@
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>
           <!-- Specially disable assertions since some Hive tests fail them -->
-          <argLine>-da -Xmx4g -XX:ReservedCodeCacheSize=${CodeCacheSize} -Dio.netty.tryReflectionSetAccessible=true</argLine>
+          <argLine>-da -Xmx4g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The main change of this pr as follows:

- Add `extraJavaTestArgs` to `argLine` of `scalatest-maven-plugin` in `sql/hive/pom.xml`
- Add  `--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED` to default java module options because some UTs failed due to

```
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private volatile int java.util.concurrent.atomic.AtomicBoolean.value accessible: module java.base does not "opens java.util.concurrent.atomic" to unnamed module @2744cc4a
```
 

### Why are the changes needed?
Pass UT with JDK 17




### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

- Pass the Jenkins or GitHub Action
- Manual test use Java17 build + Java17 run (both openjdk version "17" 2021-09-14 LTS)

Add `extraJavaTestArgs` to `scalatest-maven-plugin` in `sql/hive/pom.xml`  first and use Java 17 to run the following two commands:
 
```
build/mvn clean install -Phadoop-3.2 -Phive-2.3 -Phive -pl sql/hive -am -DskipTests
build/mvn test -Phadoop-3.2 -Phive-2.3 -Phive -pl sql/hive
```

**Before**

```
Run completed in 1 hour, 2 minutes, 3 seconds.
Total number of tests run: 3547
Suites: completed 117, aborted 0
Tests: succeeded 3525, failed 22, canceled 6, ignored 605, pending 0
*** 22 TESTS FAILED ***
```

**After**

```
Run completed in 1 hour, 4 minutes, 41 seconds.
Total number of tests run: 3547
Suites: completed 117, aborted 0
Tests: succeeded 3547, failed 0, canceled 6, ignored 605, pending 0
All tests passed.
```


- Manual test use Java8 build + Java17 run


Use Java 8(openjdk version "1.8.0_292") to run the build command:

```
build/mvn clean install -Phadoop-3.2 -Phive-2.3 -Phive -pl sql/hive -am -DskipTests
```

And Java 17(openjdk version "17" 2021-09-14 LTS) to run the test command:

```
build/mvn test -Phadoop-3.2 -Phive-2.3 -Phive -pl sql/hive
```

**Before**

```
Run completed in 1 hour, 1 minute, 10 seconds.
Total number of tests run: 3547
Suites: completed 117, aborted 0
Tests: succeeded 3525, failed 22, canceled 6, ignored 605, pending 0
*** 22 TESTS FAILED ***
```

**After**

```
Run completed in 1 hour, 6 minutes, 6 seconds.
Total number of tests run: 3547
Suites: completed 117, aborted 0
Tests: succeeded 3547, failed 0, canceled 6, ignored 605, pending 0
All tests passed.

```