### PR TITLE
spark executor pod anti affinity when run on k8s

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -359,6 +359,17 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
+  val KUBERNETES_EXECUTOR_POD_AffinityKey =
+    ConfigBuilder("spark.kubernetes.executor.podAffinityKey")
+      .doc("spark executor pod affinity key")
+      .version("3.0.0")
+      .stringConf
+      .createOptional
+
+  val KUBERNETES_EXECUTOR_POD_AffinityOperator = "spark.kubernetes.executor.podAffinityOperator"
+
+  val KUBERNETES_EXECUTOR_POD_AffinityValue = "spark.kubernetes.executor.podAffinityValue"
+
   val KUBERNETES_DRIVER_PODTEMPLATE_CONTAINER_NAME =
     ConfigBuilder("spark.kubernetes.driver.podTemplateContainerName")
       .doc("container name to be used as a basis for the driver in the given pod template")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/AffinityFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/AffinityFeatureStep.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.features
+
+import io.fabric8.kubernetes.api.model._
+
+import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
+import org.apache.spark.deploy.k8s.Config._
+
+/**
+ * Create by xxh on 2021/10/25 10:40
+ */
+private[spark] class AffinityFeatureStep(conf: KubernetesConf)
+  extends KubernetesFeatureConfigStep {
+
+  private val hasAffinity = conf.contains(KUBERNETES_EXECUTOR_POD_AffinityKey)
+
+  override def configurePod(pod: SparkPod): SparkPod = {
+    if (hasAffinity) {
+
+      val affinity = {
+        val podAntiAffinity = {
+          val labelSelector = {
+            val labelSelectorRequirement = new LabelSelectorRequirementBuilder()
+              .withKey(conf.get(KUBERNETES_EXECUTOR_POD_AffinityKey.key))
+              .withOperator(conf.get(KUBERNETES_EXECUTOR_POD_AffinityOperator))
+              .withValues(conf.get(KUBERNETES_EXECUTOR_POD_AffinityValue))
+              .build()
+            new LabelSelectorBuilder()
+              .withMatchExpressions(labelSelectorRequirement)
+              .build()
+          }
+          val podAffinityTerm = new PodAffinityTermBuilder()
+            .withLabelSelector(labelSelector)
+            .withTopologyKey("kubernetes.io/hostname")
+            .build()
+          new PodAntiAffinityBuilder()
+            .withRequiredDuringSchedulingIgnoredDuringExecution(podAffinityTerm)
+            .build()
+        }
+
+        new AffinityBuilder().withPodAntiAffinity(podAntiAffinity).build()
+      }
+
+      val podWithAffinity = new PodBuilder(pod.pod)
+        .editSpec()
+        .withAffinity(affinity)
+        .endSpec()
+        .build()
+
+      SparkPod(podWithAffinity, pod.container)
+    } else {
+      pod
+    }
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -45,7 +45,8 @@ private[spark] class KubernetesExecutorBuilder {
       new MountSecretsFeatureStep(conf),
       new EnvSecretsFeatureStep(conf),
       new MountVolumesFeatureStep(conf),
-      new LocalDirsFeatureStep(conf))
+      new LocalDirsFeatureStep(conf),
+      new AffinityFeatureStep(conf))
 
     features.foldLeft(initialPod) { case (pod, feature) => feature.configurePod(pod) }
   }


### PR DESCRIPTION
I have realized the executor pod anti affinity. This prevents too many pods from starting on one node. 