### PR TITLE
[SPARK-37106][YARN] Pass all UTs in `resource-managers/yarn` with Java 17

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -57,7 +57,7 @@ import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Python._
-import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle, YarnCommandBuilderUtils}
+import org.apache.spark.launcher.{JavaModuleOptions, LauncherBackend, SparkAppHandle, YarnCommandBuilderUtils}
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.util.{CallerContext, Utils, YarnContainerInfoHelper}
@@ -932,6 +932,11 @@ private[spark] class Client(
     amContainer.setEnvironment(launchEnv.asJava)
 
     val javaOpts = ListBuffer[String]()
+
+    // SPARK-37106: To start AM with Java 17, `JavaModuleOptions.defaultModuleOptions`
+    // is added by default. It will not affect Java 8 and Java 11 due to existence of
+    // `-XX:+IgnoreUnrecognizedVMOptions`.
+    javaOpts += JavaModuleOptions.defaultModuleOptions()
 
     // Set the environment variable through a command prefix
     // to append to the existing value of the variable


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are 13 UTs failed in `resource-managers/yarn` module when test with Java 17 due to 
```
ERROR ApplicationMaster: Uncaught exception: 
org.apache.spark.SparkException: Exception thrown in awaitResult: 
        at org.apache.spark.util.ThreadUtils$.awaitResult(ThreadUtils.scala:301)
        at org.apache.spark.deploy.yarn.ApplicationMaster.runDriver(ApplicationMaster.scala:514)
        at org.apache.spark.deploy.yarn.ApplicationMaster.run(ApplicationMaster.scala:278)
        at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$3.run(ApplicationMaster.scala:929)
        at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$3.run(ApplicationMaster.scala:928)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
        at java.base/javax.security.auth.Subject.doAs(Subject.java:439)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1878)
        at org.apache.spark.deploy.yarn.ApplicationMaster$.main(ApplicationMaster.scala:928)
        at org.apache.spark.deploy.yarn.ApplicationMaster.main(ApplicationMaster.scala)
Caused by: java.util.concurrent.ExecutionException: Boxed Error
        at scala.concurrent.impl.Promise$.resolver(Promise.scala:87)
        at scala.concurrent.impl.Promise$.scala$concurrent$impl$Promise$$resolveTry(Promise.scala:79)
        at scala.concurrent.impl.Promise$DefaultPromise.tryComplete(Promise.scala:284)
        at scala.concurrent.Promise.tryFailure(Promise.scala:112)
        at scala.concurrent.Promise.tryFailure$(Promise.scala:112)
        at scala.concurrent.impl.Promise$DefaultPromise.tryFailure(Promise.scala:187)
        at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:761)
Caused by: java.lang.IllegalAccessError: class org.apache.spark.storage.StorageUtils$ (in unnamed module @0x2a48d10f) cannot access class sun.nio.ch.DirectBuffer (in module java.base) because module java.base does not export sun.nio.ch to unnamed module @0x2a48d10f
        at org.apache.spark.storage.StorageUtils$.<init>(StorageUtils.scala:213)
        at org.apache.spark.storage.StorageUtils$.<clinit>(StorageUtils.scala)
        at org.apache.spark.storage.BlockManagerMasterEndpoint.<init>(BlockManagerMasterEndpoint.scala:110)
        at org.apache.spark.SparkEnv$.$anonfun$create$9(SparkEnv.scala:348)
        at org.apache.spark.SparkEnv$.registerOrLookupEndpoint$1(SparkEnv.scala:287)
        at org.apache.spark.SparkEnv$.create(SparkEnv.scala:336)
        at org.apache.spark.SparkEnv$.createDriverEnv(SparkEnv.scala:191)
        at org.apache.spark.SparkContext.createSparkEnv(SparkContext.scala:278)
        at org.apache.spark.SparkContext.<init>(SparkContext.scala:463)
        at org.apache.spark.deploy.yarn.YarnExternalShuffleDriver$.main(YarnShuffleIntegrationSuite.scala:130)
        at org.apache.spark.deploy.yarn.YarnExternalShuffleDriver.main(YarnShuffleIntegrationSuite.scala)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:742)
```

So this pr add `JavaModuleOptions.defaultModuleOptions()` by default for AM startup, and  it will not affect Java 8 and Java 11 due to `JavaModuleOptions.defaultModuleOptions()` includes `-XX:+IgnoreUnrecognizedVMOptions`.

### Why are the changes needed?
Pass UT with JDK 17


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

- Pass the Jenkins or GitHub Action
- Manual test use Java17 build + Java17 run (both openjdk version "17" 2021-09-14 LTS)

Use Java 17 to run the following two commands

```
build/mvn clean install -DskipTests -pl resource-managers/yarn -am -Pyarn
build/mvn test -pl resource-managers/yarn -Pyarn
```

**Before**

```
Run completed in 5 minutes, 26 seconds.
Total number of tests run: 144
Suites: completed 19, aborted 0
Tests: succeeded 131, failed 13, canceled 1, ignored 0, pending 0
*** 13 TESTS FAILED ***
```

**After**

```
Run completed in 5 minutes, 52 seconds.
Total number of tests run: 144
Suites: completed 19, aborted 0
Tests: succeeded 144, failed 0, canceled 1, ignored 0, pending 0
All tests passed.
```

- Manual test use Java8 build + Java17 run 

Use Java 8(openjdk version "1.8.0_292") to run the build command:
```
build/mvn clean install -DskipTests -pl resource-managers/yarn -am -Pyarn
```

And Java 17(openjdk version "17" 2021-09-14 LTS) to run the test command:
```
build/mvn test -pl resource-managers/yarn -Pyarn
```

**Before**
```
Run completed in 5 minutes, 32 seconds.
Total number of tests run: 144
Suites: completed 19, aborted 0
Tests: succeeded 131, failed 13, canceled 1, ignored 0, pending 0
*** 13 TESTS FAILED ***

```

**After**

```
Run completed in 7 minutes, 16 seconds.
Total number of tests run: 144
Suites: completed 19, aborted 0
Tests: succeeded 144, failed 0, canceled 1, ignored 0, pending 0
All tests passed.

```
