### PR TITLE
[SPARK-37112][BUILD] Fix MiMa failure with Scala 2.13

### DIFF
--- a/dev/change-scala-version.sh
+++ b/dev/change-scala-version.sh
@@ -88,3 +88,13 @@ else
   sed_i 's:build/sbt \-Pscala\-'$FROM_VERSION':build/sbt:' "$BASEDIR/docs/_plugins/copy_api_dirs.rb"
 fi
 sed_i 's/scala\-'$FROM_VERSION'/scala\-'$TO_VERSION'/' "$BASEDIR/docs/_plugins/copy_api_dirs.rb"
+
+echo "$BASEDIR/dev/mima"
+if [ $TO_VERSION = "2.13" ]; then
+  sed_i '/\-Pscala-'$TO_VERSION'/!s:build/sbt:build/sbt \-Pscala\-'$TO_VERSION':' "$BASEDIR/dev/mima"
+  sed_i '/\-Pscala-'$TO_VERSION'/!s;SPARK_PROFILES=\${1:\-";SPARK_PROFILES=\${1:\-"\-Pscala\-'$TO_VERSION' ;' \
+    "$BASEDIR/dev/mima"
+else
+  sed_i 's/\-Pscala\-'$FROM_VERSION' //' "$BASEDIR/dev/mima"
+fi
+chmod 775 "$BASEDIR/dev/mima"

--- a/project/MimaBuild.scala
+++ b/project/MimaBuild.scala
@@ -88,11 +88,11 @@ object MimaBuild {
     val organization = "org.apache.spark"
     val previousSparkVersion = "3.2.0"
     val project = projectRef.project
-    val fullId = "spark-" + project + "_2.12"
+    val id = "spark-" + project
 
     Seq(
       mimaFailOnNoPrevious := true,
-      mimaPreviousArtifacts := Set(organization % fullId % previousSparkVersion),
+      mimaPreviousArtifacts := Set(organization %% id % previousSparkVersion),
       mimaBinaryIssueFilters ++= ignoredABIProblems(sparkHome, version.value)
     )
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes the MiMa failure with Scala 2.13.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
SPARK-36151 (#34306) re-enabled MiMa for Scala 2.13 but it always fails in the scheduled build.
https://github.com/apache/spark/runs/3992588994?check_suite_focus=true#step:9:2303
The reason is that `dev/mima` and `MimaBuild` don't consider `2.13`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
MiMa passed on GA with modified GA config (set `SCALA_PROFILE` to `scala2.13`).
https://github.com/sarutak/spark/runs/3998022279?check_suite_focus=true#step:9:19919

I also confirmed that `dev/change-scala-version.sh 2.12` and `dev/change-scala-version.sh 2.13` are idempotent.