### PR TITLE
[SPARK-37115][SQL] HiveClientImpl should use shim to wrap all hive client calls

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -343,14 +343,14 @@ private[hive] class HiveClientImpl(
       database: CatalogDatabase,
       ignoreIfExists: Boolean): Unit = withHiveState {
     val hiveDb = toHiveDatabase(database, Some(userName))
-    client.createDatabase(hiveDb, ignoreIfExists)
+    shim.createDatabase(client, hiveDb, ignoreIfExists)
   }
 
   override def dropDatabase(
       name: String,
       ignoreIfNotExists: Boolean,
       cascade: Boolean): Unit = withHiveState {
-    client.dropDatabase(name, true, ignoreIfNotExists, cascade)
+    shim.dropDatabase(client, name, true, ignoreIfNotExists, cascade)
   }
 
   override def alterDatabase(database: CatalogDatabase): Unit = withHiveState {
@@ -361,7 +361,7 @@ private[hive] class HiveClientImpl(
       }
     }
     val hiveDb = toHiveDatabase(database)
-    client.alterDatabase(database.name, hiveDb)
+    shim.alterDatabase(client, database.name, hiveDb)
   }
 
   private def toHiveDatabase(
@@ -379,7 +379,7 @@ private[hive] class HiveClientImpl(
   }
 
   override def getDatabase(dbName: String): CatalogDatabase = withHiveState {
-    Option(client.getDatabase(dbName)).map { d =>
+    Option(shim.getDatabase(client, dbName)).map { d =>
       val params = Option(d.getParameters).map(_.asScala.toMap).getOrElse(Map()) ++
         Map(PROP_OWNER -> shim.getDatabaseOwnerName(d))
 
@@ -392,15 +392,15 @@ private[hive] class HiveClientImpl(
   }
 
   override def databaseExists(dbName: String): Boolean = withHiveState {
-    client.databaseExists(dbName)
+    shim.databaseExists(client, dbName)
   }
 
   override def listDatabases(pattern: String): Seq[String] = withHiveState {
-    client.getDatabasesByPattern(pattern).asScala.toSeq
+    shim.getDatabasesByPattern(client, pattern).asScala.toSeq
   }
 
   private def getRawTableOption(dbName: String, tableName: String): Option[HiveTable] = {
-    Option(client.getTable(dbName, tableName, false /* do not throw exception */))
+    Option(shim.getTable(client, dbName, tableName, false /* do not throw exception */))
   }
 
   private def getRawTablesByName(dbName: String, tableNames: Seq[String]): Seq[HiveTable] = {
@@ -551,7 +551,7 @@ private[hive] class HiveClientImpl(
 
   override def createTable(table: CatalogTable, ignoreIfExists: Boolean): Unit = withHiveState {
     verifyColumnDataType(table.dataSchema)
-    client.createTable(toHiveTable(table, Some(userName)), ignoreIfExists)
+    shim.createTable(client, toHiveTable(table, Some(userName)), ignoreIfExists)
   }
 
   override def dropTable(
@@ -583,7 +583,7 @@ private[hive] class HiveClientImpl(
       tableName: String,
       newDataSchema: StructType,
       schemaProps: Map[String, String]): Unit = withHiveState {
-    val oldTable = client.getTable(dbName, tableName)
+    val oldTable = shim.getTable(client, dbName, tableName)
     verifyColumnDataType(newDataSchema)
     val hiveCols = newDataSchema.map(toHiveColumn)
     oldTable.setFields(hiveCols.asJava)
@@ -630,7 +630,7 @@ private[hive] class HiveClientImpl(
       purge: Boolean,
       retainData: Boolean): Unit = withHiveState {
     // TODO: figure out how to drop multiple partitions in one call
-    val hiveTable = client.getTable(db, table, true /* throw exception */)
+    val hiveTable = shim.getTable(client, db, table, true /* throw exception */)
     // do the check at first and collect all the matching partitions
     val matchingParts =
       specs.flatMap { s =>
@@ -638,7 +638,7 @@ private[hive] class HiveClientImpl(
         // The provided spec here can be a partial spec, i.e. it will match all partitions
         // whose specs are supersets of this partial spec. E.g. If a table has partitions
         // (b='1', c='1') and (b='1', c='2'), a partial spec of (b='1') will match both.
-        val parts = client.getPartitions(hiveTable, s.asJava).asScala
+        val parts = shim.getPartitions(client, hiveTable, s.asJava).asScala
         if (parts.isEmpty && !ignoreIfNotExists) {
           throw new NoSuchPartitionsException(db, table, Seq(s))
         }
@@ -677,13 +677,13 @@ private[hive] class HiveClientImpl(
     val catalogTable = getTable(db, table)
     val hiveTable = toHiveTable(catalogTable, Some(userName))
     specs.zip(newSpecs).foreach { case (oldSpec, newSpec) =>
-      if (client.getPartition(hiveTable, newSpec.asJava, false) != null) {
+      if (shim.getPartition(client, hiveTable, newSpec.asJava, false) != null) {
         throw new PartitionAlreadyExistsException(db, table, newSpec)
       }
       val hivePart = getPartitionOption(catalogTable, oldSpec)
         .map { p => toHivePartition(p.copy(spec = newSpec), hiveTable) }
         .getOrElse { throw new NoSuchPartitionException(db, table, oldSpec) }
-      client.renamePartition(hiveTable, oldSpec.asJava, hivePart)
+      shim.renamePartition(client, hiveTable, oldSpec.asJava, hivePart)
     }
   }
 
@@ -718,10 +718,10 @@ private[hive] class HiveClientImpl(
       partialSpec match {
         case None =>
           // -1 for result limit means "no limit/return all"
-          client.getPartitionNames(table.database, table.identifier.table, -1)
+          shim.getPartitionNames(client, table.database, table.identifier.table, -1)
         case Some(s) =>
           assert(s.values.forall(_.nonEmpty), s"partition spec '$s' is invalid")
-          client.getPartitionNames(table.database, table.identifier.table, s.asJava, -1)
+          shim.getPartitionNames(client, table.database, table.identifier.table, s.asJava, -1)
       }
     hivePartitionNames.asScala.sorted.toSeq
   }
@@ -730,7 +730,7 @@ private[hive] class HiveClientImpl(
       table: CatalogTable,
       spec: TablePartitionSpec): Option[CatalogTablePartition] = withHiveState {
     val hiveTable = toHiveTable(table, Some(userName))
-    val hivePartition = client.getPartition(hiveTable, spec.asJava, false)
+    val hivePartition = shim.getPartition(client, hiveTable, spec.asJava, false)
     Option(hivePartition).map(fromHivePartition)
   }
 
@@ -753,7 +753,8 @@ private[hive] class HiveClientImpl(
         assert(s.values.forall(_.nonEmpty), s"partition spec '$s' is invalid")
         s
     }
-    val parts = client.getPartitions(hiveTable, partSpec.asJava).asScala.map(fromHivePartition)
+    val parts = shim.getPartitions(client, hiveTable, partSpec.asJava)
+      .asScala.map(fromHivePartition)
     HiveCatalogMetrics.incrementFetchedPartitions(parts.length)
     parts.toSeq
   }
@@ -769,11 +770,11 @@ private[hive] class HiveClientImpl(
   }
 
   override def listTables(dbName: String): Seq[String] = withHiveState {
-    client.getAllTables(dbName).asScala.toSeq
+    shim.getAllTables(client, dbName).asScala.toSeq
   }
 
   override def listTables(dbName: String, pattern: String): Seq[String] = withHiveState {
-    client.getTablesByPattern(dbName, pattern).asScala.toSeq
+    shim.getTablesByPattern(client, dbName, pattern).asScala.toSeq
   }
 
   override def listTablesByType(
@@ -787,7 +788,7 @@ private[hive] class HiveClientImpl(
     } catch {
       case _: UnsupportedOperationException =>
         // Fallback to filter logic if getTablesByType not supported.
-        val tableNames = client.getTablesByPattern(dbName, pattern).asScala
+        val tableNames = shim.getTablesByPattern(client, dbName, pattern).asScala
         getRawTablesByName(dbName, tableNames.toSeq)
           .filter(_.getTableType == hiveTableType)
           .map(_.getTableName)
@@ -887,7 +888,7 @@ private[hive] class HiveClientImpl(
       replace: Boolean,
       inheritTableSpecs: Boolean,
       isSrcLocal: Boolean): Unit = withHiveState {
-    val hiveTable = client.getTable(dbName, tableName, true /* throw exception */)
+    val hiveTable = shim.getTable(client, dbName, tableName, true /* throw exception */)
     shim.loadPartition(
       client,
       new Path(loadPath), // TODO: Use URI
@@ -919,7 +920,7 @@ private[hive] class HiveClientImpl(
       partSpec: java.util.LinkedHashMap[String, String],
       replace: Boolean,
       numDP: Int): Unit = withHiveState {
-    val hiveTable = client.getTable(dbName, tableName, true /* throw exception */)
+    val hiveTable = shim.getTable(client, dbName, tableName, true /* throw exception */)
     shim.loadDynamicPartitions(
       client,
       new Path(loadPath),
@@ -965,36 +966,36 @@ private[hive] class HiveClientImpl(
   }
 
   def reset(): Unit = withHiveState {
-    val allTables = client.getAllTables("default")
-    val (mvs, others) = allTables.asScala.map(t => client.getTable("default", t))
+    val allTables = shim.getAllTables(client, "default")
+    val (mvs, others) = allTables.asScala.map(t => shim.getTable(client, "default", t))
       .partition(_.getTableType.toString.equals("MATERIALIZED_VIEW"))
 
     // Remove materialized view first, otherwise caused a violation of foreign key constraint.
     mvs.foreach { table =>
       val t = table.getTableName
       logDebug(s"Deleting materialized view $t")
-      client.dropTable("default", t)
+      shim.dropTable(client, "default", t)
     }
 
     others.foreach { table =>
       val t = table.getTableName
       logDebug(s"Deleting table $t")
       try {
-        client.getIndexes("default", t, 255).asScala.foreach { index =>
+        shim.getIndexes(client, "default", t, 255).asScala.foreach { index =>
           shim.dropIndex(client, "default", t, index.getIndexName)
         }
         if (!table.isIndexTable) {
-          client.dropTable("default", t)
+          shim.dropTable(client, "default", t)
         }
       } catch {
         case _: NoSuchMethodError =>
           // HIVE-18448 Hive 3.0 remove index APIs
-          client.dropTable("default", t)
+          shim.dropTable(client, "default", t)
       }
     }
-    client.getAllDatabases.asScala.filterNot(_ == "default").foreach { db =>
+    shim.getAllDatabases(client).asScala.filterNot(_ == "default").foreach { db =>
       logDebug(s"Dropping Database: $db")
-      client.dropDatabase(db, true, false, true)
+      shim.dropDatabase(client, db, true, false, true)
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -481,14 +481,6 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       classOf[JMap[String, String]],
       classOf[Partition])
 
-  private lazy val getIndexesMethod =
-    findMethod(
-      classOf[Hive],
-      "getIndexes",
-      classOf[String],
-      classOf[String],
-      JShort.TYPE)
-
   override def setCurrentSessionState(state: SessionState): Unit = {
     // Starting from Hive 0.13, setCurrentSessionState will internally override
     // the context class loader of the current thread by the class loader set in
@@ -783,7 +775,8 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tblName: String,
       max: Short): JList[Index] = {
-    getIndexesMethod.invoke(hive, dbName, tblName, max: JShort).asInstanceOf[JList[Index]]
+    // Since Hive 3 remove getIndex method, here Spark directly call hive client's method.
+    hive.getIndexes(dbName, tblName, max: JShort)
   }
 }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hive.client
 
-import java.lang.{Boolean => JBoolean, Integer => JInteger, Long => JLong, Short => JShort}
+import java.lang.{Boolean => JBoolean, Integer => JInteger, Long => JLong}
 import java.lang.reflect.{InvocationTargetException, Method, Modifier}
 import java.net.URI
 import java.util.{ArrayList => JArrayList, List => JList, Locale, Map => JMap, Set => JSet}
@@ -627,7 +627,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tblName: String,
       max: Short): JList[String] = {
-    hive.getPartitionNames(dbName, tblName, max: JShort)
+    hive.getPartitionNames(dbName, tblName, max)
   }
 
   override def getPartitionNames(
@@ -636,7 +636,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       tblName: String,
       partSpec: JMap[String, String],
       max: Short): JList[String] = {
-    hive.getPartitionNames(dbName, tblName, partSpec, max: JShort)
+    hive.getPartitionNames(dbName, tblName, partSpec, max)
   }
 
   override def renamePartition(
@@ -652,7 +652,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tblName: String,
       max: Short): JList[Index] = {
-    hive.getIndexes(dbName, tblName, max: JShort)
+    hive.getIndexes(dbName, tblName, max)
   }
 }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -551,7 +551,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
   override def setDatabaseOwnerName(db: Database, owner: String): Unit = {}
 
   override def createDatabase(hive: Hive, db: Database, ignoreIfExists: Boolean): Unit = {
-    hive.createDatabase(db, ignoreIfExists: JBoolean)
+    hive.createDatabase(db, ignoreIfExists)
   }
 
   override def dropDatabase(
@@ -592,7 +592,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tableName: String,
       throwException: Boolean): Table = {
-    hive.getTable(dbName, tableName, throwException: JBoolean)
+    hive.getTable(dbName, tableName, throwException)
   }
 
   override def getTablesByPattern(hive: Hive, dbName: String, pattern: String): JList[String] = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -148,10 +148,10 @@ private[client] sealed abstract class Shim {
       partSpec: JMap[String, String]): JList[Partition]
 
   def getPartitionNames(
-    hive: Hive,
-    dbName: String,
-    tblName: String,
-    max: Short): JList[String]
+      hive: Hive,
+      dbName: String,
+      tblName: String,
+      max: Short): JList[String]
 
   def getPartitionNames(
       hive: Hive,
@@ -600,7 +600,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
   }
 
   override def getAllTables(hive: Hive, dbName: String): JList[String] = {
-   hive.getAllTables(dbName)
+    hive.getAllTables(dbName)
   }
 
   override def dropTable(hive: Hive, dbName: String, tableName: String): Unit = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -81,7 +81,7 @@ private[client] sealed abstract class Shim {
 
   def dropDatabase(
       hive: Hive,
-      name: String,
+      dbName: String,
       deleteData: Boolean,
       ignoreUnknownDb: Boolean,
       cascade: Boolean): Unit
@@ -150,20 +150,20 @@ private[client] sealed abstract class Shim {
   def getPartitionNames(
       hive: Hive,
       dbName: String,
-      tblName: String,
+      tableName: String,
       max: Short): JList[String]
 
   def getPartitionNames(
       hive: Hive,
       dbName: String,
-      tblName: String,
+      tableName: String,
       partSpec: JMap[String, String],
       max: Short): JList[String]
 
   def createPartitions(
       hive: Hive,
-      db: String,
-      table: String,
+      dbName: String,
+      tableName: String,
       parts: Seq[CatalogTablePartition],
       ignoreIfExists: Boolean): Unit
 
@@ -179,7 +179,7 @@ private[client] sealed abstract class Shim {
 
   def renamePartition(
       hive: Hive,
-      tbl: Table,
+      table: Table,
       oldPartSpec: JMap[String, String],
       newPart: Partition): Unit
 
@@ -242,7 +242,7 @@ private[client] sealed abstract class Shim {
 
   def getMSC(hive: Hive): IMetaStoreClient
 
-  def getIndexes(hive: Hive, dbName: String, tblName: String, max: Short): JList[Index]
+  def getIndexes(hive: Hive, dbName: String, tableName: String, max: Short): JList[Index]
 
   protected def findMethod(klass: Class[_], name: String, args: Class[_]*): Method = {
     klass.getMethod(name, args: _*)
@@ -556,11 +556,11 @@ private[client] class Shim_v0_12 extends Shim with Logging {
 
   override def dropDatabase(
       hive: Hive,
-      name: String,
+      dbName: String,
       deleteData: Boolean,
       ignoreUnknownDb: Boolean,
       cascade: Boolean): Unit = {
-    hive.dropDatabase(name, deleteData, ignoreUnknownDb, cascade)
+    hive.dropDatabase(dbName, deleteData, ignoreUnknownDb, cascade)
   }
 
   override def alterDatabase(hive: Hive, dbName: String, d: Database): Unit = {
@@ -625,34 +625,34 @@ private[client] class Shim_v0_12 extends Shim with Logging {
   override def getPartitionNames(
       hive: Hive,
       dbName: String,
-      tblName: String,
+      tableName: String,
       max: Short): JList[String] = {
-    hive.getPartitionNames(dbName, tblName, max)
+    hive.getPartitionNames(dbName, tableName, max)
   }
 
   override def getPartitionNames(
       hive: Hive,
       dbName: String,
-      tblName: String,
+      tableName: String,
       partSpec: JMap[String, String],
       max: Short): JList[String] = {
-    hive.getPartitionNames(dbName, tblName, partSpec, max)
+    hive.getPartitionNames(dbName, tableName, partSpec, max)
   }
 
   override def renamePartition(
       hive: Hive,
-      tbl: Table,
+      table: Table,
       oldPartSpec: JMap[String, String],
       newPart: Partition): Unit = {
-    hive.renamePartition(tbl, oldPartSpec, newPart)
+    hive.renamePartition(table, oldPartSpec, newPart)
   }
 
   override def getIndexes(
       hive: Hive,
       dbName: String,
-      tblName: String,
+      tableName: String,
       max: Short): JList[Index] = {
-    hive.getIndexes(dbName, tblName, max)
+    hive.getIndexes(dbName, tableName, max)
   }
 }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -476,7 +476,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
   private lazy val renamePartitionMethod =
     findMethod(
       classOf[Hive],
-      "getPartitionNames",
+      "renamePartition",
       classOf[Table],
       classOf[JMap[String, String]],
       classOf[Partition])

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -360,127 +360,6 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       classOf[String],
       classOf[JList[Partition]])
 
-  private lazy val createDatabaseMethod =
-    findMethod(
-      classOf[Hive],
-      "createDatabase",
-      classOf[Database],
-      JBoolean.TYPE)
-
-  private lazy val dropDatabaseMethod =
-    findMethod(
-      classOf[Hive],
-      "dropDatabase",
-      classOf[String],
-      JBoolean.TYPE,
-      JBoolean.TYPE,
-      JBoolean.TYPE)
-
-  private lazy val alterDatabaseMethod =
-    findMethod(
-      classOf[Hive],
-      "alterDatabase",
-      classOf[String],
-      classOf[Database])
-
-  private lazy val getDatabaseMethod =
-    findMethod(
-      classOf[Hive],
-      "getDatabase",
-      classOf[String])
-
-  private lazy val getAllDatabasesMethod =
-    findMethod(
-      classOf[Hive],
-      "getAllDatabases")
-
-  private lazy val getDatabasesByPatternMethod =
-    findMethod(
-      classOf[Hive],
-      "getDatabasesByPattern",
-      classOf[String])
-
-  private lazy val databaseExistsMethod =
-    findMethod(
-      classOf[Hive],
-      "databaseExists",
-      classOf[String])
-
-  private lazy val createTableMethod =
-    findMethod(
-      classOf[Hive],
-      "createTable",
-      classOf[Table],
-      JBoolean.TYPE)
-
-  private lazy val getTableMethod =
-    findMethod(
-      classOf[Hive],
-      "getTable",
-      classOf[String],
-      classOf[String],
-      JBoolean.TYPE)
-
-  private lazy val getTablesByPatternMethod =
-    findMethod(
-      classOf[Hive],
-      "getTablesByPattern",
-      classOf[String],
-      classOf[String])
-
-  private lazy val getAllTablesMethod =
-    findMethod(
-      classOf[Hive],
-      "getAllTables",
-      classOf[String])
-
-  private lazy val dropTableMethod =
-    findMethod(
-      classOf[Hive],
-      "dropTable",
-      classOf[String],
-      classOf[String])
-
-  private lazy val getPartitionMethod =
-    findMethod(
-      classOf[Hive],
-      "getPartition",
-      classOf[Table],
-      classOf[JMap[String, String]],
-      JBoolean.TYPE)
-
-  private lazy val getPartitionsMethod =
-    findMethod(
-      classOf[Hive],
-      "getPartitions",
-      classOf[Table],
-      classOf[JMap[String, String]])
-
-  private lazy val getPartitionNamesMethod =
-    findMethod(
-      classOf[Hive],
-      "getPartitionNames",
-      classOf[String],
-      classOf[String],
-      JShort.TYPE)
-
-  private lazy val getPartitionNamesWithSpecMethod =
-    findMethod(
-      classOf[Hive],
-      "getPartitionNames",
-      classOf[String],
-      classOf[String],
-      classOf[JMap[String, String]],
-      JShort.TYPE)
-
-  private lazy val renamePartitionMethod =
-    findMethod(
-      classOf[Hive],
-      "renamePartition",
-      classOf[Table],
-      classOf[JMap[String, String]],
-      classOf[Partition])
-
   override def setCurrentSessionState(state: SessionState): Unit = {
     // Starting from Hive 0.13, setCurrentSessionState will internally override
     // the context class loader of the current thread by the class loader set in
@@ -672,7 +551,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
   override def setDatabaseOwnerName(db: Database, owner: String): Unit = {}
 
   override def createDatabase(hive: Hive, db: Database, ignoreIfExists: Boolean): Unit = {
-    createDatabaseMethod.invoke(hive, db, ignoreIfExists: JBoolean)
+    hive.createDatabase(db, ignoreIfExists: JBoolean)
   }
 
   override def dropDatabase(
@@ -681,32 +560,31 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       deleteData: Boolean,
       ignoreUnknownDb: Boolean,
       cascade: Boolean): Unit = {
-    dropDatabaseMethod.invoke(
-      hive, name, deleteData: JBoolean, ignoreUnknownDb: JBoolean, cascade: JBoolean)
+    hive.dropDatabase(name, deleteData, ignoreUnknownDb, cascade)
   }
 
   override def alterDatabase(hive: Hive, dbName: String, d: Database): Unit = {
-    alterDatabaseMethod.invoke(hive, dbName, d)
+    hive.alterDatabase(dbName, d)
   }
 
   override def getDatabase(hive: Hive, dbName: String): Database = {
-    getDatabaseMethod.invoke(hive, dbName).asInstanceOf[Database]
+    hive.getDatabase(dbName)
   }
 
   override def getAllDatabases(hive: Hive): JList[String] = {
-    getAllDatabasesMethod.invoke(hive).asInstanceOf[JList[String]]
+    hive.getAllDatabases
   }
 
   override def getDatabasesByPattern(hive: Hive, pattern: String): JList[String] = {
-    getDatabasesByPatternMethod.invoke(hive, pattern).asInstanceOf[JList[String]]
+    hive.getDatabasesByPattern(pattern)
   }
 
   override def databaseExists(hive: Hive, dbName: String): Boolean = {
-    databaseExistsMethod.invoke(hive, dbName).asInstanceOf[Boolean]
+    hive.databaseExists(dbName)
   }
 
   override def createTable(hive: Hive, table: Table, ifNotExists: Boolean): Unit = {
-    createTableMethod.invoke(hive, table, ifNotExists: JBoolean)
+    hive.createTable(table, ifNotExists)
   }
 
   override def getTable(
@@ -714,19 +592,19 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tableName: String,
       throwException: Boolean): Table = {
-    getTableMethod.invoke(hive, dbName, tableName, throwException: JBoolean).asInstanceOf[Table]
+    hive.getTable(dbName, tableName, throwException: JBoolean)
   }
 
   override def getTablesByPattern(hive: Hive, dbName: String, pattern: String): JList[String] = {
-    getTablesByPatternMethod.invoke(hive, dbName, pattern).asInstanceOf[JList[String]]
+    hive.getTablesByPattern(dbName, pattern)
   }
 
   override def getAllTables(hive: Hive, dbName: String): JList[String] = {
-    getAllTablesMethod.invoke(hive, dbName).asInstanceOf[JList[String]]
+   hive.getAllTables(dbName)
   }
 
   override def dropTable(hive: Hive, dbName: String, tableName: String): Unit = {
-    dropTableMethod.invoke(hive, dbName, tableName)
+    hive.dropTable(dbName, tableName)
   }
 
   override def getPartition(
@@ -734,14 +612,14 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       table: Table,
       partSpec: JMap[String, String],
       forceCreate: Boolean): Partition = {
-    getPartitionMethod.invoke(hive, table, partSpec, forceCreate: JBoolean).asInstanceOf[Partition]
+    hive.getPartition(table, partSpec, forceCreate)
   }
 
   override def getPartitions(
       hive: Hive,
       table: Table,
       partSpec: JMap[String, String]): JList[Partition] = {
-    getPartitionsMethod.invoke(hive, table, partSpec).asInstanceOf[JList[Partition]]
+    hive.getPartitions(table, partSpec)
   }
 
   override def getPartitionNames(
@@ -749,7 +627,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tblName: String,
       max: Short): JList[String] = {
-    getPartitionNamesMethod.invoke(hive, dbName, tblName, max: JShort).asInstanceOf[JList[String]]
+    hive.getPartitionNames(dbName, tblName, max: JShort)
   }
 
   override def getPartitionNames(
@@ -758,8 +636,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       tblName: String,
       partSpec: JMap[String, String],
       max: Short): JList[String] = {
-    getPartitionNamesWithSpecMethod.invoke(hive, dbName, tblName, partSpec, max: JShort)
-      .asInstanceOf[JList[String]]
+    hive.getPartitionNames(dbName, tblName, partSpec, max: JShort)
   }
 
   override def renamePartition(
@@ -767,7 +644,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       tbl: Table,
       oldPartSpec: JMap[String, String],
       newPart: Partition): Unit = {
-    renamePartitionMethod.invoke(hive, tbl, oldPartSpec, newPart)
+    hive.renamePartition(tbl, oldPartSpec, newPart)
   }
 
   override def getIndexes(
@@ -775,7 +652,6 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tblName: String,
       max: Short): JList[Index] = {
-    // Since Hive 3 remove getIndex method, here Spark directly call hive client's method.
     hive.getIndexes(dbName, tblName, max: JShort)
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -90,9 +90,9 @@ private[client] sealed abstract class Shim {
 
   def getDatabase(hive: Hive, dbName: String): Database
 
-  def getAllDatabases(hive: Hive): JList[String]
+  def getAllDatabases(hive: Hive): Seq[String]
 
-  def getDatabasesByPattern(hive: Hive, pattern: String): JList[String]
+  def getDatabasesByPattern(hive: Hive, pattern: String): Seq[String]
 
   def databaseExists(hive: Hive, dbName: String): Boolean
 
@@ -130,9 +130,9 @@ private[client] sealed abstract class Shim {
       pattern: String,
       tableType: TableType): Seq[String]
 
-  def getTablesByPattern(hive: Hive, dbName: String, pattern: String): JList[String]
+  def getTablesByPattern(hive: Hive, dbName: String, pattern: String): Seq[String]
 
-  def getAllTables(hive: Hive, dbName: String): JList[String]
+  def getAllTables(hive: Hive, dbName: String): Seq[String]
 
   def dropTable(hive: Hive, dbName: String, tableName: String): Unit
 
@@ -145,20 +145,20 @@ private[client] sealed abstract class Shim {
   def getPartitions(
       hive: Hive,
       table: Table,
-      partSpec: JMap[String, String]): JList[Partition]
+      partSpec: JMap[String, String]): Seq[Partition]
 
   def getPartitionNames(
       hive: Hive,
       dbName: String,
       tableName: String,
-      max: Short): JList[String]
+      max: Short): Seq[String]
 
   def getPartitionNames(
       hive: Hive,
       dbName: String,
       tableName: String,
       partSpec: JMap[String, String],
-      max: Short): JList[String]
+      max: Short): Seq[String]
 
   def createPartitions(
       hive: Hive,
@@ -242,7 +242,7 @@ private[client] sealed abstract class Shim {
 
   def getMSC(hive: Hive): IMetaStoreClient
 
-  def getIndexes(hive: Hive, dbName: String, tableName: String, max: Short): JList[Index]
+  def getIndexes(hive: Hive, dbName: String, tableName: String, max: Short): Seq[Index]
 
   protected def findMethod(klass: Class[_], name: String, args: Class[_]*): Method = {
     klass.getMethod(name, args: _*)
@@ -571,12 +571,12 @@ private[client] class Shim_v0_12 extends Shim with Logging {
     hive.getDatabase(dbName)
   }
 
-  override def getAllDatabases(hive: Hive): JList[String] = {
-    hive.getAllDatabases
+  override def getAllDatabases(hive: Hive): Seq[String] = {
+    hive.getAllDatabases.asScala.toSeq
   }
 
-  override def getDatabasesByPattern(hive: Hive, pattern: String): JList[String] = {
-    hive.getDatabasesByPattern(pattern)
+  override def getDatabasesByPattern(hive: Hive, pattern: String): Seq[String] = {
+    hive.getDatabasesByPattern(pattern).asScala.toSeq
   }
 
   override def databaseExists(hive: Hive, dbName: String): Boolean = {
@@ -595,12 +595,12 @@ private[client] class Shim_v0_12 extends Shim with Logging {
     hive.getTable(dbName, tableName, throwException)
   }
 
-  override def getTablesByPattern(hive: Hive, dbName: String, pattern: String): JList[String] = {
-    hive.getTablesByPattern(dbName, pattern)
+  override def getTablesByPattern(hive: Hive, dbName: String, pattern: String): Seq[String] = {
+    hive.getTablesByPattern(dbName, pattern).asScala.toSeq
   }
 
-  override def getAllTables(hive: Hive, dbName: String): JList[String] = {
-    hive.getAllTables(dbName)
+  override def getAllTables(hive: Hive, dbName: String): Seq[String] = {
+    hive.getAllTables(dbName).asScala.toSeq
   }
 
   override def dropTable(hive: Hive, dbName: String, tableName: String): Unit = {
@@ -618,16 +618,16 @@ private[client] class Shim_v0_12 extends Shim with Logging {
   override def getPartitions(
       hive: Hive,
       table: Table,
-      partSpec: JMap[String, String]): JList[Partition] = {
-    hive.getPartitions(table, partSpec)
+      partSpec: JMap[String, String]): Seq[Partition] = {
+    hive.getPartitions(table, partSpec).asScala.toSeq
   }
 
   override def getPartitionNames(
       hive: Hive,
       dbName: String,
       tableName: String,
-      max: Short): JList[String] = {
-    hive.getPartitionNames(dbName, tableName, max)
+      max: Short): Seq[String] = {
+    hive.getPartitionNames(dbName, tableName, max).asScala.toSeq
   }
 
   override def getPartitionNames(
@@ -635,8 +635,8 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tableName: String,
       partSpec: JMap[String, String],
-      max: Short): JList[String] = {
-    hive.getPartitionNames(dbName, tableName, partSpec, max)
+      max: Short): Seq[String] = {
+    hive.getPartitionNames(dbName, tableName, partSpec, max).asScala.toSeq
   }
 
   override def renamePartition(
@@ -651,8 +651,8 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       hive: Hive,
       dbName: String,
       tableName: String,
-      max: Short): JList[Index] = {
-    hive.getIndexes(dbName, tableName, max)
+      max: Short): Seq[Index] = {
+    hive.getIndexes(dbName, tableName, max).asScala.toSeq
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this pr we use `shim` to wrap all hive client api to make it easier.


### Why are the changes needed?
Use `shim` to wrap all hive client api  to make it easier.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existed UT
