### PR TITLE
[SPARK-37121] [HIVE][TEST] Fix Python version detection bug in TestUtils used by HiveExternalCatalogVersionsSuite

### DIFF
--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -38,7 +38,6 @@ import scala.io.Source
 import scala.reflect.{classTag, ClassTag}
 import scala.sys.process.{Process, ProcessLogger}
 import scala.util.Try
-import scala.util.control.NonFatal
 
 import com.google.common.io.{ByteStreams, Files}
 import org.apache.commons.lang3.StringUtils
@@ -280,14 +279,8 @@ private[spark] object TestUtils {
 
   def isPythonVersionAtLeast38(): Boolean = {
     val cmdSeq = if (Utils.isWindows) Seq("cmd.exe", "/C") else Seq("sh", "-c")
-    val versionPattern = """Python 3\.(\d+)\.\d+""".r
-    try {
-      Process(cmdSeq :+ "python3 --version").!!.trim match {
-        case versionPattern(minorVersion) => minorVersion.toInt >= 8
-      }
-    } catch {
-      case NonFatal(_) => false
-    }
+    val pythonSnippet = "import sys; sys.exit(sys.version_info < (3, 8, 0))"
+    Try(Process(cmdSeq :+ s"python3 -c '$pythonSnippet'").! == 0).getOrElse(false)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -280,10 +280,10 @@ private[spark] object TestUtils {
 
   def isPythonVersionAtLeast38(): Boolean = {
     val cmdSeq = if (Utils.isWindows) Seq("cmd.exe", "/C") else Seq("sh", "-c")
-    val versionPattern = """Python (\d+)\.(\d+)\.\d+""".r
+    val versionPattern = """Python 3\.(\d+)\.\d+""".r
     try {
       Process(cmdSeq :+ "python3 --version").!!.trim match {
-        case versionPattern(v1, v2) => v1.toInt > 3 || (v1.toInt == 3 && v2.toInt >= 8)
+        case versionPattern(minorVersion) => minorVersion.toInt >= 8
       }
     } catch {
       case NonFatal(_) => false


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix a bug in `TestUtils.isPythonVersionAtLeast38` to allow for `HiveExternalCatalogVersionsSuite` to test against Spark 2.x releases in environments with Python <= 3.7.

### Why are the changes needed?
The logic in `TestUtils.isPythonVersionAtLeast38` was added in #30044 to prevent Spark 2.4 from being run in an environment where the Python3 version installed was >= Python 3.8, which is not compatible with Spark 2.4. However, this method always returns true, so only Spark 3.x versions will ever be included in the version set for `HiveExternalCatalogVersionsSuite`, regardless of the system-installed version of Python.

The problem is here:
https://github.com/apache/spark/blob/951efb80856e2a92ba3690886c95643567dae9d0/core/src/main/scala/org/apache/spark/TestUtils.scala#L280-L291
It's trying to evaluate the version of Python using a `ProcessLogger`, but the logger accepts a `String => Unit` function, i.e., it does not make use of the return value in any way (since it's meant for logging). So the result of the `startsWith` checks are thrown away, and `attempt.isSuccess && attempt.get == 0` will always be true as long as your system has a `python3` binary (of any version).

### Does this PR introduce _any_ user-facing change?
No, test changes only.

### How was this patch tested?
Confirmed by checking that `HiveExternalCatalogVersionsSuite` downloads binary distros for Spark 2.x lines as well as 3.x when I symlink my `python3` to Python 3.7, and only downloads distros for the 3.x lines when I symlink my `python3` to Python 3.9.

```bash
brew link --force python@3.7
# run HiveExternalCatalogVersionsSuite and validate that 2.x and 3.x tests get executed
brew unlink python@3.7
brew link --force python@3.9
# run HiveExternalCatalogVersionsSuite and validate that only 3.x tests get executed
```