### PR TITLE
[SPARK-37124][SQL] Support RowToColumnarExec with Arrow format

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -133,6 +133,10 @@ public final class ArrowColumnVector extends ColumnVector {
   @Override
   public ArrowColumnVector getChild(int ordinal) { return childColumns[ordinal]; }
 
+  public ValueVector getArrowVector() {
+    return accessor.vector;
+  }
+
   public ArrowColumnVector(ValueVector vector) {
     super(ArrowUtils.fromArrowField(vector.getField()));
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -386,6 +386,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val COLUMN_VECTOR_ARROW_ENABLED =
+    buildConf("spark.sql.columnVector.arrow.enabled")
+      .internal()
+      .doc("When true, use ArrowWritableColumnVector in ColumnarBatch.")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val PREFER_SORTMERGEJOIN = buildConf("spark.sql.join.preferSortMergeJoin")
     .internal()
     .doc("When true, prefer sort merge join over shuffled hash join. " +
@@ -3843,6 +3851,8 @@ class SQLConf extends Serializable with Logging {
   def inMemoryTableScanStatisticsEnabled: Boolean = getConf(IN_MEMORY_TABLE_SCAN_STATISTICS_ENABLED)
 
   def offHeapColumnVectorEnabled: Boolean = getConf(COLUMN_VECTOR_OFFHEAP_ENABLED)
+
+  def arrowColumnVectorEnabled: Boolean = getConf(COLUMN_VECTOR_ARROW_ENABLED)
 
   def columnNameOfCorruptRecord: String = getConf(COLUMN_NAME_OF_CORRUPT_RECORD)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.types._
 private[sql] object ArrowUtils {
 
   val rootAllocator = new RootAllocator(Long.MaxValue)
-  def getDefaultAllocator: RootAllocator = rootAllocator
 
   // todo: support more types.
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.types._
 private[sql] object ArrowUtils {
 
   val rootAllocator = new RootAllocator(Long.MaxValue)
+  def getDefaultAllocator: RootAllocator = rootAllocator
 
   // todo: support more types.
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -428,7 +428,8 @@ trait RowToColumnarTransition extends UnaryExecNode
  * populate with [[RowToColumnConverter]], but the performance requirements are different and it
  * would only be to reduce code.
  */
-case class RowToColumnarExec(child: SparkPlan) extends RowToColumnarTransition {
+case class RowToColumnarExec(child: SparkPlan, useArrow: Boolean = false)
+  extends RowToColumnarTransition {
   override def output: Seq[Attribute] = child.output
 
   override def outputPartitioning: Partitioning = child.outputPartitioning
@@ -452,7 +453,7 @@ case class RowToColumnarExec(child: SparkPlan) extends RowToColumnarTransition {
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     val enableOffHeapColumnVector = conf.offHeapColumnVectorEnabled
-    val enableArrowColumnVector = conf.arrowColumnVectorEnabled
+    val enableArrowColumnVector = useArrow || conf.arrowColumnVectorEnabled
     val numInputRows = longMetric("numInputRows")
     val numOutputBatches = longMetric("numOutputBatches")
     // Instead of creating a new config we are reusing columnBatchSize. In the future if we do

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ArrowColumnVectorSessionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ArrowColumnVectorSessionSuite.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.vectorized
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.{ColumnarToRowExec, RowToColumnarExec, SparkPlan, SparkPlanTest, UnaryExecNode}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
+
+class ArrowColumnVectorSessionSuite extends SparkPlanTest with SharedSparkSession {
+
+  test("use RowToColumnarExec to build ArrowColumnVector") {
+    spark.conf.set(SQLConf.COLUMN_VECTOR_ARROW_ENABLED.key, "true")
+    val data =
+      Seq(
+        Row(0, 0.1f, 0.toShort, "a", List[Int](1, 2, 3), Map[Int, String]((1, "a"), (2, "b")),
+        Row("Bobby G. can't swim")))
+    val schema = StructType(
+      Seq(
+        StructField("int", IntegerType, true),
+        StructField("float", FloatType, true),
+        StructField("short", ShortType, true),
+        StructField("string", StringType, true),
+        StructField("array", ArrayType(IntegerType), true),
+        StructField("map", MapType(IntegerType, StringType), true),
+        StructField("struct", StructType(Seq(StructField("str", StringType, true))), true)))
+    val indexData =
+      spark.createDataFrame(spark.sparkContext.parallelize(data, 1), schema)
+
+    case class ValidateExec(child: SparkPlan) extends UnaryExecNode {
+      override def supportsColumnar: Boolean = true
+      override def output: Seq[Attribute] = child.output
+      override protected def doExecute(): RDD[InternalRow] = {
+        throw new java.lang.UnsupportedOperationException()
+      }
+      override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+        copy(child = newChild)
+
+      override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+        child.executeColumnar().mapPartitions { iter =>
+          iter.map(batch => {
+            assert(batch.column(0).isInstanceOf[ArrowColumnVector])
+            assert(batch.column(0).getInt(0) == 0)
+            assert(batch.column(1).getFloat(0) == 0.1f)
+            assert(batch.column(2).getShort(0) == 0)
+            assert(batch.column(3).getUTF8String(0).toString == "a")
+            val arr1 = batch.column(4).getArray(0)
+            assert(arr1.getInt(0) == 1)
+            assert(arr1.getInt(1) == 2)
+            assert(arr1.getInt(2) == 3)
+            val map1 = batch.column(5).getMap(0)
+            assert(map1.keyArray().getInt(0) == 1)
+            assert(map1.valueArray().getUTF8String(0).toString == "a")
+            assert(map1.keyArray().getInt(1) == 2)
+            assert(map1.valueArray().getUTF8String(1).toString == "b")
+            val struct1 = batch.column(6).getStruct(0)
+            assert(struct1.getUTF8String(0).toString == "Bobby G. can't swim")
+            batch
+          })
+        }
+      }
+    }
+
+    ColumnarToRowExec(ValidateExec(RowToColumnarExec(indexData.queryExecution.executedPlan)))
+      .execute()
+      .collect()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This Jira is aim to support Arrow format in RowToColumnarExec.

### Why are the changes needed?
Current ArrowColumnVector is not fully equivalent to OnHeap/OffHeapColumnVector in spark, so RowToColumnarExec doesn't support write to Arrow format so far.

since Arrow API is now being more stable, and using pandas udf will perform much better than python udf.

### What has been done in this pull request?
I am  proposing to support RowToColumnarExec with Arrow.

What I did in this PR is to add a load api in ArrowColumnVector to load arrowRecordBatch to ArrowColumnVector, then called inside RowToColumnarExec doExecute.

### How was this patch tested?
UTs are also added to test this new API and RowToColumnarExec with ArrowFormat.

### Does this PR introduce _any_ user-facing change?
NO

Signed-off-by: Chendi Xue <chendi.xue@intel.com>