### PR TITLE
[SPARK-36348][PYTHON][FOLLOWUP] Complete test_astype for index

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -2243,8 +2243,17 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
 
         pidx = pd.Index([10, 20, 15, 30, 45, None], name="x")
         psidx = ps.Index(pidx)
-        self.assert_eq(psidx.astype(bool), pidx.astype(bool))
-        self.assert_eq(psidx.astype(str), pidx.astype(str))
+        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
+            self.assert_eq(psidx.astype(bool), pidx.astype(bool))
+            self.assert_eq(psidx.astype(str), pidx.astype(str))
+        else:
+            self.assert_eq(
+                psidx.astype(bool), ps.Index([True, True, True, True, True, True], name="x")
+            )
+            self.assert_eq(
+                psidx.astype(str),
+                ps.Index(["10.0", "20.0", "15.0", "30.0", "45.0", "nan"], name="x"),
+            )
 
         pidx = pd.Index(["hi", "hi ", " ", " \t", "", None], name="x")
         psidx = ps.Index(pidx)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is follow-up for https://github.com/apache/spark/pull/34335.


### Why are the changes needed?

The previous bug depends on the pandas version, not the Spark version.

So the difference is still alive with pandas < 1.3.

For example,

```python
# Spark 3.2 with pandas 1.2.
>>> pidx = pd.Index([10, 20, 15, 30, 45, None], name="x")
>>> psidx = ps.Index(pidx)

>>> pidx
Index([10, 20, 15, 30, 45, None], dtype='object', name='x')
>>> psidx
Float64Index([10.0, 20.0, 15.0, 30.0, 45.0, nan], dtype='float64', name='x')

>>> pidx.astype(str)
Index(['10', '20', '15', '30', '45', 'None'], dtype='object', name='x')
>>> psidx.astype(str)
Index(['10.0', '20.0', '15.0', '30.0', '45.0', 'nan'], dtype='object', name='x')
```

I think many people are still using pandas < 1.3, so maybe we'd better to separate the test for old version of pandas for now.

### Does this PR introduce _any_ user-facing change?

No, it's test only

### How was this patch tested?

Unittest