### PR TITLE
[SPARK-36975][SQL] Correct the hive client calls‘s metrics in HiveClientImpl

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -308,7 +308,6 @@ private[hive] class HiveClientImpl(
     } finally {
       state.getConf.setClassLoader(originalConfLoader)
       Thread.currentThread().setContextClassLoader(original)
-      HiveCatalogMetrics.incrementHiveClientCalls(1)
     }
     ret
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -404,6 +404,7 @@ private[hive] class HiveClientImpl(
 
   private def getRawTablesByName(dbName: String, tableNames: Seq[String]): Seq[HiveTable] = {
     try {
+      shim.recordHiveCall
       msClient.getTableObjectsByName(dbName, tableNames.asJava).asScala
         .map(extraFixesForNonView).map(new HiveTable(_)).toSeq
     } catch {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -404,7 +404,7 @@ private[hive] class HiveClientImpl(
 
   private def getRawTablesByName(dbName: String, tableNames: Seq[String]): Seq[HiveTable] = {
     try {
-      shim.recordHiveCall
+      shim.recordHiveCall()
       msClient.getTableObjectsByName(dbName, tableNames.asJava).asScala
         .map(extraFixesForNonView).map(new HiveTable(_)).toSeq
     } catch {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -493,11 +493,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       numDP: JInteger, holdDDLTime, listBucketingEnabled: JBoolean)
   }
 
-  override def dropIndex(
-      hive: Hive,
-      dbName: String,
-      tableName: String,
-      indexName: String): Unit = {
+  override def dropIndex(hive: Hive, dbName: String, tableName: String, indexName: String): Unit = {
     recordHiveCall
     dropIndexMethod.invoke(hive, dbName, tableName, indexName, deleteDataInDropIndex)
   }
@@ -568,10 +564,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
 
   override def setDatabaseOwnerName(db: Database, owner: String): Unit = {}
 
-  override def createDatabase(
-      hive: Hive,
-      db: Database,
-      ignoreIfExists: Boolean): Unit = {
+  override def createDatabase(hive: Hive, db: Database, ignoreIfExists: Boolean): Unit = {
     recordHiveCall
     hive.createDatabase(db, ignoreIfExists)
   }
@@ -625,10 +618,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
     hive.getTable(dbName, tableName, throwException)
   }
 
-  override def getTablesByPattern(
-      hive: Hive,
-      dbName: String,
-      pattern: String): Seq[String] = {
+  override def getTablesByPattern(hive: Hive, dbName: String, pattern: String): Seq[String] = {
     recordHiveCall
     hive.getTablesByPattern(dbName, pattern).asScala.toSeq
   }
@@ -799,11 +789,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
     hive.dropFunction(db, name)
   }
 
-  override def renameFunction(
-      hive: Hive,
-      db: String,
-      oldName: String,
-      newName: String): Unit = {
+  override def renameFunction(hive: Hive, db: String, oldName: String, newName: String): Unit = {
     val catalogFunc = getFunctionOption(hive, db, oldName)
       .getOrElse(throw new NoSuchPermanentFunctionException(db, oldName))
       .copy(identifier = FunctionIdentifier(newName, Some(db)))
@@ -831,10 +817,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
     CatalogFunction(name, hf.getClassName, resources.toSeq)
   }
 
-  override def getFunctionOption(
-      hive: Hive,
-      db: String,
-      name: String): Option[CatalogFunction] = {
+  override def getFunctionOption(hive: Hive, db: String, name: String): Option[CatalogFunction] = {
     try {
       recordHiveCall
       Option(hive.getFunction(db, name)).map(fromHiveFunction)
@@ -1303,11 +1286,7 @@ private[client] class Shim_v1_1 extends Shim_v1_0 {
       JBoolean.TYPE,
       JBoolean.TYPE)
 
-  override def dropIndex(
-      hive: Hive,
-      dbName: String,
-      tableName: String,
-      indexName: String): Unit = {
+  override def dropIndex(hive: Hive, dbName: String, tableName: String, indexName: String): Unit = {
     recordHiveCall
     dropIndexMethod.invoke(hive, dbName, tableName, indexName, throwExceptionInDropIndex,
       deleteDataInDropIndex)
@@ -1560,10 +1539,7 @@ private[client] class Shim_v2_1 extends Shim_v2_0 {
     alterTableMethod.invoke(hive, tableName, table, environmentContextInAlterTable)
   }
 
-  override def alterPartitions(
-      hive: Hive,
-      tableName: String,
-      newParts: JList[Partition]): Unit = {
+  override def alterPartitions(hive: Hive, tableName: String, newParts: JList[Partition]): Unit = {
     recordHiveCall
     alterPartitionsMethod.invoke(hive, tableName, newParts, environmentContextInAlterTable)
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -401,6 +401,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       val spec = s.spec.asJava
       // Since Spark don't know if it will throw exception when iterate all parts.
       // So Spark increase the hive client call metrics here when invoke getTable().
+      HiveCatalogMetrics.incrementHiveClientCalls(1)
       if (hive.getPartition(table, spec, false) != null && ignoreIfExists) {
         // Ignore this partition since it already exists and ignoreIfExists == true
       } else {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -246,7 +246,7 @@ private[client] sealed abstract class Shim {
     klass.getMethod(name, args: _*)
   }
 
-  def recordHiveCall() {
+  def recordHiveCall(): Unit {
     HiveCatalogMetrics.incrementHiveClientCalls(1)
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -246,7 +246,7 @@ private[client] sealed abstract class Shim {
     klass.getMethod(name, args: _*)
   }
 
-  def recordHiveCall(): Unit {
+  def recordHiveCall(): Unit = {
     HiveCatalogMetrics.incrementHiveClientCalls(1)
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -246,6 +246,7 @@ private[client] sealed abstract class Shim {
     klass.getMethod(name, args: _*)
   }
 
+  // This method should be called before a Hive client call is made.
   def recordHiveCall(): Unit = {
     HiveCatalogMetrics.incrementHiveClientCalls(1)
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -385,14 +385,14 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       tableName: String,
       parts: Seq[CatalogTablePartition],
       ignoreIfExists: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     val table = hive.getTable(database, tableName)
     parts.foreach { s =>
       val location = s.storage.locationUri.map(
         uri => new Path(table.getPath, new Path(uri))).orNull
       val params = if (s.parameters.nonEmpty) s.parameters.asJava else null
       val spec = s.spec.asJava
-      recordHiveCall
+      recordHiveCall()
       if (hive.getPartition(table, spec, false) != null && ignoreIfExists) {
         // Ignore this partition since it already exists and ignoreIfExists == true
       } else {
@@ -400,7 +400,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
           throw QueryExecutionErrors.illegalLocationClauseForViewPartitionError()
         }
 
-        recordHiveCall
+        recordHiveCall()
         createPartitionMethod.invoke(
           hive,
           table,
@@ -420,7 +420,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
   }
 
   override def getAllPartitions(hive: Hive, table: Table): Seq[Partition] = {
-    recordHiveCall
+    recordHiveCall()
     getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]].asScala.toSeq
   }
 
@@ -465,7 +465,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       inheritTableSpecs: Boolean,
       isSkewedStoreAsSubdir: Boolean,
       isSrcLocal: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadPartitionMethod.invoke(hive, loadPath, tableName, partSpec, replace: JBoolean,
       JBoolean.FALSE, inheritTableSpecs: JBoolean, isSkewedStoreAsSubdir: JBoolean)
   }
@@ -476,7 +476,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       tableName: String,
       replace: Boolean,
       isSrcLocal: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadTableMethod.invoke(hive, loadPath, tableName, replace: JBoolean, holdDDLTime)
   }
 
@@ -488,13 +488,13 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       replace: Boolean,
       numDP: Int,
       listBucketingEnabled: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadDynamicPartitionsMethod.invoke(hive, loadPath, tableName, partSpec, replace: JBoolean,
       numDP: JInteger, holdDDLTime, listBucketingEnabled: JBoolean)
   }
 
   override def dropIndex(hive: Hive, dbName: String, tableName: String, indexName: String): Unit = {
-    recordHiveCall
+    recordHiveCall()
     dropIndexMethod.invoke(hive, dbName, tableName, indexName, deleteDataInDropIndex)
   }
 
@@ -508,17 +508,17 @@ private[client] class Shim_v0_12 extends Shim with Logging {
     if (purge) {
       throw QueryExecutionErrors.dropTableWithPurgeUnsupportedError()
     }
-    recordHiveCall
+    recordHiveCall()
     hive.dropTable(dbName, tableName, deleteData, ignoreIfNotExists)
   }
 
   override def alterTable(hive: Hive, tableName: String, table: Table): Unit = {
-    recordHiveCall
+    recordHiveCall()
     alterTableMethod.invoke(hive, tableName, table)
   }
 
   override def alterPartitions(hive: Hive, tableName: String, newParts: JList[Partition]): Unit = {
-    recordHiveCall
+    recordHiveCall()
     alterPartitionsMethod.invoke(hive, tableName, newParts)
   }
 
@@ -532,7 +532,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
     if (purge) {
       throw QueryExecutionErrors.alterTableWithDropPartitionAndPurgeUnsupportedError()
     }
-    recordHiveCall
+    recordHiveCall()
     hive.dropPartition(dbName, tableName, part, deleteData)
   }
 
@@ -565,7 +565,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
   override def setDatabaseOwnerName(db: Database, owner: String): Unit = {}
 
   override def createDatabase(hive: Hive, db: Database, ignoreIfExists: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     hive.createDatabase(db, ignoreIfExists)
   }
 
@@ -575,37 +575,37 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       deleteData: Boolean,
       ignoreUnknownDb: Boolean,
       cascade: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     hive.dropDatabase(dbName, deleteData, ignoreUnknownDb, cascade)
   }
 
   override def alterDatabase(hive: Hive, dbName: String, d: Database): Unit = {
-    recordHiveCall
+    recordHiveCall()
     hive.alterDatabase(dbName, d)
   }
 
   override def getDatabase(hive: Hive, dbName: String): Database = {
-    recordHiveCall
+    recordHiveCall()
     hive.getDatabase(dbName)
   }
 
   override def getAllDatabases(hive: Hive): Seq[String] = {
-    recordHiveCall
+    recordHiveCall()
     hive.getAllDatabases.asScala.toSeq
   }
 
   override def getDatabasesByPattern(hive: Hive, pattern: String): Seq[String] = {
-    recordHiveCall
+    recordHiveCall()
     hive.getDatabasesByPattern(pattern).asScala.toSeq
   }
 
   override def databaseExists(hive: Hive, dbName: String): Boolean = {
-    recordHiveCall
+    recordHiveCall()
     hive.databaseExists(dbName)
   }
 
   override def createTable(hive: Hive, table: Table, ifNotExists: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     hive.createTable(table, ifNotExists)
   }
 
@@ -614,22 +614,22 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tableName: String,
       throwException: Boolean): Table = {
-    recordHiveCall
+    recordHiveCall()
     hive.getTable(dbName, tableName, throwException)
   }
 
   override def getTablesByPattern(hive: Hive, dbName: String, pattern: String): Seq[String] = {
-    recordHiveCall
+    recordHiveCall()
     hive.getTablesByPattern(dbName, pattern).asScala.toSeq
   }
 
   override def getAllTables(hive: Hive, dbName: String): Seq[String] = {
-    recordHiveCall
+    recordHiveCall()
     hive.getAllTables(dbName).asScala.toSeq
   }
 
   override def dropTable(hive: Hive, dbName: String, tableName: String): Unit = {
-    recordHiveCall
+    recordHiveCall()
     hive.dropTable(dbName, tableName)
   }
 
@@ -638,7 +638,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       table: Table,
       partSpec: JMap[String, String],
       forceCreate: Boolean): Partition = {
-    recordHiveCall
+    recordHiveCall()
     hive.getPartition(table, partSpec, forceCreate)
   }
 
@@ -646,7 +646,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       hive: Hive,
       table: Table,
       partSpec: JMap[String, String]): Seq[Partition] = {
-    recordHiveCall
+    recordHiveCall()
     hive.getPartitions(table, partSpec).asScala.toSeq
   }
 
@@ -655,7 +655,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tableName: String,
       max: Short): Seq[String] = {
-    recordHiveCall
+    recordHiveCall()
     hive.getPartitionNames(dbName, tableName, max).asScala.toSeq
   }
 
@@ -665,7 +665,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       tableName: String,
       partSpec: JMap[String, String],
       max: Short): Seq[String] = {
-    recordHiveCall
+    recordHiveCall()
     hive.getPartitionNames(dbName, tableName, partSpec, max).asScala.toSeq
   }
 
@@ -674,7 +674,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       table: Table,
       oldPartSpec: JMap[String, String],
       newPart: Partition): Unit = {
-    recordHiveCall
+    recordHiveCall()
     hive.renamePartition(table, oldPartSpec, newPart)
   }
 
@@ -683,7 +683,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       dbName: String,
       tableName: String,
       max: Short): Seq[Index] = {
-    recordHiveCall
+    recordHiveCall()
     hive.getIndexes(dbName, tableName, max).asScala.toSeq
   }
 }
@@ -754,12 +754,12 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
         addPartitionDesc.getPartition(i).setPartParams(s.parameters.asJava)
       }
     }
-    recordHiveCall
+    recordHiveCall()
     hive.createPartitions(addPartitionDesc)
   }
 
   override def getAllPartitions(hive: Hive, table: Table): Seq[Partition] = {
-    recordHiveCall
+    recordHiveCall()
     getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]].asScala.toSeq
   }
 
@@ -780,12 +780,12 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
   }
 
   override def createFunction(hive: Hive, db: String, func: CatalogFunction): Unit = {
-    recordHiveCall
+    recordHiveCall()
     hive.createFunction(toHiveFunction(func, db))
   }
 
   override def dropFunction(hive: Hive, db: String, name: String): Unit = {
-    recordHiveCall
+    recordHiveCall()
     hive.dropFunction(db, name)
   }
 
@@ -794,12 +794,12 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       .getOrElse(throw new NoSuchPermanentFunctionException(db, oldName))
       .copy(identifier = FunctionIdentifier(newName, Some(db)))
     val hiveFunc = toHiveFunction(catalogFunc, db)
-    recordHiveCall
+    recordHiveCall()
     hive.alterFunction(db, oldName, hiveFunc)
   }
 
   override def alterFunction(hive: Hive, db: String, func: CatalogFunction): Unit = {
-    recordHiveCall
+    recordHiveCall()
     hive.alterFunction(db, func.identifier.funcName, toHiveFunction(func, db))
   }
 
@@ -819,7 +819,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
 
   override def getFunctionOption(hive: Hive, db: String, name: String): Option[CatalogFunction] = {
     try {
-      recordHiveCall
+      recordHiveCall()
       Option(hive.getFunction(db, name)).map(fromHiveFunction)
     } catch {
       case NonFatal(e) if isCausedBy(e, s"$name does not exist") =>
@@ -838,7 +838,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
   }
 
   override def listFunctions(hive: Hive, db: String, pattern: String): Seq[String] = {
-    recordHiveCall
+    recordHiveCall()
     hive.getFunctions(db, pattern).asScala.toSeq
   }
 
@@ -1087,7 +1087,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
 
     val partitions =
       if (filter.isEmpty) {
-        recordHiveCall
+        recordHiveCall()
         getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
       } else {
         logDebug(s"Hive metastore filter is '$filter'.")
@@ -1103,7 +1103,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
           // Because of the above we'll fallback to use `Hive.getAllPartitionsOf` when the exception
           // occurs and the config`spark.sql.hive.metastorePartitionPruningFallbackOnException` is
           // enabled.
-          recordHiveCall
+          recordHiveCall()
           getPartitionsByFilterMethod.invoke(hive, table, filter)
             .asInstanceOf[JArrayList[Partition]]
         } catch {
@@ -1117,7 +1117,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
               s"${SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FALLBACK_ON_EXCEPTION.key} " +
               " to false and let the query fail instead.", ex)
             // HiveShim clients are expected to handle a superset of the requested partitions
-            recordHiveCall
+            recordHiveCall()
             getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
           case ex: InvocationTargetException if ex.getCause.isInstanceOf[MetaException] =>
             throw QueryExecutionErrors.getPartitionMetadataByFilterError(ex)
@@ -1218,7 +1218,7 @@ private[client] class Shim_v0_14 extends Shim_v0_13 {
       inheritTableSpecs: Boolean,
       isSkewedStoreAsSubdir: Boolean,
       isSrcLocal: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadPartitionMethod.invoke(hive, loadPath, tableName, partSpec, replace: JBoolean,
       holdDDLTime, inheritTableSpecs: JBoolean, isSkewedStoreAsSubdir: JBoolean,
       isSrcLocal: JBoolean, isAcid)
@@ -1230,7 +1230,7 @@ private[client] class Shim_v0_14 extends Shim_v0_13 {
       tableName: String,
       replace: Boolean,
       isSrcLocal: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadTableMethod.invoke(hive, loadPath, tableName, replace: JBoolean, holdDDLTime,
       isSrcLocal: JBoolean, isSkewedStoreAsSubdir, isAcid)
   }
@@ -1243,7 +1243,7 @@ private[client] class Shim_v0_14 extends Shim_v0_13 {
       replace: Boolean,
       numDP: Int,
       listBucketingEnabled: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadDynamicPartitionsMethod.invoke(hive, loadPath, tableName, partSpec, replace: JBoolean,
       numDP: JInteger, holdDDLTime, listBucketingEnabled: JBoolean, isAcid)
   }
@@ -1255,7 +1255,7 @@ private[client] class Shim_v0_14 extends Shim_v0_13 {
       deleteData: Boolean,
       ignoreIfNotExists: Boolean,
       purge: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     dropTableMethod.invoke(hive, dbName, tableName, deleteData: JBoolean,
       ignoreIfNotExists: JBoolean, purge: JBoolean)
   }
@@ -1287,7 +1287,7 @@ private[client] class Shim_v1_1 extends Shim_v1_0 {
       JBoolean.TYPE)
 
   override def dropIndex(hive: Hive, dbName: String, tableName: String, indexName: String): Unit = {
-    recordHiveCall
+    recordHiveCall()
     dropIndexMethod.invoke(hive, dbName, tableName, indexName, throwExceptionInDropIndex,
       deleteDataInDropIndex)
   }
@@ -1334,7 +1334,7 @@ private[client] class Shim_v1_2 extends Shim_v1_1 {
       replace: Boolean,
       numDP: Int,
       listBucketingEnabled: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadDynamicPartitionsMethod.invoke(hive, loadPath, tableName, partSpec, replace: JBoolean,
       numDP: JInteger, holdDDLTime, listBucketingEnabled: JBoolean, isAcid,
       txnIdInLoadDynamicPartitions)
@@ -1350,7 +1350,7 @@ private[client] class Shim_v1_2 extends Shim_v1_1 {
     val dropOptions = dropOptionsClass.getConstructor().newInstance().asInstanceOf[Object]
     dropOptionsDeleteData.setBoolean(dropOptions, deleteData)
     dropOptionsPurge.setBoolean(dropOptions, purge)
-    recordHiveCall
+    recordHiveCall()
     dropPartitionMethod.invoke(hive, dbName, tableName, part, dropOptions)
   }
 
@@ -1401,7 +1401,7 @@ private[client] class Shim_v2_0 extends Shim_v1_2 {
       inheritTableSpecs: Boolean,
       isSkewedStoreAsSubdir: Boolean,
       isSrcLocal: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadPartitionMethod.invoke(hive, loadPath, tableName, partSpec, replace: JBoolean,
       inheritTableSpecs: JBoolean, isSkewedStoreAsSubdir: JBoolean,
       isSrcLocal: JBoolean, isAcid)
@@ -1413,7 +1413,7 @@ private[client] class Shim_v2_0 extends Shim_v1_2 {
       tableName: String,
       replace: Boolean,
       isSrcLocal: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadTableMethod.invoke(hive, loadPath, tableName, replace: JBoolean, isSrcLocal: JBoolean,
       isSkewedStoreAsSubdir, isAcid)
   }
@@ -1426,7 +1426,7 @@ private[client] class Shim_v2_0 extends Shim_v1_2 {
       replace: Boolean,
       numDP: Int,
       listBucketingEnabled: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadDynamicPartitionsMethod.invoke(hive, loadPath, tableName, partSpec, replace: JBoolean,
       numDP: JInteger, listBucketingEnabled: JBoolean, isAcid, txnIdInLoadDynamicPartitions)
   }
@@ -1503,7 +1503,7 @@ private[client] class Shim_v2_1 extends Shim_v2_0 {
       inheritTableSpecs: Boolean,
       isSkewedStoreAsSubdir: Boolean,
       isSrcLocal: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadPartitionMethod.invoke(hive, loadPath, tableName, partSpec, replace: JBoolean,
       inheritTableSpecs: JBoolean, isSkewedStoreAsSubdir: JBoolean,
       isSrcLocal: JBoolean, isAcid, hasFollowingStatsTask)
@@ -1515,7 +1515,7 @@ private[client] class Shim_v2_1 extends Shim_v2_0 {
       tableName: String,
       replace: Boolean,
       isSrcLocal: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadTableMethod.invoke(hive, loadPath, tableName, replace: JBoolean, isSrcLocal: JBoolean,
       isSkewedStoreAsSubdir, isAcid, hasFollowingStatsTask)
   }
@@ -1528,19 +1528,19 @@ private[client] class Shim_v2_1 extends Shim_v2_0 {
       replace: Boolean,
       numDP: Int,
       listBucketingEnabled: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     loadDynamicPartitionsMethod.invoke(hive, loadPath, tableName, partSpec, replace: JBoolean,
       numDP: JInteger, listBucketingEnabled: JBoolean, isAcid, txnIdInLoadDynamicPartitions,
       hasFollowingStatsTask, AcidUtils.Operation.NOT_ACID)
   }
 
   override def alterTable(hive: Hive, tableName: String, table: Table): Unit = {
-    recordHiveCall
+    recordHiveCall()
     alterTableMethod.invoke(hive, tableName, table, environmentContextInAlterTable)
   }
 
   override def alterPartitions(hive: Hive, tableName: String, newParts: JList[Partition]): Unit = {
-    recordHiveCall
+    recordHiveCall()
     alterPartitionsMethod.invoke(hive, tableName, newParts, environmentContextInAlterTable)
   }
 }
@@ -1561,7 +1561,7 @@ private[client] class Shim_v2_3 extends Shim_v2_1 {
       dbName: String,
       pattern: String,
       tableType: TableType): Seq[String] = {
-    recordHiveCall
+    recordHiveCall()
     getTablesByTypeMethod.invoke(hive, dbName, pattern, tableType)
       .asInstanceOf[JList[String]].asScala.toSeq
   }
@@ -1638,7 +1638,7 @@ private[client] class Shim_v3_0 extends Shim_v2_3 {
       inheritTableSpecs: Boolean,
       isSkewedStoreAsSubdir: Boolean,
       isSrcLocal: Boolean): Unit = {
-    recordHiveCall
+    recordHiveCall()
     val table = hive.getTable(tableName)
     val loadFileType = if (replace) {
       clazzLoadFileType.getEnumConstants.find(_.toString.equalsIgnoreCase("REPLACE_ALL"))
@@ -1646,7 +1646,7 @@ private[client] class Shim_v3_0 extends Shim_v2_3 {
       clazzLoadFileType.getEnumConstants.find(_.toString.equalsIgnoreCase("KEEP_EXISTING"))
     }
     assert(loadFileType.isDefined)
-    recordHiveCall
+    recordHiveCall()
     loadPartitionMethod.invoke(hive, loadPath, table, partSpec, loadFileType.get,
       inheritTableSpecs: JBoolean, isSkewedStoreAsSubdir: JBoolean,
       isSrcLocal: JBoolean, isAcid, hasFollowingStatsTask,
@@ -1665,7 +1665,7 @@ private[client] class Shim_v3_0 extends Shim_v2_3 {
       clazzLoadFileType.getEnumConstants.find(_.toString.equalsIgnoreCase("KEEP_EXISTING"))
     }
     assert(loadFileType.isDefined)
-    recordHiveCall
+    recordHiveCall()
     loadTableMethod.invoke(hive, loadPath, tableName, loadFileType.get, isSrcLocal: JBoolean,
       isSkewedStoreAsSubdir, isAcidIUDoperation, hasFollowingStatsTask,
       writeIdInLoadTableOrPartition, stmtIdInLoadTableOrPartition: JInteger, replace: JBoolean)
@@ -1685,7 +1685,7 @@ private[client] class Shim_v3_0 extends Shim_v2_3 {
       clazzLoadFileType.getEnumConstants.find(_.toString.equalsIgnoreCase("KEEP_EXISTING"))
     }
     assert(loadFileType.isDefined)
-    recordHiveCall
+    recordHiveCall()
     loadDynamicPartitionsMethod.invoke(hive, loadPath, tableName, partSpec, loadFileType.get,
       numDP: JInteger, listBucketingLevel, isAcid, writeIdInLoadTableOrPartition,
       stmtIdInLoadTableOrPartition, hasFollowingStatsTask, AcidUtils.Operation.NOT_ACID,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableDropPartitionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableDropPartitionSuite.scala
@@ -36,14 +36,14 @@ class AlterTableDropPartitionSuite
           sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
           sql(s"INSERT INTO $t PARTITION (part=1) SELECT 1")
           sql(s"ALTER TABLE $t ADD PARTITION (part=2)") // empty partition
-          checkHiveClientCalls(expected = if (statsOn) 24 else 16) {
+          checkHiveClientCalls(expected = if (statsOn) 26 else 18) {
             sql(s"ALTER TABLE $t DROP PARTITION (part=2)")
           }
-          checkHiveClientCalls(expected = if (statsOn) 29 else 16) {
+          checkHiveClientCalls(expected = if (statsOn) 31 else 18) {
             sql(s"ALTER TABLE $t DROP PARTITION (part=0)")
           }
           sql(s"CACHE TABLE $t")
-          checkHiveClientCalls(expected = if (statsOn) 29 else 16) {
+          checkHiveClientCalls(expected = if (statsOn) 31 else 18) {
             sql(s"ALTER TABLE $t DROP PARTITION (part=1)")
           }
         }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableRenamePartitionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterTableRenamePartitionSuite.scala
@@ -32,11 +32,11 @@ class AlterTableRenamePartitionSuite
       sql(s"CREATE TABLE $t (id int, part int) $defaultUsing PARTITIONED BY (part)")
       sql(s"INSERT INTO $t PARTITION (part=0) SELECT 0")
 
-      checkHiveClientCalls(expected = 18) {
+      checkHiveClientCalls(expected = 19) {
         sql(s"ALTER TABLE $t PARTITION (part=0) RENAME TO PARTITION (part=1)")
       }
       sql(s"CACHE TABLE $t")
-      checkHiveClientCalls(expected = 18) {
+      checkHiveClientCalls(expected = 19) {
         sql(s"ALTER TABLE $t PARTITION (part=1) RENAME TO PARTITION (part=2)")
       }
     }
@@ -44,7 +44,7 @@ class AlterTableRenamePartitionSuite
     withNamespaceAndTable("ns", "tbl") { t =>
       sql(s"CREATE TABLE $t (id int, PART int) $defaultUsing PARTITIONED BY (PART)")
       sql(s"INSERT INTO $t PARTITION (PART=0) SELECT 0")
-      checkHiveClientCalls(expected = 23) {
+      checkHiveClientCalls(expected = 24) {
         sql(s"ALTER TABLE $t PARTITION (PART=0) RENAME TO PARTITION (PART=1)")
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently we collect hive client calls metrics from `withHiveState`, it's not correct that in one call `withHiveState`, there may be many hive client calls. we need to split such behaviors.

In this pr we do this in `shim`, split this metrics from `withHiveState`

### Why are the changes needed?
Make hive client calls metrics more accurate

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existed UT
