### PR TITLE
[SPARK-30537][PYTHON] Fix toPandas  wrong dtypes when applied on empty DF when Arrow enabled

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -173,7 +173,18 @@ class PandasConversionMixin(object):
                                 pdf[field.name] = _convert_map_items_to_dict(pdf[field.name])
                         return pdf
                     else:
-                        return pd.DataFrame.from_records([], columns=self.columns)
+                        corrected_panda_types = []
+                        for index, field in enumerate(self.schema):
+                            panda_type = PandasConversionMixin._to_corrected_pandas_type(
+                                field.dataType
+                            )
+                            if panda_type is None:
+                                corrected_panda_types.append((tmp_column_names[index], np.object0))
+                            else:
+                                corrected_panda_types.append((tmp_column_names[index], panda_type))
+                        pdf = pd.DataFrame(np.empty(0, dtype=corrected_panda_types), index=[])
+                        pdf.columns = self.columns
+                        return pdf
                 except Exception as e:
                     # We might have to allow fallback here as well but multiple Spark jobs can
                     # be executed. So, simply fail in this case for now.

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -173,16 +173,18 @@ class PandasConversionMixin(object):
                                 pdf[field.name] = _convert_map_items_to_dict(pdf[field.name])
                         return pdf
                     else:
-                        corrected_panda_types = []
+                        corrected_panda_types = {}
                         for index, field in enumerate(self.schema):
                             panda_type = PandasConversionMixin._to_corrected_pandas_type(
                                 field.dataType
                             )
-                            if panda_type is None:
-                                corrected_panda_types.append((tmp_column_names[index], np.object0))
-                            else:
-                                corrected_panda_types.append((tmp_column_names[index], panda_type))
-                        pdf = pd.DataFrame(np.empty(0, dtype=corrected_panda_types), index=[])
+                            corrected_panda_types[tmp_column_names[index]] = (
+                                np.object0 if panda_type is None else panda_type
+                            )
+
+                        pdf = pd.DataFrame(columns=tmp_column_names).astype(
+                            dtype=corrected_panda_types
+                        )
                         pdf.columns = self.columns
                         return pdf
                 except Exception as e:

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -42,6 +42,7 @@ from pyspark.sql.types import (
     StructField,
     ArrayType,
     NullType,
+    DayTimeIntervalType,
 )
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
@@ -208,7 +209,7 @@ class ArrowTests(ReusedSQLTestCase):
     def test_toPandas_empty_df_arrow_enabled(self):
         # SPARK-30537 test that toPandas() on an empty dataframe has the correct dtypes
         # when arrow is enabled
-        from datetime import datetime, date
+        from datetime import date
         from decimal import Decimal
 
         schema = StructType(
@@ -222,6 +223,8 @@ class ArrowTests(ReusedSQLTestCase):
                 StructField("g", DateType(), True),
                 StructField("h", BinaryType(), True),
                 StructField("i", DecimalType(38, 18), True),
+                StructField("k", TimestampNTZType(), True),
+                StructField("L", DayTimeIntervalType(0, 3), True),
             ]
         )
         df = self.spark.createDataFrame(self.spark.sparkContext.emptyRDD(), schema=schema)
@@ -230,13 +233,15 @@ class ArrowTests(ReusedSQLTestCase):
                 (
                     "a",
                     1,
-                    datetime(1969, 1, 1, 1, 1, 1),
+                    datetime.datetime(1969, 1, 1, 1, 1, 1),
                     None,
                     10,
                     0.2,
                     date(1969, 1, 1),
                     bytearray(b"a"),
                     Decimal("2.0"),
+                    datetime.datetime(1969, 1, 1, 1, 1, 1),
+                    datetime.timedelta(microseconds=123),
                 )
             ],
             schema=schema,

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -205,6 +205,49 @@ class ArrowTests(ReusedSQLTestCase):
                 with self.assertRaisesRegex(Exception, "Unsupported type"):
                     df.toPandas()
 
+    def test_toPandas_empty_df_arrow_enabled(self):
+        # SPARK-30537 test that toPandas() on an empty dataframe has the correct dtypes
+        # when arrow is enabled
+        from datetime import datetime, date
+        from decimal import Decimal
+
+        schema = StructType(
+            [
+                StructField("a", StringType(), True),
+                StructField("a", IntegerType(), True),
+                StructField("c", TimestampType(), True),
+                StructField("d", NullType(), True),
+                StructField("e", LongType(), True),
+                StructField("f", FloatType(), True),
+                StructField("g", DateType(), True),
+                StructField("h", BinaryType(), True),
+                StructField("i", DecimalType(38, 18), True),
+            ]
+        )
+        df = self.spark.createDataFrame(self.spark.sparkContext.emptyRDD(), schema=schema)
+        non_empty_df = self.spark.createDataFrame(
+            [
+                (
+                    "a",
+                    1,
+                    datetime(1969, 1, 1, 1, 1, 1),
+                    None,
+                    10,
+                    0.2,
+                    date(1969, 1, 1),
+                    bytearray(b"a"),
+                    Decimal("2.0"),
+                )
+            ],
+            schema=schema,
+        )
+
+        pdf, pdf_arrow = self._toPandas_arrow_toggle(df)
+        pdf_non_empty, pdf_arrow_non_empty = self._toPandas_arrow_toggle(non_empty_df)
+        assert_frame_equal(pdf, pdf_arrow)
+        self.assertTrue(pdf_arrow.dtypes.equals(pdf_arrow_non_empty.dtypes))
+        self.assertTrue(pdf_arrow.dtypes.equals(pdf_non_empty.dtypes))
+
     def test_null_conversion(self):
         df_null = self.spark.createDataFrame(
             [tuple([None for _ in range(len(self.data_wo_null[0]))])] + self.data_wo_null

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -860,6 +860,7 @@ class DataFrameTests(ReusedSQLTestCase):
                 self.assertEqual(types[7], np.object)
                 self.assertTrue(np.can_cast(np.datetime64, types[8]))
                 self.assertTrue(np.can_cast(np.datetime64, types[9]))
+                self.assertTrue(np.can_cast(np.timedelta64, types[10]))
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)  # type: ignore
     def test_to_pandas_from_mixed_dataframe(self):
@@ -878,9 +879,10 @@ class DataFrameTests(ReusedSQLTestCase):
         CAST(col7 AS BOOLEAN) AS boolean,
         CAST(col8 AS STRING) AS string,
         timestamp_seconds(col9) AS timestamp,
-        timestamp_seconds(col10) AS timestamp_ntz
-        FROM VALUES (1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-                    (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+        timestamp_seconds(col10) AS timestamp_ntz,
+        INTERVAL '1563:04' MINUTE TO SECOND AS day_time_interval
+        FROM VALUES (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+                    (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
         """
         arrow_enabled_status = [True, False]
         for value in arrow_enabled_status:

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -800,11 +800,12 @@ class DataFrameTests(ReusedSQLTestCase):
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)  # type: ignore
     def test_to_pandas_from_empty_dataframe(self):
-        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": False}):
-            # SPARK-29188 test that toPandas() on an empty dataframe has the correct dtypes
-            import numpy as np
+        # SPARK-29188 test that toPandas() on an empty dataframe has the correct dtypes
+        # SPARK-30537 test that toPandas() on an empty dataframe has the correct dtypes
+        # when arrow is enabled
+        import numpy as np
 
-            sql = """
+        sql = """
             SELECT CAST(1 AS TINYINT) AS tinyint,
             CAST(1 AS SMALLINT) AS smallint,
             CAST(1 AS INT) AS int,
@@ -817,17 +818,21 @@ class DataFrameTests(ReusedSQLTestCase):
             CAST('2019-01-01' AS TIMESTAMP_NTZ) AS timestamp_ntz,
             INTERVAL '1563:04' MINUTE TO SECOND AS day_time_interval
             """
-            dtypes_when_nonempty_df = self.spark.sql(sql).toPandas().dtypes
-            dtypes_when_empty_df = self.spark.sql(sql).filter("False").toPandas().dtypes
-            self.assertTrue(np.all(dtypes_when_empty_df == dtypes_when_nonempty_df))
+        arrow_enabled_status = [True, False]
+        for value in arrow_enabled_status:
+            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": value}):
+                dtypes_when_nonempty_df = self.spark.sql(sql).toPandas().dtypes
+                dtypes_when_empty_df = self.spark.sql(sql).filter("False").toPandas().dtypes
+                self.assertTrue(np.all(dtypes_when_empty_df == dtypes_when_nonempty_df))
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)  # type: ignore
     def test_to_pandas_from_null_dataframe(self):
-        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": False}):
-            # SPARK-29188 test that toPandas() on a dataframe with only nulls has correct dtypes
-            import numpy as np
+        # SPARK-29188 test that toPandas() on a dataframe with only nulls has correct dtypes
+        # SPARK-30537 test that toPandas() on a dataframe with only nulls has correct dtypes
+        # using arrow
+        import numpy as np
 
-            sql = """
+        sql = """
             SELECT CAST(NULL AS TINYINT) AS tinyint,
             CAST(NULL AS SMALLINT) AS smallint,
             CAST(NULL AS INT) AS int,
@@ -840,44 +845,49 @@ class DataFrameTests(ReusedSQLTestCase):
             CAST(NULL AS TIMESTAMP_NTZ) AS timestamp_ntz,
             INTERVAL '1563:04' MINUTE TO SECOND AS day_time_interval
             """
-            pdf = self.spark.sql(sql).toPandas()
-            types = pdf.dtypes
-            self.assertEqual(types[0], np.float64)
-            self.assertEqual(types[1], np.float64)
-            self.assertEqual(types[2], np.float64)
-            self.assertEqual(types[3], np.float64)
-            self.assertEqual(types[4], np.float32)
-            self.assertEqual(types[5], np.float64)
-            self.assertEqual(types[6], np.object)
-            self.assertEqual(types[7], np.object)
-            self.assertTrue(np.can_cast(np.datetime64, types[8]))
-            self.assertTrue(np.can_cast(np.datetime64, types[9]))
-            self.assertTrue(np.can_cast(np.timedelta64, types[10]))
+        arrow_enabled_status = [True, False]
+        for value in arrow_enabled_status:
+            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": value}):
+                pdf = self.spark.sql(sql).toPandas()
+                types = pdf.dtypes
+                self.assertEqual(types[0], np.float64)
+                self.assertEqual(types[1], np.float64)
+                self.assertEqual(types[2], np.float64)
+                self.assertEqual(types[3], np.float64)
+                self.assertEqual(types[4], np.float32)
+                self.assertEqual(types[5], np.float64)
+                self.assertEqual(types[6], np.object)
+                self.assertEqual(types[7], np.object)
+                self.assertTrue(np.can_cast(np.datetime64, types[8]))
+                self.assertTrue(np.can_cast(np.datetime64, types[9]))
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)  # type: ignore
     def test_to_pandas_from_mixed_dataframe(self):
-        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": False}):
-            # SPARK-29188 test that toPandas() on a dataframe with some nulls has correct dtypes
-            import numpy as np
+        # SPARK-29188 test that toPandas() on a dataframe with some nulls has correct dtypes
+        # SPARK-30537 test that toPandas() on a dataframe with some nulls has correct dtypes
+        # using arrow
+        import numpy as np
 
-            sql = """
-            SELECT CAST(col1 AS TINYINT) AS tinyint,
-            CAST(col2 AS SMALLINT) AS smallint,
-            CAST(col3 AS INT) AS int,
-            CAST(col4 AS BIGINT) AS bigint,
-            CAST(col5 AS FLOAT) AS float,
-            CAST(col6 AS DOUBLE) AS double,
-            CAST(col7 AS BOOLEAN) AS boolean,
-            CAST(col8 AS STRING) AS string,
-            timestamp_seconds(col9) AS timestamp,
-            timestamp_seconds(col10) AS timestamp_ntz,
-            INTERVAL '1563:04' MINUTE TO SECOND AS day_time_interval
-            FROM VALUES (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-                        (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-            """
-            pdf_with_some_nulls = self.spark.sql(sql).toPandas()
-            pdf_with_only_nulls = self.spark.sql(sql).filter("tinyint is null").toPandas()
-            self.assertTrue(np.all(pdf_with_only_nulls.dtypes == pdf_with_some_nulls.dtypes))
+        sql = """
+        SELECT CAST(col1 AS TINYINT) AS tinyint,
+        CAST(col2 AS SMALLINT) AS smallint,
+        CAST(col3 AS INT) AS int,
+        CAST(col4 AS BIGINT) AS bigint,
+        CAST(col5 AS FLOAT) AS float,
+        CAST(col6 AS DOUBLE) AS double,
+        CAST(col7 AS BOOLEAN) AS boolean,
+        CAST(col8 AS STRING) AS string,
+        timestamp_seconds(col9) AS timestamp,
+        timestamp_seconds(col10) AS timestamp_ntz
+        FROM VALUES (1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+                    (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+        """
+        arrow_enabled_status = [True, False]
+        for value in arrow_enabled_status:
+            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": value}):
+                pdf_with_some_nulls = self.spark.sql(sql).toPandas()
+                pdf_with_only_nulls = self.spark.sql(sql).filter("tinyint is null").toPandas()
+                self.assertTrue(np.all(pdf_with_only_nulls.dtypes == pdf_with_some_nulls.dtypes))
 
     def test_create_dataframe_from_array_of_long(self):
         import array

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -818,8 +818,8 @@ class DataFrameTests(ReusedSQLTestCase):
             CAST('2019-01-01' AS TIMESTAMP_NTZ) AS timestamp_ntz,
             INTERVAL '1563:04' MINUTE TO SECOND AS day_time_interval
             """
-        arrow_enabled_status = [True, False]
-        for value in arrow_enabled_status:
+        is_arrow_enabled = [True, False]
+        for value in is_arrow_enabled:
             with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": value}):
                 dtypes_when_nonempty_df = self.spark.sql(sql).toPandas().dtypes
                 dtypes_when_empty_df = self.spark.sql(sql).filter("False").toPandas().dtypes
@@ -845,8 +845,8 @@ class DataFrameTests(ReusedSQLTestCase):
             CAST(NULL AS TIMESTAMP_NTZ) AS timestamp_ntz,
             INTERVAL '1563:04' MINUTE TO SECOND AS day_time_interval
             """
-        arrow_enabled_status = [True, False]
-        for value in arrow_enabled_status:
+        is_arrow_enabled = [True, False]
+        for value in is_arrow_enabled:
             with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": value}):
                 pdf = self.spark.sql(sql).toPandas()
                 types = pdf.dtypes
@@ -884,8 +884,8 @@ class DataFrameTests(ReusedSQLTestCase):
         FROM VALUES (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
                     (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
         """
-        arrow_enabled_status = [True, False]
-        for value in arrow_enabled_status:
+        is_arrow_enabled = [True, False]
+        for value in is_arrow_enabled:
             with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": value}):
                 pdf_with_some_nulls = self.spark.sql(sql).toPandas()
                 pdf_with_only_nulls = self.spark.sql(sql).filter("tinyint is null").toPandas()


### PR DESCRIPTION
### What changes were proposed in this pull request?
toPandas will return correct dtype for empty dataframe when arrow enabled

```
from datetime import datetime
spark_df = spark.createDataFrame([(10, "Emy", datetime.today() ), (11, "Bob", datetime.today())], ["age", "name", "date"])
spark.createDataFrame(spark.sparkContext.emptyRDD(), schema=spark_df.schema).toPandas().dtypes

age              int64
name            object
date    datetime64[ns]
dtype: object

spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", True)
spark.createDataFrame(spark.sparkContext.emptyRDD(), schema=spark_df.schema).toPandas().dtypes

age              int64
name            object
date    datetime64[ns]

dtype: object

```

### Why are the changes needed?
Currently toPandas for empty dataframe return object as dtype for all the element when arrow is enabled . However things works fine when arrow is disabled . Therefore this PR will make give the correct dtype when arrow is enabled and dataframe is empty  


### Does this PR introduce any user-facing change?
Yes user will be able to see correct dtype values 

### How was this patch tested?
unit tests