### PR TITLE
[SPARK-37047][SQL][FOLLOWUP] lpad/rpad should work in non-ANSI mode if parameters str and pad are different types

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/string-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/string-functions.sql
@@ -91,10 +91,10 @@ SELECT hex(rpad(unhex('aabbcc'), 6, unhex('')));
 SELECT hex(rpad(unhex('aabbcc'), 2, unhex('ff')));
 
 -- lpad/rpad with mixed STRING and BINARY input
-SELECT lpad('abc', 5, x'12');
-SELECT lpad(x'12', 5, 'abc');
-SELECT rpad('abc', 5, x'12');
-SELECT rpad(x'12', 5, 'abc');
+SELECT lpad('abc', 5, x'57');
+SELECT lpad(x'57', 5, 'abc');
+SELECT rpad('abc', 5, x'57');
+SELECT rpad(x'57', 5, 'abc');
 
 -- decode
 select decode();

--- a/sql/core/src/test/resources/sql-tests/results/ansi/string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/string-functions.sql.out
@@ -543,39 +543,39 @@ AABB
 
 
 -- !query
-SELECT lpad('abc', 5, x'12')
+SELECT lpad('abc', 5, x'57')
 -- !query schema
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'lpad('abc', 5, X'12')' due to data type mismatch: Arguments 'str' and 'pad' of function 'lpad' must be the same type.; line 1 pos 7
+cannot resolve 'lpad('abc', 5, X'57')' due to data type mismatch: Arguments 'str' and 'pad' of function 'lpad' must be the same type.; line 1 pos 7
 
 
 -- !query
-SELECT lpad(x'12', 5, 'abc')
+SELECT lpad(x'57', 5, 'abc')
 -- !query schema
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'lpad(X'12', 5, 'abc')' due to data type mismatch: Arguments 'str' and 'pad' of function 'lpad' must be the same type.; line 1 pos 7
+cannot resolve 'lpad(X'57', 5, 'abc')' due to data type mismatch: Arguments 'str' and 'pad' of function 'lpad' must be the same type.; line 1 pos 7
 
 
 -- !query
-SELECT rpad('abc', 5, x'12')
+SELECT rpad('abc', 5, x'57')
 -- !query schema
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'rpad('abc', 5, X'12')' due to data type mismatch: Arguments 'str' and 'pad' of function 'rpad' must be the same type.; line 1 pos 7
+cannot resolve 'rpad('abc', 5, X'57')' due to data type mismatch: Arguments 'str' and 'pad' of function 'rpad' must be the same type.; line 1 pos 7
 
 
 -- !query
-SELECT rpad(x'12', 5, 'abc')
+SELECT rpad(x'57', 5, 'abc')
 -- !query schema
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'rpad(X'12', 5, 'abc')' due to data type mismatch: Arguments 'str' and 'pad' of function 'rpad' must be the same type.; line 1 pos 7
+cannot resolve 'rpad(X'57', 5, 'abc')' due to data type mismatch: Arguments 'str' and 'pad' of function 'rpad' must be the same type.; line 1 pos 7
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/string-functions.sql.out
@@ -533,39 +533,35 @@ AABB
 
 
 -- !query
-SELECT lpad('abc', 5, x'12')
+SELECT lpad('abc', 5, x'57')
 -- !query schema
-struct<>
+struct<lpad(abc, 5, X'57'):string>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'lpad('abc', 5, X'12')' due to data type mismatch: Arguments 'str' and 'pad' of function 'lpad' must be the same type.; line 1 pos 7
+WWabc
 
 
 -- !query
-SELECT lpad(x'12', 5, 'abc')
+SELECT lpad(x'57', 5, 'abc')
 -- !query schema
-struct<>
+struct<lpad(X'57', 5, abc):string>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'lpad(X'12', 5, 'abc')' due to data type mismatch: Arguments 'str' and 'pad' of function 'lpad' must be the same type.; line 1 pos 7
+abcaW
 
 
 -- !query
-SELECT rpad('abc', 5, x'12')
+SELECT rpad('abc', 5, x'57')
 -- !query schema
-struct<>
+struct<rpad(abc, 5, X'57'):string>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'rpad('abc', 5, X'12')' due to data type mismatch: Arguments 'str' and 'pad' of function 'rpad' must be the same type.; line 1 pos 7
+abcWW
 
 
 -- !query
-SELECT rpad(x'12', 5, 'abc')
+SELECT rpad(x'57', 5, 'abc')
 -- !query schema
-struct<>
+struct<rpad(X'57', 5, abc):string>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'rpad(X'12', 5, 'abc')' due to data type mismatch: Arguments 'str' and 'pad' of function 'rpad' must be the same type.; line 1 pos 7
+Wabca
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This is a followup of #34154 and #34370 . Now `lpad`/`rpad` allow the `str` and `pad` parameters to be of different types in non-ANSI mode. The result type in this case is a character string.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The changes in this PR restore the behavior (in non-ANSI mode) to that prior to #34154 and #34370 when the `lpad` and `rpad` functions take an `str` and `pad` argument and these arguments are of different types.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. The overloads for the `lpad` and `rpad` functions have not been released yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests are enough (and have been updated appropriately).
