### PR TITLE
[SPARK-37135][TEST] Fix `KryoSerializerBenchmark` and `DateTimeBenchmark` run faild

### DIFF
--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerBenchmark.scala
@@ -25,6 +25,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Kryo._
+import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.launcher.SparkLauncher.EXECUTOR_EXTRA_JAVA_OPTIONS
 import org.apache.spark.serializer.KryoTest._
 import org.apache.spark.util.ThreadUtils
@@ -57,6 +58,7 @@ object KryoSerializerBenchmark extends BenchmarkBase {
   private def run(usePool: Boolean, benchmark: Benchmark): Unit = {
     lazy val sc = createSparkContext(usePool)
 
+    System.clearProperty(IS_TESTING.key)
     benchmark.addCase(s"KryoPool:$usePool") { _ =>
       val futures = for (_ <- 0 until N) yield {
         Future {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DateTimeBenchmark.scala
@@ -61,7 +61,8 @@ object DateTimeBenchmark extends SqlBasedBenchmark {
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     withDefaultTimeZone(LA) {
-      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> LA.getId) {
+      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> LA.getId,
+        SQLConf.LEGACY_INTERVAL_ENABLED.key -> true.toString) {
         val N = 10000000
         runBenchmark("datetime +/- interval") {
           val benchmark = new Benchmark("datetime +/- interval", N, output = output)


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are 2 benchmarks failed to run:

1. org.apache.spark.serializer.KryoSerializerBenchmark (After SPARK-35315)
```
21/10/27 16:09:26 ERROR SparkContext: Error initializing SparkContext.
java.lang.AssertionError: assertion failed: spark.test.home is not set!
	at scala.Predef$.assert(Predef.scala:223)
	at org.apache.spark.deploy.worker.Worker.<init>(Worker.scala:148)
	at org.apache.spark.deploy.worker.Worker$.startRpcEnvAndEndpoint(Worker.scala:954)
	at org.apache.spark.deploy.LocalSparkCluster.$anonfun$start$2(LocalSparkCluster.scala:71)
	at org.apache.spark.deploy.LocalSparkCluster.$anonfun$start$2$adapted(LocalSparkCluster.scala:65)
	at scala.collection.immutable.Range.foreach(Range.scala:158)
	at org.apache.spark.deploy.LocalSparkCluster.start(LocalSparkCluster.scala:65)
	at org.apache.spark.SparkContext$.org$apache$spark$SparkContext$$createTaskScheduler(SparkContext.scala:2971)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:562)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:138)
	at org.apache.spark.serializer.KryoSerializerBenchmark$.createSparkContext(KryoSerializerBenchmark.scala:86)
	at org.apache.spark.serializer.KryoSerializerBenchmark$.sc$lzycompute$1(KryoSerializerBenchmark.scala:58)
	at org.apache.spark.serializer.KryoSerializerBenchmark$.sc$1(KryoSerializerBenchmark.scala:58)
	at org.apache.spark.serializer.KryoSerializerBenchmark$.$anonfun$run$3(KryoSerializerBenchmark.scala:63)
```

For fix `KryoSerializerBenchmark`, this pr clear `IS_TESTING` property before benchmark running.


2.org.apache.spark.sql.execution.benchmark.DateTimeBenchmark (After SPARK-36170)
```
Exception in thread "main" org.apache.spark.sql.catalyst.parser.ParseException: 
Cannot mix year-month and day-time fields: interval 1 month 2 day(line 1, pos 38)

== SQL ==
cast(timestamp_seconds(id) as date) + interval 1 month 2 day
--------------------------------------^^^

	at org.apache.spark.sql.errors.QueryParsingErrors$.mixedIntervalUnitsError(QueryParsingErrors.scala:214)
	at org.apache.spark.sql.catalyst.parser.AstBuilder.constructMultiUnitsIntervalLiteral(AstBuilder.scala:2435)
	at org.apache.spark.sql.catalyst.parser.AstBuilder.$anonfun$visitInterval$1(AstBuilder.scala:2479)
	at org.apache.spark.sql.catalyst.parser.ParserUtils$.withOrigin(ParserUtils.scala:133)
	at org.apache.spark.sql.catalyst.parser.AstBuilder.visitInterval(AstBuilder.scala:2454)
	at org.apache.spark.sql.catalyst.parser.AstBuilder.visitInterval(AstBuilder.scala:57)
	at org.apache.spark.sql.catalyst.parser.SqlBaseParser$IntervalContext.accept(SqlBaseParser.java:17681)
```

For fix `DateTimeBenchmark`, this pr set `SQLConf.LEGACY_INTERVAL_ENABLED.key` to `true` benchmark running.



### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass the Jenkins or GitHub Action
- Manual test：
  - [Run benchmarks: * (JDK 8)](https://github.com/LuciferYang/spark/actions/runs/1392850372)
  - [Run benchmarks: * (JDK 11)](https://github.com/LuciferYang/spark/actions/runs/1392788240)
