### PR TITLE
[SPARK-37141][TESTS] Fix WorkerSuite failure on MacOS

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/worker/WorkerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/WorkerSuite.scala
@@ -70,8 +70,9 @@ class WorkerSuite extends SparkFunSuite with Matchers with BeforeAndAfter {
     val securityMgr = new SecurityManager(conf)
     val rpcEnv = RpcEnv.create("test", "localhost", 12345, conf, securityMgr)
     val resourcesFile = conf.get(SPARK_WORKER_RESOURCE_FILE)
+    val workDir = Utils.createTempDir(namePrefix = this.getClass.getSimpleName).toString
     val localWorker = new Worker(rpcEnv, 50000, 20, 1234 * 5,
-      Array.fill(1)(RpcAddress("1.2.3.4", 1234)), "Worker", "/tmp",
+      Array.fill(1)(RpcAddress("1.2.3.4", 1234)), "Worker", workDir,
       conf, securityMgr, resourcesFile, shuffleServiceSupplier)
     if (local) {
       localWorker


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change Worker's workDir from /tmp to Utils.createTempDir in case WorkerSuite

### Why are the changes needed?
WorkerSuite fails on MacOS after pr [SPARK-35907](https://github.com/apache/spark/pull/33101).

WorkerSuite tries to create ```/tmp``` dir by ```FIles.createDirectories```, but /tmp is a softlink to /private/tmp on MacOs (both intel and m1), according to suite in [UtilsSuite](https://github.com/apache/spark/blob/master/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala#L525), create directory on existed softlink will cause fail.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
pass GA
