### PR TITLE
[SPARK-37149][SQL] Improve error messages for arithmetic overflow exceptions under ANSI mode

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -8,7 +8,7 @@
     "sqlState" : "22005"
   },
   "CANNOT_CHANGE_DECIMAL_PRECISION" : {
-    "message" : [ "%s cannot be represented as Decimal(%s, %s)." ],
+    "message" : [ "%s cannot be represented as Decimal(%s, %s). You can set %s to false to bypass this error." ],
     "sqlState" : "22005"
   },
   "CANNOT_PARSE_DECIMAL" : {
@@ -16,14 +16,14 @@
     "sqlState" : "42000"
   },
   "CAST_CAUSES_OVERFLOW" : {
-    "message" : [ "Casting %s to %s causes overflow" ],
+    "message" : [ "Casting %s to %s causes overflow. You can use 'try_cast' or set %s to false to bypass this error." ],
     "sqlState" : "22005"
   },
   "CONCURRENT_QUERY" : {
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
   },
   "DIVIDE_BY_ZERO" : {
-    "message" : [ "divide by zero" ],
+    "message" : [ "divide by zero. You can use 'try_divide' or set %s to false (except for ANSI interval type) to bypass this error." ],
     "sqlState" : "22012"
   },
   "DUPLICATE_KEY" : {

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -124,7 +124,9 @@ class SparkThrowableSuite extends SparkFunSuite {
     }
 
     // Does not fail with too many args (expects 0 args)
-    assert(getMessage("DIVIDE_BY_ZERO", Array("foo", "bar")) == "divide by zero")
+    assert(getMessage("DIVIDE_BY_ZERO", Array("foo", "bar")) ==
+      "divide by zero. You can use 'try_divide' or set foo to false " +
+        "(except for ANSI interval type) to bypass this error.")
   }
 
   test("Error message is formatted") {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -243,8 +243,8 @@ abstract class BinaryArithmetic extends BinaryOperator with NullIntolerant {
       assert(exactMathMethod.isDefined,
         s"The expression '$nodeName' must override the exactMathMethod() method " +
         "if it is supposed to operate over interval types.")
-      val mathClass = classOf[Math].getName
-      defineCodeGen(ctx, ev, (eval1, eval2) => s"$mathClass.${exactMathMethod.get}($eval1, $eval2)")
+      val mathUtils = MathUtils.getClass.getCanonicalName.stripSuffix("$")
+      defineCodeGen(ctx, ev, (eval1, eval2) => s"$mathUtils.${exactMathMethod.get}($eval1, $eval2)")
     // byte and short are casted into int when add, minus, times or divide
     case ByteType | ShortType =>
       nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
@@ -269,8 +269,8 @@ abstract class BinaryArithmetic extends BinaryOperator with NullIntolerant {
     case IntegerType | LongType =>
       nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
         val operation = if (failOnError && exactMathMethod.isDefined) {
-          val mathClass = classOf[Math].getName
-          s"$mathClass.${exactMathMethod.get}($eval1, $eval2)"
+          val mathUtils = MathUtils.getClass.getCanonicalName.stripSuffix("$")
+          s"$mathUtils.${exactMathMethod.get}($eval1, $eval2)"
         } else {
           s"$eval1 $symbol $eval2"
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -616,8 +616,8 @@ object IntervalUtils {
       monthsWithFraction: Double,
       daysWithFraction: Double,
       microsWithFraction: Double): CalendarInterval = {
-    val truncatedMonths = Math.toIntExact(monthsWithFraction.toLong)
-    val truncatedDays = Math.toIntExact(daysWithFraction.toLong)
+    val truncatedMonths = MathUtils.toIntExact(monthsWithFraction.toLong)
+    val truncatedDays = MathUtils.toIntExact(daysWithFraction.toLong)
     val micros = microsWithFraction + MICROS_PER_DAY * (daysWithFraction - truncatedDays)
     new CalendarInterval(truncatedMonths, truncatedDays, micros.round)
   }
@@ -644,9 +644,9 @@ object IntervalUtils {
    * @throws ArithmeticException if the result overflows any field value
    */
   def negateExact(interval: CalendarInterval): CalendarInterval = {
-    val months = Math.negateExact(interval.months)
-    val days = Math.negateExact(interval.days)
-    val microseconds = Math.negateExact(interval.microseconds)
+    val months = MathUtils.negateExact(interval.months)
+    val days = MathUtils.negateExact(interval.days)
+    val microseconds = MathUtils.negateExact(interval.microseconds)
     new CalendarInterval(months, days, microseconds)
   }
 
@@ -663,9 +663,9 @@ object IntervalUtils {
    * @throws ArithmeticException if the result overflows any field value
    */
   def addExact(left: CalendarInterval, right: CalendarInterval): CalendarInterval = {
-    val months = Math.addExact(left.months, right.months)
-    val days = Math.addExact(left.days, right.days)
-    val microseconds = Math.addExact(left.microseconds, right.microseconds)
+    val months = MathUtils.addExact(left.months, right.months)
+    val days = MathUtils.addExact(left.days, right.days)
+    val microseconds = MathUtils.addExact(left.microseconds, right.microseconds)
     new CalendarInterval(months, days, microseconds)
   }
 
@@ -685,9 +685,9 @@ object IntervalUtils {
    * @throws ArithmeticException if the result overflows any field value
    */
   def subtractExact(left: CalendarInterval, right: CalendarInterval): CalendarInterval = {
-    val months = Math.subtractExact(left.months, right.months)
-    val days = Math.subtractExact(left.days, right.days)
-    val microseconds = Math.subtractExact(left.microseconds, right.microseconds)
+    val months = MathUtils.subtractExact(left.months, right.months)
+    val days = MathUtils.subtractExact(left.days, right.days)
+    val microseconds = MathUtils.subtractExact(left.microseconds, right.microseconds)
     new CalendarInterval(months, days, microseconds)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.sql.errors.QueryExecutionErrors
+
+/**
+ * Helper functions for arithmetic operations with overflow.
+ */
+object MathUtils {
+
+  def addExact(a: Int, b: Int): Int = withOverflow(Math.addExact(a, b))
+
+  def addExact(a: Long, b: Long): Long = withOverflow(Math.addExact(a, b))
+
+  def subtractExact(a: Int, b: Int): Int = withOverflow(Math.subtractExact(a, b))
+
+  def subtractExact(a: Long, b: Long): Long = withOverflow(Math.subtractExact(a, b))
+
+  def multiplyExact(a: Int, b: Int): Int = withOverflow(Math.multiplyExact(a, b))
+
+  def multiplyExact(a: Long, b: Long): Long = withOverflow(Math.multiplyExact(a, b))
+
+  def negateExact(a: Int): Int = withOverflow(Math.negateExact(a))
+
+  def negateExact(a: Long): Long = withOverflow(Math.negateExact(a))
+
+  def toIntExact(a: Long): Int = withOverflow(Math.toIntExact(a))
+
+  def floorDiv(a: Int, b: Int): Int = withOverflow(Math.floorDiv(a, b), Some("try_divide"))
+
+  def floorDiv(a: Long, b: Long): Long = withOverflow(Math.floorDiv(a, b), Some("try_divide"))
+
+  def floorMod(a: Int, b: Int): Int = withOverflow(Math.floorMod(a, b))
+
+  def floorMod(a: Long, b: Long): Long = withOverflow(Math.floorMod(a, b))
+
+  private def withOverflow[A](f: => A, hint: Option[String] = None): A = {
+    try {
+      f
+    } catch {
+      case e: ArithmeticException =>
+        throw QueryExecutionErrors.arithmeticOverflowError(e.getMessage, hint)
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.types
 import scala.math.Numeric._
 import scala.math.Ordering
 
-import org.apache.spark.sql.catalyst.util.SQLOrderingUtil
+import org.apache.spark.sql.catalyst.util.{MathUtils, SQLOrderingUtil}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types.Decimal.DecimalIsConflicted
 
@@ -93,23 +93,23 @@ private[sql] object ShortExactNumeric extends ShortIsIntegral with Ordering.Shor
 
 
 private[sql] object IntegerExactNumeric extends IntIsIntegral with Ordering.IntOrdering {
-  override def plus(x: Int, y: Int): Int = Math.addExact(x, y)
+  override def plus(x: Int, y: Int): Int = MathUtils.addExact(x, y)
 
-  override def minus(x: Int, y: Int): Int = Math.subtractExact(x, y)
+  override def minus(x: Int, y: Int): Int = MathUtils.subtractExact(x, y)
 
-  override def times(x: Int, y: Int): Int = Math.multiplyExact(x, y)
+  override def times(x: Int, y: Int): Int = MathUtils.multiplyExact(x, y)
 
-  override def negate(x: Int): Int = Math.negateExact(x)
+  override def negate(x: Int): Int = MathUtils.negateExact(x)
 }
 
 private[sql] object LongExactNumeric extends LongIsIntegral with Ordering.LongOrdering {
-  override def plus(x: Long, y: Long): Long = Math.addExact(x, y)
+  override def plus(x: Long, y: Long): Long = MathUtils.addExact(x, y)
 
-  override def minus(x: Long, y: Long): Long = Math.subtractExact(x, y)
+  override def minus(x: Long, y: Long): Long = MathUtils.subtractExact(x, y)
 
-  override def times(x: Long, y: Long): Long = Math.multiplyExact(x, y)
+  override def times(x: Long, y: Long): Long = MathUtils.multiplyExact(x, y)
 
-  override def negate(x: Long): Long = Math.negateExact(x)
+  override def negate(x: Long): Long = MathUtils.negateExact(x)
 
   override def toInt(x: Long): Int =
     if (x == x.toInt) {

--- a/sql/core/src/test/resources/sql-tests/results/ansi/decimalArithmeticOperations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/decimalArithmeticOperations.sql.out
@@ -76,7 +76,7 @@ select (5e36BD + 0.1) + 5e36BD
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Decimal(expanded,10000000000000000000000000000000000000.1,39,1}) cannot be represented as Decimal(38, 1).
+Decimal(expanded,10000000000000000000000000000000000000.1,39,1}) cannot be represented as Decimal(38, 1). You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -85,7 +85,7 @@ select (-4e36BD - 0.1) - 7e36BD
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Decimal(expanded,-11000000000000000000000000000000000000.1,39,1}) cannot be represented as Decimal(38, 1).
+Decimal(expanded,-11000000000000000000000000000000000000.1,39,1}) cannot be represented as Decimal(38, 1). You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -94,7 +94,7 @@ select 12345678901234567890.0 * 12345678901234567890.0
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Decimal(expanded,152415787532388367501905199875019052100,39,0}) cannot be represented as Decimal(38, 2).
+Decimal(expanded,152415787532388367501905199875019052100,39,0}) cannot be represented as Decimal(38, 2). You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -103,7 +103,7 @@ select 1e35BD / 0.1
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Decimal(expanded,1000000000000000000000000000000000000,37,0}) cannot be represented as Decimal(38, 6).
+Decimal(expanded,1000000000000000000000000000000000000,37,0}) cannot be represented as Decimal(38, 6). You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -210,7 +210,7 @@ select interval '2 seconds' / 0
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -243,7 +243,7 @@ select interval '2' year / 0
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1750,7 +1750,7 @@ select -(a) from values (interval '-2147483648 months', interval '2147483647 mon
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1997,7 +1997,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.
+Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2006,7 +2006,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1L
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.
+Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2049,7 +2049,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.
+Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2058,7 +2058,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1L
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.
+Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1759,7 +1759,7 @@ select a - b from values (interval '-2147483648 months', interval '2147483647 mo
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1768,7 +1768,7 @@ select b + interval '1 month' from values (interval '-2147483648 months', interv
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -204,7 +204,7 @@ select interval '2 seconds' / 0
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -237,7 +237,7 @@ select interval '2' year / 0
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1739,7 +1739,7 @@ select -(a) from values (interval '-2147483648 months', interval '2147483647 mon
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1986,7 +1986,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.
+Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1995,7 +1995,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1L
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.
+Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2038,7 +2038,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.
+Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2047,7 +2047,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1L
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.
+Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1748,7 +1748,7 @@ select a - b from values (interval '-2147483648 months', interval '2147483647 mo
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1757,7 +1757,7 @@ select b + interval '1 month' from values (interval '-2147483648 months', interv
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/case.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/case.sql.out
@@ -179,7 +179,7 @@ SELECT CASE WHEN 1=0 THEN 1/0 WHEN 1=1 THEN 1 ELSE 2/0 END
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -188,7 +188,7 @@ SELECT CASE 1 WHEN 0 THEN 1/0 WHEN 1 THEN 1 ELSE 2/0 END
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -197,7 +197,7 @@ SELECT CASE WHEN i > 100 THEN 1/0 ELSE 0 END FROM case_tbl
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/float4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/float4.sql.out
@@ -325,7 +325,7 @@ SELECT int(float('2147483647'))
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting 2.14748365E9 to int causes overflow
+Casting 2.14748365E9 to int causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -342,7 +342,7 @@ SELECT int(float('-2147483900'))
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting -2.1474839E9 to int causes overflow
+Casting -2.1474839E9 to int causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -375,7 +375,7 @@ SELECT bigint(float('-9223380000000000000'))
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting -9.22338E18 to int causes overflow
+Casting -9.22338E18 to int causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/float8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/float8.sql.out
@@ -833,7 +833,7 @@ SELECT bigint(double('-9223372036854780000'))
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting -9.22337203685478E18 to long causes overflow
+Casting -9.22337203685478E18 to long causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int4.sql.out
@@ -200,7 +200,7 @@ SELECT '' AS five, i.f1, i.f1 * smallint('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -220,7 +220,7 @@ SELECT '' AS five, i.f1, i.f1 * int('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -240,7 +240,7 @@ SELECT '' AS five, i.f1, i.f1 + smallint('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -261,7 +261,7 @@ SELECT '' AS five, i.f1, i.f1 + int('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -282,7 +282,7 @@ SELECT '' AS five, i.f1, i.f1 - smallint('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -303,7 +303,7 @@ SELECT '' AS five, i.f1, i.f1 - int('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow
+integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
@@ -572,7 +572,7 @@ select bigint('9223372036854775800') / bigint('0')
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -581,7 +581,7 @@ select bigint('-9223372036854775808') / smallint('0')
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -590,7 +590,7 @@ select smallint('100') / bigint('0')
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -607,7 +607,7 @@ SELECT CAST(q1 AS int) FROM int8_tbl WHERE q2 <> 456
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting 4567890123456789 to int causes overflow
+Casting 4567890123456789 to int causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -624,7 +624,7 @@ SELECT CAST(q1 AS smallint) FROM int8_tbl WHERE q2 <> 456
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting 4567890123456789 to smallint causes overflow
+Casting 4567890123456789 to smallint causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -661,7 +661,7 @@ SELECT CAST(double('922337203685477580700.0') AS bigint)
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting 9.223372036854776E20 to long causes overflow
+Casting 9.223372036854776E20 to long causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -733,7 +733,7 @@ SELECT string(int(shiftleft(bigint(-1), 63))+1)
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting -9223372036854775808 to int causes overflow
+Casting -9223372036854775808 to int causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -742,7 +742,7 @@ SELECT bigint((-9223372036854775808)) * bigint((-1))
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow
+long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -767,7 +767,7 @@ SELECT bigint((-9223372036854775808)) * int((-1))
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow
+long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -792,7 +792,7 @@ SELECT bigint((-9223372036854775808)) * smallint((-1))
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow
+long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
@@ -392,7 +392,7 @@ SELECT '' AS three, q1, q2, q1 * q2 AS multiply FROM INT8_TBL
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow
+long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
@@ -177,7 +177,7 @@ SELECT 1 AS one FROM test_having WHERE 1/a = 1 HAVING 1 < 2
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part2.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part2.sql.out
@@ -225,7 +225,7 @@ from range(9223372036854775804, 9223372036854775807) x
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow
+long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -235,7 +235,7 @@ from range(-9223372036854775806, -9223372036854775805) x
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow
+long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-case.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-case.sql.out
@@ -179,7 +179,7 @@ SELECT CASE WHEN udf(1=0) THEN 1/0 WHEN 1=1 THEN 1 ELSE 2/0 END
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -188,7 +188,7 @@ SELECT CASE 1 WHEN 0 THEN 1/udf(0) WHEN 1 THEN 1 ELSE 2/0 END
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -197,7 +197,7 @@ SELECT CASE WHEN i > 100 THEN udf(1/0) ELSE udf(0) END FROM case_tbl
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
@@ -177,7 +177,7 @@ SELECT 1 AS one FROM test_having WHERE 1/udf(a) = 1 HAVING 1 < 2
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero
+divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR improves error messages for arithmetic overflow exceptions thrown under ANSI mode. It augments the error messages by suggesting workarounds to users:
- Turn off ANSI mode (except for ANSI interval type)
- Use `try_` function if applicable.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make error messages more actionable.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Certain error messages will be different.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests.