### PR TITLE
[SPARK-37151][CORE] Avoid ExecutorStateChanged sync attempt retry immediately when failed due to bad connection 

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2258,4 +2258,13 @@ package object config {
       .version("3.2.0")
       .stringConf
       .createOptional
+
+  private[spark] val EXECUTOR_STATE_SYNC_MAX_ATTEMPTS =
+    ConfigBuilder("spark.worker.executorStateSync.maxAttempts")
+      .internal()
+      .doc("The max attempts the worker will try to sync the ExecutorState to the Master, if " +
+        "the failed attempts reach the max attempts limit, the worker will give up and exit.")
+      .version("3.3.0")
+      .intConf
+      .createWithDefault(5)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
A worker would retry sending the ExecutorStateChanged message when the previous attempt failed. This would not be an issue when the attempt failed with TimeoutException. But if the connection between the worker and the master is broken, the attempt would fail immediately, leading to the retry attempt also fail, and quickly reaches the max attempt limitation.

The PR detects the failure reason, if an attempt failed due to bad connection, we can wait for a while (the default RPC timeout interval) before retrying. This prevents quick failure due to transient network issues.

The PR also adds a new config `spark.worker.executorStateSync.maxAttempts`, which controls the max attempt number of ExecutorStateChanged sync between a worker and the master.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To avoid a worker exit quickly due to transient network issues.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this PR adds a new config `spark.worker.executorStateSync.maxAttempts`, which controls the max attempt number of ExecutorStateChanged sync between a worker and the master.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Verified with a few customers, confirmed they didn't hit the worker exit issue again with this patch.