### PR TITLE
[SPARK-37150][SQL] Migrate DESCRIBE NAMESPACE to use V2 command by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/KeepLegacyOutputs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/KeepLegacyOutputs.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ShowNamespaces, ShowTables}
+import org.apache.spark.sql.catalyst.plans.logical.{DescribeNamespace, LogicalPlan, ShowNamespaces, ShowTables}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.internal.SQLConf
@@ -39,6 +39,10 @@ object KeepLegacyOutputs extends Rule[LogicalPlan] {
         case s: ShowNamespaces =>
           assert(s.output.length == 1)
           s.copy(output = Seq(s.output.head.withName("databaseName")))
+        case d: DescribeNamespace =>
+          assert(d.output.length == 2)
+          d.copy(output = Seq(d.output.head.withName("database_description_item"),
+            d.output.last.withName("database_description_value")))
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -105,15 +105,8 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
     case UnsetViewProperties(ResolvedView(ident, _), keys, ifExists) =>
       AlterTableUnsetPropertiesCommand(ident.asTableIdentifier, keys, ifExists, isView = true)
 
-    case DescribeNamespace(DatabaseInSessionCatalog(db), extended, output) =>
-      val newOutput = if (conf.getConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA)) {
-        assert(output.length == 2)
-        Seq(output.head.withName("database_description_item"),
-          output.last.withName("database_description_value"))
-      } else {
-        output
-      }
-      DescribeDatabaseCommand(db, extended, newOutput)
+    case DescribeNamespace(DatabaseInSessionCatalog(db), extended, output) if conf.useV1Command =>
+      DescribeDatabaseCommand(db, extended, output)
 
     case SetNamespaceProperties(DatabaseInSessionCatalog(db), properties) =>
       AlterDatabasePropertiesCommand(db, properties)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -191,7 +191,7 @@ case class DescribeDatabaseCommand(
         if (properties.isEmpty) {
           ""
         } else {
-          properties.toSeq.mkString("(", ", ", ")")
+          properties.toSeq.sortBy(_._1).mkString("(", ", ", ")")
         }
       result :+ Row("Properties", propertiesStr)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -180,7 +180,7 @@ case class DescribeDatabaseCommand(
       sparkSession.sessionState.catalog.getDatabaseMetadata(databaseName)
     val allDbProperties = dbMetadata.properties
     val result =
-      Row("Database Name", dbMetadata.name) ::
+      Row("Namespace Name", dbMetadata.name) ::
         Row("Comment", dbMetadata.description) ::
         Row("Location", CatalogUtils.URIToString(dbMetadata.locationUri))::
         Row("Owner", allDbProperties.getOrElse(PROP_OWNER, "")) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -180,7 +180,7 @@ case class DescribeDatabaseCommand(
       sparkSession.sessionState.catalog.getDatabaseMetadata(databaseName)
     val allDbProperties = dbMetadata.properties
     val result =
-      Row("Namespace Name", dbMetadata.name) ::
+      Row("Database Name", dbMetadata.name) ::
         Row("Comment", dbMetadata.description) ::
         Row("Location", CatalogUtils.URIToString(dbMetadata.locationUri))::
         Row("Owner", allDbProperties.getOrElse(PROP_OWNER, "")) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeNamespaceExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeNamespaceExec.scala
@@ -44,7 +44,7 @@ case class DescribeNamespaceExec(
     }
 
     if (isExtended) {
-      val properties = metadata.asScala -- CatalogV2Util.NAMESPACE_RESERVED_PROPERTIES
+      val properties = metadata.asScala.toMap -- CatalogV2Util.NAMESPACE_RESERVED_PROPERTIES
       val propertiesStr =
         if (properties.isEmpty) {
           ""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeNamespaceExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeNamespaceExec.scala
@@ -45,9 +45,13 @@ case class DescribeNamespaceExec(
 
     if (isExtended) {
       val properties = metadata.asScala -- CatalogV2Util.NAMESPACE_RESERVED_PROPERTIES
-      if (properties.nonEmpty) {
-        rows += toCatalystRow("Properties", properties.toSeq.mkString("(", ",", ")"))
-      }
+      val propertiesStr =
+        if (properties.isEmpty) {
+          ""
+        } else {
+          properties.toSeq.mkString("(", ", ", ")")
+        }
+      rows += toCatalystRow("Properties", propertiesStr)
     }
     rows.toSeq
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeNamespaceExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeNamespaceExec.scala
@@ -44,12 +44,13 @@ case class DescribeNamespaceExec(
     }
 
     if (isExtended) {
-      val properties = metadata.asScala.toMap -- CatalogV2Util.NAMESPACE_RESERVED_PROPERTIES
-      val propertiesStr = if (properties.isEmpty) {
-        ""
-      } else {
-        properties.toSeq.mkString("(", ", ", ")")
-      }
+      val properties = metadata.asScala -- CatalogV2Util.NAMESPACE_RESERVED_PROPERTIES
+      val propertiesStr =
+        if (properties.isEmpty) {
+          ""
+        } else {
+          properties.toSeq.sortBy(_._1).mkString("(", ", ", ")")
+        }
       rows += toCatalystRow("Properties", propertiesStr)
     }
     rows.toSeq

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeNamespaceExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeNamespaceExec.scala
@@ -45,12 +45,11 @@ case class DescribeNamespaceExec(
 
     if (isExtended) {
       val properties = metadata.asScala.toMap -- CatalogV2Util.NAMESPACE_RESERVED_PROPERTIES
-      val propertiesStr =
-        if (properties.isEmpty) {
-          ""
-        } else {
-          properties.toSeq.mkString("(", ", ", ")")
-        }
+      val propertiesStr = if (properties.isEmpty) {
+        ""
+      } else {
+        properties.toSeq.mkString("(", ", ", ")")
+      }
       rows += toCatalystRow("Properties", propertiesStr)
     }
     rows.toSeq

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1079,7 +1079,8 @@ class DataSourceV2SQLSuite
           assert(sql("DESC NAMESPACE EXTENDED testcat.reservedTest")
             .toDF("k", "v")
             .where("k='Properties'")
-            .isEmpty, s"$key is a reserved namespace property and ignored")
+            .where("v=''")
+            .count == 1, s"$key is a reserved namespace property and ignored")
           val meta =
             catalog("testcat").asNamespaceCatalog.loadNamespaceMetadata(Array("reservedTest"))
           assert(meta.get(key) == null || !meta.get(key).contains("foo"),
@@ -1244,7 +1245,7 @@ class DataSourceV2SQLSuite
         Row(SupportsNamespaces.PROP_COMMENT.capitalize, "test namespace"),
         Row(SupportsNamespaces.PROP_LOCATION.capitalize, "/tmp/ns_test"),
         Row(SupportsNamespaces.PROP_OWNER.capitalize, defaultUser),
-        Row("Properties", "((a,b),(b,a),(c,c))"))
+        Row("Properties", "((a,b), (b,a), (c,c))"))
       )
     }
   }
@@ -1270,7 +1271,8 @@ class DataSourceV2SQLSuite
           assert(sql("DESC NAMESPACE EXTENDED testcat.reservedTest")
             .toDF("k", "v")
             .where("k='Properties'")
-            .isEmpty, s"$key is a reserved namespace property and ignored")
+            .where("v=''")
+            .count == 1, s"$key is a reserved namespace property and ignored")
           val meta =
             catalog("testcat").asNamespaceCatalog.loadNamespaceMetadata(Array("reservedTest"))
           assert(meta.get(key) == null || !meta.get(key).contains("foo"),
@@ -1290,7 +1292,8 @@ class DataSourceV2SQLSuite
         Row("Namespace Name", "ns2"),
         Row(SupportsNamespaces.PROP_COMMENT.capitalize, "test namespace"),
         Row(SupportsNamespaces.PROP_LOCATION.capitalize, "/tmp/ns_test_2"),
-        Row(SupportsNamespaces.PROP_OWNER.capitalize, defaultUser))
+        Row(SupportsNamespaces.PROP_OWNER.capitalize, defaultUser),
+        Row("Properties", ""))
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -762,7 +762,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
         checkAnswer(
           sql(s"DESCRIBE DATABASE EXTENDED $dbName").toDF("key", "value")
             .where("key not like 'Owner%'"), // filter for consistency with in-memory catalog
-          Row("Database Name", dbNameWithoutBackTicks) ::
+          Row("Namespace Name", dbNameWithoutBackTicks) ::
             Row("Comment", "") ::
             Row("Location", CatalogUtils.URIToString(location)) ::
             Row("Properties", "((a,a), (b,b), (c,c))") :: Nil)
@@ -772,7 +772,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
         checkAnswer(
           sql(s"DESCRIBE DATABASE EXTENDED $dbName").toDF("key", "value")
             .where("key not like 'Owner%'"), // filter for consistency with in-memory catalog
-          Row("Database Name", dbNameWithoutBackTicks) ::
+          Row("Namespace Name", dbNameWithoutBackTicks) ::
             Row("Comment", "") ::
             Row("Location", CatalogUtils.URIToString(location)) ::
             Row("Properties", "((a,a), (b,b), (c,c), (d,d))") :: Nil)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeNamespaceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeNamespaceSuite.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.internal.SQLConf
  *   - V1 Hive External catalog:
  *     `org.apache.spark.sql.hive.execution.command.DescribeNamespaceSuite`
  */
-trait DescribeNamespaceSuiteBase extends command.DescribeNamespaceSuiteBase {
+trait DescribeNamespaceSuiteBase extends command.DescribeNamespaceSuiteBase
+    with command.TestsV1AndV2Commands {
   override def notFoundMsgPrefix: String = "Database"
 
   test("basic") {
@@ -44,7 +45,7 @@ trait DescribeNamespaceSuiteBase extends command.DescribeNamespaceSuiteBase {
         .collect()
 
       assert(result.length == 4)
-      assert(result(0) === Row("Database Name", ns))
+      assert(result(0) === Row("Namespace Name", ns))
       assert(result(1) === Row("Comment", ""))
       // Check only the key for "Location" since its value depends on warehouse path, etc.
       assert(result(2).getString(0) === "Location")
@@ -74,4 +75,6 @@ trait DescribeNamespaceSuiteBase extends command.DescribeNamespaceSuiteBase {
  * The class contains tests for the `DESCRIBE NAMESPACE` command to check V1 In-Memory
  * table catalog.
  */
-class DescribeNamespaceSuite extends DescribeNamespaceSuiteBase with CommandSuiteBase
+class DescribeNamespaceSuite extends DescribeNamespaceSuiteBase with CommandSuiteBase {
+  override def commandVersion: String = super[DescribeNamespaceSuiteBase].commandVersion
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeNamespaceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeNamespaceSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.command
-import org.apache.spark.sql.internal.SQLConf
 
 /**
  * This base suite contains unified tests for the `DESCRIBE NAMESPACE` command that checks V1
@@ -44,29 +43,13 @@ trait DescribeNamespaceSuiteBase extends command.DescribeNamespaceSuiteBase
         .where("key not like 'Owner%'") // filter for consistency with in-memory catalog
         .collect()
 
+      val namePrefix = if (conf.useV1Command) "Database" else "Namespace"
       assert(result.length == 4)
-      assert(result(0) === Row("Namespace Name", ns))
+      assert(result(0) === Row(s"$namePrefix Name", ns))
       assert(result(1) === Row("Comment", ""))
       // Check only the key for "Location" since its value depends on warehouse path, etc.
       assert(result(2).getString(0) === "Location")
       assert(result(3) === Row("Properties", ""))
-    }
-  }
-
-  test("Keep the legacy output schema") {
-    Seq(true, false).foreach { keepLegacySchema =>
-      withSQLConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA.key -> keepLegacySchema.toString) {
-        val ns = "db1"
-        withNamespace(ns) {
-          sql(s"CREATE NAMESPACE $ns")
-          val schema = sql(s"DESCRIBE NAMESPACE $ns").schema.fieldNames.toSeq
-          if (keepLegacySchema) {
-            assert(schema === Seq("database_description_item", "database_description_value"))
-          } else {
-            assert(schema === Seq("info_name", "info_value"))
-          }
-        }
-      }
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/DescribeNamespaceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/DescribeNamespaceSuite.scala
@@ -23,4 +23,6 @@ import org.apache.spark.sql.execution.command.v1
  * The class contains tests for the `DESCRIBE NAMESPACE` command to check V1 Hive external
  * table catalog.
  */
-class DescribeNamespaceSuite extends v1.DescribeNamespaceSuiteBase with CommandSuiteBase
+class DescribeNamespaceSuite extends v1.DescribeNamespaceSuiteBase with CommandSuiteBase {
+  override def commandVersion: String = super[DescribeNamespaceSuiteBase].commandVersion
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to use V2 commands as default as outlined in [SPARK-36588](https://issues.apache.org/jira/browse/SPARK-36588), and this PR migrates `DESCRIBE NAMESPACE` to use v2 command by default.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's been a while since we introduced the v2 commands,  and it seems reasonable to use v2 commands by default even for the session catalog, with a legacy config to fall back to the v1 commands.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
For non-session catalogs (v2 command), the followings are changing:
1. `Properties` row will be present with empty value even if there is no property (same behavior as v1).
2. There will be an empty space between each property pair: e.g. `((a,b), (c,d))` (new) vs. `((a,b),(c,d))` (old). This is also the same behavior as v1.

For the session catalog, now that v2 command will be used, we will use `Namespace Name` instead of `Database Name` for the name row. The user can fall back to using v1 command by setting `spark.sql.legacy.useV1Command` to `true`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests.