### PR TITLE
[SPARK-37131][SQL] Support use IN/EXISTS with subquery in Project/Aggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -687,10 +687,10 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
 
       case inSubqueryOrExistsSubquery =>
         plan match {
-          case _: Filter | _: SupportsSubquery | _: Join => // Ok
-          case _ =>
-            failAnalysis(s"IN/EXISTS predicate sub-queries can only be used in" +
-                s" Filter/Join and a few commands: $plan")
+          case _: Filter | _: SupportsSubquery | _: Join | _: Aggregate | _: Project => // Ok
+          case other =>
+            failAnalysis(s"IN/EXISTS predicate sub-queries cannot be used in " +
+                s"${other.nodeName}. and a few commands: $plan")
         }
         // Validate to make sure the correlations appearing in the query are valid and
         // allowed by spark.

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-joins.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-joins.sql
@@ -387,6 +387,14 @@ FULL OUTER JOIN s2
 ON s1.id = s2.id
 AND s1.id NOT IN (SELECT id FROM s3);
 
+-- IN with subQuery on Project
+SELECT s2.id, s2.id IN (SELECT s1.id FROM s1) AS res FROM s2;
+
+-- IN with subQuery on Aggregate
+SELECT COUNT(s2.id) AS cnt, CASE WHEN s2.id in (SELECT s1.id FROM s1) THEN 'tag1' ELSE 'tag2' END AS tag
+FROM s2
+GROUP BY CASE WHEN s2.id in (SELECT s1.id FROM s1) THEN 'tag1' ELSE 'tag2' END;
+
 
 DROP VIEW s1;
 

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-joins.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-joins.sql.out
@@ -573,6 +573,29 @@ NULL	9
 
 
 -- !query
+SELECT s2.id, s2.id IN (SELECT s1.id FROM s1) FROM s2
+-- !query schema
+struct<id:int,res:boolean>
+-- !query output
+1   true
+3   true
+4   false
+6   false
+9   true
+
+
+-- !query
+SELECT COUNT(s2.id), CASE WHEN s2.id in (SELECT s1.id FROM s1) THEN 'tag1' ELSE 'tag2' END AS tag
+FROM s2
+GROUP BY CASE WHEN s2.id in (SELECT s1.id FROM s1) THEN 'tag1' ELSE 'tag2' END
+-- !query schema
+struct<cnt:int,tag:string>
+-- !query output
+3   tag1
+2   tag2
+
+
+-- !query
 DROP VIEW s1
 -- !query schema
 struct<>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support SparkSQL use IN/EXISTS with subquery in Project/Aggregate

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, user runs the following code will report an error.
```
CREATE TABLE tbl1 (col1 INT, col2 STRING) USING PARQUET;
INSERT OVERWRITE TABLE tbl1 SELECT 0,1;
CREATE TABLE tbl2 (c1 INT, c2 STRING) USING PARQUET; 
INSERT OVERWRITE TABLE tbl2 SELECT 0,2;

case 1:
    select c1 in (select col1 from tbl1) from tbl2 
    Error msg:
        IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Project []
case 2:
    select count(1), case when c1 in (select col1 from tbl1) then "A" else "B" end as tag from tbl2 group by case when c1 in (select col1 from tbl1) then "A" else "B" end 
    Error msg:
        IN/EXISTS predicate sub-queries can only be used in Filter/Join and a few commands: Aggregate []
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Now, user can run following code correctly
```
case 1:
        select c1 in (select col1 from tbl1) from tbl2 
case 2:
        select count(1), case when c1 in (select col1 from tbl1) then "A" else "B" end as tag from tbl2 group by case when c1 in (select col1 from tbl1) then "A" else "B" end 


### How was this patch tested?
Added unit tests 
