### PR TITLE
[SPARK-37134][PYTHON][DOCS] Clarify the options in "Using PySpark Native Features"

### DIFF
--- a/python/docs/source/user_guide/python_packaging.rst
+++ b/python/docs/source/user_guide/python_packaging.rst
@@ -63,7 +63,7 @@ Using PySpark Native Features
 -----------------------------
 
 PySpark allows to upload Python files (``.py``), zipped Python packages (``.zip``), and Egg files (``.egg``)
-to the executors by:
+to the executors by one of the following:
 
 - Setting the configuration setting ``spark.submit.pyFiles``
 - Setting ``--py-files`` option in Spark scripts


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix:

```diff
- to the executors by:
+ to the executors by one of the following:
```

to clarify that doing one of many options works (instead of doing all options together).

### Why are the changes needed?

To prevent confusion.

### Does this PR introduce _any_ user-facing change?

Yes, this is user-facing documentation change.

### How was this patch tested?

Manually double checked.

Closes #34422