### PR TITLE
[SPARK-37158][DOC] Add doc about spark not supported hive built-in functions

### DIFF
--- a/docs/sql-ref-functions.md
+++ b/docs/sql-ref-functions.md
@@ -44,3 +44,28 @@ User-Defined Functions (UDFs) are a feature of Spark SQL that allows users to de
  * [Scalar User-Defined Functions (UDFs)](sql-ref-functions-udf-scalar.html)
  * [User-Defined Aggregate Functions (UDAFs)](sql-ref-functions-udf-aggregate.html)
  * [Integration with Hive UDFs/UDAFs/UDTFs](sql-ref-functions-udf-hive.html)
+
+### Not Supported Hive Built-in Functions
+
+Spark have a list of Hive built-in functions that Spark do not support. List of functions spark are explicitly not supporting are:
+
+  * compute_stats
+  * context_ngrams
+  * create_union
+  * current_user
+  * ewah_bitmap
+  * ewah_bitmap_and
+  * ewah_bitmap_empty
+  * ewah_bitmap_or
+  * field
+  * in_file
+  * index
+  * matchpath
+  * ngrams
+  * noop
+  * noopstreaming
+  * noopwithmap
+  * noopwithmapstreaming
+  * parse_url_tuple
+  * reflect2
+  * windowingtablefunction


### PR DESCRIPTION
### What changes were proposed in this pull request?
We have remove the code about check supported functions https://github.com/apache/spark/pull/34410 , in this pr add doc about hive built-in functions that  spark not supported.

Then we can have a place to explain with user and show this.


### Why are the changes needed?
Improve doc


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Not need
![image](https://user-images.githubusercontent.com/46485123/139388614-d8e2c19a-42f1-46ac-9611-59b66d29e54b.png)
