### PR TITLE
[WIP][SPARK-37163][SQL] Disallow casting Date as Numeric types

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -50,6 +50,8 @@ license: |
 
   - Since Spark 3.3, the `strfmt` in `format_string(strfmt, obj, ...)` and `printf(strfmt, obj, ...)` will no longer support to use "0$" to specify the first argument, the first argument should always reference by "1$" when use argument index to indicating the position of the argument in the argument list.
 
+  - Since Spark 3.3, casting Date type values as Numeric types is disallowed by default. In Spark 3.2 or earlier, the conversion is allowed and the result is always NULL. To restore the behavior before Spark 3.3, you can set `spark.sql.legacy.allowCastDateAsNumeric` as `true`.
+
 ## Upgrading from Spark SQL 3.1 to 3.2
 
   - Since Spark 3.2, ADD FILE/JAR/ARCHIVE commands require each path to be enclosed by `"` or `'` if the path contains whitespaces.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -87,7 +87,7 @@ object Cast {
 
     case (StringType, _: NumericType) => true
     case (BooleanType, _: NumericType) => true
-    case (DateType, _: NumericType) => true
+    case (DateType, _: NumericType) if SQLConf.get.legacyCastDateAsNumeric => true
     case (TimestampType, _: NumericType) => true
     case (_: NumericType, _: NumericType) => true
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2893,6 +2893,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val LEGACY_CAST_DATE_AS_NUMERIC =
+    buildConf("spark.sql.legacy.allowCastDateAsNumeric")
+      .internal()
+      .doc(s"When true and '${ANSI_ENABLED.key}' is false, casting Date type to Numeric type is" +
+        s" allowed. Before version 3.3.0, the conversion is allowed and the result is always NULL.")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val TRUNCATE_TABLE_IGNORE_PERMISSION_ACL =
     buildConf("spark.sql.truncateTable.ignorePermissionAcl.enabled")
       .internal()
@@ -4106,6 +4115,8 @@ class SQLConf extends Serializable with Logging {
     getConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED)
 
   def legacyStatisticalAggregate: Boolean = getConf(SQLConf.LEGACY_STATISTICAL_AGGREGATE)
+
+  def legacyCastDateAsNumeric: Boolean = getConf(SQLConf.LEGACY_CAST_DATE_AS_NUMERIC)
 
   def truncateTableIgnorePermissionAcl: Boolean =
     getConf(SQLConf.TRUNCATE_TABLE_IGNORE_PERMISSION_ACL)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -52,7 +52,9 @@ class CastSuite extends CastSuiteBase {
     checkNullCast(BooleanType, TimestampType)
     numericTypes.foreach(dt => checkNullCast(dt, TimestampType))
     numericTypes.foreach(dt => checkNullCast(TimestampType, dt))
-    numericTypes.foreach(dt => checkNullCast(DateType, dt))
+    withSQLConf(SQLConf.LEGACY_CAST_DATE_AS_NUMERIC.key -> "true") {
+      numericTypes.foreach(dt => checkNullCast(DateType, dt))
+    }
   }
 
   test("cast from long #2") {
@@ -436,14 +438,21 @@ class CastSuite extends CastSuiteBase {
   }
 
   test("cast from date") {
+    import DataTypeTestUtils._
+
     val d = Date.valueOf("1970-01-01")
-    checkEvaluation(cast(d, ShortType), null)
-    checkEvaluation(cast(d, IntegerType), null)
-    checkEvaluation(cast(d, LongType), null)
-    checkEvaluation(cast(d, FloatType), null)
-    checkEvaluation(cast(d, DoubleType), null)
-    checkEvaluation(cast(d, DecimalType.SYSTEM_DEFAULT), null)
-    checkEvaluation(cast(d, DecimalType(10, 2)), null)
+    withSQLConf(SQLConf.LEGACY_CAST_DATE_AS_NUMERIC.key -> "true") {
+      checkEvaluation(cast(d, ShortType), null)
+      checkEvaluation(cast(d, IntegerType), null)
+      checkEvaluation(cast(d, LongType), null)
+      checkEvaluation(cast(d, FloatType), null)
+      checkEvaluation(cast(d, DoubleType), null)
+      checkEvaluation(cast(d, DecimalType.SYSTEM_DEFAULT), null)
+      checkEvaluation(cast(d, DecimalType(10, 2)), null)
+    }
+    withSQLConf(SQLConf.LEGACY_CAST_DATE_AS_NUMERIC.key -> "false") {
+      numericTypes.foreach(dt => verifyCastFailure(cast(d, dt)))
+    }
     checkEvaluation(cast(d, StringType), "1970-01-01")
 
     checkEvaluation(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Disallow casting Date as Numeric types, which always returned NULL in Spark 3.2 or earlier.
If users really want to fall back to the legacy behavior, they can set the legacy flag `spark.sql.legacy.allowCastDateAsNumeric` as true.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, Date type values can be cast as Numeric types. However, the result is always NULL.
On the other hand, Numeric values can't be cast as Date type.
It doesn't make sense to keep the behavior of casting Date to NULL numeric types. I suggest to disallow the conversion. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Disallow casting Date as Numeric types. If users really want to fall back to the legacy behavior, they can set the legacy flag `spark.sql.legacy.allowCastDateAsNumeric` as true.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT