### PR TITLE
[SPARK-37164][SQL] Add ExpressionBuilder for functions with complex overloads

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -27,9 +27,10 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.commons.codec.binary.{Base64 => CommonsBase64}
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult}
+import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, FunctionRegistry, TypeCheckResult}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.trees.TreePattern.{TreePattern, UPPER_OR_LOWER}
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData, TypeUtils}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
@@ -1328,25 +1329,31 @@ case class StringLocate(substr: Expression, str: Expression, start: Expression)
 
 }
 
-/**
- * Helper class for implementing StringLPad and StringRPad.
- * Returns the default expression to be used in StringLPad or StringRPad based on the type of
- * the input expression.
- * For character string expressions the default padding expression is the string literal ' '.
- * For byte sequence expressions the default padding expression is the byte literal 0x00.
- */
-object StringPadDefaultValue {
-  def get(str: Expression): Expression = {
-    str.dataType match {
-      case StringType => Literal(" ")
-      case BinaryType => Literal(Array[Byte](0))
+trait PadExpressionBuilderBase extends ExpressionBuilder {
+  override def build(expressions: Seq[Expression]): Expression = {
+    val numArgs = expressions.length
+    if (numArgs == 2) {
+      if (expressions(0).dataType == BinaryType) {
+        createBinaryPad(expressions(0), expressions(1), Literal(Array[Byte](0)))
+      } else {
+        createStringPad(expressions(0), expressions(1), Literal(" "))
+      }
+    } else if (numArgs == 3) {
+      if (expressions(0).dataType == BinaryType && expressions(2).dataType == BinaryType) {
+        createBinaryPad(expressions(0), expressions(1), expressions(2))
+      } else {
+        createStringPad(expressions(0), expressions(1), expressions(2))
+      }
+    } else {
+      throw QueryCompilationErrors.invalidFunctionArgumentNumberError(Seq(2, 3), funcName, numArgs)
     }
   }
+
+  protected def funcName: String
+  protected def createBinaryPad(str: Expression, len: Expression, pad: Expression): Expression
+  protected def createStringPad(str: Expression, len: Expression, pad: Expression): Expression
 }
 
-/**
- * Returns str, left-padded with pad to a length of len.
- */
 @ExpressionDescription(
   usage = """
     _FUNC_(str, len[, pad]) - Returns `str`, left-padded with `pad` to a length of `len`.
@@ -1363,52 +1370,39 @@ object StringPadDefaultValue {
       > SELECT _FUNC_('hi', 5);
           hi
       > SELECT hex(_FUNC_(unhex('aabb'), 5));
-          000000AABB
+       000000AABB
       > SELECT hex(_FUNC_(unhex('aabb'), 5, unhex('1122')));
-          112211AABB
+       112211AABB
   """,
   since = "1.5.0",
   group = "string_funcs")
-case class StringLPad(str: Expression, len: Expression, pad: Expression = Literal(" "))
-  extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
-
-  def this(str: Expression, len: Expression) = {
-    this(str, len, StringPadDefaultValue.get(str))
+object LPadExpressionBuilder extends PadExpressionBuilderBase {
+  override def funcName: String = "lpad"
+  override def createBinaryPad(str: Expression, len: Expression, pad: Expression): Expression = {
+    new BinaryLPad(str, len, pad)
   }
+  override def createStringPad(str: Expression, len: Expression, pad: Expression): Expression = {
+    StringLPad(str, len, pad)
+  }
+}
+
+case class StringLPad(str: Expression, len: Expression, pad: Expression)
+  extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
   override def first: Expression = str
   override def second: Expression = len
   override def third: Expression = pad
 
   override def dataType: DataType = str.dataType
-  override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(StringType, BinaryType), IntegerType, TypeCollection(StringType, BinaryType))
-
-  override def checkInputDataTypes(): TypeCheckResult = {
-    super.checkInputDataTypes() match {
-      case fail: TypeCheckResult.TypeCheckFailure => fail
-      case _ if str.dataType != pad.dataType =>
-        TypeCheckResult.TypeCheckFailure(
-          s"Arguments 'str' and 'pad' of function '$prettyName' must be the same type.")
-      case other => other
-    }
-  }
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, IntegerType, StringType)
 
   override def nullSafeEval(string: Any, len: Any, pad: Any): Any = {
-    str.dataType match {
-      case StringType => string.asInstanceOf[UTF8String]
-        .lpad(len.asInstanceOf[Int], pad.asInstanceOf[UTF8String])
-      case BinaryType => ByteArray.lpad(string.asInstanceOf[Array[Byte]],
-        len.asInstanceOf[Int], pad.asInstanceOf[Array[Byte]])
-    }
+    string.asInstanceOf[UTF8String].lpad(len.asInstanceOf[Int], pad.asInstanceOf[UTF8String])
   }
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     defineCodeGen(ctx, ev, (string, len, pad) => {
-      str.dataType match {
-        case StringType => s"$string.lpad($len, $pad)"
-        case BinaryType => s"${classOf[ByteArray].getName}.lpad($string, $len, $pad)"
-      }
+      s"$string.lpad($len, $pad)"
     })
   }
 
@@ -1419,9 +1413,23 @@ case class StringLPad(str: Expression, len: Expression, pad: Expression = Litera
     copy(str = newFirst, len = newSecond, pad = newThird)
 }
 
-/**
- * Returns str, right-padded with pad to a length of len.
- */
+case class BinaryLPad(str: Expression, len: Expression, pad: Expression, child: Expression)
+  extends RuntimeReplaceable {
+
+  def this(str: Expression, len: Expression, pad: Expression) = this(str, len, pad, StaticInvoke(
+    classOf[ByteArray],
+    BinaryType,
+    "lpad",
+    Seq(str, len, pad),
+    Seq(BinaryType, IntegerType, BinaryType),
+    returnNullable = false)
+  )
+
+  override def prettyName: String = "lpad"
+  def exprsReplaced: Seq[Expression] = Seq(str, len, pad)
+  protected def withNewChildInternal(newChild: Expression): BinaryLPad = copy(child = newChild)
+}
+
 @ExpressionDescription(
   usage = """
     _FUNC_(str, len[, pad]) - Returns `str`, right-padded with `pad` to a length of `len`.
@@ -1438,51 +1446,39 @@ case class StringLPad(str: Expression, len: Expression, pad: Expression = Litera
       > SELECT _FUNC_('hi', 5);
        hi
       > SELECT hex(_FUNC_(unhex('aabb'), 5));
-          AABB000000
+       AABB000000
       > SELECT hex(_FUNC_(unhex('aabb'), 5, unhex('1122')));
-          AABB112211
+       AABB112211
   """,
   since = "1.5.0",
   group = "string_funcs")
+object RPadExpressionBuilder extends PadExpressionBuilderBase {
+  override def funcName: String = "rpad"
+  override def createBinaryPad(str: Expression, len: Expression, pad: Expression): Expression = {
+    new BinaryRPad(str, len, pad)
+  }
+  override def createStringPad(str: Expression, len: Expression, pad: Expression): Expression = {
+    StringRPad(str, len, pad)
+  }
+}
+
 case class StringRPad(str: Expression, len: Expression, pad: Expression = Literal(" "))
   extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
-
-  def this(str: Expression, len: Expression) = {
-    this(str, len, StringPadDefaultValue.get(str))
-  }
 
   override def first: Expression = str
   override def second: Expression = len
   override def third: Expression = pad
 
   override def dataType: DataType = str.dataType
-  override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(StringType, BinaryType), IntegerType, TypeCollection(StringType, BinaryType))
-  override def checkInputDataTypes(): TypeCheckResult = {
-    super.checkInputDataTypes() match {
-      case fail: TypeCheckResult.TypeCheckFailure => fail
-      case _ if str.dataType != pad.dataType =>
-        TypeCheckResult.TypeCheckFailure(
-          s"Arguments 'str' and 'pad' of function '$prettyName' must be the same type.")
-      case other => other
-    }
-  }
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, IntegerType, StringType)
 
   override def nullSafeEval(string: Any, len: Any, pad: Any): Any = {
-    str.dataType match {
-      case StringType => string.asInstanceOf[UTF8String]
-        .rpad(len.asInstanceOf[Int], pad.asInstanceOf[UTF8String])
-      case BinaryType => ByteArray.rpad(string.asInstanceOf[Array[Byte]],
-        len.asInstanceOf[Int], pad.asInstanceOf[Array[Byte]])
-    }
+    string.asInstanceOf[UTF8String].rpad(len.asInstanceOf[Int], pad.asInstanceOf[UTF8String])
   }
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     defineCodeGen(ctx, ev, (string, len, pad) => {
-      str.dataType match {
-        case StringType => s"$string.rpad($len, $pad)"
-        case BinaryType => s"${classOf[ByteArray].getName}.rpad($string, $len, $pad)"
-      }
+      s"$string.rpad($len, $pad)"
     })
   }
 
@@ -1491,6 +1487,23 @@ case class StringRPad(str: Expression, len: Expression, pad: Expression = Litera
   override protected def withNewChildrenInternal(
       newFirst: Expression, newSecond: Expression, newThird: Expression): StringRPad =
     copy(str = newFirst, len = newSecond, pad = newThird)
+}
+
+case class BinaryRPad(str: Expression, len: Expression, pad: Expression, child: Expression)
+  extends RuntimeReplaceable {
+
+  def this(str: Expression, len: Expression, pad: Expression) = this(str, len, pad, StaticInvoke(
+    classOf[ByteArray],
+    BinaryType,
+    "rpad",
+    Seq(str, len, pad),
+    Seq(BinaryType, IntegerType, BinaryType),
+    returnNullable = false)
+  )
+
+  override def prettyName: String = "rpad"
+  def exprsReplaced: Seq[Expression] = Seq(str, len, pad)
+  protected def withNewChildInternal(newChild: Expression): BinaryRPad = copy(child = newChild)
 }
 
 object ParseUrl {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -419,7 +419,7 @@ object QueryCompilationErrors {
   }
 
   def invalidFunctionArgumentNumberError(
-      validParametersCount: Seq[Int], name: String, params: Seq[Class[Expression]]): Throwable = {
+      validParametersCount: Seq[Int], name: String, actualNumber: Int): Throwable = {
     if (validParametersCount.length == 0) {
       new AnalysisException(s"Invalid arguments for function $name")
     } else {
@@ -429,7 +429,7 @@ object QueryCompilationErrors {
         validParametersCount.init.mkString("one of ", ", ", " and ") +
           validParametersCount.last
       }
-      invalidFunctionArgumentsError(name, expectedNumberOfParameters, params.length)
+      invalidFunctionArgumentsError(name, expectedNumberOfParameters, actualNumber)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -749,8 +749,8 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(StringLPad(s1, s2, s3), null, row3)
     checkEvaluation(StringLPad(s1, s2, s3), null, row4)
     checkEvaluation(StringLPad(s1, s2, s3), null, row5)
-    checkEvaluation(StringLPad(Literal("hi"), Literal(5)), "   hi")
-    checkEvaluation(StringLPad(Literal("hi"), Literal(1)), "h")
+    checkEvaluation(StringLPad(Literal("hi"), Literal(5), Literal(" ")), "   hi")
+    checkEvaluation(StringLPad(Literal("hi"), Literal(1), Literal(" ")), "h")
 
     checkEvaluation(StringRPad(Literal("hi"), Literal(5), Literal("??")), "hi???", row1)
     checkEvaluation(StringRPad(Literal("hi"), Literal(1), Literal("??")), "h", row1)

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2739,7 +2739,7 @@ object functions {
    * @since 3.3.0
    */
   def lpad(str: Column, len: Int, pad: Array[Byte]): Column = withExpr {
-    StringLPad(str.expr, lit(len).expr, lit(pad).expr)
+    new BinaryLPad(str.expr, lit(len).expr, lit(pad).expr)
   }
 
   /**
@@ -2828,7 +2828,7 @@ object functions {
    * @since 3.3.0
    */
   def rpad(str: Column, len: Int, pad: Array[Byte]): Column = withExpr {
-    StringRPad(str.expr, lit(len).expr, lit(pad).expr)
+    new BinaryRPad(str.expr, lit(len).expr, lit(pad).expr)
   }
 
   /**

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -153,6 +153,7 @@
 | org.apache.spark.sql.catalyst.expressions.JsonObjectKeys | json_object_keys | SELECT json_object_keys('{}') | struct<json_object_keys({}):array<string>> |
 | org.apache.spark.sql.catalyst.expressions.JsonToStructs | from_json | SELECT from_json('{"a":1, "b":0.8}', 'a INT, b DOUBLE') | struct<from_json({"a":1, "b":0.8}):struct<a:int,b:double>> |
 | org.apache.spark.sql.catalyst.expressions.JsonTuple | json_tuple | SELECT json_tuple('{"a":1, "b":2}', 'a', 'b') | struct<c0:string,c1:string> |
+| org.apache.spark.sql.catalyst.expressions.LPadExpressionBuilder$ | lpad | SELECT lpad('hi', 5, '??') | struct<lpad(hi, 5, ??):string> |
 | org.apache.spark.sql.catalyst.expressions.Lag | lag | SELECT a, b, lag(b) OVER (PARTITION BY a ORDER BY b) FROM VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1) tab(a, b) | struct<a:string,b:int,lag(b, 1, NULL) OVER (PARTITION BY a ORDER BY b ASC NULLS FIRST ROWS BETWEEN -1 FOLLOWING AND -1 FOLLOWING):int> |
 | org.apache.spark.sql.catalyst.expressions.LastDay | last_day | SELECT last_day('2009-01-12') | struct<last_day(2009-01-12):date> |
 | org.apache.spark.sql.catalyst.expressions.Lead | lead | SELECT a, b, lead(b) OVER (PARTITION BY a ORDER BY b) FROM VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1) tab(a, b) | struct<a:string,b:int,lead(b, 1, NULL) OVER (PARTITION BY a ORDER BY b ASC NULLS FIRST ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING):int> |
@@ -227,6 +228,7 @@
 | org.apache.spark.sql.catalyst.expressions.RLike | regexp | SELECT regexp('%SystemDrive%\Users\John', '%SystemDrive%\\Users.*') | struct<REGEXP(%SystemDrive%UsersJohn, %SystemDrive%\Users.*):boolean> |
 | org.apache.spark.sql.catalyst.expressions.RLike | regexp_like | SELECT regexp_like('%SystemDrive%\Users\John', '%SystemDrive%\\Users.*') | struct<REGEXP_LIKE(%SystemDrive%UsersJohn, %SystemDrive%\Users.*):boolean> |
 | org.apache.spark.sql.catalyst.expressions.RLike | rlike | SELECT rlike('%SystemDrive%\Users\John', '%SystemDrive%\\Users.*') | struct<RLIKE(%SystemDrive%UsersJohn, %SystemDrive%\Users.*):boolean> |
+| org.apache.spark.sql.catalyst.expressions.RPadExpressionBuilder$ | rpad | SELECT rpad('hi', 5, '??') | struct<rpad(hi, 5, ??):string> |
 | org.apache.spark.sql.catalyst.expressions.RaiseError | raise_error | SELECT raise_error('custom error message') | struct<raise_error(custom error message):void> |
 | org.apache.spark.sql.catalyst.expressions.Rand | rand | SELECT rand() | struct<rand():double> |
 | org.apache.spark.sql.catalyst.expressions.Rand | random | SELECT random() | struct<rand():double> |
@@ -271,10 +273,8 @@
 | org.apache.spark.sql.catalyst.expressions.Sqrt | sqrt | SELECT sqrt(4) | struct<SQRT(4):double> |
 | org.apache.spark.sql.catalyst.expressions.Stack | stack | SELECT stack(2, 1, 2, 3) | struct<col0:int,col1:int> |
 | org.apache.spark.sql.catalyst.expressions.StringInstr | instr | SELECT instr('SparkSQL', 'SQL') | struct<instr(SparkSQL, SQL):int> |
-| org.apache.spark.sql.catalyst.expressions.StringLPad | lpad | SELECT lpad('hi', 5, '??') | struct<lpad(hi, 5, ??):string> |
 | org.apache.spark.sql.catalyst.expressions.StringLocate | locate | SELECT locate('bar', 'foobarbar') | struct<locate(bar, foobarbar, 1):int> |
 | org.apache.spark.sql.catalyst.expressions.StringLocate | position | SELECT position('bar', 'foobarbar') | struct<position(bar, foobarbar, 1):int> |
-| org.apache.spark.sql.catalyst.expressions.StringRPad | rpad | SELECT rpad('hi', 5, '??') | struct<rpad(hi, 5, ??):string> |
 | org.apache.spark.sql.catalyst.expressions.StringRepeat | repeat | SELECT repeat('123', 2) | struct<repeat(123, 2):string> |
 | org.apache.spark.sql.catalyst.expressions.StringReplace | replace | SELECT replace('ABCabc', 'abc', 'DEF') | struct<replace(ABCabc, abc, DEF):string> |
 | org.apache.spark.sql.catalyst.expressions.StringSpace | space | SELECT concat(space(2), '1') | struct<concat(space(2), 1):string> |

--- a/sql/core/src/test/resources/sql-tests/inputs/string-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/string-functions.sql
@@ -91,10 +91,10 @@ SELECT hex(rpad(unhex('aabbcc'), 6, unhex('')));
 SELECT hex(rpad(unhex('aabbcc'), 2, unhex('ff')));
 
 -- lpad/rpad with mixed STRING and BINARY input
-SELECT lpad('abc', 5, x'12');
-SELECT lpad(x'12', 5, 'abc');
-SELECT rpad('abc', 5, x'12');
-SELECT rpad(x'12', 5, 'abc');
+SELECT lpad('abc', 5, x'57');
+SELECT lpad(x'57', 5, 'abc');
+SELECT rpad('abc', 5, x'57');
+SELECT rpad(x'57', 5, 'abc');
 
 -- decode
 select decode();

--- a/sql/core/src/test/resources/sql-tests/results/ansi/string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/string-functions.sql.out
@@ -543,39 +543,39 @@ AABB
 
 
 -- !query
-SELECT lpad('abc', 5, x'12')
+SELECT lpad('abc', 5, x'57')
 -- !query schema
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'lpad('abc', 5, X'12')' due to data type mismatch: Arguments 'str' and 'pad' of function 'lpad' must be the same type.; line 1 pos 7
+cannot resolve 'lpad('abc', 5, X'57')' due to data type mismatch: argument 3 requires string type, however, 'X'57'' is of binary type.; line 1 pos 7
 
 
 -- !query
-SELECT lpad(x'12', 5, 'abc')
+SELECT lpad(x'57', 5, 'abc')
 -- !query schema
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'lpad(X'12', 5, 'abc')' due to data type mismatch: Arguments 'str' and 'pad' of function 'lpad' must be the same type.; line 1 pos 7
+cannot resolve 'lpad(X'57', 5, 'abc')' due to data type mismatch: argument 1 requires string type, however, 'X'57'' is of binary type.; line 1 pos 7
 
 
 -- !query
-SELECT rpad('abc', 5, x'12')
+SELECT rpad('abc', 5, x'57')
 -- !query schema
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'rpad('abc', 5, X'12')' due to data type mismatch: Arguments 'str' and 'pad' of function 'rpad' must be the same type.; line 1 pos 7
+cannot resolve 'rpad('abc', 5, X'57')' due to data type mismatch: argument 3 requires string type, however, 'X'57'' is of binary type.; line 1 pos 7
 
 
 -- !query
-SELECT rpad(x'12', 5, 'abc')
+SELECT rpad(x'57', 5, 'abc')
 -- !query schema
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'rpad(X'12', 5, 'abc')' due to data type mismatch: Arguments 'str' and 'pad' of function 'rpad' must be the same type.; line 1 pos 7
+cannot resolve 'rpad(X'57', 5, 'abc')' due to data type mismatch: argument 1 requires string type, however, 'X'57'' is of binary type.; line 1 pos 7
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/string-functions.sql.out
@@ -533,39 +533,35 @@ AABB
 
 
 -- !query
-SELECT lpad('abc', 5, x'12')
+SELECT lpad('abc', 5, x'57')
 -- !query schema
-struct<>
+struct<lpad(abc, 5, X'57'):string>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'lpad('abc', 5, X'12')' due to data type mismatch: Arguments 'str' and 'pad' of function 'lpad' must be the same type.; line 1 pos 7
+WWabc
 
 
 -- !query
-SELECT lpad(x'12', 5, 'abc')
+SELECT lpad(x'57', 5, 'abc')
 -- !query schema
-struct<>
+struct<lpad(X'57', 5, abc):string>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'lpad(X'12', 5, 'abc')' due to data type mismatch: Arguments 'str' and 'pad' of function 'lpad' must be the same type.; line 1 pos 7
+abcaW
 
 
 -- !query
-SELECT rpad('abc', 5, x'12')
+SELECT rpad('abc', 5, x'57')
 -- !query schema
-struct<>
+struct<rpad(abc, 5, X'57'):string>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'rpad('abc', 5, X'12')' due to data type mismatch: Arguments 'str' and 'pad' of function 'rpad' must be the same type.; line 1 pos 7
+abcWW
 
 
 -- !query
-SELECT rpad(x'12', 5, 'abc')
+SELECT rpad(x'57', 5, 'abc')
 -- !query schema
-struct<>
+struct<rpad(X'57', 5, abc):string>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'rpad(X'12', 5, 'abc')' due to data type mismatch: Arguments 'str' and 'pad' of function 'rpad' must be the same type.; line 1 pos 7
+Wabca
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a new trait `ExpressionBuilder` to help register functions with complex overloads that are hard to implement in the class constructor. And use this new API to register `lpad` and `rpad` functions, to fix the breaking change and allow these two functions to have mixed string and binary inputs under non-ANSI mode.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In https://github.com/apache/spark/pull/34407 , we realized that the lpad and rpad functions are convoluted because:
1. We want to return binary if the `str` and `pad` are both binary.
2. We want to return string if the `str` and `pad` are both string.
3. If one parameter is string and the other is binary, we want to return string to not break existing queries. But with ansi mode, we want to fail as this case is likely a user mistake.

It's very hard to implement this logic with constructor, and #34407 chooses to let the function support mixed input types at runtime instead of compile time, which is a bit hacky.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests