### PR TITLE
[SPARK-37168][SQL] Improve error messages for SQL functions and operators under ANSI mode

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -69,7 +69,7 @@
     "message" : [ "%s" ]
   },
   "INVALID_ARRAY_INDEX" : {
-    "message" : [ "Invalid index: %s, numElements: %s" ]
+    "message" : [ "Invalid index: %s, numElements: %s. You can set %s to false to bypass this error." ]
   },
   "INVALID_FIELD_NAME" : {
     "message" : [ "Field name %s is invalid: %s is not a struct." ],
@@ -87,7 +87,7 @@
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
   },
   "MAP_KEY_DOES_NOT_EXIST" : {
-    "message" : [ "Key %s does not exist." ]
+    "message" : [ "Key %s does not exist. You can set %s to false to bypass this error." ]
   },
   "MISSING_COLUMN" : {
     "message" : [ "Column '%s' does not exist. Did you mean one of the following? [%s]" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -69,14 +69,14 @@
     "message" : [ "%s" ]
   },
   "INVALID_ARRAY_INDEX" : {
-    "message" : [ "Invalid index: %s, numElements: %s. You can set %s to false to bypass this error." ]
+    "message" : [ "Invalid index: %s, numElements: %s. If necessary set %s to false to bypass this error." ]
   },
   "INVALID_FIELD_NAME" : {
     "message" : [ "Field name %s is invalid: %s is not a struct." ],
     "sqlState" : "42000"
   },
   "INVALID_FRACTION_OF_SECOND" : {
-    "message" : [ "The fraction of sec must be zero. Valid range is [0, 60]. You can set %s to false to bypass this error. " ],
+    "message" : [ "The fraction of sec must be zero. Valid range is [0, 60]. If necessary set %s to false to bypass this error. " ],
     "sqlState" : "22023"
   },
   "INVALID_INPUT_SYNTAX_FOR_NUMERIC_TYPE" : {
@@ -87,7 +87,7 @@
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
   },
   "MAP_KEY_DOES_NOT_EXIST" : {
-    "message" : [ "Key %s does not exist. You can set %s to false to bypass this error." ]
+    "message" : [ "Key %s does not exist. If necessary set %s to false to bypass this error." ]
   },
   "MISSING_COLUMN" : {
     "message" : [ "Column '%s' does not exist. Did you mean one of the following? [%s]" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -76,7 +76,7 @@
     "sqlState" : "42000"
   },
   "INVALID_FRACTION_OF_SECOND" : {
-    "message" : [ "The fraction of sec must be zero. Valid range is [0, 60]." ],
+    "message" : [ "The fraction of sec must be zero. Valid range is [0, 60]. You can set %s to false to bypass this error. " ],
     "sqlState" : "22023"
   },
   "INVALID_INPUT_SYNTAX_FOR_NUMERIC_TYPE" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -323,7 +323,12 @@ case class MakeInterval(
         min.asInstanceOf[Int],
         sec.map(_.asInstanceOf[Decimal]).getOrElse(Decimal(0, Decimal.MAX_LONG_DIGITS, 6)))
     } catch {
-      case _: ArithmeticException if !failOnError => null
+      case e: ArithmeticException =>
+        if (failOnError) {
+          throw QueryExecutionErrors.arithmeticOverflowError(e.getMessage)
+        } else {
+          null
+        }
     }
   }
 
@@ -331,7 +336,11 @@ case class MakeInterval(
     nullSafeCodeGen(ctx, ev, (year, month, week, day, hour, min, sec) => {
       val iu = IntervalUtils.getClass.getName.stripSuffix("$")
       val secFrac = sec.getOrElse("0")
-      val failOnErrorBranch = if (failOnError) "throw e;" else s"${ev.isNull} = true;"
+      val failOnErrorBranch = if (failOnError) {
+        "throw QueryExecutionErrors.arithmeticOverflowError(e.getMessage);"
+      } else {
+        s"${ev.isNull} = true;"
+      }
       s"""
         try {
           ${ev.value} = $iu.makeInterval($year, $month, $week, $day, $hour, $min, $secFrac);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -337,7 +337,7 @@ case class MakeInterval(
       val iu = IntervalUtils.getClass.getName.stripSuffix("$")
       val secFrac = sec.getOrElse("0")
       val failOnErrorBranch = if (failOnError) {
-        "throw QueryExecutionErrors.arithmeticOverflowError(e.getMessage);"
+        "throw QueryExecutionErrors.arithmeticOverflowError(e);"
       } else {
         s"${ev.isNull} = true;"
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -770,8 +770,10 @@ object DateTimeUtils {
   def dateAddInterval(
      start: Int,
      interval: CalendarInterval): Int = {
-    require(interval.microseconds == 0,
-      "Cannot add hours, minutes or seconds, milliseconds, microseconds to a date")
+    if (interval.microseconds != 0) {
+      throw QueryExecutionErrors.ansiIllegalArgumentError(
+        "Cannot add hours, minutes or seconds, milliseconds, microseconds to a date")
+    }
     val ld = daysToLocalDate(start).plusMonths(interval.months).plusDays(interval.days)
     localDateToDays(ld)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -21,7 +21,9 @@ import java.io.{FileNotFoundException, IOException}
 import java.lang.reflect.InvocationTargetException
 import java.net.{URISyntaxException, URL}
 import java.sql.{SQLException, SQLFeatureNotSupportedException}
+import java.text.{ParseException => JavaParseException}
 import java.time.{DateTimeException, LocalDate}
+import java.time.format.DateTimeParseException
 import java.time.temporal.ChronoField
 import java.util.ConcurrentModificationException
 import java.util.concurrent.TimeoutException
@@ -158,12 +160,12 @@ object QueryExecutionErrors {
 
   def invalidArrayIndexError(index: Int, numElements: Int): ArrayIndexOutOfBoundsException = {
     new SparkArrayIndexOutOfBoundsException(errorClass = "INVALID_ARRAY_INDEX",
-      messageParameters = Array(index.toString, numElements.toString))
+      messageParameters = Array(index.toString, numElements.toString, SQLConf.ANSI_ENABLED.key))
   }
 
   def mapKeyNotExistError(key: Any): NoSuchElementException = {
     new SparkNoSuchElementException(errorClass = "MAP_KEY_DOES_NOT_EXIST",
-      messageParameters = Array(key.toString))
+      messageParameters = Array(key.toString, SQLConf.ANSI_ENABLED.key))
   }
 
   def rowFromCSVParserNotExpectedError(): Throwable = {
@@ -177,6 +179,34 @@ object QueryExecutionErrors {
 
   def invalidFractionOfSecondError(): DateTimeException = {
     new SparkDateTimeException(errorClass = "INVALID_FRACTION_OF_SECOND", Array.empty)
+  }
+
+  def ansiDateTimeParseError(e: DateTimeParseException): DateTimeParseException = {
+    val newMessage = s"${e.getMessage}. " +
+      s"You can set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error."
+    new DateTimeParseException(newMessage, e.getParsedString, e.getErrorIndex, e.getCause)
+  }
+
+  def ansiDateTimeError(e: DateTimeException): DateTimeException = {
+    val newMessage = s"${e.getMessage}. " +
+      s"You can set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error."
+    new DateTimeException(newMessage, e.getCause)
+  }
+
+  def ansiParseError(e: JavaParseException): JavaParseException = {
+    val newMessage = s"${e.getMessage}. " +
+      s"You can set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error."
+    new JavaParseException(newMessage, e.getErrorOffset)
+  }
+
+  def ansiIllegalArgumentError(message: String): IllegalArgumentException = {
+    val newMessage = s"$message. You can set ${SQLConf.ANSI_ENABLED.key} " +
+      s"to false to bypass this error."
+    new IllegalArgumentException(newMessage)
+  }
+
+  def ansiIllegalArgumentError(e: IllegalArgumentException): IllegalArgumentException = {
+    ansiIllegalArgumentError(e.getMessage)
   }
 
   def overflowInSumOfDecimalError(): ArithmeticException = {
@@ -225,7 +255,8 @@ object QueryExecutionErrors {
   }
 
   def invalidUrlError(url: UTF8String, e: URISyntaxException): Throwable = {
-    new IllegalArgumentException(s"Find an invaild url string ${url.toString}", e)
+    new IllegalArgumentException(s"Find an invalid url string ${url.toString}. " +
+      s"You can set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error.", e)
   }
 
   def dataTypeOperationUnsupportedError(): Throwable = {
@@ -863,7 +894,8 @@ object QueryExecutionErrors {
   }
 
   def unscaledValueTooLargeForPrecisionError(): Throwable = {
-    new ArithmeticException("Unscaled value too large for precision")
+    new ArithmeticException("Unscaled value too large for precision. " +
+      s"You can set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error.")
   }
 
   def decimalPrecisionExceedsMaxPrecisionError(precision: Int, maxPrecision: Int): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -184,24 +184,24 @@ object QueryExecutionErrors {
 
   def ansiDateTimeParseError(e: DateTimeParseException): DateTimeParseException = {
     val newMessage = s"${e.getMessage}. " +
-      s"You can set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error."
+      s"If necessary set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error."
     new DateTimeParseException(newMessage, e.getParsedString, e.getErrorIndex, e.getCause)
   }
 
   def ansiDateTimeError(e: DateTimeException): DateTimeException = {
     val newMessage = s"${e.getMessage}. " +
-      s"You can set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error."
+      s"If necessary set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error."
     new DateTimeException(newMessage, e.getCause)
   }
 
   def ansiParseError(e: JavaParseException): JavaParseException = {
     val newMessage = s"${e.getMessage}. " +
-      s"You can set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error."
+      s"If necessary set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error."
     new JavaParseException(newMessage, e.getErrorOffset)
   }
 
   def ansiIllegalArgumentError(message: String): IllegalArgumentException = {
-    val newMessage = s"$message. You can set ${SQLConf.ANSI_ENABLED.key} " +
+    val newMessage = s"$message. If necessary set ${SQLConf.ANSI_ENABLED.key} " +
       s"to false to bypass this error."
     new IllegalArgumentException(newMessage)
   }
@@ -257,7 +257,7 @@ object QueryExecutionErrors {
 
   def invalidUrlError(url: UTF8String, e: URISyntaxException): Throwable = {
     new IllegalArgumentException(s"Find an invalid url string ${url.toString}. " +
-      s"You can set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error.", e)
+      s"If necessary set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error.", e)
   }
 
   def dataTypeOperationUnsupportedError(): Throwable = {
@@ -426,8 +426,8 @@ object QueryExecutionErrors {
   }
 
   def arithmeticOverflowError(e: ArithmeticException): ArithmeticException = {
-    new ArithmeticException(s"${e.getMessage}. You can set ${SQLConf.ANSI_ENABLED.key} to false " +
-      s"to bypass this error.")
+    new ArithmeticException(s"${e.getMessage}. If necessary set ${SQLConf.ANSI_ENABLED.key} " +
+      s"to false to bypass this error.")
   }
 
   def arithmeticOverflowError(
@@ -901,7 +901,7 @@ object QueryExecutionErrors {
 
   def unscaledValueTooLargeForPrecisionError(): Throwable = {
     new ArithmeticException("Unscaled value too large for precision. " +
-      s"You can set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error.")
+      s"If necessary set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error.")
   }
 
   def decimalPrecisionExceedsMaxPrecisionError(precision: Int, maxPrecision: Int): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -178,7 +178,8 @@ object QueryExecutionErrors {
   }
 
   def invalidFractionOfSecondError(): DateTimeException = {
-    new SparkDateTimeException(errorClass = "INVALID_FRACTION_OF_SECOND", Array.empty)
+    new SparkDateTimeException(errorClass = "INVALID_FRACTION_OF_SECOND",
+      Array(SQLConf.ANSI_ENABLED.key))
   }
 
   def ansiDateTimeParseError(e: DateTimeParseException): DateTimeParseException = {
@@ -422,6 +423,11 @@ object QueryExecutionErrors {
 
   def tableStatsNotSpecifiedError(): Throwable = {
     new IllegalStateException("table stats must be specified.")
+  }
+
+  def arithmeticOverflowError(e: ArithmeticException): ArithmeticException = {
+    new ArithmeticException(s"${e.getMessage}. You can set ${SQLConf.ANSI_ENABLED.key} to false " +
+      s"to bypass this error.")
   }
 
   def arithmeticOverflowError(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -956,7 +956,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         evaluateWithoutCodegen(
           ParseUrl(Seq("https://a.b.c/index.php?params1=a|b&params2=x", "HOST")))
       }.getMessage
-      assert(msg.contains("Find an invaild url string"))
+      assert(msg.contains("Find an invalid url string"))
     }
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
       checkEvaluation(

--- a/sql/core/src/test/resources/sql-tests/results/ansi/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/array.sql.out
@@ -168,7 +168,7 @@ select element_at(array(1, 2, 3), 5)
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: 5, numElements: 3
+Invalid index: 5, numElements: 3. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -177,7 +177,7 @@ select element_at(array(1, 2, 3), -5)
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: -5, numElements: 3
+Invalid index: -5, numElements: 3. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -195,7 +195,7 @@ select elt(4, '123', '456')
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: 4, numElements: 2
+Invalid index: 4, numElements: 2. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -204,7 +204,7 @@ select elt(0, '123', '456')
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: 0, numElements: 2
+Invalid index: 0, numElements: 2. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -213,7 +213,7 @@ select elt(-1, '123', '456')
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: -1, numElements: 2
+Invalid index: -1, numElements: 2. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -222,7 +222,7 @@ select array(1, 2, 3)[5]
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: 5, numElements: 3
+Invalid index: 5, numElements: 3. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -231,4 +231,4 @@ select array(1, 2, 3)[-1]
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: -1, numElements: 3
+Invalid index: -1, numElements: 3. You can set spark.sql.ansi.enabled to false to bypass this error.

--- a/sql/core/src/test/resources/sql-tests/results/ansi/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/array.sql.out
@@ -168,7 +168,7 @@ select element_at(array(1, 2, 3), 5)
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: 5, numElements: 3. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid index: 5, numElements: 3. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -177,7 +177,7 @@ select element_at(array(1, 2, 3), -5)
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: -5, numElements: 3. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid index: -5, numElements: 3. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -195,7 +195,7 @@ select elt(4, '123', '456')
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: 4, numElements: 2. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid index: 4, numElements: 2. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -204,7 +204,7 @@ select elt(0, '123', '456')
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: 0, numElements: 2. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid index: 0, numElements: 2. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -213,7 +213,7 @@ select elt(-1, '123', '456')
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: -1, numElements: 2. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid index: -1, numElements: 2. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -222,7 +222,7 @@ select array(1, 2, 3)[5]
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: 5, numElements: 3. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid index: 5, numElements: 3. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -231,4 +231,4 @@ select array(1, 2, 3)[-1]
 struct<>
 -- !query output
 org.apache.spark.SparkArrayIndexOutOfBoundsException
-Invalid index: -1, numElements: 3. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid index: -1, numElements: 3. If necessary set spark.sql.ansi.enabled to false to bypass this error.

--- a/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
@@ -46,7 +46,7 @@ select make_date(2000, 13, 1)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for MonthOfYear (valid values 1 - 12): 13. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid value for MonthOfYear (valid values 1 - 12): 13. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -55,7 +55,7 @@ select make_date(2000, 1, 33)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for DayOfMonth (valid values 1 - 28/31): 33. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid value for DayOfMonth (valid values 1 - 28/31): 33. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -146,7 +146,7 @@ select to_date("02-29", "MM-dd")
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid date 'February 29' as '1970' is not a leap year. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid date 'February 29' as '1970' is not a leap year. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -205,7 +205,7 @@ select next_day("2015-07-23", "xx")
 struct<>
 -- !query output
 java.lang.IllegalArgumentException
-Illegal input for day of week: xx. You can set spark.sql.ansi.enabled to false to bypass this error.
+Illegal input for day of week: xx. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
@@ -46,7 +46,7 @@ select make_date(2000, 13, 1)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for MonthOfYear (valid values 1 - 12): 13
+Invalid value for MonthOfYear (valid values 1 - 12): 13. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -55,7 +55,7 @@ select make_date(2000, 1, 33)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for DayOfMonth (valid values 1 - 28/31): 33
+Invalid value for DayOfMonth (valid values 1 - 28/31): 33. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -146,7 +146,7 @@ select to_date("02-29", "MM-dd")
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid date 'February 29' as '1970' is not a leap year
+Invalid date 'February 29' as '1970' is not a leap year. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -205,7 +205,7 @@ select next_day("2015-07-23", "xx")
 struct<>
 -- !query output
 java.lang.IllegalArgumentException
-Illegal input for day of week: xx
+Illegal input for day of week: xx. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/map.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/map.sql.out
@@ -8,7 +8,7 @@ select element_at(map(1, 'a', 2, 'b'), 5)
 struct<>
 -- !query output
 org.apache.spark.SparkNoSuchElementException
-Key 5 does not exist. You can set spark.sql.ansi.enabled to false to bypass this error.
+Key 5 does not exist. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -17,4 +17,4 @@ select map(1, 'a', 2, 'b')[5]
 struct<>
 -- !query output
 org.apache.spark.SparkNoSuchElementException
-Key 5 does not exist. You can set spark.sql.ansi.enabled to false to bypass this error.
+Key 5 does not exist. If necessary set spark.sql.ansi.enabled to false to bypass this error.

--- a/sql/core/src/test/resources/sql-tests/results/ansi/map.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/map.sql.out
@@ -8,7 +8,7 @@ select element_at(map(1, 'a', 2, 'b'), 5)
 struct<>
 -- !query output
 org.apache.spark.SparkNoSuchElementException
-Key 5 does not exist.
+Key 5 does not exist. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -17,4 +17,4 @@ select map(1, 'a', 2, 'b')[5]
 struct<>
 -- !query output
 org.apache.spark.SparkNoSuchElementException
-Key 5 does not exist.
+Key 5 does not exist. You can set spark.sql.ansi.enabled to false to bypass this error.

--- a/sql/core/src/test/resources/sql-tests/results/ansi/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/timestamp.sql.out
@@ -104,7 +104,7 @@ SELECT make_timestamp(2021, 07, 11, 6, 30, 60.007)
 struct<>
 -- !query output
 org.apache.spark.SparkDateTimeException
-The fraction of sec must be zero. Valid range is [0, 60]. You can set spark.sql.ansi.enabled to false to bypass this error.
+The fraction of sec must be zero. Valid range is [0, 60]. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -129,7 +129,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 61)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 61. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid value for SecondOfMinute (valid values 0 - 59): 61. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -154,7 +154,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 99.999999)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 99. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid value for SecondOfMinute (valid values 0 - 59): 99. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -163,7 +163,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 999.999999)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 999. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid value for SecondOfMinute (valid values 0 - 59): 999. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -343,7 +343,7 @@ select to_timestamp('2019-10-06 10:11:12.', 'yyyy-MM-dd HH:mm:ss.SSSSSS[zzz]')
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '2019-10-06 10:11:12.' could not be parsed at index 20. You can set spark.sql.ansi.enabled to false to bypass this error.
+Text '2019-10-06 10:11:12.' could not be parsed at index 20. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -408,7 +408,7 @@ select to_timestamp('2019-10-06 10:11:12.1234567PST', 'yyyy-MM-dd HH:mm:ss.SSSSS
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '2019-10-06 10:11:12.1234567PST' could not be parsed, unparsed text found at index 26. You can set spark.sql.ansi.enabled to false to bypass this error.
+Text '2019-10-06 10:11:12.1234567PST' could not be parsed, unparsed text found at index 26. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -425,7 +425,7 @@ select to_timestamp('223456 2019-10-06 10:11:12.123456PST', 'SSSSSS yyyy-MM-dd H
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '223456 2019-10-06 10:11:12.123456PST' could not be parsed at index 27. You can set spark.sql.ansi.enabled to false to bypass this error.
+Text '223456 2019-10-06 10:11:12.123456PST' could not be parsed at index 27. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -490,7 +490,7 @@ select to_timestamp("12.1232019-10-06S10:11", "ss.SSSSyyyy-MM-dd'S'HH:mm")
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '12.1232019-10-06S10:11' could not be parsed at index 7. You can set spark.sql.ansi.enabled to false to bypass this error.
+Text '12.1232019-10-06S10:11' could not be parsed at index 7. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -499,7 +499,7 @@ select to_timestamp("12.1232019-10-06S10:11", "ss.SSSSyy-MM-dd'S'HH:mm")
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '12.1232019-10-06S10:11' could not be parsed at index 9. You can set spark.sql.ansi.enabled to false to bypass this error.
+Text '12.1232019-10-06S10:11' could not be parsed at index 9. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -572,7 +572,7 @@ select to_timestamp("02-29", "MM-dd")
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid date 'February 29' as '1970' is not a leap year. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid date 'February 29' as '1970' is not a leap year. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/timestamp.sql.out
@@ -104,7 +104,7 @@ SELECT make_timestamp(2021, 07, 11, 6, 30, 60.007)
 struct<>
 -- !query output
 org.apache.spark.SparkDateTimeException
-The fraction of sec must be zero. Valid range is [0, 60].
+The fraction of sec must be zero. Valid range is [0, 60]. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -129,7 +129,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 61)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 61
+Invalid value for SecondOfMinute (valid values 0 - 59): 61. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -154,7 +154,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 99.999999)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 99
+Invalid value for SecondOfMinute (valid values 0 - 59): 99. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -163,7 +163,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 999.999999)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 999
+Invalid value for SecondOfMinute (valid values 0 - 59): 999. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -343,7 +343,7 @@ select to_timestamp('2019-10-06 10:11:12.', 'yyyy-MM-dd HH:mm:ss.SSSSSS[zzz]')
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '2019-10-06 10:11:12.' could not be parsed at index 20
+Text '2019-10-06 10:11:12.' could not be parsed at index 20. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -408,7 +408,7 @@ select to_timestamp('2019-10-06 10:11:12.1234567PST', 'yyyy-MM-dd HH:mm:ss.SSSSS
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '2019-10-06 10:11:12.1234567PST' could not be parsed, unparsed text found at index 26
+Text '2019-10-06 10:11:12.1234567PST' could not be parsed, unparsed text found at index 26. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -425,7 +425,7 @@ select to_timestamp('223456 2019-10-06 10:11:12.123456PST', 'SSSSSS yyyy-MM-dd H
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '223456 2019-10-06 10:11:12.123456PST' could not be parsed at index 27
+Text '223456 2019-10-06 10:11:12.123456PST' could not be parsed at index 27. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -490,7 +490,7 @@ select to_timestamp("12.1232019-10-06S10:11", "ss.SSSSyyyy-MM-dd'S'HH:mm")
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '12.1232019-10-06S10:11' could not be parsed at index 7
+Text '12.1232019-10-06S10:11' could not be parsed at index 7. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -499,7 +499,7 @@ select to_timestamp("12.1232019-10-06S10:11", "ss.SSSSyy-MM-dd'S'HH:mm")
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '12.1232019-10-06S10:11' could not be parsed at index 9
+Text '12.1232019-10-06S10:11' could not be parsed at index 9. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -572,7 +572,7 @@ select to_timestamp("02-29", "MM-dd")
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid date 'February 29' as '1970' is not a leap year
+Invalid date 'February 29' as '1970' is not a leap year. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/date.sql.out
@@ -581,7 +581,7 @@ select make_date(2013, 2, 30)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid date 'FEBRUARY 30'
+Invalid date 'FEBRUARY 30'. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -590,7 +590,7 @@ select make_date(2013, 13, 1)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for MonthOfYear (valid values 1 - 12): 13
+Invalid value for MonthOfYear (valid values 1 - 12): 13. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -599,7 +599,7 @@ select make_date(2013, 11, -1)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for DayOfMonth (valid values 1 - 28/31): -1
+Invalid value for DayOfMonth (valid values 1 - 28/31): -1. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/date.sql.out
@@ -581,7 +581,7 @@ select make_date(2013, 2, 30)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid date 'FEBRUARY 30'. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid date 'FEBRUARY 30'. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -590,7 +590,7 @@ select make_date(2013, 13, 1)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for MonthOfYear (valid values 1 - 12): 13. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid value for MonthOfYear (valid values 1 - 12): 13. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -599,7 +599,7 @@ select make_date(2013, 11, -1)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for DayOfMonth (valid values 1 - 28/31): -1. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid value for DayOfMonth (valid values 1 - 28/31): -1. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
@@ -104,7 +104,7 @@ SELECT make_timestamp(2021, 07, 11, 6, 30, 60.007)
 struct<>
 -- !query output
 org.apache.spark.SparkDateTimeException
-The fraction of sec must be zero. Valid range is [0, 60]. You can set spark.sql.ansi.enabled to false to bypass this error.
+The fraction of sec must be zero. Valid range is [0, 60]. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -129,7 +129,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 61)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 61. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid value for SecondOfMinute (valid values 0 - 59): 61. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -154,7 +154,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 99.999999)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 99. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid value for SecondOfMinute (valid values 0 - 59): 99. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -163,7 +163,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 999.999999)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 999. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid value for SecondOfMinute (valid values 0 - 59): 999. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -343,7 +343,7 @@ select to_timestamp('2019-10-06 10:11:12.', 'yyyy-MM-dd HH:mm:ss.SSSSSS[zzz]')
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '2019-10-06 10:11:12.' could not be parsed at index 20. You can set spark.sql.ansi.enabled to false to bypass this error.
+Text '2019-10-06 10:11:12.' could not be parsed at index 20. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -408,7 +408,7 @@ select to_timestamp('2019-10-06 10:11:12.1234567PST', 'yyyy-MM-dd HH:mm:ss.SSSSS
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '2019-10-06 10:11:12.1234567PST' could not be parsed, unparsed text found at index 26. You can set spark.sql.ansi.enabled to false to bypass this error.
+Text '2019-10-06 10:11:12.1234567PST' could not be parsed, unparsed text found at index 26. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -425,7 +425,7 @@ select to_timestamp('223456 2019-10-06 10:11:12.123456PST', 'SSSSSS yyyy-MM-dd H
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '223456 2019-10-06 10:11:12.123456PST' could not be parsed at index 27. You can set spark.sql.ansi.enabled to false to bypass this error.
+Text '223456 2019-10-06 10:11:12.123456PST' could not be parsed at index 27. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -490,7 +490,7 @@ select to_timestamp("12.1232019-10-06S10:11", "ss.SSSSyyyy-MM-dd'S'HH:mm")
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '12.1232019-10-06S10:11' could not be parsed at index 7. You can set spark.sql.ansi.enabled to false to bypass this error.
+Text '12.1232019-10-06S10:11' could not be parsed at index 7. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -499,7 +499,7 @@ select to_timestamp("12.1232019-10-06S10:11", "ss.SSSSyy-MM-dd'S'HH:mm")
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '12.1232019-10-06S10:11' could not be parsed at index 9. You can set spark.sql.ansi.enabled to false to bypass this error.
+Text '12.1232019-10-06S10:11' could not be parsed at index 9. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -572,7 +572,7 @@ select to_timestamp("02-29", "MM-dd")
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid date 'February 29' as '1970' is not a leap year. You can set spark.sql.ansi.enabled to false to bypass this error.
+Invalid date 'February 29' as '1970' is not a leap year. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
@@ -104,7 +104,7 @@ SELECT make_timestamp(2021, 07, 11, 6, 30, 60.007)
 struct<>
 -- !query output
 org.apache.spark.SparkDateTimeException
-The fraction of sec must be zero. Valid range is [0, 60].
+The fraction of sec must be zero. Valid range is [0, 60]. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -129,7 +129,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 61)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 61
+Invalid value for SecondOfMinute (valid values 0 - 59): 61. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -154,7 +154,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 99.999999)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 99
+Invalid value for SecondOfMinute (valid values 0 - 59): 99. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -163,7 +163,7 @@ SELECT make_timestamp(1, 1, 1, 1, 1, 999.999999)
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid value for SecondOfMinute (valid values 0 - 59): 999
+Invalid value for SecondOfMinute (valid values 0 - 59): 999. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -343,7 +343,7 @@ select to_timestamp('2019-10-06 10:11:12.', 'yyyy-MM-dd HH:mm:ss.SSSSSS[zzz]')
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '2019-10-06 10:11:12.' could not be parsed at index 20
+Text '2019-10-06 10:11:12.' could not be parsed at index 20. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -408,7 +408,7 @@ select to_timestamp('2019-10-06 10:11:12.1234567PST', 'yyyy-MM-dd HH:mm:ss.SSSSS
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '2019-10-06 10:11:12.1234567PST' could not be parsed, unparsed text found at index 26
+Text '2019-10-06 10:11:12.1234567PST' could not be parsed, unparsed text found at index 26. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -425,7 +425,7 @@ select to_timestamp('223456 2019-10-06 10:11:12.123456PST', 'SSSSSS yyyy-MM-dd H
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '223456 2019-10-06 10:11:12.123456PST' could not be parsed at index 27
+Text '223456 2019-10-06 10:11:12.123456PST' could not be parsed at index 27. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -490,7 +490,7 @@ select to_timestamp("12.1232019-10-06S10:11", "ss.SSSSyyyy-MM-dd'S'HH:mm")
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '12.1232019-10-06S10:11' could not be parsed at index 7
+Text '12.1232019-10-06S10:11' could not be parsed at index 7. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -499,7 +499,7 @@ select to_timestamp("12.1232019-10-06S10:11", "ss.SSSSyy-MM-dd'S'HH:mm")
 struct<>
 -- !query output
 java.time.format.DateTimeParseException
-Text '12.1232019-10-06S10:11' could not be parsed at index 9
+Text '12.1232019-10-06S10:11' could not be parsed at index 9. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -572,7 +572,7 @@ select to_timestamp("02-29", "MM-dd")
 struct<>
 -- !query output
 java.time.DateTimeException
-Invalid date 'February 29' as '1970' is not a leap year
+Invalid date 'February 29' as '1970' is not a leap year. You can set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR improves error messages for SQL functions and operators when ANSI mode is enabled. See [SQL Functions](https://spark.apache.org/docs/latest/sql-ref-ansi-compliance.html#sql-functions) and [SQL Operators](https://spark.apache.org/docs/latest/sql-ref-ansi-compliance.html#sql-operators) for more details.

### Why are the changes needed?
To make error messages under ANSI mode more actionable.

### Does this PR introduce _any_ user-facing change?
Yes. Certain error messages will be changed.

### How was this patch tested?
Existing tests.
