### PR TITLE
[SPARK-37161][SQL] RowToColumnConverter support AnsiIntervalType

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -260,9 +260,9 @@ private object RowToColumnConverter {
       case BooleanType => BooleanConverter
       case ByteType => ByteConverter
       case ShortType => ShortConverter
-      case IntegerType | DateType => IntConverter
+      case IntegerType | DateType | _: YearMonthIntervalType => IntConverter
       case FloatType => FloatConverter
-      case LongType | TimestampType => LongConverter
+      case LongType | TimestampType | _: DayTimeIntervalType => LongConverter
       case DoubleType => DoubleConverter
       case StringType => StringConverter
       case CalendarIntervalType => CalendarConverter

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -1693,7 +1693,6 @@ class ColumnarBatchSuite extends SparkFunSuite {
       val schema = new StructType().add(dt.typeName, dt)
       val converter = new RowToColumnConverter(schema)
       val columns = OnHeapColumnVector.allocateColumns(10, schema)
-      val batch = new ColumnarBatch(columns.toArray, 3)
       try {
         assert(columns(0).dataType() == dt)
         (0 until 9).foreach { i =>
@@ -1704,14 +1703,13 @@ class ColumnarBatchSuite extends SparkFunSuite {
         converter.convert(new GenericInternalRow(Array[Any](null)), columns.toArray)
         assert(columns(0).isNullAt(9))
       } finally {
-        batch.close()
+        columns.foreach(_.close())
       }
     }
     DataTypeTestUtils.dayTimeIntervalTypes.foreach { dt =>
       val schema = new StructType().add(dt.typeName, dt)
       val converter = new RowToColumnConverter(schema)
       val columns = OnHeapColumnVector.allocateColumns(10, schema)
-      val batch = new ColumnarBatch(columns.toArray, 3)
       try {
         assert(columns(0).dataType() == dt)
         (0 until 9).foreach { i =>
@@ -1722,7 +1720,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
         converter.convert(new GenericInternalRow(Array[Any](null)), columns.toArray)
         assert(columns(0).isNullAt(9))
       } finally {
-        batch.close()
+        columns.foreach(_.close())
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -1688,7 +1688,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
     }
   }
 
-  test("RowToColumnConverter for AnsiIntervalType") {
+  test("SPARK-37161: RowToColumnConverter for AnsiIntervalType") {
     DataTypeTestUtils.yearMonthIntervalTypes.foreach { dt =>
       val schema = new StructType().add(dt.typeName, dt)
       val converter = new RowToColumnConverter(schema)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -1688,6 +1688,45 @@ class ColumnarBatchSuite extends SparkFunSuite {
     }
   }
 
+  test("RowToColumnConverter for AnsiIntervalType") {
+    DataTypeTestUtils.yearMonthIntervalTypes.foreach { dt =>
+      val schema = new StructType().add(dt.typeName, dt)
+      val converter = new RowToColumnConverter(schema)
+      val columns = OnHeapColumnVector.allocateColumns(10, schema)
+      val batch = new ColumnarBatch(columns.toArray, 3)
+      try {
+        assert(columns(0).dataType() == dt)
+        (0 until 9).foreach { i =>
+          val row = new GenericInternalRow(Array[Any](i))
+          converter.convert(row, columns.toArray)
+          assert(columns(0).getInt(i) == i)
+        }
+        converter.convert(new GenericInternalRow(Array[Any](null)), columns.toArray)
+        assert(columns(0).isNullAt(9))
+      } finally {
+        batch.close()
+      }
+    }
+    DataTypeTestUtils.dayTimeIntervalTypes.foreach { dt =>
+      val schema = new StructType().add(dt.typeName, dt)
+      val converter = new RowToColumnConverter(schema)
+      val columns = OnHeapColumnVector.allocateColumns(10, schema)
+      val batch = new ColumnarBatch(columns.toArray, 3)
+      try {
+        assert(columns(0).dataType() == dt)
+        (0 until 9).foreach { i =>
+          val row = new GenericInternalRow(Array[Any](i.toLong))
+          converter.convert(row, columns.toArray)
+          assert(columns(0).getLong(i) == i)
+        }
+        converter.convert(new GenericInternalRow(Array[Any](null)), columns.toArray)
+        assert(columns(0).isNullAt(9))
+      } finally {
+        batch.close()
+      }
+    }
+  }
+
   testVector("Decimal API", 4, DecimalType.IntDecimal) {
     column =>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add RowToColumnConverter for AnsiIntervalType

### Why are the changes needed?
currently, we have RowToColumnConverter for all data types except AnsiIntervalType
```
  private def getConverterForType(dataType: DataType, nullable: Boolean): TypeConverter = {
    val core = dataType match {
      case BinaryType => BinaryConverter
      case BooleanType => BooleanConverter
      case ByteType => ByteConverter
      case ShortType => ShortConverter
      case IntegerType | DateType => IntConverter
      case FloatType => FloatConverter
      case LongType | TimestampType => LongConverter
      case DoubleType => DoubleConverter
      case StringType => StringConverter
      case CalendarIntervalType => CalendarConverter
      case at: ArrayType => ArrayConverter(getConverterForType(at.elementType, at.containsNull))
      case st: StructType => new StructConverter(st.fields.map(
        (f) => getConverterForType(f.dataType, f.nullable)))
      case dt: DecimalType => new DecimalConverter(dt)
      case mt: MapType => MapConverter(getConverterForType(mt.keyType, nullable = false),
        getConverterForType(mt.valueType, mt.valueContainsNull))
      case unknown => throw QueryExecutionErrors.unsupportedDataTypeError(unknown.toString)
    }

```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add ut test