### PR TITLE
[SPARK-37170][PYTHON][DOCS] Pin PySpark version installed in the Binder environment for tagged commit

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,1 +1,2 @@
 openjdk-8-jre
+git

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -21,4 +21,15 @@
 # Jupyter notebook.
 
 VERSION=$(python -c "exec(open('python/pyspark/version.py').read()); print(__version__)")
-pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark]==$VERSION"
+TAG=$(git describe --tags --exact-match 2>/dev/null)
+
+# If a commit is tagged, exactly specified version of pyspark should be installed to avoid
+# a kind of accident that an old version of pyspark is installed in the live notebook environment.
+# See SPARK-37170
+if [ -n "$TAG" ]; then
+  SPECIFIER="=="
+else
+  SPECIFIER="<="
+fi
+
+pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark]$SPECIFIER$VERSION"

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -21,4 +21,4 @@
 # Jupyter notebook.
 
 VERSION=$(python -c "exec(open('python/pyspark/version.py').read()); print(__version__)")
-pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark]<=$VERSION"
+pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark]==$VERSION"


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to pin the version of PySpark to be installed in the live notebook environment for tagged commits.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I noticed that the PySpark `3.1.2` is installed in the live notebook environment even though the notebook is for PySpark `3.2.0`.
http://spark.apache.org/docs/3.2.0/api/python/getting_started/index.html

I guess someone accessed to Binder and built the container image with `v3.2.0` before we published the `pyspark` package to PyPi.
https://mybinder.org/

I think it's difficult to rebuild the image manually.
To avoid such accident, I'll propose this change.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Confirmed that if a commit is tagged, we can avoid building the container image with unexpected version of `pyspark` in Binder.
```
...
  Downloading plotly-5.3.1-py2.py3-none-any.whl (23.9 MB)
[91mERROR: Could not find a version that satisfies the requirement pyspark[ml,mllib,pandas_on_spark,sql]==3.3.0.dev0 (from versions: 2.1.2, 2.1.3, 2.2.0.post0, 2.2.1, 2.2.2, 2.2.3, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.4.4, 2.4.5, 2.4.6, 2.4.7, 2.4.8, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.2.0)
ERROR: No matching distribution found for pyspark[ml,mllib,pandas_on_spark,sql]==3.3.0.dev0
[0mRemoving intermediate container de55eed5966e
The command '/bin/sh -c ./binder/postBuild' returned a non-zero code: 1Built image, launching...
Failed to connect to event stream
```

If a commit is not tagged, an old version of `pyspark` can be installed if the exactly specified version is not published to PyPi.
https://hub.gke2.mybinder.org/user/sarutak-spark-ky222nbf/notebooks/python/docs/source/getting_started/quickstart_df.ipynb