### PR TITLE
[SPARK-37171][SQL]Add forany and forall to Datasets/Dataframes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1639,6 +1639,58 @@ class Dataset[T] private[sql](
     selectUntyped(c1, c2, c3, c4, c5).asInstanceOf[Dataset[(U1, U2, U3, U4, U5)]]
 
   /**
+   * Checks if the condition is true for any of the rows.
+   * {{{
+   *   peopleDs.forany($"age" > 15)
+   * }}}
+   *
+   * @group typedrel
+   * @since 3.2.0
+   */
+  def forany(condition: Column): Boolean = {
+    !filter(condition).isEmpty
+  }
+
+  /**
+   * Checks if the SQL expression is true for any of the rows.
+   * {{{
+   *   peopleDs.forany("age > 15")
+   * }}}
+   *
+   * @group typedrel
+   * @since 3.2.0
+   */
+  def forany(conditionExpr: String): Boolean = {
+    !filter(conditionExpr).isEmpty
+  }
+
+  /**
+   * Checks if the condition is true for all the rows.
+   * {{{
+   *   peopleDs.forall($"age" > 15)
+   * }}}
+   *
+   * @group typedrel
+   * @since 3.2.0
+   */
+  def forall(condition: Column): Boolean = {
+    filter(!condition).isEmpty
+  }
+
+  /**
+   * Checks if the SQL expression is true for all the rows.
+   * {{{
+   *   peopleDs.forall("age > 15")
+   * }}}
+   *
+   * @group typedrel
+   * @since 3.2.0
+   */
+  def forall(conditionExpr: String): Boolean = {
+    filter(!Column(sparkSession.sessionState.sqlParser.parseExpression(conditionExpr))).isEmpty
+  }
+
+  /**
    * Filters rows using the given condition.
    * {{{
    *   // The following are equivalent:
@@ -2859,6 +2911,26 @@ class Dataset[T] private[sql](
    * @since 1.6.0
    */
   def transform[U](t: Dataset[T] => Dataset[U]): Dataset[U] = t(this)
+
+  /**
+   * Checks if there are any elements for which `func` returns `true`.
+   *
+   * @group typedrel
+   * @since 3.2.0
+   */
+  def forany(func: T => Boolean): Boolean = {
+    !filter(func).isEmpty
+  }
+
+  /**
+   * Checks if `func` returns `true` for all elements.
+   *
+   * @group typedrel
+   * @since 3.2.0
+   */
+  def forall(func: T => Boolean): Boolean = {
+    filter((x: T) => !func(x)).isEmpty
+  }
 
   /**
    * (Scala-specific)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -395,6 +395,66 @@ class DatasetSuite extends QueryTest
     }
   }
 
+  test("SPARK-37171: forany returns true if condition is true for any row") {
+    val df = Seq("aa", "bb", "cc", "abc").toDF("zoo")
+    assert(df.forany($"zoo".contains(Array('a', 'b'))))
+  }
+
+  test("SPARK-37171: forall returns true if condition true for all rows") {
+    val df = Seq("ab", "ba").toDF("zoo")
+    assert(df.forall($"zoo".contains("a")))
+  }
+
+  test("SPARK-37171: forany returns false if condition is false for all rows") {
+    val df = Seq("aa", "bb", "cc").toDF("zoo")
+    assert(!df.forany($"zoo".contains(Array('a', 'b'))))
+  }
+
+  test("SPARK-37171: forall returns false if condition false for any rows") {
+    val df = Seq("ab", "ba").toDF("zoo")
+    assert(!df.forall($"zoo".contains("c")))
+  }
+
+  test("SPARK-37171: forany expression returns true if condition is true for any row") {
+    val df = Seq("aa", "bb", "cc", "abc").toDF("zoo")
+    assert(df.forany("zoo like 'ab%'"))
+  }
+
+  test("SPARK-37171: forall expressions returns true if condition true for all rows") {
+    val df = Seq("ab", "ba").toDF("zoo")
+    assert(df.forall("zoo like '%a%'"))
+  }
+
+  test("SPARK-37171: forany expressions returns false if condition is false for all rows") {
+    val df = Seq("aa", "bb", "cc").toDF("zoo")
+    assert(!df.forany("zoo like '%ab%'"))
+  }
+
+  test("SPARK-37171: forall expressions returns false if condition false for any rows") {
+    val df = Seq("ab", "ba").toDF("zoo")
+    assert(!df.forall("zoo like '%c%'"))
+  }
+
+  test("SPARK-37171: forany function returns true if condition is true for any row") {
+    val ds = Seq(("a", 1), ("b", 2), ("c", 3)).toDS()
+    assert(ds.forany(_._1 == "b"))
+  }
+
+  test("SPARK-37171: forall function returns true if condition is true for all rows") {
+    val ds = Seq(("a", 1), ("a", 1), ("a", 2)).toDS()
+    assert(ds.forall(_._1 == "a"))
+  }
+
+  test("SPARK-37171: forany function returns false if condition is false for all rows") {
+    val ds = Seq(("a", 1), ("b", 2), ("c", 3)).toDS()
+    assert(!ds.forany(_._1 == "d"))
+  }
+
+  test("SPARK-37171: forall function returns false if condition is false for any row") {
+    val ds = Seq(("a", 1), ("a", 1), ("a", 2)).toDS()
+    assert(!ds.forall(_._2 == 2))
+  }
+
   test("filter") {
     val ds = Seq(("a", 1), ("b", 2), ("c", 3)).toDS()
     checkDataset(


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Add forany and forall api for Dataframe/Datasets API



### Why are the changes needed?

To provide a higher level of abstraction for Spark customers



### Does this PR introduce _any_ user-facing change?

Yes, forany and forall methods are added to the Dataframe/Dataset API



### How was this patch tested?

Added new unit tests
