### PR TITLE
[MINOR][SQL][DOCS] Correct typo in sql migration guide

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -270,7 +270,7 @@ license: |
     | CAST('+inf' AS FLOAT) | NULL | Float.PositiveInfinity |
     | CAST('-infinity' AS FLOAT) | NULL | Float.NegativeInfinity |
     | CAST('-inf' AS FLOAT) | NULL | Float.NegativeInfinity |
-    | CAST('nan' AS DOUBLE) | NULL | Double.Nan |
+    | CAST('nan' AS DOUBLE) | NULL | Double.NaN |
     | CAST('nan' AS FLOAT) | NULL | Float.NaN |
 
   - In Spark 3.0, when casting interval values to string type, there is no "interval" prefix, for example, `1 days 2 hours`. In Spark version 2.4 and below, the string contains the "interval" prefix like `interval 1 days 2 hours`.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Just correct a minor typo in the migration guide. Change from `Double.Nan` to `Double.NaN`

### Why are the changes needed?
The correct `NaN` representation for `Double` is `Double.NaN`

### Does this PR introduce _any_ user-facing change?
Yes, it corrects a typo in the migration guide.

### How was this patch tested?
Docs change only.
