### PR TITLE
[SPARK-37191][SQL] Allow merging DecimalTypes with different precision values

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -641,16 +641,11 @@ object StructType extends AbstractDataType {
 
       case (DecimalType.Fixed(leftPrecision, leftScale),
         DecimalType.Fixed(rightPrecision, rightScale)) =>
-        if ((leftPrecision == rightPrecision) && (leftScale == rightScale)) {
-          DecimalType(leftPrecision, leftScale)
-        } else if ((leftPrecision != rightPrecision) && (leftScale == rightScale)) {
-          DecimalType(Math.max(leftPrecision, rightPrecision), leftScale)
-        } else if ((leftPrecision == rightPrecision) && (leftScale != rightScale)) {
+        if (leftScale == rightScale) {
+          DecimalType(leftPrecision.max(rightPrecision), leftScale)
+        } else {
           throw QueryExecutionErrors.cannotMergeDecimalTypesWithIncompatibleScaleError(
             leftScale, rightScale)
-        } else {
-          throw QueryExecutionErrors.cannotMergeDecimalTypesWithIncompatiblePrecisionAndScaleError(
-            leftPrecision, rightPrecision, leftScale, rightScale)
         }
 
       case (leftUdt: UserDefinedType[_], rightUdt: UserDefinedType[_])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -643,15 +643,14 @@ object StructType extends AbstractDataType {
         DecimalType.Fixed(rightPrecision, rightScale)) =>
         if ((leftPrecision == rightPrecision) && (leftScale == rightScale)) {
           DecimalType(leftPrecision, leftScale)
-        } else if ((leftPrecision != rightPrecision) && (leftScale != rightScale)) {
-          throw QueryExecutionErrors.cannotMergeDecimalTypesWithIncompatiblePrecisionAndScaleError(
-            leftPrecision, rightPrecision, leftScale, rightScale)
-        } else if (leftPrecision != rightPrecision) {
-          throw QueryExecutionErrors.cannotMergeDecimalTypesWithIncompatiblePrecisionError(
-            leftPrecision, rightPrecision)
-        } else {
+        } else if ((leftPrecision != rightPrecision) && (leftScale == rightScale)) {
+          DecimalType(Math.max(leftPrecision, rightPrecision), leftScale)
+        } else if ((leftPrecision == rightPrecision) && (leftScale != rightScale)) {
           throw QueryExecutionErrors.cannotMergeDecimalTypesWithIncompatibleScaleError(
             leftScale, rightScale)
+        } else {
+          throw QueryExecutionErrors.cannotMergeDecimalTypesWithIncompatiblePrecisionAndScaleError(
+            leftPrecision, rightPrecision, leftScale, rightScale)
         }
 
       case (leftUdt: UserDefinedType[_], rightUdt: UserDefinedType[_])

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
+import java.math.BigDecimal
+
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
@@ -24,6 +26,7 @@ import org.apache.parquet.io.ParquetDecodingException
 import org.apache.parquet.schema.{MessageType, MessageTypeParser}
 
 import org.apache.spark.SparkException
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.execution.datasources.SchemaColumnConvertNotSupportedException
@@ -385,6 +388,27 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
       assert(a.name == b.name)
       assert(a.dataType === b.dataType)
       assert(a.nullable === b.nullable)
+    }
+  }
+
+  test("SPARK-37191: Schema merging for DecimalType with different precision but the same scale") {
+    import testImplicits._
+
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+
+      val data1 = spark.sparkContext.parallelize(Seq(Row(new BigDecimal("123456789.11"))), 1)
+      val schema1 = StructType(StructField("col", DecimalType(12, 2)) :: Nil)
+
+      val data2 = spark.sparkContext.parallelize(Seq(Row(new BigDecimal("1234567890000.11"))), 1)
+      val schema2 = StructType(StructField("col", DecimalType(17, 2)) :: Nil)
+
+      spark.createDataFrame(data1, schema1).write.parquet(path)
+      spark.createDataFrame(data2, schema2).write.mode("append").parquet(path)
+
+      val res = spark.read.option("mergeSchema", "true").parquet(path)
+      assert(res.schema("col").dataType == DecimalType(17, 2))
+      res.foreach(_ => ()) // must not throw exception
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the code in `StructType` to allow merging `DecimalType` values with different precision but the same scale. 

We could allow merging DecimalType values with different precision if the scale is the same for both types since there should not be any data correctness issues as one of the types will be extended, for example, `DECIMAL(12, 2)` -> `DECIMAL(17, 2)`; however, this is not the case for upcasting when the scale is different - this would depend on the actual values.

This also affects Parquet schema merge which is where this issue was discovered originally.

### Why are the changes needed?

Fixes the issue of not allowing to consolidate different DecimalTypes when it should be fine to do so in case of the same scale value.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Added unit tests in StructTypeSuite and ParquetSchemaSuite.
