### PR TITLE
[SPARK-37194][SQL] Avoid unnecessary sort in FileFormatWriter if it's not dynamic partition

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -176,6 +176,7 @@ class FileStreamSink(
         outputSpec = FileFormatWriter.OutputSpec(path, Map.empty, qe.analyzed.output),
         hadoopConf = hadoopConf,
         partitionColumns = partitionColumns,
+        dynamicPartition = true,
         bucketSpec = None,
         statsTrackers = Seq(basicWriteJobStatsTracker),
         options = options)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -187,6 +187,7 @@ case class InsertIntoHiveTable(
       fileSinkConf = fileSinkConf,
       outputLocation = tmpLocation.toString,
       partitionAttributes = partitionAttributes,
+      dynamicPartition = numDynamicPartitions > 0,
       bucketSpec = table.bucketSpec)
 
     if (partition.nonEmpty) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/SaveAsHiveFile.scala
@@ -55,6 +55,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
       outputLocation: String,
       customPartitionLocations: Map[TablePartitionSpec, String] = Map.empty,
       partitionAttributes: Seq[Attribute] = Nil,
+      dynamicPartition: Boolean = false,
       bucketSpec: Option[BucketSpec] = None): Set[String] = {
 
     val isCompressed =
@@ -99,6 +100,7 @@ private[hive] trait SaveAsHiveFile extends DataWritingCommand {
         FileFormatWriter.OutputSpec(outputLocation, customPartitionLocations, outputColumns),
       hadoopConf = hadoopConf,
       partitionColumns = partitionAttributes,
+      dynamicPartition = dynamicPartition,
       bucketSpec = bucketSpec,
       statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
       options = options)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Pass a new parameter `dynamicPartition` to `FileFormatWriter.write` so that we can distinguish if we need local sort or not.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Avoid unnecessary sort in FileFormatWriter if it's not dynamic partition

`FileFormatWriter.write` will sort the partition and bucket column before writing. I think this code path assumed the input `partitionColumns` are dynamic but actually it's not. It now is used by three code path:
- `FileStreamSink`; it should be always dynamic partition
- `SaveAsHiveFile`; it followed the assuming that `InsertIntoHiveTable` has removed the static partition and `InsertIntoHiveDirCommand` has no partition
- `InsertIntoHadoopFsRelationCommand`; it passed `partitionColumns` into `FileFormatWriter.write` without removing static partition because we need it to generate the partition path in `DynamicPartitionDataWriter`

It shows that the unnecessary sort only affected the `InsertIntoHadoopFsRelationCommand` if we write data with static partition.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
It should not affect the existed behavior, just improve perf. And for perf number, I did a simple benchmak:

```sql

CREATE TABLE test (id long) USING PARQUET PARTITIONED BY (d string);

-- before this PR, it tooks 1.82  seconds
-- after this PR,  it tooks 1.072 seconds
INSERT OVERWRITE TABLE test PARTITION(d='a') SELECT id FROM range(10000000);
```

