### PR TITLE
[SPARK-37200][SQL] Support drop index for Data Source V2

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.analysis.IndexAlreadyExistsException
+import org.apache.spark.sql.catalyst.analysis.{IndexAlreadyExistsException, NoSuchIndexException}
 import org.apache.spark.sql.connector.catalog.{Catalogs, Identifier, TableCatalog}
 import org.apache.spark.sql.connector.catalog.index.SupportsIndex
 import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReference}
@@ -162,9 +162,26 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTest {
     assert(jdbcTable.indexExists("i1") == true)
     assert(jdbcTable.indexExists("i2") == true)
 
+    // This should pass without Exception
+    sql(s"CREATE index IF NOT EXISTS i1 ON $catalogName.new_table (col1)")
+
     m = intercept[IndexAlreadyExistsException] {
       sql(s"CREATE index i1 ON $catalogName.new_table (col1)")
     }.getMessage
-    assert(m.contains("Failed to create index: i1 in new_table"))
+    assert(m.contains("Failed to create index i1 in new_table"))
+
+    sql(s"DROP index i1 ON $catalogName.new_table")
+    sql(s"DROP index i2 ON $catalogName.new_table")
+
+    assert(jdbcTable.indexExists("i1") == false)
+    assert(jdbcTable.indexExists("i2") == false)
+
+    // This should pass without Exception
+    sql(s"DROP index IF EXISTS i1 ON $catalogName.new_table")
+
+    m = intercept[NoSuchIndexException] {
+      sql(s"DROP index i1 ON $catalogName.new_table")
+    }.getMessage
+    assert(m.contains("Failed to drop index i1 in new_table"))
   }
 }

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -162,7 +162,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTest {
     assert(jdbcTable.indexExists("i1") == true)
     assert(jdbcTable.indexExists("i2") == true)
 
-    // This should pass without Exception
+    // This should pass without exception
     sql(s"CREATE index IF NOT EXISTS i1 ON $catalogName.new_table (col1)")
 
     m = intercept[IndexAlreadyExistsException] {
@@ -176,7 +176,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite with V2JDBCTest {
     assert(jdbcTable.indexExists("i1") == false)
     assert(jdbcTable.indexExists("i2") == false)
 
-    // This should pass without Exception
+    // This should pass without exception
     sql(s"DROP index IF EXISTS i1 ON $catalogName.new_table")
 
     m = intercept[NoSuchIndexException] {

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -226,7 +226,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
           jdbcTable.createIndex("i1", "", Array(FieldReference("col1")),
             new util.HashMap[NamedReference, util.Map[String, String]](), properties)
         }.getMessage
-        assert(m.contains("Failed to create index: i1 in new_table"))
+        assert(m.contains("Failed to create index i1 in new_table"))
 
         var index = jdbcTable.listIndexes()
         assert(index.length == 2)
@@ -271,7 +271,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
         m = intercept[NoSuchIndexException] {
           jdbcTable.dropIndex("i2")
         }.getMessage
-        assert(m.contains("Failed to drop index: i2"))
+        assert(m.contains("Failed to drop index i2 in new_table"))
 
         testIndexProperties(jdbcTable)
       }

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -251,6 +251,7 @@ statement
         multipartIdentifier (USING indexType=identifier)?
         '(' columns=multipartIdentifierPropertyList ')'
         (OPTIONS options=propertyList)?                                #createIndex
+    | DROP INDEX (IF EXISTS)? identifier ON TABLE? multipartIdentifier #dropIndex
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
     ;
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4436,6 +4436,21 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
       options)
   }
 
+  /**
+   * Drop an index, returning a [[DropIndex]] logical plan.
+   * For example:
+   * {{{
+   *   DROP INDEX [IF EXISTS] index_name ON [TABLE] table_name
+   * }}}
+   */
+  override def visitDropIndex(ctx: DropIndexContext): LogicalPlan = withOrigin(ctx) {
+    val indexName = ctx.identifier.getText
+    DropIndex(
+      createUnresolvedTable(ctx.multipartIdentifier(), "DROP INDEX"),
+      indexName,
+      ctx.EXISTS != null)
+  }
+
   private def alterViewTypeMismatchHint: Option[String] = Some("Please use ALTER TABLE instead.")
 
   private def alterTableTypeMismatchHint: Option[String] = Some("Please use ALTER VIEW instead.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1075,9 +1075,10 @@ case class CreateIndex(
  * The logical plan of the DROP INDEX command.
  */
 case class DropIndex(
-    child: LogicalPlan,
+    table: LogicalPlan,
     indexName: String,
     ignoreIfNotExists: Boolean) extends UnaryCommand {
+  override def child: LogicalPlan = table
   override protected def withNewChildInternal(newChild: LogicalPlan): DropIndex =
-    copy(child = newChild)
+    copy(table = newChild)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1070,3 +1070,14 @@ case class CreateIndex(
   override protected def withNewChildInternal(newChild: LogicalPlan): CreateIndex =
     copy(child = newChild)
 }
+
+/**
+ * The logical plan of the DROP INDEX command.
+ */
+case class DropIndex(
+    child: LogicalPlan,
+    indexName: String,
+    ignoreIfNotExists: Boolean) extends UnaryCommand {
+  override protected def withNewChildInternal(newChild: LogicalPlan): DropIndex =
+    copy(child = newChild)
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2303,6 +2303,9 @@ class DDLParserSuite extends AnalysisTest {
   test("DROP INDEX") {
     parseCompare("DROP index i1 ON a.b.c",
       DropIndex(UnresolvedTable(Seq("a", "b", "c"), "DROP INDEX", None), "i1", false))
+
+    parseCompare("DROP index IF EXISTS i1 ON a.b.c",
+      DropIndex(UnresolvedTable(Seq("a", "b", "c"), "DROP INDEX", None), "i1", true))
   }
 
   private case class TableSpec(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2300,6 +2300,11 @@ class DDLParserSuite extends AnalysisTest {
           .zip(Seq(Map("k1" -> "v1"), Map("k2" -> "v2"))), Map("k3" -> "v3", "k4" -> "v4")))
   }
 
+  test("DROP INDEX") {
+    parseCompare("DROP index i1 ON a.b.c",
+      DropIndex(UnresolvedTable(Seq("a", "b", "c"), "DROP INDEX", None), "i1", false))
+  }
+
   private case class TableSpec(
       name: Seq[String],
       schema: Option[StructType],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -439,6 +439,14 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
           s"CreateIndex is not supported in this table ${table.name}.")
       }
 
+    case DropIndex(ResolvedTable(_, _, table, _), indexName, ifNotExists) =>
+      table match {
+        case s: SupportsIndex =>
+          DropIndexExec(s, indexName, ifNotExists) :: Nil
+        case _ => throw QueryCompilationErrors.tableIndexNotSupportedError(
+          s"DropIndex is not supported in this table ${table.name}.")
+      }
+
     case _ => Nil
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropIndexExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropIndexExec.scala
@@ -34,7 +34,7 @@ case class DropIndexExec(
       table.dropIndex(indexName)
     } catch {
       case _: NoSuchIndexException if ignoreIfNotExists =>
-        logWarning(s"Index $indexName not exists. Ignoring.")
+        logWarning(s"Index $indexName does not exist. Ignoring.")
     }
     Seq.empty
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropIndexExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropIndexExec.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.NoSuchIndexException
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.index.SupportsIndex
+
+/**
+ * Physical plan node for dropping an index.
+ */
+case class DropIndexExec(
+    table: SupportsIndex,
+    indexName: String,
+    ignoreIfNotExists: Boolean) extends LeafV2CommandExec {
+  override protected def run(): Seq[InternalRow] = {
+    try {
+      table.dropIndex(indexName)
+    } catch {
+      case _: NoSuchIndexException if ignoreIfNotExists =>
+        logWarning(s"Index $indexName not exists. Ignoring.")
+    }
+    Seq.empty
+  }
+
+  override def output: Seq[Attribute] = Seq.empty
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTable.scala
@@ -59,7 +59,7 @@ case class JDBCTable(ident: Identifier, schema: StructType, jdbcOptions: JDBCOpt
       columnsProperties: util.Map[NamedReference, util.Map[String, String]],
       properties: util.Map[String, String]): Unit = {
     JdbcUtils.withConnection(jdbcOptions) { conn =>
-      JdbcUtils.classifyException(s"Failed to create index: $indexName in $name",
+      JdbcUtils.classifyException(s"Failed to create index $indexName in $name",
         JdbcDialects.get(jdbcOptions.url)) {
         JdbcUtils.createIndex(
           conn, indexName, indexType, name, columns, columnsProperties, properties, jdbcOptions)
@@ -75,7 +75,7 @@ case class JDBCTable(ident: Identifier, schema: StructType, jdbcOptions: JDBCOpt
 
   override def dropIndex(indexName: String): Unit = {
     JdbcUtils.withConnection(jdbcOptions) { conn =>
-      JdbcUtils.classifyException(s"Failed to drop index: $indexName",
+      JdbcUtils.classifyException(s"Failed to drop index $indexName in $name",
         JdbcDialects.get(jdbcOptions.url)) {
         JdbcUtils.dropIndex(conn, indexName, name, jdbcOptions)
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -1424,8 +1424,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
     assertUnsupportedFeature { sql("UNLOCK DATABASE my_db") }
   }
 
-  test("alter index commands are not supported") {
-    assertUnsupportedFeature {
+  test("alter index command is not supported") {
     assertUnsupportedFeature { sql("ALTER INDEX my_index ON my_table REBUILD")}
     assertUnsupportedFeature {
       sql("ALTER INDEX my_index ON my_table set IDXPROPERTIES (\"prop1\"=\"val1_new\")")}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -1424,10 +1424,8 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
     assertUnsupportedFeature { sql("UNLOCK DATABASE my_db") }
   }
 
-  test("create/drop/alter index commands are not supported") {
+  test("alter index commands are not supported") {
     assertUnsupportedFeature {
-      sql("CREATE INDEX my_index ON TABLE my_table(a) as 'COMPACT' WITH DEFERRED REBUILD")}
-    assertUnsupportedFeature { sql("DROP INDEX my_index ON my_table") }
     assertUnsupportedFeature { sql("ALTER INDEX my_index ON my_table REBUILD")}
     assertUnsupportedFeature {
       sql("ALTER INDEX my_index ON my_table set IDXPROPERTIES (\"prop1\"=\"val1_new\")")}


### PR DESCRIPTION


### What changes were proposed in this pull request?
add drop index syntax
```
DROP INDEX [IF EXISTS] index_name ON [TABLE] table_name
```

### Why are the changes needed?
so user can drop index using sql


### Does this PR introduce _any_ user-facing change?
yes
new sql syntax `DROP INDEX [IF EXISTS] index_name ON [TABLE] table_name`

### How was this patch tested?
new test
