### PR TITLE
[SPARK-37202][SQL] Temp view should collect temp functions registered with catalog API

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2592,6 +2592,9 @@ class Analyzer(override val catalogManager: CatalogManager)
         case UnresolvedAlias(g: Generator, _) => hasInnerGenerator(g)
         case Alias(g: Generator, _) => hasInnerGenerator(g)
         case MultiAlias(g: Generator, _) => hasInnerGenerator(g)
+        case UnresolvedAlias(RegisteredFunction(_, g: Generator), _) => hasInnerGenerator(g)
+        case Alias(RegisteredFunction(_, g: Generator), _) => hasInnerGenerator(g)
+        case MultiAlias(RegisteredFunction(_, g: Generator), _) => hasInnerGenerator(g)
         case other => hasGenerator(other)
       }
     }
@@ -2624,6 +2627,15 @@ class Analyzer(override val catalogManager: CatalogManager)
         case MultiAlias(GeneratorOuter(g: Generator), names) if g.resolved => Some((g, names, true))
         case Alias(g: Generator, name) if g.resolved => Some((g, name :: Nil, false))
         case MultiAlias(g: Generator, names) if g.resolved => Some((g, names, false))
+        case Alias(RegisteredFunction(_, GeneratorOuter(g: Generator)), name) if g.resolved =>
+          Some((g, name :: Nil, true))
+        case MultiAlias(RegisteredFunction(_, GeneratorOuter(g: Generator)), names)
+            if g.resolved =>
+          Some((g, names, true))
+        case Alias(RegisteredFunction(_, g: Generator), name) if g.resolved =>
+          Some((g, name :: Nil, false))
+        case MultiAlias(RegisteredFunction(_, g: Generator), names) if g.resolved =>
+          Some((g, names, false))
         case _ => None
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -305,7 +305,7 @@ class SimpleFunctionRegistry
     // we can identify the functions among the expressions. It will get replaced at
     // runtime (currently by the optimizer) to the actual function.
     def wrappedBuilder: FunctionBuilder = (e: Seq[Expression]) => {
-      RegisteredSimpleFunction(name, builder(e))
+      RegisteredFunction(name, builder(e))
     }
     super.registerFunction(name, info, wrappedBuilder)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.FunctionIdentifier
-import org.apache.spark.sql.catalyst.expressions.{RegisteredSimpleFunction, _}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.xml._
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Range}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -1089,10 +1089,14 @@ trait UserDefinedExpression {
   def name: String
 }
 
-case class RegisteredSimpleFunction(
+case class RegisteredFunction(
     name: FunctionIdentifier, child: Expression) extends RuntimeReplaceable {
   override def exprsReplaced: Seq[Expression] = Seq(child)
 
   override protected def withNewChildInternal(newChild: Expression): Expression =
     copy(child = newChild)
+
+//  override lazy val canonicalized: Expression = child.canonicalized
+
+  override def sql: String = child.sql
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.expressions
 
 import java.util.Locale
 
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.expressions.aggregate.DeclarativeAggregate
 import org.apache.spark.sql.catalyst.expressions.codegen._
@@ -1087,4 +1087,12 @@ trait ComplexTypeMergingExpression extends Expression {
  */
 trait UserDefinedExpression {
   def name: String
+}
+
+case class RegisteredSimpleFunction(
+    name: FunctionIdentifier, child: Expression) extends RuntimeReplaceable {
+  override def exprsReplaced: Seq[Expression] = Seq(child)
+
+  override protected def withNewChildInternal(newChild: Expression): Expression =
+    copy(child = newChild)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{SQLConfHelper, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{GlobalTempView, LocalTempView, ViewType}
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, SessionCatalog, TemporaryViewRelation}
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, RegisteredSimpleFunction, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, RegisteredFunction, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical.{AnalysisOnlyCommand, LogicalPlan, Project, View}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.NamespaceHelper
@@ -575,7 +575,7 @@ object ViewHelper extends SQLConfHelper with Logging {
             // Catalog API: sparkSession.sessionState.catalog.registerFunction
             // The second one is not a `UserDefinedExpression` and can be any kind of `Expression`.
             // So we wrap all functions to `RegisteredSimpleFunction` in order to collect them both.
-            case RegisteredSimpleFunction(name, _)
+            case RegisteredFunction(name, _)
                 if catalog.isTemporaryFunction(name) =>
               Seq(name.funcName)
             case _ => Seq.empty

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -571,8 +571,8 @@ object ViewHelper extends SQLConfHelper with Logging {
           plan.expressions.flatMap(_.flatMap {
             case e: SubqueryExpression => collectTempFunctions(e.plan)
             // There are two ways to create a temporary function.
-            // 1. CREATE TEMP FUNCTION xxx
-            // 2. sparkSession.sessionState.catalog.registerFunction
+            // SQL API: CREATE TEMP FUNCTION xxx
+            // Catalog API: sparkSession.sessionState.catalog.registerFunction
             // The second one is not a `UserDefinedExpression` and can be any kind of `Expression`.
             // So we wrap all functions to `RegisteredSimpleFunction` in order to collect them both.
             case RegisteredSimpleFunction(name, _)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -20,7 +20,9 @@ package org.apache.spark.sql.execution
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.catalog.CatalogFunction
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.Repartition
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.internal.SQLConf._
@@ -378,7 +380,27 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
   }
 }
 
-class LocalTempViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
+abstract class TempViewTestSuite extends SQLViewTestSuite {
+
+  test("SPARK-37202: temp view should capture the function registered by catalog API") {
+    val funcName = "tempFunc"
+    val viewName = "tempView"
+    withUserDefinedFunction(funcName -> true) {
+      val catalogFunction = CatalogFunction(
+        FunctionIdentifier(funcName, None), "org.apache.spark.myFunc", Seq.empty)
+      val functionBuilder = (e: Seq[Expression]) => e.head
+      spark.sessionState.catalog.registerFunction(
+        catalogFunction, overrideIfExists = false, functionBuilder = Some(functionBuilder))
+      withView(viewName) {
+        val query = s"SELECT $funcName(max(a), min(a)) FROM VALUES (1), (2), (3) t(a)"
+        createView(viewName, query)
+        checkViewOutput(viewName, sql(query).collect())
+      }
+    }
+  }
+}
+
+class LocalTempViewTestSuite extends TempViewTestSuite with SharedSparkSession {
   override protected def viewTypeString: String = "TEMPORARY VIEW"
   override protected def formattedViewName(viewName: String): String = viewName
   override protected def tableIdentifier(viewName: String): TableIdentifier = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -408,7 +408,7 @@ class LocalTempViewTestSuite extends TempViewTestSuite with SharedSparkSession {
   }
 }
 
-class GlobalTempViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
+class GlobalTempViewTestSuite extends TempViewTestSuite with SharedSparkSession {
   private def db: String = spark.sharedState.globalTempViewManager.database
   override protected def viewTypeString: String = "GLOBAL TEMPORARY VIEW"
   override protected def formattedViewName(viewName: String): String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a new function wrapper called `RegisteredSimpleFunction`, so that we can identify
the functions among all the expressions. Because of this, when creating temp views,
we can collect all temporary functions created both by SQL or catalog API.

### Why are the changes needed?
fix regression. After we choose to store the sql text instead of a logical plan for a view, we couldn't
collect the temporary functions registered by catalog API. For example:
```scala
val func = CatalogFunction(FunctionIdentifier("tempFunc", None), ...)
val builder = (e: Seq[Expression]) => e.head
spark.sessionState.catalog.registerFunction(func, Some(builder))
sql("create temp view tv as select temp1(a, b) from values (1, 2) t(a, b)")
sql("select * from tv").collect()
```
We will get an exception for the above code:
```
Undefined function: 'tempFunc'. This function is neither a registered temporary function nor a permanent function registered in the database 'default'.;
```

### Does this PR introduce _any_ user-facing change?
No, it's a bug-fix.


### How was this patch tested?
newly added UT
