### PR TITLE
[SPARK-37203][SQL] Fix NotSerializableException when observe with TypedImperativeAggregate

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -157,6 +157,9 @@ abstract class AccumulatorV2[IN, OUT] extends Serializable {
    */
   def value: OUT
 
+  // We assume that serialization of AccumulatorV2 runs on executor is not necessary.
+  protected def withBufferSerialized(): AccumulatorV2[IN, OUT] = this
+
   // Called by Java when serializing an object
   final protected def writeReplace(): Any = {
     if (atDriverSide) {
@@ -179,7 +182,7 @@ abstract class AccumulatorV2[IN, OUT] extends Serializable {
       }
       copyAcc
     } else {
-      this
+      withBufferSerialized()
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -157,7 +157,8 @@ abstract class AccumulatorV2[IN, OUT] extends Serializable {
    */
   def value: OUT
 
-  // We assume that serialization of AccumulatorV2 runs on executor is not necessary.
+  // Serialize the buffer of this accumulator before sending back this accumulator to the driver.
+  // By default this method does nothing.
   protected def withBufferSerialized(): AccumulatorV2[IN, OUT] = this
 
   // Called by Java when serializing an object

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -226,7 +226,7 @@ object ApproximatePercentile {
    *
    * @param summaries underlying probabilistic data structure [[QuantileSummaries]].
    */
-  class PercentileDigest(private var summaries: QuantileSummaries) extends Serializable {
+  class PercentileDigest(private var summaries: QuantileSummaries) {
 
     def this(relativeError: Double) = {
       this(new QuantileSummaries(defaultCompressThreshold, relativeError, compressed = true))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -226,7 +226,7 @@ object ApproximatePercentile {
    *
    * @param summaries underlying probabilistic data structure [[QuantileSummaries]].
    */
-  class PercentileDigest(private var summaries: QuantileSummaries) {
+  class PercentileDigest(private var summaries: QuantileSummaries) extends Serializable {
 
     def this(relativeError: Double) = {
       this(new QuantileSummaries(defaultCompressThreshold, relativeError, compressed = true))
@@ -276,7 +276,7 @@ object ApproximatePercentile {
   }
 
   /**
-   * Serializer  for class [[PercentileDigest]]
+   * Serializer for class [[PercentileDigest]]
    *
    * This class is thread safe.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -622,17 +622,6 @@ abstract class TypedImperativeAggregate[T] extends ImperativeAggregate {
   }
 
   /**
-   * In-place replaces SparkSQL internally supported underlying storage format (BinaryType),
-   * with the aggregation buffer object stored at buffer's index `mutableAggBufferOffset`.
-   *
-   * This is only called when AggregatingAccumulator running on driver, after the framework
-   * shuffle in aggregate buffers.
-   */
-  final def deserializeAggregateBufferInPlace(buffer: InternalRow): Unit = {
-    buffer(mutableAggBufferOffset) = deserialize(buffer.getBinary(inputAggBufferOffset))
-  }
-
-  /**
    * Merge an input buffer into the aggregation buffer, where both buffers contain the deserialized
    * java object. This function is used by aggregating accumulators.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -622,6 +622,17 @@ abstract class TypedImperativeAggregate[T] extends ImperativeAggregate {
   }
 
   /**
+   * In-place replaces SparkSQL internally supported underlying storage format (BinaryType),
+   * with the aggregation buffer object stored at buffer's index `mutableAggBufferOffset`.
+   *
+   * This is only called when AggregatingAccumulator running on driver, after the framework
+   * shuffle in aggregate buffers.
+   */
+  final def deserializeAggregateBufferInPlace(buffer: InternalRow): Unit = {
+    buffer(mutableAggBufferOffset) = deserialize(buffer.getBinary(inputAggBufferOffset))
+  }
+
+  /**
    * Merge an input buffer into the aggregation buffer, where both buffers contain the deserialized
    * java object. This function is used by aggregating accumulators.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AggregatingAccumulator.scala
@@ -156,6 +156,15 @@ class AggregatingAccumulator private(
         case agg: AggregatingAccumulator =>
           val buffer = getOrCreateBuffer()
           val otherBuffer = agg.buffer
+          // If AggregatingAccumulator runs on driver,
+          // we should deserialize all TypedImperativeAggregate.
+          if (isAtDriverSide) {
+            var i = 0
+            while (i < typedImperatives.length) {
+              typedImperatives(i).deserializeAggregateBufferInPlace(otherBuffer)
+              i += 1
+            }
+          }
           mergeProjection.target(buffer)(joinedRow.withRight(otherBuffer))
           var i = 0
           while (i < imperatives.length) {
@@ -174,9 +183,9 @@ class AggregatingAccumulator private(
     }
   }
 
-  override def value: InternalRow = withSQLConf(false, InternalRow.empty) {
+  private def getOrCreateTempBuffer(): SpecificInternalRow = {
     // Either use the existing buffer or create a temporary one.
-    val input = if (!isZero) {
+    if (!isZero) {
       buffer
     } else {
       // Create a temporary buffer because we want to avoid changing the state of the accumulator
@@ -185,7 +194,24 @@ class AggregatingAccumulator private(
       // query execution).
       createBuffer()
     }
+  }
+
+  override def value: InternalRow = withSQLConf(false, InternalRow.empty) {
+    val input = getOrCreateTempBuffer()
     resultProjection(input)
+  }
+
+  override def withBufferSerialized(): AggregatingAccumulator = {
+    if (!isAtDriverSide) {
+      val input = getOrCreateTempBuffer()
+      var i = 0
+      // AggregatingAccumulator runs on executor, we should serialize all TypedImperativeAggregate.
+      while (i < typedImperatives.length) {
+        typedImperatives(i).serializeAggregateBufferInPlace(input)
+        i += 1
+      }
+    }
+    this
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -754,6 +754,17 @@ class DatasetSuite extends QueryTest
     assert(err2.getMessage.contains("Name must not be empty"))
   }
 
+  test("SPARK-37203: Fix NotSerializableException when observe with percentile_approx") {
+    val namedObservation = Observation("named")
+
+    val df = spark.range(100)
+    val observed_df = df.observe(
+      namedObservation, percentile_approx($"id", lit(0.5), lit(100)).as("percentile_approx_val"))
+
+    observed_df.collect()
+    assert(namedObservation.get === Map("percentile_approx_val" -> 49))
+  }
+
   test("sample with replacement") {
     val n = 100
     val data = sparkContext.parallelize(1 to n, 2).toDS()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -754,7 +754,7 @@ class DatasetSuite extends QueryTest
     assert(err2.getMessage.contains("Name must not be empty"))
   }
 
-  test("SPARK-37203: Fix NotSerializableException when observe with percentile_approx") {
+  test("SPARK-37203: Fix NotSerializableException when observe with TypedImperativeAggregate") {
     val namedObservation = Observation("named")
 
     val df = spark.range(100)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -417,7 +417,8 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
         min($"value").as("min_val"),
         max($"value").as("max_val"),
         sum($"value").as("sum_val"),
-        count(when($"value" % 2 === 0, 1)).as("num_even"))
+        count(when($"value" % 2 === 0, 1)).as("num_even"),
+        percentile_approx($"value", lit(0.5), lit(100)).as("percentile_approx_val"))
       .observe(
         name = "other_event",
         avg($"value").cast("int").as("avg_val"))
@@ -444,7 +445,7 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
         AddData(inputData, 1, 2),
         AdvanceManualClock(100),
         checkMetrics { metrics =>
-          assert(metrics.get("my_event") === Row(1, 2, 3L, 1L))
+          assert(metrics.get("my_event") === Row(1, 2, 3L, 1L, 1))
           assert(metrics.get("other_event") === Row(1))
         },
 
@@ -452,7 +453,7 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
         AddData(inputData, 10, 30, -10, 5),
         AdvanceManualClock(100),
         checkMetrics { metrics =>
-          assert(metrics.get("my_event") === Row(-10, 30, 35L, 3L))
+          assert(metrics.get("my_event") === Row(-10, 30, 35L, 3L, 5))
           assert(metrics.get("other_event") === Row(8))
         },
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, 
```
val namedObservation = Observation("named")

val df = spark.range(100)
val observed_df = df.observe(
   namedObservation, percentile_approx($"id", lit(0.5), lit(100)).as("percentile_approx_val"))

observed_df.collect()
namedObservation.get
```
throws exception as follows:
```
15:16:27.994 ERROR org.apache.spark.util.Utils: Exception encountered
java.io.NotSerializableException: org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile$PercentileDigest
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeArray(ObjectOutputStream.java:1378)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1174)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at org.apache.spark.scheduler.DirectTaskResult.$anonfun$writeExternal$2(TaskResult.scala:55)
	at org.apache.spark.scheduler.DirectTaskResult.$anonfun$writeExternal$2$adapted(TaskResult.scala:55)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at org.apache.spark.scheduler.DirectTaskResult.$anonfun$writeExternal$1(TaskResult.scala:55)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at org.apache.spark.util.Utils$.tryOrIOException(Utils.scala:1434)
	at org.apache.spark.scheduler.DirectTaskResult.writeExternal(TaskResult.scala:51)
	at java.io.ObjectOutputStream.writeExternalData(ObjectOutputStream.java:1459)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1430)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at org.apache.spark.serializer.JavaSerializationStream.writeObject(JavaSerializer.scala:44)
	at org.apache.spark.serializer.JavaSerializerInstance.serialize(JavaSerializer.scala:101)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:616)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
This PR will fix the issue. After the change, 
`assert(namedObservation.get === Map("percentile_approx_val" -> 49))`
`java.io.NotSerializableException` will not happen.


### Why are the changes needed?
Fix `NotSerializableException` when observe with `TypedImperativeAggregate`.

### Does this PR introduce _any_ user-facing change?
No. This PR change the implement of `AggregatingAccumulator` who uses serialize and deserialize of `TypedImperativeAggregate` now.


### How was this patch tested?
New tests.
