### PR TITLE
[MINOR][PYTHON][DOCS] Fix broken link in legacy Apache Arrow in PySpark page

### DIFF
--- a/python/docs/source/user_guide/arrow_pandas.rst
+++ b/python/docs/source/user_guide/arrow_pandas.rst
@@ -21,4 +21,4 @@
 Apache Arrow in PySpark
 =======================
 
-This page has been moved to `Apache Arrow in PySpark <../sql/arrow_pandas.rst>`_.
+This page has been moved to `Apache Arrow in PySpark <sql/arrow_pandas.rst>`_.

--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -343,7 +343,7 @@ Supported SQL Types
 
 Currently, all Spark SQL data types are supported by Arrow-based conversion except
 :class:`ArrayType` of :class:`TimestampType`, and nested :class:`StructType`.
-:class: `MapType` is only supported when using PyArrow 2.0.0 and above.
+:class:`MapType` is only supported when using PyArrow 2.0.0 and above.
 
 Setting Arrow Batch Size
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the broken link in the legacy page. Currently it links to:

![Screen Shot 2021-11-03 at 6 34 32 PM](https://user-images.githubusercontent.com/6477701/140037221-b7963e47-12f5-49f3-8290-8560c99c62c2.png)
![Screen Shot 2021-11-03 at 6 34 30 PM](https://user-images.githubusercontent.com/6477701/140037225-c21070fc-907f-41bb-a421-747810ae5b0d.png)


It should link to:

![Screen Shot 2021-11-03 at 6 34 35 PM](https://user-images.githubusercontent.com/6477701/140037246-dd14760f-5487-4b8b-b3f6-e9495f1d4ec9.png)
![Screen Shot 2021-11-03 at 6 34 38 PM](https://user-images.githubusercontent.com/6477701/140037251-3f97e992-6660-4ce9-9c66-77855d3c0a64.png)


### Why are the changes needed?

For users to easily navigate from legacy page to newer page.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes a bug in documentation.

### How was this patch tested?

Manually built the side and checked the link