### PR TITLE
[SPARK-37149][SQL][FOLLOWUP] Update error messages for arithmetic overflow under ANSI mode

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -8,7 +8,7 @@
     "sqlState" : "22005"
   },
   "CANNOT_CHANGE_DECIMAL_PRECISION" : {
-    "message" : [ "%s cannot be represented as Decimal(%s, %s). You can set %s to false to bypass this error." ],
+    "message" : [ "%s cannot be represented as Decimal(%s, %s). If necessary set %s to false to bypass this error." ],
     "sqlState" : "22005"
   },
   "CANNOT_PARSE_DECIMAL" : {
@@ -16,14 +16,14 @@
     "sqlState" : "42000"
   },
   "CAST_CAUSES_OVERFLOW" : {
-    "message" : [ "Casting %s to %s causes overflow. You can use 'try_cast' or set %s to false to bypass this error." ],
+    "message" : [ "Casting %s to %s causes overflow. To return NULL instead, use 'try_cast'. If necessary set %s to false to bypass this error." ],
     "sqlState" : "22005"
   },
   "CONCURRENT_QUERY" : {
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
   },
   "DIVIDE_BY_ZERO" : {
-    "message" : [ "divide by zero. You can use 'try_divide' or set %s to false (except for ANSI interval type) to bypass this error." ],
+    "message" : [ "divide by zero. To return NULL instead, use 'try_divide'. If necessary set %s to false (except for ANSI interval type) to bypass this error." ],
     "sqlState" : "22012"
   },
   "DUPLICATE_KEY" : {

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -125,7 +125,7 @@ class SparkThrowableSuite extends SparkFunSuite {
 
     // Does not fail with too many args (expects 0 args)
     assert(getMessage("DIVIDE_BY_ZERO", Array("foo", "bar")) ==
-      "divide by zero. You can use 'try_divide' or set foo to false " +
+      "divide by zero. To return NULL instead, use 'try_divide'. If necessary set foo to false " +
         "(except for ANSI interval type) to bypass this error.")
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
@@ -42,15 +42,15 @@ object MathUtils {
 
   def toIntExact(a: Long): Int = withOverflow(Math.toIntExact(a))
 
-  def floorDiv(a: Int, b: Int): Int = withOverflow(Math.floorDiv(a, b), Some("try_divide"))
+  def floorDiv(a: Int, b: Int): Int = withOverflow(Math.floorDiv(a, b), hint = "try_divide")
 
-  def floorDiv(a: Long, b: Long): Long = withOverflow(Math.floorDiv(a, b), Some("try_divide"))
+  def floorDiv(a: Long, b: Long): Long = withOverflow(Math.floorDiv(a, b), hint = "try_divide")
 
   def floorMod(a: Int, b: Int): Int = withOverflow(Math.floorMod(a, b))
 
   def floorMod(a: Long, b: Long): Long = withOverflow(Math.floorMod(a, b))
 
-  private def withOverflow[A](f: => A, hint: Option[String] = None): A = {
+  private def withOverflow[A](f: => A, hint: String = ""): A = {
     try {
       f
     } catch {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -215,7 +215,7 @@ object QueryExecutionErrors {
   }
 
   def overflowInIntegralDivideError(): ArithmeticException = {
-    arithmeticOverflowError("Overflow in integral divide", Some("try_divide"))
+    arithmeticOverflowError("Overflow in integral divide", "try_divide")
   }
 
   def mapSizeExceedArraySizeWhenZipMapError(size: Int): RuntimeException = {
@@ -430,11 +430,10 @@ object QueryExecutionErrors {
       s"to false to bypass this error.")
   }
 
-  def arithmeticOverflowError(
-      message: String, hint: Option[String] = None): ArithmeticException = {
-    new ArithmeticException(s"$message. You can ${hint.map(x => s"use '$x' or ").getOrElse("")}" +
-      s"set ${SQLConf.ANSI_ENABLED.key} to false (except for ANSI interval type) " +
-      "to bypass this error.")
+  def arithmeticOverflowError(message: String, hint: String = ""): ArithmeticException = {
+    val alternative = if (hint.nonEmpty) s"To return NULL instead, use '$hint'." else ""
+    new ArithmeticException(s"$message.$alternative If necessary set " +
+      s"${SQLConf.ANSI_ENABLED.key} to false (except for ANSI interval type) to bypass this error.")
   }
 
   def unaryMinusCauseOverflowError(originValue: AnyVal): ArithmeticException = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -431,7 +431,7 @@ object QueryExecutionErrors {
   }
 
   def arithmeticOverflowError(message: String, hint: String = ""): ArithmeticException = {
-    val alternative = if (hint.nonEmpty) s"To return NULL instead, use '$hint'." else ""
+    val alternative = if (hint.nonEmpty) s" To return NULL instead, use '$hint'." else ""
     new ArithmeticException(s"$message.$alternative If necessary set " +
       s"${SQLConf.ANSI_ENABLED.key} to false (except for ANSI interval type) to bypass this error.")
   }

--- a/sql/core/src/test/resources/sql-tests/results/ansi/decimalArithmeticOperations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/decimalArithmeticOperations.sql.out
@@ -76,7 +76,7 @@ select (5e36BD + 0.1) + 5e36BD
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Decimal(expanded,10000000000000000000000000000000000000.1,39,1}) cannot be represented as Decimal(38, 1). You can set spark.sql.ansi.enabled to false to bypass this error.
+Decimal(expanded,10000000000000000000000000000000000000.1,39,1}) cannot be represented as Decimal(38, 1). If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -85,7 +85,7 @@ select (-4e36BD - 0.1) - 7e36BD
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Decimal(expanded,-11000000000000000000000000000000000000.1,39,1}) cannot be represented as Decimal(38, 1). You can set spark.sql.ansi.enabled to false to bypass this error.
+Decimal(expanded,-11000000000000000000000000000000000000.1,39,1}) cannot be represented as Decimal(38, 1). If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -94,7 +94,7 @@ select 12345678901234567890.0 * 12345678901234567890.0
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Decimal(expanded,152415787532388367501905199875019052100,39,0}) cannot be represented as Decimal(38, 2). You can set spark.sql.ansi.enabled to false to bypass this error.
+Decimal(expanded,152415787532388367501905199875019052100,39,0}) cannot be represented as Decimal(38, 2). If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -103,7 +103,7 @@ select 1e35BD / 0.1
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Decimal(expanded,1000000000000000000000000000000000000,37,0}) cannot be represented as Decimal(38, 6). You can set spark.sql.ansi.enabled to false to bypass this error.
+Decimal(expanded,1000000000000000000000000000000000000,37,0}) cannot be represented as Decimal(38, 6). If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1997,7 +1997,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2006,7 +2006,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1L
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2049,7 +2049,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2058,7 +2058,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1L
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide.To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -210,7 +210,7 @@ select interval '2 seconds' / 0
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -243,7 +243,7 @@ select interval '2' year / 0
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1750,7 +1750,7 @@ select -(a) from values (interval '-2147483648 months', interval '2147483647 mon
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1759,7 +1759,7 @@ select a - b from values (interval '-2147483648 months', interval '2147483647 mo
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1768,7 +1768,7 @@ select b + interval '1 month' from values (interval '-2147483648 months', interv
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1997,7 +1997,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide.To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2006,7 +2006,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1L
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide.To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2049,7 +2049,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide.To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2058,7 +2058,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1L
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide.To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -204,7 +204,7 @@ select interval '2 seconds' / 0
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -237,7 +237,7 @@ select interval '2' year / 0
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1739,7 +1739,7 @@ select -(a) from values (interval '-2147483648 months', interval '2147483647 mon
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1748,7 +1748,7 @@ select a - b from values (interval '-2147483648 months', interval '2147483647 mo
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1757,7 +1757,7 @@ select b + interval '1 month' from values (interval '-2147483648 months', interv
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1986,7 +1986,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -1995,7 +1995,7 @@ SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1L
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2038,7 +2038,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -2047,7 +2047,7 @@ SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1L
 struct<>
 -- !query output
 java.lang.ArithmeticException
-Overflow in integral divide. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/case.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/case.sql.out
@@ -179,7 +179,7 @@ SELECT CASE WHEN 1=0 THEN 1/0 WHEN 1=1 THEN 1 ELSE 2/0 END
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -188,7 +188,7 @@ SELECT CASE 1 WHEN 0 THEN 1/0 WHEN 1 THEN 1 ELSE 2/0 END
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -197,7 +197,7 @@ SELECT CASE WHEN i > 100 THEN 1/0 ELSE 0 END FROM case_tbl
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/float4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/float4.sql.out
@@ -325,7 +325,7 @@ SELECT int(float('2147483647'))
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting 2.14748365E9 to int causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
+Casting 2.14748365E9 to int causes overflow. To return NULL instead, use 'try_cast'. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -342,7 +342,7 @@ SELECT int(float('-2147483900'))
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting -2.1474839E9 to int causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
+Casting -2.1474839E9 to int causes overflow. To return NULL instead, use 'try_cast'. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -375,7 +375,7 @@ SELECT bigint(float('-9223380000000000000'))
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting -9.22338E18 to int causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
+Casting -9.22338E18 to int causes overflow. To return NULL instead, use 'try_cast'. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/float8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/float8.sql.out
@@ -833,7 +833,7 @@ SELECT bigint(double('-9223372036854780000'))
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting -9.22337203685478E18 to long causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
+Casting -9.22337203685478E18 to long causes overflow. To return NULL instead, use 'try_cast'. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int4.sql.out
@@ -200,7 +200,7 @@ SELECT '' AS five, i.f1, i.f1 * smallint('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -220,7 +220,7 @@ SELECT '' AS five, i.f1, i.f1 * int('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -240,7 +240,7 @@ SELECT '' AS five, i.f1, i.f1 + smallint('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -261,7 +261,7 @@ SELECT '' AS five, i.f1, i.f1 + int('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -282,7 +282,7 @@ SELECT '' AS five, i.f1, i.f1 - smallint('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -303,7 +303,7 @@ SELECT '' AS five, i.f1, i.f1 - int('2') AS x FROM INT4_TBL i
 struct<>
 -- !query output
 java.lang.ArithmeticException
-integer overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
@@ -392,7 +392,7 @@ SELECT '' AS three, q1, q2, q1 * q2 AS multiply FROM INT8_TBL
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -572,7 +572,7 @@ select bigint('9223372036854775800') / bigint('0')
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -581,7 +581,7 @@ select bigint('-9223372036854775808') / smallint('0')
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -590,7 +590,7 @@ select smallint('100') / bigint('0')
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -607,7 +607,7 @@ SELECT CAST(q1 AS int) FROM int8_tbl WHERE q2 <> 456
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting 4567890123456789 to int causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
+Casting 4567890123456789 to int causes overflow. To return NULL instead, use 'try_cast'. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -624,7 +624,7 @@ SELECT CAST(q1 AS smallint) FROM int8_tbl WHERE q2 <> 456
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting 4567890123456789 to smallint causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
+Casting 4567890123456789 to smallint causes overflow. To return NULL instead, use 'try_cast'. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -661,7 +661,7 @@ SELECT CAST(double('922337203685477580700.0') AS bigint)
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting 9.223372036854776E20 to long causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
+Casting 9.223372036854776E20 to long causes overflow. To return NULL instead, use 'try_cast'. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -733,7 +733,7 @@ SELECT string(int(shiftleft(bigint(-1), 63))+1)
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-Casting -9223372036854775808 to int causes overflow. You can use 'try_cast' or set spark.sql.ansi.enabled to false to bypass this error.
+Casting -9223372036854775808 to int causes overflow. To return NULL instead, use 'try_cast'. If necessary set spark.sql.ansi.enabled to false to bypass this error.
 
 
 -- !query
@@ -742,7 +742,7 @@ SELECT bigint((-9223372036854775808)) * bigint((-1))
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -767,7 +767,7 @@ SELECT bigint((-9223372036854775808)) * int((-1))
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -792,7 +792,7 @@ SELECT bigint((-9223372036854775808)) * smallint((-1))
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
@@ -177,7 +177,7 @@ SELECT 1 AS one FROM test_having WHERE 1/a = 1 HAVING 1 < 2
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part2.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part2.sql.out
@@ -225,7 +225,7 @@ from range(9223372036854775804, 9223372036854775807) x
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -235,7 +235,7 @@ from range(-9223372036854775806, -9223372036854775805) x
 struct<>
 -- !query output
 java.lang.ArithmeticException
-long overflow. You can set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-case.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-case.sql.out
@@ -179,7 +179,7 @@ SELECT CASE WHEN udf(1=0) THEN 1/0 WHEN 1=1 THEN 1 ELSE 2/0 END
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -188,7 +188,7 @@ SELECT CASE 1 WHEN 0 THEN 1/udf(0) WHEN 1 THEN 1 ELSE 2/0 END
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query
@@ -197,7 +197,7 @@ SELECT CASE WHEN i > 100 THEN udf(1/0) ELSE udf(0) END FROM case_tbl
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
@@ -177,7 +177,7 @@ SELECT 1 AS one FROM test_having WHERE 1/udf(a) = 1 HAVING 1 < 2
 struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
-divide by zero. You can use 'try_divide' or set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a follow-up PR for SPARK-37149. This PR updates the wording of arithmetic overflow error messages under ANSI mode to make them more informative. 

### Why are the changes needed?
Make error messages more informative.

### Does this PR introduce _any_ user-facing change?
Yes. Certain error messages will be changed.

### How was this patch tested?
Existing tests.