### PR TITLE
[SPARK-37215][YARN] Support Application Timeouts on YARN

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -263,6 +263,8 @@ private[spark] class Client(
     appContext.setQueue(sparkConf.get(QUEUE_NAME))
     appContext.setAMContainerSpec(containerContext)
     appContext.setApplicationType(sparkConf.get(APPLICATION_TYPE))
+    val timeout = sparkConf.get(APPLICATION_LIFETIME_TIMEOUT)
+    timeout.foreach(ResourceRequestHelper.setApplicationTimeouts(appContext, _))
 
     sparkConf.get(APPLICATION_TAGS).foreach { tags =>
       appContext.setApplicationTags(new java.util.HashSet[String](tags.asJava))

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
@@ -25,8 +25,8 @@ import scala.collection.mutable
 import scala.util.Try
 
 import org.apache.hadoop.yarn.api.records.{ApplicationSubmissionContext, Resource}
-import org.apache.spark.{SparkConf, SparkException}
 
+import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -429,6 +429,13 @@ package object config extends Logging {
     .toSequence
     .createWithDefault(Nil)
 
+  private[spark] val APPLICATION_LIFETIME_TIMEOUT = ConfigBuilder("spark.yarn.app.lifetime.timeout")
+    .doc("Overall timeout for a spark application running on yarn from submitted time, " +
+      "by default it's unlimited.")
+    .version("3.3.0")
+    .timeConf(TimeUnit.SECONDS)
+    .createOptional
+
   private[yarn] val YARN_EXECUTOR_RESOURCE_TYPES_PREFIX = "spark.yarn.executor.resource."
   private[yarn] val YARN_DRIVER_RESOURCE_TYPES_PREFIX = "spark.yarn.driver.resource."
   private[yarn] val YARN_AM_RESOURCE_TYPES_PREFIX = "spark.yarn.am.resource."

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -191,6 +191,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
       .set("spark.app.name", "foo-test-app")
       .set(QUEUE_NAME, "staging-queue")
       .set(APPLICATION_PRIORITY, 1)
+      .set(APPLICATION_LIFETIME_TIMEOUT, 12345L)
     val args = new ClientArguments(Array())
 
     val appContext = Records.newRecord(classOf[ApplicationSubmissionContext])
@@ -213,6 +214,10 @@ class ClientSuite extends SparkFunSuite with Matchers {
     }
     appContext.getMaxAppAttempts should be (42)
     appContext.getPriority.getPriority should be (1)
+    if (isApplicationTimeoutAvailable) {
+      val maybeTimeouts = ResourceRequestTestHelper.getApplicationTimeouts(appContext)
+      assert(maybeTimeouts.get === 12345L)
+    }
   }
 
   test("specify a more specific type for the application") {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ResourceRequestHelperSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ResourceRequestHelperSuite.scala
@@ -17,14 +17,14 @@
 
 package org.apache.spark.deploy.yarn
 
-import org.apache.hadoop.yarn.api.records.Resource
+import org.apache.hadoop.yarn.api.records.{ApplicationSubmissionContext, Resource}
 import org.apache.hadoop.yarn.util.Records
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
 import org.apache.spark.deploy.yarn.ResourceRequestHelper._
-import org.apache.spark.deploy.yarn.ResourceRequestTestHelper.ResourceInformation
+import org.apache.spark.deploy.yarn.ResourceRequestTestHelper.{getApplicationTimeouts, ResourceInformation}
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.config.{DRIVER_CORES, DRIVER_MEMORY, EXECUTOR_CORES, EXECUTOR_MEMORY}
 import org.apache.spark.resource.ResourceUtils.AMOUNT
@@ -181,5 +181,18 @@ class ResourceRequestHelperSuite extends SparkFunSuite with Matchers {
     resource.setMemory(512)
     resource.setVirtualCores(2)
     resource
+  }
+
+  test("set application timeouts") {
+    assume(isApplicationTimeoutAvailable)
+    val submissionContext = Records.newRecord(classOf[ApplicationSubmissionContext])
+    val to1 = getApplicationTimeouts(submissionContext)
+    assert(to1.isEmpty)
+
+    Seq(-1, 0, 1000).foreach { timeout =>
+      setApplicationTimeouts(submissionContext, timeout)
+      val to = getApplicationTimeouts(submissionContext)
+      assert(to.get === timeout)
+    }
   }
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ResourceRequestTestHelper.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ResourceRequestTestHelper.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.yarn
 
 import scala.collection.JavaConverters._
 
-import org.apache.hadoop.yarn.api.records.Resource
+import org.apache.hadoop.yarn.api.records.{ApplicationSubmissionContext, Resource}
 
 import org.apache.spark.util.Utils
 
@@ -97,4 +97,12 @@ object ResourceRequestTestHelper {
   }
 
   case class ResourceInformation(name: String, value: Long, unit: String)
+
+  def getApplicationTimeouts(appContext: ApplicationSubmissionContext): Option[Long] = {
+    require(ResourceRequestHelper.isApplicationTimeoutAvailable, "Unsupported YARN version")
+    val setTimeoutMethod =
+      appContext.getClass.getMethod("getApplicationTimeouts")
+    setTimeoutMethod.invoke(appContext)
+      .asInstanceOf[java.util.Map[_, _]].values().asScala.headOption.map(_.asInstanceOf[Long])
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Since #YARN-3813/2.9.0/3.0.0, YARN supports ApplicationTimeouts. It helps enforce lifetime application SLAs. Currently, lifetime indicates the overall time spent by an application in YARN. It is calculated from its submit time to finish time, including running time and the waiting time for resource allocation.

YARN allows admins to set lifetime of an application at leaf-queue. It also allows users to set it programmatically. During application submission, user can set it in  `ApplicationSubmissionContext#setApplicationTimeouts(Map<ApplicationTimeoutType, Long> applicationTimeouts)`.

So far, YARN supports for one timeout type - LIFETIME.

In this PR, we `setApplicationTimeouts` when the YARN dependency is available, e.g. the default Hadoop 3.3 or user-specified Hadoop 2.9+ when Hadoop is provided at compile phase.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This can enforce the application SLAs.
For example, when the YARN queue is hit its limits of app concurrency or cpu/mem, an app will be pending for a very long time or even get stuck in  `ACCEPTED` state forever and do nothing. 

Sometimes, users also may want their app to succeed or timeout/failed with proper time constraints.

This is necessary for end-users use spark througth serverless spark platform like apache kyuubi(incubating) to prevent issue like https://github.com/apache/incubator-kyuubi/issues/1039, https://github.com/apache/incubator-kyuubi/issues/278 and so on.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, we add a new conf but do not change the current behavior

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new tests added
