### PR TITLE
[SPARK-37216][SQL] Add the Hive macro functionality to SparkSQL

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -252,6 +252,8 @@ statement
         '(' columns=multipartIdentifierPropertyList ')'
         (OPTIONS options=propertyList)?                                #createIndex
     | DROP INDEX (IF EXISTS)? identifier ON TABLE? multipartIdentifier #dropIndex
+    | CREATE TEMPORARY MACRO IDENTIFIER '(' colTypeList ')'
+      expression                                                       #createMacro
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
     ;
 
@@ -287,7 +289,6 @@ unsupportedHiveNativeCommands
     | kw1=LOCK kw2=DATABASE
     | kw1=UNLOCK kw2=TABLE
     | kw1=UNLOCK kw2=DATABASE
-    | kw1=CREATE kw2=TEMPORARY kw3=MACRO
     | kw1=DROP kw2=TEMPORARY kw3=MACRO
     | kw1=ALTER kw2=TABLE tableIdentifier kw3=NOT kw4=CLUSTERED
     | kw1=ALTER kw2=TABLE tableIdentifier kw3=CLUSTERED kw4=BY

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -276,6 +276,7 @@ class Analyzer(override val catalogManager: CatalogManager)
       AddMetadataColumns ::
       DeduplicateRelations ::
       ResolveReferences ::
+      ReplaceMacroFunction ::
       ResolveExpressionsWithNamePlaceholders ::
       ResolveDeserializer ::
       ResolveNewInstance ::
@@ -4163,5 +4164,18 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
 object RemoveTempResolvedColumn extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveExpressions {
     case t: TempResolvedColumn => UnresolvedAttribute(t.nameParts)
+  }
+}
+
+// replace all macro by child
+object ReplaceMacroFunction extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    plan resolveOperators {
+      case optPlan =>
+        optPlan transformExpressions{
+          case macroFunc: Macro =>
+            macroFunc.child
+        }
+    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Macro.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Macro.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.{DataType, StructField}
+
+/**
+ * @param name the macro name
+ * @param body expression wrapper
+ * @param fields columns definition
+ * @param input the attribute to compute
+ * @param idxMapUnresolvedFields maps to navigate to fields to replace
+ */
+@ExpressionDescription(
+  usage = "create temporary macro ....",
+  examples = "create temporary macro wrapperUpper(id string) upper(id)",
+  since = "3.3.0")
+case class Macro(name: String,
+                 body: Expression,
+                 fields: Seq[StructField],
+                 input: Seq[Expression],
+                 idxMapUnresolvedFields: Map[Int, UnresolvedAttribute]
+                 ) extends UnaryExpression
+                   with NullIntolerant
+                   with CodegenFallback {
+
+  if (fields.size != input.size) {
+    throw new
+        AnalysisException(s"Input column size is ${input.size} " +
+          s"but function definition input size is ${fields.size}")
+  }
+
+  fields.zip(input).zipWithIndex.foreach{
+    tuple => {
+      if (!tuple._1._1.dataType.acceptsType(tuple._1._2.dataType)) {
+        throw new AnalysisException(s"Expect dataType is ${tuple._1._1.dataType} " +
+          s"but found ${tuple._1._2.dataType} , column index: ${tuple._2}")
+      }
+    }
+  }
+
+  lazy val childExpr: Expression = {
+    val inter = body.transformUp {
+      case unresolvedAttribute: UnresolvedAttribute =>
+        val name = unresolvedAttribute.name
+        val filters = idxMapUnresolvedFields.filter(tuple => tuple._2.name == name)
+        if(filters.nonEmpty) {
+          input(filters.head._1)
+        } else {
+          throw new AnalysisException(s"Not found $unresolvedAttribute")
+        }
+
+      case other => other
+    }
+    inter
+  }
+
+  override def child: Expression = childExpr
+
+  /**
+   * Returns the [[DataType]] of the result of evaluating this expression.  It is
+   * invalid to query the dataType of an unresolved expression (i.e., when `resolved` == false).
+   */
+  override def dataType: DataType = child.dataType
+
+  override def prettyName: String = name
+
+  override protected def withNewChildInternal(newChild: Expression): Expression =
+    copy(body = newChild )
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -819,4 +819,16 @@ class SparkSqlAstBuilder extends AstBuilder {
 
     (ctx.LOCAL != null, finalStorage, Some(DDLUtils.HIVE_PROVIDER))
   }
+
+  override def visitCreateMacro(ctx: CreateMacroContext): LogicalPlan = {
+    val macroName = ctx.IDENTIFIER().getText
+    val fields = createSchema(ctx.colTypeList()).fields
+    val body = visit(ctx.expression())
+    body match {
+      case expr: Expression =>
+        CreateMacroCommand(macroName, fields, ExpressionHolder(expr))
+      case _ =>
+        operationNotAllowed("macro only support a simple expression", ctx.expression())
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
@@ -221,7 +221,7 @@ class UDFSuite
   }
 
   test("[SPARK-37216] Add the Hive macro functionality to SparkSQL ") {
-    spark.sql("CREATE  TEMPORARY macro macro1(name string) concat(name,'-suffix') ").collect()
+    spark.sql("CREATE  TEMPORARY macro macro1(name string) concat(name,'-suffix')").collect()
     val res = spark.sql("select macro1('this is a test')")
       .collect().head.get(0).asInstanceOf[String]
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
@@ -220,7 +220,7 @@ class UDFSuite
     }
   }
 
-  test("macro function") {
+  test("[SPARK-37216] Add the Hive macro functionality to SparkSQL ") {
     spark.sql("CREATE  TEMPORARY macro macro1(name string) concat(name,'-suffix') ").collect()
     val res = spark.sql("select macro1('this is a test')")
       .collect().head.get(0).asInstanceOf[String]

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
@@ -219,4 +219,12 @@ class UDFSuite
       assert(info.getSource == "hive")
     }
   }
+
+  test("macro function") {
+    spark.sql("CREATE  TEMPORARY macro macro1(name string) concat(name,'-suffix') ").collect()
+    val res = spark.sql("select macro1('this is a test')")
+      .collect().head.get(0).asInstanceOf[String]
+
+    assert("this is a test-suffix" equals res)
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -1430,10 +1430,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
       sql("ALTER INDEX my_index ON my_table set IDXPROPERTIES (\"prop1\"=\"val1_new\")")}
   }
 
-  test("create/drop macro commands are not supported") {
-    assertUnsupportedFeature {
-      sql("CREATE TEMPORARY MACRO SIGMOID (x DOUBLE) 1.0 / (1.0 + EXP(-x))")
-    }
+  test("drop macro commands are not supported") {
     assertUnsupportedFeature { sql("DROP TEMPORARY MACRO SIGMOID") }
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Add the Hive macro functionality to SparkSQL

### Why are the changes needed?

Some Hive sql can move to SparkSQL Smoothly

### Does this PR introduce _any_ user-facing change?

Some new DDL like 'create temparory macro ...'

### How was this patch tested?

unit test

Authored-by: hgs19921112 <haoguangshi@gmail.com>