### PR TITLE
[SPARK-36924][SQL] CAST between ANSI intervals and IntegralType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -641,9 +641,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case x: NumericType =>
       b => x.numeric.asInstanceOf[Numeric[Any]].toLong(b)
     case x: DayTimeIntervalType =>
-      buildCast[Long](_, i => dayTimeIntervalToLong(i, x.endField))
+      buildCast[Long](_, i => dayTimeIntervalToLong(i, x.startField, x.endField))
     case x: YearMonthIntervalType =>
-      buildCast[Int](_, i => yearMonthIntervalToInt(i, x.endField).toLong)
+      buildCast[Int](_, i => yearMonthIntervalToInt(i, x.startField, x.endField).toLong)
   }
 
   // IntConverter
@@ -673,9 +673,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case x: NumericType =>
       b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b)
     case x: DayTimeIntervalType =>
-      buildCast[Long](_, i => dayTimeIntervalToInt(i, x.endField))
+      buildCast[Long](_, i => dayTimeIntervalToInt(i, x.startField, x.endField))
     case x: YearMonthIntervalType =>
-      buildCast[Int](_, i => yearMonthIntervalToInt(i, x.endField))
+      buildCast[Int](_, i => yearMonthIntervalToInt(i, x.startField, x.endField))
   }
 
   // ShortConverter
@@ -720,9 +720,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case x: NumericType =>
       b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toShort
     case x: DayTimeIntervalType =>
-      buildCast[Long](_, i => dayTimeIntervalToShort(i, x.endField))
+      buildCast[Long](_, i => dayTimeIntervalToShort(i, x.startField, x.endField))
     case x: YearMonthIntervalType =>
-      buildCast[Int](_, i => yearMonthIntervalToShort(i, x.endField))
+      buildCast[Int](_, i => yearMonthIntervalToShort(i, x.startField, x.endField))
   }
 
   // ByteConverter
@@ -767,9 +767,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case x: NumericType =>
       b => x.numeric.asInstanceOf[Numeric[Any]].toInt(b).toByte
     case x: DayTimeIntervalType =>
-      buildCast[Long](_, i => dayTimeIntervalToByte(i, x.endField))
+      buildCast[Long](_, i => dayTimeIntervalToByte(i, x.startField, x.endField))
     case x: YearMonthIntervalType =>
-      buildCast[Int](_, i => yearMonthIntervalToByte(i, x.endField))
+      buildCast[Int](_, i => yearMonthIntervalToByte(i, x.startField, x.endField))
   }
 
   /**
@@ -1648,19 +1648,25 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   }
 
   private[this] def castDayTimeIntervalToIntegralTypeCode(
-      endFiled: Byte,
+      startField: Byte,
+      endField: Byte,
       integralType: String): CastFunction = {
     val util = IntervalUtils.getClass.getCanonicalName.stripSuffix("$")
     (c, evPrim, _) =>
-      code"""$evPrim = $util.dayTimeIntervalTo$integralType($c, (byte)$endFiled);"""
+      code"""
+        $evPrim = $util.dayTimeIntervalTo$integralType($c, (byte)$startField, (byte)$endField);
+      """
   }
 
   private[this] def castYearMonthIntervalToIntegralTypeCode(
-      endFiled: Byte,
+      startField: Byte,
+      endField: Byte,
       integralType: String): CastFunction = {
     val util = IntervalUtils.getClass.getCanonicalName.stripSuffix("$")
     (c, evPrim, _) =>
-      code"""$evPrim = $util.yearMonthIntervalTo$integralType($c, (byte)$endFiled);"""
+      code"""
+        $evPrim = $util.yearMonthIntervalTo$integralType($c, (byte)$startField, (byte)$endField);
+      """
   }
 
   private[this] def castDecimalToIntegralTypeCode(
@@ -1748,9 +1754,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (byte) $c;"
     case x: DayTimeIntervalType =>
-      castDayTimeIntervalToIntegralTypeCode(x.endField, "Byte")
+      castDayTimeIntervalToIntegralTypeCode(x.startField, x.endField, "Byte")
     case x: YearMonthIntervalType =>
-      castYearMonthIntervalToIntegralTypeCode(x.endField, "Byte")
+      castYearMonthIntervalToIntegralTypeCode(x.startField, x.endField, "Byte")
   }
 
   private[this] def castToShortCode(
@@ -1784,9 +1790,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (short) $c;"
     case x: DayTimeIntervalType =>
-      castDayTimeIntervalToIntegralTypeCode(x.endField, "Short")
+      castDayTimeIntervalToIntegralTypeCode(x.startField, x.endField, "Short")
     case x: YearMonthIntervalType =>
-      castYearMonthIntervalToIntegralTypeCode(x.endField, "Short")
+      castYearMonthIntervalToIntegralTypeCode(x.startField, x.endField, "Short")
   }
 
   private[this] def castToIntCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
@@ -1818,9 +1824,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (int) $c;"
     case x: DayTimeIntervalType =>
-      castDayTimeIntervalToIntegralTypeCode(x.endField, "Int")
+      castDayTimeIntervalToIntegralTypeCode(x.startField, x.endField, "Int")
     case x: YearMonthIntervalType =>
-      castYearMonthIntervalToIntegralTypeCode(x.endField, "Int")
+      castYearMonthIntervalToIntegralTypeCode(x.startField, x.endField, "Int")
   }
 
   private[this] def castToLongCode(from: DataType, ctx: CodegenContext): CastFunction = from match {
@@ -1851,9 +1857,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
     case x: NumericType =>
       (c, evPrim, evNull) => code"$evPrim = (long) $c;"
     case x: DayTimeIntervalType =>
-      castDayTimeIntervalToIntegralTypeCode(x.endField, "Long")
+      castDayTimeIntervalToIntegralTypeCode(x.startField, x.endField, "Long")
     case x: YearMonthIntervalType =>
-      castYearMonthIntervalToIntegralTypeCode(x.endField, "Int")
+      castYearMonthIntervalToIntegralTypeCode(x.startField, x.endField, "Int")
   }
 
   private[this] def castToFloatCode(from: DataType, ctx: CodegenContext): CastFunction = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -1256,16 +1256,19 @@ object IntervalUtils {
     intervalString
   }
 
-  def intToYearMonthInterval(v: Int, endField: Byte): Int = {
+  def integralToYearMonthInterval(v: Long, endField: Byte): Int = {
+    if (v != v.toInt) {
+      throw QueryExecutionErrors.castingCauseOverflowError(v, YM(endField).catalogString)
+    }
     endField match {
       case YEAR =>
         try {
-          Math.multiplyExact(v, MONTHS_PER_YEAR)
+          Math.multiplyExact(v.toInt, MONTHS_PER_YEAR)
         } catch {
           case _: ArithmeticException =>
             throw QueryExecutionErrors.castingCauseOverflowError(v, YM(endField).catalogString)
         }
-      case MONTH => v
+      case MONTH => v.toInt
     }
   }
 
@@ -1276,7 +1279,7 @@ object IntervalUtils {
     }
   }
 
-  def longToDayTimeInterval(v: Long, endField: Byte): Long = {
+  def integralToDayTimeInterval(v: Long, endField: Byte): Long = {
     try {
       endField match {
         case DAY => Math.multiplyExact(v, MICROS_PER_DAY)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -1256,20 +1256,25 @@ object IntervalUtils {
     intervalString
   }
 
-  def integralToYearMonthInterval(v: Long, endField: Byte): Int = {
-    if (v != v.toInt) {
-      throw QueryExecutionErrors.castingCauseOverflowError(v, YM(endField).catalogString)
-    }
+  def intToYearMonthInterval(v: Int, endField: Byte): Int = {
     endField match {
       case YEAR =>
         try {
-          Math.multiplyExact(v.toInt, MONTHS_PER_YEAR)
+          Math.multiplyExact(v, MONTHS_PER_YEAR)
         } catch {
           case _: ArithmeticException =>
             throw QueryExecutionErrors.castingCauseOverflowError(v, YM(endField).catalogString)
         }
-      case MONTH => v.toInt
+      case MONTH => v
     }
+  }
+
+  def longToYearMonthInterval(v: Long, endField: Byte): Int = {
+    val vInt = v.toInt
+    if (v != vInt) {
+      throw QueryExecutionErrors.castingCauseOverflowError(v, YM(endField).catalogString)
+    }
+    intToYearMonthInterval(vInt, endField)
   }
 
   def yearMonthIntervalToInt(v: Int, endFiled: Byte): Int = {
@@ -1279,7 +1284,40 @@ object IntervalUtils {
     }
   }
 
-  def integralToDayTimeInterval(v: Long, endField: Byte): Long = {
+  def yearMonthIntervalToShort(v: Int, endFiled: Byte): Short = {
+    val vInt = yearMonthIntervalToInt(v, endFiled)
+    val vShort = vInt.toShort
+    if (vInt != vShort) {
+      throw QueryExecutionErrors.castingCauseOverflowError(v, ShortType.catalogString)
+    }
+    vShort
+  }
+
+  def yearMonthIntervalToByte(v: Int, endFiled: Byte): Byte = {
+    val vInt = yearMonthIntervalToInt(v, endFiled)
+    val vByte = vInt.toByte
+    if (vInt != vByte) {
+      throw QueryExecutionErrors.castingCauseOverflowError(v, ByteType.catalogString)
+    }
+    vByte
+  }
+
+  def intToDayTimeInterval(v: Int, endField: Byte): Long = {
+    endField match {
+      case DAY =>
+        try {
+          Math.multiplyExact(v, MICROS_PER_DAY)
+        } catch {
+          case _: ArithmeticException =>
+            throw QueryExecutionErrors.castingCauseOverflowError(v, DT(endField).catalogString)
+        }
+      case HOUR => v * MICROS_PER_HOUR
+      case MINUTE => v * MICROS_PER_MINUTE
+      case SECOND => v * MICROS_PER_SECOND
+    }
+  }
+
+  def longToDayTimeInterval(v: Long, endField: Byte): Long = {
     try {
       endField match {
         case DAY => Math.multiplyExact(v, MICROS_PER_DAY)
@@ -1300,5 +1338,32 @@ object IntervalUtils {
       case MINUTE => v / MICROS_PER_MINUTE
       case SECOND => v / MICROS_PER_SECOND
     }
+  }
+
+  def dayTimeIntervalToInt(v: Long, endFiled: Byte): Int = {
+    val vLong = dayTimeIntervalToLong(v, endFiled)
+    val vInt = vLong.toInt
+    if (vLong != vInt) {
+      throw QueryExecutionErrors.castingCauseOverflowError(v, IntegerType.catalogString)
+    }
+    vInt
+  }
+
+  def dayTimeIntervalToShort(v: Long, endFiled: Byte): Short = {
+    val vLong = dayTimeIntervalToLong(v, endFiled)
+    val vShort = vLong.toShort
+    if (vLong != vShort) {
+      throw QueryExecutionErrors.castingCauseOverflowError(v, ShortType.catalogString)
+    }
+    vShort
+  }
+
+  def dayTimeIntervalToByte(v: Long, endFiled: Byte): Byte = {
+    val vLong = dayTimeIntervalToLong(v, endFiled)
+    val vByte = vLong.toByte
+    if (vLong != vByte) {
+      throw QueryExecutionErrors.castingCauseOverflowError(v, ByteType.catalogString)
+    }
+    vByte
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -1277,27 +1277,29 @@ object IntervalUtils {
     intToYearMonthInterval(vInt, endField)
   }
 
-  def yearMonthIntervalToInt(v: Int, endFiled: Byte): Int = {
-    endFiled match {
+  def yearMonthIntervalToInt(v: Int, startField: Byte, endField: Byte): Int = {
+    endField match {
       case YEAR => v / MONTHS_PER_YEAR
       case MONTH => v
     }
   }
 
-  def yearMonthIntervalToShort(v: Int, endFiled: Byte): Short = {
-    val vInt = yearMonthIntervalToInt(v, endFiled)
+  def yearMonthIntervalToShort(v: Int, startField: Byte, endField: Byte): Short = {
+    val vInt = yearMonthIntervalToInt(v, startField, endField)
     val vShort = vInt.toShort
     if (vInt != vShort) {
-      throw QueryExecutionErrors.castingCauseOverflowError(v, ShortType.catalogString)
+      throw QueryExecutionErrors.castingCauseOverflowError(
+        toYearMonthIntervalString(v, ANSI_STYLE, startField, endField), ShortType.catalogString)
     }
     vShort
   }
 
-  def yearMonthIntervalToByte(v: Int, endFiled: Byte): Byte = {
-    val vInt = yearMonthIntervalToInt(v, endFiled)
+  def yearMonthIntervalToByte(v: Int, startField: Byte, endField: Byte): Byte = {
+    val vInt = yearMonthIntervalToInt(v, startField, endField)
     val vByte = vInt.toByte
     if (vInt != vByte) {
-      throw QueryExecutionErrors.castingCauseOverflowError(v, ByteType.catalogString)
+      throw QueryExecutionErrors.castingCauseOverflowError(
+        toYearMonthIntervalString(v, ANSI_STYLE, startField, endField), ByteType.catalogString)
     }
     vByte
   }
@@ -1331,8 +1333,8 @@ object IntervalUtils {
     }
   }
 
-  def dayTimeIntervalToLong(v: Long, endFiled: Byte): Long = {
-    endFiled match {
+  def dayTimeIntervalToLong(v: Long, startField: Byte, endField: Byte): Long = {
+    endField match {
       case DAY => v / MICROS_PER_DAY
       case HOUR => v / MICROS_PER_HOUR
       case MINUTE => v / MICROS_PER_MINUTE
@@ -1340,29 +1342,32 @@ object IntervalUtils {
     }
   }
 
-  def dayTimeIntervalToInt(v: Long, endFiled: Byte): Int = {
-    val vLong = dayTimeIntervalToLong(v, endFiled)
+  def dayTimeIntervalToInt(v: Long, startField: Byte, endField: Byte): Int = {
+    val vLong = dayTimeIntervalToLong(v, startField, endField)
     val vInt = vLong.toInt
     if (vLong != vInt) {
-      throw QueryExecutionErrors.castingCauseOverflowError(v, IntegerType.catalogString)
+      throw QueryExecutionErrors.castingCauseOverflowError(
+        toDayTimeIntervalString(v, ANSI_STYLE, startField, endField), IntegerType.catalogString)
     }
     vInt
   }
 
-  def dayTimeIntervalToShort(v: Long, endFiled: Byte): Short = {
-    val vLong = dayTimeIntervalToLong(v, endFiled)
+  def dayTimeIntervalToShort(v: Long, startField: Byte, endField: Byte): Short = {
+    val vLong = dayTimeIntervalToLong(v, startField, endField)
     val vShort = vLong.toShort
     if (vLong != vShort) {
-      throw QueryExecutionErrors.castingCauseOverflowError(v, ShortType.catalogString)
+      throw QueryExecutionErrors.castingCauseOverflowError(
+        toDayTimeIntervalString(v, ANSI_STYLE, startField, endField), ShortType.catalogString)
     }
     vShort
   }
 
-  def dayTimeIntervalToByte(v: Long, endFiled: Byte): Byte = {
-    val vLong = dayTimeIntervalToLong(v, endFiled)
+  def dayTimeIntervalToByte(v: Long, startField: Byte, endField: Byte): Byte = {
+    val vLong = dayTimeIntervalToLong(v, startField, endField)
     val vByte = vLong.toByte
     if (vLong != vByte) {
-      throw QueryExecutionErrors.castingCauseOverflowError(v, ByteType.catalogString)
+      throw QueryExecutionErrors.castingCauseOverflowError(
+        toDayTimeIntervalString(v, ANSI_STYLE, startField, endField), ByteType.catalogString)
     }
     vByte
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.sql.{Date, Timestamp}
+import java.time.{Duration, Period}
+import java.time.temporal.ChronoUnit
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
@@ -28,6 +30,8 @@ import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DayTimeIntervalType.{DAY, HOUR, MINUTE, SECOND}
+import org.apache.spark.sql.types.YearMonthIntervalType.{MONTH, YEAR}
 import org.apache.spark.unsafe.types.UTF8String
 
 /**
@@ -579,5 +583,206 @@ class CastSuite extends CastSuiteBase {
 
   test("SPARK-36286: invalid string cast to timestamp") {
     checkEvaluation(cast(Literal("2015-03-18T"), TimestampType), null)
+  }
+
+  test("SPARK-36924: Cast DayTimeIntervalType to IntegralType") {
+    Seq(
+      (Duration.ZERO, DayTimeIntervalType(DAY), 0.toByte, 0.toShort, 0, 0L),
+      (Duration.ofDays(1), DayTimeIntervalType(DAY), 1.toByte, 1.toShort, 1, 1L),
+      (Duration.ZERO, DayTimeIntervalType(HOUR), 0.toByte, 0.toShort, 0, 0L),
+      (Duration.ofHours(1), DayTimeIntervalType(HOUR), 1.toByte, 1.toShort, 1, 1L),
+      (Duration.ZERO, DayTimeIntervalType(MINUTE), 0.toByte, 0.toShort, 0, 0L),
+      (Duration.ofMinutes(1), DayTimeIntervalType(MINUTE), 1.toByte, 1.toShort, 1, 1L),
+      (Duration.ZERO, DayTimeIntervalType(SECOND), 0.toByte, 0.toShort, 0, 0L),
+      (Duration.ofSeconds(1), DayTimeIntervalType(SECOND), 1.toByte, 1.toShort, 1, 1L)
+    ).foreach { case(v, dt, r1, r2, r3, r4) =>
+      val value = Literal.create(v, dt)
+      checkEvaluation(cast(value, ByteType), r1)
+      checkEvaluation(cast(value, ShortType), r2)
+      checkEvaluation(cast(value, IntegerType), r3)
+      checkEvaluation(cast(value, LongType), r4)
+    }
+
+    Seq(
+      (Duration.of(Long.MaxValue, ChronoUnit.MICROS),
+        DayTimeIntervalType(DAY), ByteType, 9223372022400000000L),
+      (Duration.of(Long.MaxValue, ChronoUnit.MICROS),
+        DayTimeIntervalType(HOUR), ShortType, 9223372036800000000L),
+      (Duration.of(Long.MaxValue, ChronoUnit.MICROS),
+        DayTimeIntervalType(MINUTE), IntegerType, 9223372036800000000L),
+      (Duration.of(Long.MinValue, ChronoUnit.MICROS),
+        DayTimeIntervalType(DAY), ByteType, -9223372022400000000L),
+      (Duration.of(Long.MinValue, ChronoUnit.MICROS),
+        DayTimeIntervalType(HOUR), ShortType, -9223372036800000000L),
+      (Duration.of(Long.MinValue, ChronoUnit.MICROS),
+        DayTimeIntervalType(MINUTE), IntegerType, -9223372036800000000L)
+    ).foreach { case(v, dt, toType, overflow) =>
+      val value = Literal.create(v, dt)
+      val e = intercept[ArithmeticException] {
+        cast(value, toType).eval()
+      }.getMessage
+      assert(e.contains(s"Casting ${overflow} to ${toType.catalogString} causes overflow"))
+    }
+
+    Seq(
+      (Duration.of(Long.MaxValue, ChronoUnit.MICROS), DayTimeIntervalType(SECOND), 9223372036854L),
+      (Duration.of(Long.MinValue, ChronoUnit.MICROS), DayTimeIntervalType(SECOND), -9223372036854L)
+    ).foreach {
+      case (v, dt, expect) =>
+        checkEvaluation(cast(Literal.create(v, dt), LongType), expect)
+    }
+  }
+
+  test("SPARK-36924: Cast IntegralType to DayTimeIntervalType") {
+    Seq(
+      (0, ByteType, 0L, 0L, 0L, 0L),
+      (0, ShortType, 0L, 0L, 0L, 0L),
+      (0, IntegerType, 0L, 0L, 0L, 0L),
+      (0, LongType, 0L, 0L, 0L, 0L),
+      (1, ByteType, MICROS_PER_DAY, MICROS_PER_HOUR, MICROS_PER_MINUTE, MICROS_PER_SECOND),
+      (1, ShortType, MICROS_PER_DAY, MICROS_PER_HOUR, MICROS_PER_MINUTE, MICROS_PER_SECOND),
+      (1, IntegerType, MICROS_PER_DAY, MICROS_PER_HOUR, MICROS_PER_MINUTE, MICROS_PER_SECOND),
+      (1, LongType, MICROS_PER_DAY, MICROS_PER_HOUR, MICROS_PER_MINUTE, MICROS_PER_SECOND),
+      (Byte.MaxValue, ByteType, Byte.MaxValue * MICROS_PER_DAY, Byte.MaxValue * MICROS_PER_HOUR,
+        Byte.MaxValue * MICROS_PER_MINUTE, Byte.MaxValue * MICROS_PER_SECOND),
+      (Byte.MinValue, ByteType, Byte.MinValue * MICROS_PER_DAY, Byte.MinValue * MICROS_PER_HOUR,
+        Byte.MinValue * MICROS_PER_MINUTE, Byte.MinValue * MICROS_PER_SECOND),
+      (Short.MaxValue, ShortType, Short.MaxValue * MICROS_PER_DAY, Short.MaxValue * MICROS_PER_HOUR,
+        Short.MaxValue * MICROS_PER_MINUTE, Short.MaxValue * MICROS_PER_SECOND),
+      (Short.MinValue, ShortType, Short.MinValue * MICROS_PER_DAY, Short.MinValue * MICROS_PER_HOUR,
+        Short.MinValue * MICROS_PER_MINUTE, Short.MinValue * MICROS_PER_SECOND)
+    ).foreach { case (v, dt, r1, r2, r3, r4) =>
+      checkEvaluation(cast(
+        cast(v, dt), DayTimeIntervalType(DAY)), r1)
+      checkEvaluation(cast(
+        cast(v, dt), DayTimeIntervalType(HOUR)), r2)
+      checkEvaluation(cast(
+        cast(v, dt), DayTimeIntervalType(MINUTE)), r3)
+      checkEvaluation(cast(
+        cast(v, dt), DayTimeIntervalType(SECOND)), r4)
+    }
+
+    Seq(
+      (Int.MaxValue,
+        Math.multiplyExact(Int.MaxValue.toLong, MICROS_PER_HOUR),
+        Math.multiplyExact(Int.MaxValue.toLong, MICROS_PER_MINUTE),
+        Math.multiplyExact(Int.MaxValue.toLong, MICROS_PER_SECOND)),
+      (Int.MinValue,
+        Math.multiplyExact(Int.MinValue.toLong, MICROS_PER_HOUR),
+        Math.multiplyExact(Int.MinValue.toLong, MICROS_PER_MINUTE),
+        Math.multiplyExact(Int.MinValue.toLong, MICROS_PER_SECOND))
+    ).foreach { case (v, r1, r2, r3) =>
+      checkEvaluation(cast(v, DayTimeIntervalType(HOUR)), r1)
+      checkEvaluation(cast(v, DayTimeIntervalType(MINUTE)), r2)
+      checkEvaluation(cast(v, DayTimeIntervalType(SECOND)), r3)
+    }
+
+    Seq(
+      (Int.MaxValue, DayTimeIntervalType(DAY)),
+      (Int.MinValue, DayTimeIntervalType(DAY)),
+      (Long.MaxValue, DayTimeIntervalType(DAY)),
+      (Long.MinValue, DayTimeIntervalType(DAY)),
+      (Long.MaxValue, DayTimeIntervalType(HOUR)),
+      (Long.MinValue, DayTimeIntervalType(HOUR)),
+      (Long.MaxValue, DayTimeIntervalType(MINUTE)),
+      (Long.MinValue, DayTimeIntervalType(MINUTE)),
+      (Long.MaxValue, DayTimeIntervalType(SECOND)),
+      (Long.MinValue, DayTimeIntervalType(SECOND))
+    ).foreach {
+      case (v, toType) =>
+        val e = intercept[ArithmeticException] {
+          cast(v, toType).eval()
+        }.getMessage
+        assert(e.contains(s"Casting $v to ${toType.catalogString} causes overflow"))
+    }
+  }
+
+  test("SPARK-36924: Cast YearMonthIntervalType to IntegralType") {
+    Seq(
+      (Period.ofYears(0), YearMonthIntervalType(YEAR), 0.toByte, 0.toShort, 0, 0L),
+      (Period.ofYears(1), YearMonthIntervalType(YEAR), 1.toByte, 1.toShort, 1, 1L),
+      (Period.ofMonths(0), YearMonthIntervalType(MONTH), 0.toByte, 0.toShort, 0, 0L),
+      (Period.ofMonths(1), YearMonthIntervalType(MONTH), 1.toByte, 1.toShort, 1, 1L)
+    ).foreach { case (v, dt, r1, r2, r3, r4) =>
+      val value = Literal.create(v, dt)
+      checkEvaluation(cast(value, ByteType), r1)
+      checkEvaluation(cast(value, ShortType), r2)
+      checkEvaluation(cast(value, IntegerType), r3)
+      checkEvaluation(cast(value, LongType), r4)
+    }
+
+    Seq(
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR), ByteType, 2147483640),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR), ShortType, 2147483640),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR), ByteType, -2147483640),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR), ShortType, -2147483640),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(MONTH), ByteType, Int.MaxValue),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(MONTH), ShortType, Int.MaxValue),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(MONTH), ByteType, Int.MinValue),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(MONTH), ShortType, Int.MinValue)
+    ).foreach {
+      case (v, dt, toType, overflow) =>
+        val value = Literal.create(v, dt)
+        val e = intercept[ArithmeticException] {
+          cast(value, toType).eval()
+        }.getMessage
+        assert(e.contains(s"Casting $overflow to ${toType.catalogString} causes overflow"))
+    }
+
+    Seq(
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR), IntegerType, Int.MaxValue / 12),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR), LongType, Int.MaxValue /12L),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR), IntegerType, Int.MinValue / 12),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR), LongType, Int.MinValue /12L),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(MONTH), IntegerType, Int.MaxValue),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(MONTH), LongType, Int.MaxValue.toLong),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(MONTH), IntegerType, Int.MinValue),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(MONTH), LongType, Int.MinValue.toLong)
+    ).foreach {
+      case (v, dt, toType, expect) =>
+        val value = Literal.create(v, dt)
+        checkEvaluation(cast(value, toType), expect)
+    }
+  }
+
+  test("SPARK-36924: Cast IntegralType to YearMonthIntervalType") {
+    Seq(
+      (0, 0, 0, ByteType),
+      (0, 0, 0, ShortType),
+      (0, 0, 0, IntegerType),
+      (0, 0, 0, LongType),
+      (1, 12, 1, ByteType),
+      (Byte.MaxValue, Byte.MaxValue * 12, Byte.MaxValue.toInt, ByteType),
+      (Byte.MinValue, Byte.MinValue * 12, Byte.MinValue.toInt, ByteType),
+      (1, 12, 1, ShortType),
+      (Short.MaxValue, Short.MaxValue * 12, Short.MaxValue.toInt, ShortType),
+      (Short.MinValue, Short.MinValue * 12, Short.MinValue.toInt, ShortType),
+      (1, 12, 1, IntegerType),
+      (1, 12, 1, LongType)
+    ).foreach { case (v, r1, r2, dt) =>
+      checkEvaluation(cast(
+        cast(v, dt), YearMonthIntervalType(YEAR)), r1)
+      checkEvaluation(cast(
+        cast(v, dt), YearMonthIntervalType(MONTH)), r2)
+    }
+
+    Seq(Int.MaxValue, Int.MinValue).foreach { v =>
+      checkEvaluation(cast(v, YearMonthIntervalType(MONTH)), v)
+    }
+
+    Seq(
+      (Int.MaxValue, YearMonthIntervalType(YEAR)),
+      (Int.MinValue, YearMonthIntervalType(YEAR)),
+      (Long.MaxValue, YearMonthIntervalType(YEAR)),
+      (Long.MinValue, YearMonthIntervalType(YEAR)),
+      (Long.MaxValue, YearMonthIntervalType(MONTH)),
+      (Long.MinValue, YearMonthIntervalType(MONTH))
+    ).foreach {
+      case (v, toType) =>
+        val e = intercept[ArithmeticException] {
+          cast(v, toType).eval()
+        }.getMessage
+        assert(e.contains(s"Casting $v to ${toType.catalogString} causes overflow"))
+    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -600,29 +600,23 @@ class CastSuite extends CastSuiteBase {
           checkEvaluation(cast(v2, ByteType), 1.toByte)
           checkEvaluation(cast(v2, ShortType), 1.toShort)
           checkEvaluation(cast(v2, IntegerType), 1)
-          checkEvaluation(cast(v2, LongType), 1L)
+          checkEvaluation(cast(v2, LongType), 1.toLong)
         case HOUR =>
           checkEvaluation(cast(v2, ByteType), 25.toByte)
           checkEvaluation(cast(v2, ShortType), 25.toShort)
           checkEvaluation(cast(v2, IntegerType), 25)
           checkEvaluation(cast(v2, LongType), 25L)
         case MINUTE =>
-          val e = intercept[ArithmeticException] {
-            cast(v2, ByteType).eval()
-          }.getMessage
-          assert(e.contains(s"Casting 90060000000 to tinyint causes overflow"))
+          checkExceptionInExpression[ArithmeticException](cast(v2, ByteType),
+            s"Casting ${v2.value} to tinyint causes overflow")
           checkEvaluation(cast(v2, ShortType), (MINUTES_PER_HOUR * 25 + 1).toShort)
           checkEvaluation(cast(v2, IntegerType), (MINUTES_PER_HOUR * 25 + 1).toInt)
           checkEvaluation(cast(v2, LongType), MINUTES_PER_HOUR * 25 + 1)
         case SECOND =>
-          val e1 = intercept[ArithmeticException] {
-            cast(v2, ByteType).eval()
-          }.getMessage
-          assert(e1.contains(s"Casting 90061000000 to tinyint causes overflow"))
-          val e2 = intercept[ArithmeticException] {
-            cast(v2, ShortType).eval()
-          }.getMessage
-          assert(e2.contains(s"Casting 90061000000 to smallint causes overflow"))
+          checkExceptionInExpression[ArithmeticException](cast(v2, ByteType),
+            s"Casting ${v2.value} to tinyint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v2, ShortType),
+            s"Casting ${v2.value} to smallint causes overflow")
           checkEvaluation(cast(v2, IntegerType), num.toInt)
           checkEvaluation(cast(v2, LongType), num)
       }
@@ -630,115 +624,71 @@ class CastSuite extends CastSuiteBase {
       val v3 = Literal.create(Duration.of(Long.MaxValue, ChronoUnit.MICROS), dt)
       dt.endField match {
         case DAY =>
-          val e1 = intercept[ArithmeticException] {
-            cast(v3, ByteType).eval()
-          }.getMessage
-          assert(e1.contains("Casting 9223372022400000000 to tinyint causes overflow"))
-          val e2 = intercept[ArithmeticException] {
-            cast(v3, ShortType).eval()
-          }.getMessage
-          assert(e2.contains("Casting 9223372022400000000 to smallint causes overflow"))
-          checkEvaluation(cast(v3, IntegerType), 106751991)
-          checkEvaluation(cast(v3, LongType), 106751991L)
+          checkExceptionInExpression[ArithmeticException](cast(v3, ByteType),
+            s"Casting ${v3.value} to tinyint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v3, ShortType),
+            s"Casting ${v3.value} to smallint causes overflow")
+          checkEvaluation(cast(v3, IntegerType), (Long.MaxValue / MICROS_PER_DAY).toInt)
+          checkEvaluation(cast(v3, LongType), Long.MaxValue / MICROS_PER_DAY)
         case HOUR =>
-          val e1 = intercept[ArithmeticException] {
-            cast(v3, ByteType).eval()
-          }.getMessage
-          assert(e1.contains("Casting 9223372036800000000 to tinyint causes overflow"))
-          val e2 = intercept[ArithmeticException] {
-            cast(v3, ShortType).eval()
-          }.getMessage
-          assert(e2.contains("Casting 9223372036800000000 to smallint causes overflow"))
-          val e3 = intercept[ArithmeticException] {
-            cast(v3, IntegerType).eval()
-          }.getMessage
-          assert(e3.contains("Casting 9223372036800000000 to int causes overflow"))
-          checkEvaluation(cast(v3, LongType), 2562047788L)
+          checkExceptionInExpression[ArithmeticException](cast(v3, ByteType),
+            s"Casting ${v3.value} to tinyint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v3, ShortType),
+            s"Casting ${v3.value} to smallint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v3, IntegerType),
+            s"Casting ${v3.value} to int causes overflow")
+          checkEvaluation(cast(v3, LongType), Long.MaxValue / MICROS_PER_HOUR)
         case MINUTE =>
-          val e1 = intercept[ArithmeticException] {
-            cast(v3, ByteType).eval()
-          }.getMessage
-          assert(e1.contains("Casting 9223372036800000000 to tinyint causes overflow"))
-          val e2 = intercept[ArithmeticException] {
-            cast(v3, ShortType).eval()
-          }.getMessage
-          assert(e2.contains("Casting 9223372036800000000 to smallint causes overflow"))
-          val e3 = intercept[ArithmeticException] {
-            cast(v3, IntegerType).eval()
-          }.getMessage
-          assert(e3.contains("Casting 9223372036800000000 to int causes overflow"))
-          checkEvaluation(cast(v3, LongType), 153722867280L)
+          checkExceptionInExpression[ArithmeticException](cast(v3, ByteType),
+            s"Casting ${v3.value} to tinyint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v3, ShortType),
+            s"Casting ${v3.value} to smallint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v3, IntegerType),
+            s"Casting ${v3.value} to int causes overflow")
+          checkEvaluation(cast(v3, LongType), Long.MaxValue / MICROS_PER_MINUTE)
         case SECOND =>
-          val e1 = intercept[ArithmeticException] {
-            cast(v3, ByteType).eval()
-          }.getMessage
-          assert(e1.contains("Casting 9223372036854775807 to tinyint causes overflow"))
-          val e2 = intercept[ArithmeticException] {
-            cast(v3, ShortType).eval()
-          }.getMessage
-          assert(e2.contains("Casting 9223372036854775807 to smallint causes overflow"))
-          val e3 = intercept[ArithmeticException] {
-            cast(v3, IntegerType).eval()
-          }.getMessage
-          assert(e3.contains("Casting 9223372036854775807 to int causes overflow"))
-          checkEvaluation(cast(v3, LongType), 9223372036854L)
+          checkExceptionInExpression[ArithmeticException](cast(v3, ByteType),
+            s"Casting ${v3.value} to tinyint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v3, ShortType),
+            s"Casting ${v3.value} to smallint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v3, IntegerType),
+            s"Casting ${v3.value} to int causes overflow")
+          checkEvaluation(cast(v3, LongType), Long.MaxValue / MICROS_PER_SECOND)
       }
 
       val v4 = Literal.create(Duration.of(Long.MinValue, ChronoUnit.MICROS), dt)
       dt.endField match {
         case DAY =>
-          val e1 = intercept[ArithmeticException] {
-            cast(v4, ByteType).eval()
-          }.getMessage
-          assert(e1.contains("Casting -9223372022400000000 to tinyint causes overflow"))
-          val e2 = intercept[ArithmeticException] {
-            cast(v4, ShortType).eval()
-          }.getMessage
-          assert(e2.contains("Casting -9223372022400000000 to smallint causes overflow"))
-          checkEvaluation(cast(v4, IntegerType), -106751991)
-          checkEvaluation(cast(v4, LongType), -106751991L)
+          checkExceptionInExpression[ArithmeticException](cast(v4, ByteType),
+            s"Casting ${v4.value} to tinyint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v4, ShortType),
+            s"Casting ${v4.value} to smallint causes overflow")
+          checkEvaluation(cast(v4, IntegerType), (Long.MinValue / MICROS_PER_DAY).toInt)
+          checkEvaluation(cast(v4, LongType), Long.MinValue / MICROS_PER_DAY)
         case HOUR =>
-          val e1 = intercept[ArithmeticException] {
-            cast(v4, ByteType).eval()
-          }.getMessage
-          assert(e1.contains("Casting -9223372036800000000 to tinyint causes overflow"))
-          val e2 = intercept[ArithmeticException] {
-            cast(v4, ShortType).eval()
-          }.getMessage
-          assert(e2.contains("Casting -9223372036800000000 to smallint causes overflow"))
-          val e3 = intercept[ArithmeticException] {
-            cast(v4, IntegerType).eval()
-          }.getMessage
-          assert(e3.contains("Casting -9223372036800000000 to int causes overflow"))
-          checkEvaluation(cast(v4, LongType), -2562047788L)
+          checkExceptionInExpression[ArithmeticException](cast(v4, ByteType),
+            s"Casting ${v4.value} to tinyint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v4, ShortType),
+            s"Casting ${v4.value} to smallint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v4, IntegerType),
+            s"Casting ${v4.value} to int causes overflow")
+          checkEvaluation(cast(v4, LongType), Long.MinValue / MICROS_PER_HOUR)
         case MINUTE =>
-          val e1 = intercept[ArithmeticException] {
-            cast(v4, ByteType).eval()
-          }.getMessage
-          assert(e1.contains("Casting -9223372036800000000 to tinyint causes overflow"))
-          val e2 = intercept[ArithmeticException] {
-            cast(v4, ShortType).eval()
-          }.getMessage
-          assert(e2.contains("Casting -9223372036800000000 to smallint causes overflow"))
-          val e3 = intercept[ArithmeticException] {
-            cast(v4, IntegerType).eval()
-          }.getMessage
-          assert(e3.contains("Casting -9223372036800000000 to int causes overflow"))
-          checkEvaluation(cast(v4, LongType), -153722867280L)
+          checkExceptionInExpression[ArithmeticException](cast(v4, ByteType),
+            s"Casting ${v4.value} to tinyint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v4, ShortType),
+            s"Casting ${v4.value} to smallint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v4, IntegerType),
+            s"Casting ${v4.value} to int causes overflow")
+          checkEvaluation(cast(v4, LongType), Long.MinValue / MICROS_PER_MINUTE)
         case SECOND =>
-          val e1 = intercept[ArithmeticException] {
-            cast(v4, ByteType).eval()
-          }.getMessage
-          assert(e1.contains("Casting -9223372036854775808 to tinyint causes overflow"))
-          val e2 = intercept[ArithmeticException] {
-            cast(v4, ShortType).eval()
-          }.getMessage
-          assert(e2.contains("Casting -9223372036854775808 to smallint causes overflow"))
-          val e3 = intercept[ArithmeticException] {
-            cast(v4, IntegerType).eval()
-          }.getMessage
-          assert(e3.contains("Casting -9223372036854775808 to int causes overflow"))
-          checkEvaluation(cast(v4, LongType), -9223372036854L)
+          checkExceptionInExpression[ArithmeticException](cast(v4, ByteType),
+            s"Casting ${v4.value} to tinyint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v4, ShortType),
+            s"Casting ${v4.value} to smallint causes overflow")
+          checkExceptionInExpression[ArithmeticException](cast(v4, IntegerType),
+            s"Casting ${v4.value} to int causes overflow")
+          checkEvaluation(cast(v4, LongType), Long.MinValue / MICROS_PER_SECOND)
       }
     }
   }
@@ -800,10 +750,8 @@ class CastSuite extends CastSuiteBase {
       (Long.MinValue, DayTimeIntervalType(SECOND))
     ).foreach {
       case (v, toType) =>
-        val e = intercept[ArithmeticException] {
-          cast(v, toType).eval()
-        }.getMessage
-        assert(e.contains(s"Casting $v to ${toType.catalogString} causes overflow"))
+        checkExceptionInExpression[ArithmeticException](cast(v, toType),
+          s"Casting $v to ${toType.catalogString} causes overflow")
     }
   }
 
@@ -824,25 +772,23 @@ class CastSuite extends CastSuiteBase {
     }
 
     Seq(
-      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR), ByteType, 2147483640),
-      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR), ShortType, 2147483640),
-      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR), ByteType, -2147483640),
-      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR), ShortType, -2147483640),
-      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR, MONTH), ByteType, Int.MaxValue),
-      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR, MONTH), ShortType, Int.MaxValue),
-      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR, MONTH), ByteType, Int.MinValue),
-      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR, MONTH), ShortType, Int.MinValue),
-      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(MONTH), ByteType, Int.MaxValue),
-      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(MONTH), ShortType, Int.MaxValue),
-      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(MONTH), ByteType, Int.MinValue),
-      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(MONTH), ShortType, Int.MinValue)
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR), ByteType),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR), ShortType),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR), ByteType),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR), ShortType),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR, MONTH), ByteType),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(YEAR, MONTH), ShortType),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR, MONTH), ByteType),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(YEAR, MONTH), ShortType),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(MONTH), ByteType),
+      (Period.ofMonths(Int.MaxValue), YearMonthIntervalType(MONTH), ShortType),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(MONTH), ByteType),
+      (Period.ofMonths(Int.MinValue), YearMonthIntervalType(MONTH), ShortType)
     ).foreach {
-      case (v, dt, toType, overflow) =>
+      case (v, dt, toType) =>
         val value = Literal.create(v, dt)
-        val e = intercept[ArithmeticException] {
-          cast(value, toType).eval()
-        }.getMessage
-        assert(e.contains(s"Casting $overflow to ${toType.catalogString} causes overflow"))
+        checkExceptionInExpression[ArithmeticException](cast(value, toType),
+          s"Casting ${value.value} to ${toType.catalogString} causes overflow")
     }
 
     Seq(
@@ -903,10 +849,8 @@ class CastSuite extends CastSuiteBase {
       (Long.MinValue, YearMonthIntervalType(MONTH))
     ).foreach {
       case (v, toType) =>
-        val e = intercept[ArithmeticException] {
-          cast(v, toType).eval()
-        }.getMessage
-        assert(e.contains(s"Casting $v to ${toType.catalogString} causes overflow"))
+        checkExceptionInExpression[ArithmeticException](cast(v, toType),
+          s"Casting $v to ${toType.catalogString} causes overflow")
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -608,15 +608,15 @@ class CastSuite extends CastSuiteBase {
           checkEvaluation(cast(v2, LongType), 25L)
         case MINUTE =>
           checkExceptionInExpression[ArithmeticException](cast(v2, ByteType),
-            s"Casting ${v2.value} to tinyint causes overflow")
+            s"Casting $v2 to tinyint causes overflow")
           checkEvaluation(cast(v2, ShortType), (MINUTES_PER_HOUR * 25 + 1).toShort)
           checkEvaluation(cast(v2, IntegerType), (MINUTES_PER_HOUR * 25 + 1).toInt)
           checkEvaluation(cast(v2, LongType), MINUTES_PER_HOUR * 25 + 1)
         case SECOND =>
           checkExceptionInExpression[ArithmeticException](cast(v2, ByteType),
-            s"Casting ${v2.value} to tinyint causes overflow")
+            s"Casting $v2 to tinyint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v2, ShortType),
-            s"Casting ${v2.value} to smallint causes overflow")
+            s"Casting $v2 to smallint causes overflow")
           checkEvaluation(cast(v2, IntegerType), num.toInt)
           checkEvaluation(cast(v2, LongType), num)
       }
@@ -625,34 +625,34 @@ class CastSuite extends CastSuiteBase {
       dt.endField match {
         case DAY =>
           checkExceptionInExpression[ArithmeticException](cast(v3, ByteType),
-            s"Casting ${v3.value} to tinyint causes overflow")
+            s"Casting $v3 to tinyint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v3, ShortType),
-            s"Casting ${v3.value} to smallint causes overflow")
+            s"Casting $v3 to smallint causes overflow")
           checkEvaluation(cast(v3, IntegerType), (Long.MaxValue / MICROS_PER_DAY).toInt)
           checkEvaluation(cast(v3, LongType), Long.MaxValue / MICROS_PER_DAY)
         case HOUR =>
           checkExceptionInExpression[ArithmeticException](cast(v3, ByteType),
-            s"Casting ${v3.value} to tinyint causes overflow")
+            s"Casting $v3 to tinyint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v3, ShortType),
-            s"Casting ${v3.value} to smallint causes overflow")
+            s"Casting $v3 to smallint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v3, IntegerType),
-            s"Casting ${v3.value} to int causes overflow")
+            s"Casting $v3 to int causes overflow")
           checkEvaluation(cast(v3, LongType), Long.MaxValue / MICROS_PER_HOUR)
         case MINUTE =>
           checkExceptionInExpression[ArithmeticException](cast(v3, ByteType),
-            s"Casting ${v3.value} to tinyint causes overflow")
+            s"Casting $v3 to tinyint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v3, ShortType),
-            s"Casting ${v3.value} to smallint causes overflow")
+            s"Casting $v3 to smallint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v3, IntegerType),
-            s"Casting ${v3.value} to int causes overflow")
+            s"Casting $v3 to int causes overflow")
           checkEvaluation(cast(v3, LongType), Long.MaxValue / MICROS_PER_MINUTE)
         case SECOND =>
           checkExceptionInExpression[ArithmeticException](cast(v3, ByteType),
-            s"Casting ${v3.value} to tinyint causes overflow")
+            s"Casting $v3 to tinyint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v3, ShortType),
-            s"Casting ${v3.value} to smallint causes overflow")
+            s"Casting $v3 to smallint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v3, IntegerType),
-            s"Casting ${v3.value} to int causes overflow")
+            s"Casting $v3 to int causes overflow")
           checkEvaluation(cast(v3, LongType), Long.MaxValue / MICROS_PER_SECOND)
       }
 
@@ -660,34 +660,34 @@ class CastSuite extends CastSuiteBase {
       dt.endField match {
         case DAY =>
           checkExceptionInExpression[ArithmeticException](cast(v4, ByteType),
-            s"Casting ${v4.value} to tinyint causes overflow")
+            s"Casting $v4 to tinyint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v4, ShortType),
-            s"Casting ${v4.value} to smallint causes overflow")
+            s"Casting $v4 to smallint causes overflow")
           checkEvaluation(cast(v4, IntegerType), (Long.MinValue / MICROS_PER_DAY).toInt)
           checkEvaluation(cast(v4, LongType), Long.MinValue / MICROS_PER_DAY)
         case HOUR =>
           checkExceptionInExpression[ArithmeticException](cast(v4, ByteType),
-            s"Casting ${v4.value} to tinyint causes overflow")
+            s"Casting $v4 to tinyint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v4, ShortType),
-            s"Casting ${v4.value} to smallint causes overflow")
+            s"Casting $v4 to smallint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v4, IntegerType),
-            s"Casting ${v4.value} to int causes overflow")
+            s"Casting $v4 to int causes overflow")
           checkEvaluation(cast(v4, LongType), Long.MinValue / MICROS_PER_HOUR)
         case MINUTE =>
           checkExceptionInExpression[ArithmeticException](cast(v4, ByteType),
-            s"Casting ${v4.value} to tinyint causes overflow")
+            s"Casting $v4 to tinyint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v4, ShortType),
-            s"Casting ${v4.value} to smallint causes overflow")
+            s"Casting $v4 to smallint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v4, IntegerType),
-            s"Casting ${v4.value} to int causes overflow")
+            s"Casting $v4 to int causes overflow")
           checkEvaluation(cast(v4, LongType), Long.MinValue / MICROS_PER_MINUTE)
         case SECOND =>
           checkExceptionInExpression[ArithmeticException](cast(v4, ByteType),
-            s"Casting ${v4.value} to tinyint causes overflow")
+            s"Casting $v4 to tinyint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v4, ShortType),
-            s"Casting ${v4.value} to smallint causes overflow")
+            s"Casting $v4 to smallint causes overflow")
           checkExceptionInExpression[ArithmeticException](cast(v4, IntegerType),
-            s"Casting ${v4.value} to int causes overflow")
+            s"Casting $v4 to int causes overflow")
           checkEvaluation(cast(v4, LongType), Long.MinValue / MICROS_PER_SECOND)
       }
     }
@@ -788,7 +788,7 @@ class CastSuite extends CastSuiteBase {
       case (v, dt, toType) =>
         val value = Literal.create(v, dt)
         checkExceptionInExpression[ArithmeticException](cast(value, toType),
-          s"Casting ${value.value} to ${toType.catalogString} causes overflow")
+          s"Casting $value to ${toType.catalogString} causes overflow")
     }
 
     Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add cast `AnsiIntervalType` to `IntegralType`

requirement:
1. `YearMonthIntervalType` just have one unit
2. `DayTimeIntervalType` just have one unit

cast rule:
1. The value corresponding to the unit of `YearMonthIntervalType` is the value of the `IntegralType` after conversion.
2. The value corresponding to the unit of `DayTimeIntervalType` is the value of the `IntegralType` after conversion.

Add cast `IntegralType` to `AnsiIntervalType`
requirement: 

1. `YearMonthIntervalType` just have one unit
2. `DayTimeIntervalType` just have one unit

cast rule:

1. The value of the IntegralTypeis the value of  `YearMonthIntervalType` that with the single unit after conversion.
2. The value of the IntegralTypeis the value of  `DayTimeIntervalType` that with the single unit after conversion.


### Why are the changes needed?
According to 2011 Standards
![截图](https://user-images.githubusercontent.com/41178002/140504037-b86793f0-2c97-49f7-bcbf-bb6864592aa8.PNG)

7) If TD is an interval and SD is exact numeric, then TD shall contain only a single <primary datetime field>.
8) If TD is exact numeric and SD is an interval, then SD shall contain only a single <primary datetime field>.

### Does this PR introduce _any_ user-facing change?
Yes, user can use cast function between YearMonthIntervalType to NumericType


### How was this patch tested?
add ut testcase
