### PR TITLE
[SPARK-36182][SQL] Support TimestampNTZ type in Parquet data source 

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
@@ -135,7 +135,7 @@ public class ParquetVectorUpdaterFactory {
         break;
       case INT96:
         if (sparkType == DataTypes.TimestampNTZType) {
-          converterErrorForTimestampNTZ(typeName.name());
+          convertErrorForTimestampNTZ(typeName.name());
         } else if (sparkType == DataTypes.TimestampType) {
           final boolean failIfRebase = "EXCEPTION".equals(int96RebaseMode);
           if (!shouldConvertTimestamps()) {
@@ -189,11 +189,11 @@ public class ParquetVectorUpdaterFactory {
     // This is to avoid mistakes in reading the timestamp values.
     if (((TimestampLogicalTypeAnnotation) logicalTypeAnnotation).isAdjustedToUTC() &&
       sparkType == DataTypes.TimestampNTZType) {
-      converterErrorForTimestampNTZ("int64 time(" + logicalTypeAnnotation + ")");
+      convertErrorForTimestampNTZ("int64 time(" + logicalTypeAnnotation + ")");
     }
   }
 
-  void converterErrorForTimestampNTZ(String parquetType) {
+  void convertErrorForTimestampNTZ(String parquetType) {
     throw new RuntimeException("Unable to create Parquet converter for data type " +
       DataTypes.TimestampNTZType.json() + " whose Parquet type is " + parquetType);
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
@@ -104,6 +104,7 @@ public class ParquetVectorUpdaterFactory {
           // fallbacks. We read them as decimal values.
           return new UnsignedLongUpdater();
         } else if (isTimestampTypeMatched(LogicalTypeAnnotation.TimeUnit.MICROS)) {
+          validateTimestampType(sparkType);
           if ("CORRECTED".equals(datetimeRebaseMode)) {
             return new LongUpdater();
           } else {
@@ -111,6 +112,7 @@ public class ParquetVectorUpdaterFactory {
             return new LongWithRebaseUpdater(failIfRebase);
           }
         } else if (isTimestampTypeMatched(LogicalTypeAnnotation.TimeUnit.MILLIS)) {
+          validateTimestampType(sparkType);
           if ("CORRECTED".equals(datetimeRebaseMode)) {
             return new LongAsMicrosUpdater();
           } else {
@@ -132,7 +134,9 @@ public class ParquetVectorUpdaterFactory {
         }
         break;
       case INT96:
-        if (sparkType == DataTypes.TimestampType) {
+        if (sparkType == DataTypes.TimestampNTZType) {
+          converterErrorForTimestampNTZ(typeName.name());
+        } else if (sparkType == DataTypes.TimestampType) {
           final boolean failIfRebase = "EXCEPTION".equals(int96RebaseMode);
           if (!shouldConvertTimestamps()) {
             if ("CORRECTED".equals(int96RebaseMode)) {
@@ -177,6 +181,19 @@ public class ParquetVectorUpdaterFactory {
   boolean isTimestampTypeMatched(LogicalTypeAnnotation.TimeUnit unit) {
     return logicalTypeAnnotation instanceof TimestampLogicalTypeAnnotation &&
       ((TimestampLogicalTypeAnnotation) logicalTypeAnnotation).getUnit() == unit;
+  }
+
+  void validateTimestampType(DataType sparkType) {
+    assert(logicalTypeAnnotation instanceof TimestampLogicalTypeAnnotation);
+    if (((TimestampLogicalTypeAnnotation) logicalTypeAnnotation).isAdjustedToUTC() &&
+      sparkType == DataTypes.TimestampNTZType) {
+      converterErrorForTimestampNTZ("int64 time(" + logicalTypeAnnotation.toString() + ")");
+    }
+  }
+
+  void converterErrorForTimestampNTZ(String parquetType) {
+    throw new RuntimeException("Unable to create Parquet converter for data type " +
+      DataTypes.TimestampNTZType.json() + " whose Parquet type is " + parquetType);
   }
 
   boolean isUnsignedIntTypeMatched(int bitWidth) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
@@ -185,9 +185,11 @@ public class ParquetVectorUpdaterFactory {
 
   void validateTimestampType(DataType sparkType) {
     assert(logicalTypeAnnotation instanceof TimestampLogicalTypeAnnotation);
+    // Throw an exception if the Parquet type is TimestampLTZ and the Catalyst type is TimestampNTZ.
+    // This is to avoid mistakes in reading the timestamp values.
     if (((TimestampLogicalTypeAnnotation) logicalTypeAnnotation).isAdjustedToUTC() &&
       sparkType == DataTypes.TimestampNTZType) {
-      converterErrorForTimestampNTZ("int64 time(" + logicalTypeAnnotation.toString() + ")");
+      converterErrorForTimestampNTZ("int64 time(" + logicalTypeAnnotation + ")");
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -370,6 +370,8 @@ private[parquet] class ParquetRowConverter(
           }
         }
 
+      // The converter doesn't support the TimestampLTZ Parquet type and TimestampNTZ Catalyst type.
+      // This is to avoid mistakes in reading the timestamp values.
       case TimestampNTZType
         if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 &&
           parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -371,13 +371,19 @@ private[parquet] class ParquetRowConverter(
         }
 
       case TimestampNTZType
-        if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&
+        if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 &&
+          parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&
+          !parquetType.getLogicalTypeAnnotation
+            .asInstanceOf[TimestampLogicalTypeAnnotation].isAdjustedToUTC &&
           parquetType.getLogicalTypeAnnotation
             .asInstanceOf[TimestampLogicalTypeAnnotation].getUnit == TimeUnit.MICROS =>
         new ParquetPrimitiveConverter(updater)
 
       case TimestampNTZType
-        if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&
+        if parquetType.asPrimitiveType().getPrimitiveTypeName == INT64 &&
+          parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&
+          !parquetType.getLogicalTypeAnnotation
+            .asInstanceOf[TimestampLogicalTypeAnnotation].isAdjustedToUTC &&
           parquetType.getLogicalTypeAnnotation
             .asInstanceOf[TimestampLogicalTypeAnnotation].getUnit == TimeUnit.MILLIS =>
         new ParquetPrimitiveConverter(updater) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -370,6 +370,23 @@ private[parquet] class ParquetRowConverter(
           }
         }
 
+      case TimestampNTZType
+        if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&
+          parquetType.getLogicalTypeAnnotation
+            .asInstanceOf[TimestampLogicalTypeAnnotation].getUnit == TimeUnit.MICROS =>
+        new ParquetPrimitiveConverter(updater)
+
+      case TimestampNTZType
+        if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&
+          parquetType.getLogicalTypeAnnotation
+            .asInstanceOf[TimestampLogicalTypeAnnotation].getUnit == TimeUnit.MILLIS =>
+        new ParquetPrimitiveConverter(updater) {
+          override def addLong(value: Long): Unit = {
+            val micros = DateTimeUtils.millisToMicros(value)
+            updater.setLong(micros)
+          }
+        }
+
       case DateType =>
         new ParquetPrimitiveConverter(updater) {
           override def addInt(value: Int): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
@@ -223,6 +223,12 @@ class ParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
               recordConsumer.addLong(millis)
         }
 
+      case TimestampNTZType =>
+        // For TimestampNTZType column, Spark always output as INT64 with Timestamp annotation in
+        // MICROS time unit.
+        (row: SpecializedGetters, ordinal: Int) =>
+          recordConsumer.addLong(row.getLong(ordinal))
+
       case BinaryType =>
         (row: SpecializedGetters, ordinal: Int) =>
           recordConsumer.addBinary(Binary.fromReusedByteArray(row.getBinary(ordinal)))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
@@ -226,8 +226,7 @@ class ParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
       case TimestampNTZType =>
         // For TimestampNTZType column, Spark always output as INT64 with Timestamp annotation in
         // MICROS time unit.
-        (row: SpecializedGetters, ordinal: Int) =>
-          recordConsumer.addLong(row.getLong(ordinal))
+        (row: SpecializedGetters, ordinal: Int) => recordConsumer.addLong(row.getLong(ordinal))
 
       case BinaryType =>
         (row: SpecializedGetters, ordinal: Int) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -119,7 +119,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
     withSQLConf(SQLConf.PARQUET_BINARY_AS_STRING.key -> "true")(checkParquetFile(data))
   }
 
-  test("TimestampNTZ") {
+  test("SPARK-36182: TimestampNTZ") {
     val data = Seq("2021-01-01T00:00:00", "1970-07-15T01:02:03.456789")
       .map(ts => Tuple1(LocalDateTime.parse(ts)))
     checkParquetFile(data)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import java.time.{Duration, Period}
+import java.time.{Duration, LocalDateTime, Period}
 import java.util.Locale
 
 import scala.collection.JavaConverters._
@@ -117,6 +117,12 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
     // as we store Spark SQL schema in the extra metadata.
     withSQLConf(SQLConf.PARQUET_BINARY_AS_STRING.key -> "false")(checkParquetFile(data))
     withSQLConf(SQLConf.PARQUET_BINARY_AS_STRING.key -> "true")(checkParquetFile(data))
+  }
+
+  test("TimestampNTZ") {
+    val data = Seq("2021-01-01T00:00:00", "1970-07-15T01:02:03.456789")
+      .map(ts => Tuple1(LocalDateTime.parse(ts)))
+    checkParquetFile(data)
   }
 
   testStandardAndLegacyModes("fixed-length decimals") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support TimestampNTZ type in Parquet data source. In this PR, the [timestamp types](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#timestamp) of Parquet are mapped to the two timestamp types in Spark:
<table>
    <tr colspan="3">
        <th colspan="3">Parquet type</th>
        <th>Spark Catalyst Type</th>
    </tr>
    <tr>
        <td rowspan="4">INT64 Timestamp</td>
        <td rowspan="2">isAdjustedToUTC = false</td>
        <td>unit = MILLIS</td>
        <td>TimestampNTZType</td>
    </tr>
    <tr>
        <td>unit = MICROS</td>
        <td>TimestampNTZType</td>
    </tr>
    <tr>
        <td rowspan="2">isAdjustedToUTC = true</td>
        <td>unit = MILLIS</td>
        <td>TimestampType</td>
    </tr>
    <tr>
        <td>unit = MICROS</td>
        <td>TimestampType</td>
    </tr>
    <tr>
        <td>INT96 Timestamp</td>
        <td> - </td>
        <td> - </td>
        <td> TimestampType </td>
</table>

#### Parquet writer
For TIMESTAMP_NTZ columns, it follows the Parquet Logical Type Definitions and sets the field `isAdjustedToUTC` as `false` on writing TIMESTAMP_NTZ columns. The output type is always INT64 in the MICROS time unit. Parquet's timestamp logical annotation can only be used for INT64 so that we won't support writing TIMESTAMP_NTZ as INT96. Otherwise, it is hard to decide the timestamp type on the reader side.

#### Parquet reader

- INT96 columns: The reader behavior is the same with Spark 3.2 or prior.
- Schema inference for INT64 Timestamp columns: for schema inference of one file, Spark infers TIMESTAMP_NTZ or TIMESTAMP_LTZ type according to the annotation flag `isAdjustedToUTC`.
- Row converter for INT64 Timestamp columns during reading
    - Given a TIMESTAMP_NTZ Parquet column and a catalyst schema of TIMESTAMP_LTZ type, Spark **allows** the read 
       operation since TIMESTAMP_LTZ is the "wider" type.
    - Given a TIMESTAMP_LTZ Parquet column and a catalyst schema of TIMESTAMP_NTZ type, Spark **disallows** the read operation since TIMESTAMP_NTZ is the "narrower" type.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
 Support TimestampNTZ type in Parquet data source 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, support TimestampNTZ type in Parquet data source 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UTs