### PR TITLE
[SPARK-37218][SQL][TEST] Parameterize `spark.sql.shuffle.partitions` in TPCDSQueryBenchmark

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
@@ -50,7 +50,7 @@ object TPCDSQueryBenchmark extends SqlBasedBenchmark with Logging {
       .setMaster(System.getProperty("spark.sql.test.master", "local[1]"))
       .setAppName("test-sql-context")
       .set("spark.sql.parquet.compression.codec", "snappy")
-      .set("spark.sql.shuffle.partitions", "4")
+      .set("spark.sql.shuffle.partitions", System.getProperty("spark.sql.shuffle.partitions", "4"))
       .set("spark.driver.memory", "3g")
       .set("spark.executor.memory", "3g")
       .set("spark.sql.autoBroadcastJoinThreshold", (20 * 1024 * 1024).toString)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to parameterize `spark.sql.shuffle.partitions` in TPCDSQueryBenchmark.

### Why are the changes needed?

This helps a single machine benchmark with many cores.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually.

```
bin/spark-submit \
  --driver-memory 12g --driver-java-options '-Dspark.sql.test.master=local[10]' \
  -c spark.serializer=org.apache.spark.serializer.KryoSerializer -c spark.sql.shuffle.partitions=10 \
  --class org.apache.spark.sql.execution.benchmark.TPCDSQueryBenchmark \
  --jars core/target/scala-2.12/spark-core_2.12-3.3.0-SNAPSHOT-tests.jar,sql/catalyst/target/scala-2.12/spark-catalyst_2.12-3.3.0-SNAPSHOT-tests.jar \
  sql/core/target/scala-2.12/spark-sql_2.12-3.3.0-SNAPSHOT-tests.jar \
  --data-location ~/data/10g-parquet-gzip --query-filter q72
```
