### PR TITLE
[WIP][SPARK-33574][CORE] Improve locality for push-based shuffle especially for join-like operations

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2190,6 +2190,17 @@ package object config {
       .checkValue(_ >= 0L, "Timeout must be >= 0.")
       .createWithDefaultString("10s")
 
+  private[spark] val PUSH_BASED_SHUFFLE_REUSE_MERGER_LOCATIONS =
+    ConfigBuilder("spark.shuffle.push.reuse.merger.locations")
+      .doc("For sibling shuffle map stages, i.e. ones that share common child stages, reusing " +
+        "merger locations between them can help to further increase shuffle locality ratio " +
+        "when push based shuffle is enabled. Examples include joins where the reduce stage " +
+        "needs to fetch shuffle data from multiple parent shuffle map stages. Set to 'true' " +
+        "to enable this feature.")
+      .version("3.2.1")
+      .booleanConf
+      .createWithDefault(true)
+
   private[spark] val SHUFFLE_MERGER_MAX_RETAINED_LOCATIONS =
     ConfigBuilder("spark.shuffle.push.maxRetainedMergerLocations")
       .doc("Maximum number of merger locations cached for push-based shuffle. Currently, merger" +

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.tailrec
 import scala.collection.Map
 import scala.collection.mutable
-import scala.collection.mutable.{HashMap, HashSet, ListBuffer}
+import scala.collection.mutable.{HashMap, HashSet, ListBuffer, Set}
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
@@ -164,6 +164,9 @@ private[spark] class DAGScheduler(
   // Stages that must be resubmitted due to fetch failures
   private[scheduler] val failedStages = new HashSet[Stage]
 
+  // Stages that have succeeded yet whose child stages aren't done
+  private[scheduler] val succeededStages = new HashSet[Stage]
+
   private[scheduler] val activeJobs = new HashSet[ActiveJob]
 
   /**
@@ -272,6 +275,9 @@ private[spark] class DAGScheduler(
 
   private val shuffleMergeFinalizeNumThreads =
     sc.getConf.get(config.PUSH_BASED_SHUFFLE_MERGE_FINALIZE_THREADS)
+
+  private val reuseMergerLocations =
+    sc.getConf.get(config.PUSH_BASED_SHUFFLE_REUSE_MERGER_LOCATIONS)
 
   // Since SparkEnv gets initialized after DAGScheduler, externalShuffleClient needs to be
   // initialized lazily
@@ -834,6 +840,10 @@ private[spark] class DAGScheduler(
                   logDebug("Removing stage %d from failed set.".format(stageId))
                   failedStages -= stage
                 }
+                if (succeededStages.contains(stage)) {
+                  logDebug("Removing stage %d from succeeded set.".format(stageId))
+                  succeededStages -= stage
+                }
               }
               // data structures based on StageId
               stageIdToStage -= stageId
@@ -1328,10 +1338,12 @@ private[spark] class DAGScheduler(
           logInfo("Submitting " + stage + " (" + stage.rdd + "), which has no missing parents")
           submitMissingTasks(stage, jobId.get)
         } else {
+          // Add the stage to waitingStages set before visiting parent stages. This allows
+          // discovery of sibling stages inside findCoPartitionedSiblingMapStages()
+          waitingStages += stage
           for (parent <- missing) {
             submitStage(parent)
           }
-          waitingStages += stage
         }
       }
     } else {
@@ -1388,16 +1400,73 @@ private[spark] class DAGScheduler(
   }
 
   private def getAndSetShufflePushMergerLocations(stage: ShuffleMapStage): Seq[BlockManagerId] = {
-    val mergerLocs = sc.schedulerBackend.getShufflePushMergerLocations(
-      stage.shuffleDep.partitioner.numPartitions, stage.resourceProfileId)
+    val coPartitionedSiblingStages = if (reuseMergerLocations) {
+      // Reuse merger locations for sibling stages (for eg: join cases) so that
+      // both the RDD's output will be collocated giving better locality. Since this
+      // method is invoked only within the event loop thread, it's safe to find sibling
+      // stages and set the merger locations accordingly in this way.
+      findCoPartitionedSiblingMapStages(stage)
+    } else {
+      Set.empty[ShuffleMapStage]
+    }
+    val mergerLocs = if (reuseMergerLocations) {
+      coPartitionedSiblingStages.collectFirst({
+        case s if s.shuffleDep.getMergerLocs.nonEmpty => s.shuffleDep.getMergerLocs})
+        .getOrElse(sc.schedulerBackend.getShufflePushMergerLocations(
+          stage.shuffleDep.partitioner.numPartitions, stage.resourceProfileId))
+    } else {
+      sc.schedulerBackend.getShufflePushMergerLocations(
+        stage.shuffleDep.partitioner.numPartitions, stage.resourceProfileId)
+    }
     if (mergerLocs.nonEmpty) {
       stage.shuffleDep.setMergerLocs(mergerLocs)
+      if (reuseMergerLocations) {
+        coPartitionedSiblingStages.filter(_.shuffleDep.getMergerLocs.isEmpty)
+          .foreach(_.shuffleDep.setMergerLocs(mergerLocs))
+      }
     }
 
     logDebug(s"Shuffle merge locations for shuffle ${stage.shuffleDep.shuffleId} with" +
       s" shuffle merge ${stage.shuffleDep.shuffleMergeId} is" +
       s" ${stage.shuffleDep.getMergerLocs.map(_.host).mkString(", ")}")
     mergerLocs
+  }
+
+  /**
+   * Identify sibling stages for a given ShuffleMapStage. A sibling stage is defined as
+   * one stage that shares one or more child stages with the given stage. For example,
+   * when we have a join, the reduce stage of the join will be the common child stage for
+   * the shuffle map stages shuffling the tables involved in this join. These shuffle map
+   * stages are sibling stages to each other. Being able to identify the sibling stages would
+   * allow us to set common merger locations for these shuffle map stages so that the reduce
+   * stage can have better locality especially for join operations.
+   */
+  private def findCoPartitionedSiblingMapStages(
+      stage: ShuffleMapStage): Set[ShuffleMapStage] = {
+    val numShufflePartitions = stage.shuffleDep.partitioner.numPartitions
+    val siblingStages = new HashSet[ShuffleMapStage]
+    siblingStages += stage
+    var prevSize = 0
+    val allStagesSoFar = waitingStages ++ runningStages ++ failedStages ++ succeededStages
+    do {
+      prevSize = siblingStages.size
+      siblingStages ++= allStagesSoFar.filter(_.parents.intersect(siblingStages.toSeq).nonEmpty)
+        .flatMap(_.parents).filter{ parentStage =>
+          parentStage.isInstanceOf[ShuffleMapStage] &&
+            parentStage.asInstanceOf[ShuffleMapStage]
+              .shuffleDep.partitioner.numPartitions == numShufflePartitions
+        }.map(_.asInstanceOf[ShuffleMapStage])
+    } while (siblingStages.size > prevSize)
+    // This filter will select only shuffle map stages that are/were push enabled. Notice that
+    // when we retry a push-enabled shuffle map stage, we will disable push but the merge finalized
+    // flag will remain true. We cannot do this filter in the above while loop, which would miss
+    // identifying all the sibling stages currently. Furthermore, when the final stage of a job or
+    // a map-only job gets submitted, the stage DAG for that job are visited in a depth first
+    // manner (submitStage), which means the allStagesSoFar set might not include all the sibling
+    // stages when we invoke this method. However, this is fine because when the unvisited sibling
+    // stages get visited later, their merger locations will be set accordingly.
+    siblingStages.filter(siblingStage => siblingStage.shuffleDep.shuffleMergeEnabled
+      || siblingStage.shuffleDep.shuffleMergeFinalized)
   }
 
   /** Called when stage's parents are available and we can now do its task. */
@@ -2576,6 +2645,14 @@ private[spark] class DAGScheduler(
     }
     listenerBus.post(SparkListenerStageCompleted(stage.latestInfo))
     runningStages -= stage
+    if (errorMessage.isEmpty) {
+      // Add succeeded stage into the succeeded set
+      succeededStages += stage
+      // Remove all parent stages with no pending child stages from the succeeded set
+      stage.parents.filter{ parentStage =>
+        !waitingStages.exists(_.parents.contains(parentStage))}
+        .foreach(succeededStages -= _)
+    }
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -4303,6 +4303,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
   }
 
   test("SPARK-34826: Adaptively fetch shuffle mergers") {
+
     initPushBasedShuffleConfs(conf)
     conf.set(config.SHUFFLE_MERGER_LOCATIONS_MIN_STATIC_THRESHOLD, 2)
     DAGSchedulerSuite.clearMergerLocs()
@@ -4487,7 +4488,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     assert(shuffleStage1.shuffleDep.isShuffleMergeFinalizedMarked)
     val newMergerLocs =
       scheduler.stageIdToStage(0).asInstanceOf[ShuffleMapStage].shuffleDep.getMergerLocs
-    assert(mergerLocsBeforeRetry.sortBy(_.host) !== newMergerLocs.sortBy(_.host))
+    assert(mergerLocsBeforeRetry.sortBy(_.host) == newMergerLocs.sortBy(_.host))
     val shuffleStage2 = scheduler.stageIdToStage(1).asInstanceOf[ShuffleMapStage]
     complete(taskSets(1), taskSets(1).tasks.zipWithIndex.map {
       case (_, idx) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Reuse merger locations in the case where multiple stages output is consumed by a single stage (e.g.: Joins).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For sibling shuffle map stages, i.e. ones that share common child stages, reusing merger locations between them can help to further increase shuffle locality ratio when push based shuffle is enabled. Examples include Joins where the reduce stage needs to fetch shuffle data from multiple parent shuffle map stages.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. This PR introduces a client-side config for push-based shuffle `spark.shuffle.push.reuse.merger.locations`. If push-based shuffle is turned-off then users will not see any change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Passed the added UTs.