### PR TITLE
[SPARK-37225][SQL] Support reading and writing ANSI intervals from/to Avro datasources

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -330,6 +330,12 @@ private[sql] class AvroDeserializer(
           (updater, ordinal, _) => updater.setNullAt(ordinal)
         }
 
+      case (INT, _: YearMonthIntervalType) => (updater, ordinal, value) =>
+        updater.setInt(ordinal, value.asInstanceOf[Int])
+
+      case (LONG, _: DayTimeIntervalType) => (updater, ordinal, value) =>
+        updater.setLong(ordinal, value.asInstanceOf[Long])
+
       case _ => throw new IncompatibleSchemaException(incompatibleMsg)
     }
   }

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -240,6 +240,12 @@ private[sql] class AvroSerializer(
           }
           result
 
+      case (_: YearMonthIntervalType, INT) =>
+        (getter, ordinal) => getter.getInt(ordinal)
+
+      case (_: DayTimeIntervalType, LONG) =>
+        (getter, ordinal) => getter.getLong(ordinal)
+
       case _ =>
         throw new IncompatibleSchemaException(errorPrefix +
           s"schema is incompatible (sqlType = ${catalystType.sql}, avroType = $avroType)")

--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -71,8 +71,6 @@ private[sql] object AvroUtils extends Logging {
   }
 
   def supportsDataType(dataType: DataType): Boolean = dataType match {
-    case _: AnsiIntervalType => false
-
     case _: AtomicType => true
 
     case st: StructType => st.forall { f => supportsDataType(f.dataType) }

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -2206,6 +2206,18 @@ abstract class AvroSuite
         checkAnswer(df2, df.collect().toSeq)
       }
     }
+
+    // Tests for ANSI intervals in complex types.
+    withTempPath { file =>
+      val df = spark.sql(
+        """SELECT
+          |  named_struct('interval', interval '1-2' year to month) a,
+          |  array(interval '1 2:3' day to minute) b,
+          |  map('key', interval '10' year) c""".stripMargin)
+      df.write.format("avro").save(file.getCanonicalPath)
+      val df2 = spark.read.format("avro").load(file.getCanonicalPath)
+      checkAnswer(df2, df.collect().toSeq)
+    }
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -587,7 +587,8 @@ case class DataSource(
   private def disallowWritingIntervals(
       dataTypes: Seq[DataType],
       forbidAnsiIntervals: Boolean): Unit = {
-    val isWriteAllowedSource = writeAllowedSources(providingClass)
+    val isWriteAllowedSource = writeAllowedSources(providingClass) ||
+      providingClass.getCanonicalName == "org.apache.spark.sql.avro.AvroFileFormat"
     dataTypes.foreach(
       TypeUtils.invokeOnceForInterval(_, forbidAnsiIntervals || !isWriteAllowedSource) {
       throw QueryCompilationErrors.cannotSaveIntervalIntoExternalStorageError()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -579,18 +579,11 @@ case class DataSource(
       checkEmptyGlobPath, checkFilesExist, enableGlobbing = globPaths)
   }
 
-  // TODO: Remove the Set below once all the built-in datasources support ANSI interval types
-  private val writeAllowedSources: Set[Class[_]] =
-    Set(classOf[ParquetFileFormat], classOf[CSVFileFormat],
-      classOf[JsonFileFormat], classOf[OrcFileFormat])
-
   private def disallowWritingIntervals(
       dataTypes: Seq[DataType],
       forbidAnsiIntervals: Boolean): Unit = {
-    val isWriteAllowedSource = writeAllowedSources(providingClass) ||
-      providingClass.getCanonicalName == "org.apache.spark.sql.avro.AvroFileFormat"
     dataTypes.foreach(
-      TypeUtils.invokeOnceForInterval(_, forbidAnsiIntervals || !isWriteAllowedSource) {
+      TypeUtils.invokeOnceForInterval(_, forbidAnsiIntervals) {
       throw QueryCompilationErrors.cannotSaveIntervalIntoExternalStorageError()
     })
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CommonFileDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CommonFileDataSourceSuite.scala
@@ -17,11 +17,9 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import java.util.Locale
-
 import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.spark.sql.{AnalysisException, Dataset, Encoders, FakeFileSystemRequiringDSOption, SparkSession}
+import org.apache.spark.sql.{Dataset, Encoders, FakeFileSystemRequiringDSOption, SparkSession}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 
 /**
@@ -34,31 +32,6 @@ trait CommonFileDataSourceSuite extends SQLHelper { self: AnyFunSuite =>
   protected def spark: SparkSession
   protected def dataSourceFormat: String
   protected def inputDataset: Dataset[_] = spark.createDataset(Seq("abc"))(Encoders.STRING)
-
-  test(s"SPARK-36349: disallow saving of ANSI intervals to $dataSourceFormat") {
-    if (!Set("parquet", "csv", "json", "orc", "avro")
-      .contains(dataSourceFormat.toLowerCase(Locale.ROOT))) {
-      Seq("INTERVAL '1' DAY", "INTERVAL '1' YEAR").foreach { i =>
-        withTempPath { dir =>
-          val errMsg = intercept[AnalysisException] {
-            spark.sql(s"SELECT $i").write.format(dataSourceFormat).save(dir.getAbsolutePath)
-          }.getMessage
-          assert(errMsg.contains("Cannot save interval data type into external storage"))
-        }
-      }
-
-      // Check all built-in file-based datasources except of libsvm which
-      // requires particular schema.
-      if (!Set("libsvm").contains(dataSourceFormat.toLowerCase(Locale.ROOT))) {
-        Seq("INTERVAL DAY TO SECOND", "INTERVAL YEAR TO MONTH").foreach { it =>
-          val errMsg = intercept[AnalysisException] {
-            spark.sql(s"CREATE TABLE t (i $it) USING $dataSourceFormat")
-          }.getMessage
-          assert(errMsg.contains("data source does not support"))
-        }
-      }
-    }
-  }
 
   test(s"Propagate Hadoop configs from $dataSourceFormat options to underlying file system") {
     withSQLConf(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CommonFileDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CommonFileDataSourceSuite.scala
@@ -36,7 +36,8 @@ trait CommonFileDataSourceSuite extends SQLHelper { self: AnyFunSuite =>
   protected def inputDataset: Dataset[_] = spark.createDataset(Seq("abc"))(Encoders.STRING)
 
   test(s"SPARK-36349: disallow saving of ANSI intervals to $dataSourceFormat") {
-    if (!Set("parquet", "csv", "json", "orc").contains(dataSourceFormat.toLowerCase(Locale.ROOT))) {
+    if (!Set("parquet", "csv", "json", "orc", "avro")
+      .contains(dataSourceFormat.toLowerCase(Locale.ROOT))) {
       Seq("INTERVAL '1' DAY", "INTERVAL '1' YEAR").foreach { i =>
         withTempPath { dir =>
           val errMsg = intercept[AnalysisException] {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -116,7 +116,7 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
       var msg = intercept[AnalysisException] {
         sql("select interval 1 days").write.mode("overwrite").orc(orcDir)
       }.getMessage
-      assert(msg.contains("Cannot save interval data type into external storage."))
+      assert(msg.contains("ORC data source does not support interval day data type"))
 
       msg = intercept[AnalysisException] {
         sql("select null").write.mode("overwrite").orc(orcDir)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Allow saving and loading of ANSI intervals - `YearMonthIntervalType` and `DayTimeIntervalType` to/from the **Avro** datasource. After the changes, Spark saves ANSI intervals as primitive physical Avro types:
- year-month intervals as `int`
- day-time intervals as `long`

w/o any modifications. To load the values as intervals back, Spark puts the info about interval types to the extra property `spark.sql.catalyst.type`:
```
$ java -jar avro-tools-1.9.2.jar getmeta part-00000-28176110-d0dc-4de7-81b8-31797c15c678-c000.avro
avro.schema	{"type":"record","name":"topLevelRecord","fields":[{"name":"i","type":{"type":"int","spark.sql.catalyst.type":"interval year to month"}}]}
org.apache.spark.version	3.3.0
avro.codec	snappy
```

**Note:** The given PR focus on support of ANSI intervals in the Avro datasource via write or read as a column in `Dataset`.

### Why are the changes needed?
To improve user experience with Spark SQL. At the moment, users can make ANSI intervals "inside" Spark, parallelize Java collections of `Period`/`Duration` objects or save/load to/from JSON, CSV, ORC, Parquet datasources but cannot save the intervals to **Avro** files. After the changes, users can save datasets/dataframes with year-month/day-time intervals to load them back later by Apache Spark.

For example:
```scala
scala> sql("select date'today' - date'2021-01-01' as diff").write.format("avro").save("/Users/maximgekk/tmp/avro_interval")

scala> val readback = spark.read.format("avro").load("/Users/maximgekk/tmp/avro_interval")
readback: org.apache.spark.sql.DataFrame = [diff: interval day]

scala> readback.printSchema
root
 |-- diff: interval day (nullable = true)


scala> readback.show
+------------------+
|              diff|
+------------------+
|INTERVAL '309' DAY|
+------------------+
```

### Does this PR introduce _any_ user-facing change?
In some sense, yes. Before the changes, users get an error while saving of ANSI intervals as dataframe columns to avro files but the operation should complete successfully after the changes. 

### How was this patch tested?
By running the new test:
```
$ build/sbt "test:testOnly *AvroV1Suite"
$ build/sbt "test:testOnly *AvroV2Suite"
$ build/sbt "test:testOnly *FileBasedDataSourceSuite"
$ build/sbt -Phive-2.3 "test:testOnly *HiveOrcSourceSuite"
```