### PR TITLE
[SPARK-37226][SQL] Filter push down through window if partitionSpec isEmpty

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1553,15 +1553,10 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
         case Seq(alias @ Alias(WindowExpression(_: RowNumber, WindowSpecDefinition(Nil, orderSpec,
             SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow))), _)) =>
           val aliasAttr = alias.toAttribute
-          val limitValue = splitConjunctivePredicates(condition) match {
-            case Seq(LessThanOrEqual(e, IntegerLiteral(v))) if e.semanticEquals(aliasAttr) =>
-              Some(v)
-            case Seq(EqualTo(e, IntegerLiteral(v))) if e.semanticEquals(aliasAttr) =>
-              Some(v)
-            case Seq(LessThan(e, IntegerLiteral(v))) if e.semanticEquals(aliasAttr) =>
-              Some(v - 1)
-            case _ =>
-              None
+          val limitValue = splitConjunctivePredicates(condition).collectFirst {
+            case LessThanOrEqual(e, IntegerLiteral(v)) if e.semanticEquals(aliasAttr) => v
+            case EqualTo(e, IntegerLiteral(v)) if e.semanticEquals(aliasAttr) => v
+            case LessThan(e, IntegerLiteral(v)) if e.semanticEquals(aliasAttr) => v - 1
           }
 
           limitValue match {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -1426,6 +1426,14 @@ class FilterPushdownSuite extends PlanTest {
         .where('rn < 5)
         .select('a, 'b, 'c, 'rn).analyze)
 
+    comparePlans(
+      Optimize.execute(testRelation2
+        .select('a, 'b, 'c, winExpr.as('rn)).where('rn > 2 && 'rn < 5).analyze),
+      testRelation2.select('a, 'b, 'c).orderBy('b.asc).limit(Literal(4))
+        .window(winExprAnalyzed.as('rn) :: Nil, Nil, 'b.asc :: Nil)
+        .where('rn > 2 && 'rn < 5)
+        .select('a, 'b, 'c, 'rn).analyze)
+
     // Negative case
     val originalQuery1 = testRelation2.window(winExprAnalyzed.as('rn) :: Nil, Nil, 'b.asc :: Nil)
       .where('rn > 5)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -1434,6 +1434,12 @@ class FilterPushdownSuite extends PlanTest {
         .where('rn > 2 && 'rn < 5)
         .select('a, 'b, 'c, 'rn).analyze)
 
+    comparePlans(
+      Optimize.execute(testRelation2
+        .select('a, 'b, 'c, winExpr.as('rn)).where('rn < 1).analyze),
+      LocalRelation('a.int, 'b.int, 'c.int, 'rn.int.withNullability(false))
+        .select('a, 'b, 'c, 'rn).analyze)
+
     // Negative case
     val originalQuery1 = testRelation2.window(winExprAnalyzed.as('rn) :: Nil, Nil, 'b.asc :: Nil)
       .where('rn > 5)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr enhance `PushPredicateThroughNonJoin` to support filter push down through window if window partition is empty. For example:
```scala
spark.sql("CREATE TABLE t1 using parquet AS SELECT id AS a, id AS b FROM range(1000)")
spark.sql("SELECT * FROM (SELECT *, ROW_NUMBER() OVER(ORDER BY a) AS rn FROM t1) t WHERE rn > 100 and rn <= 200").explain(true)
```
After this pr:
```
== Optimized Logical Plan ==
Filter ((rn#3 > 100) AND (rn#3 <= 200))
+- Window [row_number() windowspecdefinition(a#5L ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#3], [a#5L ASC NULLS FIRST]
   +- GlobalLimit 200
      +- LocalLimit 200
         +- Sort [a#5L ASC NULLS FIRST], true
            +- Relation default.t1[a#5L,b#6L] parquet
```

### Why are the changes needed?

Improve query performance.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test and benchmark test:
```scala
import org.apache.spark.benchmark.Benchmark
val numRows = 1024 * 1024 * 100
spark.sql(s"CREATE TABLE t1 using parquet AS SELECT id as a, id as b FROM range(${numRows}L)")
val benchmark = new Benchmark("Benchmark filter push down through window", numRows, minNumIters = 5)

Seq(1, 1000).foreach { threshold =>
  val name = s"Filter push down through window ${if (threshold > 1) "(Enabled)" else "(Disabled)"}"
  benchmark.addCase(name) { _ =>
    withSQLConf("spark.sql.execution.topKSortFallbackThreshold" -> s"$threshold") {
      spark.sql("SELECT * FROM (SELECT *, ROW_NUMBER() OVER(ORDER BY a) AS rn FROM t1) t WHERE rn > 100 and rn <= 200").write.format("noop").mode("Overwrite").save()
    }
  }
}
benchmark.run()
```
Benchmark result:
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.15.7
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark filter push down through window:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------
Filter push down through window (Disabled)          79219          87062         NaN          1.3         755.5       1.0X
Filter push down through window (Enabled)            5339           5821         425         19.6          50.9      14.8X

```

Production benchmark:

Before this PR | After this PR
--- | ---
![image](https://user-images.githubusercontent.com/5399861/141800881-c0721682-69b3-4861-80fa-0b0ee324aeeb.png)  | ![image](https://user-images.githubusercontent.com/5399861/141878272-48252c7f-108b-4834-9d9b-e8a54eb05e75.png)
