### PR TITLE
[SPARK-37231][SQL] Dynamic writes/reads of ANSI interval partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -544,6 +544,8 @@ object PartitioningUtils extends SQLConfHelper{
       }.getOrElse {
         Cast(Cast(Literal(value), DateType, Some(zoneId.getId)), dt).eval()
       }
+    case it: AnsiIntervalType =>
+      Cast(Literal(unescapePathName(value)), it).eval()
     case dt => throw QueryExecutionErrors.typeUnsupportedError(dt)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -32,6 +32,9 @@ import org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtoc
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DayTimeIntervalType.{DAY, MINUTE, SECOND}
+import org.apache.spark.sql.types.YearMonthIntervalType.{MONTH, YEAR}
 import org.apache.spark.util.Utils
 
 private class OnlyDetectCustomPathFileCommitProtocol(jobId: String, path: String)
@@ -124,13 +127,14 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  private def checkPartitionValues(file: File, expected: String): Unit = {
+    val dir = file.getParentFile()
+    val value = ExternalCatalogUtils.unescapePathName(
+      dir.getName.substring(dir.getName.indexOf("=") + 1))
+    assert(value == expected)
+  }
+
   test("timeZone setting in dynamic partition writes") {
-    def checkPartitionValues(file: File, expected: String): Unit = {
-      val dir = file.getParentFile()
-      val value = ExternalCatalogUtils.unescapePathName(
-        dir.getName.substring(dir.getName.indexOf("=") + 1))
-      assert(value == expected)
-    }
     val ts = Timestamp.valueOf("2016-12-01 00:00:00")
     val df = Seq((1, ts)).toDF("i", "ts")
     withTempPath { f =>
@@ -186,6 +190,30 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
             .saveAsTable("t")
           checkAnswer(sql("select * from t"), df)
         }
+      }
+    }
+  }
+
+  test("SPARK-37231: Dynamic writes/reads of ANSI interval partitions") {
+    Seq(
+      "INTERVAL '100' YEAR" -> YearMonthIntervalType(YEAR),
+      "INTERVAL '-1-1' YEAR TO MONTH" -> YearMonthIntervalType(YEAR, MONTH),
+      "INTERVAL '1000 02:03:04.123' DAY TO SECOND" -> DayTimeIntervalType(DAY, SECOND),
+      "INTERVAL '-10' MINUTE" -> DayTimeIntervalType(MINUTE)
+    ).foreach { case (intervalStr, intervalType) =>
+      withTempPath { f =>
+        val df = sql(s"select 0 AS id, $intervalStr AS diff")
+        assert(df.schema("diff").dataType === intervalType)
+        df.write
+          .partitionBy("diff")
+          .json(f.getAbsolutePath)
+        val files = TestUtils.recursiveList(f).filter(_.getAbsolutePath.endsWith("json"))
+        assert(files.length == 1)
+        checkPartitionValues(files.head, intervalStr)
+        val schema = new StructType()
+          .add("id", IntegerType)
+          .add("diff", intervalType)
+        checkAnswer(spark.read.schema(schema).json(f.getAbsolutePath), df)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to check that ANSI intervals can be written as partitions dynamically, and read back as intervals if the  schema is set correctly. The last one requires a fix in `PartitioningUtils. AnsiIntervalType` to handle ANSI interval types and cast partition value strings to desired interval types.

### Why are the changes needed?
1. To check that ANSI intervals can be saved as partitions values
2. To fix loading of ANSI intervals as partitions values. The example below demonstrates the issue:
```scala
scala> sql("SELECT INTERVAL '1' YEAR AS i, 0 as id").write.partitionBy("i").json("/Users/maximgekk/tmp/ansi_interval_json")

scala> spark.read.schema("i INTERVAL YEAR, id INT").json("/Users/maximgekk/tmp/ansi_interval_json")
java.lang.RuntimeException: Failed to cast value `INTERVAL %271%27 YEAR` to `YearMonthIntervalType(0,0)` for partition column `i`
  at org.apache.spark.sql.errors.QueryExecutionErrors$.failedToCastValueToDataTypeForPartitionColumnError(QueryExecutionErrors.scala:593)
  at org.apache.spark.sql.execution.datasources.PartitioningUtils$.$anonfun$parsePartitions$13(PartitioningUtils.scala:204)
```

### Does this PR introduce _any_ user-facing change?
No, this PR fixes the issues above. After the changes, the code works as expected:
```scala
scala> spark.read.schema("i INTERVAL YEAR, id INT").json("/Users/maximgekk/tmp/ansi_interval_json").show(false)
+---+-----------------+
|id |i                |
+---+-----------------+
|0  |INTERVAL '1' YEAR|
+---+-----------------+
```

### How was this patch tested?
By running new test:
```
$ build/sbt "test:testOnly *PartitionedWriteSuite"
```