### PR TITLE
[SPARK-37238][BUILD][3.2] Upgrade ORC to 1.6.12

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -195,9 +195,9 @@ objenesis/2.6//objenesis-2.6.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.6.11//orc-core-1.6.11.jar
-orc-mapreduce/1.6.11//orc-mapreduce-1.6.11.jar
-orc-shims/1.6.11//orc-shims-1.6.11.jar
+orc-core/1.6.12//orc-core-1.6.12.jar
+orc-mapreduce/1.6.12//orc-mapreduce-1.6.12.jar
+orc-shims/1.6.12//orc-shims-1.6.12.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -166,9 +166,9 @@ objenesis/2.6//objenesis-2.6.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.6.11//orc-core-1.6.11.jar
-orc-mapreduce/1.6.11//orc-mapreduce-1.6.11.jar
-orc-shims/1.6.11//orc-shims-1.6.11.jar
+orc-core/1.6.12//orc-core-1.6.12.jar
+orc-mapreduce/1.6.12//orc-mapreduce-1.6.12.jar
+orc-shims/1.6.12//orc-shims-1.6.12.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.2</parquet.version>
-    <orc.version>1.6.11</orc.version>
+    <orc.version>1.6.12</orc.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache ORC from 1.6.11 to 1.6.12 for Apache ORC 3.2.1.

### Why are the changes needed?

Apache ORC 1.6.12 is a new maintenance version including the following bug fixes (https://orc.apache.org/news/2021/11/07/ORC-1.6.12/)

- ORC-1008 Overflow detection code is incorrect in IntegerColumnStatisticsImpl
- ORC-1024 BloomFilter hash computation is inconsistent between Java and C++ clients
- ORC-1029 ServiceLoader is not thread-safe, avoid concurrent calls

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.