### PR TITLE
[SPARK-37240][SQL] Handle ANSI intervals by `ColumnVectorUtils.populate()`

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVectorUtils.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVectorUtils.java
@@ -92,9 +92,10 @@ public class ColumnVectorUtils {
         CalendarInterval c = (CalendarInterval)row.get(fieldIdx, t);
         col.getChild(0).putInts(0, capacity, c.months);
         col.getChild(1).putLongs(0, capacity, c.microseconds);
-      } else if (t instanceof DateType) {
+      } else if (t instanceof DateType || t instanceof YearMonthIntervalType) {
         col.putInts(0, capacity, row.getInt(fieldIdx));
-      } else if (t instanceof TimestampType || t instanceof TimestampNTZType) {
+      } else if (t instanceof TimestampType || t instanceof TimestampNTZType ||
+        t instanceof DayTimeIntervalType) {
         col.putLongs(0, capacity, row.getLong(fieldIdx));
       } else {
         throw new RuntimeException(String.format("DataType %s is not supported" +

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -194,7 +194,7 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-37231, SPARK-XXXXX: Dynamic writes/reads of ANSI interval partitions") {
+  test("SPARK-37231, SPARK-37240: Dynamic writes/reads of ANSI interval partitions") {
     Seq("parquet", "json").foreach { format =>
       Seq(
         "INTERVAL '100' YEAR" -> YearMonthIntervalType(YEAR),

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -194,26 +194,29 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-37231: Dynamic writes/reads of ANSI interval partitions") {
-    Seq(
-      "INTERVAL '100' YEAR" -> YearMonthIntervalType(YEAR),
-      "INTERVAL '-1-1' YEAR TO MONTH" -> YearMonthIntervalType(YEAR, MONTH),
-      "INTERVAL '1000 02:03:04.123' DAY TO SECOND" -> DayTimeIntervalType(DAY, SECOND),
-      "INTERVAL '-10' MINUTE" -> DayTimeIntervalType(MINUTE)
-    ).foreach { case (intervalStr, intervalType) =>
-      withTempPath { f =>
-        val df = sql(s"select 0 AS id, $intervalStr AS diff")
-        assert(df.schema("diff").dataType === intervalType)
-        df.write
-          .partitionBy("diff")
-          .json(f.getAbsolutePath)
-        val files = TestUtils.recursiveList(f).filter(_.getAbsolutePath.endsWith("json"))
-        assert(files.length == 1)
-        checkPartitionValues(files.head, intervalStr)
-        val schema = new StructType()
-          .add("id", IntegerType)
-          .add("diff", intervalType)
-        checkAnswer(spark.read.schema(schema).json(f.getAbsolutePath), df)
+  test("SPARK-37231, SPARK-XXXXX: Dynamic writes/reads of ANSI interval partitions") {
+    Seq("parquet", "json").foreach { format =>
+      Seq(
+        "INTERVAL '100' YEAR" -> YearMonthIntervalType(YEAR),
+        "INTERVAL '-1-1' YEAR TO MONTH" -> YearMonthIntervalType(YEAR, MONTH),
+        "INTERVAL '1000 02:03:04.123' DAY TO SECOND" -> DayTimeIntervalType(DAY, SECOND),
+        "INTERVAL '-10' MINUTE" -> DayTimeIntervalType(MINUTE)
+      ).foreach { case (intervalStr, intervalType) =>
+        withTempPath { f =>
+          val df = sql(s"select 0 AS id, $intervalStr AS diff")
+          assert(df.schema("diff").dataType === intervalType)
+          df.write
+            .partitionBy("diff")
+            .format(format)
+            .save(f.getAbsolutePath)
+          val files = TestUtils.recursiveList(f).filter(_.getAbsolutePath.endsWith(format))
+          assert(files.length == 1)
+          checkPartitionValues(files.head, intervalStr)
+          val schema = new StructType()
+            .add("id", IntegerType)
+            .add("diff", intervalType)
+          checkAnswer(spark.read.schema(schema).format(format).load(f.getAbsolutePath), df)
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to handle ANSI interval types - `YearMonthIntervalType` and `DayTimeIntervalType` in `ColumnVectorUtils.populate()`.

### Why are the changes needed?
This PR fixes the failure on reading of partitioned parquet files with ANSI interval partition values. The code below demonstrates the issue:
```scala
scala> sql("SELECT INTERVAL '1' YEAR AS i, 0 as id").write.partitionBy("i").parquet("/Users/maximgekk/tmp/ansi_interval_parquet")


scala> spark.read.schema("i INTERVAL YEAR, id INT").parquet("/Users/maximgekk/tmp/ansi_interval_parquet").show(false)
21/11/08 10:56:36 ERROR Executor: Exception in task 0.0 in stage 2.0 (TID 2)
java.lang.RuntimeException: DataType INTERVAL YEAR is not supported in column vectorized reader.
	at org.apache.spark.sql.execution.vectorized.ColumnVectorUtils.populate(ColumnVectorUtils.java:100)
	at org.apache.spark.sql.execution.datasources.parquet.VectorizedParquetRecordReader.initBatch(VectorizedParquetRecordReader.java:243)
``` 

### Does this PR introduce _any_ user-facing change?
No, this PR fixes the issue above, and the code works as expected after the changes:
```scala
scala> spark.read.schema("i INTERVAL YEAR, id INT").parquet("/Users/maximgekk/tmp/ansi_interval_parquet").show(false)
+---+-----------------+
|id |i                |
+---+-----------------+
|0  |INTERVAL '1' YEAR|
+---+-----------------+
```

### How was this patch tested?
By running the modified test:
```
$ build/sbt "test:testOnly *PartitionedWriteSuite"
```
