### PR TITLE
[SPARK-37196][SQL] HiveDecimal enforcePrecisionScale failed return null

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -101,10 +101,19 @@ private[hive] object HiveShim {
 
   def toCatalystDecimal(hdoi: HiveDecimalObjectInspector, data: Any): Decimal = {
     if (hdoi.preferWritable()) {
-      Decimal(hdoi.getPrimitiveWritableObject(data).getHiveDecimal().bigDecimalValue,
-        hdoi.precision(), hdoi.scale())
+      val value = hdoi.getPrimitiveWritableObject(data)
+      if (value == null) {
+        null
+      } else {
+        Decimal(value.getHiveDecimal().bigDecimalValue, hdoi.precision(), hdoi.scale())
+      }
     } else {
-      Decimal(hdoi.getPrimitiveJavaObject(data).bigDecimalValue(), hdoi.precision(), hdoi.scale())
+      val value = hdoi.getPrimitiveJavaObject(data)
+      if (value == null) {
+        null
+      } else {
+        Decimal(value.bigDecimalValue(), hdoi.precision(), hdoi.scale())
+      }
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -905,21 +905,4 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
       }
     }
   }
-
-  test("SPARK-37196: HiveDecimal enforcePrecisionScala failed return null") {
-    withTempDir { dir =>
-      withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET.key -> "false") {
-        withTable("test_precision") {
-          val df = sql("SELECT 'dummy' AS name, 1000000000000000000010.7000000000000010 AS value")
-          df.write.mode("Overwrite").parquet(dir.getAbsolutePath)
-          sql(
-            s"""
-               |CREATE EXTERNAL TABLE test_precision(name STRING, value DECIMAL(18,6))
-               |STORED AS PARQUET LOCATION '${dir.getAbsolutePath}'
-               |""".stripMargin)
-          checkAnswer(sql("SELECT * FROM test_precision"), Row("dummy", null))
-        }
-      }
-    }
-  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -905,4 +905,21 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
       }
     }
   }
+
+  test("SPARK-37196: HiveDecimal enforcePrecisionScala failed return null") {
+    withTempDir { dir =>
+      withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET.key -> "false") {
+        withTable("test_precision") {
+          val df = sql("SELECT 'dummy' AS name, 1000000000000000000010.7000000000000010 AS value")
+          df.write.mode("Overwrite").parquet(dir.getAbsolutePath)
+          sql(
+            s"""
+               |CREATE EXTERNAL TABLE test_precision(name STRING, value DECIMAL(18,6))
+               |STORED AS PARQUET LOCATION '${dir.getAbsolutePath}'
+               |""".stripMargin)
+          checkAnswer(sql("SELECT * FROM test_precision"), Row("dummy", null))
+        }
+      }
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2647,7 +2647,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
     withTempDir { dir =>
       withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET.key -> "false") {
         withTable("test_precision") {
-          val df = sql("SELECT 'dummy' AS name, 1000000000000000000010.7000000000000010 AS value")
+          val df = sql(s"SELECT 'dummy' AS name, ${"1" * 20}.${"2" * 18} AS value")
           df.write.mode("Overwrite").parquet(dir.getAbsolutePath)
           sql(
             s"""

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2642,6 +2642,23 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       }
     }
   }
+
+  test("SPARK-37196: HiveDecimal Precision Scale match failed should return null") {
+    withTempDir { dir =>
+      withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET.key -> "false") {
+        withTable("test_precision") {
+          val df = sql("SELECT 'dummy' AS name, 1000000000000000000010.7000000000000010 AS value")
+          df.write.mode("Overwrite").parquet(dir.getAbsolutePath)
+          sql(
+            s"""
+               |CREATE EXTERNAL TABLE test_precision(name STRING, value DECIMAL(18,6))
+               |STORED AS PARQUET LOCATION '${dir.getAbsolutePath}'
+               |""".stripMargin)
+          checkAnswer(sql("SELECT * FROM test_precision"), Row("dummy", null))
+        }
+      }
+    }
+  }
 }
 
 @SlowHiveTest


### PR DESCRIPTION
### What changes were proposed in this pull request?
For case 
```
withTempDir { dir =>
      withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET.key -> "false") {
        withTable("test_precision") {
          val df = sql("SELECT 'dummy' AS name, 1000000000000000000010.7000000000000010 AS value")
          df.write.mode("Overwrite").parquet(dir.getAbsolutePath)
          sql(
            s"""
               |CREATE EXTERNAL TABLE test_precision(name STRING, value DECIMAL(18,6))
               |STORED AS PARQUET LOCATION '${dir.getAbsolutePath}'
               |""".stripMargin)
          checkAnswer(sql("SELECT * FROM test_precision"), Row("dummy", null))
        }
      }
    }
```

We write a data with schema 


It's caused by you create a df with 
```
root
 |-- name: string (nullable = false)
 |-- value: decimal(38,16) (nullable = false)
```
but create table schema 

```
root
 |-- name: string (nullable = false)
 |-- value: decimal(18,6) (nullable = false)
```

This will cause enforcePrecisionScale return `null`
```
  public HiveDecimal getPrimitiveJavaObject(Object o) {
    return o == null ? null : this.enforcePrecisionScale(((HiveDecimalWritable)o).getHiveDecimal());
  }
```
Then throw NPE when call `toCatalystDecimal `

We should judge if the return value is `null` to avoid throw NPE

### Why are the changes needed?
Fix bug


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UT