### PR TITLE
[SPARK-37243][SQL][DOC] Fix the format of the document

### DIFF
--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -389,7 +389,7 @@ SELECT * FROM students;
 +-----------+-------------------------+-----------+
 ```
 
-#### Insert with a column list
+##### Insert with a column list
 
 ```sql
 INSERT OVERWRITE students (address, name, student_id) VALUES


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes fix the format of the document in sql-ref-syntax-dml-insert-overwrite-table.md

Currently, the format is :
![image](https://user-images.githubusercontent.com/51110188/140735867-4a7fc050-d9e4-428e-8575-2fbc667c2d90.png)

It should be normal like other parts

### Why are the changes needed?
A minor format problem

### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
manual test
