### PR TITLE
[SPARK-37120][BUILD][FOLLOWUP] Use configured Java version in SQL/Hive module runs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -137,26 +137,26 @@ jobs:
         include:
           # Hive tests
           - modules: hive
-            java: 8
+            java: ${{ needs.configure-jobs.outputs.java }}
             hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
             hive: hive2.3
             included-tags: org.apache.spark.tags.SlowHiveTest
             comment: "- slow tests"
           - modules: hive
-            java: 8
+            java: ${{ needs.configure-jobs.outputs.java }}
             hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
             hive: hive2.3
             excluded-tags: org.apache.spark.tags.SlowHiveTest
             comment: "- other tests"
           # SQL tests
           - modules: sql
-            java: 8
+            java: ${{ needs.configure-jobs.outputs.java }}
             hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
             hive: hive2.3
             included-tags: org.apache.spark.tags.ExtendedSQLTest
             comment: "- slow tests"
           - modules: sql
-            java: 8
+            java: ${{ needs.configure-jobs.outputs.java }}
             hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
             hive: hive2.3
             excluded-tags: org.apache.spark.tags.ExtendedSQLTest


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of https://github.com/apache/spark/pull/34508 .
This PR aims to use the configured Java version in SQL/Hive module runs too.

### Why are the changes needed?

Java 11/17 is used correctly in the scheduled jobs except `included modules` like SQL/Hive.
- https://github.com/apache/spark/runs/4139231636?check_suite_focus=true (Java 11)
- https://github.com/apache/spark/runs/4141378544?check_suite_focus=true (Java 17)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A