### PR TITLE
[SPARK-37244][PYTHON] Build and run tests on Python 3.10

### DIFF
--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -25,7 +25,10 @@ import sys
 import threading
 import traceback
 import types
-from collections import Callable
+try:
+    from collections.abc import Callable
+except AttributeError:
+    from collections import Callable
 
 from py4j.clientserver import ClientServer
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support building and running tests on Python 3.10.

Python 3.10 added many new features and breaking changes.
- https://docs.python.org/3/whatsnew/3.10.html

For example, the following blocks building and testing PySpark on Python 3.10.

**PYTHON 3.9.7**
```
Python 3.9.7 (default, Oct 22 2021, 13:24:00)
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from collections import Callable
<stdin>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```

**PYTHON 3.10.0**
```
Python 3.10.0 (default, Oct 29 2021, 14:35:18) [Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from collections import Callable
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'Callable' from 'collections' (/Users/dongjoon/.pyenv/versions/3.10.0/lib/python3.10/collections/__init__.py)
```

### Why are the changes needed?

**BEFORE**
```
$ build/sbt -Phadoop-cloud -Phadoop-3.2 test:package
$ python/run-tests
Running PySpark tests. Output is in /Users/dongjoon/APACHE/spark-merge/python/unit-tests.log
Will test against the following Python executables: ['/Users/dongjoon/.pyenv/versions/3.10.0/bin/python3']
Will test the following Python modules: ['pyspark-core', 'pyspark-ml', 'pyspark-mllib', 'pyspark-pandas', 'pyspark-pandas-slow', 'pyspark-resource', 'pyspark-sql', 'pyspark-streaming']
/Users/dongjoon/.pyenv/versions/3.10.0/bin/python3 python_implementation is CPython
/Users/dongjoon/.pyenv/versions/3.10.0/bin/python3 version is: Python 3.10.0
Starting test(/Users/dongjoon/.pyenv/versions/3.10.0/bin/python3): pyspark.ml.tests.test_algorithms (temp output: /var/folders/mq/c32xpgtj4tj19vt8b10wp8rc0000gn/T/Users_dongjoon_.pyenv_versions_3.10.0_bin_python3__pyspark.ml.tests.test_algorithms__nfcl9j4y.log)
Starting test(/Users/dongjoon/.pyenv/versions/3.10.0/bin/python3): pyspark.ml.tests.test_base (temp output: /var/folders/mq/c32xpgtj4tj19vt8b10wp8rc0000gn/T/Users_dongjoon_.pyenv_versions_3.10.0_bin_python3__pyspark.ml.tests.test_base__143gcgep.log)
Starting test(/Users/dongjoon/.pyenv/versions/3.10.0/bin/python3): pyspark.ml.tests.test_evaluation (temp output: /var/folders/mq/c32xpgtj4tj19vt8b10wp8rc0000gn/T/Users_dongjoon_.pyenv_versions_3.10.0_bin_python3__pyspark.ml.tests.test_evaluation__jbhwc3cs.log)
Starting test(/Users/dongjoon/.pyenv/versions/3.10.0/bin/python3): pyspark.ml.tests.test_feature (temp output: /var/folders/mq/c32xpgtj4tj19vt8b10wp8rc0000gn/T/Users_dongjoon_.pyenv_versions_3.10.0_bin_python3__pyspark.ml.tests.test_feature__0vx175eo.log)
Traceback (most recent call last):
  File "/Users/dongjoon/.pyenv/versions/3.10.0/lib/python3.10/runpy.py", line 187, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/Users/dongjoon/.pyenv/versions/3.10.0/lib/python3.10/runpy.py", line 110, in _get_module_details
    __import__(pkg_name)
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/__init__.py", line 53, in <module>
    from pyspark.rdd import RDD, RDDBarrier
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/rdd.py", line 34, in <module>
    from pyspark.java_gateway import local_connect_and_auth
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/java_gateway.py", line 32, in <module>
    from pyspark.serializers import read_int, write_with_length, UTF8Deserializer
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/serializers.py", line 68, in <module>
    from pyspark.util import print_exec  # type: ignore
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/util.py", line 28, in <module>
    from collections import Callable
ImportError: cannot import name 'Callable' from 'collections' (/Users/dongjoon/.pyenv/versions/3.10.0/lib/python3.10/collections/__init__.py)

Had test failures in pyspark.ml.tests.test_feature with /Users/dongjoon/.pyenv/versions/3.10.0/bin/python3; see logs.
```

**AFTER**
- All tests passed except `PyArrow` related-tests which is beyond of this PR.
```
$ build/sbt -Phadoop-cloud -Phadoop-3.2 test:package
$ python/run-tests
...
```

### Does this PR introduce _any_ user-facing change?

Yes, this will add the official support of Python 3.10.

### How was this patch tested?

Pass the CIs and manually run Python tests on Python 3.10.