### PR TITLE
[SPARK-37252][PYTHON][TESTS] Ignore `test_memory_limit` on non-Linux environment

### DIFF
--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 import os
+import sys
 import tempfile
 import threading
 import time
@@ -188,9 +189,9 @@ class WorkerReuseTest(PySparkTestCase):
 
 
 @unittest.skipIf(
-    not has_resource_module,
+    not has_resource_module or sys.platform != 'linux',
     "Memory limit feature in Python worker is dependent on "
-    "Python's 'resource' module; however, not found.")
+    "Python's 'resource' module on Linux; however, not found or not on Linux.")
 class WorkerMemoryTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ignore `test_memory_limit` on non-Linux environment.

### Why are the changes needed?

Like the documentation https://github.com/apache/spark/pull/23664, it fails on non-Linux environment like the following MacOS example.

**BEFORE**
```
$ build/sbt -Phadoop-cloud -Phadoop-3.2 test:package
$ python/run-tests --modules pyspark-core
...
======================================================================
FAIL: test_memory_limit (pyspark.tests.test_worker.WorkerMemoryTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/tests/test_worker.py", line 212, in test_memory_limit
    self.assertEqual(soft_limit, 2 * 1024 * 1024 * 1024)
AssertionError: 9223372036854775807 != 2147483648

----------------------------------------------------------------------
```

**AFTER**
```
...
Tests passed in 104 seconds

Skipped tests in pyspark.tests.test_serializers with /Users/dongjoon/.pyenv/versions/3.8.12/bin/python3:
    test_serialize (pyspark.tests.test_serializers.SciPyTests) ... skipped 'SciPy not installed'

Skipped tests in pyspark.tests.test_worker with /Users/dongjoon/.pyenv/versions/3.8.12/bin/python3:
    test_memory_limit (pyspark.tests.test_worker.WorkerMemoryTest) ... skipped "Memory limit feature in Python worker is dependent on Python's 'resource' module on Linux; however, not found or not on Linux."
```

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manual.