### PR TITLE
[SPARK-37202][SQL] Treat `injectedFunctions` as custom built-in functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -228,7 +228,9 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
       builder: FunctionBuilder): Unit = {
     // We didn't do any check when replacing a function even if it's a builtin one.
     // So no need to do any extra check here.
-    customBuiltinFunctions.add(normalizeFuncName(name).funcName)
+    if (name.database.isEmpty) {
+      customBuiltinFunctions.add(normalizeFuncName(name).funcName)
+    }
     registerFunction(name, info, builder)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -235,7 +235,7 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
   }
 
   override def customBuiltinFunctionExists(name: FunctionIdentifier): Boolean = {
-    name.database.isEmpty && customBuiltinFunctions.contains(name.funcName)
+    name.database.isEmpty && customBuiltinFunctions.contains(normalizeFuncName(name).funcName)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1512,7 +1512,12 @@ class SessionCatalog(
     name.database.isEmpty &&
       (functionRegistry.functionExists(name) || tableFunctionRegistry.functionExists(name)) &&
       !FunctionRegistry.builtin.functionExists(name) &&
-      !TableFunctionRegistry.builtin.functionExists(name)
+      !TableFunctionRegistry.builtin.functionExists(name) &&
+      !functionRegistry.customBuiltinFunctionExists(name)
+  }
+
+  def isCustomBuiltinFunction(name: FunctionIdentifier): Boolean = {
+    functionRegistry.customBuiltinFunctionExists(name)
   }
 
   def isTempFunction(name: String): Boolean = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1854,12 +1854,20 @@ object QueryCompilationErrors {
     new AnalysisException(s"Cannot drop native function '$functionName'")
   }
 
+  def cannotDropCustomBuiltInFuncError(functionName: String): Throwable = {
+    new AnalysisException(s"Cannot drop custom built-in function '$functionName'")
+  }
+
   def cannotRefreshBuiltInFuncError(functionName: String): Throwable = {
     new AnalysisException(s"Cannot refresh built-in function $functionName")
   }
 
   def cannotRefreshTempFuncError(functionName: String): Throwable = {
     new AnalysisException(s"Cannot refresh temporary function $functionName")
+  }
+
+  def cannotRefreshCustomBuiltInFuncError(functionName: String): Throwable = {
+    new AnalysisException(s"Cannot refresh custom built-in function $functionName")
   }
 
   def noSuchFunctionError(identifier: FunctionIdentifier): Throwable = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
@@ -267,7 +267,7 @@ class SparkSessionExtensions {
 
   private[sql] def registerFunctions(functionRegistry: FunctionRegistry) = {
     for ((name, expressionInfo, function) <- injectedFunctions) {
-      functionRegistry.registerFunction(name, expressionInfo, function)
+      functionRegistry.registerCustomBuiltinFunction(name, expressionInfo, function)
     }
     functionRegistry
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -171,6 +171,9 @@ case class DropFunctionCommand(
       if (FunctionRegistry.builtin.functionExists(FunctionIdentifier(functionName))) {
         throw QueryCompilationErrors.cannotDropNativeFuncError(functionName)
       }
+      if (catalog.isCustomBuiltinFunction(FunctionIdentifier(functionName))) {
+        throw QueryCompilationErrors.cannotDropCustomBuiltInFuncError(functionName)
+      }
       catalog.dropTempFunction(functionName, ifExists)
     } else {
       // We are dropping a permanent function.
@@ -246,6 +249,9 @@ case class RefreshFunctionCommand(
     }
     if (catalog.isTemporaryFunction(FunctionIdentifier(functionName, databaseName))) {
       throw QueryCompilationErrors.cannotRefreshTempFuncError(functionName)
+    }
+    if (catalog.isCustomBuiltinFunction(FunctionIdentifier(functionName, databaseName))) {
+      throw QueryCompilationErrors.cannotRefreshCustomBuiltInFuncError(functionName)
     }
 
     val identifier = FunctionIdentifier(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -140,6 +140,16 @@ class SparkSessionExtensionSuite extends SparkFunSuite {
     }
   }
 
+  test("SPARK-37202: temp view refers a inject function") {
+    val extensions = create { extensions =>
+      extensions.injectFunction(MyExtensions.myFunction)
+    }
+    withSession(extensions) { session =>
+      session.sql("CREATE TEMP VIEW v AS SELECT myFunction(a) FROM VALUES(1), (2) t(a)")
+      session.sql("SELECT * FROM v")
+    }
+  }
+
   case class MyHintRule(spark: SparkSession) extends Rule[LogicalPlan] {
     val MY_HINT_NAME = Set("CONVERT_TO_EMPTY")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -145,6 +145,7 @@ class SparkSessionExtensionSuite extends SparkFunSuite {
       extensions.injectFunction(MyExtensions.myFunction)
     }
     withSession(extensions) { session =>
+      assert(!session.sessionState.catalog.isTemporaryFunction(MyExtensions.myFunction._1))
       session.sql("CREATE TEMP VIEW v AS SELECT myFunction(a) FROM VALUES(1), (2) t(a)")
       session.sql("SELECT * FROM v")
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes an issue that the `injectedFunctions` in `SparkSessionExtensions` can't be
resolved correctly if it's referred by a temporary view. This is because the injected functions
are not `UserDefinedExpression`. So they will be treated as temporary functions but couldn't
be captured as temporary functions during view creation. As a result, the function resolution
will fail if it's reffered by a temp view.

This PR adds a new concept `customBuiltinFunction`, so that the injected functions will be
treated as builtin functions intead of tempoary ones. With with way, it's not needed to be
captured by temp view anymore.

### Why are the changes needed?
bug fix


### Does this PR introduce _any_ user-facing change?
After this PR, the `SparkSessionExtensions.injectedFunctions` are not temporary functions anymore.
```scala
val extensions = create { extensions =>
  extensions.injectFunction(MyExtensions.myFunction)
}
withSession(extensions) { session =>
  // return `false` after this PR, and `true` before this PR
  session.sessionState.catalog.isTemporaryFunction(MyExtensions.myFunction._1)
}
```


### How was this patch tested?
newly added test