### PR TITLE
[SPARK-37239][YARN][TESTS][FOLLOWUP] Add UT to cover `Client.prepareLocalResources` with custom `STAGING_FILE_REPLICATION`

### DIFF
--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -351,6 +351,9 @@ class ClientSuite extends SparkFunSuite with Matchers {
     val client = createClient(sparkConf)
     client.prepareLocalResources(new Path(temp.getAbsolutePath()), Nil)
 
+    // It is difficult to assert the result of `setReplication` in UT because this method in
+    // `RawLocalFileSystem` always return true and not change the value of `replication`.
+    // So we can only assert the call of `client.copyFileToRemote` has passed in a non `None`.
     verify(client).copyFileToRemote(any(classOf[Path]), meq(new Path(archive.toURI())),
       meq(Some(replication.toShort)), any(classOf[MutableHashMap[URI, Path]]), anyBoolean(), any())
     classpath(client) should contain (buildPath(PWD, LOCALIZED_LIB_DIR, "*"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr add a new UT to cover `o.a.s.deploy.yarn.Client.prepareLocalResources` method with custom `STAGING_FILE_REPLICATION` configuration and change other related UTs to verify that the `replication` passed into the `copyFileToRemote` method is `None` explicitly.

### Why are the changes needed?
Add new UT.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass the Jenkins or GitHub Action
