### PR TITLE
[SPARK-37257][PYTHON] Update setup.py for Python 3.10

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -280,6 +280,7 @@ try:
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
             'Typing :: Typed'],


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes `setup.py` to note that PySpark works with Python 3.10.

### Why are the changes needed?

To officially support Python 3.10.

### Does this PR introduce _any_ user-facing change?

Yes, it officially supports Python 3.10.

### How was this patch tested?

It has been tested in https://github.com/apache/spark/pull/34526.
Arrow related features are technically optional.
