### PR TITLE
[SPARK-37201][SQL] GeneratorNestedColumnAliasing support Generate with Filter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -314,6 +314,10 @@ object NestedColumnAliasing {
  */
 object GeneratorNestedColumnAliasing {
   def unapply(plan: LogicalPlan): Option[LogicalPlan] = plan match {
+    // Either `nestedPruningOnExpressions` or `nestedSchemaPruningEnabled` is enabled, we
+    // need to prune nested columns through Project with under Filter then under Generate.
+    // The difference is when `nestedSchemaPruningEnabled` is on, nested columns will
+    // be pruned further at file format readers if it is supported.
     case Project(projectList, Filter(condition, g: Generate))
       if (SQLConf.get.nestedPruningOnExpressions ||
         SQLConf.get.nestedSchemaPruningEnabled) && canPruneGenerator(g.generator) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -314,6 +314,15 @@ object NestedColumnAliasing {
  */
 object GeneratorNestedColumnAliasing {
   def unapply(plan: LogicalPlan): Option[LogicalPlan] = plan match {
+    case Project(projectList, Filter(condition, g: Generate))
+      if (SQLConf.get.nestedPruningOnExpressions ||
+        SQLConf.get.nestedSchemaPruningEnabled) && canPruneGenerator(g.generator) =>
+      // On top on `Generate`, a `Project` that might have nested column accessors.
+      // We try to get alias maps for both project list and generator's children expressions.
+      val attrToExtractValues = NestedColumnAliasing.getAttributeToExtractValues(
+        projectList ++ Seq(condition) ++ g.generator.children, Seq.empty)
+      rewritePlanIfSubsetFieldsUsed(plan, g, attrToExtractValues)
+
     // Either `nestedPruningOnExpressions` or `nestedSchemaPruningEnabled` is enabled, we
     // need to prune nested columns through Project and under Generate. The difference is
     // when `nestedSchemaPruningEnabled` is on, nested columns will be pruned further at
@@ -324,82 +333,7 @@ object GeneratorNestedColumnAliasing {
       // We try to get alias maps for both project list and generator's children expressions.
       val attrToExtractValues = NestedColumnAliasing.getAttributeToExtractValues(
         projectList ++ g.generator.children, Seq.empty)
-      if (attrToExtractValues.isEmpty) {
-        return None
-      }
-      val generatorOutputSet = AttributeSet(g.qualifiedGeneratorOutput)
-      val (attrToExtractValuesOnGenerator, attrToExtractValuesNotOnGenerator) =
-        attrToExtractValues.partition { case (attr, _) =>
-          attr.references.subsetOf(generatorOutputSet) }
-
-      val pushedThrough = NestedColumnAliasing.rewritePlanWithAliases(
-        plan, attrToExtractValuesNotOnGenerator)
-
-      // If the generator output is `ArrayType`, we cannot push through the extractor.
-      // It is because we don't allow field extractor on two-level array,
-      // i.e., attr.field when attr is a ArrayType(ArrayType(...)).
-      // Similarily, we also cannot push through if the child of generator is `MapType`.
-      g.generator.children.head.dataType match {
-        case _: MapType => return Some(pushedThrough)
-        case ArrayType(_: ArrayType, _) => return Some(pushedThrough)
-        case _ =>
-      }
-
-      // Pruning on `Generator`'s output. We only process single field case.
-      // For multiple field case, we cannot directly move field extractor into
-      // the generator expression. A workaround is to re-construct array of struct
-      // from multiple fields. But it will be more complicated and may not worth.
-      // TODO(SPARK-34956): support multiple fields.
-      val nestedFieldsOnGenerator = attrToExtractValuesOnGenerator.values.flatten.toSet
-      if (nestedFieldsOnGenerator.size > 1 || nestedFieldsOnGenerator.isEmpty) {
-        Some(pushedThrough)
-      } else {
-        // Only one nested column accessor.
-        // E.g., df.select(explode($"items").as("item")).select($"item.a")
-        val nestedFieldOnGenerator = nestedFieldsOnGenerator.head
-        pushedThrough match {
-          case p @ Project(_, newG: Generate) =>
-            // Replace the child expression of `ExplodeBase` generator with
-            // nested column accessor.
-            // E.g., df.select(explode($"items").as("item")).select($"item.a") =>
-            //       df.select(explode($"items.a").as("item.a"))
-            val rewrittenG = newG.transformExpressions {
-              case e: ExplodeBase =>
-                val extractor = nestedFieldOnGenerator.transformUp {
-                  case _: Attribute =>
-                    e.child
-                  case g: GetStructField =>
-                    ExtractValue(g.child, Literal(g.extractFieldName), SQLConf.get.resolver)
-                }
-                e.withNewChildren(Seq(extractor))
-            }
-
-            // As we change the child of the generator, its output data type must be updated.
-            val updatedGeneratorOutput = rewrittenG.generatorOutput
-              .zip(rewrittenG.generator.elementSchema.toAttributes)
-              .map { case (oldAttr, newAttr) =>
-                newAttr.withExprId(oldAttr.exprId).withName(oldAttr.name)
-              }
-            assert(updatedGeneratorOutput.length == rewrittenG.generatorOutput.length,
-              "Updated generator output must have the same length " +
-                "with original generator output.")
-            val updatedGenerate = rewrittenG.copy(generatorOutput = updatedGeneratorOutput)
-
-            // Replace nested column accessor with generator output.
-            val attrExprIdsOnGenerator = attrToExtractValuesOnGenerator.keys.map(_.exprId).toSet
-            val updatedProject = p.withNewChildren(Seq(updatedGenerate)).transformExpressions {
-              case f: ExtractValue if nestedFieldsOnGenerator.contains(f) =>
-                updatedGenerate.output
-                  .find(a => attrExprIdsOnGenerator.contains(a.exprId))
-                  .getOrElse(f)
-            }
-            Some(updatedProject)
-
-          case other =>
-            // We should not reach here.
-            throw new IllegalStateException(s"Unreasonable plan after optimization: $other")
-        }
-      }
+      rewritePlanIfSubsetFieldsUsed(plan, g, attrToExtractValues)
 
     case g: Generate if SQLConf.get.nestedSchemaPruningEnabled &&
       canPruneGenerator(g.generator) =>
@@ -412,6 +346,88 @@ object GeneratorNestedColumnAliasing {
 
     case _ =>
       None
+  }
+
+  def rewritePlanIfSubsetFieldsUsed(
+      plan: LogicalPlan,
+      gen: Generate,
+      attrToExtractValues: Map[Attribute, Seq[ExtractValue]]): Option[LogicalPlan] = {
+    if (attrToExtractValues.isEmpty) {
+      return None
+    }
+    val generatorOutputSet = AttributeSet(gen.qualifiedGeneratorOutput)
+    val (attrToExtractValuesOnGenerator, attrToExtractValuesNotOnGenerator) =
+      attrToExtractValues.partition { case (attr, _) =>
+        attr.references.subsetOf(generatorOutputSet) }
+
+    val pushedThrough = NestedColumnAliasing.rewritePlanWithAliases(
+      plan, attrToExtractValuesNotOnGenerator)
+
+    // If the generator output is `ArrayType`, we cannot push through the extractor.
+    // It is because we don't allow field extractor on two-level array,
+    // i.e., attr.field when attr is a ArrayType(ArrayType(...)).
+    // Similarily, we also cannot push through if the child of generator is `MapType`.
+    gen.generator.children.head.dataType match {
+      case _: MapType => return Some(pushedThrough)
+      case ArrayType(_: ArrayType, _) => return Some(pushedThrough)
+      case _ =>
+    }
+
+    // Pruning on `Generator`'s output. We only process single field case.
+    // For multiple field case, we cannot directly move field extractor into
+    // the generator expression. A workaround is to re-construct array of struct
+    // from multiple fields. But it will be more complicated and may not worth.
+    // TODO(SPARK-34956): support multiple fields.
+    val nestedFieldsOnGenerator = attrToExtractValuesOnGenerator.values.flatten.toSet
+    if (nestedFieldsOnGenerator.size > 1 || nestedFieldsOnGenerator.isEmpty) {
+      Some(pushedThrough)
+    } else {
+      // Only one nested column accessor.
+      // E.g., df.select(explode($"items").as("item")).select($"item.a")
+      val nestedFieldOnGenerator = nestedFieldsOnGenerator.head
+      pushedThrough match {
+        case p @ Project(_, newG: Generate) =>
+          // Replace the child expression of `ExplodeBase` generator with
+          // nested column accessor.
+          // E.g., df.select(explode($"items").as("item")).select($"item.a") =>
+          //       df.select(explode($"items.a").as("item.a"))
+          val rewrittenG = newG.transformExpressions {
+            case e: ExplodeBase =>
+              val extractor = nestedFieldOnGenerator.transformUp {
+                case _: Attribute =>
+                  e.child
+                case g: GetStructField =>
+                  ExtractValue(g.child, Literal(g.extractFieldName), SQLConf.get.resolver)
+              }
+              e.withNewChildren(Seq(extractor))
+          }
+
+          // As we change the child of the generator, its output data type must be updated.
+          val updatedGeneratorOutput = rewrittenG.generatorOutput
+            .zip(rewrittenG.generator.elementSchema.toAttributes)
+            .map { case (oldAttr, newAttr) =>
+              newAttr.withExprId(oldAttr.exprId).withName(oldAttr.name)
+            }
+          assert(updatedGeneratorOutput.length == rewrittenG.generatorOutput.length,
+            "Updated generator output must have the same length " +
+              "with original generator output.")
+          val updatedGenerate = rewrittenG.copy(generatorOutput = updatedGeneratorOutput)
+
+          // Replace nested column accessor with generator output.
+          val attrExprIdsOnGenerator = attrToExtractValuesOnGenerator.keys.map(_.exprId).toSet
+          val updatedProject = p.withNewChildren(Seq(updatedGenerate)).transformExpressions {
+            case f: ExtractValue if nestedFieldsOnGenerator.contains(f) =>
+              updatedGenerate.output
+                .find(a => attrExprIdsOnGenerator.contains(a.exprId))
+                .getOrElse(f)
+          }
+          Some(updatedProject)
+
+        case other =>
+          // We should not reach here.
+          throw new IllegalStateException(s"Unreasonable plan after optimization: $other")
+      }
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -321,8 +321,9 @@ object GeneratorNestedColumnAliasing {
     case Project(projectList, Filter(condition, g: Generate))
       if (SQLConf.get.nestedPruningOnExpressions ||
         SQLConf.get.nestedSchemaPruningEnabled) && canPruneGenerator(g.generator) =>
-      // On top on `Generate`, a `Project` that might have nested column accessors.
-      // We try to get alias maps for both project list and generator's children expressions.
+      // On top on `Generate`, a `Project` and `Filter`'s condition that might have nested
+      // column accessors. We try to get alias maps for both project list and generator's
+      // children expressions.
       val attrToExtractValues = NestedColumnAliasing.getAttributeToExtractValues(
         projectList ++ Seq(condition) ++ g.generator.children, Seq.empty)
       rewritePlanIfSubsetFieldsUsed(plan, g, attrToExtractValues)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In current ` GeneratorNestedColumnAliasing`, spark only support  push down case with Project as below
```
Project [v1#225, el#226]
   +- Project [struct#220.v1 AS v1#225, el#226, struct#220]
      +- Generate explode(array#221), false, [el#226]
         +- SubqueryAlias spark_catalog.default.table
            +- Relation default.table[struct#220,array#221] parquet
```

In this pr we support push dow with Project and Filter as below
```
Project [v1#225, el#226]
 +- Project [struct#220.v1 AS v1#225, el#226, struct#220]
    +- Filter ((el#226 = cx1) AND (struct#220.v2 = v3))
      +- Generate explode(array#221), false, [el#226]
         +- SubqueryAlias spark_catalog.default.table
            +- Relation default.table[struct#220,array#221] parquet
```

### Why are the changes needed?
Improve GeneratorNestedColumnAliasing to support more case


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add UT
