### PR TITLE
[SPARK-37120][BUILD][FOLLOWUP] Test master branch and skip mima/unidoc in Java11/17 tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -78,15 +78,15 @@ jobs:
           echo '::set-output name=hadoop::hadoop3.2'
         elif [ "${{ github.event.schedule }}" = "0 13 * * *" ]; then
           echo '::set-output name=java::11'
-          echo '::set-output name=branch::branch-3.2'
+          echo '::set-output name=branch::master'
           echo '::set-output name=type::scheduled'
-          echo '::set-output name=envs::{}'
+          echo '::set-output name=envs::{"SKIP_MIMA": "true", "SKIP_UNIDOC": "true"}'
           echo '::set-output name=hadoop::hadoop3.2'
         elif [ "${{ github.event.schedule }}" = "0 16 * * *" ]; then
           echo '::set-output name=java::17'
-          echo '::set-output name=branch::branch-3.2'
+          echo '::set-output name=branch::master'
           echo '::set-output name=type::scheduled'
-          echo '::set-output name=envs::{}'
+          echo '::set-output name=envs::{"SKIP_MIMA": "true", "SKIP_UNIDOC": "true"}'
           echo '::set-output name=hadoop::hadoop3.2'
         else
           echo '::set-output name=java::8'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #34508 . 
This PR aims to switch the test branch from `branch-3.2` to `master` and skip MiMa/unidoc in Java11/17 tests.

### Why are the changes needed?

Apache Spark use only Java 8 for MiMa/Unidoc steps.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A