### PR TITLE
[SPARK-37264][BUILD] Exclude `hadoop-client-api` transitive dependency from `orc-core`

### DIFF
--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -70,6 +70,7 @@ JAVA_VERSION=$($MVN -q \
     --non-recursive \
     org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)
 if [[ $(echo "$JAVA_VERSION" | grep "^17") ]]; then
+  # TODO(SPARK-37265) Support Java 17 in dev/test-dependencies.sh
   echo "Skip dependency testing on Java $JAVA_VERSION"
   exit 0
 fi

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -63,18 +63,6 @@ if [[ "$SCALA_BINARY_VERSION" != "2.12" ]]; then
   echo "Skip dependency testing on $SCALA_BINARY_VERSION"
   exit 0
 fi
-
-JAVA_VERSION=$($MVN -q \
-    -Dexec.executable="echo" \
-    -Dexec.args='${java.version}' \
-    --non-recursive \
-    org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)
-if [[ $(echo "$JAVA_VERSION" | grep "^17") ]]; then
-  # TODO(SPARK-37265) Support Java 17 in dev/test-dependencies.sh
-  echo "Skip dependency testing on Java $JAVA_VERSION"
-  exit 0
-fi
-
 set -e
 TEMP_VERSION="spark-$(python3 -S -c "import random; print(random.randrange(100000, 999999))")"
 

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -63,6 +63,17 @@ if [[ "$SCALA_BINARY_VERSION" != "2.12" ]]; then
   echo "Skip dependency testing on $SCALA_BINARY_VERSION"
   exit 0
 fi
+
+JAVA_VERSION=$($MVN -q \
+    -Dexec.executable="echo" \
+    -Dexec.args='${java.version}' \
+    --non-recursive \
+    org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)
+if [[ $(echo "$JAVA_VERSION" | grep "^17") ]]; then
+  echo "Skip dependency testing on Java $JAVA_VERSION"
+  exit 0
+fi
+
 set -e
 TEMP_VERSION="spark-$(python3 -S -c "import random; print(random.randrange(100000, 999999))")"
 

--- a/pom.xml
+++ b/pom.xml
@@ -2328,6 +2328,10 @@
             <artifactId>hadoop-hdfs</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-storage-api</artifactId>
           </exclusion>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Like `hadoop-common` and `hadoop-hdfs`, this PR proposes to exclude `hadoop-client-api` transitive dependency from `orc-core`.

### Why are the changes needed?

Since Apache Hadoop 2.7 doesn't work on Java 17, Apache ORC has a dependency on Hadoop 3.3.1.
This causes `test-dependencies.sh` failure on Java 17 on `hadoop-2.7` profile.  As a result, `run-tests.py` also fails.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Confirmed that `test-dependencyies.sh` works on Java 17 correctly because the transitive dependency is cut.
```
JAVA_HOME=/path/to/java17/ build/mvn -Phadoop-2.7 dependency:tree
...
[INFO] +- org.apache.orc:orc-core:jar:1.7.1:compile
[INFO] |  +- org.apache.orc:orc-shims:jar:1.7.1:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:2.5.0:compile
[INFO] |  +- io.airlift:aircompressor:jar:0.21:compile
[INFO] |  +- org.jetbrains:annotations:jar:17.0.0:compile
[INFO] |  \- org.threeten:threeten-extra:jar:1.5.0:compile

...
```