### PR TITLE
[SPARK-37266][SQL] View text can only be SELECT queries

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, ExpressionInfo, UpCast}
-import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParserInterface}
+import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, SubqueryAlias, View}
 import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, StringUtils}
 import org.apache.spark.sql.connector.catalog.CatalogManager
@@ -877,7 +877,12 @@ class SessionCatalog(
     }
     val viewConfigs = metadata.viewSQLConfigs
     val parsedPlan = SQLConf.withExistingConf(View.effectiveSQLConf(viewConfigs, isTempView)) {
-      parser.parsePlan(viewText)
+      try {
+        parser.parseQuery(viewText)
+      } catch {
+        case _: ParseException => throw new AnalysisException(
+          s"Invalid view text of view ${metadata.qualifiedName}, it may have been tampered with")
+      }
     }
     val projectList = if (!isHiveCreatedView(metadata)) {
       val viewColumnNames = if (metadata.viewQueryColumnNames.isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -880,8 +880,8 @@ class SessionCatalog(
       try {
         parser.parseQuery(viewText)
       } catch {
-        case _: ParseException => throw new AnalysisException(
-          s"Invalid view text of view ${metadata.qualifiedName}, it may have been tampered with")
+        case _: ParseException =>
+          throw QueryCompilationErrors.invalidViewText(viewText, metadata.qualifiedName)
       }
     }
     val projectList = if (!isHiveCreatedView(metadata)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -73,6 +73,11 @@ abstract class AbstractSqlParser extends ParserInterface with SQLConfHelper with
     astBuilder.visitSingleTableSchema(parser.singleTableSchema())
   }
 
+  /** Creates LogicalPlan of query for a given SQL string. */
+  override def parseQuery(sqlText: String): LogicalPlan = parse(sqlText) { parser =>
+    astBuilder.visitQuery(parser.query())
+  }
+
   /** Creates LogicalPlan for a given SQL string. */
   override def parsePlan(sqlText: String): LogicalPlan = parse(sqlText) { parser =>
     astBuilder.visitSingleStatement(parser.singleStatement()) match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -73,7 +73,7 @@ abstract class AbstractSqlParser extends ParserInterface with SQLConfHelper with
     astBuilder.visitSingleTableSchema(parser.singleTableSchema())
   }
 
-  /** Creates LogicalPlan of query for a given SQL string. */
+  /** Creates LogicalPlan for a given SQL string of query. */
   override def parseQuery(sqlText: String): LogicalPlan = parse(sqlText) { parser =>
     astBuilder.visitQuery(parser.query())
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserInterface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserInterface.scala
@@ -72,7 +72,7 @@ trait ParserInterface {
   def parseDataType(sqlText: String): DataType
 
   /**
-   * Parse a string to a [[LogicalPlan]] of query.
+   * Parse a query string to a [[LogicalPlan]].
    */
   @throws[ParseException]("Text cannot be parsed to a LogicalPlan")
   def parseQuery(sqlText: String): LogicalPlan

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserInterface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserInterface.scala
@@ -70,4 +70,10 @@ trait ParserInterface {
    */
   @throws[ParseException]("Text cannot be parsed to a DataType")
   def parseDataType(sqlText: String): DataType
+
+  /**
+   * Parse a string to a [[LogicalPlan]] of query.
+   */
+  @throws[ParseException]("Text cannot be parsed to a LogicalPlan")
+  def parseQuery(sqlText: String): LogicalPlan
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2366,4 +2366,9 @@ object QueryCompilationErrors {
   def tableIndexNotSupportedError(errorMessage: String): Throwable = {
     new AnalysisException(errorMessage)
   }
+
+  def invalidViewText(viewText: String, tableName: String): Throwable = {
+    new AnalysisException(
+      s"Invalid view text: $viewText. The view $tableName may have been tampered with")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -431,6 +431,9 @@ case class MyParser(spark: SparkSession, delegate: ParserInterface) extends Pars
 
   override def parseDataType(sqlText: String): DataType =
     delegate.parseDataType(sqlText)
+
+  override def parseQuery(sqlText: String): LogicalPlan =
+    delegate.parseQuery(sqlText)
 }
 
 object MyExtensions {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -536,18 +536,14 @@ class PersistedViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
       sql("CREATE VIEW v AS SELECT 1")
       val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("v"))
       val dropView = "DROP VIEW v"
-      try {
-        // Simulate the behavior of hackers
-        val tamperedTable = table.copy(viewText = Some(dropView))
-        spark.sessionState.catalog.alterTable(tamperedTable)
-        val message = intercept[AnalysisException] {
-          sql("SELECT * FROM v")
-        }.getMessage
-        assert(message.contains(s"Invalid view text: $dropView." +
-          s" The view ${table.qualifiedName} may have been tampered with"))
-      } finally {
-        sql(dropView)
-      }
+      // Simulate the behavior of hackers
+      val tamperedTable = table.copy(viewText = Some(dropView))
+      spark.sessionState.catalog.alterTable(tamperedTable)
+      val message = intercept[AnalysisException] {
+        sql("SELECT * FROM v")
+      }.getMessage
+      assert(message.contains(s"Invalid view text: $dropView." +
+        s" The view ${table.qualifiedName} may have been tampered with"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -531,22 +531,23 @@ class PersistedViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
     }
   }
 
-  test("SPARK-37266: Optimize the analysis for view text of persistent view and" +
-    " fix security vulnerabilities caused by sql tampering") {
-    sql("CREATE VIEW v AS SELECT 1")
-    val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("v"))
-    val dropView = "DROP VIEW v"
-    try {
-      // Simulate the behavior of hackers
-      val tamperedTable = table.copy(viewText = Some(dropView))
-      spark.sessionState.catalog.alterTable(tamperedTable)
-      val message = intercept[AnalysisException] {
-        sql("SELECT * FROM v")
-      }.getMessage
-      assert(message.contains(s"Invalid view text: $dropView." +
-        s" The view ${table.qualifiedName} may have been tampered with"))
-    } finally {
-      sql(dropView)
+  test("SPARK-37266: View text can only be SELECT queries") {
+    withView("v") {
+      sql("CREATE VIEW v AS SELECT 1")
+      val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("v"))
+      val dropView = "DROP VIEW v"
+      try {
+        // Simulate the behavior of hackers
+        val tamperedTable = table.copy(viewText = Some(dropView))
+        spark.sessionState.catalog.alterTable(tamperedTable)
+        val message = intercept[AnalysisException] {
+          sql("SELECT * FROM v")
+        }.getMessage
+        assert(message.contains(s"Invalid view text: $dropView." +
+          s" The view ${table.qualifiedName} may have been tampered with"))
+      } finally {
+        sql(dropView)
+      }
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -62,6 +62,7 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
     sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month = 2) SELECT 3, 3")
     sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month = 3) SELECT 3, 3")
     sql("CREATE VIEW parquet_view1 as select * from parquet_tab4")
+    sql("CREATE VIEW parquet_view2 as select * from parquet_tab4")
   }
 
   override protected def afterAll(): Unit = {
@@ -327,15 +328,17 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
 
   test("SPARK-37266: Optimize the analysis for view text of persistent view and" +
     " fix security vulnerabilities caused by sql tampering") {
-    val table = hiveContext.sessionState.catalog.getTableMetadata(TableIdentifier("parquet_view1"))
-    val tamperedTable = table.copy(viewText = Some("drop table parquet_tab1"))
+    val table = hiveContext.sessionState.catalog.getTableMetadata(TableIdentifier("parquet_view2"))
     try {
       // Simulate the behavior of hackers
+      val tamperedViewText = "drop view parquet_view2"
+      val tamperedTable = table.copy(viewText = Some(tamperedViewText))
       hiveContext.sessionState.catalog.alterTable(tamperedTable)
       val message = intercept[AnalysisException] {
-        sql("SELECT * FROM parquet_view1")
+        sql("SELECT * FROM parquet_view2")
       }.getMessage
-      assert(message.contains("Invalid view text of view default.parquet_view1"))
+      assert(message.contains(s"Invalid view text: $tamperedViewText." +
+        s" The view ${table.qualifiedName} may have been tampered with"))
     } finally {
       hiveContext.sessionState.catalog.alterTable(table)
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -330,6 +330,7 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
     val table = hiveContext.sessionState.catalog.getTableMetadata(TableIdentifier("parquet_view1"))
     val tamperedTable = table.copy(viewText = Some("drop table parquet_tab1"))
     try {
+      // Simulate hacker behavior
       hiveContext.sessionState.catalog.alterTable(tamperedTable)
       val message = intercept[AnalysisException] {
         sql("SELECT * FROM parquet_view1")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -62,7 +62,6 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
     sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month = 2) SELECT 3, 3")
     sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month = 3) SELECT 3, 3")
     sql("CREATE VIEW parquet_view1 as select * from parquet_tab4")
-    sql("CREATE VIEW parquet_view2 as select * from parquet_tab4")
   }
 
   override protected def afterAll(): Unit = {
@@ -328,6 +327,7 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
 
   test("SPARK-37266: Optimize the analysis for view text of persistent view and" +
     " fix security vulnerabilities caused by sql tampering") {
+    sql("CREATE VIEW parquet_view2 as select * from parquet_tab4")
     val table = hiveContext.sessionState.catalog.getTableMetadata(TableIdentifier("parquet_view2"))
     try {
       // Simulate the behavior of hackers
@@ -340,7 +340,7 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       assert(message.contains(s"Invalid view text: $tamperedViewText." +
         s" The view ${table.qualifiedName} may have been tampered with"))
     } finally {
-      hiveContext.sessionState.catalog.alterTable(table)
+      sql("DROP VIEW parquet_view2")
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -330,7 +330,7 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
     val table = hiveContext.sessionState.catalog.getTableMetadata(TableIdentifier("parquet_view1"))
     val tamperedTable = table.copy(viewText = Some("drop table parquet_tab1"))
     try {
-      // Simulate hacker behavior
+      // Simulate the behavior of hackers
       hiveContext.sessionState.catalog.alterTable(tamperedTable)
       val message = intercept[AnalysisException] {
         sql("SELECT * FROM parquet_view1")


### PR DESCRIPTION
### What changes were proposed in this pull request?

The current implementation of persistent view is create hive table with view text.
The view text is just a query string, so the hackers may tamper with it through various means.
Such as, `select * from tab1` tampered with `drop table tab1`.


### Why are the changes needed?
First, the view text is query string, `parser.parsePlan(viewText)` occurs more overhead than `parser.parseQuery(viewText)`.
Second, the view text can be tampered by hackers and issue security vulnerabilities.


### Does this PR introduce _any_ user-facing change?
'No'. Unless hackers tamper view text, user will not see any change.


### How was this patch tested?
New tests.
