### PR TITLE
[SPARK-37022][PYTHON][FOLLOW-UP] Change python/pyproject.toml to dev/pyproject.toml in reformat-python script

### DIFF
--- a/dev/reformat-python
+++ b/dev/reformat-python
@@ -28,4 +28,4 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-$BLACK_BUILD --config python/pyproject.toml python/pyspark
+$BLACK_BUILD --config dev/pyproject.toml python/pyspark


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a small followup of https://github.com/apache/spark/pull/34297. There was a mistake during moving file from `python/pyproject.toml` to `dev/pyproject.toml` in `reformat-python` script. We should also fix `reformat-python`.

### Why are the changes needed?

To make `reformat-python` script runnable.

### Does this PR introduce _any_ user-facing change?

No, dev only.

### How was this patch tested?

Manually tested via running `./dev/reformat-python` script.

**Before:**

```
Usage: __main__.py [OPTIONS] SRC ...
Try '__main__.py -h' for help.

Error: Invalid value for '--config': File 'python/pyproject.toml' does not exist.
```

**After:**

```
All done! ✨ 🍰 ✨
358 files left unchanged.
```