### PR TITLE
[SPARK-37272][TESTS] Add `ExtendedRocksDBTest` and disable RocksDB tests on Apple Silicon

### DIFF
--- a/common/tags/src/test/java/org/apache/spark/tags/ExtendedRocksDBTest.java
+++ b/common/tags/src/test/java/org/apache/spark/tags/ExtendedRocksDBTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.tags;
+
+import org.scalatest.TagAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ExtendedRocksDBTest { }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -27,7 +27,9 @@ import org.apache.spark.sql.execution.streaming.{MemoryStream, StreamingQueryWra
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming._
+import org.apache.spark.tags.ExtendedRocksDBTest
 
+@ExtendedRocksDBTest
 class RocksDBStateStoreIntegrationSuite extends StreamTest {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -30,9 +30,11 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.StatefulOperatorStateInfo
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.tags.ExtendedRocksDBTest
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.Utils
 
+@ExtendedRocksDBTest
 class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvider]
   with BeforeAndAfter {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -29,8 +29,10 @@ import org.apache.spark._
 import org.apache.spark.sql.catalyst.util.quietly
 import org.apache.spark.sql.execution.streaming.CreateAtomicTestManager
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.tags.ExtendedRocksDBTest
 import org.apache.spark.util.{ThreadUtils, Utils}
 
+@ExtendedRocksDBTest
 class RocksDBSuite extends SparkFunSuite {
 
   test("RocksDB: get, put, iterator, commit, load") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
@@ -52,7 +52,8 @@ class StreamingSessionWindowSuite extends StreamTest
     // RocksDB doesn't support Apple Silicon yet
     if (System.getProperty("os.name").equals("Mac OS X") &&
         System.getProperty("os.arch").equals("aarch64")) {
-      providerOptions = providerOptions.take(1)
+      providerOptions = providerOptions
+        .filterNot(_._2.contains(classOf[RocksDBStateStoreProvider].getSimpleName))
     }
 
     val availableOptions = for (

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
@@ -43,11 +43,16 @@ class StreamingSessionWindowSuite extends StreamTest
     val mergingSessionOptions = Seq(true, false).map { value =>
       (SQLConf.STREAMING_SESSION_WINDOW_MERGE_SESSIONS_IN_LOCAL_PARTITION.key, value)
     }
-    val providerOptions = Seq(
+    var providerOptions = Seq(
       classOf[HDFSBackedStateStoreProvider].getCanonicalName,
       classOf[RocksDBStateStoreProvider].getCanonicalName
     ).map { value =>
       (SQLConf.STATE_STORE_PROVIDER_CLASS.key, value.stripSuffix("$"))
+    }
+    // RocksDB doesn't support Apple Silicon yet
+    if (System.getProperty("os.name").equals("Mac OS X") &&
+        System.getProperty("os.arch").equals("aarch64")) {
+      providerOptions = providerOptions.take(1)
     }
 
     val availableOptions = for (


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `ExtendedRocksDBTest` to disable `RocksDB` selectively on Apple Silicon.
- Add `ExtendedRocksDBTest` test tag
- Disable RocksDB test cases from `StreamingSessionWindowSuite`.

### Why are the changes needed?

Since `RocksDBJNI` still doesn't support Apple Silicon natively, the following failures occur on M1.

**BEFORE**
```
$ build/sbt "sql/testOnly *RocksDB* *.StreamingSessionWindowSuite"
...
[info] Run completed in 23 seconds, 281 milliseconds.
[info] Total number of tests run: 32
[info] Suites: completed 2, aborted 2
[info] Tests: succeeded 22, failed 10, canceled 0, ignored 0, pending 0
[info] *** 2 SUITES ABORTED ***
[info] *** 10 TESTS FAILED ***
[error] Failed tests:
[error] 	org.apache.spark.sql.streaming.StreamingSessionWindowSuite
[error] 	org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreIntegrationSuite
[error] Error during tests:
[error] 	org.apache.spark.sql.execution.streaming.state.RocksDBSuite
[error] 	org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreSuite
[error] (sql / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 43 s, completed Nov 10, 2021 4:29:50 PM
```

**AFTER**
```
$ build/sbt "sql/testOnly *RocksDB* *.StreamingSessionWindowSuite" -Dtest.exclude.tags=org.apache.spark.tags.ExtendedRocksDBTest
...
[info] Run completed in 21 seconds, 353 milliseconds.
[info] Total number of tests run: 14
[info] Suites: completed 4, aborted 0
[info] Tests: succeeded 14, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 41 s, completed Nov 10, 2021 4:37:01 PM
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually test on Apple Silicon (M1/M1 Pro/M1 Max).