### PR TITLE
[SPARK-37263][PYTHON] Add PandasAPIOnSparkAdviceWarning class

### DIFF
--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -133,6 +133,19 @@ _options: List[Option] = [
         ),
     ),
     Option(
+        key="display.log_advice",
+        doc=(
+            "This determines whether or not to issue advice log for pandas-on-Spark APIs. "
+            "pandas API on Spark exposes appropriate warnings using a function called log_advice "
+            "because there are many expensive operations and users who are not familiar with "
+            "distributed environments can easily make mistakes. "
+            "However, sometimes these warnings appear so often that they can annoy users. "
+            "Thus, this option can be used to decide whether to turn the log_advice on or off."
+        ),
+        default=False,
+        types=bool,
+    ),
+    Option(
         key="compute.max_rows",
         doc=(
             "'compute.max_rows' sets the limit of the current pandas-on-Spark DataFrame. "

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -133,19 +133,6 @@ _options: List[Option] = [
         ),
     ),
     Option(
-        key="display.log_advice",
-        doc=(
-            "This determines whether or not to issue advice log for pandas-on-Spark APIs. "
-            "pandas API on Spark exposes appropriate warnings using a function called log_advice "
-            "because there are many expensive operations and users who are not familiar with "
-            "distributed environments can easily make mistakes. "
-            "However, sometimes these warnings appear so often that they can annoy users. "
-            "Thus, this option can be used to decide whether to turn the log_advice on or off."
-        ),
-        default=False,
-        types=bool,
-    ),
-    Option(
         key="compute.max_rows",
         doc=(
             "'compute.max_rows' sets the limit of the current pandas-on-Spark DataFrame. "

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -964,7 +964,10 @@ def log_advice(message: str) -> None:
     for the existing pandas/PySpark users who may not be familiar with distributed environments
     or the behavior of pandas.
     """
-    warnings.warn(message, UserWarning)
+    from pyspark.pandas.config import get_option
+
+    if get_option("display.log_advice"):
+        warnings.warn(message, UserWarning)
 
 
 def _test() -> None:

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -65,6 +65,10 @@ ERROR_MESSAGE_CANNOT_COMBINE = (
 SPARK_CONF_ARROW_ENABLED = "spark.sql.execution.arrow.pyspark.enabled"
 
 
+class PandasAPIOnSparkAdviceWarning(Warning):
+    pass
+
+
 def same_anchor(
     this: Union["DataFrame", "IndexOpsMixin", "InternalFrame"],
     that: Union["DataFrame", "IndexOpsMixin", "InternalFrame"],
@@ -964,10 +968,7 @@ def log_advice(message: str) -> None:
     for the existing pandas/PySpark users who may not be familiar with distributed environments
     or the behavior of pandas.
     """
-    from pyspark.pandas.config import get_option
-
-    if get_option("display.log_advice"):
-        warnings.warn(message, UserWarning)
+    warnings.warn(message, PandasAPIOnSparkAdviceWarning)
 
 
 def _test() -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes add warning class `PandasAPIOnSparkAdviceWarning`, so that users can manually turn the warning off by using `warnings.simplefilter`.

The `PandasAPIOnSparkAdviceWarning` is issued by default as below:

```python
>>> psdf.to_pandas()
/Users/haejoon.lee/Desktop/git_store/spark/python/pyspark/pandas/utils.py:971: PandasAPIOnSparkAdviceWarning: `to_pandas` loads all data into the driver's memory. It should only be used if the resulting pandas DataFrame is expected to be small.
  warnings.warn(message, PandasAPIOnSparkAdviceWarning)
   A
0  1
1  2
2  3
3  4

```

For silencing the advice warning message, you can use `warnings.simplefilter` with specifying the `PandasAPIOnSparkAdviceWarning` class  as below:

```python
>>> from pyspark.pandas.utils import PandasAPIOnSparkAdviceWarning
>>> with warnings.catch_warnings():
...     warnings.simplefilter('ignore', PandasAPIOnSparkAdviceWarning)
...     psdf.to_pandas()
...
   A
0  1
1  2
2  3
3  4
```

### Why are the changes needed?

Sometimes the messages are too verbose to display, so someone might not need to see the advice log.

### Does this PR introduce _any_ user-facing change?

The `UserWarning` for log_advice is changed to `PandasAPIOnSparkAdviceWarning`.


### How was this patch tested?

Manually test