### PR TITLE
[SPARK-37288][PYTHON][3.2] Backport  since annotation update

### DIFF
--- a/python/pyspark/__init__.pyi
+++ b/python/pyspark/__init__.pyi
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Callable, Optional, TypeVar
+from typing import Callable, Optional, TypeVar, Union
 
 from pyspark.accumulators import (  # noqa: F401
     Accumulator as Accumulator,
@@ -67,7 +67,7 @@ from pyspark.sql import (  # noqa: F401
 T = TypeVar("T")
 F = TypeVar("F", bound=Callable)
 
-def since(version: str) -> Callable[[T], T]: ...
+def since(version: Union[str, float]) -> Callable[[T], T]: ...
 def copy_func(
     f: F,
     name: Optional[str] = ...,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes since annotation to support `float` arguments:

```python
def since(version: Union[str, float]) -> Callable[[T], T]: ...
```

### Why are the changes needed?

`since` is used with both `str` and `float` both in Spark and related libraries and this change has been already done for Spark >= 3.3 (SPARK-36906),

Note that this technically fixes a bug in the downstream projects that run mypy checks against `pyspark.since`. When they use it, for example, with `pyspark.since(3.2)`, mypy checks fails; however, this case is legitimate. After this change, the mypy check can pass in thier CIs.

### Does this PR introduce _any_ user-facing change?

```python
@since(3.2)
def f():
    ...
```

is going to type check if downstream projects run mypy to validate the types.

Otherwise, it does not affect anything invasive or user-facing behavior change.

### How was this patch tested?

Existing tests and manual testing.