### PR TITLE
[SPARK-37289][SQL][3.2] Remove the unnecessary function calle…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -460,7 +460,7 @@ case class FileSourceScanExec(
       driverMetrics("staticFilesNum") = filesNum
       driverMetrics("staticFilesSize") = filesSize
     }
-    if (relation.partitionSchemaOption.isDefined) {
+    if (relation.partitionSchema.nonEmpty) {
       driverMetrics("numPartitions") = partitions.length
     }
   }
@@ -479,7 +479,7 @@ case class FileSourceScanExec(
       None
     }
   } ++ {
-    if (relation.partitionSchemaOption.isDefined) {
+    if (relation.partitionSchema.nonEmpty) {
       Map(
         "numPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions read"),
         "pruningTime" ->

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFsRelation.scala
@@ -57,9 +57,6 @@ case class HadoopFsRelation(
     PartitioningUtils.mergeDataAndPartitionSchema(dataSchema,
       partitionSchema, sparkSession.sessionState.conf.caseSensitiveAnalysis)
 
-  def partitionSchemaOption: Option[StructType] =
-    if (partitionSchema.isEmpty) None else Some(partitionSchema)
-
   override def toString: String = {
     fileFormat match {
       case source: DataSourceRegister => source.shortName()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -90,7 +90,7 @@ private[sql] object PruneFileSourcePartitions
             _,
             _,
             _))
-        if filters.nonEmpty && fsRelation.partitionSchemaOption.isDefined =>
+        if filters.nonEmpty && fsRelation.partitionSchema.nonEmpty =>
       val (partitionKeyFilters, _) = getPartitionKeyFiltersAndDataFilters(
         fsRelation.sparkSession, logicalRelation, partitionSchema, filters,
         logicalRelation.output)


### PR DESCRIPTION
[SPARK-37289][SQL][3.2] Remove the unnecessary function

### What changes were proposed in this pull request?

This PR remove the unnecessary function called partitionSchemaOption in HadoopFsRelation.scala.

### Why are the changes needed?

The partitionSchemaOption is unnecessary in HadoopFsRelation, it will make more complicated logical in HadoopFsRelation,which we can simply use partitionSchema.isEmpty or partitionSchema.nonEmpty instead

### Does this PR introduce _any_ user-facing change?
No,only change the expression.

### How was this patch tested?
Pass existed tests.