### PR TITLE
[SPARK-37019][SQL] Add codegen support to array higher-order functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
@@ -146,9 +146,13 @@ class EquivalentExpressions(
   // There are some special expressions that we should not recurse into all of its children.
   //   1. CodegenFallback: it's children will not be used to generate code (call eval() instead)
   //   2. ConditionalExpression: use its children that will always be evaluated.
+  //   3. HigherOrderFunction: lambda functions operate in the context of local lambdas and can't
+  //        be called outside of that scope, only the arguments can be evaluated ahead of
+  //        time.
   private def childrenToRecurse(expr: Expression): Seq[Expression] = expr match {
     case _: CodegenFallback => Nil
     case c: ConditionalExpression => c.alwaysEvaluatedInputs.map(skipForShortcut)
+    case h: HigherOrderFunction => h.arguments
     case other => skipForShortcut(other).children
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
@@ -147,12 +147,12 @@ class EquivalentExpressions(
   //   1. CodegenFallback: it's children will not be used to generate code (call eval() instead)
   //   2. ConditionalExpression: use its children that will always be evaluated.
   //   3. HigherOrderFunction: lambda functions operate in the context of local lambdas and can't
-  //        be called outside of that scope, only the arguments can be evaluated ahead of
-  //        time.
+  //        be called outside of that scope, only always-evaluated arguments can be evaluated
+  //        ahead of time.
   private def childrenToRecurse(expr: Expression): Seq[Expression] = expr match {
     case _: CodegenFallback => Nil
     case c: ConditionalExpression => c.alwaysEvaluatedInputs.map(skipForShortcut)
-    case h: HigherOrderFunction => h.arguments
+    case h: HigherOrderFunction => h.alwaysEvaluatedArguments
     case other => skipForShortcut(other).children
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1888,7 +1888,7 @@ object CodeGenerator extends Logging {
     } else {
       "update"
     }
-    if (isNull.isDefined && isPrimitiveType) {
+    if (isNull.isDefined) {
       s"""
          |if (${isNull.get}) {
          |  $array.setNullAt($i);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -183,6 +183,41 @@ class CodegenContext extends Logging {
   var currentPartitionIndexVar: String = "partitionIndex"
 
   /**
+   * Holding a map of current lambda variables.
+   */
+  var currentLambdaVars: mutable.Map[Long, ExprCode] = mutable.HashMap.empty
+
+  def withLambdaVars(
+      namedLambdas: Seq[NamedLambdaVariable],
+      f: Seq[ExprCode] => ExprCode): ExprCode = {
+    val lambdaVars = namedLambdas.map { lambda =>
+      val id = lambda.exprId.id
+      if (currentLambdaVars.get(id).nonEmpty) {
+        throw QueryExecutionErrors.lambdaVariableAlreadyDefinedError(id)
+      }
+      val isNull = if (lambda.nullable) {
+        JavaCode.isNullGlobal(addMutableState(JAVA_BOOLEAN, "lambdaIsNull"))
+      } else {
+        FalseLiteral
+      }
+      val value = addMutableState(javaType(lambda.dataType), "lambdaValue")
+      val lambdaVar = ExprCode(isNull, JavaCode.global(value, lambda.dataType))
+      currentLambdaVars.put(id, lambdaVar)
+      lambdaVar
+    }
+
+    val result = f(lambdaVars)
+    namedLambdas.map(_.exprId.id).foreach(currentLambdaVars.remove)
+    result
+  }
+
+  def getLambdaVar(id: Long): ExprCode = {
+    currentLambdaVars.getOrElse(
+      id,
+      throw QueryExecutionErrors.lambdaVariableNotDefinedError(id))
+  }
+
+  /**
    * Holding expressions' inlined mutable states like `MonotonicallyIncreasingID.count` as a
    * 2-tuple: java type, variable name.
    * As an example, ("int", "count") will produce code:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -1259,10 +1259,10 @@ case class ArrayAggregate(
         }
 
         val initialAssignment = assignVar(accForMergeCode, mergeAtomic, zeroCode.value,
-          zeroCode.isNull, zero.nullable)
+          zeroCode.isNull, accForMergeVar.nullable)
 
         val mergeAssignment = assignVar(accForMergeCode, mergeAtomic, mergeCopy,
-          mergeCode.isNull, merge.nullable)
+          mergeCode.isNull, accForMergeVar.nullable)
 
         val finishAssignment = assignVar(accForFinishCode, finishAtomic, accForMergeCode.value,
           accForMergeCode.isNull, accForMergeVar.nullable)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -1256,7 +1256,7 @@ case class ArrayAggregate(
           mergeCode.isNull, merge.nullable)
 
         val finishAssignment = assignVar(accForFinishCode, finishAtomic, accForMergeCode.value,
-          accForMergeCode.isNull, merge.nullable)
+          accForMergeCode.isNull, accForMergeVar.nullable)
 
         s"""
             |final int $numElements = ${arg}.numElements();

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -460,7 +460,7 @@ case class ArrayTransform(
         val initialization = CodeGenerator.createArrayData(
           arrayData, dataType.elementType, numElements, s" $prettyName failed.")
 
-        val functionCode = function.genCode(ctx)
+        val functionCode = functionForEval.genCode(ctx)
 
         val elementAssignment = assignArrayElement(ctx, arg, elementCode, elementVar, i)
         val indexAssignment = indexCode.map(c => assignIndex(ctx, c, indexVar.get, i))
@@ -779,7 +779,7 @@ case class ArrayFilter(
         val resultInit = CodeGenerator.createArrayData(
           arrayData, arrayType.elementType, count, s" $prettyName failed.")
 
-        val functionCode = function.genCode(ctx)
+        val functionCode = functionForEval.genCode(ctx)
 
         val elementAssignment = assignArrayElement(ctx, arg, elementCode, elementVar, i)
         val indexAssignment = indexCode.map(c => assignIndex(ctx, c, indexVar.get, i))
@@ -918,7 +918,7 @@ case class ArrayExists(
         val foundNull = ctx.freshName("foundNull")
         val i = ctx.freshName("i")
 
-        val functionCode = function.genCode(ctx)
+        val functionCode = functionForEval.genCode(ctx)
         val elementAssignment = assignArrayElement(ctx, arg, elementCode, elementVar, i)
         val threeWayLogic = if (followThreeValuedLogic) TrueLiteral else FalseLiteral
 
@@ -1041,7 +1041,7 @@ case class ArrayForAll(
         val foundNull = ctx.freshName("foundNull")
         val i = ctx.freshName("i")
 
-        val functionCode = function.genCode(ctx)
+        val functionCode = functionForEval.genCode(ctx)
         val elementAssignment = assignArrayElement(ctx, arg, elementCode, elementVar, i)
 
         val nullCheck = if (nullable) {
@@ -1233,8 +1233,9 @@ case class ArrayAggregate(
         val i = ctx.freshName("i")
 
         val zeroCode = zero.genCode(ctx)
-        val mergeCode = merge.genCode(ctx)
-        val finishCode = finish.genCode(ctx)
+        val Seq(mergeForCodegen, finishForCodegen) = functionsForEval
+        val mergeCode = mergeForCodegen.genCode(ctx)
+        val finishCode = finishForCodegen.genCode(ctx)
 
         val elementAssignment = assignArrayElement(ctx, arg, elementCode, elementVar, i)
         val mergeAtomic = ctx.addReferenceObj(accForMergeVar.name,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -169,6 +169,11 @@ trait HigherOrderFunction extends Expression with ExpectsInputTypes {
    */
   def arguments: Seq[Expression]
 
+  /**
+   * Arguments that are always evaluated when the higher order function is evaluated.
+   */
+  def alwaysEvaluatedArguments: Seq[Expression] = arguments
+
   def argumentTypes: Seq[AbstractDataType]
 
   /**
@@ -763,6 +768,7 @@ case class ArrayFilter(
         val count = ctx.freshName("count")
         val arrayTracker = ctx.freshName("arrayTracker")
         val arrayData = ctx.freshName("arrayData")
+        val keep = ctx.freshName("keep")
         val i = ctx.freshName("i")
         val j = ctx.freshName("j")
 
@@ -780,7 +786,7 @@ case class ArrayFilter(
         val varAssignments = (Seq(elementAssignment) ++ indexAssignment).mkString("\n")
 
         val resultAssignment = CodeGenerator.setArrayElement(arrayTracker, BooleanType,
-          i, functionCode.value, isNull = None)
+          i, keep, isNull = None)
 
         val getTrackerValue = CodeGenerator.getValue(arrayTracker, BooleanType, i)
         val copy = CodeGenerator.createArrayAssignment(arrayData, arrayType.elementType, arg,
@@ -799,8 +805,9 @@ case class ArrayFilter(
             |for (int $i = 0; $i < $numElements; $i++) {
             |  $varAssignments
             |  ${functionCode.code}
+            |  boolean $keep = !${functionCode.isNull} && ${functionCode.value};
             |  $resultAssignment
-            |  if ((boolean)${functionCode.value}) {
+            |  if ($keep) {
             |    $count++;
             |  }
             |}
@@ -1107,6 +1114,8 @@ case class ArrayAggregate(
   }
 
   override def arguments: Seq[Expression] = argument :: zero :: Nil
+
+  override def alwaysEvaluatedArguments: Seq[Expression] = argument :: Nil
 
   override def argumentTypes: Seq[AbstractDataType] = ArrayType :: AnyDataType :: Nil
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -1151,7 +1151,7 @@ case class ArrayAggregate(
     // Be very conservative with nullable. We cannot be sure that the accumulator does not
     // evaluate to null. So we always set nullable to true here.
     val ArrayType(elementType, containsNull) = argument.dataType
-    val acc = zero.dataType -> true
+    val acc = zero.dataType.asNullable -> true
     val newMerge = f(merge, acc :: (elementType, containsNull) :: Nil)
     val newFinish = f(finish, acc :: Nil)
     copy(merge = newMerge, finish = newFinish)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -448,6 +448,15 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         s"failed to match ${toSQLId(funcName)} at `addNewFunction`.")
   }
 
+  def lambdaVariableAlreadyDefinedError(id: Long): Throwable = {
+    new IllegalArgumentException(s"Lambda variable $id cannot be redefined")
+  }
+
+  def lambdaVariableNotDefinedError(id: Long): Throwable = {
+    new IllegalArgumentException(
+      s"Lambda variable $id is not defined in the current codegen scope")
+  }
+
   def cannotGenerateCodeForIncomparableTypeError(
       codeType: String, dataType: DataType): Throwable = {
     SparkException.internalError(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
@@ -440,6 +440,10 @@ class HigherOrderFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(aggregate(ai0, 0, (acc, elem) => acc + elem, acc => acc * 10), 60)
     checkEvaluation(aggregate(ai1, 0, (acc, elem) => acc + coalesce(elem, 0), acc => acc * 10), 40)
     checkEvaluation(aggregate(ai2, 0, (acc, elem) => acc + elem, acc => acc * 10), 0)
+    checkEvaluation(
+      aggregate(ai2, Literal.create(null, IntegerType),
+        (acc, elem) => coalesce(acc, 0) + elem, acc => acc.isNull),
+      true)
     checkEvaluation(aggregate(ain, 0, (acc, elem) => acc + elem, acc => acc * 10), null)
 
     val as0 = Literal.create(Seq("a", "b", "c"), ArrayType(StringType, containsNull = false))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -313,6 +314,33 @@ class HigherOrderFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper 
       Seq(Seq(1, 3), null, Seq(5)))
     checkEvaluation(transform(aai, ix => filter(ix, indexIsEven)),
       Seq(Seq(1, 3), null, Seq(4)))
+  }
+
+  test("ArrayFilter treats null predicate results as false in generated code") {
+    val input = new GenericArrayData(Array[Any](null)) {
+      override def isNullAt(ordinal: Int): Boolean = true
+      override def getBoolean(ordinal: Int): Boolean = true
+    }
+    val expr = filter(Literal(input, ArrayType(BooleanType, containsNull = true)), x => x)
+
+    checkEvaluation(expr, Seq.empty)
+  }
+
+  test("array higher order functions preserve null complex elements in generated code") {
+    val nestedType = ArrayType(IntegerType, containsNull = false)
+    val inputType = ArrayType(nestedType, containsNull = true)
+    val input = new GenericArrayData(Array[Any](
+      new GenericArrayData(Array[Any](9)),
+      new GenericArrayData(Array[Any](1)))) {
+      override def isNullAt(ordinal: Int): Boolean = ordinal == 0 || super.isNullAt(ordinal)
+      override def get(ordinal: Int, dataType: DataType): AnyRef = {
+        if (ordinal == 0) null else super.get(ordinal, dataType)
+      }
+    }
+    val literal = Literal(input, inputType)
+
+    checkEvaluation(transform(literal, x => x), Seq(null, Seq(1)))
+    checkEvaluation(filter(literal, x => x.isNull), Seq(null))
   }
 
   test("ArrayExists") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
@@ -189,6 +189,16 @@ class HigherOrderFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper 
       Seq("[1, 3, 5]", null, "[4, 6]"))
   }
 
+  test("ArrayTransform codegen rebinds fallback lambda variables by expression ID") {
+    val input = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType, containsNull = false))
+    val arg = NamedLambdaVariable("arg", IntegerType, nullable = false)
+    val detachedArg = arg.copy(value = new java.util.concurrent.atomic.AtomicReference[Any]())
+    val function = LambdaFunction(CodegenFallbackExpr(detachedArg + 1), Seq(arg))
+    val expr = ArrayTransform(input, function).bind(validateBinding)
+
+    checkEvaluation(expr, Seq(2, 3, 4))
+  }
+
   test("ArraySort") {
     val a0 = Literal.create(Seq(2, 1, 3), ArrayType(IntegerType))
     val a1 = Literal.create(Seq[Integer](), ArrayType(IntegerType))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
@@ -23,6 +23,7 @@ import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.sql.catalyst.DefinedByConstructorParams
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.objects.MapObjects
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -205,6 +206,33 @@ class DataFrameComplexTypeSuite extends SharedSparkSession {
         map().cast("map<string, string>"),
         (acc, s) => map_concat(acc, map(s, reverse(s)))))
     checkAnswer(testMap, Row(Map("abc" -> "cba", "def" -> "fed")) :: Nil)
+  }
+
+  test("ArrayAggregate codegen respects widened accumulator nested nullability") {
+    val queries = Seq(
+      """
+        |SELECT aggregate(
+        |  array(1),
+        |  array(1),
+        |  (acc, x) -> array(CAST(NULL AS INT)),
+        |  acc -> acc[0])
+        |""".stripMargin,
+      """
+        |SELECT aggregate(
+        |  array(1),
+        |  map(1, 1),
+        |  (acc, x) -> map(1, CAST(NULL AS INT)),
+        |  acc -> acc[1])
+        |""".stripMargin)
+
+    Seq(CodegenObjectFactoryMode.CODEGEN_ONLY, CodegenObjectFactoryMode.NO_CODEGEN).foreach {
+      codegenMode =>
+        withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> codegenMode.toString) {
+          queries.foreach { query =>
+            checkAnswer(sql(query), Row(null))
+          }
+        }
+    }
   }
 
   test("SPARK-31552: array encoder with different types") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -4776,6 +4776,23 @@ class DataFrameFunctionsSuite extends SharedSparkSession {
     testArrayOfPrimitiveTypeNotContainsNull()
   }
 
+  test("aggregate function - null array does not evaluate zero expression through CSE") {
+    withSQLConf(
+        SQLConf.ANSI_ENABLED.key -> "true",
+        SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY",
+        SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true") {
+      checkAnswer(
+        spark.range(1).selectExpr(
+          """
+            |aggregate(
+            |  CAST(NULL AS ARRAY<INT>),
+            |  (CAST(id AS INT) / 0) + (CAST(id AS INT) / 0),
+            |  (acc, x) -> acc + x)
+            |""".stripMargin),
+        Row(null))
+    }
+  }
+
   test("aggregate function - array for primitive type containing null") {
     val df = Seq[Seq[Integer]](
       Seq(1, 9, 8, 7),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -4793,6 +4793,36 @@ class DataFrameFunctionsSuite extends SharedSparkSession {
     }
   }
 
+  test("aggregate function - generated code clears accumulator null state within row") {
+    withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY") {
+      checkAnswer(
+        spark.range(1).selectExpr(
+          """
+            |aggregate(
+            |  array(CAST(id AS INT) + 1, CAST(id AS INT) + 2),
+            |  CAST(NULL AS INT),
+            |  (acc, x) -> coalesce(acc, 0) + x,
+            |  acc -> coalesce(acc, -1))
+            |""".stripMargin),
+        Row(3))
+    }
+  }
+
+  test("aggregate function - generated code clears accumulator null state across rows") {
+    withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY") {
+      checkAnswer(
+        spark.range(0, 2, 1, 1).selectExpr(
+          """
+            |aggregate(
+            |  CASE WHEN id = 0 THEN array(CAST(NULL AS INT)) ELSE array() END,
+            |  0,
+            |  (acc, x) -> acc + x,
+            |  acc -> coalesce(acc, -1))
+            |""".stripMargin),
+        Seq(Row(-1), Row(0)))
+    }
+  }
+
   test("aggregate function - array for primitive type containing null") {
     val df = Seq[Seq[Integer]](
       Seq(1, 9, 8, 7),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/HigherOrderFunctionsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/HigherOrderFunctionsBenchmark.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Synthetic benchmark for higher order functions.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class>
+ *        --jars <spark core test jar>,<spark catalyst test jar> <sql core test jar>
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/HigherOrderFunctionsBenchmark-results.txt".
+ * }}}
+ */
+object HigherOrderFunctionsBenchmark extends SqlBasedBenchmark {
+  private val N = 100_000_00
+  private val M = 10
+
+  private val df = spark.range(N).select(array(col("id"), col("id"), col("id")).alias("arr"))
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runBenchmark("Higher order functions") {
+      def benchFunction(name: String, col: Column) = {
+        var benchmark = new Benchmark(name, N, output = output)
+        benchmark.addCase("codegen", M) { _ =>
+          withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key ->
+              CodegenObjectFactoryMode.CODEGEN_ONLY.toString()) {
+            df.select(col).noop()
+          }
+        }
+
+        benchmark.addCase("interpreted", M) { _ =>
+          withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key ->
+              CodegenObjectFactoryMode.NO_CODEGEN.toString()) {
+            df.select(col).noop()
+          }
+        }
+        benchmark.run()
+      }
+
+      benchFunction("transform", transform(col("arr"), x => x + 1))
+      benchFunction("filter", filter(col("arr"), x => x > 1))
+      benchFunction("forall - fast", forall(col("arr"), x => x < 0))
+      benchFunction("forall - slow", forall(col("arr"), x => x >= 0))
+      benchFunction("exists - fast", exists(col("arr"), x => x >= 0))
+      benchFunction("exists - slow", exists(col("arr"), x => x < 0))
+      benchFunction("aggregate", aggregate(col("arr"), lit(0L), (acc, x) => acc + x))
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds codegen support to array based higher order functions except ArraySort. This is my first time playing around with codegen, so definitely looking for any feedback.

A few notes:
- Disabled subexpression elimination for lambda functions (this already was the case because it was CodegenFallback). I plan to explore supprting subexpression elimination inside lambda functions later on, as it will require special handling.
- I set the AtomicReference for all lambda values as well in case a child expression reverts to interpreted evaluation for any reason (CodegenFallback or otherwise)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To improve performance of array higher-order function operations, letting the children be codegen'd and participate in WholeStageCodegen

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, only performance improvements.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing unit tests, let me know if there's other codegen-specific unit tests I should add.