### PR TITLE
[SPARK-37291][PYTHON][SQL] PySpark init SparkSession should copy conf to sharedState

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -285,7 +285,7 @@ class SparkSession(SparkConversionMixin):
     _instantiatedSession: ClassVar[Optional["SparkSession"]] = None
     _activeSession: ClassVar[Optional["SparkSession"]] = None
 
-    def __init__(self, sparkContext: SparkContext, jsparkSession: Optional[JavaObject] = None, options: Dict[str, Any] = None):
+    def __init__(self, sparkContext: SparkContext, jsparkSession: Optional[JavaObject] = None, options: Optional[Dict[str, Any]] = None):
         from pyspark.sql.context import SQLContext
 
         self._sc = sparkContext
@@ -297,12 +297,14 @@ class SparkSession(SparkConversionMixin):
                 and not self._jvm.SparkSession.getDefaultSession().get().sparkContext().isStopped()
             ):
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
-                for key, value in options.items():
-                    jsparkSession.sessionState().conf().setConfString(key, value)
+                if options is not None:
+                    for key, value in options.items():
+                        jsparkSession.sessionState().conf().setConfString(key, value)
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc())
-                for key, value in options.items():
-                    jsparkSession.sharedState().conf().set(key, value)
+                if options is not None:
+                    for key, value in options.items():
+                        jsparkSession.sharedState().conf().set(key, value)
         self._jsparkSession = jsparkSession
         self._jwrapped = self._jsparkSession.sqlContext()
         self._wrapped = SQLContext(self._sc, self, self._jwrapped)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -278,7 +278,7 @@ class SparkSession(SparkConversionMixin):
                     # by all sessions.
                     session = SparkSession(sc)
                 for key, value in self._options.items():
-                    session._jsparkSession.sessionState().conf().set(key, value)
+                    session._jsparkSession.sharedState().conf().set(key, value)
                 return session
 
     builder = Builder()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -277,8 +277,8 @@ class SparkSession(SparkConversionMixin):
                     # Do not update `SparkConf` for existing `SparkContext`, as it's shared
                     # by all sessions.
                     session = SparkSession(sc, options=self._options)
-                    for key, value in self._options.items():
-                        session._jsparkSession.sessionState().conf().setConfString(key, value)
+                for key, value in self._options.items():
+                    session._jsparkSession.sessionState().conf().setConfString(key, value)
                 return session
 
     builder = Builder()
@@ -294,7 +294,6 @@ class SparkSession(SparkConversionMixin):
         options: Optional[Dict[str, Any]] = None):
         from pyspark.sql.context import SQLContext
 
-        print("xxxxxx")
         self._sc = sparkContext
         self._jsc = self._sc._jsc  # type: ignore[attr-defined]
         self._jvm = self._sc._jvm  # type: ignore[attr-defined]
@@ -304,15 +303,11 @@ class SparkSession(SparkConversionMixin):
                 and not self._jvm.SparkSession.getDefaultSession().get().sparkContext().isStopped()
             ):
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
-                # if options is not None:
-                #     for key, value in options.items():
-                #         jsparkSession.sessionState().conf().setConfString(key, value)
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc())
-                # if options is not None:
-                #     for key, value in options.items():
-                #         jsparkSession.sharedState().conf().set(key, value)
-                #         jsparkSession.sessionState().conf().setConfString(key, value)
+                if options is not None:
+                    for key, value in options.items():
+                        jsparkSession.sharedState().conf().set(key, value)
         self._jsparkSession = jsparkSession
         self._jwrapped = self._jsparkSession.sqlContext()
         self._wrapped = SQLContext(self._sc, self, self._jwrapped)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -291,7 +291,8 @@ class SparkSession(SparkConversionMixin):
         self,
         sparkContext: SparkContext,
         jsparkSession: Optional[JavaObject] = None,
-        options: Optional[Dict[str, Any]] = None):
+        options: Optional[Dict[str, Any]] = None
+    ):
         from pyspark.sql.context import SQLContext
 
         self._sc = sparkContext

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -278,7 +278,7 @@ class SparkSession(SparkConversionMixin):
                     # by all sessions.
                     session = SparkSession(sc)
                 for key, value in self._options.items():
-                    session._jsparkSession.sessionState().conf().setConfString(key, value)
+                    session._jsparkSession.sessionState().conf().set(key, value)
                 return session
 
     builder = Builder()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -276,7 +276,7 @@ class SparkSession(SparkConversionMixin):
                         sc = SparkContext.getOrCreate(sparkConf)
                     # Do not update `SparkConf` for existing `SparkContext`, as it's shared
                     # by all sessions.
-                    session = SparkSession(sc, options = self._options)
+                    session = SparkSession(sc, options=self._options)
                 return session
 
     builder = Builder()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -291,7 +291,7 @@ class SparkSession(SparkConversionMixin):
         self,
         sparkContext: SparkContext,
         jsparkSession: Optional[JavaObject] = None,
-        options: Optional[Dict[str, Any]] = None
+        options: Optional[Dict[str, Any]] = None,
     ):
         from pyspark.sql.context import SQLContext
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -277,6 +277,8 @@ class SparkSession(SparkConversionMixin):
                     # Do not update `SparkConf` for existing `SparkContext`, as it's shared
                     # by all sessions.
                     session = SparkSession(sc, options=self._options)
+                    for key, value in self._options.items():
+                        session._jsparkSession.sessionState().conf().setConfString(key, value)
                 return session
 
     builder = Builder()
@@ -285,9 +287,14 @@ class SparkSession(SparkConversionMixin):
     _instantiatedSession: ClassVar[Optional["SparkSession"]] = None
     _activeSession: ClassVar[Optional["SparkSession"]] = None
 
-    def __init__(self, sparkContext: SparkContext, jsparkSession: Optional[JavaObject] = None, options: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        sparkContext: SparkContext,
+        jsparkSession: Optional[JavaObject] = None,
+        options: Optional[Dict[str, Any]] = None):
         from pyspark.sql.context import SQLContext
 
+        print("xxxxxx")
         self._sc = sparkContext
         self._jsc = self._sc._jsc  # type: ignore[attr-defined]
         self._jvm = self._sc._jvm  # type: ignore[attr-defined]
@@ -297,14 +304,15 @@ class SparkSession(SparkConversionMixin):
                 and not self._jvm.SparkSession.getDefaultSession().get().sparkContext().isStopped()
             ):
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
-                if options is not None:
-                    for key, value in options.items():
-                        jsparkSession.sessionState().conf().setConfString(key, value)
+                # if options is not None:
+                #     for key, value in options.items():
+                #         jsparkSession.sessionState().conf().setConfString(key, value)
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc())
-                if options is not None:
-                    for key, value in options.items():
-                        jsparkSession.sharedState().conf().set(key, value)
+                # if options is not None:
+                #     for key, value in options.items():
+                #         jsparkSession.sharedState().conf().set(key, value)
+                #         jsparkSession.sessionState().conf().setConfString(key, value)
         self._jsparkSession = jsparkSession
         self._jwrapped = self._jsparkSession.sqlContext()
         self._wrapped = SQLContext(self._sc, self, self._jwrapped)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -276,7 +276,7 @@ class SparkSession(SparkConversionMixin):
                         sc = SparkContext.getOrCreate(sparkConf)
                     # Do not update `SparkConf` for existing `SparkContext`, as it's shared
                     # by all sessions.
-                    session = SparkSession(sc)
+                    session = SparkSession(sc, options = self._options)
                 return session
 
     builder = Builder()
@@ -285,7 +285,7 @@ class SparkSession(SparkConversionMixin):
     _instantiatedSession: ClassVar[Optional["SparkSession"]] = None
     _activeSession: ClassVar[Optional["SparkSession"]] = None
 
-    def __init__(self, sparkContext: SparkContext, jsparkSession: Optional[JavaObject] = None):
+    def __init__(self, sparkContext: SparkContext, jsparkSession: Optional[JavaObject] = None, options: Dict[str, Any] = None):
         from pyspark.sql.context import SQLContext
 
         self._sc = sparkContext
@@ -297,11 +297,11 @@ class SparkSession(SparkConversionMixin):
                 and not self._jvm.SparkSession.getDefaultSession().get().sparkContext().isStopped()
             ):
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
-                for key, value in self._options.items():
+                for key, value in options.items():
                     jsparkSession.sessionState().conf().setConfString(key, value)
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc())
-                for key, value in self._options.items():
+                for key, value in options.items():
                     jsparkSession.sharedState().conf().set(key, value)
         self._jsparkSession = jsparkSession
         self._jwrapped = self._jsparkSession.sqlContext()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -277,8 +277,6 @@ class SparkSession(SparkConversionMixin):
                     # Do not update `SparkConf` for existing `SparkContext`, as it's shared
                     # by all sessions.
                     session = SparkSession(sc)
-                for key, value in self._options.items():
-                    session._jsparkSession.sharedState().conf().set(key, value)
                 return session
 
     builder = Builder()
@@ -299,8 +297,12 @@ class SparkSession(SparkConversionMixin):
                 and not self._jvm.SparkSession.getDefaultSession().get().sparkContext().isStopped()
             ):
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
+                for key, value in self._options.items():
+                    jsparkSession.sessionState().conf().setConfString(key, value)
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc())
+                for key, value in self._options.items():
+                    jsparkSession.sharedState().conf().set(key, value)
         self._jsparkSession = jsparkSession
         self._jwrapped = self._jsparkSession.sqlContext()
         self._wrapped = SQLContext(self._sc, self, self._jwrapped)

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -295,16 +295,23 @@ class SparkSessionBuilderTests(unittest.TestCase):
         try:
             conf = SparkConf().set("key1", "value1")
             sc = SparkContext("local[4]", "SessionBuilderTests", conf=conf)
-            session = SparkSession.builder.config("key2", "value2").getOrCreate()
+            session = (
+                SparkSession.builder.config("key2", "value2").enableHiveSupport().getOrCreate()
+            )
 
             self.assertEqual(session._jsparkSession.sharedState().conf().get("key1"), "value1")
             self.assertEqual(session._jsparkSession.sharedState().conf().get("key2"), "value2")
+            self.assertEqual(
+                session._jsparkSession.sharedState().conf().get("spark.sql.catalogImplementation"),
+                "hive",
+            )
             self.assertEqual(session.sparkContext, sc)
         finally:
             if session is not None:
                 session.stop()
             if sc is not None:
                 sc.stop()
+
 
 class SparkExtensionsTest(unittest.TestCase):
     # These tests are separate because it uses 'spark.sql.extensions' which is

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -289,6 +289,22 @@ class SparkSessionBuilderTests(unittest.TestCase):
             if session2 is not None:
                 session2.stop()
 
+    def test_create_spark_context_first_and_copy_options_to_sharedState(self):
+        sc = None
+        session = None
+        try:
+            conf = SparkConf().set("key1", "value1")
+            sc = SparkContext("local[4]", "SessionBuilderTests", conf=conf)
+            session = SparkSession.builder.config("key2", "value2").getOrCreate()
+
+            self.assertEqual(session._jsparkSession.sharedState().conf().get("key1"), "value1")
+            self.assertEqual(session._jsparkSession.sharedState().conf().get("key2"), "value2")
+            self.assertEqual(session.sparkContext, sc)
+        finally:
+            if session is not None:
+                session.stop()
+            if sc is not None:
+                sc.stop()
 
 class SparkExtensionsTest(unittest.TestCase):
     # These tests are separate because it uses 'spark.sql.extensions' which is


### PR DESCRIPTION
### What changes were proposed in this pull request?
When use write pyspark script like
```
conf = SparkConf().setAppName("test")
sc = SparkContext(conf = conf)
session = SparkSession().build().enableHiveSupport().getOrCreate()
```

It will build a session without hive support since we use a existed SparkContext and we create SparkSession use 
```
SparkSession(sc)
```
This cause we loss configuration added by `config()` such as catalog implement.

In scala class `SparkSession`, we create `SparkSession` with `SparkContext` and option configurations and will pass option configurations to `SharedState` then use `SharedState`'s conf create SessionState, but in pyspark, we won't pass options configuration to `SharedState`, but pass to `SessionState`, but this time `SessionState` has been initialized.  So it won't support hive.

In this pr, I pass option configurations to `SharedState` when first init `SparkSession`, then when  init `SessionState`, this options will be passed to `SessionState` too.

### Why are the changes needed?
Avoid loss configuration when build SparkSession in pyspark


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manuel tested & added UT
