### PR TITLE
[SPARK-37293][TESTS] Remove explicit GC options from Scala tests

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1135,7 +1135,6 @@ object TestSettings {
     (Test / javaOptions) ++= System.getProperties.asScala.filter(_._1.startsWith("spark"))
       .map { case (k,v) => s"-D$k=$v" }.toSeq,
     (Test / javaOptions) += "-ea",
-    // SPARK-29282 This is for consistency between JDK8 and JDK11.
     (Test / javaOptions) ++= {
       val metaspaceSize = sys.env.get("METASPACE_SIZE").getOrElse("1300m")
       val extraTestJavaArgs = Array("-XX:+IgnoreUnrecognizedVMOptions",
@@ -1156,7 +1155,7 @@ object TestSettings {
         // to mock `j.u.Random`, "-add-exports=java.base/jdk.internal.util.random=ALL-UNNAMED"
         // is added. Should remove it when `mockito` can mock `j.u.Random` directly.
         "--add-exports=java.base/jdk.internal.util.random=ALL-UNNAMED").mkString(" ")
-      s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:+UseParallelGC -XX:-UseDynamicNumberOfGCThreads -XX:ReservedCodeCacheSize=128m $extraTestJavaArgs"
+      s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m $extraTestJavaArgs"
         .split(" ").toSeq
     },
     javaOptions ++= {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the explicit GC options in Scala tests.

### Why are the changes needed?

At Apache Spark 3.0, SPARK-29282 introduced the explicit GC options in Scala tests to see the consistent result between Java8/Java11. Now, we have Java 17 additionally and SPARK-37120 added Java 11/17 GitHub Action jobs.

This PR aims to use the default GC options for each JVM. This is a partial revert of SPARK-29282.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action CIs without memory issues.