### PR TITLE
[SPARK-37294][SQL][TESTS] Check inserting of ANSI intervals into a table partitioned by the interval columns

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2917,9 +2917,8 @@ class DataSourceV2SQLSuite
 
   test("SPARK-37294: insert ANSI intervals into a table partitioned by the interval columns") {
     val tbl = "testpart.interval_table"
-    Seq(PartitionOverwriteMode.DYNAMIC.toString,
-      PartitionOverwriteMode.STATIC.toString).foreach { mode =>
-      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> mode) {
+    Seq(PartitionOverwriteMode.DYNAMIC, PartitionOverwriteMode.STATIC).foreach { mode =>
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> mode.toString) {
         withTable(tbl) {
           sql(
             s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2923,7 +2923,7 @@ class DataSourceV2SQLSuite
         withTable(tbl) {
           sql(
             s"""
-               |CREATE TABLE $tbl (i int, part1 INTERVAL YEAR, part2 INTERVAL DAY) USING $v2Format
+               |CREATE TABLE $tbl (i INT, part1 INTERVAL YEAR, part2 INTERVAL DAY) USING $v2Format
                |PARTITIONED BY (part1, part2)
               """.stripMargin)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector
 
 import java.sql.Timestamp
-import java.time.LocalDate
+import java.time.{Duration, LocalDate, Period}
 
 import scala.collection.JavaConverters._
 
@@ -2941,9 +2941,9 @@ class DataSourceV2SQLSuite
 
           checkAnswer(
             spark.table(tbl),
-            Seq(Row(1, java.time.Period.ofYears(2), java.time.Duration.ofDays(3)),
-              Row(4, java.time.Period.ofYears(5), java.time.Duration.ofDays(6)),
-              Row(7, java.time.Period.ofYears(8), java.time.Duration.ofDays(9))))
+            Seq(Row(1, Period.ofYears(2), Duration.ofDays(3)),
+              Row(4, Period.ofYears(5), Duration.ofDays(6)),
+              Row(7, Period.ofYears(8), Duration.ofDays(9))))
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2915,6 +2915,40 @@ class DataSourceV2SQLSuite
     }
   }
 
+  test("SPARK-37294: insert ANSI intervals into a table partitioned by the interval columns") {
+    val tbl = "testpart.interval_table"
+    Seq(PartitionOverwriteMode.DYNAMIC.toString,
+      PartitionOverwriteMode.STATIC.toString).foreach { mode =>
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> mode) {
+        withTable(tbl) {
+          sql(
+            s"""
+               |CREATE TABLE $tbl (i int, part1 INTERVAL YEAR, part2 INTERVAL DAY) USING $v2Format
+               |PARTITIONED BY (part1, part2)
+              """.stripMargin)
+
+          sql(
+            s"""ALTER TABLE $tbl ADD PARTITION (
+               |part1 = INTERVAL '2' YEAR,
+               |part2 = INTERVAL '3' DAY)""".stripMargin)
+          sql(s"INSERT OVERWRITE TABLE $tbl SELECT 1, INTERVAL '2' YEAR, INTERVAL '3' DAY")
+          sql(s"INSERT INTO TABLE $tbl SELECT 4, INTERVAL '5' YEAR, INTERVAL '6' DAY")
+          sql(
+            s"""
+               |INSERT INTO $tbl
+               | PARTITION (part1 = INTERVAL '8' YEAR, part2 = INTERVAL '9' DAY)
+               |SELECT 7""".stripMargin)
+
+          checkAnswer(
+            spark.table(tbl),
+            Seq(Row(1, java.time.Period.ofYears(2), java.time.Duration.ofDays(3)),
+              Row(4, java.time.Period.ofYears(5), java.time.Duration.ofDays(6)),
+              Row(7, java.time.Period.ofYears(8), java.time.Duration.ofDays(9))))
+        }
+      }
+    }
+  }
+
   private def testNotSupportedV2Command(sqlCommand: String, sqlParams: String): Unit = {
     val e = intercept[AnalysisException] {
       sql(s"$sqlCommand $sqlParams")

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1072,7 +1072,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         withTable(tbl) {
           sql(
             s"""
-              |CREATE TABLE $tbl (i int, part1 INTERVAL YEAR, part2 INTERVAL DAY) USING PARQUET
+              |CREATE TABLE $tbl (i INT, part1 INTERVAL YEAR, part2 INTERVAL DAY) USING PARQUET
               |PARTITIONED BY (part1, part2)
               """.stripMargin)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1067,9 +1067,8 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
 
   test("SPARK-37294: insert ANSI intervals into a table partitioned by the interval columns") {
     val tbl = "interval_table"
-    Seq(PartitionOverwriteMode.DYNAMIC.toString,
-      PartitionOverwriteMode.STATIC.toString).foreach { mode =>
-      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> mode) {
+    Seq(PartitionOverwriteMode.DYNAMIC, PartitionOverwriteMode.STATIC).foreach { mode =>
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> mode.toString) {
         withTable(tbl) {
           sql(
             s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.sources
 
 import java.io.{File, IOException}
 import java.sql.Date
+import java.time.{Duration, Period}
 
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FSDataOutputStream, Path, RawLocalFileSystem}
 
@@ -1090,9 +1091,9 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
 
           checkAnswer(
             spark.table(tbl),
-            Seq(Row(1, java.time.Period.ofYears(2), java.time.Duration.ofDays(3)),
-              Row(4, java.time.Period.ofYears(5), java.time.Duration.ofDays(6)),
-              Row(7, java.time.Period.ofYears(8), java.time.Duration.ofDays(9))))
+            Seq(Row(1, Period.ofYears(2), Duration.ofDays(3)),
+              Row(4, Period.ofYears(5), Duration.ofDays(6)),
+              Row(7, Period.ofYears(8), Duration.ofDays(9))))
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add new tests to check that ANSI intervals are supported by `INSERT INTO` for tables partitioned by the interval columns. New tests check v1/v2 In-Memory catalog and static/dynamic overwrite.

### Why are the changes needed?
To improve test coverage.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running new tests:
```
$ build/sbt "test:testOnly *DataSourceV2SQLSuite"
$ build/sbt "test:testOnly *InsertSuite"
```