### PR TITLE
[SPARK-37296][PYTHON] Add missing type hints in python/pyspark/util.py

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -95,9 +95,6 @@ disallow_untyped_defs = False
 [mypy-pyspark.traceback_utils]
 disallow_untyped_defs = False
 
-[mypy-pyspark.util]
-disallow_untyped_defs = False
-
 [mypy-pyspark.worker]
 disallow_untyped_defs = False
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds missing type hints in `python/pyspark/util.py`.

### Why are the changes needed?

Some of type hints in `python/pyspark/util.py` are missing, but the error was ignored by setting `disallow_untyped_defs = False` in `mypy.ini`. We should remove the setting and add the missing type hints.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`lint-python` should pass.
