### PR TITLE
[SPARK-37022][PYTHON][FOLLOWUP] Remove unnecessary comment in lint-python

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -255,7 +255,6 @@ function black_test {
     fi
 
     echo "starting black test..."
-    # Black is only applied for pandas API on Spark for now.
     BLACK_REPORT=$( ($BLACK_BUILD  --config dev/pyproject.toml --check python/pyspark) 2>&1)
     BLACK_STATUS=$?
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is follow up for https://github.com/apache/spark/pull/34297.


### Why are the changes needed?

As we now apply the black to the whole PySpark project, the comment "Black is only applied for pandas API on Spark for now." is no longer valid.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No test needed. Just remove the comment