### PR TITLE
[MINOR][PYTHON][DOCS] Remove the reference of typeName as DDL format in documentation

### DIFF
--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -411,9 +411,7 @@ class SQLContext(object):
             a :class:`pyspark.sql.types.DataType` or a datatype string or a list of
             column names, default is None.  The data type string format equals to
             :class:`pyspark.sql.types.DataType.simpleString`, except that top level struct type can
-            omit the ``struct<>`` and atomic types use ``typeName()`` as their format, e.g. use
-            ``byte`` instead of ``tinyint`` for :class:`pyspark.sql.types.ByteType`.
-            We can also use ``int`` as a short name for :class:`pyspark.sql.types.IntegerType`.
+            omit the ``struct<>``.
         samplingRatio : float, optional
             the sample ratio of rows used for inferring
         verifySchema : bool, optional

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -776,9 +776,7 @@ class SparkSession(SparkConversionMixin):
             a :class:`pyspark.sql.types.DataType` or a datatype string or a list of
             column names, default is None.  The data type string format equals to
             :class:`pyspark.sql.types.DataType.simpleString`, except that top level struct type can
-            omit the ``struct<>`` and atomic types use ``typeName()`` as their format, e.g. use
-            ``byte`` instead of ``tinyint`` for :class:`pyspark.sql.types.ByteType`.
-            We can also use ``int`` as a short name for :class:`pyspark.sql.types.IntegerType`.
+            omit the ``struct<>``.
         samplingRatio : float, optional
             the sample ratio of rows used for inferring
         verifySchema : bool, optional

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -911,9 +911,7 @@ def _parse_datatype_string(s: str) -> DataType:
     """
     Parses the given data type string to a :class:`DataType`. The data type string format equals
     :class:`DataType.simpleString`, except that the top level struct type can omit
-    the ``struct<>`` and atomic types use ``typeName()`` as their format, e.g. use ``byte`` instead
-    of ``tinyint`` for :class:`ByteType`. We can also use ``int`` as a short name
-    for :class:`IntegerType`. Since Spark 2.3, this also supports a schema in a DDL-formatted
+    the ``struct<>``. Since Spark 2.3, this also supports a schema in a DDL-formatted
     string and case-insensitive strings.
 
     Examples


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes about the reference of ``typeName()`` in PySpark documentation. Using `DataType.typeName` is PySpark specific legacy behaviour. We should better stick to one format in documentation.

### Why are the changes needed?

Using `typeName` is not actually correct for DDL parsing. Differences between `DataType.typeName` and `DataType.simpleString` are:

- `byte` <> `tinyint`
- `short` <> `smallint`
- `decimal` <> `decimal(10,0)`
- `integer` <> `int`

While other cases are fine, `decimal` will lost precision and scale if we encourage to use `DataType.typeName`

The only reason  why `DataType.typeName` was mentioned is about JSON parsing (at https://github.com/apache/spark/commit/d57daf1f7732a7ac54a91fe112deeda0a254f9ef) because internally we use `DataType.typeName` but that format is internal.

### Does this PR introduce _any_ user-facing change?

It changes documentation in PySpark API documentation.

### How was this patch tested?

CI in this PR should test it out.
