### PR TITLE
[SPARK-36825][FOLLOWUP] Move the test code from `ParquetIOSuite` to `ParquetFileFormatSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import java.time.{Duration, LocalDateTime, Period}
+import java.time.LocalDateTime
 import java.util.Locale
 
 import scala.collection.JavaConverters._
@@ -1064,29 +1064,6 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
           assert(Seq(866, 20, 492, 76, 824, 604, 343, 820, 864, 243)
             .zip(last10Df).forall(d =>
             d._1 == d._2.getDecimal(0).unscaledValue().intValue()))
-      }
-    }
-  }
-
-  test("SPARK-36825, SPARK-36854: year-month/day-time intervals written and read as INT32/INT64") {
-    Seq(false, true).foreach { offHeapEnabled =>
-      withSQLConf(SQLConf.COLUMN_VECTOR_OFFHEAP_ENABLED.key -> offHeapEnabled.toString) {
-        Seq(
-          YearMonthIntervalType() -> ((i: Int) => Period.of(i, i, 0)),
-          DayTimeIntervalType() -> ((i: Int) => Duration.ofDays(i).plusSeconds(i))
-        ).foreach { case (it, f) =>
-          val data = (1 to 10).map(i => Row(i, f(i)))
-          val schema = StructType(Array(StructField("d", IntegerType, false),
-            StructField("i", it, false)))
-          withTempPath { file =>
-            val df = spark.createDataFrame(sparkContext.parallelize(data), schema)
-            df.write.parquet(file.getCanonicalPath)
-            withAllParquetReaders {
-              val df2 = spark.read.parquet(file.getCanonicalPath)
-              checkAnswer(df2, df.collect().toSeq)
-            }
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR moves the test code added in SPARK-36825 (#34057) from `ParquetIOSuite` to `ParquetFileFormatSuite`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To test for both V1 and V2 tables.
In `ParquetIOSuite`, it doesn't test for V2 table.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
The test moved.