### PR TITLE
[SPARK-37307][CORE] Don't obtain JDBC connection for empty partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -658,6 +658,11 @@ object JdbcUtils extends Logging with SQLConfHelper {
       dialect: JdbcDialect,
       isolationLevel: Int,
       options: JDBCOptions): Unit = {
+
+    if (iterator.isEmpty) {
+      return
+    }
+
     val outMetrics = TaskContext.get().taskMetrics().outputMetrics
 
     val conn = getConnection()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Return immediately from JdbcUtils:savePartition for empty partitions, rather than obtain a database connection that will be unused.

### Why are the changes needed?

Avoids the overhead of opening and closing a DB connection that will not be used.

### Does this PR introduce _any_ user-facing change?

It should not.

### How was this patch tested?

Existing tests