### PR TITLE
[SPARK-37292][SQL][FOLLOWUP] Simplify the condition when removing outer join if it only has DISTINCT on streamed side

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -179,12 +179,10 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
         if a.groupOnly && a.references.subsetOf(right.outputSet) =>
       a.copy(child = right)
     case a @ Aggregate(_, _, p @ Project(_, Join(left, _, LeftOuter, _, _)))
-        if a.groupOnly && p.outputSet.subsetOf(a.references) &&
-          AttributeSet(p.projectList.flatMap(_.references)).subsetOf(left.outputSet) =>
+        if a.groupOnly && p.references.subsetOf(left.outputSet) =>
       a.copy(child = p.copy(child = left))
     case a @ Aggregate(_, _, p @ Project(_, Join(_, right, RightOuter, _, _)))
-        if a.groupOnly && p.outputSet.subsetOf(a.references) &&
-          AttributeSet(p.projectList.flatMap(_.references)).subsetOf(right.outputSet) =>
+        if a.groupOnly && p.references.subsetOf(right.outputSet) =>
       a.copy(child = p.copy(child = right))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Simplify the condition when removing outer join if it only has DISTINCT on streamed side with alias. See: https://github.com/apache/spark/pull/34557#discussion_r748005299.

### Why are the changes needed?

Simplify the code.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit test.
