### PR TITLE
[SPARK-37139][PYTHON][FOLLOWUP] Fix class variable type hints in taskcontext.py

### DIFF
--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Type, Dict, List, Optional, Union, cast
+from typing import ClassVar, Type, Dict, List, Optional, Union, cast
 
 from pyspark.java_gateway import local_connect_and_auth
 from pyspark.resource import ResourceInformation
@@ -29,7 +29,7 @@ class TaskContext(object):
     :meth:`TaskContext.get`.
     """
 
-    _taskContext: Optional["TaskContext"] = None
+    _taskContext: ClassVar[Optional["TaskContext"]] = None
 
     _attemptNumber: Optional[int] = None
     _partitionId: Optional[int] = None
@@ -171,8 +171,8 @@ class BarrierTaskContext(TaskContext):
     This API is experimental
     """
 
-    _port = None
-    _secret = None
+    _port: ClassVar[Optional[Union[str, int]]] = None
+    _secret: ClassVar[Optional[str]] = None
 
     @classmethod
     def _getOrCreate(cls: Type["BarrierTaskContext"]) -> "BarrierTaskContext":


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes class variable type hints in taskcontext.py.

### Why are the changes needed?

In `taskcontext.py`, a variable `_taskContext` should be annotated as `ClassVar` of `TaskContext`.
Also, `_port` and `_secret` of `BarrierTaskContext ` should be annotated.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`lint-python` should pass.