### PR TITLE
[SPARK-37312][TESTS] Add `.java-version` to `.gitignore` and `.rat-excludes`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.pyo
 *.swp
 *~
+.java-version
 .DS_Store
 .bsp/
 .cache

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -10,6 +10,7 @@ cache
 .generated-mima-member-excludes
 .rat-excludes
 .*md
+.java-version
 derby.log
 licenses/*
 licenses-binary/*


### PR DESCRIPTION
### What changes were proposed in this pull request?

To support Java 8/11/17 test more easily, this PR aims to add `.java-version` to `.gitignore` and `.rat-excludes`.

### Why are the changes needed?

When we use `jenv`, `dev/check-license` and `dev/run-tests` fails.

```
========================================================================
Running Apache RAT checks
========================================================================
Could not find Apache license headers in the following files:
 !????? /Users/dongjoon/APACHE/spark-merge/.java-version
[error] running /Users/dongjoon/APACHE/spark-merge/dev/check-license ; received return code 1
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
$ jenv local 17
$ dev/check-license
```