### PR TITLE
[SPARK-37315][ML][TEST] Mitigate ConcurrentModificationException thrown from a test in MLEventSuite

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/MLEventsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/MLEventsSuite.scala
@@ -234,9 +234,11 @@ class MLEventsSuite
         }
       }
       // Test if they can be ser/de via JSON protocol.
-      assert(events.nonEmpty)
-      events.map(JsonProtocol.sparkEventToJson).foreach { event =>
-        assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+      eventually(timeout(10.seconds), interval(1.second)) {
+        assert(events.nonEmpty)
+        events.map(JsonProtocol.sparkEventToJson).foreach { event =>
+          assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+        }
       }
       sc.listenerBus.waitUntilEmpty(timeoutMillis = 10000)
 
@@ -260,9 +262,11 @@ class MLEventsSuite
         }
       }
       // Test if they can be ser/de via JSON protocol.
-      assert(events.nonEmpty)
-      events.map(JsonProtocol.sparkEventToJson).foreach { event =>
-        assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+      eventually(timeout(10.seconds), interval(1.second)) {
+        assert(events.nonEmpty)
+        events.map(JsonProtocol.sparkEventToJson).foreach { event =>
+          assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+        }
       }
     }
   }
@@ -293,9 +297,11 @@ class MLEventsSuite
         }
       }
       // Test if they can be ser/de via JSON protocol.
-      assert(events.nonEmpty)
-      events.map(JsonProtocol.sparkEventToJson).foreach { event =>
-        assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+      eventually(timeout(10.seconds), interval(1.second)) {
+        assert(events.nonEmpty)
+        events.map(JsonProtocol.sparkEventToJson).foreach { event =>
+          assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+        }
       }
       sc.listenerBus.waitUntilEmpty(timeoutMillis = 10000)
 
@@ -319,9 +325,11 @@ class MLEventsSuite
         }
       }
       // Test if they can be ser/de via JSON protocol.
-      assert(events.nonEmpty)
-      events.map(JsonProtocol.sparkEventToJson).foreach { event =>
-        assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+      eventually(timeout(10.seconds), interval(1.second)) {
+        assert(events.nonEmpty)
+        events.map(JsonProtocol.sparkEventToJson).foreach { event =>
+          assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR is to mitigate `ConcurrentModificationException` sometimes thrown from a test.
Recently, I notice the exception is thrown from the following part of the test `pipeline read/write events` in `MLEventSuite` when Scala 2.13 is used.
```
events.map(JsonProtocol.sparkEventToJson).foreach { event =>
  assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
}
```

We can also find this issue from the scheduled build.
https://github.com/apache/spark/runs/4196812399?check_suite_focus=true#step:9:17616

I think the root cause is the `ArrayBuffer` (`events`) is updated asynchronously by the following part.
```
private val listener: SparkListener = new SparkListener {
  override def onOtherEvent(event: SparkListenerEvent): Unit = event match {
    case e: MLEvent => events.append(e)
    case _ =>
  }
}
```
You can easily reproduce this issue by applying the following diff to the commit hash 4d29becee1ee8afa990f91684d84d717.
```
diff --git a/mllib/src/test/scala/org/apache/spark/ml/MLEventsSuite.scala b/mllib/src/test/scala/org/apache/spark/ml/MLEventsSuite.scala
index f2343b7a88..ff63639e00 100644
--- a/mllib/src/test/scala/org/apache/spark/ml/MLEventsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/MLEventsSuite.scala
@@ -42,7 +42,9 @@ class MLEventsSuite
   private val events = mutable.ArrayBuffer.empty[MLEvent]
   private val listener: SparkListener = new SparkListener {
     override def onOtherEvent(event: SparkListenerEvent): Unit = event match {
-      case e: MLEvent => events.append(e)
+      case e: MLEvent =>
+        events.append(e)
+        Thread.sleep(500)
       case _ =>
     }
   }
@@ -235,11 +237,13 @@ class MLEventsSuite
       }
       // Test if they can be ser/de via JSON protocol.
       assert(events.nonEmpty)
-      events.map(JsonProtocol.sparkEventToJson).foreach { event =>
-        assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
-      }
+        events.map { x =>
+          Thread.sleep(500)
+          JsonProtocol.sparkEventToJson(x)
+        }.foreach { event =>
+          assert(JsonProtocol.sparkEventFromJson(event).isInstanceOf[MLEvent])
+        }
       sc.listenerBus.waitUntilEmpty(timeoutMillis = 10000)
-
       events.clear()
       val pipelineReader = Pipeline.read
       assert(events.isEmpty)
```

This is a kind of race condition but I think we can mitigate by retrying.

Actually, I have never seen this issue when I used Scala 2.13.5 and recently we upgrade to 2.13.7.
Scala 2.13.7 includes an update to detect `ConcurrentModificationException` more precisely.
https://github.com/scala/scala/pull/9786

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For test stability.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I manually modified the test code, inserting sleep like the diff shown above, and confirmed no ConcurrentModificationException is thrown.