### PR TITLE
[SPARK-37317][MLLIB][TESTS] Reduce weights in GaussianMixtureSuite

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/GaussianMixtureSuite.scala
@@ -268,7 +268,7 @@ class GaussianMixtureSuite extends MLTest with DefaultReadWriteTest {
     val gm1 = new GaussianMixture().setK(k).setMaxIter(20).setSeed(seed)
     val gm2 = new GaussianMixture().setK(k).setMaxIter(20).setSeed(seed).setWeightCol("weight")
 
-    Seq(1.0, 10.0, 100.0).foreach { w =>
+    Seq(1.0, 10.0, 90.0).foreach { w =>
       val gmm1 = gm1.fit(dataset)
       val ds2 = dataset.select(col("features"), lit(w).as("weight"))
       val gmm2 = gm2.fit(ds2)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce the test weight `100` to `90` to improve the robustness of test case `GMM support instance weighting`.
```scala
test("GMM support instance weighting") {
  val gm1 = new GaussianMixture().setK(k).setMaxIter(20).setSeed(seed)
  val gm2 = new GaussianMixture().setK(k).setMaxIter(20).setSeed(seed).setWeightCol("weight")
- Seq(1.0, 10.0, 100.0).foreach { w =>
+ Seq(1.0, 10.0, 90.0).foreach { w =>
```

### Why are the changes needed?

As mentioned in https://github.com/apache/spark/pull/26735#discussion_r352551174, the weights of model changes when the weights grow. And, the final weight `100` seems to be high enough to cause failures on some JVMs. This is observed in Java 17 M1 native mode.

```
$ java -version
openjdk version "17" 2021-09-14 LTS
OpenJDK Runtime Environment Zulu17.28+13-CA (build 17+35-LTS)
OpenJDK 64-Bit Server VM Zulu17.28+13-CA (build 17+35-LTS, mixed mode, sharing)
```

**BEFORE**
```
$ build/sbt "mllib/test"
...
[info] - GMM support instance weighting *** FAILED *** (1 second, 722 milliseconds)
[info]   Expected 0.10476714410584752 and 1.209081654091291E-14 to be within 0.001 using absolute tolerance. (TestingUtils.scala:88)
...
[info] *** 1 TEST FAILED ***
[error] Failed: Total 1760, Failed 1, Errors 0, Passed 1759, Ignored 7
[error] Failed tests:
[error] 	org.apache.spark.ml.clustering.GaussianMixtureSuite
[error] (mllib / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 625 s (10:25), completed Nov 13, 2021, 6:21:13 PM
```

**AFTER**
```
[info] Total number of tests run: 1638
[info] Suites: completed 205, aborted 0
[info] Tests: succeeded 1638, failed 0, canceled 0, ignored 7, pending 0
[info] All tests passed.
[info] Passed: Total 1760, Failed 0, Errors 0, Passed 1760, Ignored 7
[success] Total time: 568 s (09:28), completed Nov 13, 2021, 6:09:16 PM
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.