### PR TITLE
[SPARK-36876][SQL][TESTS][FOLLOW-UP] Remove unnecessary matching cases for hive table tests in DynamicPartitionPruningHiveScanSuite

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.hive.execution.HiveTableScanExec
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.test.SQLTestUtils
 
-abstract class DynamicPartitionPruningHiveScanSuite
+abstract class DynamicPartitionPruningHiveScanSuiteBase
     extends DynamicPartitionPruningSuiteBase with TestHiveSingleton with SQLTestUtils {
 
   override val tableFormat: String = "hive"

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -32,6 +32,9 @@ abstract class DynamicPartitionPruningHiveScanSuiteBase
 
   override protected def collectDynamicPruningExpressions(plan: SparkPlan): Seq[Expression] = {
     flatMap(plan) {
+      case s: FileSourceScanExec => s.partitionFilters.collect {
+        case d: DynamicPruningExpression => d.child
+      }
       case h: HiveTableScanExec => h.partitionPruningPred.collect {
         case d: DynamicPruningExpression => d.child
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -40,8 +40,8 @@ abstract class DynamicPartitionPruningHiveScanSuiteBase
   }
 }
 
-class DynamicPartitionPruningHiveScanSuiteAEOff extends DynamicPartitionPruningHiveScanSuite
+class DynamicPartitionPruningHiveScanSuiteAEOff extends DynamicPartitionPruningHiveScanSuiteBase
   with DisableAdaptiveExecutionSuite
 
-class DynamicPartitionPruningHiveScanSuiteAEOn extends DynamicPartitionPruningHiveScanSuite
+class DynamicPartitionPruningHiveScanSuiteAEOn extends DynamicPartitionPruningHiveScanSuiteBase
   with EnableAdaptiveExecutionSuite

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{DynamicPruningExpression, Expression}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.{DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
-import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.hive.execution.HiveTableScanExec
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.test.SQLTestUtils

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -33,12 +33,6 @@ abstract class DynamicPartitionPruningHiveScanSuite
 
   override protected def collectDynamicPruningExpressions(plan: SparkPlan): Seq[Expression] = {
     flatMap(plan) {
-      case s: FileSourceScanExec => s.partitionFilters.collect {
-        case d: DynamicPruningExpression => d.child
-      }
-      case s: BatchScanExec => s.runtimeFilters.collect {
-        case d: DynamicPruningExpression => d.child
-      }
       case h: HiveTableScanExec => h.partitionPruningPred.collect {
         case d: DynamicPruningExpression => d.child
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove redundant branches. In this suite,  table format is 'hive table', so these branches won't enter.

### Why are the changes needed?
Clean code.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Exist UT
