### PR TITLE
[SPARK-32567][SQL][FOLLOWUP] Fix CompileException when code generate for FULL OUTER shuffled hash join

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -376,7 +376,7 @@ case class ShuffledHashJoinExec(
     val consumeFullOuterJoinRow = ctx.freshName("consumeFullOuterJoinRow")
     ctx.addNewFunction(consumeFullOuterJoinRow,
       s"""
-         |private void $consumeFullOuterJoinRow() {
+         |private void $consumeFullOuterJoinRow() throws java.io.IOException {
          |  ${metricTerm(ctx, "numOutputRows")}.add(1);
          |  ${consume(ctx, resultVars)}
          |}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -213,7 +213,6 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       Seq(Row(0, 0, 0), Row(1, 1, null), Row(2, 2, 2), Row(3, 3, null), Row(4, 4, null),
         Row(null, 5, null), Row(null, 6, null), Row(null, 7, null), Row(null, 8, null),
         Row(null, 9, null), Row(null, null, 1)))
-
   }
 
   test("Left/Right Outer SortMergeJoin should be included in WholeStageCodegen") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -212,6 +212,13 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       Seq(Row(0, 0, 0), Row(1, 1, null), Row(2, 2, 2), Row(3, 3, null), Row(4, 4, null),
         Row(null, 5, null), Row(null, 6, null), Row(null, 7, null), Row(null, 8, null),
         Row(null, 9, null), Row(null, null, 1)))
+
+    // test join with Aggregate
+    val joinWithAggregateDF = df1.join(df2.hint("SHUFFLE_HASH"), $"k1" === $"k2", "full_outer")
+    assert(joinWithAggregateDF.queryExecution.executedPlan.collect {
+      case WholeStageCodegenExec(_ : ShuffledHashJoinExec) => true
+    }.size === 1)
+    assert(joinWithAggregateDF.count() === 10)
   }
 
   test("Left/Right Outer SortMergeJoin should be included in WholeStageCodegen") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -183,6 +183,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     }.size === 1)
     checkAnswer(joinUniqueDF, Seq(Row(0, 0), Row(1, 1), Row(2, 2), Row(3, 3), Row(4, 4),
       Row(null, 5), Row(null, 6), Row(null, 7), Row(null, 8), Row(null, 9)))
+    assert(joinUniqueDF.count() === 10)
 
     // test one join with non-unique key from build side
     val joinNonUniqueDF = df1.join(df2.hint("SHUFFLE_HASH"), $"k1" === $"k2" % 3, "full_outer")
@@ -213,12 +214,6 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         Row(null, 5, null), Row(null, 6, null), Row(null, 7, null), Row(null, 8, null),
         Row(null, 9, null), Row(null, null, 1)))
 
-    // test join with Aggregate
-    val joinWithAggregateDF = df1.join(df2.hint("SHUFFLE_HASH"), $"k1" === $"k2", "full_outer")
-    assert(joinWithAggregateDF.queryExecution.executedPlan.collect {
-      case WholeStageCodegenExec(_ : ShuffledHashJoinExec) => true
-    }.size === 1)
-    assert(joinWithAggregateDF.count() === 10)
   }
 
   test("Left/Right Outer SortMergeJoin should be included in WholeStageCodegen") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `throws IOException` to `consumeFullOuterJoinRow` in ShuffledHashJoinExec

### Why are the changes needed?
pr #34444 add code-gen for full outer shuffled hash join. If we don't have this patch,   when the dataframes are `fullter outer` shuffled hash joined, and then aggregate the results.  the dataframes will throw a `CompileException`. 
For example:
```scala
    val df1 = spark.range(5).select($"id".as("k1"))
    val df2 = spark.range(10).select($"id".as("k2"))
    df1.join(df2.hint("SHUFFLE_HASH"), $"k1" === $"k2", "full_outer").count()
```
The dataframe will throw an Exception which is as follows:
```
23:28:19.079 ERROR org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator: failed to compile: org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 175, Column 1: Thrown exception of type "java.io.IOException" is neither caught by a "try...catch" block nor declared in the "throws" clause of the declaring function
org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 175, Column 1: Thrown exception of type "java.io.IOException" is neither caught by a "try...catch" block nor declared in the "throws" clause of the declaring function
	at org.codehaus.janino.UnitCompiler.compileError(UnitCompiler.java:12021)
	at org.codehaus.janino.UnitCompiler.checkThrownException(UnitCompiler.java:9801)
	at org.codehaus.janino.UnitCompiler.checkThrownExceptions(UnitCompiler.java:9720)
	at org.codehaus.janino.UnitCompiler.findIMethod(UnitCompiler.java:9163)
	at org.codehaus.janino.UnitCompiler.compileGet2(UnitCompiler.java:5055)
```
### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add a new UT
