### PR TITLE
[SPARK-37322][TESTS] `run_scala_tests` should respect test module order

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -469,7 +469,8 @@ def run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, inc
     `determine_test_suites` function"""
     set_title_and_block("Running Spark unit tests", "BLOCK_SPARK_UNIT_TESTS")
 
-    test_modules = set(test_modules)
+    # Remove duplicates while keeping the test module order
+    test_modules = list(dict.fromkeys(test_modules))
 
     test_profiles = extra_profiles + \
         list(set(itertools.chain.from_iterable(m.build_profile_flags for m in test_modules)))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to make `run_scala_tests` respect test module order


### Why are the changes needed?
Currently the execution order is random.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually through the following and check if the catalyst module runs first. 

```
$ SKIP_MIMA=1 SKIP_UNIDOC=1 ./dev/run-tests --parallelism 1 --modules "catalyst,hive-thriftserver"
```
