### PR TITLE
[SPARK-37323][INFRA][3.1] Pin `docutils` to 0.17.x

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -337,7 +337,7 @@ jobs:
         #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
         # Jinja2 3.0.0+ causes error when building with Sphinx.
         #   See also https://issues.apache.org/jira/browse/SPARK-35375.
-        python3.6 -m pip install flake8 'sphinx<3.1.0' numpy pydata_sphinx_theme ipython nbsphinx mypy numpydoc 'jinja2<3.0.0'
+        python3.6 -m pip install flake8 'sphinx<3.1.0' numpy pydata_sphinx_theme ipython nbsphinx mypy numpydoc 'jinja2<3.0.0' 'docutils<0.18'
     - name: Install R linter dependencies and SparkR
       run: |
         apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ping `docutils` to `0.17.x` to recover branch-3.1 GitHub Action linter job.

### Why are the changes needed?

`docutils` 0.18 is released October 26 and causes Python linter failure in branch-3.1.
- https://pypi.org/project/docutils/#history
- https://github.com/apache/spark/commits/branch-3.1

```
Exception occurred:
  File "/__t/Python/3.6.15/x64/lib/python3.6/site-packages/docutils/writers/html5_polyglot/__init__.py", line 445, in section_title_tags
    if (ids and self.settings.section_self_link
AttributeError: 'Values' object has no attribute 'section_self_link'
The full traceback has been saved in /tmp/sphinx-err-y2ttd83t.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [Makefile:20: html] Error 2
Error: Process completed with exit code 2.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the linter job on this PR.