### PR TITLE
[SPARK-36533][SS][FOLLOWUP] Address Trigger.AvailableNow in PySpark in SS guide doc

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -2878,6 +2878,12 @@ df.writeStream \
   .trigger(once=True) \
   .start()
 
+# Available-now trigger
+df.writeStream \
+  .format("console") \
+  .trigger(availableNow=True) \
+  .start()
+
 # Continuous trigger with one-second checkpointing interval
 df.writeStream
   .format("console")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR addresses missing piece on adding Trigger.AvailableNow in Python code example in SS guide doc.

![스크린샷 2021-11-15 오후 12 47 08](https://user-images.githubusercontent.com/1317309/141719753-4e102adc-adba-4fd6-8d10-959f9b41e412.png)

### Why are the changes needed?

The SS guide doc doesn't mention a new trigger in Python code example.

### Does this PR introduce _any_ user-facing change?

Yes, doc change as above screenshot.

### How was this patch tested?

N/A