### PR TITLE
[SPARK-37328][SQL] Fix bug that OptimizeSkewedJoin may not work after it was moved from queryStageOptimizerRules to queryStagePreparationRules.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -310,8 +310,10 @@ case class OptimizeSkewedJoin(
     if (plan2NewQueryStageMapping(plan)) {
       Seq(plan)
     } else {
+      // return exchange rather than it's child because ensureRequirements with requiredDistribution
+      // may bring extra shuffle if we just return child of exchange
       plan.collect {
-        case e: Exchange if plan2NewQueryStageMapping(e.child) => e.child
+        case e: Exchange if plan2NewQueryStageMapping(e.child) => e
       }
     }
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix the issue that OptimizeSkewedJoin may not work.
Since OptimizeSkewedJoin was moved from `queryStageOptimizerRules` to `queryStagePreparationRules,` the position OptimizeSkewedJoin was applied has been moved from `newQueryStage()` to `reOptimize()`. The plan OptimizeSkewedJoin applied on changed from plan of new stage which is about to submit to whole spark plan.
In the cases where skewedJoin is not last stage, OptimizeSkewedJoin may not work because the number of collected shuffleStages is more than 2.


### Why are the changes needed?
Bug fix.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New test.
