### PR TITLE
[SPARK-37702][SQL][FOLLOWUP] Store referred temp functions for CacheTableAsSelect

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1027,7 +1027,8 @@ case class CacheTableAsSelect(
     originalText: String,
     isLazy: Boolean,
     options: Map[String, String],
-    isAnalyzed: Boolean = false) extends AnalysisOnlyCommand {
+    isAnalyzed: Boolean = false,
+    referredTempFunctions: Seq[String] = Seq.empty) extends AnalysisOnlyCommand {
   override protected def withNewChildrenInternal(
       newChildren: IndexedSeq[LogicalPlan]): CacheTableAsSelect = {
     assert(!isAnalyzed)
@@ -1036,7 +1037,12 @@ case class CacheTableAsSelect(
 
   override def childrenToAnalyze: Seq[LogicalPlan] = plan :: Nil
 
-  override def markAsAnalyzed(ac: AnalysisContext): LogicalPlan = copy(isAnalyzed = true)
+  override def markAsAnalyzed(ac: AnalysisContext): LogicalPlan = {
+    copy(
+      isAnalyzed = true,
+      // Collect the referred temporary functions from AnalysisContext
+      referredTempFunctions = ac.referredTempFunctionNames.toSeq)
+  }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CacheTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CacheTableExec.scala
@@ -88,7 +88,8 @@ case class CacheTableAsSelectExec(
     query: LogicalPlan,
     originalText: String,
     override val isLazy: Boolean,
-    override val options: Map[String, String]) extends BaseCacheTableExec {
+    override val options: Map[String, String],
+    referredTempFunctions: Seq[String]) extends BaseCacheTableExec {
   override lazy val relationName: String = tempViewName
 
   override lazy val planToCache: LogicalPlan = {
@@ -102,7 +103,8 @@ case class CacheTableAsSelectExec(
       allowExisting = false,
       replace = false,
       viewType = LocalTempView,
-      isAnalyzed = true
+      isAnalyzed = true,
+      referredTempFunctions = referredTempFunctions
     ).run(session)
 
     dataFrameForCachedPlan.logicalPlan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -418,7 +418,8 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       CacheTableExec(r.table, r.multipartIdentifier, r.isLazy, r.options) :: Nil
 
     case r: CacheTableAsSelect =>
-      CacheTableAsSelectExec(r.tempViewName, r.plan, r.originalText, r.isLazy, r.options) :: Nil
+      CacheTableAsSelectExec(
+        r.tempViewName, r.plan, r.originalText, r.isLazy, r.options, r.referredTempFunctions) :: Nil
 
     case r: UncacheTable =>
       def isTempView(table: LogicalPlan): Boolean = table match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1643,4 +1643,12 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
       }
     }
   }
+
+  test("SPARK-37702: cache table with temporary function ") {
+    spark.udf.register("udf", (id: Int) => id + 1)
+    withTempView("cached_t") {
+      sql("CACHE TABLE cached_t as SELECT udf(id) FROM VALUES (1), (2) t(id)")
+      checkAnswer(sql("SELECT * FROM cached_t"), Row(2) :: Row(3) :: Nil)
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1645,10 +1645,12 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
   }
 
   test("SPARK-37702: cache table with temporary function ") {
-    spark.udf.register("udf", (id: Int) => id + 1)
-    withTempView("cached_t") {
-      sql("CACHE TABLE cached_t as SELECT udf(id) FROM VALUES (1), (2) t(id)")
-      checkAnswer(sql("SELECT * FROM cached_t"), Row(2) :: Row(3) :: Nil)
+    withUserDefinedFunction("udf" -> true) {
+      spark.udf.register("udf", (id: Int) => id + 1)
+      withTempView("cached_t") {
+        sql("CACHE TABLE cached_t as SELECT udf(id) FROM VALUES (1), (2) t(id)")
+        checkAnswer(sql("SELECT * FROM cached_t"), Row(2) :: Row(3) :: Nil)
+      }
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a follow-up of PR #34546 which uses the `AnalysisContext` to store referred
temporary functions when creating temp views. But the `CacheTableAsSelect` also
needs to update the temporary functions because it's a temp view under the hood.


### Why are the changes needed?
Followup of #34546


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
newly added ut
