### PR TITLE
[SPARK-37336][ML][PYTHON] Migrate _java2py from SQLContext to SparkSession

### DIFF
--- a/python/pyspark/ml/common.py
+++ b/python/pyspark/ml/common.py
@@ -96,7 +96,7 @@ def _java2py(sc, r, encoding="bytes"):
             return RDD(jrdd, sc)
 
         if clsName == "Dataset":
-            return DataFrame(r, SparkSession(sc))
+            return DataFrame(r, SparkSession(sc)._wrapped)
 
         if clsName in _picklable_classes:
             r = sc._jvm.org.apache.spark.ml.python.MLSerDe.dumps(r)

--- a/python/pyspark/ml/common.py
+++ b/python/pyspark/ml/common.py
@@ -22,7 +22,7 @@ from py4j.java_collections import JavaArray, JavaList
 
 from pyspark import RDD, SparkContext
 from pyspark.serializers import PickleSerializer, AutoBatchedSerializer
-from pyspark.sql import DataFrame, SQLContext
+from pyspark.sql import DataFrame, SparkSession
 
 # Hack for support float('inf') in Py4j
 _old_smart_decode = py4j.protocol.smart_decode
@@ -96,7 +96,7 @@ def _java2py(sc, r, encoding="bytes"):
             return RDD(jrdd, sc)
 
         if clsName == "Dataset":
-            return DataFrame(r, SQLContext.getOrCreate(sc))
+            return DataFrame(r, SparkSession(sc))
 
         if clsName in _picklable_classes:
             r = sc._jvm.org.apache.spark.ml.python.MLSerDe.dumps(r)
@@ -104,7 +104,7 @@ def _java2py(sc, r, encoding="bytes"):
             try:
                 r = sc._jvm.org.apache.spark.ml.python.MLSerDe.dumps(r)
             except Py4JJavaError:
-                pass  # not pickable
+                pass  # not picklable
 
     if isinstance(r, (bytearray, bytes)):
         r = PickleSerializer().loads(bytes(r), encoding=encoding)

--- a/python/pyspark/mllib/common.py
+++ b/python/pyspark/mllib/common.py
@@ -22,7 +22,7 @@ from py4j.java_collections import JavaArray, JavaList
 
 from pyspark import RDD, SparkContext
 from pyspark.serializers import PickleSerializer, AutoBatchedSerializer
-from pyspark.sql import DataFrame, SQLContext
+from pyspark.sql import DataFrame, SparkSession
 
 # Hack for support float('inf') in Py4j
 _old_smart_decode = py4j.protocol.smart_decode
@@ -98,7 +98,7 @@ def _java2py(sc, r, encoding="bytes"):
             return RDD(jrdd, sc)
 
         if clsName == "Dataset":
-            return DataFrame(r, SQLContext.getOrCreate(sc))
+            return DataFrame(r, SparkSession(sc)._wrapped)
 
         if clsName in _picklable_classes:
             r = sc._jvm.org.apache.spark.mllib.api.python.SerDe.dumps(r)


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://github.com/apache/spark/blob/2fe9af8b2b91d0a46782dd6fff57eca8609be105/python/pyspark/ml/common.py#L99

`_java2py()` uses a deprecated method to create a SparkSession. This triggers a warning:

https://github.com/apache/spark/blob/007afbbde9b128fc22c133035ad52239943a7290/python/pyspark/sql/context.py#L162-L165

This PR updates `_java2py()` so it creates a SparkSession using the builder.

### Why are the changes needed?

Non-deprecated internal methods should not invoke deprecated methods that trigger user-visible warnings.

### Does this PR introduce _any_ user-facing change?

Yes, this PR eliminates a user-facing deprecation warning, e.g. when invoking ML methods.

### How was this patch tested?

Manual testing.