### PR TITLE
[SPARK-37339][K8S] Add `spark-version`  label to driver and executor pods

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -19,6 +19,7 @@ package org.apache.spark.deploy.k8s
 private[spark] object Constants {
 
   // Labels
+  val SPARK_VERSION_LABEL = "spark-version"
   val SPARK_APP_ID_LABEL = "spark-app-selector"
   val SPARK_APP_NAME_LABEL = "spark-app-name"
   val SPARK_EXECUTOR_ID_LABEL = "spark-exec-id"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -21,7 +21,7 @@ import java.util.{Locale, UUID}
 import io.fabric8.kubernetes.api.model.{LocalObjectReference, LocalObjectReferenceBuilder, Pod}
 import org.apache.commons.lang3.StringUtils
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SPARK_VERSION, SparkConf}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.submit._
@@ -94,6 +94,7 @@ private[spark] class KubernetesDriverConf(
 
   override def labels: Map[String, String] = {
     val presetLabels = Map(
+      SPARK_VERSION_LABEL -> SPARK_VERSION,
       SPARK_APP_ID_LABEL -> appId,
       SPARK_APP_NAME_LABEL -> KubernetesConf.getAppNameLabel(appName),
       SPARK_ROLE_LABEL -> SPARK_POD_DRIVER_ROLE)
@@ -155,6 +156,7 @@ private[spark] class KubernetesExecutorConf(
 
   override def labels: Map[String, String] = {
     val presetLabels = Map(
+      SPARK_VERSION_LABEL -> SPARK_VERSION,
       SPARK_EXECUTOR_ID_LABEL -> executorId,
       SPARK_APP_ID_LABEL -> appId,
       SPARK_APP_NAME_LABEL -> KubernetesConf.getAppNameLabel(appName),

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.k8s
 
 import io.fabric8.kubernetes.api.model.{LocalObjectReferenceBuilder, PodBuilder}
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.{SPARK_VERSION, SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.submit._
@@ -88,6 +88,7 @@ class KubernetesConfSuite extends SparkFunSuite {
       APP_ARGS,
       None)
     assert(conf.labels === Map(
+      SPARK_VERSION_LABEL -> SPARK_VERSION,
       SPARK_APP_ID_LABEL -> KubernetesTestConf.APP_ID,
       SPARK_APP_NAME_LABEL -> KubernetesConf.getAppNameLabel(conf.appName),
       SPARK_ROLE_LABEL -> SPARK_POD_DRIVER_ROLE) ++
@@ -154,6 +155,7 @@ class KubernetesConfSuite extends SparkFunSuite {
       KubernetesTestConf.APP_ID,
       Some(DRIVER_POD))
     assert(conf.labels === Map(
+      SPARK_VERSION_LABEL -> SPARK_VERSION,
       SPARK_EXECUTOR_ID_LABEL -> EXECUTOR_ID,
       SPARK_APP_ID_LABEL -> KubernetesTestConf.APP_ID,
       SPARK_APP_NAME_LABEL -> KubernetesConf.getAppNameLabel(conf.appName),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `spark-version` label additionally to the driver and executor pods.

### Why are the changes needed?

This enables the users select Spark jobs by the versions.

```
$ bin/spark-submit \
--master k8s://https://kubernetes.docker.internal:6443 \
--deploy-mode cluster \
-c spark.executor.instances=2 \
-c spark.kubernetes.container.image=dongjoon/spark:v3.3.0 \
--class org.apache.spark.examples.SparkPi \
local:///opt/spark/examples/jars/spark-examples_2.12-3.3.0-SNAPSHOT.jar 200000
...
21/11/15 14:19:57 INFO LoggingPodStatusWatcherImpl: State changed, new state:
	 pod name: org-apache-spark-examples-sparkpi-e7c7e17d25af7a9e-driver
	 namespace: default
	 labels:
           spark-app-name -> org-apache-spark-examples-sparkpi,
           spark-app-selector -> spark-ba77aee3ee284c80b5112d204f778067,
           spark-role -> driver,
           spark-version -> 3.3.0-SNAPSHOT
```

```
$ k get pod -l spark-version=3.3.0-SNAPSHOT
NAME                                                        READY   STATUS    RESTARTS   AGE
org-apache-spark-examples-sparkpi-e7c7e17d25af7a9e-driver   1/1     Running   0          37s
spark-pi-8a81ea7d25af8638-exec-1                            1/1     Running   0          34s
spark-pi-8a81ea7d25af8638-exec-2                            1/1     Running   0          34s
```

### Does this PR introduce _any_ user-facing change?

Yes, but it's a new K8s label.

### How was this patch tested?

Pass the CIs with the newly added test cases.