### PR TITLE
[SPARK-35867][SQL] Enable vectorized read for VectorizedPlainValuesReader.readBooleans

### DIFF
--- a/sql/core/benchmarks/DataSourceReadBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DataSourceReadBenchmark-jdk11-results.txt
@@ -1,252 +1,275 @@
 ================================================================================================
+SQL Single Boolean Column Scan
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+SQL CSV                                           12646          12949         429          1.2         804.0       1.0X
+SQL Json                                          11373          11432          83          1.4         723.1       1.1X
+SQL Parquet Vectorized                              143            171          22        110.1           9.1      88.5X
+SQL Parquet MR                                     2575           2585          14          6.1         163.7       4.9X
+SQL ORC Vectorized                                  181            238          57         87.0          11.5      69.9X
+SQL ORC MR                                         1915           1938          32          8.2         121.7       6.6X
+
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+ParquetReader Vectorized                             110            121          15        143.4           7.0       1.0X
+ParquetReader Vectorized -> Row                       49             52           3        318.8           3.1       2.2X
+
+
+================================================================================================
 SQL Single Numeric Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           13405          13422          24          1.2         852.3       1.0X
-SQL Json                                          10723          10788          92          1.5         681.7       1.3X
-SQL Parquet Vectorized                              164            217          50         95.9          10.4      81.8X
-SQL Parquet MR                                     2349           2440         129          6.7         149.3       5.7X
-SQL ORC Vectorized                                  312            346          23         50.4          19.8      43.0X
-SQL ORC MR                                         1610           1659          69          9.8         102.4       8.3X
+SQL CSV                                           14713          14785         102          1.1         935.4       1.0X
+SQL Json                                          12537          12551          21          1.3         797.1       1.2X
+SQL Parquet Vectorized                              169            203          39         93.3          10.7      87.3X
+SQL Parquet MR                                     2774           2794          27          5.7         176.4       5.3X
+SQL ORC Vectorized                                  253            295          41         62.3          16.1      58.3X
+SQL ORC MR                                         1855           1870          20          8.5         118.0       7.9X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single TINYINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                             187            209          20         84.3          11.9       1.0X
-ParquetReader Vectorized -> Row                       89             95           5        177.6           5.6       2.1X
+ParquetReader Vectorized                             206            218          12         76.5          13.1       1.0X
+ParquetReader Vectorized -> Row                       96            104           7        163.8           6.1       2.1X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           14214          14549         474          1.1         903.7       1.0X
-SQL Json                                          11866          11934          95          1.3         754.4       1.2X
-SQL Parquet Vectorized                              294            342          53         53.6          18.7      48.4X
-SQL Parquet MR                                     2929           3004         107          5.4         186.2       4.9X
-SQL ORC Vectorized                                  312            328          15         50.4          19.8      45.5X
-SQL ORC MR                                         2037           2097          84          7.7         129.5       7.0X
+SQL CSV                                           15546          15573          38          1.0         988.4       1.0X
+SQL Json                                          13027          13031           5          1.2         828.3       1.2X
+SQL Parquet Vectorized                              209            243          32         75.3          13.3      74.4X
+SQL Parquet MR                                     3129           3150          29          5.0         199.0       5.0X
+SQL ORC Vectorized                                  320            353          26         49.1          20.4      48.5X
+SQL ORC MR                                         2236           2258          31          7.0         142.1       7.0X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single SMALLINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                              249            266          18         63.1          15.8       1.0X
-ParquetReader Vectorized -> Row                       192            247          36         82.1          12.2       1.3X
+ParquetReader Vectorized                              295            307          11         53.3          18.8       1.0X
+ParquetReader Vectorized -> Row                       323            333           8         48.6          20.6       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           15502          15817         446          1.0         985.6       1.0X
-SQL Json                                          12638          12646          11          1.2         803.5       1.2X
-SQL Parquet Vectorized                              193            256          44         81.7          12.2      80.5X
-SQL Parquet MR                                     2943           2953          14          5.3         187.1       5.3X
-SQL ORC Vectorized                                  324            370          34         48.5          20.6      47.8X
-SQL ORC MR                                         2110           2163          75          7.5         134.1       7.3X
+SQL CSV                                           17181          17202          30          0.9        1092.4       1.0X
+SQL Json                                          13669          13701          45          1.2         869.0       1.3X
+SQL Parquet Vectorized                              190            252          36         82.9          12.1      90.6X
+SQL Parquet MR                                     3081           3117          50          5.1         195.9       5.6X
+SQL ORC Vectorized                                  374            392          15         42.1          23.8      46.0X
+SQL ORC MR                                         2225           2244          27          7.1         141.5       7.7X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single INT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            276            287          14         57.0          17.6       1.0X
-ParquetReader Vectorized -> Row                     309            320           9         50.9          19.6       0.9X
+ParquetReader Vectorized                            313            325          10         50.2          19.9       1.0X
+ParquetReader Vectorized -> Row                     315            335          16         50.0          20.0       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           20156          20694         761          0.8        1281.5       1.0X
-SQL Json                                          15228          15380         214          1.0         968.2       1.3X
-SQL Parquet Vectorized                              325            346          20         48.4          20.7      62.0X
-SQL Parquet MR                                     3144           3228         118          5.0         199.9       6.4X
-SQL ORC Vectorized                                  516            526           7         30.5          32.8      39.0X
-SQL ORC MR                                         2353           2367          19          6.7         149.6       8.6X
+SQL CSV                                           23590          23599          12          0.7        1499.8       1.0X
+SQL Json                                          16229          16277          67          1.0        1031.8       1.5X
+SQL Parquet Vectorized                              331            352          26         47.5          21.1      71.2X
+SQL Parquet MR                                     3198           3206          11          4.9         203.3       7.4X
+SQL ORC Vectorized                                  490            547          38         32.1          31.1      48.2X
+SQL ORC MR                                         2455           2462          11          6.4         156.1       9.6X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single BIGINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            372            396          24         42.3          23.6       1.0X
-ParquetReader Vectorized -> Row                     437            462          25         36.0          27.8       0.9X
+ParquetReader Vectorized                            378            390          12         41.6          24.0       1.0X
+ParquetReader Vectorized -> Row                     466            474           5         33.7          29.6       0.8X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           17413          17599         263          0.9        1107.1       1.0X
-SQL Json                                          14416          14453          53          1.1         916.5       1.2X
-SQL Parquet Vectorized                              181            225          35         86.8          11.5      96.1X
-SQL Parquet MR                                     2940           2996          78          5.3         186.9       5.9X
-SQL ORC Vectorized                                  470            494          29         33.5          29.9      37.1X
-SQL ORC MR                                         2351           2379          39          6.7         149.5       7.4X
+SQL CSV                                           17771          17772           1          0.9        1129.9       1.0X
+SQL Json                                          15675          15714          54          1.0         996.6       1.1X
+SQL Parquet Vectorized                              180            218          30         87.6          11.4      98.9X
+SQL Parquet MR                                     3006           3082         107          5.2         191.1       5.9X
+SQL ORC Vectorized                                  569            593          23         27.6          36.2      31.2X
+SQL ORC MR                                         2512           2512           1          6.3         159.7       7.1X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single FLOAT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            268            282          14         58.7          17.0       1.0X
-ParquetReader Vectorized -> Row                     298            321          18         52.8          18.9       0.9X
+ParquetReader Vectorized                            297            306          10         52.9          18.9       1.0X
+ParquetReader Vectorized -> Row                     343            357          10         45.9          21.8       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           21666          21697          43          0.7        1377.5       1.0X
-SQL Json                                          18307          18363          79          0.9        1163.9       1.2X
-SQL Parquet Vectorized                              310            337          22         50.7          19.7      69.9X
-SQL Parquet MR                                     3089           3103          19          5.1         196.4       7.0X
-SQL ORC Vectorized                                  589            617          31         26.7          37.5      36.8X
-SQL ORC MR                                         2307           2377          98          6.8         146.7       9.4X
+SQL CSV                                           23089          23137          68          0.7        1468.0       1.0X
+SQL Json                                          20451          20492          58          0.8        1300.2       1.1X
+SQL Parquet Vectorized                              329            347          17         47.8          20.9      70.1X
+SQL Parquet MR                                     3215           3221           9          4.9         204.4       7.2X
+SQL ORC Vectorized                                  617            623           7         25.5          39.2      37.4X
+SQL ORC MR                                         2597           2608          16          6.1         165.1       8.9X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single DOUBLE Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            400            415          18         39.3          25.4       1.0X
-ParquetReader Vectorized -> Row                     393            406          11         40.1          25.0       1.0X
+ParquetReader Vectorized                            359            375          30         43.9          22.8       1.0X
+ParquetReader Vectorized -> Row                     400            417          17         39.3          25.4       0.9X
 
 
 ================================================================================================
 Int and String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           17703          17719          22          0.6        1688.3       1.0X
-SQL Json                                          13095          13168         103          0.8        1248.9       1.4X
-SQL Parquet Vectorized                             2253           2266          19          4.7         214.8       7.9X
-SQL Parquet MR                                     4913           4977          91          2.1         468.5       3.6X
-SQL ORC Vectorized                                 2457           2467          14          4.3         234.3       7.2X
-SQL ORC MR                                         4433           4464          44          2.4         422.8       4.0X
+SQL CSV                                           16308          16319          15          0.6        1555.3       1.0X
+SQL Json                                          14512          14590         110          0.7        1384.0       1.1X
+SQL Parquet Vectorized                             2367           2439         102          4.4         225.7       6.9X
+SQL Parquet MR                                     5324           5328           5          2.0         507.8       3.1X
+SQL ORC Vectorized                                 2495           2510          21          4.2         237.9       6.5X
+SQL ORC MR                                         4559           4630         100          2.3         434.8       3.6X
 
 
 ================================================================================================
 Repeated String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9741           9804          89          1.1         929.0       1.0X
-SQL Json                                           8230           8401         241          1.3         784.9       1.2X
-SQL Parquet Vectorized                              618            650          31         17.0          58.9      15.8X
-SQL Parquet MR                                     2258           2311          75          4.6         215.4       4.3X
-SQL ORC Vectorized                                  608            629          15         17.3          58.0      16.0X
-SQL ORC MR                                         2466           2479          18          4.3         235.2       4.0X
+SQL CSV                                            9046           9050           6          1.2         862.7       1.0X
+SQL Json                                           9316           9329          19          1.1         888.4       1.0X
+SQL Parquet Vectorized                              742            747           4         14.1          70.8      12.2X
+SQL Parquet MR                                     2452           2475          33          4.3         233.8       3.7X
+SQL ORC Vectorized                                  620            635          13         16.9          59.2      14.6X
+SQL ORC MR                                         2396           2449          76          4.4         228.5       3.8X
 
 
 ================================================================================================
 Partitioned Table Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Partitioned Table:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Data column - CSV                                 24195          24573         534          0.7        1538.3       1.0X
-Data column - Json                                14746          14883         194          1.1         937.5       1.6X
-Data column - Parquet Vectorized                    352            385          34         44.7          22.4      68.7X
-Data column - Parquet MR                           3674           3694          27          4.3         233.6       6.6X
-Data column - ORC Vectorized                        480            505          26         32.8          30.5      50.4X
-Data column - ORC MR                               2913           3004         128          5.4         185.2       8.3X
-Partition column - CSV                             7527           7544          23          2.1         478.6       3.2X
-Partition column - Json                           11955          12051         135          1.3         760.1       2.0X
-Partition column - Parquet Vectorized                65             92          29        242.5           4.1     373.0X
-Partition column - Parquet MR                      1614           1628          21          9.7         102.6      15.0X
-Partition column - ORC Vectorized                    71             99          29        220.1           4.5     338.5X
-Partition column - ORC MR                          1761           1769          11          8.9         112.0      13.7X
-Both columns - CSV                                24077          24127          70          0.7        1530.8       1.0X
-Both columns - Json                               15286          15479         273          1.0         971.9       1.6X
-Both columns - Parquet Vectorized                   376            412          40         41.9          23.9      64.4X
-Both columns - Parquet MR                          3808           3826          26          4.1         242.1       6.4X
-Both columns - ORC Vectorized                       560            604          42         28.1          35.6      43.2X
-Both columns - ORC MR                              3046           3080          49          5.2         193.7       7.9X
+Data column - CSV                                 23350          23425         106          0.7        1484.6       1.0X
+Data column - Json                                15620          15796         248          1.0         993.1       1.5X
+Data column - Parquet Vectorized                    328            348          16         47.9          20.9      71.1X
+Data column - Parquet MR                           3784           3815          45          4.2         240.6       6.2X
+Data column - ORC Vectorized                        541            584          41         29.1          34.4      43.1X
+Data column - ORC MR                               3093           3097           7          5.1         196.6       7.6X
+Partition column - CSV                             8173           8222          69          1.9         519.6       2.9X
+Partition column - Json                           13335          13408         103          1.2         847.8       1.8X
+Partition column - Parquet Vectorized                67             96          25        234.3           4.3     347.8X
+Partition column - Parquet MR                      1668           1723          78          9.4         106.0      14.0X
+Partition column - ORC Vectorized                    69             95          19        227.1           4.4     337.1X
+Partition column - ORC MR                          1923           1926           4          8.2         122.2      12.1X
+Both columns - CSV                                22532          22643         157          0.7        1432.6       1.0X
+Both columns - Json                               16645          16678          47          0.9        1058.2       1.4X
+Both columns - Parquet Vectorized                   416            455          35         37.9          26.4      56.2X
+Both columns - Parquet MR                          3766           3768           4          4.2         239.4       6.2X
+Both columns - ORC Vectorized                       534            562          21         29.4          34.0      43.7X
+Both columns - ORC MR                              3119           3119           1          5.0         198.3       7.5X
 
 
 ================================================================================================
 String with Nulls Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           11805          12021         306          0.9        1125.8       1.0X
-SQL Json                                          12051          12105          77          0.9        1149.3       1.0X
-SQL Parquet Vectorized                             1474           1545         100          7.1         140.6       8.0X
-SQL Parquet MR                                     4488           4492           4          2.3         428.1       2.6X
-ParquetReader Vectorized                           1140           1140           1          9.2         108.7      10.4X
-SQL ORC Vectorized                                 1164           1178          20          9.0         111.0      10.1X
-SQL ORC MR                                         3745           3817         102          2.8         357.1       3.2X
+SQL CSV                                           10928          10941          19          1.0        1042.1       1.0X
+SQL Json                                          13465          13521          79          0.8        1284.1       0.8X
+SQL Parquet Vectorized                             1558           1578          29          6.7         148.5       7.0X
+SQL Parquet MR                                     4749           4761          17          2.2         452.9       2.3X
+ParquetReader Vectorized                           1155           1189          48          9.1         110.2       9.5X
+SQL ORC Vectorized                                 1234           1281          65          8.5         117.7       8.9X
+SQL ORC MR                                         3934           3960          37          2.7         375.2       2.8X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9814           9837          33          1.1         936.0       1.0X
-SQL Json                                           9317           9445         182          1.1         888.5       1.1X
-SQL Parquet Vectorized                             1117           1155          52          9.4         106.6       8.8X
-SQL Parquet MR                                     3463           3538         106          3.0         330.3       2.8X
-ParquetReader Vectorized                           1033           1039           8         10.1          98.6       9.5X
-SQL ORC Vectorized                                 1307           1353          65          8.0         124.7       7.5X
-SQL ORC MR                                         3644           3690          65          2.9         347.5       2.7X
+SQL CSV                                            9031           9052          29          1.2         861.2       1.0X
+SQL Json                                          10715          10727          17          1.0        1021.9       0.8X
+SQL Parquet Vectorized                             1249           1250           3          8.4         119.1       7.2X
+SQL Parquet MR                                     3677           3686          12          2.9         350.7       2.5X
+ParquetReader Vectorized                           1186           1187           1          8.8         113.1       7.6X
+SQL ORC Vectorized                                 1305           1321          22          8.0         124.5       6.9X
+SQL ORC MR                                         3629           3638          13          2.9         346.0       2.5X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            8145           8270         176          1.3         776.8       1.0X
-SQL Json                                           5714           5764          71          1.8         544.9       1.4X
-SQL Parquet Vectorized                              235            264          15         44.6          22.4      34.7X
-SQL Parquet MR                                     2398           2412          19          4.4         228.7       3.4X
-ParquetReader Vectorized                            248            262          11         42.3          23.6      32.9X
-SQL ORC Vectorized                                  430            462          37         24.4          41.0      18.9X
-SQL ORC MR                                         1983           1993          14          5.3         189.1       4.1X
+SQL CSV                                            7777           7780           4          1.3         741.7       1.0X
+SQL Json                                           6923           6963          57          1.5         660.2       1.1X
+SQL Parquet Vectorized                              309            325          10         34.0          29.4      25.2X
+SQL Parquet MR                                     2553           2580          38          4.1         243.5       3.0X
+ParquetReader Vectorized                            308            318          10         34.0          29.4      25.2X
+SQL ORC Vectorized                                  433            471          51         24.2          41.3      17.9X
+SQL ORC MR                                         2036           2037           1          5.1         194.2       3.8X
 
 
 ================================================================================================
 Single Column Scan From Wide Columns
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Single Column Scan from 10 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            2448           2461          18          0.4        2334.3       1.0X
-SQL Json                                           3332           3370          53          0.3        3177.6       0.7X
-SQL Parquet Vectorized                               51             87          25         20.7          48.2      48.4X
-SQL Parquet MR                                      239            278          35          4.4         227.5      10.3X
-SQL ORC Vectorized                                   60             82          19         17.5          57.3      40.8X
-SQL ORC MR                                          197            219          26          5.3         188.3      12.4X
+SQL CSV                                            2411           2490         113          0.4        2299.1       1.0X
+SQL Json                                           3681           3690          13          0.3        3510.4       0.7X
+SQL Parquet Vectorized                               58             83          25         18.1          55.2      41.6X
+SQL Parquet MR                                      252            280          26          4.2         240.7       9.6X
+SQL ORC Vectorized                                   68             89          20         15.5          64.7      35.6X
+SQL ORC MR                                          207            232          27          5.1         197.2      11.7X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Single Column Scan from 50 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            6034           6061          39          0.2        5754.0       1.0X
-SQL Json                                          12232          12315         118          0.1       11665.4       0.5X
-SQL Parquet Vectorized                               73            120          30         14.4          69.6      82.6X
-SQL Parquet MR                                      316            368          44          3.3         301.1      19.1X
-SQL ORC Vectorized                                   76            122          36         13.7          72.9      79.0X
-SQL ORC MR                                          206            261          47          5.1         196.5      29.3X
+SQL CSV                                            5393           5409          22          0.2        5143.6       1.0X
+SQL Json                                          14438          14458          29          0.1       13769.0       0.4X
+SQL Parquet Vectorized                               85            127          32         12.3          81.1      63.4X
+SQL Parquet MR                                      272            316          51          3.9         259.2      19.8X
+SQL ORC Vectorized                                   82            114          34         12.7          78.7      65.4X
+SQL ORC MR                                          234            256          21          4.5         223.6      23.0X
 
-OpenJDK 64-Bit Server VM 11.0.10+9-LTS on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10307          10309           4          0.1        9829.0       1.0X
-SQL Json                                          23412          23539         180          0.0       22327.7       0.4X
-SQL Parquet Vectorized                              105            151          23         10.0          99.9      98.4X
-SQL Parquet MR                                      295            325          29          3.6         281.5      34.9X
-SQL ORC Vectorized                                   85            112          31         12.4          81.0     121.4X
-SQL ORC MR                                          212            255          66          4.9         202.3      48.6X
+SQL CSV                                            9174           9188          19          0.1        8749.1       1.0X
+SQL Json                                          27437          28102         940          0.0       26165.9       0.3X
+SQL Parquet Vectorized                              121            182          47          8.7         115.2      76.0X
+SQL Parquet MR                                      325            348          23          3.2         310.1      28.2X
+SQL ORC Vectorized                                  100            126          21         10.5          95.0      92.1X
+SQL ORC MR                                          244            271          45          4.3         233.2      37.5X
 
 

--- a/sql/core/benchmarks/DataSourceReadBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DataSourceReadBenchmark-jdk11-results.txt
@@ -3,22 +3,22 @@ SQL Single Boolean Column Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           12646          12949         429          1.2         804.0       1.0X
-SQL Json                                          11373          11432          83          1.4         723.1       1.1X
-SQL Parquet Vectorized                              143            171          22        110.1           9.1      88.5X
-SQL Parquet MR                                     2575           2585          14          6.1         163.7       4.9X
-SQL ORC Vectorized                                  181            238          57         87.0          11.5      69.9X
-SQL ORC MR                                         1915           1938          32          8.2         121.7       6.6X
+SQL CSV                                            9748           9907         225          1.6         619.7       1.0X
+SQL Json                                           8466           8468           3          1.9         538.2       1.2X
+SQL Parquet Vectorized                              124            149          21        127.2           7.9      78.8X
+SQL Parquet MR                                     2057           2071          20          7.6         130.8       4.7X
+SQL ORC Vectorized                                  183            232          40         86.1          11.6      53.3X
+SQL ORC MR                                         1517           1546          41         10.4          96.4       6.4X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                             110            121          15        143.4           7.0       1.0X
-ParquetReader Vectorized -> Row                       49             52           3        318.8           3.1       2.2X
+ParquetReader Vectorized                             100            107          13        157.1           6.4       1.0X
+ParquetReader Vectorized -> Row                       52             54           3        303.1           3.3       1.9X
 
 
 ================================================================================================
@@ -26,112 +26,112 @@ SQL Single Numeric Column Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           14713          14785         102          1.1         935.4       1.0X
-SQL Json                                          12537          12551          21          1.3         797.1       1.2X
-SQL Parquet Vectorized                              169            203          39         93.3          10.7      87.3X
-SQL Parquet MR                                     2774           2794          27          5.7         176.4       5.3X
-SQL ORC Vectorized                                  253            295          41         62.3          16.1      58.3X
-SQL ORC MR                                         1855           1870          20          8.5         118.0       7.9X
+SQL CSV                                           11664          11685          30          1.3         741.6       1.0X
+SQL Json                                           9144           9154          14          1.7         581.3       1.3X
+SQL Parquet Vectorized                              136            152          24        115.7           8.6      85.8X
+SQL Parquet MR                                     2157           2172          22          7.3         137.1       5.4X
+SQL ORC Vectorized                                  212            251          30         74.0          13.5      54.9X
+SQL ORC MR                                         1626           1628           3          9.7         103.4       7.2X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single TINYINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                             206            218          12         76.5          13.1       1.0X
-ParquetReader Vectorized -> Row                       96            104           7        163.8           6.1       2.1X
+ParquetReader Vectorized                             183            192          10         85.8          11.7       1.0X
+ParquetReader Vectorized -> Row                       93             97           9        169.9           5.9       2.0X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           15546          15573          38          1.0         988.4       1.0X
-SQL Json                                          13027          13031           5          1.2         828.3       1.2X
-SQL Parquet Vectorized                              209            243          32         75.3          13.3      74.4X
-SQL Parquet MR                                     3129           3150          29          5.0         199.0       5.0X
-SQL ORC Vectorized                                  320            353          26         49.1          20.4      48.5X
-SQL ORC MR                                         2236           2258          31          7.0         142.1       7.0X
+SQL CSV                                           12278          12303          35          1.3         780.6       1.0X
+SQL Json                                           9534           9546          16          1.6         606.2       1.3X
+SQL Parquet Vectorized                              167            205          32         93.9          10.6      73.3X
+SQL Parquet MR                                     2543           2564          30          6.2         161.7       4.8X
+SQL ORC Vectorized                                  217            265          32         72.6          13.8      56.7X
+SQL ORC MR                                         1832           1861          41          8.6         116.4       6.7X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single SMALLINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                              295            307          11         53.3          18.8       1.0X
-ParquetReader Vectorized -> Row                       323            333           8         48.6          20.6       0.9X
+ParquetReader Vectorized                              230            238           9         68.3          14.7       1.0X
+ParquetReader Vectorized -> Row                       238            276          16         66.1          15.1       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           17181          17202          30          0.9        1092.4       1.0X
-SQL Json                                          13669          13701          45          1.2         869.0       1.3X
-SQL Parquet Vectorized                              190            252          36         82.9          12.1      90.6X
-SQL Parquet MR                                     3081           3117          50          5.1         195.9       5.6X
-SQL ORC Vectorized                                  374            392          15         42.1          23.8      46.0X
-SQL ORC MR                                         2225           2244          27          7.1         141.5       7.7X
+SQL CSV                                           13444          13450           9          1.2         854.7       1.0X
+SQL Json                                          10255          10268          19          1.5         652.0       1.3X
+SQL Parquet Vectorized                              156            191          29        100.6           9.9      86.0X
+SQL Parquet MR                                     2462           2469          10          6.4         156.5       5.5X
+SQL ORC Vectorized                                  310            320           7         50.8          19.7      43.4X
+SQL ORC MR                                         1826           1843          25          8.6         116.1       7.4X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single INT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            313            325          10         50.2          19.9       1.0X
-ParquetReader Vectorized -> Row                     315            335          16         50.0          20.0       1.0X
+ParquetReader Vectorized                            254            261          10         61.8          16.2       1.0X
+ParquetReader Vectorized -> Row                     267            272           7         59.0          16.9       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           23590          23599          12          0.7        1499.8       1.0X
-SQL Json                                          16229          16277          67          1.0        1031.8       1.5X
-SQL Parquet Vectorized                              331            352          26         47.5          21.1      71.2X
-SQL Parquet MR                                     3198           3206          11          4.9         203.3       7.4X
-SQL ORC Vectorized                                  490            547          38         32.1          31.1      48.2X
-SQL ORC MR                                         2455           2462          11          6.4         156.1       9.6X
+SQL CSV                                           17777          17780           5          0.9        1130.2       1.0X
+SQL Json                                          12226          12230           5          1.3         777.3       1.5X
+SQL Parquet Vectorized                              222            261          18         70.7          14.1      79.9X
+SQL Parquet MR                                     2559           2568          13          6.1         162.7       6.9X
+SQL ORC Vectorized                                  394            430          24         39.9          25.1      45.1X
+SQL ORC MR                                         2123           2136          19          7.4         135.0       8.4X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single BIGINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            378            390          12         41.6          24.0       1.0X
-ParquetReader Vectorized -> Row                     466            474           5         33.7          29.6       0.8X
+ParquetReader Vectorized                            325            361          28         48.3          20.7       1.0X
+ParquetReader Vectorized -> Row                     325            332           9         48.5          20.6       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           17771          17772           1          0.9        1129.9       1.0X
-SQL Json                                          15675          15714          54          1.0         996.6       1.1X
-SQL Parquet Vectorized                              180            218          30         87.6          11.4      98.9X
-SQL Parquet MR                                     3006           3082         107          5.2         191.1       5.9X
-SQL ORC Vectorized                                  569            593          23         27.6          36.2      31.2X
-SQL ORC MR                                         2512           2512           1          6.3         159.7       7.1X
+SQL CSV                                           14029          14032           5          1.1         891.9       1.0X
+SQL Json                                          12515          12565          70          1.3         795.7       1.1X
+SQL Parquet Vectorized                              146            185          37        107.7           9.3      96.0X
+SQL Parquet MR                                     2478           2488          14          6.3         157.5       5.7X
+SQL ORC Vectorized                                  441            444           3         35.7          28.0      31.8X
+SQL ORC MR                                         2026           2026           0          7.8         128.8       6.9X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single FLOAT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            297            306          10         52.9          18.9       1.0X
-ParquetReader Vectorized -> Row                     343            357          10         45.9          21.8       0.9X
+ParquetReader Vectorized                            248            258          12         63.3          15.8       1.0X
+ParquetReader Vectorized -> Row                     291            297           7         54.1          18.5       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           23089          23137          68          0.7        1468.0       1.0X
-SQL Json                                          20451          20492          58          0.8        1300.2       1.1X
-SQL Parquet Vectorized                              329            347          17         47.8          20.9      70.1X
-SQL Parquet MR                                     3215           3221           9          4.9         204.4       7.2X
-SQL ORC Vectorized                                  617            623           7         25.5          39.2      37.4X
-SQL ORC MR                                         2597           2608          16          6.1         165.1       8.9X
+SQL CSV                                           18540          18581          58          0.8        1178.7       1.0X
+SQL Json                                          16731          16754          32          0.9        1063.7       1.1X
+SQL Parquet Vectorized                              229            260          27         68.6          14.6      80.9X
+SQL Parquet MR                                     2588           2590           3          6.1         164.6       7.2X
+SQL ORC Vectorized                                  507            534          23         31.0          32.2      36.6X
+SQL ORC MR                                         2143           2162          28          7.3         136.2       8.7X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single DOUBLE Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            359            375          30         43.9          22.8       1.0X
-ParquetReader Vectorized -> Row                     400            417          17         39.3          25.4       0.9X
+ParquetReader Vectorized                            282            312          27         55.9          17.9       1.0X
+ParquetReader Vectorized -> Row                     324            331           8         48.5          20.6       0.9X
 
 
 ================================================================================================
@@ -139,15 +139,15 @@ Int and String Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           16308          16319          15          0.6        1555.3       1.0X
-SQL Json                                          14512          14590         110          0.7        1384.0       1.1X
-SQL Parquet Vectorized                             2367           2439         102          4.4         225.7       6.9X
-SQL Parquet MR                                     5324           5328           5          2.0         507.8       3.1X
-SQL ORC Vectorized                                 2495           2510          21          4.2         237.9       6.5X
-SQL ORC MR                                         4559           4630         100          2.3         434.8       3.6X
+SQL CSV                                           13489          13514          35          0.8        1286.4       1.0X
+SQL Json                                          11294          11305          15          0.9        1077.1       1.2X
+SQL Parquet Vectorized                             2067           2073           8          5.1         197.2       6.5X
+SQL Parquet MR                                     4278           4287          13          2.5         408.0       3.2X
+SQL ORC Vectorized                                 2164           2165           1          4.8         206.4       6.2X
+SQL ORC MR                                         3701           3717          22          2.8         353.0       3.6X
 
 
 ================================================================================================
@@ -155,15 +155,15 @@ Repeated String Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9046           9050           6          1.2         862.7       1.0X
-SQL Json                                           9316           9329          19          1.1         888.4       1.0X
-SQL Parquet Vectorized                              742            747           4         14.1          70.8      12.2X
-SQL Parquet MR                                     2452           2475          33          4.3         233.8       3.7X
-SQL ORC Vectorized                                  620            635          13         16.9          59.2      14.6X
-SQL ORC MR                                         2396           2449          76          4.4         228.5       3.8X
+SQL CSV                                            7460           7647         264          1.4         711.5       1.0X
+SQL Json                                           6856           6859           4          1.5         653.8       1.1X
+SQL Parquet Vectorized                              597            608           9         17.6          56.9      12.5X
+SQL Parquet MR                                     1982           2001          27          5.3         189.0       3.8X
+SQL ORC Vectorized                                  537            550          18         19.5          51.2      13.9X
+SQL ORC MR                                         1973           1978           7          5.3         188.1       3.8X
 
 
 ================================================================================================
@@ -171,27 +171,27 @@ Partitioned Table Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Partitioned Table:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Data column - CSV                                 23350          23425         106          0.7        1484.6       1.0X
-Data column - Json                                15620          15796         248          1.0         993.1       1.5X
-Data column - Parquet Vectorized                    328            348          16         47.9          20.9      71.1X
-Data column - Parquet MR                           3784           3815          45          4.2         240.6       6.2X
-Data column - ORC Vectorized                        541            584          41         29.1          34.4      43.1X
-Data column - ORC MR                               3093           3097           7          5.1         196.6       7.6X
-Partition column - CSV                             8173           8222          69          1.9         519.6       2.9X
-Partition column - Json                           13335          13408         103          1.2         847.8       1.8X
-Partition column - Parquet Vectorized                67             96          25        234.3           4.3     347.8X
-Partition column - Parquet MR                      1668           1723          78          9.4         106.0      14.0X
-Partition column - ORC Vectorized                    69             95          19        227.1           4.4     337.1X
-Partition column - ORC MR                          1923           1926           4          8.2         122.2      12.1X
-Both columns - CSV                                22532          22643         157          0.7        1432.6       1.0X
-Both columns - Json                               16645          16678          47          0.9        1058.2       1.4X
-Both columns - Parquet Vectorized                   416            455          35         37.9          26.4      56.2X
-Both columns - Parquet MR                          3766           3768           4          4.2         239.4       6.2X
-Both columns - ORC Vectorized                       534            562          21         29.4          34.0      43.7X
-Both columns - ORC MR                              3119           3119           1          5.0         198.3       7.5X
+Data column - CSV                                 18598          18612          20          0.8        1182.4       1.0X
+Data column - Json                                12173          12178           7          1.3         773.9       1.5X
+Data column - Parquet Vectorized                    227            282          36         69.4          14.4      82.0X
+Data column - Parquet MR                           2977           3002          36          5.3         189.3       6.2X
+Data column - ORC Vectorized                        405            434          31         38.8          25.8      45.9X
+Data column - ORC MR                               2474           2541          95          6.4         157.3       7.5X
+Partition column - CSV                             6214           6220           8          2.5         395.1       3.0X
+Partition column - Json                            9933          10075         201          1.6         631.5       1.9X
+Partition column - Parquet Vectorized                60             77          17        263.5           3.8     311.6X
+Partition column - Parquet MR                      1555           1595          56         10.1          98.9      12.0X
+Partition column - ORC Vectorized                    56             74          19        282.2           3.5     333.7X
+Partition column - ORC MR                          1616           1618           3          9.7         102.8      11.5X
+Both columns - CSV                                18792          18811          28          0.8        1194.7       1.0X
+Both columns - Json                               12996          12997           2          1.2         826.3       1.4X
+Both columns - Parquet Vectorized                   319            340          18         49.3          20.3      58.3X
+Both columns - Parquet MR                          3092           3095           4          5.1         196.6       6.0X
+Both columns - ORC Vectorized                       444            475          24         35.4          28.2      41.9X
+Both columns - ORC MR                              2559           2561           3          6.1         162.7       7.3X
 
 
 ================================================================================================
@@ -199,40 +199,40 @@ String with Nulls Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10928          10941          19          1.0        1042.1       1.0X
-SQL Json                                          13465          13521          79          0.8        1284.1       0.8X
-SQL Parquet Vectorized                             1558           1578          29          6.7         148.5       7.0X
-SQL Parquet MR                                     4749           4761          17          2.2         452.9       2.3X
-ParquetReader Vectorized                           1155           1189          48          9.1         110.2       9.5X
-SQL ORC Vectorized                                 1234           1281          65          8.5         117.7       8.9X
-SQL ORC MR                                         3934           3960          37          2.7         375.2       2.8X
+SQL CSV                                            8844           8855          16          1.2         843.4       1.0X
+SQL Json                                          10118          10135          24          1.0         964.9       0.9X
+SQL Parquet Vectorized                             1271           1323          73          8.2         121.2       7.0X
+SQL Parquet MR                                     3833           3834           1          2.7         365.6       2.3X
+ParquetReader Vectorized                            947            969          35         11.1          90.3       9.3X
+SQL ORC Vectorized                                 1084           1104          28          9.7         103.3       8.2X
+SQL ORC MR                                         3253           3268          21          3.2         310.2       2.7X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9031           9052          29          1.2         861.2       1.0X
-SQL Json                                          10715          10727          17          1.0        1021.9       0.8X
-SQL Parquet Vectorized                             1249           1250           3          8.4         119.1       7.2X
-SQL Parquet MR                                     3677           3686          12          2.9         350.7       2.5X
-ParquetReader Vectorized                           1186           1187           1          8.8         113.1       7.6X
-SQL ORC Vectorized                                 1305           1321          22          8.0         124.5       6.9X
-SQL ORC MR                                         3629           3638          13          2.9         346.0       2.5X
+SQL CSV                                            7398           7399           1          1.4         705.6       1.0X
+SQL Json                                           7791           7796           6          1.3         743.0       0.9X
+SQL Parquet Vectorized                             1079           1107          40          9.7         102.9       6.9X
+SQL Parquet MR                                     2974           2979           7          3.5         283.6       2.5X
+ParquetReader Vectorized                           1023           1028           7         10.3          97.6       7.2X
+SQL ORC Vectorized                                 1199           1216          24          8.7         114.4       6.2X
+SQL ORC MR                                         3057           3101          63          3.4         291.5       2.4X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            7777           7780           4          1.3         741.7       1.0X
-SQL Json                                           6923           6963          57          1.5         660.2       1.1X
-SQL Parquet Vectorized                              309            325          10         34.0          29.4      25.2X
-SQL Parquet MR                                     2553           2580          38          4.1         243.5       3.0X
-ParquetReader Vectorized                            308            318          10         34.0          29.4      25.2X
-SQL ORC Vectorized                                  433            471          51         24.2          41.3      17.9X
-SQL ORC MR                                         2036           2037           1          5.1         194.2       3.8X
+SQL CSV                                            6086           6086           0          1.7         580.4       1.0X
+SQL Json                                           4679           4681           4          2.2         446.2       1.3X
+SQL Parquet Vectorized                              255            262          11         41.2          24.3      23.9X
+SQL Parquet MR                                     1992           1995           5          5.3         189.9       3.1X
+ParquetReader Vectorized                            271            273           2         38.6          25.9      22.4X
+SQL ORC Vectorized                                  392            426          44         26.7          37.4      15.5X
+SQL ORC MR                                         1773           1774           1          5.9         169.1       3.4X
 
 
 ================================================================================================
@@ -240,36 +240,36 @@ Single Column Scan From Wide Columns
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 10 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            2411           2490         113          0.4        2299.1       1.0X
-SQL Json                                           3681           3690          13          0.3        3510.4       0.7X
-SQL Parquet Vectorized                               58             83          25         18.1          55.2      41.6X
-SQL Parquet MR                                      252            280          26          4.2         240.7       9.6X
-SQL ORC Vectorized                                   68             89          20         15.5          64.7      35.6X
-SQL ORC MR                                          207            232          27          5.1         197.2      11.7X
+SQL CSV                                            2051           2075          33          0.5        1956.4       1.0X
+SQL Json                                           2826           2828           2          0.4        2695.3       0.7X
+SQL Parquet Vectorized                               45             65          19         23.4          42.7      45.8X
+SQL Parquet MR                                      204            222          24          5.2         194.2      10.1X
+SQL ORC Vectorized                                   54             69          18         19.3          51.7      37.8X
+SQL ORC MR                                          170            189          38          6.2         162.2      12.1X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 50 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            5393           5409          22          0.2        5143.6       1.0X
-SQL Json                                          14438          14458          29          0.1       13769.0       0.4X
-SQL Parquet Vectorized                               85            127          32         12.3          81.1      63.4X
-SQL Parquet MR                                      272            316          51          3.9         259.2      19.8X
-SQL ORC Vectorized                                   82            114          34         12.7          78.7      65.4X
-SQL ORC MR                                          234            256          21          4.5         223.6      23.0X
+SQL CSV                                            5162           5167           7          0.2        4923.1       1.0X
+SQL Json                                          11072          11184         159          0.1       10559.1       0.5X
+SQL Parquet Vectorized                               60             91          22         17.4          57.6      85.5X
+SQL Parquet MR                                      223            246          27          4.7         212.7      23.1X
+SQL ORC Vectorized                                   69             94          34         15.2          65.8      74.8X
+SQL ORC MR                                          186            210          30          5.6         177.2      27.8X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9174           9188          19          0.1        8749.1       1.0X
-SQL Json                                          27437          28102         940          0.0       26165.9       0.3X
-SQL Parquet Vectorized                              121            182          47          8.7         115.2      76.0X
-SQL Parquet MR                                      325            348          23          3.2         310.1      28.2X
-SQL ORC Vectorized                                  100            126          21         10.5          95.0      92.1X
-SQL ORC MR                                          244            271          45          4.3         233.2      37.5X
+SQL CSV                                            9138           9139           1          0.1        8714.3       1.0X
+SQL Json                                          20892          21127         333          0.1       19924.0       0.4X
+SQL Parquet Vectorized                               88            124          25         11.9          84.3     103.4X
+SQL Parquet MR                                      253            277          33          4.1         241.6      36.1X
+SQL ORC Vectorized                                   81             96          20         13.0          77.2     112.9X
+SQL ORC MR                                          199            217          26          5.3         189.7      45.9X
 
 

--- a/sql/core/benchmarks/DataSourceReadBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DataSourceReadBenchmark-jdk11-results.txt
@@ -1,275 +1,270 @@
 ================================================================================================
-SQL Single Boolean Column Scan
-================================================================================================
-
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9748           9907         225          1.6         619.7       1.0X
-SQL Json                                           8466           8468           3          1.9         538.2       1.2X
-SQL Parquet Vectorized                              124            149          21        127.2           7.9      78.8X
-SQL Parquet MR                                     2057           2071          20          7.6         130.8       4.7X
-SQL ORC Vectorized                                  183            232          40         86.1          11.6      53.3X
-SQL ORC MR                                         1517           1546          41         10.4          96.4       6.4X
-
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                             100            107          13        157.1           6.4       1.0X
-ParquetReader Vectorized -> Row                       52             54           3        303.1           3.3       1.9X
-
-
-================================================================================================
 SQL Single Numeric Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+SQL CSV                                            9999          10058          83          1.6         635.7       1.0X
+SQL Json                                           8857           8883          37          1.8         563.1       1.1X
+SQL Parquet Vectorized                              132            157          16        119.0           8.4      75.7X
+SQL Parquet MR                                     1987           1997          14          7.9         126.3       5.0X
+SQL ORC Vectorized                                  186            227          34         84.3          11.9      53.6X
+SQL ORC MR                                         1559           1602          62         10.1          99.1       6.4X
+
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+ParquetReader Vectorized                             110            117           9        143.0           7.0       1.0X
+ParquetReader Vectorized -> Row                       57             59           3        276.2           3.6       1.9X
+
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           11664          11685          30          1.3         741.6       1.0X
-SQL Json                                           9144           9154          14          1.7         581.3       1.3X
-SQL Parquet Vectorized                              136            152          24        115.7           8.6      85.8X
-SQL Parquet MR                                     2157           2172          22          7.3         137.1       5.4X
-SQL ORC Vectorized                                  212            251          30         74.0          13.5      54.9X
-SQL ORC MR                                         1626           1628           3          9.7         103.4       7.2X
+SQL CSV                                           12897          12916          28          1.2         819.9       1.0X
+SQL Json                                           9739           9770          44          1.6         619.2       1.3X
+SQL Parquet Vectorized                              226            237          14         69.7          14.3      57.2X
+SQL Parquet MR                                     2124           2127           4          7.4         135.1       6.1X
+SQL ORC Vectorized                                  213            250          39         73.9          13.5      60.6X
+SQL ORC MR                                         1535           1548          19         10.2          97.6       8.4X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single TINYINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                             183            192          10         85.8          11.7       1.0X
-ParquetReader Vectorized -> Row                       93             97           9        169.9           5.9       2.0X
+ParquetReader Vectorized                             259            269          15         60.6          16.5       1.0X
+ParquetReader Vectorized -> Row                      168            184          33         93.9          10.7       1.5X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           12278          12303          35          1.3         780.6       1.0X
-SQL Json                                           9534           9546          16          1.6         606.2       1.3X
-SQL Parquet Vectorized                              167            205          32         93.9          10.6      73.3X
-SQL Parquet MR                                     2543           2564          30          6.2         161.7       4.8X
-SQL ORC Vectorized                                  217            265          32         72.6          13.8      56.7X
-SQL ORC MR                                         1832           1861          41          8.6         116.4       6.7X
+SQL CSV                                           12765          12774          13          1.2         811.6       1.0X
+SQL Json                                          10144          10158          21          1.6         644.9       1.3X
+SQL Parquet Vectorized                              168            208          34         93.7          10.7      76.1X
+SQL Parquet MR                                     2443           2458          21          6.4         155.3       5.2X
+SQL ORC Vectorized                                  300            313          16         52.4          19.1      42.5X
+SQL ORC MR                                         1736           1780          62          9.1         110.4       7.4X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single SMALLINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                              230            238           9         68.3          14.7       1.0X
-ParquetReader Vectorized -> Row                       238            276          16         66.1          15.1       1.0X
+ParquetReader Vectorized                              229            239           9         68.6          14.6       1.0X
+ParquetReader Vectorized -> Row                       224            265          26         70.2          14.3       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           13444          13450           9          1.2         854.7       1.0X
-SQL Json                                          10255          10268          19          1.5         652.0       1.3X
-SQL Parquet Vectorized                              156            191          29        100.6           9.9      86.0X
-SQL Parquet MR                                     2462           2469          10          6.4         156.5       5.5X
-SQL ORC Vectorized                                  310            320           7         50.8          19.7      43.4X
-SQL ORC MR                                         1826           1843          25          8.6         116.1       7.4X
+SQL CSV                                           14055          14060           6          1.1         893.6       1.0X
+SQL Json                                          10692          10738          64          1.5         679.8       1.3X
+SQL Parquet Vectorized                              167            223          34         94.0          10.6      84.0X
+SQL Parquet MR                                     2416           2482          94          6.5         153.6       5.8X
+SQL ORC Vectorized                                  329            344          12         47.8          20.9      42.7X
+SQL ORC MR                                         1773           1789          23          8.9         112.7       7.9X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single INT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            254            261          10         61.8          16.2       1.0X
-ParquetReader Vectorized -> Row                     267            272           7         59.0          16.9       1.0X
+ParquetReader Vectorized                            232            239           9         67.9          14.7       1.0X
+ParquetReader Vectorized -> Row                     262            295          23         60.1          16.6       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           17777          17780           5          0.9        1130.2       1.0X
-SQL Json                                          12226          12230           5          1.3         777.3       1.5X
-SQL Parquet Vectorized                              222            261          18         70.7          14.1      79.9X
-SQL Parquet MR                                     2559           2568          13          6.1         162.7       6.9X
-SQL ORC Vectorized                                  394            430          24         39.9          25.1      45.1X
-SQL ORC MR                                         2123           2136          19          7.4         135.0       8.4X
+SQL CSV                                           18964          18975          17          0.8        1205.7       1.0X
+SQL Json                                          13173          13189          23          1.2         837.5       1.4X
+SQL Parquet Vectorized                              278            290          11         56.6          17.7      68.2X
+SQL Parquet MR                                     2565           2589          34          6.1         163.1       7.4X
+SQL ORC Vectorized                                  432            481          48         36.4          27.5      43.9X
+SQL ORC MR                                         2052           2061          12          7.7         130.5       9.2X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single BIGINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            325            361          28         48.3          20.7       1.0X
-ParquetReader Vectorized -> Row                     325            332           9         48.5          20.6       1.0X
+ParquetReader Vectorized                            296            321          29         53.2          18.8       1.0X
+ParquetReader Vectorized -> Row                     329            335           7         47.7          20.9       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           14029          14032           5          1.1         891.9       1.0X
-SQL Json                                          12515          12565          70          1.3         795.7       1.1X
-SQL Parquet Vectorized                              146            185          37        107.7           9.3      96.0X
-SQL Parquet MR                                     2478           2488          14          6.3         157.5       5.7X
-SQL ORC Vectorized                                  441            444           3         35.7          28.0      31.8X
-SQL ORC MR                                         2026           2026           0          7.8         128.8       6.9X
+SQL CSV                                           15092          15095           5          1.0         959.5       1.0X
+SQL Json                                          12166          12169           5          1.3         773.5       1.2X
+SQL Parquet Vectorized                              161            198          27         97.4          10.3      93.5X
+SQL Parquet MR                                     2407           2412           6          6.5         153.0       6.3X
+SQL ORC Vectorized                                  476            509          30         33.1          30.2      31.7X
+SQL ORC MR                                         1978           1981           5          8.0         125.7       7.6X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single FLOAT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            248            258          12         63.3          15.8       1.0X
-ParquetReader Vectorized -> Row                     291            297           7         54.1          18.5       0.9X
+ParquetReader Vectorized                            256            261           9         61.4          16.3       1.0X
+ParquetReader Vectorized -> Row                     210            257          22         74.7          13.4       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           18540          18581          58          0.8        1178.7       1.0X
-SQL Json                                          16731          16754          32          0.9        1063.7       1.1X
-SQL Parquet Vectorized                              229            260          27         68.6          14.6      80.9X
-SQL Parquet MR                                     2588           2590           3          6.1         164.6       7.2X
-SQL ORC Vectorized                                  507            534          23         31.0          32.2      36.6X
-SQL ORC MR                                         2143           2162          28          7.3         136.2       8.7X
+SQL CSV                                           19785          19786           1          0.8        1257.9       1.0X
+SQL Json                                          16339          16340           1          1.0        1038.8       1.2X
+SQL Parquet Vectorized                              284            302          19         55.4          18.1      69.7X
+SQL Parquet MR                                     2570           2576           8          6.1         163.4       7.7X
+SQL ORC Vectorized                                  473            519          32         33.3          30.0      41.9X
+SQL ORC MR                                         2136           2142           9          7.4         135.8       9.3X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single DOUBLE Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            282            312          27         55.9          17.9       1.0X
-ParquetReader Vectorized -> Row                     324            331           8         48.5          20.6       0.9X
+ParquetReader Vectorized                            298            351          32         52.8          18.9       1.0X
+ParquetReader Vectorized -> Row                     370            375           9         42.5          23.5       0.8X
 
 
 ================================================================================================
 Int and String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           13489          13514          35          0.8        1286.4       1.0X
-SQL Json                                          11294          11305          15          0.9        1077.1       1.2X
-SQL Parquet Vectorized                             2067           2073           8          5.1         197.2       6.5X
-SQL Parquet MR                                     4278           4287          13          2.5         408.0       3.2X
-SQL ORC Vectorized                                 2164           2165           1          4.8         206.4       6.2X
-SQL ORC MR                                         3701           3717          22          2.8         353.0       3.6X
+SQL CSV                                           13811          13824          18          0.8        1317.1       1.0X
+SQL Json                                          11546          11589          61          0.9        1101.1       1.2X
+SQL Parquet Vectorized                             2143           2164          30          4.9         204.4       6.4X
+SQL Parquet MR                                     4369           4386          24          2.4         416.7       3.2X
+SQL ORC Vectorized                                 2289           2294           8          4.6         218.3       6.0X
+SQL ORC MR                                         3770           3847         109          2.8         359.5       3.7X
 
 
 ================================================================================================
 Repeated String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            7460           7647         264          1.4         711.5       1.0X
-SQL Json                                           6856           6859           4          1.5         653.8       1.1X
-SQL Parquet Vectorized                              597            608           9         17.6          56.9      12.5X
-SQL Parquet MR                                     1982           2001          27          5.3         189.0       3.8X
-SQL ORC Vectorized                                  537            550          18         19.5          51.2      13.9X
-SQL ORC MR                                         1973           1978           7          5.3         188.1       3.8X
+SQL CSV                                            7344           7377          47          1.4         700.3       1.0X
+SQL Json                                           7117           7153          51          1.5         678.7       1.0X
+SQL Parquet Vectorized                              598            618          18         17.5          57.0      12.3X
+SQL Parquet MR                                     1955           1969          20          5.4         186.5       3.8X
+SQL ORC Vectorized                                  559            565           8         18.8          53.3      13.1X
+SQL ORC MR                                         1923           1932          13          5.5         183.4       3.8X
 
 
 ================================================================================================
 Partitioned Table Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Partitioned Table:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Data column - CSV                                 18598          18612          20          0.8        1182.4       1.0X
-Data column - Json                                12173          12178           7          1.3         773.9       1.5X
-Data column - Parquet Vectorized                    227            282          36         69.4          14.4      82.0X
-Data column - Parquet MR                           2977           3002          36          5.3         189.3       6.2X
-Data column - ORC Vectorized                        405            434          31         38.8          25.8      45.9X
-Data column - ORC MR                               2474           2541          95          6.4         157.3       7.5X
-Partition column - CSV                             6214           6220           8          2.5         395.1       3.0X
-Partition column - Json                            9933          10075         201          1.6         631.5       1.9X
-Partition column - Parquet Vectorized                60             77          17        263.5           3.8     311.6X
-Partition column - Parquet MR                      1555           1595          56         10.1          98.9      12.0X
-Partition column - ORC Vectorized                    56             74          19        282.2           3.5     333.7X
-Partition column - ORC MR                          1616           1618           3          9.7         102.8      11.5X
-Both columns - CSV                                18792          18811          28          0.8        1194.7       1.0X
-Both columns - Json                               12996          12997           2          1.2         826.3       1.4X
-Both columns - Parquet Vectorized                   319            340          18         49.3          20.3      58.3X
-Both columns - Parquet MR                          3092           3095           4          5.1         196.6       6.0X
-Both columns - ORC Vectorized                       444            475          24         35.4          28.2      41.9X
-Both columns - ORC MR                              2559           2561           3          6.1         162.7       7.3X
+Data column - CSV                                 19266          19281          21          0.8        1224.9       1.0X
+Data column - Json                                13119          13126          10          1.2         834.1       1.5X
+Data column - Parquet Vectorized                    305            334          27         51.6          19.4      63.2X
+Data column - Parquet MR                           2978           3022          63          5.3         189.3       6.5X
+Data column - ORC Vectorized                        446            480          32         35.3          28.3      43.2X
+Data column - ORC MR                               2451           2469          24          6.4         155.9       7.9X
+Partition column - CSV                             6640           6641           1          2.4         422.2       2.9X
+Partition column - Json                           10485          10512          37          1.5         666.6       1.8X
+Partition column - Parquet Vectorized                65             88          24        241.2           4.1     295.4X
+Partition column - Parquet MR                      1403           1434          44         11.2          89.2      13.7X
+Partition column - ORC Vectorized                    62             86          21        253.8           3.9     310.9X
+Partition column - ORC MR                          1523           1525           3         10.3          96.8      12.6X
+Both columns - CSV                                19347          19354          10          0.8        1230.0       1.0X
+Both columns - Json                               13788          13793           6          1.1         876.6       1.4X
+Both columns - Parquet Vectorized                   346            414          70         45.5          22.0      55.7X
+Both columns - Parquet MR                          3022           3032          14          5.2         192.1       6.4X
+Both columns - ORC Vectorized                       479            519          28         32.9          30.4      40.2X
+Both columns - ORC MR                              2539           2540           1          6.2         161.4       7.6X
 
 
 ================================================================================================
 String with Nulls Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            8844           8855          16          1.2         843.4       1.0X
-SQL Json                                          10118          10135          24          1.0         964.9       0.9X
-SQL Parquet Vectorized                             1271           1323          73          8.2         121.2       7.0X
-SQL Parquet MR                                     3833           3834           1          2.7         365.6       2.3X
-ParquetReader Vectorized                            947            969          35         11.1          90.3       9.3X
-SQL ORC Vectorized                                 1084           1104          28          9.7         103.3       8.2X
-SQL ORC MR                                         3253           3268          21          3.2         310.2       2.7X
+SQL CSV                                            9158           9163           8          1.1         873.3       1.0X
+SQL Json                                          10429          10448          27          1.0         994.6       0.9X
+SQL Parquet Vectorized                             1363           1660         420          7.7         130.0       6.7X
+SQL Parquet MR                                     3894           3898           5          2.7         371.4       2.4X
+ParquetReader Vectorized                           1021           1031          14         10.3          97.4       9.0X
+SQL ORC Vectorized                                 1168           1191          33          9.0         111.4       7.8X
+SQL ORC MR                                         3267           3287          28          3.2         311.6       2.8X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            7398           7399           1          1.4         705.6       1.0X
-SQL Json                                           7791           7796           6          1.3         743.0       0.9X
-SQL Parquet Vectorized                             1079           1107          40          9.7         102.9       6.9X
-SQL Parquet MR                                     2974           2979           7          3.5         283.6       2.5X
-ParquetReader Vectorized                           1023           1028           7         10.3          97.6       7.2X
-SQL ORC Vectorized                                 1199           1216          24          8.7         114.4       6.2X
-SQL ORC MR                                         3057           3101          63          3.4         291.5       2.4X
+SQL CSV                                            7570           7577          11          1.4         721.9       1.0X
+SQL Json                                           8085           8096          14          1.3         771.1       0.9X
+SQL Parquet Vectorized                             1097           1101           5          9.6         104.7       6.9X
+SQL Parquet MR                                     2999           3014          21          3.5         286.0       2.5X
+ParquetReader Vectorized                           1052           1064          18         10.0         100.3       7.2X
+SQL ORC Vectorized                                 1286           2162        1239          8.2         122.6       5.9X
+SQL ORC MR                                         3053           3123         100          3.4         291.1       2.5X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            6086           6086           0          1.7         580.4       1.0X
-SQL Json                                           4679           4681           4          2.2         446.2       1.3X
-SQL Parquet Vectorized                              255            262          11         41.2          24.3      23.9X
-SQL Parquet MR                                     1992           1995           5          5.3         189.9       3.1X
-ParquetReader Vectorized                            271            273           2         38.6          25.9      22.4X
-SQL ORC Vectorized                                  392            426          44         26.7          37.4      15.5X
-SQL ORC MR                                         1773           1774           1          5.9         169.1       3.4X
+SQL CSV                                            6211           6214           3          1.7         592.4       1.0X
+SQL Json                                           4977           4994          24          2.1         474.6       1.2X
+SQL Parquet Vectorized                              260            272          10         40.3          24.8      23.9X
+SQL Parquet MR                                     1981           1985           5          5.3         188.9       3.1X
+ParquetReader Vectorized                            268            276          11         39.1          25.6      23.2X
+SQL ORC Vectorized                                  428            457          35         24.5          40.8      14.5X
+SQL ORC MR                                         1696           1705          12          6.2         161.8       3.7X
 
 
 ================================================================================================
 Single Column Scan From Wide Columns
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 10 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            2051           2075          33          0.5        1956.4       1.0X
-SQL Json                                           2826           2828           2          0.4        2695.3       0.7X
-SQL Parquet Vectorized                               45             65          19         23.4          42.7      45.8X
-SQL Parquet MR                                      204            222          24          5.2         194.2      10.1X
-SQL ORC Vectorized                                   54             69          18         19.3          51.7      37.8X
-SQL ORC MR                                          170            189          38          6.2         162.2      12.1X
+SQL CSV                                            2067           2093          36          0.5        1971.6       1.0X
+SQL Json                                           3047           5663         NaN          0.3        2906.0       0.7X
+SQL Parquet Vectorized                               50             73          21         20.9          47.7      41.3X
+SQL Parquet MR                                      205            224          28          5.1         195.3      10.1X
+SQL ORC Vectorized                                   60             79          23         17.4          57.5      34.3X
+SQL ORC MR                                          173            196          25          6.1         165.1      11.9X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 50 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            5162           5167           7          0.2        4923.1       1.0X
-SQL Json                                          11072          11184         159          0.1       10559.1       0.5X
-SQL Parquet Vectorized                               60             91          22         17.4          57.6      85.5X
-SQL Parquet MR                                      223            246          27          4.7         212.7      23.1X
-SQL ORC Vectorized                                   69             94          34         15.2          65.8      74.8X
-SQL ORC MR                                          186            210          30          5.6         177.2      27.8X
+SQL CSV                                            4841           4844           5          0.2        4616.4       1.0X
+SQL Json                                          11721          11745          34          0.1       11177.9       0.4X
+SQL Parquet Vectorized                               67            101          27         15.7          63.8      72.4X
+SQL Parquet MR                                      225            247          27          4.7         214.2      21.5X
+SQL ORC Vectorized                                   75             99          26         13.9          71.7      64.4X
+SQL ORC MR                                          192            219          26          5.5         183.4      25.2X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1020-azure
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9138           9139           1          0.1        8714.3       1.0X
-SQL Json                                          20892          21127         333          0.1       19924.0       0.4X
-SQL Parquet Vectorized                               88            124          25         11.9          84.3     103.4X
-SQL Parquet MR                                      253            277          33          4.1         241.6      36.1X
-SQL ORC Vectorized                                   81             96          20         13.0          77.2     112.9X
-SQL ORC MR                                          199            217          26          5.3         189.7      45.9X
+SQL CSV                                            8410           8414           5          0.1        8020.8       1.0X
+SQL Json                                          22537          22923         547          0.0       21492.8       0.4X
+SQL Parquet Vectorized                              101            141          32         10.4          96.2      83.4X
+SQL Parquet MR                                      262            289          45          4.0         249.9      32.1X
+SQL ORC Vectorized                                   90            113          32         11.7          85.4      93.9X
+SQL ORC MR                                          210            232          36          5.0         200.3      40.0X
 
 

--- a/sql/core/benchmarks/DataSourceReadBenchmark-results.txt
+++ b/sql/core/benchmarks/DataSourceReadBenchmark-results.txt
@@ -6,19 +6,19 @@ OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           14552          14660         152          1.1         925.2       1.0X
-SQL Json                                           9024           9218         275          1.7         573.7       1.6X
-SQL Parquet Vectorized                              154            174          16        102.2           9.8      94.6X
-SQL Parquet MR                                     1952           1977          35          8.1         124.1       7.5X
-SQL ORC Vectorized                                  202            212          10         77.9          12.8      72.1X
-SQL ORC MR                                         1849           1849           1          8.5         117.5       7.9X
+SQL CSV                                           13472          13878         574          1.2         856.5       1.0X
+SQL Json                                          10036          10477         623          1.6         638.0       1.3X
+SQL Parquet Vectorized                              144            167          12        109.2           9.2      93.5X
+SQL Parquet MR                                     2224           2230           7          7.1         141.4       6.1X
+SQL ORC Vectorized                                  191            203           6         82.3          12.2      70.5X
+SQL ORC MR                                         1865           1870           7          8.4         118.6       7.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                             140            147           6        112.4           8.9       1.0X
-ParquetReader Vectorized -> Row                       77             82           6        204.5           4.9       1.8X
+ParquetReader Vectorized                             119            125           8        131.9           7.6       1.0X
+ParquetReader Vectorized -> Row                       60             63           2        260.2           3.8       2.0X
 
 
 ================================================================================================
@@ -29,109 +29,109 @@ OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           17338          17483         205          0.9        1102.3       1.0X
-SQL Json                                          10492          10557          91          1.5         667.1       1.7X
-SQL Parquet Vectorized                              157            172          13        100.0          10.0     110.3X
-SQL Parquet MR                                     2188           2197          13          7.2         139.1       7.9X
-SQL ORC Vectorized                                  142            148           6        110.9           9.0     122.3X
-SQL ORC MR                                         1735           1743          12          9.1         110.3      10.0X
+SQL CSV                                           16820          16859          54          0.9        1069.4       1.0X
+SQL Json                                          11583          11586           4          1.4         736.4       1.5X
+SQL Parquet Vectorized                              164            177          11         96.0          10.4     102.7X
+SQL Parquet MR                                     2839           2857          25          5.5         180.5       5.9X
+SQL ORC Vectorized                                  150            161           7        104.8           9.5     112.1X
+SQL ORC MR                                         1915           1923          12          8.2         121.7       8.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single TINYINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                             199            207           6         79.1          12.6       1.0X
-ParquetReader Vectorized -> Row                       98            102           3        160.1           6.2       2.0X
+ParquetReader Vectorized                             211            218           5         74.6          13.4       1.0X
+ParquetReader Vectorized -> Row                      286            293           7         55.1          18.2       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           18100          18211         157          0.9        1150.8       1.0X
-SQL Json                                          11036          11085          70          1.4         701.6       1.6X
-SQL Parquet Vectorized                              249            256           8         63.1          15.8      72.7X
-SQL Parquet MR                                     2485           2517          47          6.3         158.0       7.3X
-SQL ORC Vectorized                                  207            212           4         76.2          13.1      87.6X
-SQL ORC MR                                         1940           1955          21          8.1         123.4       9.3X
+SQL CSV                                           17475          17516          58          0.9        1111.0       1.0X
+SQL Json                                          12039          12060          30          1.3         765.4       1.5X
+SQL Parquet Vectorized                              254            266          14         61.9          16.2      68.7X
+SQL Parquet MR                                     2666           2666           0          5.9         169.5       6.6X
+SQL ORC Vectorized                                  221            226           5         71.1          14.1      79.0X
+SQL ORC MR                                         2110           2113           5          7.5         134.1       8.3X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single SMALLINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                              321            332           8         49.0          20.4       1.0X
-ParquetReader Vectorized -> Row                       314            325           9         50.0          20.0       1.0X
+ParquetReader Vectorized                              337            345           6         46.7          21.4       1.0X
+ParquetReader Vectorized -> Row                       339            344           4         46.4          21.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           20118          20198         114          0.8        1279.0       1.0X
-SQL Json                                          11448          11545         137          1.4         727.9       1.8X
-SQL Parquet Vectorized                              193            205          10         81.3          12.3     104.0X
-SQL Parquet MR                                     2677           2677           1          5.9         170.2       7.5X
-SQL ORC Vectorized                                  295            303           8         53.3          18.8      68.2X
-SQL ORC MR                                         1978           2017          55          8.0         125.8      10.2X
+SQL CSV                                           19292          19298           9          0.8        1226.6       1.0X
+SQL Json                                          12705          12729          35          1.2         807.8       1.5X
+SQL Parquet Vectorized                              197            208           9         79.8          12.5      97.8X
+SQL Parquet MR                                     2656           2657           1          5.9         168.9       7.3X
+SQL ORC Vectorized                                  300            304           3         52.4          19.1      64.2X
+SQL ORC MR                                         2172           2177           8          7.2         138.1       8.9X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single INT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            284            292           5         55.3          18.1       1.0X
-ParquetReader Vectorized -> Row                     267            281           9         58.8          17.0       1.1X
+ParquetReader Vectorized                            286            293           8         55.0          18.2       1.0X
+ParquetReader Vectorized -> Row                     283            291          11         55.6          18.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           25472          25641         238          0.6        1619.5       1.0X
-SQL Json                                          14927          14933           9          1.1         949.1       1.7X
-SQL Parquet Vectorized                              290            304          14         54.3          18.4      87.9X
-SQL Parquet MR                                     2646           2667          29          5.9         168.2       9.6X
-SQL ORC Vectorized                                  343            360          11         45.8          21.8      74.2X
-SQL ORC MR                                         2068           2071           5          7.6         131.5      12.3X
+SQL CSV                                           25437          25438           2          0.6        1617.2       1.0X
+SQL Json                                          16605          16710         149          0.9        1055.7       1.5X
+SQL Parquet Vectorized                              287            302          12         54.7          18.3      88.5X
+SQL Parquet MR                                     2886           2906          28          5.5         183.5       8.8X
+SQL ORC Vectorized                                  372            377           5         42.3          23.6      68.4X
+SQL ORC MR                                         2272           2272           0          6.9         144.5      11.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single BIGINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            375            432         114         42.0          23.8       1.0X
-ParquetReader Vectorized -> Row                     353            368          13         44.5          22.5       1.1X
+ParquetReader Vectorized                            377            426         102         41.8          23.9       1.0X
+ParquetReader Vectorized -> Row                     371            380           8         42.4          23.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           20609          20641          44          0.8        1310.3       1.0X
-SQL Json                                          13997          14032          49          1.1         889.9       1.5X
-SQL Parquet Vectorized                              180            187           8         87.3          11.5     114.4X
-SQL Parquet MR                                     2398           2423          35          6.6         152.5       8.6X
-SQL ORC Vectorized                                  401            409           6         39.2          25.5      51.4X
-SQL ORC MR                                         2076           2108          45          7.6         132.0       9.9X
+SQL CSV                                           21529          21584          77          0.7        1368.8       1.0X
+SQL Json                                          14621          14675          76          1.1         929.6       1.5X
+SQL Parquet Vectorized                              178            184           9         88.4          11.3     121.0X
+SQL Parquet MR                                     2648           2649           2          5.9         168.3       8.1X
+SQL ORC Vectorized                                  436            443          12         36.1          27.7      49.4X
+SQL ORC MR                                         2213           2218           6          7.1         140.7       9.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single FLOAT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            285            290           5         55.1          18.1       1.0X
-ParquetReader Vectorized -> Row                     256            262           9         61.4          16.3       1.1X
+ParquetReader Vectorized                            267            272           5         59.0          17.0       1.0X
+ParquetReader Vectorized -> Row                     262            271           8         60.0          16.7       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           26320          26408         125          0.6        1673.4       1.0X
-SQL Json                                          18703          18753          70          0.8        1189.1       1.4X
-SQL Parquet Vectorized                              254            275          15         61.9          16.2     103.5X
-SQL Parquet MR                                     2677           2694          25          5.9         170.2       9.8X
-SQL ORC Vectorized                                  490            496           6         32.1          31.1      53.8X
-SQL ORC MR                                         2206           2224          26          7.1         140.2      11.9X
+SQL CSV                                           27492          27492           1          0.6        1747.9       1.0X
+SQL Json                                          19830          19865          50          0.8        1260.7       1.4X
+SQL Parquet Vectorized                              270            275           7         58.3          17.1     101.9X
+SQL Parquet MR                                     2808           2816          11          5.6         178.5       9.8X
+SQL ORC Vectorized                                  499            504           4         31.5          31.7      55.1X
+SQL ORC MR                                         2347           2370          32          6.7         149.2      11.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single DOUBLE Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            369            421          97         42.6          23.5       1.0X
-ParquetReader Vectorized -> Row                     353            364          14         44.6          22.4       1.0X
+ParquetReader Vectorized                            370            416          93         42.5          23.5       1.0X
+ParquetReader Vectorized -> Row                     356            366          13         44.2          22.6       1.0X
 
 
 ================================================================================================
@@ -142,12 +142,12 @@ OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           18401          18505         147          0.6        1754.9       1.0X
-SQL Json                                          13685          13702          24          0.8        1305.1       1.3X
-SQL Parquet Vectorized                             2313           2357          62          4.5         220.6       8.0X
-SQL Parquet MR                                     4467           4520          74          2.3         426.0       4.1X
-SQL ORC Vectorized                                 2227           2246          26          4.7         212.4       8.3X
-SQL ORC MR                                         4139           4159          29          2.5         394.7       4.4X
+SQL CSV                                           19211          19276          92          0.5        1832.1       1.0X
+SQL Json                                          14722          14756          48          0.7        1404.0       1.3X
+SQL Parquet Vectorized                             2383           2401          26          4.4         227.3       8.1X
+SQL Parquet MR                                     4891           4895           6          2.1         466.5       3.9X
+SQL ORC Vectorized                                 2350           2351           2          4.5         224.1       8.2X
+SQL ORC MR                                         4240           4269          41          2.5         404.4       4.5X
 
 
 ================================================================================================
@@ -158,12 +158,12 @@ OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10599          10674         106          1.0        1010.8       1.0X
-SQL Json                                           8434           8469          50          1.2         804.3       1.3X
-SQL Parquet Vectorized                              821            833          16         12.8          78.3      12.9X
-SQL Parquet MR                                     1889           1929          56          5.5         180.2       5.6X
-SQL ORC Vectorized                                  498            506           7         21.1          47.5      21.3X
-SQL ORC MR                                         2104           2152          69          5.0         200.6       5.0X
+SQL CSV                                           10035          10118         118          1.0         957.0       1.0X
+SQL Json                                           8728           8734           9          1.2         832.3       1.1X
+SQL Parquet Vectorized                              825            832           7         12.7          78.7      12.2X
+SQL Parquet MR                                     1965           2016          72          5.3         187.4       5.1X
+SQL ORC Vectorized                                  517            529          12         20.3          49.4      19.4X
+SQL ORC MR                                         2237           2248          15          4.7         213.4       4.5X
 
 
 ================================================================================================
@@ -174,24 +174,24 @@ OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Partitioned Table:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Data column - CSV                                 26005          26106         143          0.6        1653.3       1.0X
-Data column - Json                                15212          15238          38          1.0         967.1       1.7X
-Data column - Parquet Vectorized                    282            291           8         55.9          17.9      92.4X
-Data column - Parquet MR                           2913           2923          15          5.4         185.2       8.9X
-Data column - ORC Vectorized                        353            363           7         44.5          22.5      73.6X
-Data column - ORC MR                               2440           2453          18          6.4         155.2      10.7X
-Partition column - CSV                             7427           7437          14          2.1         472.2       3.5X
-Partition column - Json                           11476          11480           5          1.4         729.6       2.3X
-Partition column - Parquet Vectorized                65             70           4        240.8           4.2     398.2X
-Partition column - Parquet MR                      1458           1470          18         10.8          92.7      17.8X
-Partition column - ORC Vectorized                    67             72           6        234.2           4.3     387.3X
-Partition column - ORC MR                          1567           1603          51         10.0          99.6      16.6X
-Both columns - CSV                                25383          25512         183          0.6        1613.8       1.0X
-Both columns - Json                               16176          16192          22          1.0        1028.5       1.6X
-Both columns - Parquet Vectorized                   335            346          11         46.9          21.3      77.6X
-Both columns - Parquet MR                          2903           2915          16          5.4         184.6       9.0X
-Both columns - ORC Vectorized                       407            421          11         38.7          25.9      64.0X
-Both columns - ORC MR                              2507           2572          92          6.3         159.4      10.4X
+Data column - CSV                                 26876          26936          85          0.6        1708.7       1.0X
+Data column - Json                                15652          15723         101          1.0         995.1       1.7X
+Data column - Parquet Vectorized                    286            296           9         55.0          18.2      94.0X
+Data column - Parquet MR                           3045           3047           3          5.2         193.6       8.8X
+Data column - ORC Vectorized                        377            386           8         41.8          23.9      71.4X
+Data column - ORC MR                               2497           2507          14          6.3         158.8      10.8X
+Partition column - CSV                             8444           8466          32          1.9         536.8       3.2X
+Partition column - Json                           12021          12085          91          1.3         764.2       2.2X
+Partition column - Parquet Vectorized                66             70           3        239.4           4.2     409.2X
+Partition column - Parquet MR                      1591           1599          12          9.9         101.1      16.9X
+Partition column - ORC Vectorized                    71             79          11        222.5           4.5     380.2X
+Partition column - ORC MR                          1642           1652          14          9.6         104.4      16.4X
+Both columns - CSV                                27949          28070         171          0.6        1777.0       1.0X
+Both columns - Json                               16718          16734          22          0.9        1062.9       1.6X
+Both columns - Parquet Vectorized                   329            340          10         47.8          20.9      81.7X
+Both columns - Parquet MR                          3127           3127           0          5.0         198.8       8.6X
+Both columns - ORC Vectorized                       420            426           4         37.5          26.7      64.0X
+Both columns - ORC MR                              2639           2640           2          6.0         167.8      10.2X
 
 
 ================================================================================================
@@ -202,37 +202,37 @@ OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           12504          12651         208          0.8        1192.5       1.0X
-SQL Json                                          13198          13205          10          0.8        1258.7       0.9X
-SQL Parquet Vectorized                             1565           1568           4          6.7         149.3       8.0X
-SQL Parquet MR                                     3776           3782           9          2.8         360.1       3.3X
-ParquetReader Vectorized                           1109           1110           1          9.5         105.8      11.3X
-SQL ORC Vectorized                                 1058           1062           6          9.9         100.9      11.8X
-SQL ORC MR                                         3504           3518          20          3.0         334.1       3.6X
+SQL CSV                                           12979          13015          51          0.8        1237.8       1.0X
+SQL Json                                          13190          13203          17          0.8        1257.9       1.0X
+SQL Parquet Vectorized                             1588           1603          22          6.6         151.4       8.2X
+SQL Parquet MR                                     4115           4125          15          2.5         392.4       3.2X
+ParquetReader Vectorized                           1184           1186           3          8.9         112.9      11.0X
+SQL ORC Vectorized                                 1067           1082          21          9.8         101.8      12.2X
+SQL ORC MR                                         3787           3791           5          2.8         361.2       3.4X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9794           9877         116          1.1         934.1       1.0X
-SQL Json                                           9469           9487          26          1.1         903.0       1.0X
-SQL Parquet Vectorized                             1142           1148           9          9.2         108.9       8.6X
-SQL Parquet MR                                     2911           2925          19          3.6         277.6       3.4X
-ParquetReader Vectorized                            997           1019          32         10.5          95.1       9.8X
-SQL ORC Vectorized                                 1236           1241           6          8.5         117.9       7.9X
-SQL ORC MR                                         3294           3368         105          3.2         314.1       3.0X
+SQL CSV                                           10126          10179          75          1.0         965.7       1.0X
+SQL Json                                           9834           9880          65          1.1         937.8       1.0X
+SQL Parquet Vectorized                             1203           1211          12          8.7         114.7       8.4X
+SQL Parquet MR                                     3115           3115           1          3.4         297.0       3.3X
+ParquetReader Vectorized                           1081           1090          12          9.7         103.1       9.4X
+SQL ORC Vectorized                                 1249           1264          22          8.4         119.1       8.1X
+SQL ORC MR                                         3378           3418          57          3.1         322.2       3.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            7364           7389          35          1.4         702.3       1.0X
-SQL Json                                           5400           5417          24          1.9         514.9       1.4X
-SQL Parquet Vectorized                              263            280          15         39.8          25.1      28.0X
-SQL Parquet MR                                     1888           1904          22          5.6         180.1       3.9X
-ParquetReader Vectorized                            252            260           7         41.6          24.0      29.2X
-SQL ORC Vectorized                                  456            468           8         23.0          43.5      16.1X
-SQL ORC MR                                         1776           1777           1          5.9         169.4       4.1X
+SQL CSV                                            8067           8090          32          1.3         769.4       1.0X
+SQL Json                                           5947           5963          23          1.8         567.1       1.4X
+SQL Parquet Vectorized                              271            279          10         38.7          25.9      29.7X
+SQL Parquet MR                                     2031           2037           9          5.2         193.7       4.0X
+ParquetReader Vectorized                            275            282          10         38.1          26.2      29.3X
+SQL ORC Vectorized                                  443            450           5         23.7          42.2      18.2X
+SQL ORC MR                                         1832           1858          36          5.7         174.7       4.4X
 
 
 ================================================================================================
@@ -243,33 +243,33 @@ OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Single Column Scan from 10 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            2539           2550          15          0.4        2421.7       1.0X
-SQL Json                                           3355           3403          68          0.3        3199.4       0.8X
-SQL Parquet Vectorized                               59             65          10         17.8          56.1      43.1X
-SQL Parquet MR                                      217            226           5          4.8         207.4      11.7X
-SQL ORC Vectorized                                   63             70          12         16.6          60.3      40.2X
-SQL ORC MR                                          191            197           6          5.5         181.9      13.3X
+SQL CSV                                            2920           2933          19          0.4        2785.0       1.0X
+SQL Json                                           3442           3450          11          0.3        3282.8       0.8X
+SQL Parquet Vectorized                               56             64           8         18.8          53.1      52.4X
+SQL Parquet MR                                      226            233           5          4.6         215.6      12.9X
+SQL ORC Vectorized                                   63             69          11         16.7          59.9      46.5X
+SQL ORC MR                                          207            219          12          5.1         197.2      14.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Single Column Scan from 50 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            5989           5991           3          0.2        5711.4       1.0X
-SQL Json                                          12595          12809         302          0.1       12011.6       0.5X
-SQL Parquet Vectorized                               73             84          10         14.3          70.1      81.5X
-SQL Parquet MR                                      238            247           8          4.4         227.1      25.2X
-SQL ORC Vectorized                                   77             86          12         13.7          73.0      78.3X
-SQL ORC MR                                          205            216           8          5.1         195.7      29.2X
+SQL CSV                                            7068           7089          30          0.1        6740.3       1.0X
+SQL Json                                          13731          13919         265          0.1       13095.3       0.5X
+SQL Parquet Vectorized                               76             85          12         13.8          72.6      92.8X
+SQL Parquet MR                                      256            262           7          4.1         244.3      27.6X
+SQL ORC Vectorized                                   83             92          16         12.6          79.5      84.8X
+SQL ORC MR                                          223            228           4          4.7         212.5      31.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
 Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10430          10449          27          0.1        9946.5       1.0X
-SQL Json                                          24695          24726          44          0.0       23551.2       0.4X
-SQL Parquet Vectorized                              108            120          10          9.7         102.8      96.8X
-SQL Parquet MR                                      284            292           8          3.7         271.1      36.7X
-SQL ORC Vectorized                                   96            105          13         10.9          91.3     108.9X
-SQL ORC MR                                          226            237          10          4.6         215.6      46.1X
+SQL CSV                                           12181          12191          14          0.1       11616.7       1.0X
+SQL Json                                          25757          26003         348          0.0       24564.3       0.5X
+SQL Parquet Vectorized                              110            118           9          9.5         104.7     110.9X
+SQL Parquet MR                                      288            297          10          3.6         274.4      42.3X
+SQL ORC Vectorized                                  100            111          11         10.4          95.7     121.4X
+SQL ORC MR                                          245            252           5          4.3         233.6      49.7X
 
 

--- a/sql/core/benchmarks/DataSourceReadBenchmark-results.txt
+++ b/sql/core/benchmarks/DataSourceReadBenchmark-results.txt
@@ -1,252 +1,275 @@
 ================================================================================================
+SQL Single Boolean Column Scan
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+SQL CSV                                           14552          14660         152          1.1         925.2       1.0X
+SQL Json                                           9024           9218         275          1.7         573.7       1.6X
+SQL Parquet Vectorized                              154            174          16        102.2           9.8      94.6X
+SQL Parquet MR                                     1952           1977          35          8.1         124.1       7.5X
+SQL ORC Vectorized                                  202            212          10         77.9          12.8      72.1X
+SQL ORC MR                                         1849           1849           1          8.5         117.5       7.9X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+ParquetReader Vectorized                             140            147           6        112.4           8.9       1.0X
+ParquetReader Vectorized -> Row                       77             82           6        204.5           4.9       1.8X
+
+
+================================================================================================
 SQL Single Numeric Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           15943          15956          18          1.0        1013.6       1.0X
-SQL Json                                           9109           9158          70          1.7         579.1       1.8X
-SQL Parquet Vectorized                              168            191          16         93.8          10.7      95.1X
-SQL Parquet MR                                     1938           1950          17          8.1         123.2       8.2X
-SQL ORC Vectorized                                  191            199           6         82.2          12.2      83.3X
-SQL ORC MR                                         1523           1537          20         10.3          96.8      10.5X
+SQL CSV                                           17338          17483         205          0.9        1102.3       1.0X
+SQL Json                                          10492          10557          91          1.5         667.1       1.7X
+SQL Parquet Vectorized                              157            172          13        100.0          10.0     110.3X
+SQL Parquet MR                                     2188           2197          13          7.2         139.1       7.9X
+SQL ORC Vectorized                                  142            148           6        110.9           9.0     122.3X
+SQL ORC MR                                         1735           1743          12          9.1         110.3      10.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single TINYINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                             203            206           3         77.5          12.9       1.0X
-ParquetReader Vectorized -> Row                       97            100           2        161.6           6.2       2.1X
+ParquetReader Vectorized                             199            207           6         79.1          12.6       1.0X
+ParquetReader Vectorized -> Row                       98            102           3        160.1           6.2       2.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           17062          17089          38          0.9        1084.8       1.0X
-SQL Json                                           9718           9720           3          1.6         617.9       1.8X
-SQL Parquet Vectorized                              326            333           7         48.2          20.7      52.3X
-SQL Parquet MR                                     2305           2329          34          6.8         146.6       7.4X
-SQL ORC Vectorized                                  201            205           3         78.2          12.8      84.8X
-SQL ORC MR                                         1795           1796           0          8.8         114.1       9.5X
+SQL CSV                                           18100          18211         157          0.9        1150.8       1.0X
+SQL Json                                          11036          11085          70          1.4         701.6       1.6X
+SQL Parquet Vectorized                              249            256           8         63.1          15.8      72.7X
+SQL Parquet MR                                     2485           2517          47          6.3         158.0       7.3X
+SQL ORC Vectorized                                  207            212           4         76.2          13.1      87.6X
+SQL ORC MR                                         1940           1955          21          8.1         123.4       9.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single SMALLINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                              333            339           7         47.2          21.2       1.0X
-ParquetReader Vectorized -> Row                       283            285           3         55.7          18.0       1.2X
+ParquetReader Vectorized                              321            332           8         49.0          20.4       1.0X
+ParquetReader Vectorized -> Row                       314            325           9         50.0          20.0       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           18722          18809         123          0.8        1190.3       1.0X
-SQL Json                                          10192          10249          80          1.5         648.0       1.8X
-SQL Parquet Vectorized                              155            162           8        101.6           9.8     120.9X
-SQL Parquet MR                                     2348           2360          16          6.7         149.3       8.0X
-SQL ORC Vectorized                                  265            275           7         59.3          16.9      70.5X
-SQL ORC MR                                         1892           1938          65          8.3         120.3       9.9X
+SQL CSV                                           20118          20198         114          0.8        1279.0       1.0X
+SQL Json                                          11448          11545         137          1.4         727.9       1.8X
+SQL Parquet Vectorized                              193            205          10         81.3          12.3     104.0X
+SQL Parquet MR                                     2677           2677           1          5.9         170.2       7.5X
+SQL ORC Vectorized                                  295            303           8         53.3          18.8      68.2X
+SQL ORC MR                                         1978           2017          55          8.0         125.8      10.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single INT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            243            251           7         64.8          15.4       1.0X
-ParquetReader Vectorized -> Row                     222            229           5         70.9          14.1       1.1X
+ParquetReader Vectorized                            284            292           5         55.3          18.1       1.0X
+ParquetReader Vectorized -> Row                     267            281           9         58.8          17.0       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           24299          24358          84          0.6        1544.9       1.0X
-SQL Json                                          13349          13429         114          1.2         848.7       1.8X
-SQL Parquet Vectorized                              215            241          59         73.3          13.6     113.2X
-SQL Parquet MR                                     2508           2508           0          6.3         159.4       9.7X
-SQL ORC Vectorized                                  323            330           6         48.7          20.5      75.2X
-SQL ORC MR                                         1993           2009          22          7.9         126.7      12.2X
+SQL CSV                                           25472          25641         238          0.6        1619.5       1.0X
+SQL Json                                          14927          14933           9          1.1         949.1       1.7X
+SQL Parquet Vectorized                              290            304          14         54.3          18.4      87.9X
+SQL Parquet MR                                     2646           2667          29          5.9         168.2       9.6X
+SQL ORC Vectorized                                  343            360          11         45.8          21.8      74.2X
+SQL ORC MR                                         2068           2071           5          7.6         131.5      12.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single BIGINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            310            351          74         50.8          19.7       1.0X
-ParquetReader Vectorized -> Row                     281            297           8         55.9          17.9       1.1X
+ParquetReader Vectorized                            375            432         114         42.0          23.8       1.0X
+ParquetReader Vectorized -> Row                     353            368          13         44.5          22.5       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           19745          19811          93          0.8        1255.4       1.0X
-SQL Json                                          12523          12760         335          1.3         796.2       1.6X
-SQL Parquet Vectorized                              153            160           6        102.9           9.7     129.2X
-SQL Parquet MR                                     2325           2338          18          6.8         147.8       8.5X
-SQL ORC Vectorized                                  389            401           8         40.5          24.7      50.8X
-SQL ORC MR                                         2009           2009           1          7.8         127.7       9.8X
+SQL CSV                                           20609          20641          44          0.8        1310.3       1.0X
+SQL Json                                          13997          14032          49          1.1         889.9       1.5X
+SQL Parquet Vectorized                              180            187           8         87.3          11.5     114.4X
+SQL Parquet MR                                     2398           2423          35          6.6         152.5       8.6X
+SQL ORC Vectorized                                  401            409           6         39.2          25.5      51.4X
+SQL ORC MR                                         2076           2108          45          7.6         132.0       9.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single FLOAT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            240            244           4         65.5          15.3       1.0X
-ParquetReader Vectorized -> Row                     223            230           6         70.5          14.2       1.1X
+ParquetReader Vectorized                            285            290           5         55.1          18.1       1.0X
+ParquetReader Vectorized -> Row                     256            262           9         61.4          16.3       1.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           27223          27293          99          0.6        1730.8       1.0X
-SQL Json                                          18601          18646          63          0.8        1182.6       1.5X
-SQL Parquet Vectorized                              247            251           3         63.8          15.7     110.4X
-SQL Parquet MR                                     2724           2773          69          5.8         173.2      10.0X
-SQL ORC Vectorized                                  474            484          10         33.2          30.1      57.4X
-SQL ORC MR                                         2342           2368          37          6.7         148.9      11.6X
+SQL CSV                                           26320          26408         125          0.6        1673.4       1.0X
+SQL Json                                          18703          18753          70          0.8        1189.1       1.4X
+SQL Parquet Vectorized                              254            275          15         61.9          16.2     103.5X
+SQL Parquet MR                                     2677           2694          25          5.9         170.2       9.8X
+SQL ORC Vectorized                                  490            496           6         32.1          31.1      53.8X
+SQL ORC MR                                         2206           2224          26          7.1         140.2      11.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Parquet Reader Single DOUBLE Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            326            335          13         48.3          20.7       1.0X
-ParquetReader Vectorized -> Row                     358            365           7         44.0          22.7       0.9X
+ParquetReader Vectorized                            369            421          97         42.6          23.5       1.0X
+ParquetReader Vectorized -> Row                     353            364          14         44.6          22.4       1.0X
 
 
 ================================================================================================
 Int and String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           18706          18716          15          0.6        1783.9       1.0X
-SQL Json                                          12665          12762         138          0.8        1207.8       1.5X
-SQL Parquet Vectorized                             2408           2419          15          4.4         229.6       7.8X
-SQL Parquet MR                                     4599           4620          30          2.3         438.6       4.1X
-SQL ORC Vectorized                                 2397           2400           3          4.4         228.6       7.8X
-SQL ORC MR                                         4267           4288          30          2.5         406.9       4.4X
+SQL CSV                                           18401          18505         147          0.6        1754.9       1.0X
+SQL Json                                          13685          13702          24          0.8        1305.1       1.3X
+SQL Parquet Vectorized                             2313           2357          62          4.5         220.6       8.0X
+SQL Parquet MR                                     4467           4520          74          2.3         426.0       4.1X
+SQL ORC Vectorized                                 2227           2246          26          4.7         212.4       8.3X
+SQL ORC MR                                         4139           4159          29          2.5         394.7       4.4X
 
 
 ================================================================================================
 Repeated String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10822          10838          23          1.0        1032.0       1.0X
-SQL Json                                           7459           7488          41          1.4         711.4       1.5X
-SQL Parquet Vectorized                              875            895          26         12.0          83.5      12.4X
-SQL Parquet MR                                     1976           2002          37          5.3         188.4       5.5X
-SQL ORC Vectorized                                  533            539           8         19.7          50.9      20.3X
-SQL ORC MR                                         2191           2194           5          4.8         208.9       4.9X
+SQL CSV                                           10599          10674         106          1.0        1010.8       1.0X
+SQL Json                                           8434           8469          50          1.2         804.3       1.3X
+SQL Parquet Vectorized                              821            833          16         12.8          78.3      12.9X
+SQL Parquet MR                                     1889           1929          56          5.5         180.2       5.6X
+SQL ORC Vectorized                                  498            506           7         21.1          47.5      21.3X
+SQL ORC MR                                         2104           2152          69          5.0         200.6       5.0X
 
 
 ================================================================================================
 Partitioned Table Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Partitioned Table:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Data column - CSV                                 31196          31449         359          0.5        1983.4       1.0X
-Data column - Json                                16118          16855        1041          1.0        1024.8       1.9X
-Data column - Parquet Vectorized                    243            251           9         64.8          15.4     128.4X
-Data column - Parquet MR                           4213           4288         106          3.7         267.8       7.4X
-Data column - ORC Vectorized                        335            341           4         46.9          21.3      93.1X
-Data column - ORC MR                               3119           3146          38          5.0         198.3      10.0X
-Partition column - CSV                             9616           9915         423          1.6         611.3       3.2X
-Partition column - Json                           14136          14164          39          1.1         898.8       2.2X
-Partition column - Parquet Vectorized                64             70           6        243.9           4.1     483.8X
-Partition column - Parquet MR                      1954           1980          38          8.1         124.2      16.0X
-Partition column - ORC Vectorized                    67             74           8        233.4           4.3     462.9X
-Partition column - ORC MR                          2461           2479          26          6.4         156.4      12.7X
-Both columns - CSV                                30327          30666         479          0.5        1928.2       1.0X
-Both columns - Json                               18656          18789         188          0.8        1186.1       1.7X
-Both columns - Parquet Vectorized                   291            297           7         54.0          18.5     107.2X
-Both columns - Parquet MR                          4430           4443          19          3.6         281.6       7.0X
-Both columns - ORC Vectorized                       403            411          11         39.0          25.6      77.4X
-Both columns - ORC MR                              3580           3584           5          4.4         227.6       8.7X
+Data column - CSV                                 26005          26106         143          0.6        1653.3       1.0X
+Data column - Json                                15212          15238          38          1.0         967.1       1.7X
+Data column - Parquet Vectorized                    282            291           8         55.9          17.9      92.4X
+Data column - Parquet MR                           2913           2923          15          5.4         185.2       8.9X
+Data column - ORC Vectorized                        353            363           7         44.5          22.5      73.6X
+Data column - ORC MR                               2440           2453          18          6.4         155.2      10.7X
+Partition column - CSV                             7427           7437          14          2.1         472.2       3.5X
+Partition column - Json                           11476          11480           5          1.4         729.6       2.3X
+Partition column - Parquet Vectorized                65             70           4        240.8           4.2     398.2X
+Partition column - Parquet MR                      1458           1470          18         10.8          92.7      17.8X
+Partition column - ORC Vectorized                    67             72           6        234.2           4.3     387.3X
+Partition column - ORC MR                          1567           1603          51         10.0          99.6      16.6X
+Both columns - CSV                                25383          25512         183          0.6        1613.8       1.0X
+Both columns - Json                               16176          16192          22          1.0        1028.5       1.6X
+Both columns - Parquet Vectorized                   335            346          11         46.9          21.3      77.6X
+Both columns - Parquet MR                          2903           2915          16          5.4         184.6       9.0X
+Both columns - ORC Vectorized                       407            421          11         38.7          25.9      64.0X
+Both columns - ORC MR                              2507           2572          92          6.3         159.4      10.4X
 
 
 ================================================================================================
 String with Nulls Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           15606          15614          11          0.7        1488.3       1.0X
-SQL Json                                          15406          15451          63          0.7        1469.3       1.0X
-SQL Parquet Vectorized                             1555           1573          25          6.7         148.3      10.0X
-SQL Parquet MR                                     5369           5377          11          2.0         512.0       2.9X
-ParquetReader Vectorized                           1145           1150           7          9.2         109.2      13.6X
-SQL ORC Vectorized                                 1023           1027           6         10.2          97.6      15.3X
-SQL ORC MR                                         4421           4542         172          2.4         421.6       3.5X
+SQL CSV                                           12504          12651         208          0.8        1192.5       1.0X
+SQL Json                                          13198          13205          10          0.8        1258.7       0.9X
+SQL Parquet Vectorized                             1565           1568           4          6.7         149.3       8.0X
+SQL Parquet MR                                     3776           3782           9          2.8         360.1       3.3X
+ParquetReader Vectorized                           1109           1110           1          9.5         105.8      11.3X
+SQL ORC Vectorized                                 1058           1062           6          9.9         100.9      11.8X
+SQL ORC MR                                         3504           3518          20          3.0         334.1       3.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           11096          11159          90          0.9        1058.2       1.0X
-SQL Json                                          10797          11304         717          1.0        1029.7       1.0X
-SQL Parquet Vectorized                             1218           1230          16          8.6         116.2       9.1X
-SQL Parquet MR                                     3778           3806          40          2.8         360.3       2.9X
-ParquetReader Vectorized                           1108           1118          14          9.5         105.7      10.0X
-SQL ORC Vectorized                                 1361           1371          13          7.7         129.8       8.2X
-SQL ORC MR                                         4186           4196          14          2.5         399.2       2.7X
+SQL CSV                                            9794           9877         116          1.1         934.1       1.0X
+SQL Json                                           9469           9487          26          1.1         903.0       1.0X
+SQL Parquet Vectorized                             1142           1148           9          9.2         108.9       8.6X
+SQL Parquet MR                                     2911           2925          19          3.6         277.6       3.4X
+ParquetReader Vectorized                            997           1019          32         10.5          95.1       9.8X
+SQL ORC Vectorized                                 1236           1241           6          8.5         117.9       7.9X
+SQL ORC MR                                         3294           3368         105          3.2         314.1       3.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            8803           8866          90          1.2         839.5       1.0X
-SQL Json                                           7220           7249          42          1.5         688.5       1.2X
-SQL Parquet Vectorized                              258            265           7         40.6          24.6      34.1X
-SQL Parquet MR                                     2760           2761           0          3.8         263.2       3.2X
-ParquetReader Vectorized                            277            283           5         37.8          26.4      31.7X
-SQL ORC Vectorized                                  514            522           6         20.4          49.1      17.1X
-SQL ORC MR                                         2523           2591          96          4.2         240.6       3.5X
+SQL CSV                                            7364           7389          35          1.4         702.3       1.0X
+SQL Json                                           5400           5417          24          1.9         514.9       1.4X
+SQL Parquet Vectorized                              263            280          15         39.8          25.1      28.0X
+SQL Parquet MR                                     1888           1904          22          5.6         180.1       3.9X
+ParquetReader Vectorized                            252            260           7         41.6          24.0      29.2X
+SQL ORC Vectorized                                  456            468           8         23.0          43.5      16.1X
+SQL ORC MR                                         1776           1777           1          5.9         169.4       4.1X
 
 
 ================================================================================================
 Single Column Scan From Wide Columns
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Single Column Scan from 10 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            3022           3032          14          0.3        2881.9       1.0X
-SQL Json                                           4047           4051           5          0.3        3859.5       0.7X
-SQL Parquet Vectorized                               50             54           6         20.8          48.1      59.9X
-SQL Parquet MR                                      299            301           2          3.5         285.0      10.1X
-SQL ORC Vectorized                                   59             63          11         17.9          55.9      51.6X
-SQL ORC MR                                          255            259           5          4.1         243.4      11.8X
+SQL CSV                                            2539           2550          15          0.4        2421.7       1.0X
+SQL Json                                           3355           3403          68          0.3        3199.4       0.8X
+SQL Parquet Vectorized                               59             65          10         17.8          56.1      43.1X
+SQL Parquet MR                                      217            226           5          4.8         207.4      11.7X
+SQL ORC Vectorized                                   63             70          12         16.6          60.3      40.2X
+SQL ORC MR                                          191            197           6          5.5         181.9      13.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Single Column Scan from 50 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            7250           7252           3          0.1        6914.4       1.0X
-SQL Json                                          15641          15718         109          0.1       14916.8       0.5X
-SQL Parquet Vectorized                               66             72           8         15.9          62.9     110.0X
-SQL Parquet MR                                      320            323           3          3.3         305.0      22.7X
-SQL ORC Vectorized                                   72             77          11         14.6          68.6     100.9X
-SQL ORC MR                                          269            273           5          3.9         256.8      26.9X
+SQL CSV                                            5989           5991           3          0.2        5711.4       1.0X
+SQL Json                                          12595          12809         302          0.1       12011.6       0.5X
+SQL Parquet Vectorized                               73             84          10         14.3          70.1      81.5X
+SQL Parquet MR                                      238            247           8          4.4         227.1      25.2X
+SQL ORC Vectorized                                   77             86          12         13.7          73.0      78.3X
+SQL ORC MR                                          205            216           8          5.1         195.7      29.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_282-b08 on Linux 5.4.0-1043-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10962          11340         535          0.1       10454.1       1.0X
-SQL Json                                          24951          25755        1137          0.0       23795.0       0.4X
-SQL Parquet Vectorized                               84             93           6         12.4          80.5     129.9X
-SQL Parquet MR                                      280            296          14          3.7         266.8      39.2X
-SQL ORC Vectorized                                   70             76           6         15.0          66.6     156.9X
-SQL ORC MR                                          231            242          13          4.5         220.1      47.5X
+SQL CSV                                           10430          10449          27          0.1        9946.5       1.0X
+SQL Json                                          24695          24726          44          0.0       23551.2       0.4X
+SQL Parquet Vectorized                              108            120          10          9.7         102.8      96.8X
+SQL Parquet MR                                      284            292           8          3.7         271.1      36.7X
+SQL ORC Vectorized                                   96            105          13         10.9          91.3     108.9X
+SQL ORC MR                                          226            237          10          4.6         215.6      46.1X
 
 

--- a/sql/core/benchmarks/DataSourceReadBenchmark-results.txt
+++ b/sql/core/benchmarks/DataSourceReadBenchmark-results.txt
@@ -1,137 +1,132 @@
 ================================================================================================
-SQL Single Boolean Column Scan
-================================================================================================
-
-OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
-SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           13472          13878         574          1.2         856.5       1.0X
-SQL Json                                          10036          10477         623          1.6         638.0       1.3X
-SQL Parquet Vectorized                              144            167          12        109.2           9.2      93.5X
-SQL Parquet MR                                     2224           2230           7          7.1         141.4       6.1X
-SQL ORC Vectorized                                  191            203           6         82.3          12.2      70.5X
-SQL ORC MR                                         1865           1870           7          8.4         118.6       7.2X
-
-OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
-Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                             119            125           8        131.9           7.6       1.0X
-ParquetReader Vectorized -> Row                       60             63           2        260.2           3.8       2.0X
-
-
-================================================================================================
 SQL Single Numeric Column Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+SQL CSV                                           11497          11744         349          1.4         731.0       1.0X
+SQL Json                                           7073           7099          37          2.2         449.7       1.6X
+SQL Parquet Vectorized                              105            126          17        149.9           6.7     109.6X
+SQL Parquet MR                                     1647           1648           2          9.6         104.7       7.0X
+SQL ORC Vectorized                                  157            167           5        100.0          10.0      73.1X
+SQL ORC MR                                         1466           1485          27         10.7          93.2       7.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+ParquetReader Vectorized                             114            123           8        137.8           7.3       1.0X
+ParquetReader Vectorized -> Row                       42             44           1        372.1           2.7       2.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           16820          16859          54          0.9        1069.4       1.0X
-SQL Json                                          11583          11586           4          1.4         736.4       1.5X
-SQL Parquet Vectorized                              164            177          11         96.0          10.4     102.7X
-SQL Parquet MR                                     2839           2857          25          5.5         180.5       5.9X
-SQL ORC Vectorized                                  150            161           7        104.8           9.5     112.1X
-SQL ORC MR                                         1915           1923          12          8.2         121.7       8.8X
+SQL CSV                                           15825          15961         193          1.0        1006.1       1.0X
+SQL Json                                           7966           8054         125          2.0         506.5       2.0X
+SQL Parquet Vectorized                              136            148           9        115.4           8.7     116.1X
+SQL Parquet MR                                     1814           1825          15          8.7         115.4       8.7X
+SQL ORC Vectorized                                  138            147           6        114.4           8.7     115.1X
+SQL ORC MR                                         1299           1382         117         12.1          82.6      12.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single TINYINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                             211            218           5         74.6          13.4       1.0X
-ParquetReader Vectorized -> Row                      286            293           7         55.1          18.2       0.7X
+ParquetReader Vectorized                             179            185           9         88.0          11.4       1.0X
+ParquetReader Vectorized -> Row                       91            101           3        172.6           5.8       2.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           17475          17516          58          0.9        1111.0       1.0X
-SQL Json                                          12039          12060          30          1.3         765.4       1.5X
-SQL Parquet Vectorized                              254            266          14         61.9          16.2      68.7X
-SQL Parquet MR                                     2666           2666           0          5.9         169.5       6.6X
-SQL ORC Vectorized                                  221            226           5         71.1          14.1      79.0X
-SQL ORC MR                                         2110           2113           5          7.5         134.1       8.3X
+SQL CSV                                           15449          16211        1077          1.0         982.2       1.0X
+SQL Json                                           7955           8292         476          2.0         505.8       1.9X
+SQL Parquet Vectorized                              195            211           8         80.7          12.4      79.2X
+SQL Parquet MR                                     1866           1890          33          8.4         118.7       8.3X
+SQL ORC Vectorized                                  163            173           8         96.6          10.4      94.9X
+SQL ORC MR                                         1550           1555           8         10.1          98.5      10.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single SMALLINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                              337            345           6         46.7          21.4       1.0X
-ParquetReader Vectorized -> Row                       339            344           4         46.4          21.6       1.0X
+ParquetReader Vectorized                              299            302           4         52.5          19.0       1.0X
+ParquetReader Vectorized -> Row                       264            280          14         59.6          16.8       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           19292          19298           9          0.8        1226.6       1.0X
-SQL Json                                          12705          12729          35          1.2         807.8       1.5X
-SQL Parquet Vectorized                              197            208           9         79.8          12.5      97.8X
-SQL Parquet MR                                     2656           2657           1          5.9         168.9       7.3X
-SQL ORC Vectorized                                  300            304           3         52.4          19.1      64.2X
-SQL ORC MR                                         2172           2177           8          7.2         138.1       8.9X
+SQL CSV                                           16640          16834         273          0.9        1058.0       1.0X
+SQL Json                                           8859           8862           3          1.8         563.3       1.9X
+SQL Parquet Vectorized                              144            155           8        109.0           9.2     115.3X
+SQL Parquet MR                                     1960           2023          89          8.0         124.6       8.5X
+SQL ORC Vectorized                                  218            233          11         72.3          13.8      76.5X
+SQL ORC MR                                         1440           1442           3         10.9          91.6      11.6X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single INT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            286            293           8         55.0          18.2       1.0X
-ParquetReader Vectorized -> Row                     283            291          11         55.6          18.0       1.0X
+ParquetReader Vectorized                            224            241          13         70.2          14.2       1.0X
+ParquetReader Vectorized -> Row                     214            221          10         73.6          13.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           25437          25438           2          0.6        1617.2       1.0X
-SQL Json                                          16605          16710         149          0.9        1055.7       1.5X
-SQL Parquet Vectorized                              287            302          12         54.7          18.3      88.5X
-SQL Parquet MR                                     2886           2906          28          5.5         183.5       8.8X
-SQL ORC Vectorized                                  372            377           5         42.3          23.6      68.4X
-SQL ORC MR                                         2272           2272           0          6.9         144.5      11.2X
+SQL CSV                                           22998          23324         461          0.7        1462.2       1.0X
+SQL Json                                          12165          12179          20          1.3         773.4       1.9X
+SQL Parquet Vectorized                              237            265          69         66.3          15.1      96.9X
+SQL Parquet MR                                     2199           2199           0          7.2         139.8      10.5X
+SQL ORC Vectorized                                  303            311          10         51.9          19.3      76.0X
+SQL ORC MR                                         1750           1763          18          9.0         111.3      13.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single BIGINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            377            426         102         41.8          23.9       1.0X
-ParquetReader Vectorized -> Row                     371            380           8         42.4          23.6       1.0X
+ParquetReader Vectorized                            331            368          80         47.6          21.0       1.0X
+ParquetReader Vectorized -> Row                     314            318           6         50.0          20.0       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           21529          21584          77          0.7        1368.8       1.0X
-SQL Json                                          14621          14675          76          1.1         929.6       1.5X
-SQL Parquet Vectorized                              178            184           9         88.4          11.3     121.0X
-SQL Parquet MR                                     2648           2649           2          5.9         168.3       8.1X
-SQL ORC Vectorized                                  436            443          12         36.1          27.7      49.4X
-SQL ORC MR                                         2213           2218           6          7.1         140.7       9.7X
+SQL CSV                                           17442          18560        1581          0.9        1108.9       1.0X
+SQL Json                                          10833          11056         315          1.5         688.8       1.6X
+SQL Parquet Vectorized                              150            162          10        105.0           9.5     116.5X
+SQL Parquet MR                                     1804           1922         167          8.7         114.7       9.7X
+SQL ORC Vectorized                                  317            336          20         49.6          20.2      55.0X
+SQL ORC MR                                         1550           1648         139         10.1          98.5      11.3X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single FLOAT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            267            272           5         59.0          17.0       1.0X
-ParquetReader Vectorized -> Row                     262            271           8         60.0          16.7       1.0X
+ParquetReader Vectorized                            240            263          11         65.7          15.2       1.0X
+ParquetReader Vectorized -> Row                     224            235          15         70.4          14.2       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           27492          27492           1          0.6        1747.9       1.0X
-SQL Json                                          19830          19865          50          0.8        1260.7       1.4X
-SQL Parquet Vectorized                              270            275           7         58.3          17.1     101.9X
-SQL Parquet MR                                     2808           2816          11          5.6         178.5       9.8X
-SQL ORC Vectorized                                  499            504           4         31.5          31.7      55.1X
-SQL ORC MR                                         2347           2370          32          6.7         149.2      11.7X
+SQL CSV                                           22438          23472        1462          0.7        1426.5       1.0X
+SQL Json                                          15839          15888          70          1.0        1007.0       1.4X
+SQL Parquet Vectorized                              215            229          12         73.3          13.6     104.6X
+SQL Parquet MR                                     1928           2061         188          8.2         122.6      11.6X
+SQL ORC Vectorized                                  393            421          17         40.0          25.0      57.0X
+SQL ORC MR                                         1799           1814          22          8.7         114.4      12.5X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Parquet Reader Single DOUBLE Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized                            370            416          93         42.5          23.5       1.0X
-ParquetReader Vectorized -> Row                     356            366          13         44.2          22.6       1.0X
+ParquetReader Vectorized                            310            316           9         50.7          19.7       1.0X
+ParquetReader Vectorized -> Row                     289            302          20         54.3          18.4       1.1X
 
 
 ================================================================================================
@@ -139,15 +134,15 @@ Int and String Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           19211          19276          92          0.5        1832.1       1.0X
-SQL Json                                          14722          14756          48          0.7        1404.0       1.3X
-SQL Parquet Vectorized                             2383           2401          26          4.4         227.3       8.1X
-SQL Parquet MR                                     4891           4895           6          2.1         466.5       3.9X
-SQL ORC Vectorized                                 2350           2351           2          4.5         224.1       8.2X
-SQL ORC MR                                         4240           4269          41          2.5         404.4       4.5X
+SQL CSV                                           15669          15869         283          0.7        1494.3       1.0X
+SQL Json                                          10126          10559         613          1.0         965.7       1.5X
+SQL Parquet Vectorized                             2056           2064          11          5.1         196.0       7.6X
+SQL Parquet MR                                     3918           3927          13          2.7         373.6       4.0X
+SQL ORC Vectorized                                 1786           1887         143          5.9         170.3       8.8X
+SQL ORC MR                                         3521           3555          48          3.0         335.8       4.4X
 
 
 ================================================================================================
@@ -155,15 +150,15 @@ Repeated String Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10035          10118         118          1.0         957.0       1.0X
-SQL Json                                           8728           8734           9          1.2         832.3       1.1X
-SQL Parquet Vectorized                              825            832           7         12.7          78.7      12.2X
-SQL Parquet MR                                     1965           2016          72          5.3         187.4       5.1X
-SQL ORC Vectorized                                  517            529          12         20.3          49.4      19.4X
-SQL ORC MR                                         2237           2248          15          4.7         213.4       4.5X
+SQL CSV                                            8659           8948         409          1.2         825.8       1.0X
+SQL Json                                           6410           6536         177          1.6         611.3       1.4X
+SQL Parquet Vectorized                              655            709          47         16.0          62.4      13.2X
+SQL Parquet MR                                     1528           1531           3          6.9         145.7       5.7X
+SQL ORC Vectorized                                  388            416          24         27.0          37.0      22.3X
+SQL ORC MR                                         1599           1700         142          6.6         152.5       5.4X
 
 
 ================================================================================================
@@ -171,27 +166,27 @@ Partitioned Table Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Partitioned Table:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Data column - CSV                                 26876          26936          85          0.6        1708.7       1.0X
-Data column - Json                                15652          15723         101          1.0         995.1       1.7X
-Data column - Parquet Vectorized                    286            296           9         55.0          18.2      94.0X
-Data column - Parquet MR                           3045           3047           3          5.2         193.6       8.8X
-Data column - ORC Vectorized                        377            386           8         41.8          23.9      71.4X
-Data column - ORC MR                               2497           2507          14          6.3         158.8      10.8X
-Partition column - CSV                             8444           8466          32          1.9         536.8       3.2X
-Partition column - Json                           12021          12085          91          1.3         764.2       2.2X
-Partition column - Parquet Vectorized                66             70           3        239.4           4.2     409.2X
-Partition column - Parquet MR                      1591           1599          12          9.9         101.1      16.9X
-Partition column - ORC Vectorized                    71             79          11        222.5           4.5     380.2X
-Partition column - ORC MR                          1642           1652          14          9.6         104.4      16.4X
-Both columns - CSV                                27949          28070         171          0.6        1777.0       1.0X
-Both columns - Json                               16718          16734          22          0.9        1062.9       1.6X
-Both columns - Parquet Vectorized                   329            340          10         47.8          20.9      81.7X
-Both columns - Parquet MR                          3127           3127           0          5.0         198.8       8.6X
-Both columns - ORC Vectorized                       420            426           4         37.5          26.7      64.0X
-Both columns - ORC MR                              2639           2640           2          6.0         167.8      10.2X
+Data column - CSV                                 21094          21357         372          0.7        1341.1       1.0X
+Data column - Json                                11163          11434         383          1.4         709.7       1.9X
+Data column - Parquet Vectorized                    225            238          13         69.9          14.3      93.7X
+Data column - Parquet MR                           2218           2342         175          7.1         141.0       9.5X
+Data column - ORC Vectorized                        276            300          20         56.9          17.6      76.4X
+Data column - ORC MR                               1851           1863          17          8.5         117.7      11.4X
+Partition column - CSV                             5834           6119         403          2.7         370.9       3.6X
+Partition column - Json                            9746           9754          11          1.6         619.6       2.2X
+Partition column - Parquet Vectorized                57             61           2        273.9           3.7     367.4X
+Partition column - Parquet MR                      1164           1167           5         13.5          74.0      18.1X
+Partition column - ORC Vectorized                    60             64           3        261.3           3.8     350.4X
+Partition column - ORC MR                          1298           1304           8         12.1          82.5      16.2X
+Both columns - CSV                                22632          22636           4          0.7        1438.9       0.9X
+Both columns - Json                               12568          12587          26          1.3         799.1       1.7X
+Both columns - Parquet Vectorized                   283            288           7         55.5          18.0      74.4X
+Both columns - Parquet MR                          2547           2553           8          6.2         161.9       8.3X
+Both columns - ORC Vectorized                       343            346           4         45.8          21.8      61.5X
+Both columns - ORC MR                              2177           2178           2          7.2         138.4       9.7X
 
 
 ================================================================================================
@@ -199,40 +194,40 @@ String with Nulls Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           12979          13015          51          0.8        1237.8       1.0X
-SQL Json                                          13190          13203          17          0.8        1257.9       1.0X
-SQL Parquet Vectorized                             1588           1603          22          6.6         151.4       8.2X
-SQL Parquet MR                                     4115           4125          15          2.5         392.4       3.2X
-ParquetReader Vectorized                           1184           1186           3          8.9         112.9      11.0X
-SQL ORC Vectorized                                 1067           1082          21          9.8         101.8      12.2X
-SQL ORC MR                                         3787           3791           5          2.8         361.2       3.4X
+SQL CSV                                           11364          11364           0          0.9        1083.7       1.0X
+SQL Json                                          10555          10562           9          1.0        1006.6       1.1X
+SQL Parquet Vectorized                             1299           1309          13          8.1         123.9       8.7X
+SQL Parquet MR                                     3350           3351           1          3.1         319.5       3.4X
+ParquetReader Vectorized                            983            987           5         10.7          93.8      11.6X
+SQL ORC Vectorized                                  912            913           1         11.5          87.0      12.5X
+SQL ORC MR                                         3056           3059           5          3.4         291.4       3.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10126          10179          75          1.0         965.7       1.0X
-SQL Json                                           9834           9880          65          1.1         937.8       1.0X
-SQL Parquet Vectorized                             1203           1211          12          8.7         114.7       8.4X
-SQL Parquet MR                                     3115           3115           1          3.4         297.0       3.3X
-ParquetReader Vectorized                           1081           1090          12          9.7         103.1       9.4X
-SQL ORC Vectorized                                 1249           1264          22          8.4         119.1       8.1X
-SQL ORC MR                                         3378           3418          57          3.1         322.2       3.0X
+SQL CSV                                            8651           8654           5          1.2         825.0       1.0X
+SQL Json                                           7791           7794           4          1.3         743.0       1.1X
+SQL Parquet Vectorized                             1045           1055          15         10.0          99.7       8.3X
+SQL Parquet MR                                     2516           2519           3          4.2         240.0       3.4X
+ParquetReader Vectorized                            927            933           6         11.3          88.4       9.3X
+SQL ORC Vectorized                                 1285           1286           2          8.2         122.5       6.7X
+SQL ORC MR                                         3013           3013           0          3.5         287.4       2.9X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            8067           8090          32          1.3         769.4       1.0X
-SQL Json                                           5947           5963          23          1.8         567.1       1.4X
-SQL Parquet Vectorized                              271            279          10         38.7          25.9      29.7X
-SQL Parquet MR                                     2031           2037           9          5.2         193.7       4.0X
-ParquetReader Vectorized                            275            282          10         38.1          26.2      29.3X
-SQL ORC Vectorized                                  443            450           5         23.7          42.2      18.2X
-SQL ORC MR                                         1832           1858          36          5.7         174.7       4.4X
+SQL CSV                                            6272           6288          23          1.7         598.1       1.0X
+SQL Json                                           4469           4469           0          2.3         426.2       1.4X
+SQL Parquet Vectorized                              231            235           7         45.4          22.0      27.2X
+SQL Parquet MR                                     1673           1674           2          6.3         159.5       3.7X
+ParquetReader Vectorized                            243            244           3         43.1          23.2      25.8X
+SQL ORC Vectorized                                  471            472           2         22.2          45.0      13.3X
+SQL ORC MR                                         1606           1618          17          6.5         153.2       3.9X
 
 
 ================================================================================================
@@ -240,36 +235,36 @@ Single Column Scan From Wide Columns
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 10 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            2920           2933          19          0.4        2785.0       1.0X
-SQL Json                                           3442           3450          11          0.3        3282.8       0.8X
-SQL Parquet Vectorized                               56             64           8         18.8          53.1      52.4X
-SQL Parquet MR                                      226            233           5          4.6         215.6      12.9X
-SQL ORC Vectorized                                   63             69          11         16.7          59.9      46.5X
-SQL ORC MR                                          207            219          12          5.1         197.2      14.1X
+SQL CSV                                            2171           2173           2          0.5        2070.8       1.0X
+SQL Json                                           2266           2278          17          0.5        2161.3       1.0X
+SQL Parquet Vectorized                               51             55           7         20.4          49.0      42.2X
+SQL Parquet MR                                      190            192           2          5.5         180.9      11.4X
+SQL ORC Vectorized                                   57             61           8         18.4          54.2      38.2X
+SQL ORC MR                                          161            164           2          6.5         153.8      13.5X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 50 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            7068           7089          30          0.1        6740.3       1.0X
-SQL Json                                          13731          13919         265          0.1       13095.3       0.5X
-SQL Parquet Vectorized                               76             85          12         13.8          72.6      92.8X
-SQL Parquet MR                                      256            262           7          4.1         244.3      27.6X
-SQL ORC Vectorized                                   83             92          16         12.6          79.5      84.8X
-SQL ORC MR                                          223            228           4          4.7         212.5      31.7X
+SQL CSV                                            5200           5211          15          0.2        4959.5       1.0X
+SQL Json                                           8312           8318           8          0.1        7927.1       0.6X
+SQL Parquet Vectorized                               67             73          10         15.7          63.9      77.6X
+SQL Parquet MR                                      210            214           4          5.0         200.4      24.8X
+SQL ORC Vectorized                                   70             77          16         15.0          66.7      74.3X
+SQL ORC MR                                          182            184           2          5.8         173.6      28.6X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1020-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           12181          12191          14          0.1       11616.7       1.0X
-SQL Json                                          25757          26003         348          0.0       24564.3       0.5X
-SQL Parquet Vectorized                              110            118           9          9.5         104.7     110.9X
-SQL Parquet MR                                      288            297          10          3.6         274.4      42.3X
-SQL ORC Vectorized                                  100            111          11         10.4          95.7     121.4X
-SQL ORC MR                                          245            252           5          4.3         233.6      49.7X
+SQL CSV                                            9030           9032           2          0.1        8611.8       1.0X
+SQL Json                                          15429          15462          46          0.1       14714.5       0.6X
+SQL Parquet Vectorized                               91             97           8         11.5          87.2      98.8X
+SQL Parquet MR                                      235            239           3          4.5         224.2      38.4X
+SQL ORC Vectorized                                   80             84           9         13.1          76.4     112.8X
+SQL ORC MR                                          192            201           7          5.5         183.4      47.0X
 
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -38,7 +38,7 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   // Only used for booleans.
   private int bitOffset;
-  private byte currentByte = 0;
+  private int currentByte = 0;
 
   public VectorizedPlainValuesReader() {
   }
@@ -53,20 +53,45 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
     throw new UnsupportedOperationException();
   }
 
+  private void updateCurrentByte() {
+    try {
+      currentByte = in.read();
+    } catch (IOException e) {
+      throw new ParquetDecodingException("Failed to read a byte", e);
+    }
+  }
+
   @Override
   public final void readBooleans(int total, WritableColumnVector c, int rowId) {
-    // TODO: properly vectorize this
-    for (int i = 0; i < total; i++) {
-      c.putBoolean(rowId + i, readBoolean());
+    int i = 0;
+    if (bitOffset > 0) {
+      i = Math.min(8 - bitOffset, total);
+      c.putBooleans(rowId, i, currentByte, bitOffset);
+      bitOffset = (bitOffset + i) & 7;
+    }
+    for (; i + 7 < total; i += 8) {
+      updateCurrentByte();
+      c.putBooleans(rowId + i, currentByte);
+    }
+    if (i < total) {
+      updateCurrentByte();
+      bitOffset = total - i;
+      c.putBooleans(rowId + i, bitOffset, currentByte, 0);
     }
   }
 
   @Override
   public final void skipBooleans(int total) {
-    // TODO: properly vectorize this
-    for (int i = 0; i < total; i++) {
-      readBoolean();
+    int totalByte = total / 8;
+    if (totalByte > 0) {
+      try {
+        in.skipFully(totalByte - 1L);
+        currentByte = in.read();
+      } catch (IOException e) {
+        throw new ParquetDecodingException("Failed to skip bytes", e);
+      }
     }
+    bitOffset = (bitOffset + total % 8) & 7;
   }
 
   private ByteBuffer getBuffer(int length) {
@@ -276,13 +301,8 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   @Override
   public final boolean readBoolean() {
-    // TODO: vectorize decoding and keep boolean[] instead of currentByte
     if (bitOffset == 0) {
-      try {
-        currentByte = (byte) in.read();
-      } catch (IOException e) {
-        throw new ParquetDecodingException("Failed to read a byte", e);
-      }
+      updateCurrentByte();
     }
 
     boolean v = (currentByte & (1 << bitOffset)) != 0;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -82,7 +82,10 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   @Override
   public final void skipBooleans(int total) {
-    // using >>3 instead of /8 below since Java division rounds towards zero i.e. (-1)/8=0
+    // Using >>3 instead of /8 below. The difference is important when (total-(8-bitOffset))<0.
+    // E.g. (-1)>>3=(-1) vs. (-1)/8=0. The latter incorrectly enters the if(numBytesToSkip>=0){.
+    // (total-(8-bitOffset))<0 means there will be still unread bits left in the currentByte.
+    // In that case, updateCurrentByte() should not be called.
     int numBytesToSkip = (total - (8 - bitOffset)) >> 3;
     bitOffset = (bitOffset + total) & 7;
     if (numBytesToSkip >= 0) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -82,7 +82,7 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   @Override
   public final void skipBooleans(int total) {
-    int skipBytes = (bitOffset + total - 8) / 8;
+    int skipBytes = (bitOffset + total) / 8 - 1;
     bitOffset = (bitOffset + total) & 7;
     if (skipBytes >= 0) {
       try {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -82,11 +82,11 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   @Override
   public final void skipBooleans(int total) {
-    int totalBytes = (bitOffset + total) / 8;
+    int skipBytes = (bitOffset + total - 8) / 8;
     bitOffset = (bitOffset + total) & 7;
-    if (totalBytes > 0) {
+    if (skipBytes >= 0) {
       try {
-        in.skipFully(totalBytes - 1L);
+        in.skipFully(skipBytes);
         if (bitOffset > 0) {
           currentByte = in.read();
         }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -82,7 +82,7 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   @Override
   public final void skipBooleans(int total) {
-    int numBytesToSkip = (bitOffset + total) / 8 - 1;
+    int numBytesToSkip = (bitOffset + total - 8) >> 3;
     bitOffset = (bitOffset + total) & 7;
     if (numBytesToSkip >= 0) {
       try {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -38,7 +38,7 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   // Only used for booleans.
   private int bitOffset;
-  private int currentByte = 0;
+  private byte currentByte = 0;
 
   public VectorizedPlainValuesReader() {
   }
@@ -55,7 +55,7 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   private void updateCurrentByte() {
     try {
-      currentByte = in.read();
+      currentByte = (byte) in.read();
     } catch (IOException e) {
       throw new ParquetDecodingException("Failed to read a byte", e);
     }
@@ -88,7 +88,7 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
       try {
         in.skipFully(skipBytes);
         if (bitOffset > 0) {
-          currentByte = in.read();
+          currentByte = (byte) in.read();
         }
       } catch (IOException e) {
         throw new ParquetDecodingException("Failed to skip bytes", e);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -82,7 +82,8 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   @Override
   public final void skipBooleans(int total) {
-    int numBytesToSkip = (bitOffset + total - 8) >> 3;
+    // using >>3 instead of /8 below since Java division rounds towards zero i.e. (-1)/8=0
+    int numBytesToSkip = (total - (8 - bitOffset)) >> 3;
     bitOffset = (bitOffset + total) & 7;
     if (numBytesToSkip >= 0) {
       try {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -82,16 +82,16 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   @Override
   public final void skipBooleans(int total) {
-    int totalByte = total / 8;
-    if (totalByte > 0) {
+    int totalBytes = (bitOffset + total) / 8;
+    if (totalBytes > 0) {
       try {
-        in.skipFully(totalByte - 1L);
+        in.skipFully(totalBytes - 1L);
         currentByte = in.read();
       } catch (IOException e) {
         throw new ParquetDecodingException("Failed to skip bytes", e);
       }
     }
-    bitOffset = (bitOffset + total % 8) & 7;
+    bitOffset = (bitOffset + total) & 7;
   }
 
   private ByteBuffer getBuffer(int length) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -83,15 +83,17 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
   @Override
   public final void skipBooleans(int total) {
     int totalBytes = (bitOffset + total) / 8;
+    bitOffset = (bitOffset + total) & 7;
     if (totalBytes > 0) {
       try {
         in.skipFully(totalBytes - 1L);
-        currentByte = in.read();
+        if (bitOffset > 0) {
+          currentByte = in.read();
+        }
       } catch (IOException e) {
         throw new ParquetDecodingException("Failed to skip bytes", e);
       }
     }
-    bitOffset = (bitOffset + total) & 7;
   }
 
   private ByteBuffer getBuffer(int length) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -82,16 +82,16 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
 
   @Override
   public final void skipBooleans(int total) {
-    int skipBytes = (bitOffset + total) / 8 - 1;
+    int numBytesToSkip = (bitOffset + total) / 8 - 1;
     bitOffset = (bitOffset + total) & 7;
-    if (skipBytes >= 0) {
+    if (numBytesToSkip >= 0) {
       try {
-        in.skipFully(skipBytes);
-        if (bitOffset > 0) {
-          currentByte = (byte) in.read();
-        }
+        in.skipFully(numBytesToSkip);
       } catch (IOException e) {
         throw new ParquetDecodingException("Failed to skip bytes", e);
+      }
+      if (bitOffset > 0) {
+        updateCurrentByte();
       }
     }
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -153,6 +153,18 @@ public final class OffHeapColumnVector extends WritableColumnVector {
   }
 
   @Override
+  public void putBooleans(int rowId, byte src) {
+    Platform.putByte(null, data + rowId, (byte)(src & 1));
+    Platform.putByte(null, data + rowId + 1, (byte)(src >>> 1 & 1));
+    Platform.putByte(null, data + rowId + 2, (byte)(src >>> 2 & 1));
+    Platform.putByte(null, data + rowId + 3, (byte)(src >>> 3 & 1));
+    Platform.putByte(null, data + rowId + 4, (byte)(src >>> 4 & 1));
+    Platform.putByte(null, data + rowId + 5, (byte)(src >>> 5 & 1));
+    Platform.putByte(null, data + rowId + 6, (byte)(src >>> 6 & 1));
+    Platform.putByte(null, data + rowId + 7, (byte)(src >>> 7 & 1));
+  }
+
+  @Override
   public boolean getBoolean(int rowId) { return Platform.getByte(null, data + rowId) == 1; }
 
   @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -148,6 +148,11 @@ public final class OnHeapColumnVector extends WritableColumnVector {
   }
 
   @Override
+  public void putBooleans(int rowId, int src) {
+    ByteBuffer.wrap(byteData, rowId, 8).putLong(toBitPerByte(src));
+  }
+
+  @Override
   public boolean getBoolean(int rowId) {
     return byteData[rowId] == 1;
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -148,8 +148,15 @@ public final class OnHeapColumnVector extends WritableColumnVector {
   }
 
   @Override
-  public void putBooleans(int rowId, int src) {
-    ByteBuffer.wrap(byteData, rowId, 8).putLong(toBitPerByte(src));
+  public void putBooleans(int rowId, byte src) {
+    byteData[rowId] = (byte)(src & 1);
+    byteData[rowId + 1] = (byte)(src >>> 1 & 1);
+    byteData[rowId + 2] = (byte)(src >>> 2 & 1);
+    byteData[rowId + 3] = (byte)(src >>> 3 & 1);
+    byteData[rowId + 4] = (byte)(src >>> 4 & 1);
+    byteData[rowId + 5] = (byte)(src >>> 5 & 1);
+    byteData[rowId + 6] = (byte)(src >>> 6 & 1);
+    byteData[rowId + 7] = (byte)(src >>> 7 & 1);
   }
 
   @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -189,7 +189,7 @@ public abstract class WritableColumnVector extends ColumnVector {
    *    return ByteBuffer.wrap(a).getLong();
    */
   protected final long toBitPerByte(int bits) {
-    return ((bits * 0x100804020100804L) | (bits >> 7)) & 0x101010101010101L;
+    return ((bits * 0x8040201008040201L) >>> 7) & 0x101010101010101L;
   }
 
   /**

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -217,9 +217,12 @@ public abstract class WritableColumnVector extends ColumnVector {
     byte8[7] = (byte)(src >>> 7 & 1);
     putBytes(rowId, count, byte8, srcIndex);
   }
-  public void putBooleans(int rowId, byte src) {
-    putBooleans(rowId, 8, src, 0);
-  }
+
+  /**
+   * Sets bits from [src[0], src[7]] to [rowId, rowId + 7]
+   * src must contain bit-packed 8 Booleans in the byte.
+   */
+  public abstract void putBooleans(int rowId, byte src);
 
   /**
    * Sets `value` to the value at rowId.

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution.vectorized;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 
 import com.google.common.annotations.VisibleForTesting;
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -207,6 +207,7 @@ public abstract class WritableColumnVector extends ColumnVector {
    * src must contain bit-packed 8 booleans in the byte.
    */
   public void putBooleans(int rowId, int count, byte src, int srcIndex) {
+    assert ((srcIndex + count) < 8);
     byte8[0] = (byte)(src & 1);
     byte8[1] = (byte)(src >>> 1 & 1);
     byte8[2] = (byte)(src >>> 2 & 1);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -204,7 +204,7 @@ public abstract class WritableColumnVector extends ColumnVector {
 
   /**
    * Sets bits from [src[srcIndex], src[srcIndex + count]) to [rowId, rowId + count)
-   * src must contain bit-packed 8 Booleans in the byte.
+   * src must contain bit-packed 8 booleans in the byte.
    */
   public void putBooleans(int rowId, int count, byte src, int srcIndex) {
     byte8[0] = (byte)(src & 1);
@@ -220,7 +220,7 @@ public abstract class WritableColumnVector extends ColumnVector {
 
   /**
    * Sets bits from [src[0], src[7]] to [rowId, rowId + 7]
-   * src must contain bit-packed 8 Booleans in the byte.
+   * src must contain bit-packed 8 booleans in the byte.
    */
   public abstract void putBooleans(int rowId, byte src);
 
@@ -495,7 +495,7 @@ public abstract class WritableColumnVector extends ColumnVector {
 
   /**
    * Append bits from [src[offset], src[offset + count])
-   * src must contain bit-packed 8 Booleans in the byte.
+   * src must contain bit-packed 8 booleans in the byte.
    */
   public final int appendBooleans(int count, byte src, int offset) {
     reserve(elementsAppended + count);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -207,7 +207,7 @@ public abstract class WritableColumnVector extends ColumnVector {
    * src must contain bit-packed 8 booleans in the byte.
    */
   public void putBooleans(int rowId, int count, byte src, int srcIndex) {
-    assert ((srcIndex + count) < 8);
+    assert ((srcIndex + count) <= 8);
     byte8[0] = (byte)(src & 1);
     byte8[1] = (byte)(src >>> 1 & 1);
     byte8[2] = (byte)(src >>> 2 & 1);

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
@@ -119,31 +119,36 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
 
         prepareTable(dir, spark.sql(s"SELECT CAST(value as ${dataType.sql}) id FROM t1"))
 
+        val query = dataType match {
+          case BooleanType => "sum(cast(id as bigint))"
+          case _ => "sum(id)"
+        }
+
         sqlBenchmark.addCase("SQL CSV") { _ =>
-          spark.sql("select sum(id) from csvTable").noop()
+          spark.sql(s"select $query from csvTable").noop()
         }
 
         sqlBenchmark.addCase("SQL Json") { _ =>
-          spark.sql("select sum(id) from jsonTable").noop()
+          spark.sql(s"select $query from jsonTable").noop()
         }
 
         sqlBenchmark.addCase("SQL Parquet Vectorized") { _ =>
-          spark.sql("select sum(id) from parquetTable").noop()
+          spark.sql(s"select $query from parquetTable").noop()
         }
 
         sqlBenchmark.addCase("SQL Parquet MR") { _ =>
           withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
-            spark.sql("select sum(id) from parquetTable").noop()
+            spark.sql(s"select $query from parquetTable").noop()
           }
         }
 
         sqlBenchmark.addCase("SQL ORC Vectorized") { _ =>
-          spark.sql("SELECT sum(id) FROM orcTable").noop()
+          spark.sql(s"SELECT $query FROM orcTable").noop()
         }
 
         sqlBenchmark.addCase("SQL ORC MR") { _ =>
           withSQLConf(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> "false") {
-            spark.sql("SELECT sum(id) FROM orcTable").noop()
+            spark.sql(s"SELECT $query FROM orcTable").noop()
           }
         }
 
@@ -157,6 +162,7 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
           var longSum = 0L
           var doubleSum = 0.0
           val aggregateValue: (ColumnVector, Int) => Unit = dataType match {
+            case BooleanType => (col: ColumnVector, i: Int) => if (col.getBoolean(i)) longSum += 1L
             case ByteType => (col: ColumnVector, i: Int) => longSum += col.getByte(i)
             case ShortType => (col: ColumnVector, i: Int) => longSum += col.getShort(i)
             case IntegerType => (col: ColumnVector, i: Int) => longSum += col.getInt(i)
@@ -191,6 +197,7 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
           var longSum = 0L
           var doubleSum = 0.0
           val aggregateValue: (InternalRow) => Unit = dataType match {
+            case BooleanType => (col: InternalRow) => if (col.getBoolean(0)) longSum += 1L
             case ByteType => (col: InternalRow) => longSum += col.getByte(0)
             case ShortType => (col: InternalRow) => longSum += col.getShort(0)
             case IntegerType => (col: InternalRow) => longSum += col.getInt(0)
@@ -541,6 +548,9 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runBenchmark("SQL Single Boolean Column Scan") {
+      numericScanBenchmark(1024 * 1024 * 15, BooleanType)
+    }
     runBenchmark("SQL Single Numeric Column Scan") {
       Seq(ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType).foreach {
         dataType => numericScanBenchmark(1024 * 1024 * 15, dataType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
@@ -548,11 +548,8 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    runBenchmark("SQL Single Boolean Column Scan") {
-      numericScanBenchmark(1024 * 1024 * 15, BooleanType)
-    }
     runBenchmark("SQL Single Numeric Column Scan") {
-      Seq(ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType).foreach {
+      Seq(BooleanType, ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType).foreach {
         dataType => numericScanBenchmark(1024 * 1024 * 15, dataType)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
@@ -29,14 +29,15 @@ import org.apache.spark.sql.test.SharedSparkSession
 class ParquetEncodingSuite extends ParquetCompatibilityTest with SharedSparkSession {
   import testImplicits._
 
-  val ROW = ((1).toByte, 2, 3L, "abc", Period.of(1, 1, 0), Duration.ofMillis(100))
+  val ROW = ((1).toByte, 2, 3L, "abc", Period.of(1, 1, 0), Duration.ofMillis(100), true)
   val NULL_ROW = (
     null.asInstanceOf[java.lang.Byte],
     null.asInstanceOf[Integer],
     null.asInstanceOf[java.lang.Long],
     null.asInstanceOf[String],
     null.asInstanceOf[Period],
-    null.asInstanceOf[Duration])
+    null.asInstanceOf[Duration],
+    null.asInstanceOf[java.lang.Boolean])
 
   test("All Types Dictionary") {
     (1 :: 1000 :: Nil).foreach { n => {
@@ -59,6 +60,7 @@ class ParquetEncodingSuite extends ParquetCompatibilityTest with SharedSparkSess
           assert(batch.column(3).getUTF8String(i).toString == "abc")
           assert(batch.column(4).getInt(i) == 13)
           assert(batch.column(5).getLong(i) == 100000)
+          assert(batch.column(6).getBoolean(i) == true)
           i += 1
         }
         reader.close()
@@ -88,6 +90,7 @@ class ParquetEncodingSuite extends ParquetCompatibilityTest with SharedSparkSess
           assert(batch.column(3).isNullAt(i))
           assert(batch.column(4).isNullAt(i))
           assert(batch.column(5).isNullAt(i))
+          assert(batch.column(6).isNullAt(i))
           i += 1
         }
         reader.close()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -25,9 +25,11 @@ import java.util.NoSuchElementException
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.language.implicitConversions
 import scala.util.Random
 
 import org.apache.arrow.vector.IntVector
+import org.apache.parquet.bytes.ByteBufferInputStream
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.memory.MemoryMode
@@ -36,8 +38,10 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapBuilder, DateTimeUtils, GenericArrayData, MapData}
 import org.apache.spark.sql.execution.RowToColumnConverter
+import org.apache.spark.sql.execution.datasources.parquet.VectorizedPlainValuesReader
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.ArrowUtils
+
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnarBatchRow, ColumnVector}
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
@@ -137,10 +141,10 @@ class ColumnarBatchSuite extends SparkFunSuite {
       var values = Array(true, false, true, false, false)
       var bits = values.foldRight(0)((b, i) => i << 1 | (if (b) 1 else 0)).toByte
       column.appendBooleans(2, bits, 0)
-      reference ++= values.take(2)
+      reference ++= values.slice(0, 2)
 
       column.appendBooleans(3, bits, 2)
-      reference ++= values.takeRight(3)
+      reference ++= values.slice(2, 5)
 
       column.appendBooleans(6, true)
       reference ++= Array.fill(6)(true)
@@ -150,15 +154,19 @@ class ColumnarBatchSuite extends SparkFunSuite {
 
       var idx = column.elementsAppended
 
-      values = Array(true, true, false, true, false)
+      values = Array(true, true, false, true, false, true, false, true)
       bits = values.foldRight(0)((b, i) => i << 1 | (if (b) 1 else 0)).toByte
       column.putBooleans(idx, 2, bits, 0)
-      reference ++= values.take(2)
+      reference ++= values.slice(0, 2)
       idx += 2
 
       column.putBooleans(idx, 3, bits, 2)
-      reference ++= values.takeRight(3)
+      reference ++= values.slice(2, 5)
       idx += 3
+
+      column.putBooleans(idx, bits)
+      reference ++= values
+      idx += 8
 
       column.putBoolean(idx, false)
       reference += false
@@ -167,6 +175,42 @@ class ColumnarBatchSuite extends SparkFunSuite {
       column.putBooleans(idx, 3, true)
       reference ++= Array.fill(3)(true)
       idx += 3
+
+      implicit def intToByte(i: Int): Byte = i.toByte
+      val buf = ByteBuffer.wrap(Array(0x33, 0x5A, 0xA5, 0xCC, 0x0F, 0xF0, 0xEE))
+      val reader = new VectorizedPlainValuesReader()
+      reader.initFromPage(0, ByteBufferInputStream.wrap(buf))
+      column.putBoolean(idx, reader.readBoolean) // bit index 0
+      reference += true
+      idx += 1
+
+      reader.skipBooleans(1)
+
+      column.putBoolean(idx, reader.readBoolean) // bit index 2
+      reference += false
+      idx += 1
+
+      reader.skipBooleans(5)
+
+      column.putBoolean(idx, reader.readBoolean) // bit index 8
+      reference += false
+      idx += 1
+
+      reader.skipBooleans(8)
+
+      column.putBoolean(idx, reader.readBoolean) // bit index 17
+      reference += false
+      idx += 1
+
+      reader.skipBooleans(16)
+
+      reader.readBooleans(4, column, idx) // bit index [34, 37]
+      reference ++= Array(true, true, false, false)
+      idx += 4
+
+      reader.readBooleans(11, column, idx) // bit index [38, 48]
+      reference ++= Array(false, false, false, false, false, false, true, true, true, true, false)
+      idx += 11
 
       reference.zipWithIndex.foreach { v =>
         assert(v._1 == column.getBoolean(v._2), "VectorType=" + column.getClass.getSimpleName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -41,7 +41,6 @@ import org.apache.spark.sql.execution.RowToColumnConverter
 import org.apache.spark.sql.execution.datasources.parquet.VectorizedPlainValuesReader
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.ArrowUtils
-
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnarBatchRow, ColumnVector}
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -176,7 +176,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       idx += 3
 
       implicit def intToByte(i: Int): Byte = i.toByte
-      val buf = ByteBuffer.wrap(Array(0x33, 0x5A, 0xA5, 0xCC, 0x0F, 0xF0, 0xEE))
+      val buf = ByteBuffer.wrap(Array(0x33, 0x5A, 0xA5, 0xCC, 0x0F, 0xF0, 0xEE, 0x77, 0x88))
       val reader = new VectorizedPlainValuesReader()
       reader.initFromPage(0, ByteBufferInputStream.wrap(buf))
       column.putBoolean(idx, reader.readBoolean) // bit index 0
@@ -211,6 +211,12 @@ class ColumnarBatchSuite extends SparkFunSuite {
       reader.readBooleans(11, column, idx) // bit index [38, 48]
       reference ++= Array(false, false, false, false, false, false, true, true, true, true, false)
       idx += 11
+
+      reader.skipBooleans(7)
+
+      reader.readBooleans(9, column, idx) // bit index [56, 64]
+      reference ++= Array(true, true, true, false, true, true, true, false, false)
+      idx += 9
 
       reference.zipWithIndex.foreach { v =>
         assert(v._1 == column.getBoolean(v._2), "VectorType=" + column.getClass.getSimpleName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -130,8 +130,8 @@ class ColumnarBatchSuite extends SparkFunSuite {
       }
   }
 
-  testVector("[SPARK35867] Boolean APIs", 1024, BooleanType) {
-    column => ()
+  testVector("Boolean APIs", 1024, BooleanType) {
+    column =>
       val reference = mutable.ArrayBuffer.empty[Boolean]
 
       var values = Array(true, false, true, false, false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -179,30 +179,31 @@ class ColumnarBatchSuite extends SparkFunSuite {
       val buf = ByteBuffer.wrap(Array(0x33, 0x5A, 0xA5, 0xCC, 0x0F, 0xF0, 0xEE, 0x77, 0x88))
       val reader = new VectorizedPlainValuesReader()
       reader.initFromPage(0, ByteBufferInputStream.wrap(buf))
-      column.putBoolean(idx, reader.readBoolean) // bit index 0
+
+      reader.skipBooleans(1) // bit index 0
+
+      column.putBoolean(idx, reader.readBoolean) // bit index 1
       reference += true
       idx += 1
-
-      reader.skipBooleans(1)
 
       column.putBoolean(idx, reader.readBoolean) // bit index 2
       reference += false
       idx += 1
 
-      reader.skipBooleans(5)
+      reader.skipBooleans(5) // bit index [3, 7]
 
       column.putBoolean(idx, reader.readBoolean) // bit index 8
       reference += false
       idx += 1
 
-      reader.skipBooleans(8)
-      reader.skipBooleans(0)
+      reader.skipBooleans(8) // bit index [9, 16]
+      reader.skipBooleans(0) // no-op
 
       column.putBoolean(idx, reader.readBoolean) // bit index 17
       reference += false
       idx += 1
 
-      reader.skipBooleans(16)
+      reader.skipBooleans(16) // bit index [18, 33]
 
       reader.readBooleans(4, column, idx) // bit index [34, 37]
       reference ++= Array(true, true, false, false)
@@ -212,7 +213,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       reference ++= Array(false, false, false, false, false, false, true, true, true, true, false)
       idx += 11
 
-      reader.skipBooleans(7)
+      reader.skipBooleans(7) // bit index [49, 55]
 
       reader.readBooleans(9, column, idx) // bit index [56, 64]
       reference ++= Array(true, true, true, false, true, true, true, false, false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -135,10 +135,11 @@ class ColumnarBatchSuite extends SparkFunSuite {
       val reference = mutable.ArrayBuffer.empty[Boolean]
 
       var values = Array(true, false, true, false, false)
-      column.appendBooleans(2, values.foldRight(0)((b, i) => (i << 1) | (if (b) 1 else 0)), 0)
+      var bits = values.foldRight(0)((b, i) => i << 1 | (if (b) 1 else 0)).toByte
+      column.appendBooleans(2, bits, 0)
       reference ++= values.take(2)
 
-      column.appendBooleans(3, values.foldRight(0)((b, i) => (i << 1) | (if (b) 1 else 0)), 2)
+      column.appendBooleans(3, bits, 2)
       reference ++= values.takeRight(3)
 
       column.appendBooleans(6, true)
@@ -150,11 +151,12 @@ class ColumnarBatchSuite extends SparkFunSuite {
       var idx = column.elementsAppended
 
       values = Array(true, true, false, true, false)
-      column.putBooleans(idx, 2, values.foldRight(0)((b, i) => (i << 1) | (if (b) 1 else 0)), 0)
+      bits = values.foldRight(0)((b, i) => i << 1 | (if (b) 1 else 0)).toByte
+      column.putBooleans(idx, 2, bits, 0)
       reference ++= values.take(2)
       idx += 2
 
-      column.putBooleans(idx, 3, values.foldRight(0)((b, i) => (i << 1) | (if (b) 1 else 0)), 2)
+      column.putBooleans(idx, 3, bits, 2)
       reference ++= values.takeRight(3)
       idx += 3
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -196,6 +196,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       idx += 1
 
       reader.skipBooleans(8)
+      reader.skipBooleans(0)
 
       column.putBoolean(idx, reader.readBoolean) // bit index 17
       reference += false


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to enable vectorized read for ` VectorizedPlainValuesReader.readBooleans`. Currently `readBooleans` unpacks encoded boolean values bit by bit such as
```
  public final void readBooleans(int total, WritableColumnVector c, int rowId) {
    // TODO: properly vectorize this
    for (int i = 0; i < total; i++) {
      c.putBoolean(rowId + i, readBoolean());
    }
  }
```
The main idea is to unpack 8 bits (a byte) at once instead of bit by bit whenever the alignment allows.


### Why are the changes needed?
With this PR, we observed up-to 100% scan performance gain.
#### JDK11 (Main Branch)
```
Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)
-------------------------------------------------------------------------------------------------------------
SQL Parquet Vectorized                              161            189          24         97.6          10.2

Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)
--------------------------------------------------------------------------------------------------------------
ParquetReader Vectorized                             140            147           9        112.7           8.9
ParquetReader Vectorized -> Row                       85             88           3        184.4           5.4
```
#### JDK11 (This PR)
```
Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)
-------------------------------------------------------------------------------------------------------------
SQL Parquet Vectorized                              124            149          21        127.2           7.9

Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)
--------------------------------------------------------------------------------------------------------------
ParquetReader Vectorized                             100            107          13        157.1           6.4
ParquetReader Vectorized -> Row                       52             54           3        303.1           3.3
```

#### JDK8 (Main Branch)
```
Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)
-------------------------------------------------------------------------------------------------------------
SQL Parquet Vectorized                              189            210          20         83.1          12.0

Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)
--------------------------------------------------------------------------------------------------------------
ParquetReader Vectorized                             178            179           3         88.5          11.3
ParquetReader Vectorized -> Row                      125            126           2        126.1           7.9
```
#### JDK8 (This PR)
```
Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)
-------------------------------------------------------------------------------------------------------------
SQL Parquet Vectorized                              144            167          12        109.2           9.2

Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
Parquet Reader Single BOOLEAN Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)
--------------------------------------------------------------------------------------------------------------
ParquetReader Vectorized                             119            125           8        131.9           7.6
ParquetReader Vectorized -> Row                       60             63           2        260.2           3.8
```

The benchmarks are run on GitHub Actions. The results are attached in this PR.
```
sql/core/benchmarks/DataSourceReadBenchmark-jdk11-results.txt
sql/core/benchmarks/DataSourceReadBenchmark-results.txt
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Updated unit tests
```
build/sbt "testOnly *ParquetEncodingSuite"
build/sbt "testOnly *ColumnarBatchSuite"
```
