### PR TITLE
[SPARK-37279][PYTHON][SQL] Support DayTimeIntervalType in createDataFrame, collect and Python UDF

### DIFF
--- a/python/docs/source/reference/pyspark.sql.rst
+++ b/python/docs/source/reference/pyspark.sql.rst
@@ -302,6 +302,7 @@ Data Types
     StructType
     TimestampNTZType
     TimestampType
+    YearMonthIntervalType
 
 
 Observation

--- a/python/docs/source/reference/pyspark.sql.rst
+++ b/python/docs/source/reference/pyspark.sql.rst
@@ -302,7 +302,7 @@ Data Types
     StructType
     TimestampNTZType
     TimestampType
-    YearMonthIntervalType
+    DayTimeIntervalType
 
 
 Observation

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -35,6 +35,7 @@ from pyspark.sql.types import (
     FloatType,
     DateType,
     TimestampType,
+    DayTimeIntervalType,
     MapType,
     StringType,
     StructType,
@@ -144,6 +145,7 @@ class TypesTests(ReusedSQLTestCase):
             "a",
             datetime.date(1970, 1, 1),
             datetime.datetime(1970, 1, 1, 0, 0),
+            datetime.timedelta(microseconds=123456678),
             1.0,
             array.array("d", [1]),
             [1],
@@ -165,6 +167,7 @@ class TypesTests(ReusedSQLTestCase):
             "string",
             "date",
             "timestamp",
+            "interval day to second",
             "double",
             "array<double>",
             "array<bigint>",
@@ -290,7 +293,7 @@ class TypesTests(ReusedSQLTestCase):
         self.assertEqual(df.first(), Row(key=1, value="1"))
 
     def test_apply_schema(self):
-        from datetime import date, datetime
+        from datetime import date, datetime, timedelta
 
         rdd = self.sc.parallelize(
             [
@@ -303,6 +306,7 @@ class TypesTests(ReusedSQLTestCase):
                     1.0,
                     date(2010, 1, 1),
                     datetime(2010, 1, 1, 1, 1, 1),
+                    timedelta(days=1),
                     {"a": 1},
                     (2,),
                     [1, 2, 3],
@@ -320,6 +324,11 @@ class TypesTests(ReusedSQLTestCase):
                 StructField("float1", FloatType(), False),
                 StructField("date1", DateType(), False),
                 StructField("time1", TimestampType(), False),
+                StructField(
+                    "daytime1",
+                    DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.SECOND),
+                    False,
+                ),
                 StructField("map1", MapType(StringType(), IntegerType(), False), False),
                 StructField("struct1", StructType([StructField("b", ShortType(), False)]), False),
                 StructField("list1", ArrayType(ByteType(), False), False),
@@ -337,6 +346,7 @@ class TypesTests(ReusedSQLTestCase):
                 x.float1,
                 x.date1,
                 x.time1,
+                x.daytime1,
                 x.map1["a"],
                 x.struct1.b,
                 x.list1,
@@ -352,6 +362,7 @@ class TypesTests(ReusedSQLTestCase):
             1.0,
             date(2010, 1, 1),
             datetime(2010, 1, 1, 1, 1, 1),
+            timedelta(days=1),
             1,
             2,
             [1, 2, 3],
@@ -928,6 +939,52 @@ class TypesTests(ReusedSQLTestCase):
             with self.assertRaisesRegex(TypeError, "infer the type of the field myarray"):
                 a = array.array(t)
                 self.spark.createDataFrame([Row(myarray=a)]).collect()
+
+    def test_daytime_interval_type(self):
+        # SPARK-37277: Support DayTimeIntervalType in createDataFrame
+        timedetlas = [
+            (datetime.timedelta(microseconds=123),),
+            (
+                datetime.timedelta(
+                    days=1, seconds=23, microseconds=123, milliseconds=4, minutes=5, hours=11
+                ),
+            ),
+            (datetime.timedelta(microseconds=-123),),
+            (datetime.timedelta(days=-1),),
+        ]
+        df = self.spark.createDataFrame(timedetlas, schema="td interval day to second")
+        self.assertEqual(set(r.td for r in df.collect()), set(set(r[0] for r in timedetlas)))
+
+        exprs = [
+            "INTERVAL '1 02:03:04' DAY TO SECOND AS a",
+            "INTERVAL '1 02:03' DAY TO MINUTE AS b",
+            "INTERVAL '1 02' DAY TO HOUR AS c",
+            "INTERVAL '1' DAY AS d",
+            "INTERVAL '26:03:04' HOUR TO SECOND AS e",
+            "INTERVAL '26:03' HOUR TO MINUTE AS f",
+            "INTERVAL '26' HOUR AS g",
+            "INTERVAL '1563:04' MINUTE TO SECOND AS h",
+            "INTERVAL '1563' MINUTE AS i",
+            "INTERVAL '93784' SECOND AS j",
+        ]
+        df = self.spark.range(1).selectExpr(exprs)
+
+        actual = list(df.first())
+        expected = [
+            datetime.timedelta(days=1, hours=2, minutes=3, seconds=4),
+            datetime.timedelta(days=1, hours=2, minutes=3),
+            datetime.timedelta(days=1, hours=2),
+            datetime.timedelta(days=1),
+            datetime.timedelta(hours=26, minutes=3, seconds=4),
+            datetime.timedelta(hours=26, minutes=3),
+            datetime.timedelta(hours=26),
+            datetime.timedelta(minutes=1563, seconds=4),
+            datetime.timedelta(minutes=1563),
+            datetime.timedelta(seconds=93784),
+        ]
+
+        for n, (a, e) in enumerate(zip(actual, expected)):
+            self.assertEqual(a, e, "%s does not match with %s" % (exprs[n], expected[n]))
 
 
 class DataTypeTests(unittest.TestCase):

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -189,6 +189,7 @@ class TypesTests(ReusedSQLTestCase):
             "a",
             datetime.date(1970, 1, 1),
             datetime.datetime(1970, 1, 1, 0, 0),
+            datetime.timedelta(microseconds=123456678),
             1.0,
             [1.0],
             [1],

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1101,7 +1101,7 @@ def _parse_datatype_json_value(json_value: Union[dict, str]) -> DataType:
             return DecimalType(int(m.group(1)), int(m.group(2)))  # type: ignore[union-attr]
         elif _INTERVAL_DAYTIME.match(json_value):
             m = _INTERVAL_DAYTIME.match(json_value)
-            inverted_fields = DayTimeIntervalType._inverted_fields  # type: ignore[union-attr]
+            inverted_fields = DayTimeIntervalType._inverted_fields
             first_field = inverted_fields.get(m.group(1))  # type: ignore[union-attr]
             second_field = inverted_fields.get(m.group(3))  # type: ignore[union-attr]
             if first_field is not None and second_field is None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements `DayTimeIntervalType` in PySpark's `DataFrame.collect()`, `SparkSession.createDataFrame()` and `functions.udf`.
This type is mapped to [`datetime.timedelta`](https://docs.python.org/3/library/datetime.html#timedelta-objects).

Arrow code path will be separately implemented at SPARK-37277, and Py4J support will be done at SPARK-37281.

### Why are the changes needed?

- In order to support `datetime.timedelta` out of the box via PySpark.
- To seamlessly support ANSI standard types

Semantically [`datetime.timedelta`](https://docs.python.org/3/library/datetime.html#timedelta-objects) is mapped to `DayTimeIntervalType`. Python's timedelta does not support months, years, etc.

### Does this PR introduce _any_ user-facing change?

Yes, users will be able to use `datetime.timedelta` in PySpark with `DayTimeIntervalType` at `DataFrame.collect()`, `SparkSession.createDataFrame()` and `functions.udf`:

```python
>>> import datetime
>>> df = spark.createDataFrame([(datetime.timedelta(days=1),)])
>>> df.collect()
[Row(_1=datetime.timedelta(days=1))]
```

```python
>>> from pyspark.sql.functions import udf
>>> df.select(udf(lambda x: x, "interval day to second")("_1")).show()
+--------------------+
|        <lambda>(_1)|
+--------------------+
|INTERVAL '1 00:00...|
+--------------------+
```

### How was this patch tested?

Unittests were added, and the