### PR TITLE
[SPARK-37344][SQL][DOC] spark-sql cli will keep `\` when match `\;` after spark3

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -338,6 +338,11 @@ license: |
 
   - In Spark 3.0, datetime pattern letter `F` is **aligned day of week in month** that represents the concept of the count of days within the period of a week where the weeks are aligned to the start of the month. In Spark version 2.4 and earlier, it is **week of month** that represents the concept of the count of weeks within the month where weeks start on a fixed day-of-week, e.g. `2020-07-30` is 30 days (4 weeks and 2 days) after the first day of the month, so `date_format(date '2020-07-30', 'F')` returns 2 in Spark 3.0, but as a week count in Spark 2.x, it returns 5 because it locates in the 5th week of July 2020, where week one is 2020-07-01 to 07-04.
 
+  - In Spark 3.0, Spark will keep backslash in `spark-sql` interface when process command match `\;`, in Spark 2.4, Spark will not keep backslash in `spark-sql` interface when process command match `\;` and only keep `;`. Below examples show the sql will be executed when we pass the example query in to `spark-sql` interface:
+      | Query | Spark 2.4 | Spark 3.0 |
+      | ----- | --------- | --------- |
+      |`SELECT SPLIT('SPARK SQL;Quick', '\\\\;');` | `SELECT SPLIT('SPARK SQL;Quick', '\\\;');` | `SELECT SPLIT('SPARK SQL;Quick', '\\\\;');` |
+
 ### Data Sources
 
   - In Spark version 2.4 and below, when reading a Hive SerDe table with Spark native data sources(parquet/orc), Spark infers the actual file schema and update the table schema in metastore. In Spark 3.0, Spark doesn't infer the schema anymore. This should not cause any problems to end users, but if it does, set `spark.sql.hive.caseSensitiveInferenceMode` to `INFER_AND_SAVE`.

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -342,7 +342,7 @@ license: |
       
       | Query | Spark 2.4 | Spark 3.0 |
       | ----- | --------- | --------- |
-      |`SELECT SPLIT('SPARK SQL;Quick', '\\\\;');` | `SELECT SPLIT('SPARK SQL;Quick', '\\\;');` | `SELECT SPLIT('SPARK SQL;Quick', '\\\\;');` |
+      |`SELECT SPLIT('SPARK;SQL', '\\\\;');`| `SELECT SPLIT('SPARK;SQL', '\\\;');`| `SELECT SPLIT('SPARK;SQL', '\\\\;');`|
 
 ### Data Sources
 

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -338,7 +338,8 @@ license: |
 
   - In Spark 3.0, datetime pattern letter `F` is **aligned day of week in month** that represents the concept of the count of days within the period of a week where the weeks are aligned to the start of the month. In Spark version 2.4 and earlier, it is **week of month** that represents the concept of the count of weeks within the month where weeks start on a fixed day-of-week, e.g. `2020-07-30` is 30 days (4 weeks and 2 days) after the first day of the month, so `date_format(date '2020-07-30', 'F')` returns 2 in Spark 3.0, but as a week count in Spark 2.x, it returns 5 because it locates in the 5th week of July 2020, where week one is 2020-07-01 to 07-04.
 
-  - In Spark 3.0, Spark will keep backslash in `spark-sql` interface when process command match `\;`, in Spark 2.4, Spark will not keep backslash in `spark-sql` interface when process command match `\;` and only keep `;`. Below examples show the sql will be executed when we pass the example query in to `spark-sql` interface:
+  - In Spark version 2.4 and below, `spark-sql` interface will chop `\` when query match `\;`. In Spark 3.0, `spark-sql` interface will not chop `\` when query match `\;`. See [HIVE-15297](https://issues.apache.org/jira/browse/HIVE-15297) for more details. For example:
+      
       | Query | Spark 2.4 | Spark 3.0 |
       | ----- | --------- | --------- |
       |`SELECT SPLIT('SPARK SQL;Quick', '\\\\;');` | `SELECT SPLIT('SPARK SQL;Quick', '\\\;');` | `SELECT SPLIT('SPARK SQL;Quick', '\\\\;');` |


### PR DESCRIPTION
### What changes were proposed in this pull request?
Before Spark 3, if we pass a SQL like `select split('Spark SQL', '\;')`  to spark-sql, after process, it will actually execute  `select split('Spark SQL', ';')`.

spark-sql with verbose log:
```
[info]   2021-11-16 18:05:34.86 - stdout> spark-sql> select split('dawdawdawd','\;');
[info]   2021-11-16 18:05:34.875 - stdout> select split('dawdawdawd',';')
```

But after Spark 3 It will execute  `select split('Spark SQL', '\;')`
spark-sql with verbose log:
```
[info]   2021-11-16 18:05:34.86 - stdout> spark-sql> select split('dawdawdawd','\;');
[info]   2021-11-16 18:05:34.875 - stdout> select split('dawdawdawd','\;')
```


In this PR we doc this change.

This change is caused by hive commit : https://github.com/apache/hive/commit/65a65826a0d351a3d918bdb98595bdd106d37adb#diff-79277c3cfeb5bc38066fbbe2b90dcee5c870100b8b1e106d53ed0d56817bd0ee

Related JIRA ID : https://issues.apache.org/jira/browse/HIVE-15297 


### Why are the changes needed?
Update migration guide


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Not need

![image](https://user-images.githubusercontent.com/46485123/142100077-a3c9151d-4a8d-4817-874a-c28dd03131ff.png)
