### PR TITLE
[SPARK-37181][PYTHON] pyspark.pandas.read_csv() should support latin-1 encoding

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -224,6 +224,7 @@ def read_csv(
     quotechar: Optional[str] = None,
     escapechar: Optional[str] = None,
     comment: Optional[str] = None,
+    encoding: Optional[str] = None,
     **options: Any,
 ) -> Union[DataFrame, Series]:
     """Read CSV (comma-separated) file into DataFrame or Series.
@@ -276,6 +277,8 @@ def read_csv(
         One-character string used to escape delimiter
     comment: str, optional
         Indicates the line should not be parsed.
+    encoding: str, optional
+        Indicates the encoding to read file
     options : dict
         All other options passed directly into Spark's data source.
 
@@ -291,6 +294,9 @@ def read_csv(
     --------
     >>> ps.read_csv('data.csv')  # doctest: +SKIP
     """
+    # For latin-1 encoding is same as iso-8859-1, that's why its mapped to iso-8859-1.
+    encoding_mapping = {"latin-1": "iso-8859-1"}
+
     if "options" in options and isinstance(options.get("options"), dict) and len(options) == 1:
         options = options.get("options")
 
@@ -327,6 +333,11 @@ def read_csv(
             reader.option("comment", comment)
 
         reader.options(**options)
+
+        if encoding is not None:
+            if encoding in encoding_mapping:
+                encoding = encoding_mapping[encoding]
+            reader.option("encoding", encoding)
 
         column_labels: Dict[Any, str]
         if isinstance(names, str):

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -335,9 +335,7 @@ def read_csv(
         reader.options(**options)
 
         if encoding is not None:
-            if encoding in encoding_mapping:
-                encoding = encoding_mapping[encoding]
-            reader.option("encoding", encoding)
+            reader.option("encoding", encoding_mapping.get(encoding, encoding))
 
         column_labels: Dict[Any, str]
         if isinstance(names, str):

--- a/python/pyspark/pandas/tests/test_csv.py
+++ b/python/pyspark/pandas/tests/test_csv.py
@@ -239,6 +239,13 @@ class CsvTest(PandasOnSparkTestCase, TestUtils):
             actual = ps.read_csv(fn, comment="#", nrows=2)
             self.assert_eq(expected, actual, almost=True)
 
+    def test_read_csv_with_encoding(self):
+        # SPARK-37181: Read csv supporting latin-1 encoding.
+        with self.csv_file(self.csv_text) as fn:
+            expected = pd.read_csv(fn, encoding="latin-1")
+            actual = ps.read_csv(fn, encoding="latin-1")
+            self.assert_eq(expected, actual, almost=True)
+
     def test_read_csv_with_sep(self):
         with self.csv_file(self.tab_delimited_csv_text) as fn:
             expected = pd.read_csv(fn, sep="\t")


### PR DESCRIPTION
### What changes were proposed in this pull request?
pyspark pandas will read csv with latin-1 encoding. 
```
from pyspark import pandas as ps
ps.read_csv("<>", encoding="latin-1")
```

### Why are the changes needed?
Earlier it throws "pyspark.sql.utils.illegalArgumentException: latin-1" whereas pandas read csv is able to read "latin-1" encoding. 
In order to have the same behavior of pd.read_csv and ps.read_csv this change is needed.


### Does this PR introduce any user-facing change?
Yes user will be able to provide latin-1 encoding with pyspark pandas

### How was this patch tested?
unit tests