### PR TITLE
[SPARK-37219][SQL][FOLLOWUP] Make AS OF syntax more flexible

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -600,8 +600,8 @@ fromClause
     ;
 
 temporalClause
-    : ((FOR SYSTEM_VERSION) | VERSION) AS OF version=(INTEGER_VALUE | STRING)
-    | ((FOR SYSTEM_TIME) | TIMESTAMP) AS OF timestamp=STRING
+    : FOR? (SYSTEM_VERSION | VERSION) AS OF version=(INTEGER_VALUE | STRING)
+    | FOR? (SYSTEM_TIME | TIMESTAMP) AS OF timestamp=STRING
     ;
 
 aggregationClause

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2453,9 +2453,25 @@ class DDLParserSuite extends AnalysisTest {
           new CaseInsensitiveStringMap(properties),
           timeTravelSpec = timeTravel)))
 
+    comparePlans(
+      parsePlan("SELECT * FROM a.b.c FOR VERSION AS OF 'Snapshot123456789'"),
+      Project(Seq(UnresolvedStar(None)),
+        UnresolvedRelation(
+          Seq("a", "b", "c"),
+          new CaseInsensitiveStringMap(properties),
+          timeTravelSpec = timeTravel)))
+
     timeTravel = TimeTravelSpec.create(None, Some("123456789"))
     comparePlans(
       parsePlan("SELECT * FROM a.b.c FOR SYSTEM_VERSION AS OF 123456789"),
+      Project(Seq(UnresolvedStar(None)),
+        UnresolvedRelation(
+          Seq("a", "b", "c"),
+          new CaseInsensitiveStringMap(properties),
+          timeTravelSpec = timeTravel)))
+
+    comparePlans(
+      parsePlan("SELECT * FROM a.b.c SYSTEM_VERSION AS OF 123456789"),
       Project(Seq(UnresolvedStar(None)),
         UnresolvedRelation(
           Seq("a", "b", "c"),
@@ -2470,8 +2486,25 @@ class DDLParserSuite extends AnalysisTest {
           Seq("a", "b", "c"),
           new CaseInsensitiveStringMap(properties),
           timeTravelSpec = timeTravel)))
+
+    comparePlans(
+      parsePlan("SELECT * FROM a.b.c FOR TIMESTAMP AS OF '2019-01-29 00:37:58'"),
+      Project(Seq(UnresolvedStar(None)),
+        UnresolvedRelation(
+          Seq("a", "b", "c"),
+          new CaseInsensitiveStringMap(properties),
+          timeTravelSpec = timeTravel)))
+
     comparePlans(
       parsePlan("SELECT * FROM a.b.c FOR SYSTEM_TIME AS OF '2019-01-29 00:37:58'"),
+      Project(Seq(UnresolvedStar(None)),
+        UnresolvedRelation(
+          Seq("a", "b", "c"),
+          new CaseInsensitiveStringMap(properties),
+          timeTravelSpec = timeTravel)))
+
+    comparePlans(
+      parsePlan("SELECT * FROM a.b.c SYSTEM_TIME AS OF '2019-01-29 00:37:58'"),
       Project(Seq(UnresolvedStar(None)),
         UnresolvedRelation(
           Seq("a", "b", "c"),
@@ -2486,8 +2519,25 @@ class DDLParserSuite extends AnalysisTest {
           Seq("a", "b", "c"),
           new CaseInsensitiveStringMap(properties),
           timeTravelSpec = timeTravel)))
+
+    comparePlans(
+      parsePlan("SELECT * FROM a.b.c FOR TIMESTAMP AS OF '2019-01-29'"),
+      Project(Seq(UnresolvedStar(None)),
+        UnresolvedRelation(
+          Seq("a", "b", "c"),
+          new CaseInsensitiveStringMap(properties),
+          timeTravelSpec = timeTravel)))
+
     comparePlans(
       parsePlan("SELECT * FROM a.b.c FOR SYSTEM_TIME AS OF '2019-01-29'"),
+      Project(Seq(UnresolvedStar(None)),
+        UnresolvedRelation(
+          Seq("a", "b", "c"),
+          new CaseInsensitiveStringMap(properties),
+          timeTravelSpec = timeTravel)))
+
+    comparePlans(
+      parsePlan("SELECT * FROM a.b.c SYSTEM_TIME AS OF '2019-01-29'"),
       Project(Seq(UnresolvedStar(None)),
         UnresolvedRelation(
           Seq("a", "b", "c"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2966,9 +2966,18 @@ class DataSourceV2SQLSuite
         === Array(Row(1), Row(2)))
       assert(sql("SELECT * FROM t VERSION AS OF 2345678910").collect
         === Array(Row(3), Row(4)))
+      assert(sql("SELECT * FROM t FOR VERSION AS OF 'Snapshot123456789'").collect
+        === Array(Row(1), Row(2)))
+      assert(sql("SELECT * FROM t FOR VERSION AS OF 2345678910").collect
+        === Array(Row(3), Row(4)))
+
       assert(sql("SELECT * FROM t FOR SYSTEM_VERSION AS OF 'Snapshot123456789'").collect
         === Array(Row(1), Row(2)))
       assert(sql("SELECT * FROM t FOR SYSTEM_VERSION AS OF 2345678910").collect
+        === Array(Row(3), Row(4)))
+      assert(sql("SELECT * FROM t SYSTEM_VERSION AS OF 'Snapshot123456789'").collect
+        === Array(Row(1), Row(2)))
+      assert(sql("SELECT * FROM t SYSTEM_VERSION AS OF 2345678910").collect
         === Array(Row(3), Row(4)))
     }
 
@@ -2994,9 +3003,18 @@ class DataSourceV2SQLSuite
         === Array(Row(5), Row(6)))
       assert(sql("SELECT * FROM t TIMESTAMP AS OF '2021-01-29 00:37:58'").collect
         === Array(Row(7), Row(8)))
+      assert(sql("SELECT * FROM t FOR TIMESTAMP AS OF '2019-01-29 00:37:58'").collect
+        === Array(Row(5), Row(6)))
+      assert(sql("SELECT * FROM t FOR TIMESTAMP AS OF '2021-01-29 00:37:58'").collect
+        === Array(Row(7), Row(8)))
+
       assert(sql("SELECT * FROM t FOR SYSTEM_TIME AS OF '2019-01-29 00:37:58'").collect
         === Array(Row(5), Row(6)))
       assert(sql("SELECT * FROM t FOR SYSTEM_TIME AS OF '2021-01-29 00:37:58'").collect
+        === Array(Row(7), Row(8)))
+      assert(sql("SELECT * FROM t SYSTEM_TIME AS OF '2019-01-29 00:37:58'").collect
+        === Array(Row(5), Row(6)))
+      assert(sql("SELECT * FROM t SYSTEM_TIME AS OF '2021-01-29 00:37:58'").collect
         === Array(Row(7), Row(8)))
     }
   }


### PR DESCRIPTION


### What changes were proposed in this pull request?
Make `AS OF` syntax more flexible


### Why are the changes needed?
`((FOR SYSTEM_VERSION) | VERSION)` -> `FOR? (SYSTEM_VERSION | VERSION) AS OF`


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
Existing tests
