### PR TITLE
[SPARK-37340][UI] Display StageIds in Operators for SQL UI

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -77,7 +77,7 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
             {jobLinks(JobExecutionStatus.FAILED, "Failed Jobs:")}
             <li>
               <strong>Completed Stages: </strong>
-              {sqlStore.getStageAttempt(executionId).sorted.map { case (stage, attempt) =>
+              {sqlStore.getStageAttempts(executionId).sorted.map { case (stage, attempt) =>
               <a href={stageURL(request, stage, attempt)}>{stage}</a><span>&nbsp;</span>
             }}
             </li>
@@ -147,7 +147,7 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
     "%s/jobs/job/?id=%s".format(UIUtils.prependBaseUri(request, parent.basePath), jobId)
 
   private def stageURL(request: HttpServletRequest, stageId: Int, attemptId: Int): String =
-    "%s/stages/stage/?id=%s&attempt=%s".format(
+    "%s/stages/stage/?id=%d&attempt=%d".format(
       UIUtils.prependBaseUri(request, parent.basePath), stageId, attemptId)
 
   private def physicalPlanDescription(physicalPlanDescription: String): Seq[Node] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
@@ -244,7 +244,7 @@ class SQLAppStatusListener(
       .format(nodeNameToAccumulatorIds.mkString("\n ")))
 
     // Gets each stage and its list of distinct accumulatorIDs
-    // which is retrived upon completion of a stage.
+    // which is retrieved upon completion of a stage.
     val stageIdToAccumulatorIDs = stageAccumulators.asScala
     logDebug("each Stage's Metrics represented by AccumulatorIds are: \n %s\n"
       .format(stageIdToAccumulatorIDs.mkString("\n ")))
@@ -253,13 +253,15 @@ class SQLAppStatusListener(
     // between nodeMetrics and stageAccumulateIDs
     val operatorToStage = nodeNameToAccumulatorIds.map { case (nodeName, accumulatorIds1) =>
       val mappedStages = stageIdToAccumulatorIDs.flatMap { case (stageId, accumulatorIds2) =>
-        if (accumulatorIds1.intersect(accumulatorIds2).nonEmpty) Some(stageId)
-        else None
+        if (accumulatorIds1.intersect(accumulatorIds2).nonEmpty) {
+          Some(stageId)
+        } else {
+          None
+        }
       }.toList.sorted
       (nodeName, accumulatorIds1, mappedStages)
     }
-    val operatorToStageString = operatorToStage.mkString("\n")
-    logDebug(s"Each Operator's AccumulatorIds and Stages are:\n $operatorToStageString")
+    logDebug(s"Each Operator's AccumulatorIds and Stages are:\n ${operatorToStage.mkString("\n")}")
 
     // Connect SparkGraphNode IDs to StageIDs for rendering in SQL UI in
     // SparkPlanGraph's makeDotFile.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
@@ -550,6 +550,8 @@ class SQLAppStatusListener(
     toDelete.foreach { e =>
       kvstore.delete(e.getClass(), e.executionId)
       kvstore.delete(classOf[SparkPlanGraphWrapper], e.executionId)
+      kvstore.delete(classOf[GraphNodeToStages], e.executionId)
+      kvstore.delete(classOf[StageAttempt], e.executionId)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
@@ -62,6 +62,14 @@ class SQLAppStatusStore(
     store.count(classOf[SparkPlanGraphWrapper])
   }
 
+  def graphNodeToStagesCount(): Long = {
+    store.count(classOf[GraphNodeToStages])
+  }
+
+  def stageAttemptCount(): Long = {
+    store.count(classOf[StageAttempt])
+  }
+
   def executionMetrics(executionId: Long): Map[Long, String] = {
     def metricsFromStore(): Option[Map[Long, String]] = {
       val exec = store.read(classOf[SQLExecutionUIData], executionId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
@@ -79,7 +79,25 @@ class SQLAppStatusStore(
   def planGraph(executionId: Long): SparkPlanGraph = {
     store.read(classOf[SparkPlanGraphWrapper], executionId).toSparkPlanGraph()
   }
+
+  def getStageAttempt(executionId: Long): List[(Int, Int)] = {
+    store.read(classOf[StageAttempt], executionId).stageAttempts
+  }
+
+  def getGraphStages(executionId: Long): Map[Long, List[Int]] = {
+    store.read(classOf[GraphNodeToStages], executionId).stages
+  }
 }
+
+case class StageAttempt(
+ @KVIndexParam val executionId: Long,
+ val stageAttempts: List[(Int, Int)]
+)
+
+case class GraphNodeToStages(
+  @KVIndexParam val executionId: Long,
+  val stages: Map[Long, List[Int]]
+)
 
 class SQLExecutionUIData(
     @KVIndexParam val executionId: Long,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
@@ -80,7 +80,7 @@ class SQLAppStatusStore(
     store.read(classOf[SparkPlanGraphWrapper], executionId).toSparkPlanGraph()
   }
 
-  def getStageAttempt(executionId: Long): List[(Int, Int)] = {
+  def getStageAttempts(executionId: Long): List[(Int, Int)] = {
     store.read(classOf[StageAttempt], executionId).stageAttempts
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -209,7 +209,7 @@ class SparkPlanGraphCluster(
   extends SparkPlanGraphNode(id, name, desc, metrics) {
 
   override def makeDotNode(metricsValue: Map[Long, String],
-                           stagesGraph: Map[Long, List[Int]]): String = {
+    stagesGraph: Map[Long, List[Int]]): String = {
     val duration = metrics.filter(_.name.startsWith(WholeStageCodegenExec.PIPELINE_DURATION_METRIC))
     val stageStr = if (!stagesGraph.getOrElse(id, List()).isEmpty) {
       "Stages: " + stagesGraph.getOrElse(this.id, List()).mkString(",") + "\n" } else " "

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -55,9 +55,7 @@ case class SparkPlanGraph(
   }
 
   def getAllIds: Seq[Long] = {
-    allNodes.map {
-      node => node.id
-    }
+    allNodes.map(_.id)
   }
 }
 
@@ -185,8 +183,8 @@ class SparkPlanGraphNode(
       // Note: whitespace between two "\n"s is to create an empty line between the name of
       // SparkPlan and metrics. If removing it, it won't display the empty line in UI.
       builder ++= "<br><br>"
-      if (!stagesGraph.getOrElse(id, List()).isEmpty) {
-        builder ++= "Stages: " + stagesGraph.getOrElse(id, List()).mkString(",") + "\n"
+      if (!stagesGraph.getOrElse(id, Nil).isEmpty) {
+        builder ++= "Stages: " + stagesGraph.getOrElse(id, Nil).mkString(",") + "\n"
       }
       builder ++= values.mkString("<br>")
       val labelStr = StringEscapeUtils.escapeJava(builder.toString().replaceAll("\n", "<br>"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -553,7 +553,7 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
     assert(statusStore.execution(0).get.stages === (0 to 3).toSet)
 
     // Check stage and attemptID are gathered correctly.
-    val stageAttempt = statusStore.getStageAttempt(executionId)
+    val stageAttempt = statusStore.getStageAttempts(executionId)
     assert(stageAttempt.length == 4)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -551,6 +551,10 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
 
     assertJobs(statusStore.execution(0), completed = 0 to 1)
     assert(statusStore.execution(0).get.stages === (0 to 3).toSet)
+
+    // Check stage and attemptID are gathered correctly.
+    val stageAttempt = statusStore.getStageAttempt(executionId)
+    assert(stageAttempt.length == 4)
   }
 
   test("SPARK-11126: no memory leak when running non SQL jobs") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -1052,6 +1052,8 @@ class SQLAppStatusListenerMemoryLeakSuite extends SparkFunSuite {
         val statusStore = spark.sharedState.statusStore
         assert(statusStore.executionsCount() <= 50)
         assert(statusStore.planGraphCount() <= 50)
+        assert(statusStore.graphNodeToStagesCount() <= 50)
+        assert(statusStore.stageAttemptCount() <= 50)
         // No live data should be left behind after all executions end.
         assert(statusStore.listener.get.noLiveData())
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add explicit stageId to operator mapping in the Spark UI that is a more general version of https://issues.apache.org/jira/browse/SPARK-30209, where a stageId-> operator mapping is done with the following algorithm.
 1. Read SparkGraph to get every Node's name and respective AccumulatorIDs.
 2. Gets each stage's AccumulatorIDs.
 3. Maps Operators to stages by checking for non-zero intersection of Step 1 and 2's AccumulatorIDs.
 4. Connect SparkGraphNodes to respective StageIDs for rendering in SQL UI.
As a result, some operators without max metrics values will also have stageIds in the UI. In some cases, there is no operator->StageID mapping made because no stageIds have accumulatorIds that are a part of the Operator's accumulatorIds. URL links at the top to go to the succeeded jobs and completed stages that were executed as a part of the selected query are also provided.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Makes for easier and quicker debugging and navigation.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes, `Succeeded Jobs:` and `Completed Stages:`listed at the top of the UI, along with `Stages:` in some of the operators.
<img width="697" alt="Screen Shot 2021-11-16 at 11 35 51 AM" src="https://user-images.githubusercontent.com/16739760/142054791-8229d142-41cd-4706-a53e-7abb51e5901c.png">

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Manual test locally in SQL UI.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
