### PR TITLE
[SPARK-37230][DOCS][PYTHON] Document DataFrame.mapInArrow in PySpark documentation

### DIFF
--- a/python/docs/source/reference/pyspark.sql.rst
+++ b/python/docs/source/reference/pyspark.sql.rst
@@ -178,6 +178,7 @@ DataFrame APIs
     DataFrame.limit
     DataFrame.localCheckpoint
     DataFrame.mapInPandas
+    DataFrame.mapInArrow
     DataFrame.na
     DataFrame.observe
     DataFrame.orderBy


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR documents `DataFrame.mapInArrow` in PySpark (https://github.com/apache/spark/pull/34505).
I initially planned to document like `DataFrame.mapInPandas` (https://github.com/apache/spark/pull/25025) but decided to don't publicly document like that because this is an unstable developer API.

### Why are the changes needed?

For users to refer to, and use.

### Does this PR introduce _any_ user-facing change?

Yes, it documents `DataFrame.mapInArrow` as below:

<img width="1205" alt="Screen Shot 2021-11-17 at 1 27 18 PM" src="https://user-images.githubusercontent.com/6477701/142134690-05ececab-c2c4-46a3-a57e-17c91f3d31b3.png">

### How was this patch tested?

Manually tested by building PySpark documentation.