### PR TITLE
[SPARK-37281][PYTHON] Support DayTimeIntervalType in Py4J

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -792,6 +792,11 @@ class FunctionsTests(ReusedSQLTestCase):
             assert_true(shiftRightUnsigned(col("id"), 2) == shiftrightunsigned(col("id"), 2))
         ).collect()
 
+    def test_lit_day_time_interval(self):
+        td = datetime.timedelta(days=1, hours=12, milliseconds=123)
+        actual = self.spark.range(1).select(lit(td)).first()[0]
+        self.assertEqual(actual, td)
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1953,10 +1953,24 @@ class DatetimeNTZConverter(object):
         )
 
 
+class DayTimeIntervalTypeConverter(object):
+    def can_convert(self, obj: Any) -> bool:
+        return isinstance(obj, datetime.timedelta)
+
+    def convert(self, obj: datetime.timedelta, gateway_client: JavaGateway) -> JavaObject:
+        from pyspark import SparkContext
+
+        jvm = SparkContext._jvm  # type: ignore[attr-defined]
+        return jvm.org.apache.spark.sql.catalyst.util.IntervalUtils.microsToDuration(
+            (math.floor(obj.total_seconds()) * 1000000) + obj.microseconds
+        )
+
+
 # datetime is a subclass of date, we should register DatetimeConverter first
 register_input_converter(DatetimeNTZConverter())
 register_input_converter(DatetimeConverter())
 register_input_converter(DateConverter())
+register_input_converter(DayTimeIntervalTypeConverter())
 
 
 def _test() -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the support of `DayTimeIntervalType` to Py4J. Namely, it will automatically convert `datetime.timedelta` to `java.util.Duration` that is mapped to `DayTimeIntervalType` in Scala/Java.

### Why are the changes needed?

To complete ANSI interval type supports in PySpark.

### Does this PR introduce _any_ user-facing change?

Yes, after this changes, users can use `datetime.timedelta` as an arguments in PySpark APIs. For example,

```python
import datetime
from pyspark.sql.functions import lit
spark.range(1).select(lit(datetime.timedelta(days=1, hours=12, milliseconds=123))).show()
```

### How was this patch tested?

Manually tested, and unittest was added.