### PR TITLE
[SPARK-37355][CORE]Avoid Block Manager registrations when Executor is shutting down

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -620,14 +620,12 @@ private[spark] class BlockManager(
    * Note that this method must be called without any BlockInfo locks held.
    */
   def reregister(): Unit = {
-    SparkContext.getActive.map { context =>
-      if (!context.stopped.get()) {
-        // TODO: We might need to rate limit re-registering.
-        logInfo(s"BlockManager $blockManagerId re-registering with master")
-        master.registerBlockManager(blockManagerId, diskBlockManager.localDirsString,
-          maxOnHeapMemory, maxOffHeapMemory, storageEndpoint)
-        reportAllBlocks()
-      }
+    if (!SparkEnv.get.isStopped) {
+      // TODO: We might need to rate limit re-registering.
+      logInfo(s"BlockManager $blockManagerId re-registering with master")
+      master.registerBlockManager(blockManagerId, diskBlockManager.localDirsString,
+        maxOnHeapMemory, maxOffHeapMemory, storageEndpoint)
+      reportAllBlocks()
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -620,11 +620,15 @@ private[spark] class BlockManager(
    * Note that this method must be called without any BlockInfo locks held.
    */
   def reregister(): Unit = {
-    // TODO: We might need to rate limit re-registering.
-    logInfo(s"BlockManager $blockManagerId re-registering with master")
-    master.registerBlockManager(blockManagerId, diskBlockManager.localDirsString, maxOnHeapMemory,
-      maxOffHeapMemory, storageEndpoint)
-    reportAllBlocks()
+    SparkContext.getActive.map { context =>
+      if (!context.stopped.get()) {
+        // TODO: We might need to rate limit re-registering.
+        logInfo(s"BlockManager $blockManagerId re-registering with master")
+        master.registerBlockManager(blockManagerId, diskBlockManager.localDirsString,
+          maxOnHeapMemory, maxOffHeapMemory, storageEndpoint)
+        reportAllBlocks()
+      }
+    }
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.storage
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.file.Files
-import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -664,8 +663,6 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
   }
 
   test("reregistration on block update") {
-    when(sc.stopped).thenReturn(new AtomicBoolean(false))
-    SparkContext.setActiveContext(sc)
     val store = makeBlockManager(2000)
     val a1 = new Array[Byte](400)
     val a2 = new Array[Byte](400)
@@ -681,7 +678,6 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
 
     assert(master.getLocations("a1").size == 0, "a1 was not reregistered with master")
     assert(master.getLocations("a2").size == 0, "master was not told about a2")
-    SparkContext.clearActiveContext()
   }
 
   test("reregistration doesn't dead lock") {

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.storage
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -663,6 +664,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
   }
 
   test("reregistration on block update") {
+    when(sc.stopped).thenReturn(new AtomicBoolean(false))
+    SparkContext.setActiveContext(sc)
     val store = makeBlockManager(2000)
     val a1 = new Array[Byte](400)
     val a2 = new Array[Byte](400)
@@ -678,6 +681,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
 
     assert(master.getLocations("a1").size > 0, "a1 was not reregistered with master")
     assert(master.getLocations("a2").size > 0, "master was not told about a2")
+    SparkContext.clearActiveContext()
   }
 
   test("reregistration doesn't dead lock") {

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -679,8 +679,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     store.putSingle("a2", a2, StorageLevel.MEMORY_ONLY)
     store.waitForAsyncReregister()
 
-    assert(master.getLocations("a1").size > 0, "a1 was not reregistered with master")
-    assert(master.getLocations("a2").size > 0, "master was not told about a2")
+    assert(master.getLocations("a1").size == 0, "a1 was not reregistered with master")
+    assert(master.getLocations("a2").size == 0, "master was not told about a2")
     SparkContext.clearActiveContext()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid BlockManager registrations when executor is shutting down.

### Why are the changes needed?

The block manager should not do re-register if the executor is shutting down by driver.


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests.
