### PR TITLE
[SPARK-37224][SS][FOLLOWUP] Add benchmark on basic state store operations

### DIFF
--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
@@ -1,0 +1,183 @@
+================================================================================================
+put rows
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                            6              9           1          1.6         614.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              51             55           1          0.2        5147.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                             13             16           1          0.8        1295.6       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+putting 10000 rows (7500 rows to overwrite - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                          7             10           1          1.5         650.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            48             52           1          0.2        4821.3       0.1X
+RocksDB (trackTotalNumberOfRows: false)                           13             16           1          0.8        1273.7       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                          6              9           1          1.6         618.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            44             48           1          0.2        4398.4       0.1X
+RocksDB (trackTotalNumberOfRows: false)                           13             16           1          0.8        1308.2       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+putting 10000 rows (2500 rows to overwrite - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                          6              8           1          1.7         604.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            41             44           1          0.2        4082.0       0.1X
+RocksDB (trackTotalNumberOfRows: false)                           13             16           1          0.8        1283.1       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                          6              8           1          1.7         579.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            39             42           1          0.3        3876.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                           13             16           1          0.7        1344.4       0.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+putting 10000 rows (500 rows to overwrite - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                        6              7           1          1.7         573.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                          37             40           1          0.3        3696.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                         12             14           1          0.8        1229.4       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                      5              7           1          1.9         533.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        35             37           1          0.3        3492.5       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       13             14           0          0.8        1264.3       0.4X
+
+
+================================================================================================
+delete rows
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                                        1              1           0         14.9          67.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          35             36           1          0.3        3493.2       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         11             13           0          0.9        1129.2       0.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+trying to delete 10000 rows from 10000 rows(7500 rows are non-existing - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                                      4              5           0          2.8         351.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        38             41           1          0.3        3832.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       11             13           0          0.9        1131.1       0.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                                      4              6           1          2.5         399.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        42             45           1          0.2        4198.3       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       11             13           0          0.9        1127.1       0.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+trying to delete 10000 rows from 10000 rows(2500 rows are non-existing - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                                      5              6           1          2.2         452.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        45             48           1          0.2        4515.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       11             13           0          0.9        1127.5       0.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                                      5              7           1          2.1         476.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        47             49           1          0.2        4683.2       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       11             13           0          0.9        1136.9       0.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+trying to delete 10000 rows from 10000 rows(500 rows are non-existing - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                                    5              7           1          2.1         478.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                      47             50           1          0.2        4727.8       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                     11             13           0          0.9        1122.8       0.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                                  5              7           1          2.1         478.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    48             51           1          0.2        4791.4       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   11             13           0          0.9        1125.6       0.4X
+
+
+================================================================================================
+evict rows
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                            5              5           0          2.2         459.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              42             44           1          0.2        4199.9       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                              9             10           0          1.1         943.3       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+evicting 7500 rows (maxTimestampToEvictInMillis: 7499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                           4              5           0          2.5         398.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             33             34           1          0.3        3280.3       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             8              8           0          1.3         770.2       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                           4              4           0          2.8         359.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             23             24           0          0.4        2293.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             6              7           0          1.6         629.2       0.6X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+evicting 2500 rows (maxTimestampToEvictInMillis: 2499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                           3              4           0          3.1         321.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             13             14           0          0.8        1310.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             5              5           0          2.1         481.3       0.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                          3              4           0          3.4         291.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             7              7           0          1.4         715.7       0.4X
+RocksDB (trackTotalNumberOfRows: false)                                            4              4           0          2.5         394.2       0.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+evicting 500 rows (maxTimestampToEvictInMillis: 499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                         3              3           0          3.4         295.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                            5              5           0          1.9         531.3       0.6X
+RocksDB (trackTotalNumberOfRows: false)                                           4              4           0          2.7         366.8       0.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10 on Linux 5.4.0-1045-aws
+Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
+evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------
+In-memory                                                                      1              1           0         17.0          58.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         3              3           0          3.0         336.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                        3              3           0          3.0         335.9       0.2X
+
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/StateStoreBasicOperationsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/StateStoreBasicOperationsBenchmark.scala
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import scala.util.Random
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.execution.streaming.state.{HDFSBackedStateStoreProvider, RocksDBStateStoreProvider, StateStore, StateStoreConf, StateStoreId, StateStoreProvider}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType, TimestampType}
+import org.apache.spark.util.Utils
+
+/**
+ * Synthetic benchmark for State Store basic operations.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class>
+ *        --jars <spark core test jar>,<spark catalyst test jar> <sql core test jar>
+ *   2. build/sbt "sql/test:runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *      Results will be written to "benchmarks/StateStoreBasicOperationsBenchmark-results.txt".
+ * }}}
+ */
+object StateStoreBasicOperationsBenchmark extends SqlBasedBenchmark {
+
+  private val keySchema = StructType(
+    Seq(StructField("key1", IntegerType, true), StructField("key2", TimestampType, true)))
+  private val valueSchema = StructType(Seq(StructField("value", IntegerType, true)))
+
+  private val keyProjection = UnsafeProjection.create(keySchema)
+  private val valueProjection = UnsafeProjection.create(valueSchema)
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runPutBenchmark()
+    runDeleteBenchmark()
+    runEvictBenchmark()
+  }
+
+  final def skip(benchmarkName: String)(func: => Any): Unit = {
+    output.foreach(_.write(s"$benchmarkName is skipped".getBytes))
+  }
+
+  private def runPutBenchmark(): Unit = {
+    def registerPutBenchmarkCase(
+        benchmark: Benchmark,
+        testName: String,
+        provider: StateStoreProvider,
+        version: Long,
+        rows: Seq[(UnsafeRow, UnsafeRow)]): Unit = {
+      benchmark.addTimerCase(testName) { timer =>
+        val store = provider.getStore(version)
+
+        timer.startTiming()
+        updateRows(store, rows)
+        timer.stopTiming()
+
+        store.abort()
+      }
+    }
+
+    runBenchmark("put rows") {
+      val numOfRows = Seq(10000)
+      val overwriteRates = Seq(100, 75, 50, 25, 10, 5, 0)
+
+      numOfRows.foreach { numOfRow =>
+        val testData = constructRandomizedTestData(numOfRow,
+          (1 to numOfRow).map(_ * 1000L).toList, 0)
+
+        val inMemoryProvider = newHDFSBackedStateStoreProvider()
+        val rocksDBProvider = newRocksDBStateProvider()
+        val rocksDBWithNoTrackProvider = newRocksDBStateProvider(trackTotalNumberOfRows = false)
+
+        val committedInMemoryVersion = loadInitialData(inMemoryProvider, testData)
+        val committedRocksDBVersion = loadInitialData(rocksDBProvider, testData)
+        val committedRocksDBWithNoTrackVersion = loadInitialData(
+          rocksDBWithNoTrackProvider, testData)
+
+        overwriteRates.foreach { overwriteRate =>
+          val numOfRowsToOverwrite = numOfRow * overwriteRate / 100
+
+          val numOfNewRows = numOfRow - numOfRowsToOverwrite
+          val newRows = if (numOfNewRows > 0) {
+            constructRandomizedTestData(numOfNewRows,
+              (1 to numOfNewRows).map(_ * 1000L).toList, 0)
+          } else {
+            Seq.empty[(UnsafeRow, UnsafeRow)]
+          }
+          val existingRows = if (numOfRowsToOverwrite > 0) {
+            Random.shuffle(testData).take(numOfRowsToOverwrite)
+          } else {
+            Seq.empty[(UnsafeRow, UnsafeRow)]
+          }
+          val rowsToPut = Random.shuffle(newRows ++ existingRows)
+
+          val benchmark = new Benchmark(s"putting $numOfRow rows " +
+            s"($numOfRowsToOverwrite rows to overwrite - rate $overwriteRate)",
+            numOfRow, minNumIters = 10000, output = output)
+
+          registerPutBenchmarkCase(benchmark, "In-memory", inMemoryProvider,
+            committedInMemoryVersion, rowsToPut)
+          registerPutBenchmarkCase(benchmark, "RocksDB (trackTotalNumberOfRows: true)",
+            rocksDBProvider, committedRocksDBVersion, rowsToPut)
+          registerPutBenchmarkCase(benchmark, "RocksDB (trackTotalNumberOfRows: false)",
+            rocksDBWithNoTrackProvider, committedRocksDBWithNoTrackVersion, rowsToPut)
+
+          benchmark.run()
+        }
+
+        inMemoryProvider.close()
+        rocksDBProvider.close()
+        rocksDBWithNoTrackProvider.close()
+      }
+    }
+  }
+
+  private def runDeleteBenchmark(): Unit = {
+    def registerDeleteBenchmarkCase(
+        benchmark: Benchmark,
+        testName: String,
+        provider: StateStoreProvider,
+        version: Long,
+        keys: Seq[UnsafeRow]): Unit = {
+      benchmark.addTimerCase(testName) { timer =>
+        val store = provider.getStore(version)
+
+        timer.startTiming()
+        deleteRows(store, keys)
+        timer.stopTiming()
+
+        store.abort()
+      }
+    }
+
+    runBenchmark("delete rows") {
+      val numOfRows = Seq(10000)
+      val nonExistRates = Seq(100, 75, 50, 25, 10, 5, 0)
+      numOfRows.foreach { numOfRow =>
+        val testData = constructRandomizedTestData(numOfRow,
+          (1 to numOfRow).map(_ * 1000L).toList, 0)
+
+        val inMemoryProvider = newHDFSBackedStateStoreProvider()
+        val rocksDBProvider = newRocksDBStateProvider()
+        val rocksDBWithNoTrackProvider = newRocksDBStateProvider(trackTotalNumberOfRows = false)
+
+        val committedInMemoryVersion = loadInitialData(inMemoryProvider, testData)
+        val committedRocksDBVersion = loadInitialData(rocksDBProvider, testData)
+        val committedRocksDBWithNoTrackVersion = loadInitialData(
+          rocksDBWithNoTrackProvider, testData)
+
+        nonExistRates.foreach { nonExistRate =>
+          val numOfRowsNonExist = numOfRow * nonExistRate / 100
+
+          val numOfExistingRows = numOfRow - numOfRowsNonExist
+          val nonExistingRows = if (numOfRowsNonExist > 0) {
+            constructRandomizedTestData(numOfRowsNonExist,
+              (numOfRow + 1 to numOfRow + numOfRowsNonExist).map(_ * 1000L).toList, 0)
+          } else {
+            Seq.empty[(UnsafeRow, UnsafeRow)]
+          }
+          val existingRows = if (numOfExistingRows > 0) {
+            Random.shuffle(testData).take(numOfExistingRows)
+          } else {
+            Seq.empty[(UnsafeRow, UnsafeRow)]
+          }
+          val keysToDelete = Random.shuffle(nonExistingRows ++ existingRows).map(_._1)
+
+          val benchmark = new Benchmark(s"trying to delete $numOfRow rows " +
+            s"from $numOfRow rows" +
+            s"($numOfRowsNonExist rows are non-existing - rate $nonExistRate)",
+            numOfRow, minNumIters = 10000, output = output)
+
+          registerDeleteBenchmarkCase(benchmark, "In-memory", inMemoryProvider,
+            committedInMemoryVersion, keysToDelete)
+          registerDeleteBenchmarkCase(benchmark, "RocksDB (trackTotalNumberOfRows: true)",
+            rocksDBProvider, committedRocksDBVersion, keysToDelete)
+          registerDeleteBenchmarkCase(benchmark, "RocksDB (trackTotalNumberOfRows: false)",
+            rocksDBWithNoTrackProvider, committedRocksDBWithNoTrackVersion, keysToDelete)
+
+          benchmark.run()
+        }
+
+        inMemoryProvider.close()
+        rocksDBProvider.close()
+        rocksDBWithNoTrackProvider.close()
+      }
+    }
+  }
+
+  private def runEvictBenchmark(): Unit = {
+    def registerEvictBenchmarkCase(
+        benchmark: Benchmark,
+        testName: String,
+        provider: StateStoreProvider,
+        version: Long,
+        maxTimestampToEvictInMillis: Long,
+        expectedNumOfRows: Long): Unit = {
+      benchmark.addTimerCase(testName) { timer =>
+        val store = provider.getStore(version)
+
+        timer.startTiming()
+        evictAsFullScanAndRemove(store, maxTimestampToEvictInMillis,
+          expectedNumOfRows)
+        timer.stopTiming()
+
+        store.abort()
+      }
+    }
+
+    runBenchmark("evict rows") {
+      val numOfRows = Seq(10000)
+      val numOfEvictionRates = Seq(100, 75, 50, 25, 10, 5, 0)
+
+      numOfRows.foreach { numOfRow =>
+        val timestampsInMicros = (0L until numOfRow).map(ts => ts * 1000L).toList
+
+        val testData = constructRandomizedTestData(numOfRow, timestampsInMicros, 0)
+
+        val inMemoryProvider = newHDFSBackedStateStoreProvider()
+        val rocksDBProvider = newRocksDBStateProvider()
+        val rocksDBWithNoTrackProvider = newRocksDBStateProvider(trackTotalNumberOfRows = false)
+
+        val committedInMemoryVersion = loadInitialData(inMemoryProvider, testData)
+        val committedRocksDBVersion = loadInitialData(rocksDBProvider, testData)
+        val committedRocksDBWithNoTrackVersion = loadInitialData(
+          rocksDBWithNoTrackProvider, testData)
+
+        numOfEvictionRates.foreach { numOfEvictionRate =>
+          val numOfRowsToEvict = numOfRow * numOfEvictionRate / 100
+          val maxTimestampToEvictInMillis = timestampsInMicros
+            .take(numOfRow * numOfEvictionRate / 100)
+            .lastOption.map(_ / 1000).getOrElse(-1L)
+
+          val benchmark = new Benchmark(s"evicting $numOfRowsToEvict rows " +
+            s"(maxTimestampToEvictInMillis: $maxTimestampToEvictInMillis) " +
+            s"from $numOfRow rows",
+            numOfRow, minNumIters = 10000, output = output)
+
+          registerEvictBenchmarkCase(benchmark, "In-memory", inMemoryProvider,
+            committedInMemoryVersion, maxTimestampToEvictInMillis, numOfRowsToEvict)
+
+          registerEvictBenchmarkCase(benchmark, "RocksDB (trackTotalNumberOfRows: true)",
+            rocksDBProvider, committedRocksDBVersion, maxTimestampToEvictInMillis,
+            numOfRowsToEvict)
+
+          registerEvictBenchmarkCase(benchmark, "RocksDB (trackTotalNumberOfRows: false)",
+            rocksDBWithNoTrackProvider, committedRocksDBWithNoTrackVersion,
+            maxTimestampToEvictInMillis, numOfRowsToEvict)
+
+          benchmark.run()
+        }
+
+        inMemoryProvider.close()
+        rocksDBProvider.close()
+        rocksDBWithNoTrackProvider.close()
+      }
+    }
+  }
+
+  private def getRows(store: StateStore, keys: Seq[UnsafeRow]): Seq[UnsafeRow] = {
+    keys.map(store.get)
+  }
+
+  private def loadInitialData(
+      provider: StateStoreProvider,
+      data: Seq[(UnsafeRow, UnsafeRow)]): Long = {
+    val store = provider.getStore(0)
+    updateRows(store, data)
+    store.commit()
+  }
+
+  private def updateRows(
+      store: StateStore,
+      rows: Seq[(UnsafeRow, UnsafeRow)]): Unit = {
+    rows.foreach { case (key, value) =>
+      store.put(key, value)
+    }
+  }
+
+  private def deleteRows(
+      store: StateStore,
+      rows: Seq[UnsafeRow]): Unit = {
+    rows.foreach { key =>
+      store.remove(key)
+    }
+  }
+
+  private def evictAsFullScanAndRemove(
+      store: StateStore,
+      maxTimestampToEvictMillis: Long,
+      expectedNumOfRows: Long): Unit = {
+    var removedRows: Long = 0
+    store.iterator().foreach { r =>
+      if (r.key.getLong(1) <= maxTimestampToEvictMillis * 1000L) {
+        store.remove(r.key)
+        removedRows += 1
+      }
+    }
+    assert(removedRows == expectedNumOfRows,
+      s"expected: $expectedNumOfRows actual: $removedRows")
+  }
+
+  // This prevents created keys to be in order, which may affect the performance on RocksDB.
+  private def constructRandomizedTestData(
+      numRows: Int,
+      timestamps: List[Long],
+      minIdx: Int = 0): Seq[(UnsafeRow, UnsafeRow)] = {
+    assert(numRows >= timestamps.length)
+    assert(numRows % timestamps.length == 0)
+
+    (1 to numRows).map { idx =>
+      val keyRow = new GenericInternalRow(2)
+      keyRow.setInt(0, Random.nextInt(Int.MaxValue))
+      keyRow.setLong(1, timestamps((minIdx + idx) % timestamps.length)) // microseconds
+      val valueRow = new GenericInternalRow(1)
+      valueRow.setInt(0, minIdx + idx)
+
+      val keyUnsafeRow = keyProjection(keyRow).copy()
+      val valueUnsafeRow = valueProjection(valueRow).copy()
+
+      (keyUnsafeRow, valueUnsafeRow)
+    }
+  }
+
+  private def newHDFSBackedStateStoreProvider(): StateStoreProvider = {
+    val storeId = StateStoreId(newDir(), Random.nextInt(), 0)
+    val provider = new HDFSBackedStateStoreProvider()
+    val storeConf = new StateStoreConf(new SQLConf())
+    provider.init(
+      storeId, keySchema, valueSchema, 0,
+      storeConf, new Configuration)
+    provider
+  }
+
+  private def newRocksDBStateProvider(
+      trackTotalNumberOfRows: Boolean = true): StateStoreProvider = {
+    val storeId = StateStoreId(newDir(), Random.nextInt(), 0)
+    val provider = new RocksDBStateStoreProvider()
+    val sqlConf = new SQLConf()
+    sqlConf.setConfString("spark.sql.streaming.stateStore.rocksdb.trackTotalNumberOfRows",
+      trackTotalNumberOfRows.toString)
+    val storeConf = new StateStoreConf(sqlConf)
+
+    provider.init(
+      storeId, keySchema, valueSchema, 0,
+      storeConf, new Configuration)
+    provider
+  }
+
+  private def newDir(): String = Utils.createTempDir().toString
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add a new benchmark to measure the performance on basic state store operations, and the result file.

The proposed change of SPARK-37224 (#34502) is applied in the benchmark. As the benchmark number provides, turning off the config brings lots of performance gain in micro-benchmark perspective, while it is still slower than memory-based state store.

### Why are the changes needed?

To track and verify further performance improvements.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Result file from manual run is included in this PR.