### PR TITLE
[SPARK-37277][PYTHON][SQL] Support DayTimeIntervalType in pandas UDF and Arrow optimization

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -24,6 +24,8 @@ license: |
 
 ## Upgrading from Spark SQL 3.2 to 3.3
 
+  - Since Spark 3.3, `DayTimeIntervalType` in Spark SQL is mapped to Arrow's `Duration` type in `ArrowWriter` and `ArrowColumnVector` developer APIs. Previously, `DayTimeIntervalType` was mapped to Arrow's `Interval` type which does not match with the types of other languages Spark SQL maps. For example, `DayTimeIntervalType` is mapped to `java.time.Duration` in Java.
+
   - Since Spark 3.3, the functions `lpad` and `rpad` have been overloaded to support byte sequences. When the first argument is a byte sequence, the optional padding pattern must also be a byte sequence and the result is a BINARY value. The default padding pattern in this case is the zero byte.
 
   - Since Spark 3.3, Spark turns a non-nullable schema into nullable for API `DataFrameReader.schema(schema: StructType).json(jsonDataset: Dataset[String])` and `DataFrameReader.schema(schema: StructType).csv(csvDataset: Dataset[String])` when the schema is specified by the user and contains non-nullable fields.

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -227,7 +227,7 @@ class PandasConversionMixin(object):
             else:
                 series = pdf[column_name]
 
-            # No need to cast for empty series for timedelta.
+            # No need to cast for non-empty series for timedelta. The type is already correct.
             should_check_timedelta = is_timedelta64_dtype(t) and len(pdf) == 0
 
             if (t is not None and not is_timedelta64_dtype(t)) or should_check_timedelta:

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -35,6 +35,7 @@ from pyspark.sql.types import (
     DateType,
     TimestampType,
     TimestampNTZType,
+    DayTimeIntervalType,
     ArrayType,
     MapType,
     StructType,
@@ -81,6 +82,8 @@ def to_arrow_type(dt: DataType) -> "pa.DataType":
         arrow_type = pa.timestamp("us", tz="UTC")
     elif type(dt) == TimestampNTZType:
         arrow_type = pa.timestamp("us", tz=None)
+    elif type(dt) == DayTimeIntervalType:
+        arrow_type = pa.duration("us")
     elif type(dt) == ArrayType:
         if type(dt.elementType) in [StructType, TimestampType]:
             raise TypeError("Unsupported type in conversion to Arrow: " + str(dt))
@@ -153,6 +156,8 @@ def from_arrow_type(at: "pa.DataType", prefer_timestamp_ntz: bool = False) -> Da
         spark_type = TimestampNTZType()
     elif types.is_timestamp(at):
         spark_type = TimestampType()
+    elif types.is_duration(at):
+        spark_type = DayTimeIntervalType()
     elif types.is_list(at):
         if types.is_timestamp(at.value_type):
             raise TypeError("Unsupported type in conversion from Arrow: " + str(at))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -57,7 +57,7 @@ private[sql] object ArrowUtils {
       new ArrowType.Timestamp(TimeUnit.MICROSECOND, null)
     case NullType => ArrowType.Null.INSTANCE
     case _: YearMonthIntervalType => new ArrowType.Interval(IntervalUnit.YEAR_MONTH)
-    case _: DayTimeIntervalType => new ArrowType.Interval(IntervalUnit.DAY_TIME)
+    case _: DayTimeIntervalType => new ArrowType.Duration(TimeUnit.MICROSECOND)
     case _ =>
       throw QueryExecutionErrors.unsupportedDataTypeError(dt.catalogString)
   }
@@ -81,7 +81,7 @@ private[sql] object ArrowUtils {
     case ts: ArrowType.Timestamp if ts.getUnit == TimeUnit.MICROSECOND => TimestampType
     case ArrowType.Null.INSTANCE => NullType
     case yi: ArrowType.Interval if yi.getUnit == IntervalUnit.YEAR_MONTH => YearMonthIntervalType()
-    case di: ArrowType.Interval if di.getUnit == IntervalUnit.DAY_TIME => DayTimeIntervalType()
+    case di: ArrowType.Duration if di.getUnit == TimeUnit.MICROSECOND => DayTimeIntervalType()
     case _ => throw QueryExecutionErrors.unsupportedDataTypeError(dt.toString)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -24,7 +24,6 @@ import org.apache.arrow.vector.complex._
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
-import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_DAY, MICROS_PER_MILLIS}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.ArrowUtils
@@ -77,7 +76,7 @@ object ArrowWriter {
         new StructWriter(vector, children.toArray)
       case (NullType, vector: NullVector) => new NullWriter(vector)
       case (_: YearMonthIntervalType, vector: IntervalYearVector) => new IntervalYearWriter(vector)
-      case (_: DayTimeIntervalType, vector: IntervalDayVector) => new IntervalDayWriter(vector)
+      case (_: DayTimeIntervalType, vector: DurationVector) => new DurationWriter(vector)
       case (dt, _) =>
         throw QueryExecutionErrors.unsupportedDataTypeError(dt.catalogString)
     }
@@ -422,16 +421,13 @@ private[arrow] class IntervalYearWriter(val valueVector: IntervalYearVector)
   }
 }
 
-private[arrow] class IntervalDayWriter(val valueVector: IntervalDayVector)
+private[arrow] class DurationWriter(val valueVector: DurationVector)
   extends ArrowFieldWriter {
   override def setNull(): Unit = {
     valueVector.setNull(count)
   }
 
   override def setValue(input: SpecializedGetters, ordinal: Int): Unit = {
-    val totalMicroseconds = input.getLong(ordinal)
-    val days = totalMicroseconds / MICROS_PER_DAY
-    val millis = (totalMicroseconds % MICROS_PER_DAY) / MICROS_PER_MILLIS
-    valueVector.set(count, days.toInt, millis.toInt)
+    valueVector.set(count, input.getLong(ordinal))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to support `DayTimeIntervalType` in pandas UDF and Arrow optimization. 

- Change the mapping of Arrow's  `IntervalType` to `DurationType` for `DayTimeIntervalType` (migration guide updated for Arrow developer APIs).
- Add a type mapping for other code paths: `numpy.timedelta64` <> `pyarrow.duration("us")` <> `DayTimeIntervalType`

### Why are the changes needed?

For changing the mapping of Arrow's  `Interval` type to `Duration` type for `DayTimeIntervalType`, please refer to https://github.com/apache/spark/pull/32340#discussion_r750909587.

`DayTimeIntervalType` is already mapped to the concept of duration instead of calendar instance: it's is matched to `pyarrow.duration("us")`, `datetime.timedelta`, and `java.util.Duration`.

**Spark SQL example**

```scala
scala> sql("SELECT timestamp '2029-01-01 00:00:00' - timestamp '2019-01-01 00:00:00'").show()
```
```
+-------------------------------------------------------------------+
|(TIMESTAMP '2029-01-01 00:00:00' - TIMESTAMP '2019-01-01 00:00:00')|
+-------------------------------------------------------------------+
|                                               INTERVAL '3653 00...|
+-------------------------------------------------------------------+
```

```scala
scala> sql("SELECT timestamp '2029-01-01 00:00:00' - timestamp '2019-01-01 00:00:00'").printSchema()
```
```
root
 |-- (TIMESTAMP '2029-01-01 00:00:00' - TIMESTAMP '2019-01-01 00:00:00'): interval day to second (nullable = false)
```

**Python example:**

```python
>>> import datetime
>>> datetime.datetime.now() - datetime.datetime.now()
datetime.timedelta(days=-1, seconds=86399, microseconds=999996)
```

**pandas / PyArrow example:**

```python
>>> import pyarrow as pa
>>> import pandas as pd
>>> pdf = pd.DataFrame({'a': [datetime.datetime.now() - datetime.datetime.now()]})
>>> tbl = pa.Table.from_pandas(pdf)
>>> tbl.schema
a: duration[ns]
-- schema metadata --
pandas: '{"index_columns": [{"kind": "range", "name": null, "start": 0, "' + 368
```

### Does this PR introduce _any_ user-facing change?

Yes, after this change, users can use `DayTimeIntervalType` in `SparkSession.createDataFrame(pandas_df)`, `DataFrame.to_pandas`, and pandas UDFs:

```python
>>> import datetime
>>> import pandas as pd
>>> from pyspark.sql.functions import pandas_udf
>>>
>>> @pandas_udf("interval day to second")
... def noop(s: pd.Series) -> pd.Series:
...     assert s.iloc[0] == datetime.timedelta(microseconds=123)
...     return s
...
>>> df = spark.createDataFrame(pd.DataFrame({"a": [pd.Timedelta(microseconds=123)]}))
>>> df.toPandas()
                       a
0 0 days 00:00:00.000123
```

### How was this patch tested?

Manually tested, and unittests were added.