### PR TITLE
[SPARK-37214][SQL][3.2][FOLLOWUP] No db prefix for temp view is an analyzer error

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2237,9 +2237,6 @@ class DDLParserSuite extends AnalysisTest {
       false,
       LocalTempView)
     comparePlans(parsed2, expected2)
-
-    val v3 = "CREATE TEMPORARY VIEW a.b AS SELECT 1"
-    intercept(v3, "It is not allowed to add database prefix")
   }
 
   test("create view - full") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2459,14 +2459,6 @@ class DataSourceV2SQLSuite
 
   test("SPARK-30799: temp view name can't contain catalog name") {
     val sessionCatalogName = CatalogManager.SESSION_CATALOG_NAME
-    withTempView("v") {
-      spark.range(10).createTempView("v")
-      val e1 = intercept[AnalysisException](
-        sql(s"CACHE TABLE $sessionCatalogName.v")
-      )
-      assert(e1.message.contains(
-        "Table or view not found: spark_catalog.v"))
-    }
     val e2 = intercept[AnalysisException] {
       sql(s"CREATE TEMP VIEW $sessionCatalogName.v AS SELECT 1")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2457,6 +2457,22 @@ class DataSourceV2SQLSuite
       .head().getString(1) === expectedComment)
   }
 
+  test("SPARK-30799: temp view name can't contain catalog name") {
+    val sessionCatalogName = CatalogManager.SESSION_CATALOG_NAME
+    withTempView("v") {
+      spark.range(10).createTempView("v")
+      val e1 = intercept[AnalysisException](
+        sql(s"CACHE TABLE $sessionCatalogName.v")
+      )
+      assert(e1.message.contains(
+        "Table or view not found: spark_catalog.v"))
+    }
+    val e2 = intercept[AnalysisException] {
+      sql(s"CREATE TEMP VIEW $sessionCatalogName.v AS SELECT 1")
+    }
+    assert(e2.message.contains("It is not allowed to add database prefix"))
+  }
+
   test("SPARK-31015: star expression should work for qualified column names for v2 tables") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
followup of #34490 in branch-3.2, which moves the test for checking
`notAllowedToAddDBPrefixForTempViewError` in the parser phase. But it only passes in master.
In branch-3.2, the error happens in the analyzer phase.

diverge happens in PR #34283

### Why are the changes needed?
fix test


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
pass the restored test.
