### PR TITLE
[SPARK-37205][YARN] Introduce a new config 'spark.yarn.am.tokenConfRegex' to support renewing delegation tokens in a multi-cluster environment

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -351,9 +351,9 @@ private[spark] class Client(
     // SPARK-37205: this regex is used to grep a list of configurations and send them to YARN RM
     // for fetching delegation tokens. See YARN-5910 for more details.
     // The feature is only supported in Hadoop 3.x and up, hence the check below.
-    val regex = sparkConf.get(config.AM_SEND_TOKEN_CONF)
+    val regex = sparkConf.get(config.AM_TOKEN_CONF_REGEX)
     if (regex.nonEmpty && VersionUtils.isHadoop3) {
-      logInfo(s"Processing token conf (spark.yarn.am.sendTokenConf) with regex $regex")
+      logInfo(s"Processing token conf (spark.yarn.am.tokenConfRegex) with regex $regex")
       val dob = new DataOutputBuffer();
       val copy = new Configuration(false);
       copy.clear();

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -349,12 +349,14 @@ private[spark] class Client(
     // The feature is only supported in Hadoop 3.x and up, hence the check below.
     val regex = sparkConf.get(config.AM_SEND_TOKEN_CONF)
     if (regex != null && regex.nonEmpty && VersionUtils.isHadoop3) {
+      logInfo(s"Processing token conf (spark.yarn.am.sendTokenConf) with regex $regex")
       val dob = new DataOutputBuffer();
       val copy = new Configuration(false);
       copy.clear();
       hadoopConf.asScala.foreach { entry =>
         if (entry.getKey.matches(regex)) {
           copy.set(entry.getKey, entry.getValue)
+          logInfo(s"Captured key: ${entry.getKey} -> value: ${entry.getValue}")
         }
       }
       copy.write(dob);

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -78,6 +78,20 @@ package object config extends Logging {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val AM_SEND_TOKEN_CONF =
+    ConfigBuilder("spark.yarn.am.sendTokenConf")
+        .doc("The value of this config is a regex expression used to grep a list of " +
+          "config entries from the job's configuration file (e.g., hdfs-site.xml) and send to " +
+          "RM, which will then use them when renewing delegation tokens. A typical use case of " +
+          "this feature is to support delegation tokens in a multi-cluster environment, where " +
+          "the RM may not have configs for all the (HDFS) clusters a YARN job wants to talk to, " +
+          "e.g., dfs.nameservices, dfs.ha.namenodes.x, dfs.namenode.rpc-address.x, and so on. " +
+          "This config mirrors 'mapreduce.job.send-token-conf'. For more details, please check " +
+          "YARN-5910.")
+        .version("3.3.0")
+        .stringConf
+        .createWithDefault("")
+
   private[spark] val EXECUTOR_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS =
     ConfigBuilder("spark.yarn.executor.failuresValidityInterval")
       .doc("Interval after which Executor failures will be considered independent and not " +

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -80,17 +80,17 @@ package object config extends Logging {
 
   private[spark] val AM_SEND_TOKEN_CONF =
     ConfigBuilder("spark.yarn.am.sendTokenConf")
-        .doc("The value of this config is a regex expression used to grep a list of " +
-          "config entries from the job's configuration file (e.g., hdfs-site.xml) and send to " +
-          "RM, which uses them when renewing delegation tokens. A typical use case of " +
-          "this feature is to support delegation tokens in an environment where a YARN cluster " +
-          "needs to talk to multiple downstream HDFS clusters, where the YARN RM may not have " +
-          "configs (e.g., dfs.nameservices, dfs.ha.namenodes.*, dfs.namenode.rpc-address.*)" +
-          "to connect to these clusters. This config is very similar to " +
-          "'mapreduce.job.send-token-conf'. Please check YARN-5910 for more details.")
-        .version("3.3.0")
-        .stringConf
-        .createWithDefault("")
+      .doc("This config is only supported for Hadoop 3.x profile. The value of this config is a " +
+        "regex expression used to grep a list of config entries from the job's configuration " +
+        "file (e.g., hdfs-site.xml) and send to RM, which uses them when renewing delegation " +
+        "tokens. A typical use case of this feature is to support delegation tokens in an " +
+        "environment where a YARN cluster needs to talk to multiple downstream HDFS clusters, " +
+        "where the YARN RM may not have configs (e.g., dfs.nameservices, dfs.ha.namenodes.*, " +
+        "dfs.namenode.rpc-address.*) to connect to these clusters. This config is very similar " +
+        "to 'mapreduce.job.send-token-conf'. Please check YARN-5910 for more details.")
+      .version("3.3.0")
+      .stringConf
+      .createOptional
 
   private[spark] val EXECUTOR_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS =
     ConfigBuilder("spark.yarn.executor.failuresValidityInterval")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -80,14 +80,14 @@ package object config extends Logging {
 
   private[spark] val AM_TOKEN_CONF_REGEX =
     ConfigBuilder("spark.yarn.am.tokenConfRegex")
-      .doc("This config is only supported for Hadoop 3.x profile. The value of this config is a " +
-        "regex expression used to grep a list of config entries from the job's configuration " +
-        "file (e.g., hdfs-site.xml) and send to RM, which uses them when renewing delegation " +
-        "tokens. A typical use case of this feature is to support delegation tokens in an " +
-        "environment where a YARN cluster needs to talk to multiple downstream HDFS clusters, " +
-        "where the YARN RM may not have configs (e.g., dfs.nameservices, dfs.ha.namenodes.*, " +
-        "dfs.namenode.rpc-address.*) to connect to these clusters. In this scenario, Spark " +
-        "users can specify the config value to be " +
+      .doc("This config is only supported when Hadoop version is 2.9+ or 3.x (e.g., when using " +
+        "the Hadoop 3.x profile). The value of this config is a regex expression used to grep a " +
+        "list of config entries from the job's configuration file (e.g., hdfs-site.xml) and send " +
+        "to RM, which uses them when renewing delegation tokens. A typical use case of this " +
+        "feature is to support delegation tokens in an environment where a YARN cluster needs to " +
+        "talk to multiple downstream HDFS clusters, where the YARN RM may not have configs " +
+        "(e.g., dfs.nameservices, dfs.ha.namenodes.*, dfs.namenode.rpc-address.*) to connect to " +
+        "these clusters. In this scenario, Spark users can specify the config value to be " +
         "'^dfs.nameservices$|^dfs.namenode.rpc-address.*$|^dfs.ha.namenodes.*$' to parse " +
         "these HDFS configs from the job's local configuration files. This config is very " +
         "similar to 'mapreduce.job.send-token-conf'. Please check YARN-5910 for more details.")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -78,16 +78,19 @@ package object config extends Logging {
       .booleanConf
       .createWithDefault(false)
 
-  private[spark] val AM_SEND_TOKEN_CONF =
-    ConfigBuilder("spark.yarn.am.sendTokenConf")
+  private[spark] val AM_TOKEN_CONF_REGEX =
+    ConfigBuilder("spark.yarn.am.tokenConfRegex")
       .doc("This config is only supported for Hadoop 3.x profile. The value of this config is a " +
         "regex expression used to grep a list of config entries from the job's configuration " +
         "file (e.g., hdfs-site.xml) and send to RM, which uses them when renewing delegation " +
         "tokens. A typical use case of this feature is to support delegation tokens in an " +
         "environment where a YARN cluster needs to talk to multiple downstream HDFS clusters, " +
         "where the YARN RM may not have configs (e.g., dfs.nameservices, dfs.ha.namenodes.*, " +
-        "dfs.namenode.rpc-address.*) to connect to these clusters. This config is very similar " +
-        "to 'mapreduce.job.send-token-conf'. Please check YARN-5910 for more details.")
+        "dfs.namenode.rpc-address.*) to connect to these clusters. In this scenario, Spark " +
+        "users can specify the config value to be " +
+        "'^dfs.nameservices$|^dfs.namenode.rpc-address.*$|^dfs.ha.namenodes.*$' to parse " +
+        "these HDFS configs from the job's local configuration files. This config is very " +
+        "similar to 'mapreduce.job.send-token-conf'. Please check YARN-5910 for more details.")
       .version("3.3.0")
       .stringConf
       .createOptional

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -82,12 +82,12 @@ package object config extends Logging {
     ConfigBuilder("spark.yarn.am.sendTokenConf")
         .doc("The value of this config is a regex expression used to grep a list of " +
           "config entries from the job's configuration file (e.g., hdfs-site.xml) and send to " +
-          "RM, which will then use them when renewing delegation tokens. A typical use case of " +
-          "this feature is to support delegation tokens in a multi-cluster environment, where " +
-          "the RM may not have configs for all the (HDFS) clusters a YARN job wants to talk to, " +
-          "e.g., dfs.nameservices, dfs.ha.namenodes.x, dfs.namenode.rpc-address.x, and so on. " +
-          "This config mirrors 'mapreduce.job.send-token-conf'. For more details, please check " +
-          "YARN-5910.")
+          "RM, which uses them when renewing delegation tokens. A typical use case of " +
+          "this feature is to support delegation tokens in an environment where a YARN cluster " +
+          "needs to talk to multiple downstream HDFS clusters, where the YARN RM may not have " +
+          "configs (e.g., dfs.nameservices, dfs.ha.namenodes.*, dfs.namenode.rpc-address.*)" +
+          "to connect to these clusters. This config is very similar to " +
+          "'mapreduce.job.send-token-conf'. Please check YARN-5910 for more details.")
         .version("3.3.0")
         .stringConf
         .createWithDefault("")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This adds a new config `spark.yarn.am.tokenConfRegex` which is similar to `mapreduce.job.send-token-conf` introduced via [YARN-5910](https://issues.apache.org/jira/browse/YARN-5910). It is used for YARN AM to pass Hadoop configs, such as `dfs.nameservices`, `dfs.ha.namenodes.`, `dfs.namenode.rpc-address.`, etc, to RM for renewing delegation tokens.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

[YARN-5910](https://issues.apache.org/jira/browse/YARN-5910) introduced a new config `mapreduce.job.send-token-conf` which can be used to pass a job's local configuration to RM which uses them when renewing delegation tokens. A typical use case is when a YARN cluster needs to talk to multiple HDFS clusters, where the RM may not have all the configs (e.g., `dfs.nameservices`, `dfs.ha.namenodes.<nameservice>.*`, `dfs.namenode.rpc-address`) to connect to these clusters when renewing delegation tokens. In this case, the clients can use the feature to pass their local HDFS configs to RM.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, a new config `spark.yarn.am.tokenConfRegex` will be introduced to Spark users. By default it is disabled.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

It seems difficult to come up with a unit test for this. I manually tested it against a YARN cluster with Hadoop version 3.x and it worked as expected.

```
$SPARK_HOME/bin/spark-shell --master yarn \
            --deploy-mode client \
            --conf spark.driver.extraClassPath="${HADOOP_CONF_DIR}" \
            --conf spark.executor.extraclasspath="${HADOOP_CONF_DIR}" \
            --conf spark.yarn.am.tokenConfRegex="^dfs.nameservices$|^dfs.namenode.rpc-address.*$|^dfs.ha.namenodes.*$|^dfs.client.failover.proxy.provider.*$|^dfs.namenode.kerberos.principal|^dfs.namenode.kerberos.principal.pattern" \
            --conf spark.yarn.access.hadoopFileSystems="<HDFS_URI>"
```