### PR TITLE
[SPARK-37349][SQL] add SQL Rest API parsing logic

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -63,6 +63,10 @@ object MimaExcludes {
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.deploy.DeployMessages#RequestExecutors.copy$default$2"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.deploy.DeployMessages#RequestExecutors.this"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.deploy.DeployMessages#RequestExecutors.apply")
+
+    // [SPARK-37349][SQL] Include more granular metrics for SQL Rest API
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.status.api.v1.sql.Metric.*"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.status.api.v1.sql.Metric.*")
   )
 
   // Exclude rules for 3.3.x from 3.2.0
@@ -75,7 +79,6 @@ object MimaExcludes {
 
     // [SPARK-37391][SQL] JdbcConnectionProvider tells if it modifies security context
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.jdbc.JdbcConnectionProvider.modifiesSecurityContext"),
-
     // [SPARK-37780][SQL] QueryExecutionListener support SQLConf as constructor parameter
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.util.ExecutionListenerManager.this"),
     // [SPARK-37786][SQL] StreamingQueryListener support use SQLConf.get to get corresponding SessionState's SQLConf

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
@@ -22,15 +22,18 @@ import javax.ws.rs._
 import javax.ws.rs.core.MediaType
 
 import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 
 import org.apache.spark.JobExecutionStatus
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.ui.{SparkPlanGraph, SparkPlanGraphCluster, SparkPlanGraphNode, SQLAppStatusStore, SQLExecutionUIData}
 import org.apache.spark.status.api.v1.{BaseAppResource, NotFoundException}
 
 @Produces(Array(MediaType.APPLICATION_JSON))
-private[v1] class SqlResource extends BaseAppResource {
+private[v1] class SqlResource extends BaseAppResource with Logging {
 
   val WHOLE_STAGE_CODEGEN = "WholeStageCodegen"
+  val COMMA = ","
 
   @GET
   def sqlList(
@@ -123,7 +126,8 @@ private[v1] class SqlResource extends BaseAppResource {
 
       metricValues.get(accumulatorId).map( mv => {
         val metricValue = if (mv.startsWith("\n")) mv.substring(1, mv.length) else mv
-        Metric(metricName, metricValue)
+        val value = extractMetric(metricName, metricValue)
+        Metric(metricName, value)
       })
     }
 
@@ -156,6 +160,86 @@ private[v1] class SqlResource extends BaseAppResource {
       case Success(wscgId) => Some(wscgId)
       case Failure(t) => None
     }
+  }
+
+  private def extractMetric(metricName: String, metricValue: String): Value = {
+    try {
+      extractMetricValue(metricValue)
+    } catch {
+      case NonFatal(t) => logError("Unsupported Metric Format found. " +
+          s"MetricName: $metricName - MetricValue: $metricValue - Cause: ${t.getMessage}")
+        Value()
+    }
+  }
+
+  private def extractMetricValue(metricValue: String): Value = {
+    val trimmedMetricValue = metricValue.replace(COMMA, "").trim
+
+    if (trimmedMetricValue.startsWith("(") && trimmedMetricValue.endsWith(")")) {
+      val arr = getValueArray(trimmedMetricValue)
+      Value(amount = None, min = Some(arr(0)), med = Some(arr(1)), max = Some(arr(2))
+        , stageId = Some(arr(3)), taskId = Some(arr(4)))
+    } else if (trimmedMetricValue.contains("driver")) {
+      processDriverString(trimmedMetricValue)
+    } else {
+      processString(trimmedMetricValue)
+    }
+  }
+
+  private def processDriverString(str: String): Value = {
+    // Driver String looks like "total (min, med, max (stageId: taskId))
+    // 194.0 B (97.0 B, 97.0 B, 97.0 B (driver))"
+    val metricValues = str.split("\n").last.split("(?<!\\G\\S+)\\s")
+    val cleanMetricValues = metricValues.map( x => x.replaceAll("[(]|[)]|[:]", ""))
+    require(cleanMetricValues.size == 5,
+      s"Array size should be 5 as total, min, med, max, driver +" +
+        s" but found metric value: $str")
+    logDebug("final values are:" + cleanMetricValues.mkString(",") + "\n")
+    Value(amount = Some(cleanMetricValues(0)), min = Some(cleanMetricValues(1)),
+      med = Some(cleanMetricValues(2)), max = Some(cleanMetricValues(3)))
+  }
+
+  private def processString(str: String): Value = {
+    def processTotalString(totalStr: String): Value = {
+      // totalStr looks like total (min med max (stageId: taskId))\n
+      // 4 ms (2 ms 2 ms 2 ms (stage 6.0: task 17))
+      // Using regex to first split second line based on every 2 spaces, then removing "(" "(" ":"
+      // special characters
+      val metricValues = totalStr.split("\n").last.split("(?<!\\G\\S+)\\s")
+      val cleanMetricValues = metricValues.map( x => x.replaceAll("[(]|[)]|[:]", ""))
+      require(cleanMetricValues.size == 6,
+        s"Array size should be 6 as total, min, med, max, stageId, TaskId" +
+          s" but found metric value: $totalStr")
+      cleanMetricValues(4) = cleanMetricValues(4).replace("stage ", "")
+      cleanMetricValues(5) = cleanMetricValues(5).replace("task ", "")
+      logDebug("final values are:" + cleanMetricValues.mkString(",") + "\n")
+      Value(amount = Some(cleanMetricValues(0)), min = Some(cleanMetricValues(1)),
+        med = Some(cleanMetricValues(2)), max = Some(cleanMetricValues(3)),
+        stageId = Some(cleanMetricValues(4)), taskId = Some(cleanMetricValues(5)))
+    }
+    val arr = str.trim.split(" ")
+    val result = arr.length match {
+      case 1 => Value(amount = Some(str)) // Singular numeric string like "1" with no units.
+      case 2 => Value(amount = Some(str)) // Numeric string with units like "1 ms"
+      case 17 => processTotalString(str) // Sample value in processTotalString commented lines.
+      case _ => logError("Unsupported Metric Value found. " +
+        s"MetricValue: $str - Cause: Different string length")
+        Value(amount = Some(str))
+      // Default when metric value is unexpected.
+    }
+    result
+  }
+
+  private def getValueArray(metricValue: String): Array[String] = {
+    // metricValue looks like (min med max (stageId: taskId)):
+    // (1 1 1 (stage 8.0: task 9)), so using regex to replace
+    // everything that isn't part off a number with a space then splitting the string by
+    // its spaces.
+    val cleanMetricValue = metricValue.replaceAll("[^\\d.]", " ").trim
+    val valueArray = cleanMetricValue.split("\\s+")
+    require(valueArray.size == 5, s"Array size should be 5 as min, med, max, stageId, TaskId" +
+      s" but found metric value: $metricValue")
+    valueArray.map(_.trim)
   }
 
 }

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
@@ -39,8 +39,6 @@ case class Node private[spark](
     wholeStageCodegenId: Option[Long] = None,
     metrics: Seq[Metric])
 
-case class Metric private[spark] (name: String, value: String)
-
 class SQLDiagnosticData private[spark] (
     val id: Long,
     val physicalPlan: String,
@@ -50,3 +48,9 @@ class SQLDiagnosticData private[spark] (
     val planChanges: Seq[AdaptivePlanChange])
 
 case class AdaptivePlanChange(updateTime: Date, physicalPlan: String)
+
+case class Metric private[spark] (name: String, value: Value)
+
+case class Value private[spark] (stageId: Option[String] = None, taskId: Option[String] = None,
+     amount: Option[String] = None, min: Option[String] = None,
+     med: Option[String] = None, max: Option[String] = None)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsTestUtils.scala
@@ -155,6 +155,9 @@ trait SQLMetricsTestUtils extends SQLTestUtils {
     }
   }
 
+  protected def getSparkPlanGraph(plan: SparkPlan): SparkPlanGraph =
+    SparkPlanGraph(SparkPlanInfo.fromSparkPlan(plan))
+
   /**
    * Call `df.collect()` and collect necessary metrics from execution data.
    *


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Following up on https://issues.apache.org/jira/browse/SPARK-31440, values like
`"value" : "total (min, med, max (stageId: taskId))\n177.0 B (59.0 B, 59.0 B, 59.0 B (stage 1.0: task 5))"` are currently shown from Rest API calls which are not easily digested in its current form.New processing logic of the values is introduced along with the creation of the following class in the SQL Rest API to organize the metric values: 
```
case class Value private[spark] (stageId: Option[String] = None, taskId: Option[String] = None,
                                 amount: Option[String] = None, min: Option[String] = None,
                                 med: Option[String] = None, max: Option[String] = None)
```
Which after processing, would make the output look like 
`{
      "value" : {
        "stageId" : "1.0",
        "taskId" : "5",
        "amount" : "177.0 B",
        "min" : "59.0 B",
        "med" : "59.0 B",
        "max" : "59.0 B"
      }`

Currently not in the PR but could be added if there is interest is the normalization of metrics for aggregation purposes such as the following:
- The conversion of hour, minute and second time units to milliseconds.
- PB,TB, GB, MB, KB units are converted to Bytes.
- Comma is removed from Comma formatted Long values (e.g: 8389632)

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To organize and process new metric fields in a more user friendly manner.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, see output below which are gathered from `Check Sql Rest Api Endpoints` Unit Test in SqlResourceWithActualMetricsSuite.scala with AQE set to true.
Before Changes:
[BeforeSpark37349UT.txt](https://github.com/apache/spark/files/7566623/BeforeSpark37349UT.txt)
After changes:
[AfterSpark37349UT.txt](https://github.com/apache/spark/files/7566624/AfterSpark37349UT.txt)

Backward Compatibility:
API Changes were made in `sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala`.
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new Unit Test, manual testing locally.