### PR TITLE
[SPARK-37308][SQL][TESTS] Partially revert SPARK-37214's test due to flakiness

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -360,7 +360,7 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
       LocalTempView)
     comparePlans(parsed2, expected2)
 
-    // TODO(SPARK-37367): Reeable exception test in DDLParserSuite.create view -- basic
+    // TODO(SPARK-37367): Reenable exception test in DDLParserSuite.create view -- basic
     // val v3 = "CREATE TEMPORARY VIEW a.b AS SELECT 1"
     // intercept(v3, "It is not allowed to add database prefix")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -359,6 +359,10 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
       false,
       LocalTempView)
     comparePlans(parsed2, expected2)
+
+    // TODO(SPARK-37367): Reeable exception test in DDLParserSuite.create view -- basic
+    // val v3 = "CREATE TEMPORARY VIEW a.b AS SELECT 1"
+    // intercept(v3, "It is not allowed to add database prefix")
   }
 
   test("create temp view - full") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -359,9 +359,6 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
       false,
       LocalTempView)
     comparePlans(parsed2, expected2)
-
-    val v3 = "CREATE TEMPORARY VIEW a.b AS SELECT 1"
-    intercept(v3, "It is not allowed to add database prefix")
   }
 
   test("create temp view - full") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reverts one of the tests added at https://github.com/apache/spark/pull/34490 which is (pretty seriously) flaky.

### Why are the changes needed?

Other tests seem passing fine so it's likely test specific issue. so only test is proposed to be reverted for now.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI in this PR should test this out.