### PR TITLE
[SPARK-37368][SQL][TESTS] Explicit GC for TPC-DS query runs

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
@@ -180,9 +180,11 @@ class TPCDSQueryTestSuite extends QueryTest with TPCDSBase with SQLQueryTestHelp
         classLoader = Thread.currentThread().getContextClassLoader)
       test(name) {
         val goldenFile = new File(s"$baseResourcePath/v1_4", s"$name.sql.out")
+        System.gc()  // Workaround for GitHub Actions memory limitation, see also SPARK-37368
         runQuery(queryString, goldenFile, joinConfSet.head.toSeq, false)
         if (!regenerateGoldenFiles) {
           joinConfSet.tail.foreach { conf =>
+            System.gc()  // SPARK-37368
             runQuery(queryString, goldenFile, conf.toSeq, true)
           }
         }
@@ -194,9 +196,11 @@ class TPCDSQueryTestSuite extends QueryTest with TPCDSBase with SQLQueryTestHelp
         classLoader = Thread.currentThread().getContextClassLoader)
       test(s"$name-v2.7") {
         val goldenFile = new File(s"$baseResourcePath/v2_7", s"$name.sql.out")
+        System.gc()  // SPARK-37368
         runQuery(queryString, goldenFile, joinConfSet.head.toSeq, false)
         if (!regenerateGoldenFiles) {
           joinConfSet.tail.foreach { conf =>
+            System.gc()  // SPARK-37368
             runQuery(queryString, goldenFile, conf.toSeq, true)
           }
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to explicitly GC between each query of TPC-DS.

### Why are the changes needed?

Due to the lack of memory in GitHub Actions machines, they easily die in the middle of testing. This is rather a bandaid workaround.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

It has been tested in the fork of Spark in the company I work for.