### PR TITLE
[SPARK-36180][SQL] Support TimestampNTZ type in Hive

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -392,6 +392,8 @@ object DataType {
               equalsIgnoreCaseAndNullability(l.dataType, r.dataType)
           }
 
+      case (TimestampNTZType, TimestampType) => true
+
       case (fromDataType, toDataType) => fromDataType == toDataType
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -992,6 +992,7 @@ private[hive] class HiveClientImpl(
 private[hive] object HiveClientImpl extends Logging {
   /** Converts the native StructField to Hive's FieldSchema. */
   def toHiveColumn(c: StructField): FieldSchema = {
+    // Store timestamp_ntz in a hive-compatible way, by storing both ntz and ltz as hive timestamp
     val field = c.dataType match {
       case TimestampNTZType => c.copy(dataType = TimestampType)
       case _ => c

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -46,6 +46,8 @@ import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.SlowHiveTest
 
+import java.time.LocalDateTime
+
 case class Nested1(f1: Nested2)
 case class Nested2(f2: Nested3)
 case class Nested3(f3: Int)
@@ -2686,6 +2688,19 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
           }
         }
       }
+    }
+  }
+
+  test("SPARK-36180: Support TimestampNTZ type in Hive") {
+    withTable("tb") {
+      val dt = "2018-11-17 13:33:33.0"
+      val ddl =
+        s"CREATE TABLE tb as SELECT TIMESTAMP_LTZ'$dt' as c0, TIMESTAMP_NTZ '$dt' as c1"
+      sql(ddl)
+      val df = sql("SELECT c0, c1 FROM tb")
+      checkAnswer(df, Row(
+        Timestamp.valueOf(dt),
+        LocalDateTime.of(2018, 11, 17, 13, 33, 33)))
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
+import java.time.LocalDateTime
 import java.util.{Locale, Set}
 
 import com.google.common.io.Files
@@ -45,8 +46,6 @@ import org.apache.spark.sql.internal.StaticSQLConf.GLOBAL_TEMP_DATABASE
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.SlowHiveTest
-
-import java.time.LocalDateTime
 
 case class Nested1(f1: Nested2)
 case class Nested2(f2: Nested3)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2694,7 +2694,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
     withTable("tb") {
       val dt = "2018-11-17 13:33:33.0"
       val ddl =
-        s"CREATE TABLE tb as SELECT TIMESTAMP_LTZ'$dt' as c0, TIMESTAMP_NTZ '$dt' as c1"
+        s"CREATE TABLE tb as SELECT TIMESTAMP_LTZ '$dt' as c0, TIMESTAMP_NTZ '$dt' as c1"
       sql(ddl)
       val df = sql("SELECT c0, c1 FROM tb")
       checkAnswer(df, Row(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark not supports TimestampNTZ type in Hive.

```
[info] Caused by: java.lang.IllegalArgumentException: Error: type expected at the position 0 of 'timestamp_ntz:timestamp' but 'timestamp_ntz' is found.[info] Caused by: java.lang.IllegalArgumentException: Error: type expected at the position 0 of 'timestamp_ntz:timestamp' but 'timestamp_ntz' is found.
[info]  at org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils$TypeInfoParser.expect(TypeInfoUtils.java:372)
[info]  at org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils$TypeInfoParser.expect(TypeInfoUtils.java:355)
[info]  at org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils$TypeInfoParser.parseType(TypeInfoUtils.java:416)
[info]  at org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils$TypeInfoParser.parseTypeInfos(TypeInfoUtils.java:329)
[info]  at org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils.getTypeInfosFromTypeString(TypeInfoUtils.java:814)
[info]  at org.apache.hadoop.hive.serde2.lazy.LazySerDeParameters.extractColumnInfo(LazySerDeParameters.java:162)[info]  at org.apache.hadoop.hive.serde2.lazy.LazySerDeParameters.<init>(LazySerDeParameters.java:91)
[info]  at org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe.initialize(LazySimpleSerDe.java:116)
[info]  at org.apache.hadoop.hive.serde2.AbstractSerDe.initialize(AbstractSerDe.java:54)
[info]  at org.apache.hadoop.hive.serde2.SerDeUtils.initializeSerDe(SerDeUtils.java:533)
[info]  at org.apache.hadoop.hive.metastore.MetaStoreUtils.getDeserializer(MetaStoreUtils.java:453)
[info]  at org.apache.hadoop.hive.metastore.MetaStoreUtils.getDeserializer(MetaStoreUtils.java:440)
[info]  at org.apache.hadoop.hive.ql.metadata.Table.getDeserializerFromMetaStore(Table.java:281)
[info]  at org.apache.hadoop.hive.ql.metadata.Table.checkValidity(Table.java:199)
[info]  at org.apache.hadoop.hive.ql.metadata.Hive.createTable(Hive.java:842)
...
```

Hive only providers the timestamp type, so Spark should write both timestamp_ltz and timestamp_ntz as Hive' timestamp.
When Spark read schema form Hive, We should restore the timestamp_ntz type.

### Why are the changes needed?
The hive 2.3.9 does not have 2 timestamp or a type named timestamp_ntz.
FYI, In hive 3.0, the will be a timestamp with local timezone added.


### Does this PR introduce _any_ user-facing change?
'No'. timestamp_ntz is new and not public yet


### How was this patch tested?
New test
