### PR TITLE
[SPARK-37282][TESTS][FOLLOWUP] Extract `Utils.isMacOnAppleSilicon` for reuse in UTs

### DIFF
--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBIteratorSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBIteratorSuite.java
@@ -41,7 +41,7 @@ public class LevelDBIteratorSuite extends DBIteratorSuite {
 
   @Override
   protected KVStore createStore() throws Exception {
-    assumeFalse(SystemUtils.IS_OS_MAC_OSX && System.getProperty("os.arch").equals("aarch64"));
+    assumeFalse(SystemUtils.IS_OS_MAC_OSX && SystemUtils.OS_ARCH.equals("aarch64"));
     dbpath = File.createTempFile("test.", ".ldb");
     dbpath.delete();
     db = new LevelDB(dbpath);

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -52,7 +52,7 @@ public class LevelDBSuite {
 
   @Before
   public void setup() throws Exception {
-    assumeFalse(SystemUtils.IS_OS_MAC_OSX && System.getProperty("os.arch").equals("aarch64"));
+    assumeFalse(SystemUtils.IS_OS_MAC_OSX && SystemUtils.OS_ARCH.equals("aarch64"));
     dbpath = File.createTempFile("test.", ".ldb");
     dbpath.delete();
     db = new LevelDB(dbpath);

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1962,6 +1962,11 @@ private[spark] object Utils extends Logging {
   val isMac = SystemUtils.IS_OS_MAC_OSX
 
   /**
+   * Whether the underlying operating system is Mac OS X and processor is Apple Silicon.
+   */
+  val isAppleSilicon = SystemUtils.IS_OS_MAC_OSX && SystemUtils.OS_ARCH.equals("aarch64")
+
+  /**
    * Pattern for matching a Windows drive, which contains only a single alphabet character.
    */
   val windowsDrive = "([a-zA-Z])".r

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1964,7 +1964,7 @@ private[spark] object Utils extends Logging {
   /**
    * Whether the underlying operating system is Mac OS X and processor is Apple Silicon.
    */
-  val isAppleSilicon = SystemUtils.IS_OS_MAC_OSX && SystemUtils.OS_ARCH.equals("aarch64")
+  val isMacOnAppleSilicon = SystemUtils.IS_OS_MAC_OSX && SystemUtils.OS_ARCH.equals("aarch64")
 
   /**
    * Pattern for matching a Windows drive, which contains only a single alphabet character.

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1652,7 +1652,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
 
     if (!inMemory) {
       // LevelDB doesn't support Apple Silicon yet
-      assume(!(Utils.isMac && System.getProperty("os.arch").equals("aarch64")))
+      assume(!Utils.isAppleSilicon)
       conf.set(LOCAL_STORE_DIR, Utils.createTempDir().getAbsolutePath())
     }
     conf.set(HYBRID_STORE_ENABLED, useHybridStore)

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1652,7 +1652,7 @@ class FsHistoryProviderSuite extends SparkFunSuite with Matchers with Logging {
 
     if (!inMemory) {
       // LevelDB doesn't support Apple Silicon yet
-      assume(!Utils.isAppleSilicon)
+      assume(!Utils.isMacOnAppleSilicon)
       conf.set(LOCAL_STORE_DIR, Utils.createTempDir().getAbsolutePath())
     }
     conf.set(HYBRID_STORE_ENABLED, useHybridStore)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -87,7 +87,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       .set(EXECUTOR_PROCESS_TREE_METRICS_ENABLED, true)
     conf.setAll(extraConf)
     // Since LevelDB doesn't support Apple Silicon yet, fallback to in-memory provider
-    if (Utils.isMac && System.getProperty("os.arch").equals("aarch64")) {
+    if (Utils.isAppleSilicon) {
       conf.remove(LOCAL_STORE_DIR)
     }
     provider = new FsHistoryProvider(conf)
@@ -389,7 +389,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       .set(LOCAL_STORE_DIR, storeDir.getAbsolutePath())
       .remove(IS_TESTING)
     // Since LevelDB doesn't support Apple Silicon yet, fallback to in-memory provider
-    if (Utils.isMac && System.getProperty("os.arch").equals("aarch64")) {
+    if (Utils.isAppleSilicon) {
       myConf.remove(LOCAL_STORE_DIR)
     }
     val provider = new FsHistoryProvider(myConf)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -87,7 +87,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       .set(EXECUTOR_PROCESS_TREE_METRICS_ENABLED, true)
     conf.setAll(extraConf)
     // Since LevelDB doesn't support Apple Silicon yet, fallback to in-memory provider
-    if (Utils.isAppleSilicon) {
+    if (Utils.isMacOnAppleSilicon) {
       conf.remove(LOCAL_STORE_DIR)
     }
     provider = new FsHistoryProvider(conf)
@@ -389,7 +389,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       .set(LOCAL_STORE_DIR, storeDir.getAbsolutePath())
       .remove(IS_TESTING)
     // Since LevelDB doesn't support Apple Silicon yet, fallback to in-memory provider
-    if (Utils.isAppleSilicon) {
+    if (Utils.isMacOnAppleSilicon) {
       myConf.remove(LOCAL_STORE_DIR)
     }
     val provider = new FsHistoryProvider(myConf)

--- a/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
@@ -84,7 +84,7 @@ class AppStatusStoreSuite extends SparkFunSuite {
       return AppStatusStore.createLiveStore(conf)
     }
     // LevelDB doesn't support Apple Silicon yet
-    if (Utils.isMac && System.getProperty("os.arch").equals("aarch64") && disk) {
+    if (Utils.isAppleSilicon && disk) {
       return null
     }
 

--- a/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
@@ -84,7 +84,7 @@ class AppStatusStoreSuite extends SparkFunSuite {
       return AppStatusStore.createLiveStore(conf)
     }
     // LevelDB doesn't support Apple Silicon yet
-    if (Utils.isAppleSilicon && disk) {
+    if (Utils.isMacOnAppleSilicon && disk) {
       return null
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
@@ -51,7 +51,7 @@ class StreamingSessionWindowSuite extends StreamTest
       (SQLConf.STATE_STORE_PROVIDER_CLASS.key, value.stripSuffix("$"))
     }
     // RocksDB doesn't support Apple Silicon yet
-    if (Utils.isAppleSilicon) {
+    if (Utils.isMacOnAppleSilicon) {
       providerOptions = providerOptions
         .filterNot(_._2.contains(classOf[RocksDBStateStoreProvider].getSimpleName))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
@@ -51,7 +51,7 @@ class StreamingSessionWindowSuite extends StreamTest
       (SQLConf.STATE_STORE_PROVIDER_CLASS.key, value.stripSuffix("$"))
     }
     // RocksDB doesn't support Apple Silicon yet
-    if (Utils.isMac && System.getProperty("os.arch").equals("aarch64")) {
+    if (Utils.isAppleSilicon) {
       providerOptions = providerOptions
         .filterNot(_._2.contains(classOf[RocksDBStateStoreProvider].getSimpleName))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-37282 use code similar to `SystemUtils.IS_OS_MAC_OSX && SystemUtils.OS_ARCH.equals("aarch64")` to determine whether the current test environment is `isMacOnAppleSilicon`. This pr extracted this duplicate code to `Utils.isMacOnAppleSilicon` and reuse it in UTs.  




### Why are the changes needed?
Remove duplicate codes.




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass the Jenkins or GitHub Action
- Manual test changed UTs use Apple Silicon passed
