### PR TITLE
[SPARK-37376][SQL] Introduce a new DataSource V2 interface HasPartitionKey

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/HasPartitionKey.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/HasPartitionKey.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+
+/**
+ * A mix-in for input partitions whose records are clustered on the same set of partition keys
+ * (provided via {@link SupportsReportPartitioning}, see below). Data sources can opt-in to
+ * implement this interface for the partitions they report to Spark, which will use the
+ * information to avoid data shuffling in certain scenarios, such as join, aggregate, etc. Note
+ * that Spark requires ALL input partitions to implement this interface, otherwise it can't take
+ * advantage of it.
+ * <p>
+ * This interface should be used in combination with {@link SupportsReportPartitioning}, which
+ * allows data sources to report distribution and ordering spec to Spark. In particular, Spark
+ * expects data sources to report
+ * {@link org.apache.spark.sql.connector.distributions.ClusteredDistribution} whenever its input
+ * partitions implement this interface. Spark derives partition keys spec (e.g., column names,
+ * transforms) from the distribution, and partition values from the input partitions.
+ * <p>
+ * It is implementor's responsibility to ensure that when an input partition implements this
+ * interface, its records all have the same value for the partition keys. Spark doesn't check
+ * this property.
+ *
+ * @see org.apache.spark.sql.connector.read.SupportsReportPartitioning
+ * @see org.apache.spark.sql.connector.read.partitioning.Partitioning
+ */
+public interface HasPartitionKey extends InputPartition {
+  /**
+   * Returns the value of the partition key(s) associated to this partition. An input partition
+   * implementing this interface needs to ensure that all its records have the same value for the
+   * partition keys. Note that the value is after partition transform has been applied, if there
+   * is any.
+   */
+  InternalRow partitionKey();
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
@@ -173,8 +173,8 @@ class InMemoryTable(
       partitionSchema: StructType,
       from: Seq[Any],
       to: Seq[Any]): Boolean = {
-    val rows = dataMap.remove(from).getOrElse(new BufferedRows(from.mkString("/")))
-    val newRows = new BufferedRows(to.mkString("/"))
+    val rows = dataMap.remove(from).getOrElse(new BufferedRows(from))
+    val newRows = new BufferedRows(to)
     rows.rows.foreach { r =>
       val newRow = new GenericInternalRow(r.numFields)
       for (i <- 0 until r.numFields) newRow.update(i, r.get(i, schema(i).dataType))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
@@ -197,7 +197,7 @@ class InMemoryTable(
 
   protected def createPartitionKey(key: Seq[Any]): Unit = dataMap.synchronized {
     if (!dataMap.contains(key)) {
-      val emptyRows = new BufferedRows(key.toArray.mkString("/"))
+      val emptyRows = new BufferedRows(key)
       val rows = if (key.length == schema.length) {
         emptyRows.withRow(InternalRow.fromSeq(key))
       } else emptyRows
@@ -215,7 +215,7 @@ class InMemoryTable(
       val key = getKey(row)
       dataMap += dataMap.get(key)
         .map(key -> _.withRow(row))
-        .getOrElse(key -> new BufferedRows(key.toArray.mkString("/")).withRow(row))
+        .getOrElse(key -> new BufferedRows(key).withRow(row))
       addPartitionKey(key)
     })
     this
@@ -290,7 +290,7 @@ class InMemoryTable(
           case In(attrName, values) if attrName == partitioning.head.name =>
             val matchingKeys = values.map(_.toString).toSet
             data = data.filter(partition => {
-              val key = partition.asInstanceOf[BufferedRows].key
+              val key = partition.asInstanceOf[BufferedRows].keyString
               matchingKeys.contains(key)
             })
 
@@ -508,13 +508,19 @@ object InMemoryTable {
   }
 }
 
-class BufferedRows(
-    val key: String = "") extends WriterCommitMessage with InputPartition with Serializable {
+class BufferedRows(val key: Seq[Any] = Seq.empty) extends WriterCommitMessage
+    with InputPartition with HasPartitionKey with Serializable {
   val rows = new mutable.ArrayBuffer[InternalRow]()
 
   def withRow(row: InternalRow): BufferedRows = {
     rows.append(row)
     this
+  }
+
+  def keyString(): String = key.toArray.mkString("/")
+
+  override def partitionKey(): InternalRow = {
+    InternalRow.fromSeq(key)
   }
 
   def clear(): Unit = rows.clear()
@@ -538,7 +544,7 @@ private class BufferedRowsReader(
   private def addMetadata(row: InternalRow): InternalRow = {
     val metadataRow = new GenericInternalRow(metadataColumnNames.map {
       case "index" => index
-      case "_partition" => UTF8String.fromString(partition.key)
+      case "_partition" => UTF8String.fromString(partition.keyString)
     }.toArray)
     new JoinedRow(row, metadataRow)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR introduces a new V2 min-in `HasPartitionKey` which can be used to return the partition value(s) of a `InputPartition`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As part of the Storage Partitioned Join work ([SPIP](https://issues.apache.org/jira/browse/SPARK-37166)), we'll need to introduce a way for a V2 `InputPartition` to return its partition values, which can then be used to compare whether both sides of a join operator can be considered "compatible" and thus allows Spark to eliminate shuffle. The info will also be used to group input partitions.

This will be used later in follow-up PRs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, a new V2 mix-in `HasPartitionKey` will be introduced.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Extended `InMemoryTable` to support this new interface, and added a new unit test to verify the API.
