### PR TITLE
[SPARK-37511][PYTHON] Introduce TimedeltaIndex to pandas API on Spark

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/indexing.rst
+++ b/python/docs/source/reference/pyspark.pandas/indexing.rst
@@ -336,6 +336,13 @@ DatatimeIndex
 
    DatetimeIndex
 
+TimedeltaIndex
+-------------
+.. autosummary::
+   :toctree: api/
+
+   TimedeltaIndex
+
 Time/date components
 ~~~~~~~~~~~~~~~~~~~~
 .. autosummary::

--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -61,6 +61,7 @@ from pyspark.pandas.indexes.category import CategoricalIndex
 from pyspark.pandas.indexes.datetimes import DatetimeIndex
 from pyspark.pandas.indexes.multi import MultiIndex
 from pyspark.pandas.indexes.numeric import Float64Index, Int64Index
+from pyspark.pandas.indexes.timedelta import TimedeltaIndex
 from pyspark.pandas.series import Series
 from pyspark.pandas.groupby import NamedAgg
 
@@ -79,6 +80,7 @@ __all__ = [  # noqa: F405
     "Float64Index",
     "CategoricalIndex",
     "DatetimeIndex",
+    "TimedeltaIndex",
     "sql",
     "range",
     "concat",

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -31,6 +31,7 @@ from pyspark.sql.types import (
     BooleanType,
     DataType,
     DateType,
+    DayTimeIntervalType,
     DecimalType,
     FractionalType,
     IntegralType,
@@ -234,6 +235,7 @@ class DataTypeOps(object, metaclass=ABCMeta):
             IntegralOps,
         )
         from pyspark.pandas.data_type_ops.string_ops import StringOps, StringExtensionOps
+        from pyspark.pandas.data_type_ops.timedelta_ops import TimedeltaOps
         from pyspark.pandas.data_type_ops.udt_ops import UDTOps
 
         if isinstance(dtype, CategoricalDtype):
@@ -271,6 +273,8 @@ class DataTypeOps(object, metaclass=ABCMeta):
             return object.__new__(DatetimeNTZOps)
         elif isinstance(spark_type, DateType):
             return object.__new__(DateOps)
+        elif isinstance(spark_type, DayTimeIntervalType):
+            return object.__new__(TimedeltaOps)
         elif isinstance(spark_type, BinaryType):
             return object.__new__(BinaryOps)
         elif isinstance(spark_type, ArrayType):

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.pandas.data_type_ops.base import DataTypeOps
+
+
+class TimedeltaOps(DataTypeOps):
+    """
+    The class for binary operations of pandas-on-Spark objects with spark type: DayTimeIntervalType.
+    """
+
+    @property
+    def pretty_name(self) -> str:
+        return "timedelta"

--- a/python/pyspark/pandas/indexes/__init__.py
+++ b/python/pyspark/pandas/indexes/__init__.py
@@ -19,4 +19,3 @@ from pyspark.pandas.indexes.datetimes import DatetimeIndex  # noqa: F401
 from pyspark.pandas.indexes.multi import MultiIndex  # noqa: F401
 from pyspark.pandas.indexes.numeric import Float64Index, Int64Index  # noqa: F401
 from pyspark.pandas.indexes.timedelta import TimedeltaIndex  # noqa: F401
-

--- a/python/pyspark/pandas/indexes/__init__.py
+++ b/python/pyspark/pandas/indexes/__init__.py
@@ -18,3 +18,5 @@ from pyspark.pandas.indexes.base import Index  # noqa: F401
 from pyspark.pandas.indexes.datetimes import DatetimeIndex  # noqa: F401
 from pyspark.pandas.indexes.multi import MultiIndex  # noqa: F401
 from pyspark.pandas.indexes.numeric import Float64Index, Int64Index  # noqa: F401
+from pyspark.pandas.indexes.timedelta import TimedeltaIndex  # noqa: F401
+

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -37,7 +37,13 @@ from pandas.api.types import CategoricalDtype, is_hashable
 from pandas._libs import lib
 
 from pyspark.sql import functions as F, Column
-from pyspark.sql.types import FractionalType, IntegralType, TimestampType, TimestampNTZType
+from pyspark.sql.types import (
+    DayTimeIntervalType,
+    FractionalType,
+    IntegralType,
+    TimestampType,
+    TimestampNTZType,
+)
 
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import Dtype, Label, Name, Scalar
@@ -178,6 +184,7 @@ class Index(IndexOpsMixin):
         from pyspark.pandas.indexes.datetimes import DatetimeIndex
         from pyspark.pandas.indexes.multi import MultiIndex
         from pyspark.pandas.indexes.numeric import Float64Index, Int64Index
+        from pyspark.pandas.indexes.timedelta import TimedeltaIndex
 
         instance: Index
         if anchor._internal.index_level > 1:
@@ -197,6 +204,11 @@ class Index(IndexOpsMixin):
             (TimestampType, TimestampNTZType),
         ):
             instance = object.__new__(DatetimeIndex)
+        elif isinstance(
+            anchor._internal.spark_type_for(anchor._internal.index_spark_columns[0]),
+            DayTimeIntervalType,
+        ):
+            instance = object.__new__(TimedeltaIndex)
         else:
             instance = object.__new__(Index)
 

--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Any
+from functools import partial
+
+from pyspark.pandas.indexes.base import Index
+from pyspark.pandas.missing.indexes import MissingPandasLikeTimedeltaIndex
+
+
+class TimedeltaIndex(Index):
+    """
+    Immutable ndarray-like of timedelta64 data, represented internally as int64, and
+    which can be boxed to timedelta objects.
+
+    See Also
+    --------
+    Index : The base pandas Index type.
+    """
+
+    def __getattr__(self, item: str) -> Any:
+        if hasattr(MissingPandasLikeTimedeltaIndex, item):
+            property_or_func = getattr(MissingPandasLikeTimedeltaIndex, item)
+            if isinstance(property_or_func, property):
+                return property_or_func.fget(self)
+            else:
+                return partial(property_or_func, self)
+    raise AttributeError("'TimedeltaIndex' object has no attribute '{}'".format(item))

--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -39,4 +39,4 @@ class TimedeltaIndex(Index):
             else:
                 return partial(property_or_func, self)
 
-    raise AttributeError("'TimedeltaIndex' object has no attribute '{}'".format(item))
+        raise AttributeError("'TimedeltaIndex' object has no attribute '{}'".format(item))

--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -32,9 +32,30 @@ class TimedeltaIndex(Index):
     Immutable ndarray-like of timedelta64 data, represented internally as int64, and
     which can be boxed to timedelta objects.
 
+    Parameters
+    ----------
+    data  : array-like (1-dimensional), optional
+        Optional timedelta-like data to construct index with.
+    unit : unit of the arg (D,h,m,s,ms,us,ns) denote the unit, optional
+        Which is an integer/float number.
+    freq : str or pandas offset object, optional
+        One of pandas date offset strings or corresponding objects. The string
+        'infer' can be passed in order to set the frequency of the index as the
+        inferred frequency upon creation.
+    copy  : bool
+        Make a copy of input ndarray.
+    name : object
+        Name to be stored in the index.
+
     See Also
     --------
     Index : The base pandas Index type.
+
+    Examples
+    --------
+    >>> from datetime import timedelta
+    >>> ps.TimedeltaIndex([timedelta(1), timedelta(microseconds=2)])
+    TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'], dtype='timedelta64[ns]', freq=None)
     """
 
     @no_type_check
@@ -66,8 +87,7 @@ class TimedeltaIndex(Index):
         )
         if freq is not _NoValue:
             kwargs["freq"] = freq
-        x = pd.TimedeltaIndex(**kwargs)
-        ps.from_pandas(x)
+
         return cast(TimedeltaIndex, ps.from_pandas(pd.TimedeltaIndex(**kwargs)))
 
     def __getattr__(self, item: str) -> Any:

--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -38,4 +38,5 @@ class TimedeltaIndex(Index):
                 return property_or_func.fget(self)
             else:
                 return partial(property_or_func, self)
+
     raise AttributeError("'TimedeltaIndex' object has no attribute '{}'".format(item))

--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -73,9 +73,8 @@ class TimedeltaIndex(Index):
             raise TypeError("Index.name must be a hashable type")
 
         if isinstance(data, (Series, Index)):
-            if dtype is None:
-                dtype = "timedelta64[ns]"
-            return cast(TimedeltaIndex, Index(data, dtype=dtype, copy=copy, name=name))
+            # TODO(SPARK-37512): Support TimedeltaIndex creation given a timedelta Series/Index
+            raise NotImplementedError("Create a TimedeltaIndex from Index/Series is not supported")
 
         kwargs = dict(
             data=data,

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -1524,6 +1524,17 @@ class InternalFrame(object):
         >>> data_fields
         [InternalField(dtype=datetime64[ns],struct_field=StructField(dt,TimestampNTZType,false)),
          InternalField(dtype=object,struct_field=StructField(dt_obj,TimestampNTZType,false))]
+
+        >>> pdf = pd.DataFrame({
+        ...     "td": [datetime.timedelta(0)], "td_obj": [datetime.timedelta(0)]
+        ... })
+        >>> pdf.td_obj = pdf.td_obj.astype("object")
+        >>> _, _, _, _, data_fields = (
+        ...     InternalFrame.prepare_pandas_frame(pdf)
+        ... )
+        >>> data_fields  # doctest: +NORMALIZE_WHITESPACE
+        [InternalField(dtype=timedelta64[ns],struct_field=StructField(td,DayTimeIntervalType(0,3),false)),
+         InternalField(dtype=object,struct_field=StructField(td_obj,DayTimeIntervalType(0,3),false))]
         """
         pdf = pdf.copy()
 

--- a/python/pyspark/pandas/missing/indexes.py
+++ b/python/pyspark/pandas/missing/indexes.py
@@ -112,11 +112,9 @@ class MissingPandasLikeTimedeltaIndex(MissingPandasLikeIndex):
 
     # Functions
     to_pytimedelta = _unsupported_function("to_pytimedelta", cls="TimedeltaIndex")
-    to_series = _unsupported_function("to_series", cls="TimedeltaIndex")
     round = _unsupported_function("round", cls="TimedeltaIndex")
     floor = _unsupported_function("floor", cls="TimedeltaIndex")
     ceil = _unsupported_function("ceil", cls="TimedeltaIndex")
-    to_frame = _unsupported_function("to_frame", cls="TimedeltaIndex")
     mean = _unsupported_function("mean", cls="TimedeltaIndex")
 
 

--- a/python/pyspark/pandas/missing/indexes.py
+++ b/python/pyspark/pandas/missing/indexes.py
@@ -100,6 +100,26 @@ class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
     std = _unsupported_function("std", cls="DatetimeIndex")
 
 
+class MissingPandasLikeTimedeltaIndex(MissingPandasLikeIndex):
+
+    # Properties
+    days = _unsupported_property("days", cls="TimedeltaIndex")
+    seconds = _unsupported_property("seconds", cls="TimedeltaIndex")
+    microseconds = _unsupported_property("microseconds", cls="TimedeltaIndex")
+    nanoseconds = _unsupported_property("nanoseconds", cls="TimedeltaIndex")
+    components = _unsupported_property("components", cls="TimedeltaIndex")
+    inferred_freq = _unsupported_property("inferred_freq", cls="TimedeltaIndex")
+
+    # Functions
+    to_pytimedelta = _unsupported_function("to_pytimedelta", cls="TimedeltaIndex")
+    to_series = _unsupported_function("to_series", cls="TimedeltaIndex")
+    round = _unsupported_function("round", cls="TimedeltaIndex")
+    floor = _unsupported_function("floor", cls="TimedeltaIndex")
+    ceil = _unsupported_function("ceil", cls="TimedeltaIndex")
+    to_frame = _unsupported_function("to_frame", cls="TimedeltaIndex")
+    mean = _unsupported_function("mean", cls="TimedeltaIndex")
+
+
 class MissingPandasLikeMultiIndex(object):
 
     # Functions

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -457,7 +457,7 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
                 "b": [4, 5, 6],
                 "c": pd.date_range("2011-01-01", freq="D", periods=3),
                 "d": pd.Categorical(["a", "b", "c"]),
-                "e": [timedelta(1), timedelta(2), timedelta(3)]
+                "e": [timedelta(1), timedelta(2), timedelta(3)],
             }
         )
 

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -29,6 +29,7 @@ from pyspark.pandas.missing.indexes import (
     MissingPandasLikeDatetimeIndex,
     MissingPandasLikeIndex,
     MissingPandasLikeMultiIndex,
+    MissingPandasLikeTimedeltaIndex,
 )
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils, SPARK_CONF_ARROW_ENABLED
 
@@ -522,6 +523,27 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
             ):
                 getattr(psdf.set_index("c").index, name)()
 
+        # TimedeltaIndex functions
+        missing_functions = inspect.getmembers(MissingPandasLikeTimedeltaIndex, inspect.isfunction)
+        unsupported_functions = [
+            name for (name, type_) in missing_functions if type_.__name__ == "unsupported_function"
+        ]
+        for name in unsupported_functions:
+            with self.assertRaisesRegex(
+                PandasNotImplementedError,
+                "method.*Index.*{}.*not implemented( yet\\.|\\. .+)".format(name),
+            ):
+                getattr(psdf.set_index("c").index, name)()
+
+        deprecated_functions = [
+            name for (name, type_) in missing_functions if type_.__name__ == "deprecated_function"
+        ]
+        for name in deprecated_functions:
+            with self.assertRaisesRegex(
+                PandasNotImplementedError, "method.*Index.*{}.*is deprecated".format(name)
+            ):
+                getattr(psdf.set_index("c").index, name)()
+
         # Index properties
         missing_properties = inspect.getmembers(
             MissingPandasLikeIndex, lambda o: isinstance(o, property)
@@ -577,6 +599,22 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
                 getattr(psdf.set_index(["a", "b"]).index, name)
 
         # DatetimeIndex properties
+        missing_properties = inspect.getmembers(
+            MissingPandasLikeDatetimeIndex, lambda o: isinstance(o, property)
+        )
+        unsupported_properties = [
+            name
+            for (name, type_) in missing_properties
+            if type_.fget.__name__ == "unsupported_property"
+        ]
+        for name in unsupported_properties:
+            with self.assertRaisesRegex(
+                PandasNotImplementedError,
+                "property.*Index.*{}.*not implemented( yet\\.|\\. .+)".format(name),
+            ):
+                getattr(psdf.set_index("c").index, name)
+
+        # TimedeltaIndex properties
         missing_properties = inspect.getmembers(
             MissingPandasLikeDatetimeIndex, lambda o: isinstance(o, property)
         )

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -457,7 +457,7 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
                 "b": [4, 5, 6],
                 "c": pd.date_range("2011-01-01", freq="D", periods=3),
                 "d": pd.Categorical(["a", "b", "c"]),
-                "e": timedelta(1),
+                "e": [timedelta(1), timedelta(2), timedelta(3)]
             }
         )
 

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -18,7 +18,7 @@
 import inspect
 import unittest
 from distutils.version import LooseVersion
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
@@ -457,6 +457,7 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
                 "b": [4, 5, 6],
                 "c": pd.date_range("2011-01-01", freq="D", periods=3),
                 "d": pd.Categorical(["a", "b", "c"]),
+                "e": timedelta(1),
             }
         )
 
@@ -533,7 +534,7 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
                 PandasNotImplementedError,
                 "method.*Index.*{}.*not implemented( yet\\.|\\. .+)".format(name),
             ):
-                getattr(psdf.set_index("c").index, name)()
+                getattr(psdf.set_index("e").index, name)()
 
         deprecated_functions = [
             name for (name, type_) in missing_functions if type_.__name__ == "deprecated_function"
@@ -542,7 +543,7 @@ class IndexesTest(PandasOnSparkTestCase, TestUtils):
             with self.assertRaisesRegex(
                 PandasNotImplementedError, "method.*Index.*{}.*is deprecated".format(name)
             ):
-                getattr(psdf.set_index("c").index, name)()
+                getattr(psdf.set_index("e").index, name)()
 
         # Index properties
         missing_properties = inspect.getmembers(

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -217,6 +217,10 @@ def as_spark_type(
     elif tpe in (datetime.datetime, np.datetime64, "datetime64[ns]", "M"):
         return types.TimestampNTZType() if prefer_timestamp_ntz else types.TimestampType()
 
+    # DayTimeIntervalType
+    elif tpe in (datetime.timedelta, np.timedelta64, "timedelta64[ns]"):
+        return types.DayTimeIntervalType()
+
     # categorical types
     elif isinstance(tpe, CategoricalDtype) or (isinstance(tpe, str) and type == "category"):
         return types.LongType()
@@ -330,6 +334,8 @@ def pandas_on_spark_type(tpe: Union[str, type, Dtype]) -> Tuple[Dtype, types.Dat
     (dtype('O'), DateType)
     >>> pandas_on_spark_type(datetime.datetime)
     (dtype('<M8[ns]'), TimestampType)
+    >>> pandas_on_spark_type(datetime.timedelta)
+    (dtype('<m8[ns]'), DayTimeIntervalType(0,3))
     >>> pandas_on_spark_type(List[bool])
     (dtype('O'), ArrayType(BooleanType,true))
     """


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce TimedeltaIndex to pandas API on Spark.

Properties, functions, and basic operations of TimedeltaIndex will be supported in follow-up PRs.

#### Note
Please note that PySpark DayTimeIntervalType follows python datetime.timedelta, in which the smallest time unit is `microsecond`. However, pandas TimedeltaIndex has `nanosecond` support. 
Thus, we may observe the inconsistency as below:
```py
>>> pidx = pd.TimedeltaIndex([1])
>>> pidx
TimedeltaIndex(['0 days 00:00:00.000000001'], dtype='timedelta64[ns]', freq=None)
>>> ps.from_pandas(pidx)
TimedeltaIndex(['0 days'], dtype='timedelta64[ns]', freq=None)
```

To inspect further in PySpark side:
```py
>>> pdf  # nanosecond
          __index_level_0__
0 0 days 00:00:00.000000001

>>> sdf = spark.createDataFrame(pdf)

>>> sdf.show(2, False)
+-----------------------------------+
|__index_level_0__                  |
+-----------------------------------+
|INTERVAL '0 00:00:00' DAY TO SECOND|
+-----------------------------------+
```


### Why are the changes needed?
Since DayTimeIntervalType is supported in PySpark, we may add TimedeltaIndex support in pandas API on Spark accordingly.

### Does this PR introduce _any_ user-facing change?
Yes.
```py
# TimedeltaIndex is introduced
>>> ps.TimedeltaIndex([timedelta(1)])
TimedeltaIndex(['1 days'], dtype='timedelta64[ns]', freq=None)
>>> ps.TimedeltaIndex([timedelta(seconds=1)])
TimedeltaIndex(['0 days 00:00:01'], dtype='timedelta64[ns]', freq=None)
>>> ps.from_pandas(pd.TimedeltaIndex([timedelta(seconds=1)]))
TimedeltaIndex(['0 days 00:00:01'], dtype='timedelta64[ns]', freq=None)
```

```py
# timedelta64 Series/DataFrame is also supported as a consequence
>>> ps.DataFrame({'td': [timedelta(hours=1, minutes=30)]})
               td
0 0 days 01:30:00
>>> ps.Series([timedelta(hours=1, minutes=30)])
0   0 days 01:30:00
dtype: timedelta64[ns]
```

### How was this patch tested?
Unit tests.