### PR TITLE
[SPARK-37384][CORE][TESTS] Increase timeout for job termination in SchedulerIntegrationSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/SchedulerIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SchedulerIntegrationSuite.scala
@@ -55,7 +55,7 @@ abstract class SchedulerIntegrationSuite[T <: MockBackend: ClassTag] extends Spa
   var backend: T = _
   // Even though the tests aren't doing much, occasionally we see flakiness from pauses over
   // a second (probably from GC?) so we leave a long timeout in here
-  val duration = Duration(10, SECONDS)
+  val duration = Duration(20, SECONDS)
 
   override def beforeEach(): Unit = {
     if (taskScheduler != null) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to increase timeout for job termination in SchedulerIntegrationSuite to deflake the tests.

### Why are the changes needed?

Currently `HealthTrackerIntegrationSuite.If preferred node is bad, without excludeOnFailure job will fail` is flaky:

```
sbt.ForkMain$ForkError: java.util.concurrent.TimeoutException: Futures timed out after [10 seconds]
	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:259)
	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:187)
	at org.apache.spark.util.ThreadUtils$.awaitReady(ThreadUtils.scala:334)
	at org.apache.spark.scheduler.SchedulerIntegrationSuite.awaitJobTermination(SchedulerIntegrationSuite.scala:274)
	at org.apache.spark.scheduler.HealthTrackerIntegrationSuite.$anonfun$new$3(HealthTrackerIntegrationSuite.scala:50)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at org.apache.spark.scheduler.SchedulerIntegrationSuite.withBackend(SchedulerIntegrationSuite.scala:261)
	at org.apache.spark.scheduler.HealthTrackerIntegrationSuite.$anonfun$new$1(HealthTrackerIntegrationSuite.scala:48)
	at org.apache.spark.scheduler.SchedulerIntegrationSuite.$anonfun$testScheduler$1(SchedulerIntegrationSuite.scala:98)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:226)
	at org.apache.spark.SparkFunSuite.withFixture(SparkFunSuite.scala:190)
	at org.scalatest.funsuite.AnyFunSuiteLike.invokeWithFixture$1(AnyFunSuiteLike.scala:224)
	at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTest$1(AnyFunSuiteLike.scala:236)
```

e.g.) https://github.com/apache/spark/runs/4259932001

This PR fixes it.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Should monitor GitHub Actions builds after it got merged.