### PR TITLE
[SPARK-37385][SQL][TESTS] Add tests for TimestampNTZ and TimestampLTZ for Parquet data source 

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -122,7 +122,63 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
   test("SPARK-36182: TimestampNTZ") {
     val data = Seq("2021-01-01T00:00:00", "1970-07-15T01:02:03.456789")
       .map(ts => Tuple1(LocalDateTime.parse(ts)))
-    checkParquetFile(data)
+    withAllParquetReaders {
+      checkParquetFile(data)
+    }
+  }
+
+  test("SC-88419: Read TimestampNTZ and TimestampLTZ for various logical TIMESTAMP types") {
+    val schema = MessageTypeParser.parseMessageType(
+      """message root {
+        |  required int64 timestamp_ltz_millis_depr(TIMESTAMP_MILLIS);
+        |  required int64 timestamp_ltz_micros_depr(TIMESTAMP_MICROS);
+        |  required int64 timestamp_ltz_millis(TIMESTAMP(MILLIS,true));
+        |  required int64 timestamp_ltz_micros(TIMESTAMP(MICROS,true));
+        |  required int64 timestamp_ntz_millis(TIMESTAMP(MILLIS,false));
+        |  required int64 timestamp_ntz_micros(TIMESTAMP(MICROS,false));
+        |}
+      """.stripMargin)
+
+    for (dictEnabled <- Seq(true, false)) {
+      withTempDir { dir =>
+        val tablePath = new Path(s"${dir.getCanonicalPath}/timestamps.parquet")
+        val numRecords = 100
+
+        val writer = createParquetWriter(schema, tablePath, dictionaryEnabled = dictEnabled)
+        (0 until numRecords).map { i =>
+          val record = new SimpleGroup(schema)
+          for (group <- Seq(0, 2, 4)) {
+            record.add(group, 1000L) // millis
+            record.add(group + 1, 1000000L) // micros
+          }
+          writer.write(record)
+        }
+        writer.close
+
+        withAllParquetReaders {
+          val df = spark.read.parquet(tablePath.toString)
+          assertResult(df.schema) {
+            StructType(
+              StructField("timestamp_ltz_millis_depr", TimestampType, nullable = true) ::
+              StructField("timestamp_ltz_micros_depr", TimestampType, nullable = true) ::
+              StructField("timestamp_ltz_millis", TimestampType, nullable = true) ::
+              StructField("timestamp_ltz_micros", TimestampType, nullable = true) ::
+              StructField("timestamp_ntz_millis", TimestampNTZType, nullable = true) ::
+              StructField("timestamp_ntz_micros", TimestampNTZType, nullable = true) ::
+              Nil
+            )
+          }
+
+          val exp = (0 until numRecords).map { _ =>
+            val ltz_value = new java.sql.Timestamp(1000L)
+            val ntz_value = LocalDateTime.of(1970, 1, 1, 0, 0, 1)
+            (ltz_value, ltz_value, ltz_value, ltz_value, ntz_value, ntz_value)
+          }.toDF()
+
+          checkAnswer(df, exp)
+        }
+      }
+    }
   }
 
   testStandardAndLegacyModes("fixed-length decimals") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -127,7 +127,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
     }
   }
 
-  test("SC-88419: Read TimestampNTZ and TimestampLTZ for various logical TIMESTAMP types") {
+  test("Read TimestampNTZ and TimestampLTZ for various logical TIMESTAMP types") {
     val schema = MessageTypeParser.parseMessageType(
       """message root {
         |  required int64 timestamp_ltz_millis_depr(TIMESTAMP_MILLIS);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

The PR updates/adds more tests for TimestampNTZ and TimestampLTZ types support in Parquet data source to make sure most of the cases are covered.

### Why are the changes needed?

Improves test coverage of the TimestampNTZ feature.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
Existing unit tests.